### PR TITLE
Generic variance

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -22,6 +22,7 @@ use PHPStan\Reflection\PassedByReference;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -263,7 +264,18 @@ class PhpDocNodeResolver
 			foreach ($phpDocNode->getTemplateTagValues($tagName) as $tagValue) {
 				$resolved[$tagValue->name] = new TemplateTag(
 					$tagValue->name,
-					$tagValue->bound !== null ? $this->typeNodeResolver->resolve($tagValue->bound, $nameScope) : new MixedType()
+					$tagValue->bound !== null ? $this->typeNodeResolver->resolve($tagValue->bound, $nameScope) : new MixedType(),
+					TemplateTypeVariance::createInvariant()
+				);
+			}
+		}
+
+		foreach (['@template-covariant', '@psalm-template-covariant', '@phpstan-template-covariant'] as $tagName) {
+			foreach ($phpDocNode->getTemplateTagValues($tagName) as $tagValue) {
+				$resolved[$tagValue->name] = new TemplateTag(
+					$tagValue->name,
+					$tagValue->bound !== null ? $this->typeNodeResolver->resolve($tagValue->bound, $nameScope) : new MixedType(),
+					TemplateTypeVariance::createCovariant()
 				);
 			}
 		}

--- a/src/PhpDoc/Tag/TemplateTag.php
+++ b/src/PhpDoc/Tag/TemplateTag.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\PhpDoc\Tag;
 
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Type;
 
 class TemplateTag
@@ -13,10 +14,14 @@ class TemplateTag
 	/** @var \PHPStan\Type\Type */
 	private $bound;
 
-	public function __construct(string $name, Type $bound)
+	/** @var TemplateTypeVariance */
+	private $variance;
+
+	public function __construct(string $name, Type $bound, TemplateTypeVariance $variance)
 	{
 		$this->name = $name;
 		$this->bound = $bound;
+		$this->variance = $variance;
 	}
 
 	public function getName(): string
@@ -29,6 +34,11 @@ class TemplateTag
 		return $this->bound;
 	}
 
+	public function getVariance(): TemplateTypeVariance
+	{
+		return $this->variance;
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return self
@@ -37,7 +47,8 @@ class TemplateTag
 	{
 		return new self(
 			$properties['name'],
-			$properties['bound']
+			$properties['bound'],
+			$properties['variance']
 		);
 	}
 

--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -25,9 +25,13 @@ final class TemplateMixedType extends MixedType implements TemplateType
 	/** @var TemplateTypeStrategy */
 	private $strategy;
 
+	/** @var TemplateTypeVariance */
+	private $variance;
+
 	public function __construct(
 		TemplateTypeScope $scope,
 		TemplateTypeStrategy $templateTypeStrategy,
+		TemplateTypeVariance $templateTypeVariance,
 		string $name,
 		?Type $subtractedType = null
 	)
@@ -36,6 +40,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 
 		$this->scope = $scope;
 		$this->strategy = $templateTypeStrategy;
+		$this->variance = $templateTypeVariance;
 		$this->name = $name;
 	}
 
@@ -143,9 +148,15 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		return new self(
 			$this->scope,
 			new TemplateTypeArgumentStrategy(),
+			$this->variance,
 			$this->name,
 			$this->getSubtractedType()
 		);
+	}
+
+	public function isValidVariance(Type $a, Type $b): bool
+	{
+		return $this->variance->isValidVariance($a, $b);
 	}
 
 	public function subtract(Type $type): Type
@@ -160,6 +171,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		return new self(
 			$this->scope,
 			$this->strategy,
+			$this->variance,
 			$this->name,
 			$type
 		);
@@ -170,6 +182,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		return new self(
 			$this->scope,
 			$this->strategy,
+			$this->variance,
 			$this->name,
 			null
 		);
@@ -180,6 +193,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		return new self(
 			$this->scope,
 			$this->strategy,
+			$this->variance,
 			$this->name,
 			$subtractedType
 		);
@@ -194,6 +208,7 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		return new self(
 			$properties['scope'],
 			$properties['strategy'],
+			$properties['variance'],
 			$properties['name'],
 			$properties['subtractedType']
 		);

--- a/src/Type/Generic/TemplateType.php
+++ b/src/Type/Generic/TemplateType.php
@@ -18,4 +18,6 @@ interface TemplateType extends CompoundType
 
 	public function isArgument(): bool;
 
+	public function isValidVariance(Type $a, Type $b): bool;
+
 }

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -11,16 +11,16 @@ use PHPStan\Type\Type;
 final class TemplateTypeFactory
 {
 
-	public static function create(TemplateTypeScope $scope, string $name, ?Type $bound): Type
+	public static function create(TemplateTypeScope $scope, string $name, ?Type $bound, TemplateTypeVariance $variance): Type
 	{
 		$strategy = new TemplateTypeParameterStrategy();
 
 		if ($bound instanceof ObjectType) {
-			return new TemplateObjectType($scope, $strategy, $name, $bound->getClassName());
+			return new TemplateObjectType($scope, $strategy, $variance, $name, $bound->getClassName());
 		}
 
 		if ($bound === null || get_class($bound) === MixedType::class) {
-			return new TemplateMixedType($scope, $strategy, $name);
+			return new TemplateMixedType($scope, $strategy, $variance, $name);
 		}
 
 		return new ErrorType();
@@ -28,7 +28,7 @@ final class TemplateTypeFactory
 
 	public static function fromTemplateTag(TemplateTypeScope $scope, TemplateTag $tag): Type
 	{
-		return self::create($scope, $tag->getName(), $tag->getBound());
+		return self::create($scope, $tag->getName(), $tag->getBound(), $tag->getVariance());
 	}
 
 }

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+
+class TemplateTypeVariance
+{
+
+	private const INVARIANT = 1;
+	private const COVARIANT = 2;
+	private const CONTRAVARIANT = 3;
+
+	/** @var self[] */
+	private static $registry;
+
+	/** @var int */
+	private $value;
+
+	private function __construct(int $value)
+	{
+		$this->value = $value;
+	}
+
+	private static function create(int $value): self
+	{
+		self::$registry[$value] = self::$registry[$value] ?? new self($value);
+		return self::$registry[$value];
+	}
+
+	public static function createInvariant(): self
+	{
+		return self::create(self::INVARIANT);
+	}
+
+	public static function createCovariant(): self
+	{
+		return self::create(self::COVARIANT);
+	}
+
+	public static function createContravariant(): self
+	{
+		return self::create(self::CONTRAVARIANT);
+	}
+
+	public function invariant(): bool
+	{
+		return $this->value === self::INVARIANT;
+	}
+
+	public function covariant(): bool
+	{
+		return $this->value === self::COVARIANT;
+	}
+
+	public function contravariant(): bool
+	{
+		return $this->value === self::CONTRAVARIANT;
+	}
+
+	public function isValidVariance(Type $a, Type $b): bool
+	{
+		if ($a instanceof MixedType && !$a instanceof TemplateType) {
+			return true;
+		}
+
+		if ($b instanceof MixedType && !$b instanceof TemplateType) {
+			return true;
+		}
+
+		if ($this->invariant()) {
+			return $a->equals($b);
+		}
+
+		if ($this->covariant()) {
+			return $a->isSuperTypeOf($b)->yes();
+		}
+
+		if ($this->contravariant()) {
+			return $b->isSuperTypeOf($a)->yes();
+		}
+
+		throw new \PHPStan\ShouldNotHappenException();
+	}
+
+	public function equals(self $other): bool
+	{
+		return $other->value === $this->value;
+	}
+
+	/**
+	 * @param array{value: int} $properties
+	 * @return self
+	 */
+	public static function __set_state(array $properties): self
+	{
+		return new self($properties['value']);
+	}
+
+}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -771,12 +771,12 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			$type = TypeCombinator::union($this->subtractedType, $type);
 		}
 
-		return new self($this->className, $type);
+		return $this->changeSubtractedType($type);
 	}
 
 	public function getTypeWithoutSubtractedType(): Type
 	{
-		return new self($this->className);
+		return $this->changeSubtractedType(null);
 	}
 
 	public function changeSubtractedType(?Type $subtractedType): Type

--- a/tests/PHPStan/Generics/GenericsIntegrationTest.php
+++ b/tests/PHPStan/Generics/GenericsIntegrationTest.php
@@ -13,6 +13,7 @@ class GenericsIntegrationTest extends \PHPStan\Testing\LevelsTestCase
 			['pick'],
 			['varyingAcceptor'],
 			['classes'],
+			['variance'],
 		];
 	}
 

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -6,6 +6,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -44,7 +45,8 @@ class TemplateTypeFactoryTest extends \PHPStan\Testing\TestCase
 				TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('a'),
 					'U',
-					null
+					null,
+					TemplateTypeVariance::createInvariant()
 				),
 				false,
 			],
@@ -64,7 +66,12 @@ class TemplateTypeFactoryTest extends \PHPStan\Testing\TestCase
 	public function testCreate(?Type $bound, bool $expectSuccess): void
 	{
 		$scope = TemplateTypeScope::createWithFunction('a');
-		$templateType = TemplateTypeFactory::create($scope, 'T', $bound);
+		$templateType = TemplateTypeFactory::create(
+			$scope,
+			'T',
+			$bound,
+			TemplateTypeVariance::createInvariant()
+		);
 
 		if ($expectSuccess) {
 			$this->assertInstanceOf(TemplateType::class, $templateType);

--- a/tests/PHPStan/Generics/data/variance-5.json
+++ b/tests/PHPStan/Generics/data/variance-5.json
@@ -1,0 +1,7 @@
+[
+    {
+        "message": "Parameter #1 $it of function PHPStan\\Generics\\Variance\\acceptInvariantIterOfDateTimeInterface expects PHPStan\\Generics\\Variance\\InvariantIter<DateTimeInterface>, PHPStan\\Generics\\Variance\\InvariantIter<DateTime> given.",
+        "line": 46,
+        "ignorable": true
+    }
+]

--- a/tests/PHPStan/Generics/data/variance.php
+++ b/tests/PHPStan/Generics/data/variance.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PHPStan\Generics\Variance;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleError;
+
+/** @template T */
+interface InvariantIter {
+	/** @return T */
+	public function next();
+}
+
+
+/** @template-covariant T */
+interface Iter {
+	/** @return T */
+	public function next();
+}
+
+/** @param InvariantIter<\DateTime> $it */
+function acceptInvariantIterOfDateTime($it): void {
+}
+
+/** @param InvariantIter<\DateTimeInterface> $it */
+function acceptInvariantIterOfDateTimeInterface($it): void {
+}
+
+/** @param Iter<\DateTime> $it */
+function acceptIterOfDateTime($it): void {
+}
+
+/** @param Iter<\DateTimeInterface> $it */
+function acceptIterOfDateTimeInterface($it): void {
+}
+
+/**
+ * @param Iter<\DateTime> $itOfDateTime
+ * @param InvariantIter<\DateTime> $invariantItOfDateTime
+ */
+function test($itOfDateTime, $invariantItOfDateTime): void {
+	acceptInvariantIterOfDateTime($invariantItOfDateTime);
+	acceptInvariantIterOfDateTimeInterface($invariantItOfDateTime);
+
+	acceptIterOfDateTime($itOfDateTime);
+	acceptIterOfDateTimeInterface($itOfDateTime);
+}

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
@@ -30,7 +31,8 @@ class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction('a'),
 				$name,
-				$type
+				$type,
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -12,6 +12,7 @@ use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
@@ -397,7 +398,8 @@ class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
 						TemplateTypeFactory::create(
 							TemplateTypeScope::createWithFunction('a'),
 							'T',
-							null
+							null,
+							TemplateTypeVariance::createInvariant()
 						),
 						false,
 						PassedByReference::createNo(),

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -7,6 +7,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class ArrayTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -144,7 +145,8 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction('a'),
 				$name,
-				new MixedType()
+				new MixedType(),
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -8,6 +8,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\HasMethodType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class CallableTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -179,7 +180,8 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction('a'),
 				$name,
-				new MixedType()
+				new MixedType(),
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -7,6 +7,7 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
@@ -205,7 +206,8 @@ class ConstantArrayTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction('a'),
 				$name,
-				new MixedType()
+				new MixedType(),
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -8,6 +8,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Test\A;
 use PHPStan\Type\Test\B;
+use PHPStan\Type\Test\C;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -51,6 +52,36 @@ class GenericObjectTypeTest extends \PHPStan\Testing\TestCase
 			'implementation with @extends with different type args' => [
 				new GenericObjectType(B\I::class, [new ObjectType('DateTimeInteface')]),
 				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createNo(),
+			],
+			'invariant with equals types' => [
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'invariant with sub type' => [
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createNo(),
+			],
+			'invariant with super type' => [
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')]),
+				TrinaryLogic::createNo(),
+			],
+			'covariant with equals types' => [
+				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'covariant with sub type' => [
+				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTimeInterface')]),
+				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'covariant with super type' => [
+				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTimeInterface')]),
 				TrinaryLogic::createNo(),
 			],
 		];
@@ -139,7 +170,8 @@ class GenericObjectTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction('a'),
 				$name,
-				$bound ?? new MixedType()
+				$bound ?? new MixedType(),
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 

--- a/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
@@ -14,7 +14,8 @@ class TemplateTypeHelperTest extends \PHPStan\Testing\TestCase
 		$templateType = TemplateTypeFactory::create(
 			TemplateTypeScope::createWithFunction('a'),
 			'T',
-			null
+			null,
+			TemplateTypeVariance::createInvariant()
 		);
 
 		$type = TemplateTypeHelper::resolveTemplateTypes(

--- a/tests/PHPStan/Type/Generic/data/generic-classes-c.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-c.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Test\C;
+
+/** @template T */
+interface Invariant {
+}
+
+/** @template-covariant T */
+interface Covariant {
+}

--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class IterableTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -188,7 +189,8 @@ class IterableTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction('a'),
 				$name,
-				new MixedType()
+				new MixedType(),
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 
@@ -255,7 +257,8 @@ class IterableTypeTest extends \PHPStan\Testing\TestCase
 		$templateType = TemplateTypeFactory::create(
 			TemplateTypeScope::createWithFunction('a'),
 			'T',
-			null
+			null,
+			TemplateTypeVariance::createInvariant()
 		);
 
 		return [

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -7,6 +7,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class TemplateTypeTest extends \PHPStan\Testing\TestCase
 {
@@ -17,7 +18,8 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction($functionName ?? '_'),
 				$name,
-				$bound
+				$bound,
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 
@@ -93,7 +95,8 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction($functionName ?? '_'),
 				$name,
-				$bound
+				$bound,
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 
@@ -186,7 +189,8 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 			return TemplateTypeFactory::create(
 				TemplateTypeScope::createWithFunction($functionName ?? '_'),
 				$name,
-				$bound
+				$bound,
+				TemplateTypeVariance::createInvariant()
 			);
 		};
 

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -12,9 +12,11 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 {
@@ -1104,7 +1106,8 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						null
+						null,
+						TemplateTypeVariance::createInvariant()
 					),
 					new ObjectType('DateTime'),
 				],
@@ -1116,7 +1119,8 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 					new ObjectType('DateTime'),
 				],
@@ -1128,12 +1132,14 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 				],
 				TemplateType::class,
@@ -1144,12 +1150,14 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'U',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 				],
 				UnionType::class,
@@ -1413,6 +1421,42 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 				MixedType::class,
 				'mixed',
 			],
+			[
+				[
+					new GenericObjectType(Variance\Invariant::class, [
+						new ObjectType(\DateTimeInterface::class),
+					]),
+					new GenericObjectType(Variance\Invariant::class, [
+						new ObjectType(\DateTimeInterface::class),
+					]),
+				],
+				GenericObjectType::class,
+				'PHPStan\Type\Variance\Invariant<DateTimeInterface>',
+			],
+			[
+				[
+					new GenericObjectType(Variance\Invariant::class, [
+						new ObjectType(\DateTimeInterface::class),
+					]),
+					new GenericObjectType(Variance\Invariant::class, [
+						new ObjectType(\DateTime::class),
+					]),
+				],
+				UnionType::class,
+				'PHPStan\Type\Variance\Invariant<DateTime>|PHPStan\Type\Variance\Invariant<DateTimeInterface>',
+			],
+			[
+				[
+					new GenericObjectType(Variance\Covariant::class, [
+						new ObjectType(\DateTimeInterface::class),
+					]),
+					new GenericObjectType(Variance\Covariant::class, [
+						new ObjectType(\DateTime::class),
+					]),
+				],
+				GenericObjectType::class,
+				'PHPStan\Type\Variance\Covariant<DateTimeInterface>',
+			],
 		];
 	}
 
@@ -1519,7 +1563,8 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 						TemplateTypeFactory::create(
 							TemplateTypeScope::createWithFunction('_'),
 							'T',
-							null
+							null,
+							TemplateTypeVariance::createInvariant()
 						)
 					),
 				],
@@ -2052,7 +2097,8 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						null
+						null,
+						TemplateTypeVariance::createInvariant()
 					),
 					new ObjectType('DateTime'),
 				],
@@ -2064,7 +2110,8 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 					new ObjectType('DateTime'),
 				],
@@ -2076,12 +2123,14 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 				],
 				TemplateType::class,
@@ -2092,12 +2141,14 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'U',
-						new ObjectType('DateTime')
+						new ObjectType('DateTime'),
+						TemplateTypeVariance::createInvariant()
 					),
 				],
 				IntersectionType::class,
@@ -2108,7 +2159,8 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('a'),
 						'T',
-						null
+						null,
+						TemplateTypeVariance::createInvariant()
 					),
 					new MixedType(),
 				],
@@ -2346,6 +2398,18 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 				],
 				MixedType::class,
 				'mixed',
+			],
+			[
+				[
+					new GenericObjectType(Variance\Covariant::class, [
+						new ObjectType(\DateTimeInterface::class),
+					]),
+					new GenericObjectType(Variance\Covariant::class, [
+						new ObjectType(\DateTime::class),
+					]),
+				],
+				GenericObjectType::class,
+				'PHPStan\Type\Variance\Covariant<DateTime>',
 			],
 		];
 	}


### PR DESCRIPTION
This builds on https://github.com/phpstan/phpdoc-parser/pull/34 to support covariance of type variables, via `@template-covariant`.

Missing:
- Rule to allow covariant type variables only as return types (`f(): T`), or as covariant type parameter (`Bar<T>` when `Bar` has `@template-covariant`).