### PR TITLE
Add rule checking arguments to unset (#2605)

### DIFF
--- a/src/Rules/Functions/UnsetRule.php
+++ b/src/Rules/Functions/UnsetRule.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Rules\Functions;
 

--- a/src/Rules/Functions/UnsetRule.php
+++ b/src/Rules/Functions/UnsetRule.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\VerbosityLevel;
+
+class UnsetRule implements \PHPStan\Rules\Rule
+{
+
+	/** @var bool */
+	private $checkMaybeUndefinedVariables;
+
+	public function __construct(bool $checkMaybeUndefinedVariables)
+	{
+		$this->checkMaybeUndefinedVariables = $checkMaybeUndefinedVariables;
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\Unset_::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		/** @var Node\Stmt\Unset_ $node */
+		$functionArguments = $node->vars;
+		$messages = [];
+
+		foreach ($functionArguments as $argument) {
+			$this->canBeUnset($argument, $scope, $messages);
+		}
+
+		return $messages;
+	}
+
+	private function canBeUnset(Node $node, Scope $scope, array &$messages): void
+	{
+		if ($node instanceof Node\Expr\Variable) {
+			$scopeHasVariable = $scope->hasVariableType($node->name);
+
+			if ($scopeHasVariable->no()) {
+				$messages[] = RuleErrorBuilder::message(
+					sprintf('Call to function unset() contains undefined variable $%s.', $node->name)
+				)->line($node->getLine())->build();
+			} elseif ($this->checkMaybeUndefinedVariables && $scopeHasVariable->maybe()) {
+				$messages[] = RuleErrorBuilder::message(
+					sprintf('Call to function unset() contains possibly undefined variable $%s.', $node->name)
+				)->line($node->getLine())->build();
+			}
+		}
+
+		if ($node instanceof Node\Expr\ArrayDimFetch) {
+			$type = $scope->getType($node->var);
+			$dimType = $scope->getType($node->dim);
+
+			$isInaccessibleIterable = $type instanceof IterableType && $type->getIterableKeyType()->isSuperTypeOf($dimType)->no();
+
+			if ($isInaccessibleIterable || $type->hasOffsetValueType($dimType)->no()) {
+				$messages[] = RuleErrorBuilder::message(
+					sprintf(
+						'Cannot unset offset %s on %s.',
+						$dimType->describe(VerbosityLevel::value()),
+						$type->describe(VerbosityLevel::value())
+					)
+				)->line($node->getLine())->build();
+			}
+		}
+	}
+
+}

--- a/src/Rules/Functions/UnsetRule.php
+++ b/src/Rules/Functions/UnsetRule.php
@@ -50,7 +50,7 @@ class UnsetRule implements \PHPStan\Rules\Rule
 			$type = $scope->getType($node->var);
 			$dimType = $scope->getType($node->dim);
 
-			$isOffsetAccessible = $type->isOffsetAccessible() && $type->getIterableKeyType()->isSuperTypeOf($dimType)->no();
+			$isOffsetAccessible = !$type->isOffsetAccessible()->no() && $type->getIterableKeyType()->isSuperTypeOf($dimType)->no();
 
 			if ($isOffsetAccessible || $type->hasOffsetValueType($dimType)->no()) {
 				return RuleErrorBuilder::message(

--- a/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
@@ -7,6 +7,7 @@ namespace PHPStan\Rules\Functions;
  */
 class UnsetRuleTest extends \PHPStan\Testing\RuleTestCase
 {
+
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		return new UnsetRule(true);
@@ -46,4 +47,5 @@ class UnsetRuleTest extends \PHPStan\Testing\RuleTestCase
 			],
 		]);
 	}
+
 }

--- a/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
@@ -10,7 +10,7 @@ class UnsetRuleTest extends \PHPStan\Testing\RuleTestCase
 
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		return new UnsetRule(true);
+		return new UnsetRule();
 	}
 
 	public function testUnsetRule(): void
@@ -19,31 +19,27 @@ class UnsetRuleTest extends \PHPStan\Testing\RuleTestCase
 		$this->analyse([__DIR__ . '/data/unset.php'], [
 			[
 				'Call to function unset() contains undefined variable $notSetVariable.',
-				3,
+				6,
 			],
 			[
 				'Cannot unset offset \'a\' on 3.',
-				7,
+				10,
 			],
 			[
 				'Cannot unset offset \'b\' on 1.',
-				11,
+				14,
 			],
 			[
 				'Cannot unset offset \'c\' on 1.',
-				15,
+				18,
 			],
 			[
 				'Cannot unset offset \'b\' on 1.',
-				15,
-			],
-			[
-				'Call to function unset() contains possibly undefined variable $maybeSet.',
-				21,
+				18,
 			],
 			[
 				'Cannot unset offset \'string\' on iterable<int, int>.',
-				30,
+				31,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+class UnsetRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new UnsetRule(true);
+	}
+
+	public function testUnsetRule(): void
+	{
+		require_once __DIR__ . '/data/unset.php';
+		$this->analyse([__DIR__ . '/data/unset.php'], [
+			[
+				'Call to function unset() contains undefined variable $notSetVariable.',
+				3,
+			],
+			[
+				'Cannot unset offset \'a\' on 3.',
+				7,
+			],
+			[
+				'Cannot unset offset \'b\' on 1.',
+				11,
+			],
+			[
+				'Cannot unset offset \'c\' on 1.',
+				15,
+			],
+			[
+				'Cannot unset offset \'b\' on 1.',
+				15,
+			],
+			[
+				'Call to function unset() contains possibly undefined variable $maybeSet.',
+				21,
+			],
+			[
+				'Cannot unset offset \'string\' on iterable<int, int>.',
+				30,
+			],
+		]);
+	}
+}

--- a/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/UnsetRuleTest.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Rules\Functions;
 
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<UnsetRule>
+ */
 class UnsetRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 	protected function getRule(): \PHPStan\Rules\Rule

--- a/tests/PHPStan/Rules/Functions/data/unset.php
+++ b/tests/PHPStan/Rules/Functions/data/unset.php
@@ -1,0 +1,31 @@
+<?php
+
+unset($notSetVariable);
+
+$scalar = 3;
+
+unset($scalar['a']);
+
+$singleDimArray = ['a' => 1];
+
+unset($singleDimArray['a']['b']);
+
+$multiDimArray = ['a' => ['b' => 1]];
+
+unset($multiDimArray['a']['b']['c'], $scalar, $singleDimArray['a']['b']);
+
+if (rand()) {
+	$maybeSet = 1;
+}
+
+unset($maybeSet);
+
+/** @param iterable<int> $iterable */
+function unsetOnMaybeIterable(iterable $iterable) {
+	unset($iterable['string']);
+}
+
+/** @param iterable<int, int> $iterable */
+function unsetOnYesIterable(iterable $iterable) {
+	unset($iterable['string']);
+}

--- a/tests/PHPStan/Rules/Functions/data/unset.php
+++ b/tests/PHPStan/Rules/Functions/data/unset.php
@@ -1,31 +1,32 @@
 <?php
 
-unset($notSetVariable);
+function unsetInaccessible ()
+{
 
-$scalar = 3;
+	unset($notSetVariable);
 
-unset($scalar['a']);
+	$scalar = 3;
 
-$singleDimArray = ['a' => 1];
+	unset($scalar['a']);
 
-unset($singleDimArray['a']['b']);
+	$singleDimArray = ['a' => 1];
 
-$multiDimArray = ['a' => ['b' => 1]];
+	unset($singleDimArray['a']['b']);
 
-unset($multiDimArray['a']['b']['c'], $scalar, $singleDimArray['a']['b']);
+	$multiDimArray = ['a' => ['b' => 1]];
 
-if (rand()) {
-	$maybeSet = 1;
+	unset($multiDimArray['a']['b']['c'], $scalar, $singleDimArray['a']['b']);
+
 }
 
-unset($maybeSet);
-
 /** @param iterable<int> $iterable */
-function unsetOnMaybeIterable(iterable $iterable) {
+function unsetOnMaybeIterable(iterable $iterable)
+{
 	unset($iterable['string']);
 }
 
 /** @param iterable<int, int> $iterable */
-function unsetOnYesIterable(iterable $iterable) {
+function unsetOnYesIterable(iterable $iterable)
+{
 	unset($iterable['string']);
 }


### PR DESCRIPTION
Adds a rule for checking the arguments to `unset`. Fixes [#2605](https://github.com/phpstan/phpstan/issues/2605).