### PR TITLE
Common variance rules don't apply to constructors

### DIFF
--- a/src/Rules/Generics/FunctionSignatureVarianceRule.php
+++ b/src/Rules/Generics/FunctionSignatureVarianceRule.php
@@ -47,7 +47,8 @@ class FunctionSignatureVarianceRule implements Rule
 		return $this->varianceCheck->checkParametersAcceptor(
 			ParametersAcceptorSelector::selectSingle($functionReflection->getVariants()),
 			sprintf('in parameter %%s of function %s()', $functionName),
-			sprintf('in return type of function %s()', $functionName)
+			sprintf('in return type of function %s()', $functionName),
+			false
 		);
 	}
 

--- a/src/Rules/Generics/MethodSignatureVarianceRule.php
+++ b/src/Rules/Generics/MethodSignatureVarianceRule.php
@@ -40,7 +40,8 @@ class MethodSignatureVarianceRule implements Rule
 		return $this->varianceCheck->checkParametersAcceptor(
 			ParametersAcceptorSelector::selectSingle($method->getVariants()),
 			sprintf('in parameter %%s of method %s::%s()', $className, $methodName),
-			sprintf('in return type of method %s::%s()', $className, $methodName)
+			sprintf('in return type of method %s::%s()', $className, $methodName),
+			$methodName === '__construct'
 		);
 	}
 

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -16,13 +16,16 @@ class VarianceCheck
 	public function checkParametersAcceptor(
 		ParametersAcceptor $parametersAcceptor,
 		string $parameterTypeMessage,
-		string $returnTypeMessage
+		string $returnTypeMessage,
+		bool $isConstructor
 	): array
 	{
 		$errors = [];
 
 		foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
-			$variance = TemplateTypeVariance::createContravariant();
+			$variance = $isConstructor
+				? TemplateTypeVariance::createConstructor()
+				: TemplateTypeVariance::createContravariant();
 			$type = $parameterReflection->getType();
 			$message = sprintf($parameterTypeMessage, $parameterReflection->getName());
 			foreach ($this->check($variance, $type, $message) as $error) {
@@ -64,11 +67,7 @@ class VarianceCheck
 
 	private function isTemplateTypeVarianceValid(TemplateTypeVariance $positionVariance, TemplateType $type): bool
 	{
-		if ($type->getVariance()->invariant()) {
-			return true;
-		}
-
-		return $type->getVariance()->equals($positionVariance);
+		return $positionVariance->validPosition($type->getVariance());
 	}
 
 }

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -11,6 +11,7 @@ class TemplateTypeVariance
 	private const INVARIANT = 1;
 	private const COVARIANT = 2;
 	private const CONTRAVARIANT = 3;
+	private const CONSTRUCTOR = 4;
 
 	/** @var self[] */
 	private static $registry;
@@ -44,6 +45,11 @@ class TemplateTypeVariance
 		return self::create(self::CONTRAVARIANT);
 	}
 
+	public static function createConstructor(): self
+	{
+		return self::create(self::CONSTRUCTOR);
+	}
+
 	public function invariant(): bool
 	{
 		return $this->value === self::INVARIANT;
@@ -57,6 +63,11 @@ class TemplateTypeVariance
 	public function contravariant(): bool
 	{
 		return $this->value === self::CONTRAVARIANT;
+	}
+
+	public function constructor(): bool
+	{
+		return $this->value === self::CONSTRUCTOR;
 	}
 
 	public function compose(self $other): self
@@ -114,6 +125,13 @@ class TemplateTypeVariance
 		return $other->value === $this->value;
 	}
 
+	public function validPosition(self $other): bool
+	{
+		return $other->value === $this->value
+			|| $other->invariant()
+			|| $this->constructor();
+	}
+
 	public function describe(): string
 	{
 		switch ($this->value) {
@@ -123,6 +141,8 @@ class TemplateTypeVariance
 				return 'covariant';
 			case self::CONTRAVARIANT:
 				return 'contravariant';
+			case self::CONSTRUCTOR:
+				return 'constructor';
 		}
 
 		throw new \PHPStan\ShouldNotHappenException();

--- a/tests/PHPStan/Generics/data/variance-2.json
+++ b/tests/PHPStan/Generics/data/variance-2.json
@@ -68,5 +68,10 @@
         "message": "Template type T is declared as covariant, but occurs in invariant position in return type of function PHPStan\\Generics\\Variance\\returnInvariant().",
         "line": 117,
         "ignorable": true
+    },
+    {
+        "message": "Template type T is declared as covariant, but occurs in invariant position in parameter v of method PHPStan\\Generics\\Variance\\Constructor::__construct().",
+        "line": 134,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Generics/data/variance-5.json
+++ b/tests/PHPStan/Generics/data/variance-5.json
@@ -1,7 +1,7 @@
 [
     {
         "message": "Parameter #1 $it of function PHPStan\\Generics\\Variance\\acceptInvariantIterOfDateTimeInterface expects PHPStan\\Generics\\Variance\\InvariantIter<DateTimeInterface>, PHPStan\\Generics\\Variance\\InvariantIter<DateTime> given.",
-        "line": 127,
+        "line": 145,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Generics/data/variance.php
+++ b/tests/PHPStan/Generics/data/variance.php
@@ -119,6 +119,24 @@ function returnInvariant() {
 }
 
 /**
+ * @template-covariant T
+ * @template U
+ */
+class Constructor {
+	/** @var mixed */
+	private $data;
+	/**
+	 * @param T $t
+	 * @param U $u
+	 * @param Invariant<T> $v
+	 * @param Out<T> $w
+	 */
+	public function __construct($t, $u, $v, $w) {
+		$this->data = [$t, $u, $v, $w];
+	}
+}
+
+/**
  * @param Iter<\DateTime> $itOfDateTime
  * @param InvariantIter<\DateTime> $invariantItOfDateTime
  */


### PR DESCRIPTION
This allows constructors to take covariant parameters, which is safe and quite useful. After this PR, https://phpstan.org/r/16b7f23e-34e1-42b3-9ec7-f80beb120caa reports no error.