### PR TITLE
Handle bad reflection parameters more gracefully

### DIFF
--- a/src/Reflection/BadParameterFromReflectionException.php
+++ b/src/Reflection/BadParameterFromReflectionException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection;
+
+class BadParameterFromReflectionException extends \PHPStan\AnalysedCodeException
+{
+
+	public function __construct(
+		string $className,
+		string $methodName,
+		?string $currentFilename
+	)
+	{
+		parent::__construct(
+			sprintf(
+				'Bad parameter for method %s() found in reflection of class %s - probably either the wrong version of class is autoloaded or, in case of an extension, its signature is missing from the map.%s',
+				$methodName,
+				$className,
+				$currentFilename !== null
+					? sprintf(' The currently loaded version is at: %s', $currentFilename)
+					: ''
+			)
+		);
+	}
+
+}

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -256,6 +256,17 @@ class PhpMethodReflection implements MethodReflection
 	{
 		if ($this->parameters === null) {
 			$this->parameters = array_map(function (\ReflectionParameter $reflection): PhpParameterReflection {
+				/** @var string|null */
+				$parameterName = $reflection->getName();
+				if ($parameterName === null) {
+					$filename = $this->declaringClass->getFileName();
+					throw new \PHPStan\Reflection\BadParameterFromReflectionException(
+						$this->declaringClass->getName(),
+						$this->reflection->getName(),
+						$filename !== false ? $filename : null
+					);
+				}
+
 				return new PhpParameterReflection(
 					$reflection,
 					$this->phpDocParameterTypes[$reflection->getName()] ?? null

--- a/tests/PHPStan/Reflection/Php/PhpMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Php/PhpMethodReflectionTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Php;
+
+use PHPStan\Broker\Broker;
+use PHPStan\Cache\Cache;
+use PHPStan\Parser\FunctionCallStatementFinder;
+use PHPStan\Parser\Parser;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\Generic\TemplateTypeMap;
+
+class PhpMethodReflectionTest extends \PHPStan\Testing\TestCase
+{
+
+	public function testGetVariantsWithGoodParameter(): void
+	{
+		$classReflection = $this->createMock(ClassReflection::class);
+		$classReflection->method('getName')->willReturn('MyClass');
+		$classReflection->method('getFileName')->willReturn(false);
+
+		$niceParameter = $this->createMock(\ReflectionParameter::class);
+		$niceParameter->method('getName')->willReturn('niceParam');
+
+		$nativeMethodReflection = $this->createMock(BuiltinMethodReflection::class);
+		$nativeMethodReflection->method('getName')->willReturn('someMethod');
+		$nativeMethodReflection->method('getParameters')->willReturn([$niceParameter]);
+
+		$methodReflection = $this->createPhpMethodReflection($classReflection, $nativeMethodReflection);
+
+		$this->assertNotEmpty($methodReflection->getVariants());
+	}
+
+	public function testGetVariantsWithBadParameter(): void
+	{
+		$classReflection = $this->createMock(ClassReflection::class);
+		$classReflection->method('getName')->willReturn('MyClass');
+		$classReflection->method('getFileName')->willReturn('/path/to/some/file');
+
+		$badParameter = $this->createMock(\ReflectionParameter::class);
+		$badParameter->method('getName')->willReturn(null);
+
+		$nativeMethodReflection = $this->createMock(BuiltinMethodReflection::class);
+		$nativeMethodReflection->method('getName')->willReturn('someMethod');
+		$nativeMethodReflection->method('getParameters')->willReturn([$badParameter]);
+
+		$methodReflection = $this->createPhpMethodReflection($classReflection, $nativeMethodReflection);
+
+		try {
+			$methodReflection->getVariants();
+			$this->fail('Bad parameter should trigger an exception.');
+		} catch (\PHPStan\Reflection\BadParameterFromReflectionException $exception) {
+			$this->assertContains(' MyClass ', $exception->getMessage());
+			$this->assertContains(' someMethod() ', $exception->getMessage());
+			$this->assertContains('/path/to/some/file', $exception->getMessage());
+		}
+	}
+
+	private function createPhpMethodReflection(
+		ClassReflection $classReflection,
+		BuiltinMethodReflection $nativeMethodReflection
+	): PhpMethodReflection
+	{
+		return new PhpMethodReflection(
+			$classReflection,
+			null,
+			$nativeMethodReflection,
+			$this->createMock(Broker::class),
+			$this->createMock(Parser::class),
+			$this->createMock(FunctionCallStatementFinder::class),
+			$this->createMock(Cache::class),
+			$this->createMock(TemplateTypeMap::class),
+			[],
+			null,
+			null,
+			null,
+			false,
+			false,
+			false,
+			null
+		);
+	}
+
+}


### PR DESCRIPTION
The method `\ReflectionParameter::getName()` is supposed to always return a string. However, it is also possible that `null` gets returned. This happened with the method `get` of the PHP extension
`Memcache` on version 3.0.8+.

This PR throws a new `BadParameterFromReflectionException` in case a bad reflection paramer is encountered. A future user then at least knows the name of the class and the method at fault without extensive debugging and can go on from there.

Relates to https://github.com/phpstan/phpstan/issues/2697