### PR TITLE
Template type variance rules

### DIFF
--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -15,9 +15,11 @@ rules:
 	- PHPStan\Rules\Generics\ClassAncestorsRule
 	- PHPStan\Rules\Generics\ClassTemplateTypeRule
 	- PHPStan\Rules\Generics\FunctionTemplateTypeRule
+	- PHPStan\Rules\Generics\FunctionSignatureVarianceRule
 	- PHPStan\Rules\Generics\InterfaceAncestorsRule
 	- PHPStan\Rules\Generics\InterfaceTemplateTypeRule
 	- PHPStan\Rules\Generics\MethodTemplateTypeRule
+	- PHPStan\Rules\Generics\MethodSignatureVarianceRule
 	- PHPStan\Rules\Generics\TraitTemplateTypeRule
 	- PHPStan\Rules\Methods\IncompatibleDefaultParameterTypeRule
 	- PHPStan\Rules\Operators\InvalidBinaryOperationRule

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -378,6 +378,9 @@ services:
 			checkClassCaseSensitivity: %checkClassCaseSensitivity%
 
 	-
+		class: PHPStan\Rules\Generics\VarianceCheck
+
+	-
 		class: PHPStan\Rules\MissingTypehintCheck
 		arguments:
 			checkGenericClassInNonGenericObjectType: %checkGenericClassInNonGenericObjectType%

--- a/src/Rules/Generics/ClassAncestorsRule.php
+++ b/src/Rules/Generics/ClassAncestorsRule.php
@@ -73,7 +73,8 @@ class ClassAncestorsRule implements Rule
 			'Generic type %s in PHPDoc tag @extends specifies %d template types, but class %s supports only %d: %s',
 			'Type %s in generic type %s in PHPDoc tag @extends is not subtype of template type %s of class %s.',
 			'PHPDoc tag @extends has invalid type %s.',
-			sprintf('Class %s extends generic class %%s but does not specify its types: %%s', $className)
+			sprintf('Class %s extends generic class %%s but does not specify its types: %%s', $className),
+			sprintf('in extended type %%s of class %s', $className)
 		);
 
 		$implementsErrors = $this->genericAncestorsCheck->check(
@@ -89,7 +90,8 @@ class ClassAncestorsRule implements Rule
 			'Generic type %s in PHPDoc tag @implements specifies %d template types, but interface %s supports only %d: %s',
 			'Type %s in generic type %s in PHPDoc tag @implements is not subtype of template type %s of interface %s.',
 			'PHPDoc tag @implements has invalid type %s.',
-			sprintf('Class %s implements generic interface %%s but does not specify its types: %%s', $className)
+			sprintf('Class %s implements generic interface %%s but does not specify its types: %%s', $className),
+			sprintf('in implemented type %%s of class %s', $className)
 		);
 
 		return array_merge($extendsErrors, $implementsErrors);

--- a/src/Rules/Generics/FunctionSignatureVarianceRule.php
+++ b/src/Rules/Generics/FunctionSignatureVarianceRule.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Function_>
+ */
+class FunctionSignatureVarianceRule implements Rule
+{
+
+	/** @var \PHPStan\Broker\Broker */
+	private $broker;
+
+	/** @var \PHPStan\Rules\Generics\VarianceCheck */
+	private $varianceCheck;
+
+	public function __construct(Broker $broker, VarianceCheck $varianceCheck)
+	{
+		$this->broker = $broker;
+		$this->varianceCheck = $varianceCheck;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\Function_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$functionName = $node->name->name;
+		if (isset($node->namespacedName)) {
+			$functionName = (string) $node->namespacedName;
+		}
+		$functionNameName = new Name($functionName);
+		if (!$this->broker->hasCustomFunction($functionNameName, null)) {
+			return [];
+		}
+		$functionReflection = $this->broker->getCustomFunction($functionNameName, null);
+
+		return $this->varianceCheck->checkParametersAcceptor(
+			ParametersAcceptorSelector::selectSingle($functionReflection->getVariants()),
+			sprintf('in parameter %%s of function %s()', $functionName),
+			sprintf('in return type of function %s()', $functionName)
+		);
+	}
+
+}

--- a/src/Rules/Generics/InterfaceAncestorsRule.php
+++ b/src/Rules/Generics/InterfaceAncestorsRule.php
@@ -71,7 +71,8 @@ class InterfaceAncestorsRule implements Rule
 			'Generic type %s in PHPDoc tag @extends specifies %d template types, but interface %s supports only %d: %s',
 			'Type %s in generic type %s in PHPDoc tag @extends is not subtype of template type %s of interface %s.',
 			'PHPDoc tag @extends has invalid type %s.',
-			sprintf('Interface %s extends generic interface %%s but does not specify its types: %%s', $interfaceName)
+			sprintf('Interface %s extends generic interface %%s but does not specify its types: %%s', $interfaceName),
+			sprintf('in extended type %%s of interface %s', $interfaceName)
 		);
 
 		$implementsErrors = $this->genericAncestorsCheck->check(
@@ -81,6 +82,7 @@ class InterfaceAncestorsRule implements Rule
 			}, $implementsTags),
 			sprintf('Interface %s @implements tag contains incompatible type %%s.', $interfaceName),
 			sprintf('Interface %s has @implements tag, but can not implement any interface, must extend from it.', $interfaceName),
+			'',
 			'',
 			'',
 			'',

--- a/src/Rules/Generics/MethodSignatureVarianceRule.php
+++ b/src/Rules/Generics/MethodSignatureVarianceRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\ClassMethod>
+ */
+class MethodSignatureVarianceRule implements Rule
+{
+
+	/** @var \PHPStan\Rules\Generics\VarianceCheck */
+	private $varianceCheck;
+
+	public function __construct(VarianceCheck $varianceCheck)
+	{
+		$this->varianceCheck = $varianceCheck;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\ClassMethod::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$scope->isInClass()) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		$classReflection = $scope->getClassReflection();
+		$className = $classReflection->getDisplayName();
+		$methodName = $node->name->toString();
+		$method = $classReflection->getNativeMethod($methodName);
+
+		return $this->varianceCheck->checkParametersAcceptor(
+			ParametersAcceptorSelector::selectSingle($method->getVariants()),
+			sprintf('in parameter %%s of method %s::%s()', $className, $methodName),
+			sprintf('in return type of method %s::%s()', $className, $methodName)
+		);
+	}
+
+}

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Type;
+
+class VarianceCheck
+{
+
+	/** @return RuleError[] */
+	public function checkParametersAcceptor(
+		ParametersAcceptor $parametersAcceptor,
+		string $parameterTypeMessage,
+		string $returnTypeMessage
+	): array
+	{
+		$errors = [];
+
+		foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
+			$variance = TemplateTypeVariance::createContravariant();
+			$type = $parameterReflection->getType();
+			$message = sprintf($parameterTypeMessage, $parameterReflection->getName());
+			foreach ($this->check($variance, $type, $message) as $error) {
+				$errors[] = $error;
+			}
+		}
+
+		$variance = TemplateTypeVariance::createCovariant();
+		$type = $parametersAcceptor->getReturnType();
+		foreach ($this->check($variance, $type, $returnTypeMessage) as $error) {
+			$errors[] = $error;
+		}
+
+		return $errors;
+	}
+
+	/** @return RuleError[] */
+	public function check(TemplateTypeVariance $positionVariance, Type $type, string $messageContext): array
+	{
+		$errors = [];
+
+		foreach ($type->getReferencedTemplateTypes($positionVariance) as $reference) {
+			$referredType = $reference->getType();
+			if ($this->isTemplateTypeVarianceValid($reference->getPositionVariance(), $referredType)) {
+				continue;
+			}
+
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'Template type %s is declared as %s, but occurs in %s position %s.',
+				$referredType->getName(),
+				$referredType->getVariance()->describe(),
+				$reference->getPositionVariance()->describe(),
+				$messageContext
+			))->build();
+		}
+
+		return $errors;
+	}
+
+	private function isTemplateTypeVarianceValid(TemplateTypeVariance $positionVariance, TemplateType $type): bool
+	{
+		if ($type->getVariance()->invariant()) {
+			return true;
+		}
+
+		return $type->getVariance()->equals($positionVariance);
+	}
+
+}

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -10,6 +10,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -319,6 +320,16 @@ class ArrayType implements Type
 		}
 
 		return TemplateTypeMap::createEmpty();
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		$variance = $positionVariance->compose(TemplateTypeVariance::createInvariant());
+
+		return array_merge(
+			$this->getKeyType()->getReferencedTemplateTypes($variance),
+			$this->getItemType()->getReferencedTemplateTypes($variance)
+		);
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -13,6 +13,7 @@ use PHPStan\Type\CompoundType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
@@ -527,6 +528,26 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		return TemplateTypeMap::createEmpty();
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		$variance = $positionVariance->compose(TemplateTypeVariance::createInvariant());
+		$references = [];
+
+		foreach ($this->keyTypes as $type) {
+			foreach ($type->getReferencedTemplateTypes($variance) as $reference) {
+				$references[] = $reference;
+			}
+		}
+
+		foreach ($this->valueTypes as $type) {
+			foreach ($type->getReferencedTemplateTypes($variance) as $reference) {
+				$references[] = $reference;
+			}
+		}
+
+		return $references;
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -136,6 +136,13 @@ class GenericClassStringType extends ClassStringType
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		$variance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
+
+		return $this->type->getReferencedTemplateTypes($variance);
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -200,6 +200,31 @@ final class GenericObjectType extends ObjectType
 		return $typeMap;
 	}
 
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		$classReflection = $this->getClassReflection();
+		if ($classReflection !== null) {
+			$typeList = $classReflection->typeMapToList($classReflection->getTemplateTypeMap());
+		} else {
+			$typeList = [];
+		}
+
+		$references = [];
+
+		foreach ($this->types as $i => $type) {
+			$variance = $positionVariance->compose(
+				isset($typeList[$i]) && $typeList[$i] instanceof TemplateType
+					? $typeList[$i]->getVariance()
+					: TemplateTypeVariance::createInvariant()
+			);
+			foreach ($type->getReferencedTemplateTypes($variance) as $reference) {
+				$references[] = $reference;
+			}
+		}
+
+		return $references;
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		$subtractedType = $this->getSubtractedType() !== null ? $cb($this->getSubtractedType()) : null;

--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -145,6 +145,11 @@ final class TemplateMixedType extends MixedType implements TemplateType
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return [new TemplateTypeReference($this, $positionVariance)];
+	}
+
 	public function isArgument(): bool
 	{
 		return $this->strategy->isArgument();
@@ -204,6 +209,11 @@ final class TemplateMixedType extends MixedType implements TemplateType
 			$this->name,
 			$subtractedType
 		);
+	}
+
+	public function getVariance(): TemplateTypeVariance
+	{
+		return $this->variance;
 	}
 
 	/**

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -157,6 +157,11 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 		return TemplateTypeMap::createEmpty();
 	}
 
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return [new TemplateTypeReference($this, $positionVariance)];
+	}
+
 	public function isArgument(): bool
 	{
 		return $this->strategy->isArgument();
@@ -189,6 +194,11 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 			$this->getClassName(),
 			$subtractedType
 		);
+	}
+
+	public function getVariance(): TemplateTypeVariance
+	{
+		return $this->variance;
 	}
 
 	/**

--- a/src/Type/Generic/TemplateObjectWithoutClassType.php
+++ b/src/Type/Generic/TemplateObjectWithoutClassType.php
@@ -220,6 +220,17 @@ class TemplateObjectWithoutClassType extends ObjectWithoutClassType implements T
 		return TemplateTypeMap::createEmpty();
 	}
 
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return [];
+	}
+
+	public function getVariance(): TemplateTypeVariance
+	{
+		return $this->variance;
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/src/Type/Generic/TemplateType.php
+++ b/src/Type/Generic/TemplateType.php
@@ -20,4 +20,6 @@ interface TemplateType extends CompoundType
 
 	public function isValidVariance(Type $a, Type $b): bool;
 
+	public function getVariance(): TemplateTypeVariance;
+
 }

--- a/src/Type/Generic/TemplateTypeReference.php
+++ b/src/Type/Generic/TemplateTypeReference.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+class TemplateTypeReference
+{
+
+	/** @var TemplateType */
+	private $type;
+
+	/** @var TemplateTypeVariance */
+	private $positionVariance;
+
+	public function __construct(TemplateType $type, TemplateTypeVariance $positionVariance)
+	{
+		$this->type = $type;
+		$this->positionVariance = $positionVariance;
+	}
+
+	public function getType(): TemplateType
+	{
+		return $this->type;
+	}
+
+	public function getPositionVariance(): TemplateTypeVariance
+	{
+		return $this->positionVariance;
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -59,6 +59,31 @@ class TemplateTypeVariance
 		return $this->value === self::CONTRAVARIANT;
 	}
 
+	public function compose(self $other): self
+	{
+		if ($this->contravariant()) {
+			if ($other->contravariant()) {
+				return self::createCovariant();
+			}
+			if ($other->covariant()) {
+				return self::createContravariant();
+			}
+			return self::createInvariant();
+		}
+
+		if ($this->covariant()) {
+			if ($other->contravariant()) {
+				return self::createCovariant();
+			}
+			if ($other->covariant()) {
+				return self::createCovariant();
+			}
+			return self::createInvariant();
+		}
+
+		return $other;
+	}
+
 	public function isValidVariance(Type $a, Type $b): bool
 	{
 		if ($a instanceof MixedType && !$a instanceof TemplateType) {
@@ -87,6 +112,20 @@ class TemplateTypeVariance
 	public function equals(self $other): bool
 	{
 		return $other->value === $this->value;
+	}
+
+	public function describe(): string
+	{
+		switch ($this->value) {
+			case self::INVARIANT:
+				return 'invariant';
+			case self::COVARIANT:
+				return 'covariant';
+			case self::CONTRAVARIANT:
+				return 'contravariant';
+		}
+
+		throw new \PHPStan\ShouldNotHappenException();
 	}
 
 	/**

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\Type\IntersectionTypeMethodReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class IntersectionType implements CompoundType
 {
@@ -389,6 +390,19 @@ class IntersectionType implements CompoundType
 		}
 
 		return $types;
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		$references = [];
+
+		foreach ($this->types as $type) {
+			foreach ($type->getReferencedTemplateTypes($positionVariance) as $reference) {
+				$references[] = $reference;
+			}
+		}
+
+		return $references;
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
@@ -219,6 +220,14 @@ class IterableType implements CompoundType
 		$valueTypeMap = $this->getIterableValueType()->inferTemplateTypes($receivedType->getIterableValueType());
 
 		return $keyTypeMap->union($valueTypeMap);
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return array_merge(
+			$this->getIterableKeyType()->getReferencedTemplateTypes(TemplateTypeVariance::createCovariant()),
+			$this->getIterableValueType()->getReferencedTemplateTypes(TemplateTypeVariance::createCovariant())
+		);
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/Traits/NonGenericTypeTrait.php
+++ b/src/Type/Traits/NonGenericTypeTrait.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Type;
 
 trait NonGenericTypeTrait
@@ -11,6 +12,11 @@ trait NonGenericTypeTrait
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
 		return TemplateTypeMap::createEmpty();
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return [];
 	}
 
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -8,6 +8,8 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeReference;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 interface Type
 {
@@ -90,6 +92,24 @@ interface Type
 	 * the received Type.
 	 */
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap;
+
+	/**
+	 * Returns the template types referenced by this Type, recursively
+	 *
+	 * The return value is a list of TemplateTypeReferences, who contain the
+	 * referenced template type as well as the variance position in which it was
+	 * found.
+	 *
+	 * For example, calling this on array<Foo<T>,Bar> (with T a template type)
+	 * will return one TemplateTypeReference for the type T.
+	 *
+	 * @param TemplateTypeVariance $positionVariance The variance position in
+	 *                                               which the receiver type was
+	 *                                               found.
+	 *
+	 * @return TemplateTypeReference[]
+	 */
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array;
 
 	/**
 	 * Traverses inner types

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -11,6 +11,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 
 class UnionType implements CompoundType
 {
@@ -571,6 +572,19 @@ class UnionType implements CompoundType
 		}
 
 		return $types;
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		$references = [];
+
+		foreach ($this->types as $type) {
+			foreach ($type->getReferencedTemplateTypes($positionVariance) as $reference) {
+				$references[] = $reference;
+			}
+		}
+
+		return $references;
 	}
 
 	public function traverse(callable $cb): Type

--- a/tests/PHPStan/Generics/data/variance-2.json
+++ b/tests/PHPStan/Generics/data/variance-2.json
@@ -1,0 +1,72 @@
+[
+    {
+        "message": "Template type T is declared as covariant, but occurs in contravariant position in parameter a of method PHPStan\\Generics\\Variance\\Foo::x().",
+        "line": 52,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in contravariant position in parameter c of method PHPStan\\Generics\\Variance\\Foo::x().",
+        "line": 52,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in contravariant position in parameter e of method PHPStan\\Generics\\Variance\\Foo::x().",
+        "line": 52,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in parameter b of method PHPStan\\Generics\\Variance\\Foo::x().",
+        "line": 52,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in parameter d of method PHPStan\\Generics\\Variance\\Foo::x().",
+        "line": 52,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in extended type PHPStan\\Generics\\Variance\\Invariant<T> of interface PHPStan\\Generics\\Variance\\Bar.",
+        "line": 60,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in implemented type PHPStan\\Generics\\Variance\\Invariant<T> of class PHPStan\\Generics\\Variance\\Qux.",
+        "line": 76,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in extended type PHPStan\\Generics\\Variance\\Quux<T> of class PHPStan\\Generics\\Variance\\Quuz.",
+        "line": 89,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in contravariant position in parameter a of function PHPStan\\Generics\\Variance\\x().",
+        "line": 101,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in contravariant position in parameter c of function PHPStan\\Generics\\Variance\\x().",
+        "line": 101,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in contravariant position in parameter e of function PHPStan\\Generics\\Variance\\x().",
+        "line": 101,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in parameter b of function PHPStan\\Generics\\Variance\\x().",
+        "line": 101,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in parameter d of function PHPStan\\Generics\\Variance\\x().",
+        "line": 101,
+        "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in return type of function PHPStan\\Generics\\Variance\\returnInvariant().",
+        "line": 117,
+        "ignorable": true
+    }
+]

--- a/tests/PHPStan/Generics/data/variance-5.json
+++ b/tests/PHPStan/Generics/data/variance-5.json
@@ -1,7 +1,7 @@
 [
     {
         "message": "Parameter #1 $it of function PHPStan\\Generics\\Variance\\acceptInvariantIterOfDateTimeInterface expects PHPStan\\Generics\\Variance\\InvariantIter<DateTimeInterface>, PHPStan\\Generics\\Variance\\InvariantIter<DateTime> given.",
-        "line": 40,
+        "line": 127,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Generics/data/variance.php
+++ b/tests/PHPStan/Generics/data/variance.php
@@ -31,6 +31,93 @@ function acceptIterOfDateTime($it): void {
 function acceptIterOfDateTimeInterface($it): void {
 }
 
+/** @template T */
+interface Invariant {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template-covariant T */
+interface Foo {
+	/**
+	 * @param T $a
+	 * @param Invariant<T> $b
+	 * @param Out<T> $c
+	 * @param array<T> $d
+	 * @param Out<Out<Out<T>>> $e
+	 * @return T
+	 */
+	function x($a, $b, $c, $d, $e);
+}
+
+/**
+ * @template-covariant T
+ * @extends Invariant<T>
+ * @extends Out<T>
+ */
+interface Bar extends Invariant, Out {
+}
+
+/**
+ * @template T
+ * @extends Invariant<T>
+ * @extends Out<T>
+ */
+interface Baz extends Invariant, Out {
+}
+
+/**
+ * @template-covariant T
+ * @implements Invariant<T>
+ * @implements Out<T>
+ */
+class Qux implements Invariant, Out {
+}
+
+/**
+ * @template T
+ */
+class Quux {
+}
+
+/**
+ * @template-covariant T
+ * @extends Quux<T>
+ */
+class Quuz extends Quux {
+}
+
+/**
+ * @template-covariant T
+ * @param T $a
+ * @param Invariant<T> $b
+ * @param Out<T> $c
+ * @param array<T> $d
+ * @param Out<Out<Out<T>>> $e
+ * @return T
+ */
+function x($a, $b, $c, $d, $e) {
+	return $a;
+}
+
+/**
+ * @template-covariant T
+ * @return Out<T>
+ */
+function returnOut() {
+	throw new \Exception();
+}
+
+/**
+ * @template-covariant T
+ * @return Invariant<T>
+ */
+function returnInvariant() {
+	throw new \Exception();
+}
+
 /**
  * @param Iter<\DateTime> $itOfDateTime
  * @param InvariantIter<\DateTime> $invariantItOfDateTime

--- a/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
@@ -19,6 +19,7 @@ class ClassAncestorsRuleTest extends RuleTestCase
 			new GenericAncestorsCheck(
 				$this->createBroker(),
 				new GenericObjectTypeCheck(),
+				new VarianceCheck(),
 				true
 			)
 		);
@@ -86,6 +87,10 @@ class ClassAncestorsRuleTest extends RuleTestCase
 			[
 				'Class ClassAncestorsExtends\FooExtendsGenericClass extends generic class ClassAncestorsExtends\FooGeneric but does not specify its types: T, U',
 				174,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in invariant position in extended type ClassAncestorsExtends\FooGeneric8<T, T> of class ClassAncestorsExtends\FooGeneric9.',
+				192,
 			],
 		]);
 	}
@@ -164,6 +169,10 @@ class ClassAncestorsRuleTest extends RuleTestCase
 			[
 				'Class ClassAncestorsImplements\FooImplementsGenericInterface implements generic interface ClassAncestorsImplements\FooGeneric but does not specify its types: T, U',
 				198,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in invariant position in implemented type ClassAncestorsImplements\FooGeneric9<T, T> of class ClassAncestorsImplements\FooGeneric10.',
+				216,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Generics/FunctionSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionSignatureVarianceRuleTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<FunctionSignatureVarianceRule>
+ */
+class FunctionSignatureVarianceRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$broker = $this->createBroker();
+		return new FunctionSignatureVarianceRule(
+			$broker,
+			self::getContainer()->getByType(VarianceCheck::class)
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/function-signature-variance.php'], [
+			[
+				'Template type T is declared as covariant, but occurs in contravariant position in parameter a of function FunctionSignatureVariance\f().',
+				20,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in invariant position in parameter b of function FunctionSignatureVariance\f().',
+				20,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in contravariant position in parameter c of function FunctionSignatureVariance\f().',
+				20,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Generics/InterfaceAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/InterfaceAncestorsRuleTest.php
@@ -19,6 +19,7 @@ class InterfaceAncestorsRuleTest extends RuleTestCase
 			new GenericAncestorsCheck(
 				$this->createBroker(),
 				new GenericObjectTypeCheck(),
+				new VarianceCheck(),
 				true
 			)
 		);
@@ -184,6 +185,10 @@ class InterfaceAncestorsRuleTest extends RuleTestCase
 			[
 				'Interface InterfaceAncestorsExtends\ExtendsGenericInterface extends generic interface InterfaceAncestorsExtends\FooGeneric but does not specify its types: T, U',
 				197,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in invariant position in extended type InterfaceAncestorsExtends\FooGeneric9<T, T> of interface InterfaceAncestorsExtends\FooGeneric10.',
+				215,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<MethodSignatureVarianceRule>
+ */
+class MethodSignatureVarianceRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new MethodSignatureVarianceRule(
+			self::getContainer()->getByType(VarianceCheck::class)
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/method-signature-variance.php'], [
+			[
+				'Template type T is declared as covariant, but occurs in contravariant position in parameter a of method MethodSignatureVariance\C::a().',
+				23,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in invariant position in parameter b of method MethodSignatureVariance\C::a().',
+				23,
+			],
+			[
+				'Template type T is declared as covariant, but occurs in contravariant position in parameter c of method MethodSignatureVariance\C::a().',
+				23,
+			],
+			[
+				'Template type U is declared as covariant, but occurs in contravariant position in parameter a of method MethodSignatureVariance\C::b().',
+				33,
+			],
+			[
+				'Template type U is declared as covariant, but occurs in invariant position in parameter b of method MethodSignatureVariance\C::b().',
+				33,
+			],
+			[
+				'Template type U is declared as covariant, but occurs in contravariant position in parameter c of method MethodSignatureVariance\C::b().',
+				33,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Generics/data/class-ancestors-extends.php
+++ b/tests/PHPStan/Rules/Generics/data/class-ancestors-extends.php
@@ -175,3 +175,21 @@ class FooExtendsGenericClass extends FooGeneric
 {
 
 }
+
+/**
+ * @template-covariant T
+ * @template U
+ */
+class FooGeneric8
+{
+
+}
+
+/**
+ * @template-covariant T
+ * @extends FooGeneric8<T, T>
+ */
+class FooGeneric9 extends FooGeneric8
+{
+
+}

--- a/tests/PHPStan/Rules/Generics/data/class-ancestors-implements.php
+++ b/tests/PHPStan/Rules/Generics/data/class-ancestors-implements.php
@@ -199,3 +199,21 @@ class FooImplementsGenericInterface implements FooGeneric
 {
 
 }
+
+/**
+ * @template-covariant T
+ * @template U
+ */
+interface FooGeneric9
+{
+
+}
+
+/**
+ * @template-covariant T
+ * @implements FooGeneric9<T, T>
+ */
+class FooGeneric10 implements FooGeneric9
+{
+
+}

--- a/tests/PHPStan/Rules/Generics/data/function-signature-variance.php
+++ b/tests/PHPStan/Rules/Generics/data/function-signature-variance.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FunctionSignatureVariance;
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template-covariant T
+ * @param Out<T> $a
+ * @param Invariant<T> $b
+ * @param T $c
+ * @return T
+ */
+function f($a, $b, $c) {
+	return $c;
+}

--- a/tests/PHPStan/Rules/Generics/data/interface-ancestors-extends.php
+++ b/tests/PHPStan/Rules/Generics/data/interface-ancestors-extends.php
@@ -198,3 +198,21 @@ interface ExtendsGenericInterface extends FooGeneric
 {
 
 }
+
+/**
+ * @template-covariant T
+ * @template U
+ */
+interface FooGeneric9
+{
+
+}
+
+/**
+ * @template-covariant T
+ * @extends FooGeneric9<T, T>
+ */
+interface FooGeneric10 extends FooGeneric9
+{
+
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MethodSignatureVariance;
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template-covariant T
+ */
+class C {
+	/**
+	 * @param Out<T> $a
+	 * @param Invariant<T> $b
+	 * @param T $c
+	 * @return T
+	 */
+	function a($a, $b, $c) {
+		return $c;
+	}
+	/**
+	 * @template-covariant U
+	 * @param Out<U> $a
+	 * @param Invariant<U> $b
+	 * @param U $c
+	 * @return U
+	 */
+	function b($a, $b, $c) {
+		return $c;
+	}
+}

--- a/tests/PHPStan/Type/Generic/data/generic-classes-d.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-d.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Test\D;
+
+/** @template T */
+interface Invariant {
+	/** @return T */
+	public function get();
+}
+
+/** @template-covariant T */
+interface Out {
+	/** @return T */
+	public function get();
+}


### PR DESCRIPTION
This adds rules to check passing variant template types in incompatible positions. Specifically, this is checked in parameter types, return types, and @extends/@implements types.

A template-covariant template type can only be used in a covariant position: As return type, or where a template type parameter is covariant itself, with some twists.