### PR TITLE
Properties in SimpleXMLElement may be null

### DIFF
--- a/src/Type/BenevolentUnionType.php
+++ b/src/Type/BenevolentUnionType.php
@@ -42,4 +42,12 @@ class BenevolentUnionType extends UnionType
 		return TrinaryLogic::createNo();
 	}
 
+	/**
+	 * @param callable(Type $type): TrinaryLogic $getResult
+	 * @return TrinaryLogic
+	 */
+	protected function unionResults(callable $getResult): TrinaryLogic
+	{
+		return TrinaryLogic::maxMin(...array_map($getResult, $this->getTypes()));
+	}
 }

--- a/src/Type/BenevolentUnionType.php
+++ b/src/Type/BenevolentUnionType.php
@@ -50,4 +50,5 @@ class BenevolentUnionType extends UnionType
 	{
 		return TrinaryLogic::maxMin(...array_map($getResult, $this->getTypes()));
 	}
+
 }

--- a/src/Type/Php/SimpleXMLElementClassPropertyReflectionExtension.php
+++ b/src/Type/Php/SimpleXMLElementClassPropertyReflectionExtension.php
@@ -6,6 +6,8 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\SimpleXMLElementProperty;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\BenevolentUnionType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 
 class SimpleXMLElementClassPropertyReflectionExtension implements PropertiesClassReflectionExtension
@@ -19,7 +21,7 @@ class SimpleXMLElementClassPropertyReflectionExtension implements PropertiesClas
 
 	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
-		return new SimpleXMLElementProperty($classReflection, new ObjectType('SimpleXMLElement'));
+		return new SimpleXMLElementProperty($classReflection, new BenevolentUnionType([new ObjectType('SimpleXMLElement'), new NullType()]));
 	}
 
 }

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -620,7 +620,7 @@ class UnionType implements CompoundType
 	 * @param callable(Type $type): TrinaryLogic $getResult
 	 * @return TrinaryLogic
 	 */
-	private function unionResults(callable $getResult): TrinaryLogic
+	protected function unionResults(callable $getResult): TrinaryLogic
 	{
 		return TrinaryLogic::extremeIdentity(...array_map($getResult, $this->types));
 	}

--- a/tests/PHPStan/Rules/Classes/data/impossible-instanceof.php
+++ b/tests/PHPStan/Rules/Classes/data/impossible-instanceof.php
@@ -375,3 +375,13 @@ class InvalidTypeTest
 		}
 	}
 }
+
+class InstanceofBenevolentUnionType
+{
+	public function doFoo(\SimpleXMLElement $xml)
+	{
+		echo $xml->branch1 instanceof \SimpleXMLElement;
+		echo $xml->branch2->branch3 instanceof \SimpleXMLElement;
+	}
+
+}


### PR DESCRIPTION
As discussed in phpstan/phpstan/issues/2784 this returns a BenevolentUnionType(SimpleXMLElement|null) on properties for SimpleXMLElement.

It then allows operations on BenevolentUnionType by overriding unionResults (the method implementing the logic for whether an operation is permitted). While UnionType allow an operation if it's allowed on every Type in the Union, BenevolenUnionType allow the operation if it's allowed on at least one Type in the Union.

I added a test on impossible-instanceof. Without the modification in SimpleXML, it returned
```
385: Instanceof between SimpleXMLElement and SimpleXMLElement will always evaluate to true.
```
and with the modification, it doesn't return anything.

As you said in phpstan/phpstan/issues/2784:
> It's completely valid use-case that people are sure about their XML structure and know some attribute isn't going to be null.

I believe some functions in SimpleXMLElement should return BenevolentUnionType as well, such as SimpleXMLElement::attributes, who currently return SimpleXMLElement|null. Unfortunately, I tried modifying the type to (SimpleXMLElement|null) in FunctionMap but it doesn't seem to be resolved into a BenevolentUnionType. This could be for a future PR.
