### PR TITLE
Fix bugs in SimpleRelativePathHelper

### DIFF
--- a/src/File/SimpleRelativePathHelper.php
+++ b/src/File/SimpleRelativePathHelper.php
@@ -6,16 +6,36 @@ class SimpleRelativePathHelper implements RelativePathHelper
 {
 
 	/** @var string */
-	private $currentWorkingDirectory;
+	private $directorySeparator;
 
-	public function __construct(string $currentWorkingDirectory)
+	/** @var string */
+	private $currentWorkingDirectory = '';
+
+	public function __construct(string $currentWorkingDirectory, string $directorySeparator = DIRECTORY_SEPARATOR)
 	{
+		$this->directorySeparator = $directorySeparator;
+
+		if ($currentWorkingDirectory !== $directorySeparator) {
+			$currentWorkingDirectory = rtrim($currentWorkingDirectory, $directorySeparator);
+		}
 		$this->currentWorkingDirectory = $currentWorkingDirectory;
 	}
 
 	public function getRelativePath(string $filename): string
 	{
-		if ($this->currentWorkingDirectory !== '' && strpos($filename, $this->currentWorkingDirectory) === 0) {
+		if ($this->currentWorkingDirectory === '') {
+			return $filename;
+		}
+
+		if ($this->currentWorkingDirectory === $this->directorySeparator) {
+			if (strpos($filename, $this->currentWorkingDirectory) === 0) {
+				return substr($filename, strlen($this->currentWorkingDirectory));
+			}
+
+			return $filename;
+		}
+
+		if (strpos($filename, $this->currentWorkingDirectory . $this->directorySeparator) === 0) {
 			return substr($filename, strlen($this->currentWorkingDirectory) + 1);
 		}
 

--- a/tests/PHPStan/File/SimpleRelativePathHelperTest.php
+++ b/tests/PHPStan/File/SimpleRelativePathHelperTest.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+class SimpleRelativePathHelperTest extends \PHPUnit\Framework\TestCase
+{
+
+	public function dataGetRelativePath(): array
+	{
+		return [
+			[
+				'/usr',
+				'/',
+				'/usr/app/test.php',
+				'app/test.php',
+			],
+			[
+				'',
+				'/',
+				'/usr/app/test.php',
+				'/usr/app/test.php',
+			],
+			[
+				'/var',
+				'/',
+				'/usr/app/test.php',
+				'/usr/app/test.php',
+			],
+			[
+				'/usr/app',
+				'/',
+				'/usr/app/src/test.php',
+				'src/test.php',
+			],
+			[
+				'/',
+				'/',
+				'/usr/app/test.php',
+				'usr/app/test.php',
+			],
+			[
+				'/usr/',
+				'/',
+				'/usr/app/test.php',
+				'app/test.php',
+			],
+			[
+				'/usr/app',
+				'/',
+				'/usr/application/test.php',
+				'/usr/application/test.php',
+			],
+			[
+				'C:\\app',
+				'\\',
+				'C:\\app\\test.php',
+				'test.php',
+			],
+			[
+				'C:\\app\\',
+				'\\',
+				'C:\\app\\src\\test.php',
+				'src\\test.php',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetRelativePath
+	 * @param string $currentWorkingDirectory
+	 * @param string $directorySeparator
+	 * @param string $filenameToRelativize
+	 * @param string $expectedResult
+	 */
+	public function testGetRelativePathOnUnix(
+		string $currentWorkingDirectory,
+		string $directorySeparator,
+		string $filenameToRelativize,
+		string $expectedResult
+	): void
+	{
+		$helper = new SimpleRelativePathHelper($currentWorkingDirectory, $directorySeparator);
+		$this->assertSame(
+			$expectedResult,
+			$helper->getRelativePath($filenameToRelativize)
+		);
+	}
+
+}


### PR DESCRIPTION
Republishing https://github.com/phpstan/phpstan/pull/2519 with the requested changes

This fixes and adds tests for the following:
- If CWD ended in a directory separator path+1 was stripped ('/home' =
'ome')
- Even if CWD partially matched it would strip the path ('/homeFolder' =
'Folder')
- getRelativePath didn't work with Windows paths