### PR TITLE
Make isSuperTypeOf() a little stricter on GenericObjectType (fixes #2620)

### DIFF
--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -101,7 +101,7 @@ final class GenericObjectType extends ObjectType
 
 		$ancestor = $type->getAncestorWithClassName($this->getClassName());
 		if ($ancestor === null) {
-			return $nakedSuperTypeOf->and(TrinaryLogic::createMaybe());
+			return TrinaryLogic::createNo();
 		}
 		if (!$ancestor instanceof self) {
 			if ($acceptsContext) {

--- a/tests/PHPStan/Generics/GenericsIntegrationTest.php
+++ b/tests/PHPStan/Generics/GenericsIntegrationTest.php
@@ -15,6 +15,7 @@ class GenericsIntegrationTest extends \PHPStan\Testing\LevelsTestCase
 			['classes'],
 			['variance'],
 			['bug2577'],
+			['bug2620'],
 		];
 	}
 

--- a/tests/PHPStan/Generics/data/bug2620-3.json
+++ b/tests/PHPStan/Generics/data/bug2620-3.json
@@ -1,0 +1,7 @@
+[
+    {
+        "message": "Return type (Traversable<int, Generics\\Bug2620\\Bar>) of method Generics\\Bug2620\\SomeIterator::getIterator() should be compatible with return type (Iterator<int, Generics\\Bug2620\\Foo>) of method IteratorAggregate<int,Generics\\Bug2620\\Foo>::getIterator()",
+        "line": 17,
+        "ignorable": true
+    }
+]

--- a/tests/PHPStan/Generics/data/bug2620.php
+++ b/tests/PHPStan/Generics/data/bug2620.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Generics\Bug2620;
+
+class Foo {
+    public function someMethod() : void {}
+}
+class Bar {}
+
+/**
+ * @implements \IteratorAggregate<int, Foo>
+ */
+class SomeIterator implements \IteratorAggregate {
+    /**
+     * @return \Traversable<int, Bar>
+     */
+    public function getIterator() {
+         yield new Bar;
+    }
+}
+
+/**
+ * @param \IteratorAggregate<int, Foo> $i
+ */
+function takesIteratorAggregate(\IteratorAggregate $i): void {
+    foreach ($i as $foo) {
+        $foo->someMethod();
+    }
+}
+
+function test(): void {
+	takesIteratorAggregate(new SomeIterator());
+}


### PR DESCRIPTION
When comparing generic object types with `isSuperTypeOf()`, if the two classes are "maybe super type of", but the received type does not have an ancestor whose class is the receiver's class, return No instead of Maybe.

This can happen when the receiver is an interface, for example.

Rationale:

- Although we can't prove they are not related, we can't prove they are related either, so `No` is the only type safe answer.
- `ObjectType` returns `Maybe` in this case, which supports progressive typing, which is great. (This generates an error in strict mode.)
- Making more advanced constructs (such as generics) stricter looks ok to me.