### PR TITLE
Allow JSON_THROW_ON_ERROR in any bitwise-or-expression

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9241,12 +9241,20 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'json_encode($mixed,  JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
+				'string',
+				'json_encode($mixed,  $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
+			],
+			[
 				'mixed',
 				'json_decode($mixed)',
 			],
 			[
 				'mixed~false',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
+			],
+			[
+				'mixed~false',
+				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
 				'int|string|null',

--- a/tests/PHPStan/Analyser/data/php73_functions.php
+++ b/tests/PHPStan/Analyser/data/php73_functions.php
@@ -7,12 +7,14 @@ class Foo
 
 	/**
 	 * @param $mixed
+	 * @param int $integer
 	 * @param array $mixedArray
 	 * @param array $nonEmptyArray
 	 * @param array<string, mixed> $arrayWithStringKeys
 	 */
 	public function doFoo(
 		$mixed,
+		int $integer,
 		array $mixedArray,
 		array $nonEmptyArray,
 		array $arrayWithStringKeys


### PR DESCRIPTION
This adjusts the return type of `json_decode`/`json_encode` for arbitrary bitwise-or-expressions containing `JSON_THROW_ON_ERROR`. 
Not sure if this is the best approach, but I do think there is a valid use case for this.
For example, passing through other options and adding `JSON_THROW_ON_ERROR` like this:

```php
function encode(string $input, int $options): string {
    return json_encode($input, JSON_THROW_ON_ERROR | $options);
}
```
[Playground](https://phpstan.org/r/353b267a-ce6c-41ec-a290-c83f811765dd)