### PR TITLE
SoapClient - fixed signature map for SoapClient::__call

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -10241,7 +10241,7 @@ return [
 'snmpset' => ['bool', 'host'=>'string', 'community'=>'string', 'object_id'=>'string', 'type'=>'string', 'value'=>'mixed', 'timeout='=>'int', 'retries='=>'int'],
 'snmpwalk' => ['array|false', 'host'=>'string', 'community'=>'string', 'object_id'=>'string', 'timeout='=>'int', 'retries='=>'int'],
 'snmpwalkoid' => ['array|false', 'hostname'=>'string', 'community'=>'string', 'object_id'=>'string', 'timeout='=>'int', 'retries='=>'int'],
-'SoapClient::__call' => ['', 'function_name'=>'string', 'arguments'=>'string'],
+'SoapClient::__call' => ['', 'function_name'=>'string', 'arguments'=>'array'],
 'SoapClient::__construct' => ['void', 'wsdl'=>'mixed', 'options='=>'array'],
 'SoapClient::__doRequest' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
 'SoapClient::__getCookies' => ['array'],


### PR DESCRIPTION
I've recently met this error:
```
Parameter #2 $arguments of method SoapClient::__call() expects string, array given.
```

PR contains fix for signature map.

Reference: https://www.php.net/manual/en/soapclient.call.php