### PR TITLE
fix .gitattributes for php-file line-ending to LF (for windows compat)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+*.php text eol=lf
+
 tests/PHPStan/Command/ErrorFormatter/data/WindowsNewlines.php eol=crlf


### PR DESCRIPTION
otherwise phpstan cannot be build on windows when `core.autocrlf` is enabled.
(because all files get checked out with CRLF then, and the build fast-exists because of CS issues)

![image](https://user-images.githubusercontent.com/47448731/70644240-ed20f200-1c42-11ea-996b-34b2af2ab6e5.png)


I wasnt able to build the project on windows when git is configured using `core.autocrlf=true`

hopefully this will fix it.