### PR TITLE
Let exceptions fly while bootstrapping

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -77,17 +77,21 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 			throw new \PHPStan\ShouldNotHappenException();
 		}
 
-		$inceptionResult = CommandHelper::begin(
-			$input,
-			$output,
-			$paths,
-			$pathsFile,
-			$memoryLimit,
-			$autoloadFile,
-			$configuration,
-			$level,
-			$allowXdebug
-		);
+		try {
+			$inceptionResult = CommandHelper::begin(
+				$input,
+				$output,
+				$paths,
+				$pathsFile,
+				$memoryLimit,
+				$autoloadFile,
+				$configuration,
+				$level,
+				$allowXdebug
+			);
+		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
+			return 1;
+		}
 
 		$errorOutput = $inceptionResult->getErrorOutput();
 		$errorFormat = $input->getOption('error-format');

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -87,7 +87,8 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 				$autoloadFile,
 				$configuration,
 				$level,
-				$allowXdebug
+				$allowXdebug,
+				$this->getApplication()
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -77,21 +77,17 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 			throw new \PHPStan\ShouldNotHappenException();
 		}
 
-		try {
-			$inceptionResult = CommandHelper::begin(
-				$input,
-				$output,
-				$paths,
-				$pathsFile,
-				$memoryLimit,
-				$autoloadFile,
-				$configuration,
-				$level,
-				$allowXdebug
-			);
-		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
-			return 1;
-		}
+		$inceptionResult = CommandHelper::begin(
+			$input,
+			$output,
+			$paths,
+			$pathsFile,
+			$memoryLimit,
+			$autoloadFile,
+			$configuration,
+			$level,
+			$allowXdebug
+		);
 
 		$errorOutput = $inceptionResult->getErrorOutput();
 		$errorFormat = $input->getOption('error-format');

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -303,7 +303,7 @@ class CommandHelper
 				})($bootstrapFile);
 			} catch (\Throwable $e) {
 				$errorOutput->writeln($e->getMessage());
-				throw new \PHPStan\Command\InceptionNotSuccessfulException($e->getMessage(), 0, $e);
+				throw new \PHPStan\Command\InceptionNotSuccessfulException();
 			}
 		}
 

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -14,6 +14,7 @@ use PHPStan\DependencyInjection\LoaderFactory;
 use PHPStan\DependencyInjection\NeonAdapter;
 use PHPStan\File\FileFinder;
 use PHPStan\File\FileHelper;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -36,7 +37,8 @@ class CommandHelper
 		?string $autoloadFile,
 		?string $projectConfigFile,
 		?string $level,
-		bool $allowXdebug
+		bool $allowXdebug,
+		Application $application
 	): InceptionResult
 	{
 		if (!$allowXdebug) {
@@ -129,7 +131,7 @@ class CommandHelper
 			try {
 				$projectConfig = $loader->load($projectConfigFile, null);
 			} catch (\Nette\InvalidStateException | \Nette\FileNotFoundException $e) {
-				$errorOutput->writeln($e->getMessage());
+				$application->renderException($e);
 				throw new \PHPStan\Command\InceptionNotSuccessfulException();
 			}
 			$defaultParameters = [
@@ -302,7 +304,8 @@ class CommandHelper
 					require_once $file;
 				})($bootstrapFile);
 			} catch (\Throwable $e) {
-				$errorOutput->writeln($e->getMessage());
+				$application->renderException($e);
+
 				throw new \PHPStan\Command\InceptionNotSuccessfulException();
 			}
 		}

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -303,7 +303,7 @@ class CommandHelper
 				})($bootstrapFile);
 			} catch (\Throwable $e) {
 				$errorOutput->writeln($e->getMessage());
-				throw new \PHPStan\Command\InceptionNotSuccessfulException();
+				throw new \PHPStan\Command\InceptionNotSuccessfulException($e->getMessage(), 0, $e);
 			}
 		}
 

--- a/src/Command/DumpDependenciesCommand.php
+++ b/src/Command/DumpDependenciesCommand.php
@@ -61,7 +61,8 @@ class DumpDependenciesCommand extends \Symfony\Component\Console\Command\Command
 				$autoloadFile,
 				$configurationFile,
 				'0', // irrelevant but prevents an error when a config file is passed
-				$allowXdebug
+				$allowXdebug,
+				$this->getApplication()
 			);
 		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
 			return 1;


### PR DESCRIPTION
with this change we get a proper exception stacktrace on the CLI.

without this change a Exception thrown while bootstrapping will just emit its message, e.g.

```sh
$ php ../phpstan-src/bin/phpstan analyse  -c app/partner/phpstan.neon.dist
Required package "complex/rocket" is not installed: cannot detect its version
```


after this changes we get a proper stacktrace, like one would expect who is used to symfony-console applications, which means depending on the use of `-v` parameter you get more details about the actual error:

```sh
$ php ../phpstan-src/bin/phpstan analyse  -c app/partner/phpstan.neon.dist
Required package "complex/rocket" is not installed: cannot detect its version

In CommandHelper.php line 306:

  [PHPStan\Command\InceptionNotSuccessfulException]


analyse [--paths-file PATHS-FILE] [-c|--configuration CONFIGURATION] [-l|--level LEVEL] [--no-progress] [--debug] [-a|--autoload-file AUTOLOAD-FILE] [--error-format ERROR-FORMAT] [--memory-limit MEMORY-LIMIT] [
--xdebug] [--] [<paths>...]
```

adding `-v`:
```sh
$ php ../phpstan-src/bin/phpstan analyse -v -c app/partner/phpstan.neon.dist
Required package "complex/rocket" is not installed: cannot detect its version

In CommandHelper.php line 306:

  [PHPStan\Command\InceptionNotSuccessfulException]


Exception trace:
  at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\src\Command\CommandHelper.php:306
 PHPStan\Command\CommandHelper::begin() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\src\Command\AnalyseCommand.php:89
 PHPStan\Command\AnalyseCommand->execute() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\vendor\symfony\console\Command\Command.php:255
 Symfony\Component\Console\Command\Command->run() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\vendor\symfony\console\Application.php:934
 Symfony\Component\Console\Application->doRunCommand() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\vendor\symfony\console\Application.php:273
 Symfony\Component\Console\Application->doRun() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\vendor\symfony\console\Application.php:149
 Symfony\Component\Console\Application->run() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\bin\phpstan:60
 {closure}() at C:\dvl\Zend\DefaultWorkspace13\phpstan-src\bin\phpstan:61

analyse [--paths-file PATHS-FILE] [-c|--configuration CONFIGURATION] [-l|--level LEVEL] [--no-progress] [--debug] [-a|--autoload-file AUTOLOAD-FILE] [--error-format ERROR-FORMAT] [--memory-limit MEMORY-LIMIT] [
--xdebug] [--] [<paths>...]
```

DX wise this is a major improvement and saves a lot of time while debugging the cause of a error (without the need to install/activate xdebug)