### PR TITLE
Add return type to pcntl_signal_get_handler

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -8259,7 +8259,7 @@ return [
 'pcntl_setpriority' => ['bool', 'priority'=>'int', 'pid='=>'int', 'process_identifier='=>'int'],
 'pcntl_signal' => ['bool', 'signo'=>'int', 'handle'=>'callable|int', 'restart_syscalls='=>'bool'],
 'pcntl_signal_dispatch' => ['bool'],
-'pcntl_signal_get_handler' => ['int|string', 'signo'=>'int'],
+'pcntl_signal_get_handler' => ['int|string|false', 'signo'=>'int'],
 'pcntl_sigprocmask' => ['bool', 'how'=>'int', 'set'=>'array', '&w_oldset='=>'array'],
 'pcntl_sigtimedwait' => ['int', 'set'=>'array', '&w_siginfo='=>'array', 'seconds='=>'int', 'nanoseconds='=>'int'],
 'pcntl_sigwaitinfo' => ['int', 'set'=>'array', '&w_siginfo='=>'array'],


### PR DESCRIPTION
The php function `pcntl_signal_get_handler` also returns `false` on error, which is missing in the documentation, but mentioned in the comments. I tested it myself (php 7.2 and php 7.3) and when you pass a signal that does not exist (e.g. `255`), it returns `false`.

The problem is that using the following code:

```php
$prevSigHandler = pcntl_signal_get_handler($signo);
if ($prevSigHandler === false) {
    // Do some error handling.
}
```

Results in the following phpstan error on max level:

> Strict comparison using === between int|string and false will always evaluate to false. 