### PR TITLE
Fixed return value of ssh2_sftp according to its documentation

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -11522,7 +11522,7 @@ return [
 'ssh2_publickey_remove' => ['bool', 'pkey'=>'resource', 'algoname'=>'string', 'blob'=>'string'],
 'ssh2_scp_recv' => ['bool', 'session'=>'resource', 'remote_file'=>'string', 'local_file'=>'string'],
 'ssh2_scp_send' => ['bool', 'session'=>'resource', 'local_file'=>'string', 'remote_file'=>'string', 'create_mode='=>'int'],
-'ssh2_sftp' => ['resource', 'session'=>'resource'],
+'ssh2_sftp' => ['resource|false', 'session'=>'resource'],
 'ssh2_sftp_chmod' => ['bool', 'sftp'=>'resource', 'filename'=>'string', 'mode'=>'int'],
 'ssh2_sftp_lstat' => ['array', 'sftp'=>'resource', 'path'=>'string'],
 'ssh2_sftp_mkdir' => ['bool', 'sftp'=>'resource', 'dirname'=>'string', 'mode='=>'int', 'recursive='=>'bool'],


### PR DESCRIPTION
Documentation says about `ssh2_sftp`:

> This method returns an SSH2 SFTP resource for use with all other ssh2_sftp_*() methods and the ssh2.sftp:// fopen wrapper, or **FALSE** on failure. 

https://www.php.net/manual/en/function.ssh2-sftp.php

I fixed the return value in `functionMap`.