### PR TITLE
Fix spelling error in method name

### DIFF
--- a/src/Parser/CachedParser.php
+++ b/src/Parser/CachedParser.php
@@ -102,7 +102,7 @@ class CachedParser implements Parser
 		return $this->cachedNodesByStringCount;
 	}
 
-	public function getCachedNodesByStingCountMax(): int
+	public function getCachedNodesByStringCountMax(): int
 	{
 		return $this->cachedNodesByStringCountMax;
 	}

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -32,7 +32,7 @@ class CachedParserTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertEquals(
 			$cachedNodesByStringCountMax,
-			$parser->getCachedNodesByStingCountMax()
+			$parser->getCachedNodesByStringCountMax()
 		);
 
 		// Add files to cache


### PR DESCRIPTION
This fix ensures that the getter name is spelled the same as the property it's getting.