### PR TITLE
change relative phpunit path to url

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
 	bootstrap="bootstrap.php"
 	colors="true"
 	failOnRisky="true"


### PR DESCRIPTION
A phpunit.xsd relative path was added in https://github.com/phpstan/phpstan-src/commit/77cb95bd1c5daa6c4c71cc7339928c5fb84c9cf0 

With the deployment of phpunit-shim in https://github.com/phpstan/phpstan-src/commit/0beef32cc580fc6849f1c05f7ac229eaefecd206 , the directory doesn't exist anymore and xml autocompletion is broken.

This PR return to the previous behaviour but bump the phpunit version in url to 7.5 to match with the actual phpunit version