### PR TITLE
Add InvalidNullCoalesce as level 4 rule

### DIFF
--- a/conf/config.level4.neon
+++ b/conf/config.level4.neon
@@ -8,6 +8,7 @@ rules:
 	- PHPStan\Rules\Comparison\BooleanOrConstantConditionRule
 	- PHPStan\Rules\Comparison\ElseIfConstantConditionRule
 	- PHPStan\Rules\Comparison\IfConstantConditionRule
+	- PHPStan\Rules\Comparison\InvalidNullCoalesce
 	- PHPStan\Rules\Comparison\TernaryOperatorConstantConditionRule
 	- PHPStan\Rules\Comparison\NumberComparisonOperatorsConstantConditionRule
 	- PHPStan\Rules\Comparison\UnreachableIfBranchesRule

--- a/src/Rules/Comparison/InvalidNullCoalesce.php
+++ b/src/Rules/Comparison/InvalidNullCoalesce.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\NullType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\BinaryOp\Coalesce>
+ */
+class InvalidNullCoalesce implements Rule
+{
+
+	/**
+	 * @phpstan-return class-string<\PhpParser\Node\Expr\BinaryOp\Coalesce>
+	 * @return string
+	 */
+	public function getNodeType(): string
+	{
+		return Node\Expr\BinaryOp\Coalesce::class;
+	}
+
+	/**
+	 * @phpstan-param \PhpParser\Node\Expr\BinaryOp\Coalesce $node
+	 * @param \PhpParser\Node $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return RuleError[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$type = $scope->getType($node->left);
+		$onlyNull = $type instanceof NullType;
+		if($onlyNull || $type->accepts(new NullType(), $scope->isDeclareStrictTypes())->no()) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'Null coalesce on type %s is always %s.',
+					$type->describe(VerbosityLevel::value()),
+					$onlyNull ? 'true' : 'false'
+				))->line($node->left->getLine())->build(),
+			];
+		}
+		return [];
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/InvalidNullCoalesceTest.php
+++ b/tests/PHPStan/Rules/Comparison/InvalidNullCoalesceTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<InvalidNullCoalesce>
+ */
+class InvalidNullCoalesceTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new InvalidNullCoalesce();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/invalid-null-coalesce.php'], [
+			[
+				'Null coalesce on type array is always false.',
+				10,
+			],
+			[
+				'Null coalesce on type int is always false.',
+				11,
+			],
+			[
+				'Null coalesce on type bool is always false.',
+				12,
+			],
+			[
+				'Null coalesce on type string is always false.',
+				16,
+			],
+			[
+				'Null coalesce on type int|string is always false.',
+				27,
+			],
+			[
+			'Null coalesce on type int|false is always false.',
+				36,
+			],
+			[
+				'Null coalesce on type null is always true.',
+				38,
+			],
+		]);
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/invalid-null-coalesce.php
+++ b/tests/PHPStan/Rules/Comparison/data/invalid-null-coalesce.php
@@ -1,0 +1,40 @@
+<?php
+
+function (
+	$mixed,
+	array $array,
+	int $integer,
+	?string $nullableString
+) {
+	$mixed ?? 10;
+	$array ?? 10;
+	$integer ?? 10;
+	(function (): bool {
+		return true;
+	})() ?? false;
+	$nullableString ?? true;
+	(string) $mixed ?? 10;
+};
+
+/**
+ * @param int|string $union
+ * @param int|stdClass|null $nullableUnion
+ */
+function foo(
+	$union,
+	$nullableUnion
+) {
+	$union ?? 10;
+	$nullableUnion ?? 10;
+}
+
+function(
+	string $one,
+	string $two,
+	?string $nullableString
+) {
+	strpos($one, $two) ?? 'foo';
+	if (!is_string($nullableString)) {
+		$nullableString ?? 10;
+	}
+};


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/2371 & https://github.com/phpstan/phpstan/issues/2504

I've implemented it as a level 4 rule, as that is where other 'always true & always false' rules are.

There is probably some cs issues in here as i couldn't get cs-fixer to run on php 7.4 on my local machine.

If this looks good i'll go ahead and fix the issues found by this new rule as well