### PR TITLE
add JUnit error formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"phpstan/phpstan": "self.version"
 	},
 	"require-dev": {
+		"ext-dom": "*",
 		"ext-intl": "*",
 		"ext-mysqli": "*",
 		"ext-simplexml": "*",

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -886,6 +886,11 @@ services:
 		arguments:
 			pretty: false
 
+	errorFormatter.junit:
+		class: PHPStan\Command\ErrorFormatter\JunitErrorFormatter
+		arguments:
+			relativePathHelper: @simpleRelativePathHelper
+
 	errorFormatter.prettyJson:
 		class: PHPStan\Command\ErrorFormatter\JsonErrorFormatter
 		arguments:

--- a/src/Command/ErrorFormatter/JunitErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JunitErrorFormatter.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use DOMDocument;
+use DOMElement;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+use PHPStan\File\RelativePathHelper;
+use function sprintf;
+
+class JunitErrorFormatter implements ErrorFormatter
+{
+
+	/** @var \PHPStan\File\RelativePathHelper */
+	private $relativePathHelper;
+
+	public function __construct(RelativePathHelper $relativePathHelper)
+	{
+		$this->relativePathHelper = $relativePathHelper;
+	}
+
+	public function formatErrors(
+		AnalysisResult $analysisResult,
+		Output $output
+	): int
+	{
+		$dom = new DOMDocument('1.0', 'UTF-8');
+		$dom->formatOutput = true;
+
+		$testsuite = $dom->createElement('testsuite');
+		$testsuite->setAttribute('failures', (string) $analysisResult->getTotalErrorsCount());
+		$testsuite->setAttribute('name', 'phpstan');
+		$testsuite->setAttribute('tests', (string) $analysisResult->getTotalErrorsCount());
+		$testsuite->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+		$testsuite->setAttribute('xsi:noNamespaceSchemaLocation', 'https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd');
+		$dom->appendChild($testsuite);
+
+		foreach ($analysisResult->getFileSpecificErrors() as $error) {
+			$fileName = $this->relativePathHelper->getRelativePath($error->getFile());
+			$this->createTestCase($dom, $testsuite, sprintf('%s:%s', $fileName, (string) $error->getLine()), $error->getMessage());
+		}
+
+		foreach ($analysisResult->getNotFileSpecificErrors() as $genericError) {
+			$this->createTestCase($dom, $testsuite, 'Generic error', $genericError);
+		}
+
+		if (!$analysisResult->hasErrors()) {
+			$this->createTestCase($dom, $testsuite, 'phpstan');
+		}
+
+		$output->writeRaw($dom->saveXML());
+
+		return intval($analysisResult->hasErrors());
+	}
+
+	private function createTestCase(DOMDocument $dom, DOMElement $testsuite, string $reference, ?string $message = null): void
+	{
+		$testcase = $dom->createElement('testcase');
+		$testcase->setAttribute('name', $reference);
+
+		if ($message !== null) {
+			$failure = $dom->createElement('failure');
+			$failure->setAttribute('message', $message);
+
+			$testcase->appendChild($failure);
+		}
+
+		$testsuite->appendChild($testcase);
+	}
+
+}

--- a/src/Command/ErrorFormatter/JunitErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JunitErrorFormatter.php
@@ -30,16 +30,16 @@ class JunitErrorFormatter implements ErrorFormatter
 			$analysisResult->getTotalErrorsCount()
 		);
 
-		foreach ($analysisResult->getFileSpecificErrors() as $error) {
-			$fileName = $this->relativePathHelper->getRelativePath($error->getFile());
+		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+			$fileName = $this->relativePathHelper->getRelativePath($fileSpecificError->getFile());
 			$result .= $this->createTestCase(
-				sprintf('%s:%s', $fileName, (string) $error->getLine()),
-				$this->escape($error->getMessage())
+				sprintf('%s:%s', $fileName, (string) $fileSpecificError->getLine()),
+				$this->escape($fileSpecificError->getMessage())
 			);
 		}
 
-		foreach ($analysisResult->getNotFileSpecificErrors() as $genericError) {
-			$result .= $this->createTestCase('Generic error', $this->escape($genericError));
+		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
+			$result .= $this->createTestCase('General error', $this->escape($notFileSpecificError));
 		}
 
 		if (!$analysisResult->hasErrors()) {

--- a/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use DOMDocument;
+use Generator;
+use PHPStan\File\SimpleRelativePathHelper;
+use PHPStan\Testing\ErrorFormatterTestCase;
+
+class JunitErrorFormatterTest extends ErrorFormatterTestCase
+{
+
+	/** @var \PHPStan\Command\ErrorFormatter\JunitErrorFormatter */
+	private $formatter;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->formatter = new JunitErrorFormatter(new SimpleRelativePathHelper(self::DIRECTORY_PATH));
+	}
+
+	/**
+	 * @return \Generator<array<int, string|int>>
+	 */
+	public function dataFormatterOutputProvider(): Generator
+	{
+		yield 'No errors' => [
+			0,
+			0,
+			0,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="0" name="phpstan" tests="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testcase name="phpstan"/>
+</testsuite>
+',
+		];
+
+		yield 'One file error' => [
+			1,
+			1,
+			0,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4">
+    <failure message="Foo" />
+  </testcase>
+</testsuite>
+',
+		];
+
+		yield 'One generic error' => [
+			1,
+			0,
+			1,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testcase name="Generic error">
+    <failure message="first generic error" />
+  </testcase>
+</testsuite>
+',
+		];
+
+		yield 'Multiple file errors' => [
+			1,
+			4,
+			0,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="4" name="phpstan" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
+    <failure message="Bar" />
+  </testcase>
+  <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4">
+    <failure message="Foo" />
+  </testcase>
+  <testcase name="foo.php:1">
+    <failure message="Foo"/>
+  </testcase>
+  <testcase name="foo.php:5">
+    <failure message="Bar"/>
+  </testcase>
+</testsuite>
+',
+		];
+
+		yield 'Multiple generic errors' => [
+			1,
+			0,
+			2,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="2" name="phpstan" tests="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testcase name="Generic error">
+    <failure message="first generic error" />
+  </testcase>
+  <testcase name="Generic error">
+    <failure message="second generic error"/>
+  </testcase>
+</testsuite>
+',
+		];
+
+		yield 'Multiple file, multiple generic errors' => [
+			1,
+			4,
+			2,
+			'<?xml version="1.0" encoding="UTF-8"?>
+<testsuite failures="6" name="phpstan" tests="6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
+    <failure message="Bar" />
+  </testcase>
+  <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4">
+    <failure message="Foo" />
+  </testcase>
+  <testcase name="foo.php:1">
+    <failure message="Foo"/>
+  </testcase>
+  <testcase name="foo.php:5">
+    <failure message="Bar"/>
+  </testcase>
+  <testcase name="Generic error">
+    <failure message="first generic error" />
+  </testcase>
+  <testcase name="Generic error">
+    <failure message="second generic error"/>
+  </testcase>
+</testsuite>
+',
+		];
+	}
+
+	/**
+	 * Test generated use cases for JUnit output format.
+	 *
+	 * @dataProvider dataFormatterOutputProvider
+	 */
+	public function testFormatErrors(
+		int $exitCode,
+		int $numFileErrors,
+		int $numGenericErrors,
+		string $expected
+	): void
+	{
+		$this->assertSame(
+			$exitCode,
+			$this->formatter->formatErrors(
+				$this->getAnalysisResult($numFileErrors, $numGenericErrors),
+				$this->getOutput()
+			),
+			'Response code do not match'
+		);
+
+		$xml = new DOMDocument();
+		$xml->loadXML($this->getOutputContent());
+
+		$this->assertTrue(
+			$xml->schemaValidate('https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd'),
+			'Schema do not validate'
+		);
+
+		$this->assertXmlStringEqualsXmlString(
+			$expected,
+			$this->getOutputContent(),
+			'XML do not match'
+		);
+	}
+
+}

--- a/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
@@ -55,7 +55,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 			1,
 			'<?xml version="1.0" encoding="UTF-8"?>
 <testsuite failures="1" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
-  <testcase name="Generic error">
+  <testcase name="General error">
     <failure message="first generic error" />
   </testcase>
 </testsuite>
@@ -90,10 +90,10 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 			2,
 			'<?xml version="1.0" encoding="UTF-8"?>
 <testsuite failures="2" name="phpstan" tests="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
-  <testcase name="Generic error">
+  <testcase name="General error">
     <failure message="first generic error" />
   </testcase>
-  <testcase name="Generic error">
+  <testcase name="General error">
     <failure message="second generic error"/>
   </testcase>
 </testsuite>
@@ -118,10 +118,10 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
   <testcase name="foo.php:5">
     <failure message="Bar"/>
   </testcase>
-  <testcase name="Generic error">
+  <testcase name="General error">
     <failure message="first generic error" />
   </testcase>
-  <testcase name="Generic error">
+  <testcase name="General error">
     <failure message="second generic error"/>
   </testcase>
 </testsuite>
@@ -137,14 +137,14 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 	public function testFormatErrors(
 		int $exitCode,
 		int $numFileErrors,
-		int $numGenericErrors,
+		int $numGeneralErrors,
 		string $expected
 	): void
 	{
 		$this->assertSame(
 			$exitCode,
 			$this->formatter->formatErrors(
-				$this->getAnalysisResult($numFileErrors, $numGenericErrors),
+				$this->getAnalysisResult($numFileErrors, $numGeneralErrors),
 				$this->getOutput()
 			),
 			'Response code do not match'


### PR DESCRIPTION
SSIA

@ondrejmirtes the CI fail since we are going to use and extension that is not required in the composer.json, we have three options:

 - [x] Rewrite the code to do not use the DOM extension (using string concat to build XML)
 - [ ] ~~Include ext-dom as dependency~~
 - [ ] ~~Ignoring the error~~

Let me know what's your favourite solution :)