### PR TITLE
Fix optional last parameter of ldap_bind

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -5853,7 +5853,7 @@ return [
 'ldap_8859_to_t61' => ['string', 'value'=>'string'],
 'ldap_add' => ['bool', 'link_identifier'=>'resource', 'dn'=>'string', 'entry'=>'array', 'servercontrols='=>'array'],
 'ldap_add_ext' => ['resource|false', 'link_identifier'=>'resource', 'dn'=>'string', 'entry'=>'array', 'servercontrols='=>'array'],
-'ldap_bind' => ['bool', 'link_identifier'=>'resource', 'bind_rdn='=>'string|null', 'bind_password='=>'string|null', 'serverctrls' => 'array'],
+'ldap_bind' => ['bool', 'link_identifier'=>'resource', 'bind_rdn='=>'string|null', 'bind_password='=>'string|null', 'serverctrls=' => 'array'],
 'ldap_bind_ext' => ['resource|false', 'link_identifier'=>'resource', 'bind_rdn='=>'string|null', 'bind_password='=>'string|null', 'serverctrls' => 'array'],
 'ldap_close' => ['bool', 'link_identifier'=>'resource'],
 'ldap_compare' => ['bool', 'link_identifier'=>'resource', 'dn'=>'string', 'attr'=>'string', 'value'=>'string'],


### PR DESCRIPTION
This should solve false negative `Function ldap_bind invoked with 1 parameter, 2-4 required.`

The last parameter is actually an array by default. If there is a different approach to mark this distinction, I'll force push asap.