### PR TITLE
Update signature of RedisCluster::__construct

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9437,7 +9437,7 @@ return [
 'RedisArray::_hosts' => ['array'],
 'RedisArray::_rehash' => [''],
 'RedisArray::_target' => ['string', 'key'=>'string'],
-'RedisCluster::__construct' => ['void', 'name'=>'string', 'seeds'=>'array', 'timeout='=>'float', 'readTimeout='=>'float', 'persistent='=>'bool|false', 'auth'=>'string|null'],
+'RedisCluster::__construct' => ['void', 'name'=>'string', 'seeds'=>'array', 'timeout='=>'float', 'readTimeout='=>'float', 'persistent='=>'bool|false', 'auth='=>'string|null'],
 'RedisCluster::_masters' => ['array'],
 'RedisCluster::_prefix' => ['string', 'value'=>'mixed'],
 'RedisCluster::_serialize' => ['mixed', 'value'=>'mixed'],

--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9437,7 +9437,7 @@ return [
 'RedisArray::_hosts' => ['array'],
 'RedisArray::_rehash' => [''],
 'RedisArray::_target' => ['string', 'key'=>'string'],
-'RedisCluster::__construct' => ['void', 'name'=>'string', 'seeds'=>'array', 'timeout='=>'float', 'readTimeout='=>'float', 'persistent='=>'bool|false'],
+'RedisCluster::__construct' => ['void', 'name'=>'string', 'seeds'=>'array', 'timeout='=>'float', 'readTimeout='=>'float', 'persistent='=>'bool|false', 'auth'=>'string|null'],
 'RedisCluster::_masters' => ['array'],
 'RedisCluster::_prefix' => ['string', 'value'=>'mixed'],
 'RedisCluster::_serialize' => ['mixed', 'value'=>'mixed'],


### PR DESCRIPTION
Improved version of #61 with no removals.

As I pointed out in https://github.com/phan/phan/issues/3593 I'm getting this error in phpstan as well:

`Class RedisCluster constructor invoked with 6 parameters, 2-5 required.`

The parameter was added to phpredis here: phpredis/phpredis#1355

See also:
https://github.com/zgb7mtr/phpredis_cluster_phpdoc/blob/master/src/RedisCluster.php#L96
