### PR TITLE
Fixed return value of substr according to its documentation

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -11758,7 +11758,7 @@ return [
 'strtr' => ['string', 'str'=>'string', 'from'=>'string', 'to'=>'string'],
 'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array'],
 'strval' => ['string', 'var'=>'mixed'],
-'substr' => ['string', 'str'=>'string', 'start'=>'int', 'length='=>'int'],
+'substr' => ['string|false', 'str'=>'string', 'start'=>'int', 'length='=>'int'],
 'substr_compare' => ['int|false', 'main_str'=>'string', 'str'=>'string', 'offset'=>'int', 'length='=>'int', 'case_sensitivity='=>'bool'],
 'substr_count' => ['int', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int', 'length='=>'int'],
 'substr_replace' => ['string|array', 'str'=>'string|array', 'repl'=>'mixed', 'start'=>'mixed', 'length='=>'mixed'],


### PR DESCRIPTION
Documentation says about `substr`:

> Returns the extracted part of **string**; or **FALSE** on failure, or an empty string. 

https://www.php.net/manual/en/function.substr.php

I fixed the return value in functionMap.