### PR TITLE
Add support for FILTER_NULL_ON_FAILURE flag in filter_var

### DIFF
--- a/build/composer-require-checker.json
+++ b/build/composer-require-checker.json
@@ -4,7 +4,11 @@
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
     "PHPUnit\\Framework\\TestCase", "PHPUnit\\Framework\\AssertionFailedError",
-    "JSON_THROW_ON_ERROR", "SimpleXMLElement", "PHPStan\\ExtensionInstaller\\GeneratedConfig", "Nette\\DI\\InvalidConfigurationException"
+    "JSON_THROW_ON_ERROR", "SimpleXMLElement", "PHPStan\\ExtensionInstaller\\GeneratedConfig", "Nette\\DI\\InvalidConfigurationException",
+    "FILTER_SANITIZE_EMAIL", "FILTER_SANITIZE_EMAIL", "FILTER_SANITIZE_ENCODED", "FILTER_SANITIZE_MAGIC_QUOTES", "FILTER_SANITIZE_NUMBER_FLOAT",
+    "FILTER_SANITIZE_NUMBER_INT", "FILTER_SANITIZE_SPECIAL_CHARS", "FILTER_SANITIZE_STRING", "FILTER_SANITIZE_URL", "FILTER_VALIDATE_BOOLEAN",
+    "FILTER_VALIDATE_EMAIL", "FILTER_VALIDATE_FLOAT", "FILTER_VALIDATE_INT", "FILTER_VALIDATE_IP", "FILTER_VALIDATE_MAC", "FILTER_VALIDATE_REGEXP",
+    "FILTER_VALIDATE_URL", "FILTER_NULL_ON_FAILURE", "FILTER_FORCE_ARRAY"
   ],
   "php-core-extensions" : [
     "Core",

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -35,6 +35,10 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 
 	public function __construct()
 	{
+		if (!defined('FILTER_SANITIZE_EMAIL')) {
+			return;
+		}
+
 		$booleanType = new BooleanType();
 		$floatType = new FloatType();
 		$intType = new IntegerType();
@@ -86,7 +90,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
-		return strtolower($functionReflection->getName()) === 'filter_var';
+		return defined('FILTER_SANITIZE_EMAIL') && strtolower($functionReflection->getName()) === 'filter_var';
 	}
 
 	public function getTypeFromFunctionCall(

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -8007,6 +8007,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'filter_var($mixed, FILTER_SANITIZE_EMAIL)',
 			],
 			[
+				'array<string|false>',
+				'filter_var($mixed, FILTER_SANITIZE_EMAIL, FILTER_FORCE_ARRAY)',
+			],
+			[
 				'string|false',
 				'filter_var($mixed, FILTER_SANITIZE_ENCODED)',
 			],
@@ -8066,6 +8070,19 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'float|null',
 				'filter_var($mixed, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE)',
 			],
+
+			[
+				'array<float|false>',
+				'filter_var($mixed, FILTER_VALIDATE_FLOAT, FILTER_FORCE_ARRAY)',
+			],
+			[
+				'array<float|null>',
+				'filter_var($mixed, FILTER_VALIDATE_FLOAT, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'array<float|null>',
+				'filter_var($mixed, FILTER_VALIDATE_FLOAT, $forceArrayFilter | $nullFilter)',
+			],
 			[
 				'float|null',
 				'filter_var($mixed, FILTER_VALIDATE_FLOAT ,["flags" => FILTER_NULL_ON_FAILURE])',
@@ -8088,11 +8105,23 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 			],
 			[
 				'string|false',
+				'filter_var($mixed, $filterIp)',
+			],
+			[
+				'string|false',
 				'filter_var($mixed, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)',
 			],
 			[
 				'string|null',
 				'filter_var($mixed, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4)',
+			],
+			[
+				'array<string|null>',
+				'filter_var($mixed, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4 | FILTER_FORCE_ARRAY)',
 			],
 			[
 				'string|null',
@@ -8115,6 +8144,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'filter_var($mixed, FILTER_VALIDATE_REGEXP)',
 			],
 			[
+				'string|false',
+				'filter_var($mixed, FILTER_VALIDATE_REGEXP, ["options" => ["regexp" => "/match/"]])',
+			],
+			[
 				'string|null',
 				'filter_var($mixed, FILTER_VALIDATE_REGEXP, FILTER_NULL_ON_FAILURE)',
 			],
@@ -8123,8 +8156,20 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'filter_var($mixed, FILTER_VALIDATE_REGEXP ,["flags" => FILTER_NULL_ON_FAILURE])',
 			],
 			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_REGEXP ,["flags" => FILTER_NULL_ON_FAILURE, "options" => ["regexp" => "/match/"]])',
+			],
+			[
 				'string|false',
 				'filter_var($mixed, FILTER_VALIDATE_URL)',
+			],
+			[
+				'string|false',
+				'filter_var($mixed, FILTER_VALIDATE_URL, $mixed)',
+			],
+			[
+				'string|false',
+				'filter_var($mixed, FILTER_VALIDATE_URL ,["flags" => $mixed])',
 			],
 			[
 				'string|null',
@@ -8132,7 +8177,15 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 			],
 			[
 				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_URL, $nullFilter)',
+			],
+			[
+				'string|null',
 				'filter_var($mixed, FILTER_VALIDATE_URL ,["flags" => FILTER_NULL_ON_FAILURE])',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_URL ,["flags" => $nullFilter])',
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -8039,16 +8039,48 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'filter_var($mixed, FILTER_VALIDATE_BOOLEAN)',
 			],
 			[
+				'bool|null',
+				'filter_var($mixed, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'bool|null',
+				'filter_var($mixed, FILTER_VALIDATE_BOOLEAN ,["flags" => FILTER_NULL_ON_FAILURE])',
+			],
+			[
 				'string|false',
 				'filter_var($mixed, FILTER_VALIDATE_EMAIL)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_EMAIL ,["flags" => FILTER_NULL_ON_FAILURE])',
 			],
 			[
 				'float|false',
 				'filter_var($mixed, FILTER_VALIDATE_FLOAT)',
 			],
 			[
+				'float|null',
+				'filter_var($mixed, FILTER_VALIDATE_FLOAT, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'float|null',
+				'filter_var($mixed, FILTER_VALIDATE_FLOAT ,["flags" => FILTER_NULL_ON_FAILURE])',
+			],
+			[
 				'int|false',
 				'filter_var($mixed, FILTER_VALIDATE_INT)',
+			],
+			[
+				'int|null',
+				'filter_var($mixed, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'int|null',
+				'filter_var($mixed, FILTER_VALIDATE_INT ,["flags" => FILTER_NULL_ON_FAILURE])',
 			],
 			[
 				'string|false',
@@ -8056,15 +8088,51 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 			],
 			[
 				'string|false',
+				'filter_var($mixed, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_IP ,["flags" => FILTER_NULL_ON_FAILURE])',
+			],
+			[
+				'string|false',
 				'filter_var($mixed, FILTER_VALIDATE_MAC)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_MAC, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_MAC ,["flags" => FILTER_NULL_ON_FAILURE])',
 			],
 			[
 				'string|false',
 				'filter_var($mixed, FILTER_VALIDATE_REGEXP)',
 			],
 			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_REGEXP, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_REGEXP ,["flags" => FILTER_NULL_ON_FAILURE])',
+			],
+			[
 				'string|false',
 				'filter_var($mixed, FILTER_VALIDATE_URL)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)',
+			],
+			[
+				'string|null',
+				'filter_var($mixed, FILTER_VALIDATE_URL ,["flags" => FILTER_NULL_ON_FAILURE])',
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/data/filterVar.php
+++ b/tests/PHPStan/Analyser/data/filterVar.php
@@ -5,6 +5,9 @@ namespace FilterVar;
 function () {
 	/** @var mixed $mixed */
 	$mixed = null;
+	$nullFilter = \FILTER_NULL_ON_FAILURE;
+	$forceArrayFilter = \FILTER_FORCE_ARRAY;
+	$filterIp = FILTER_VALIDATE_IP;
 
 	die;
 };


### PR DESCRIPTION
This adds support for the  `FILTER_NULL_ON_FAILURE` flag.

This doesn't cover all possible edge cases of the `filter_var` function, namely:

* Default values

Fixes https://github.com/phpstan/phpstan/issues/1959