### PR TITLE
Allow symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 		"nette/utils": "^3.0",
 		"nikic/php-parser": "^4.3.0",
 		"phpstan/phpdoc-parser": "^0.4",
-		"symfony/console": "^4.3|^5.0",
-		"symfony/finder": "^4.3|^5.0"
+		"symfony/console": "^4.3 || ^5.0",
+		"symfony/finder": "^4.3 || ^5.0"
 	},
 	"replace": {
 		"phpstan/phpstan": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 		"nette/utils": "^3.0",
 		"nikic/php-parser": "^4.3.0",
 		"phpstan/phpdoc-parser": "^0.4",
-		"symfony/console": "^4.3",
-		"symfony/finder": "^4.3"
+		"symfony/console": "^4.3|^5.0",
+		"symfony/finder": "^4.3|^5.0"
 	},
 	"replace": {
 		"phpstan/phpstan": "self.version"


### PR DESCRIPTION
Allows `symfony/console` and `symfony/finder` to have `^5.0`