### PR TITLE
bump dev dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
 		"phpstan/phpstan-php-parser": "^0.12",
 		"phpstan/phpstan-phpunit": "^0.12",
 		"phpstan/phpstan-strict-rules": "^0.12",
-		"slevomat/coding-standard": "^4.7.2",
-		"squizlabs/php_codesniffer": "^3.3.2"
+		"slevomat/coding-standard": "^4.7.2||^5.0||^6.0",
+		"squizlabs/php_codesniffer": "^3.5.3"
 	},
 	"config": {
 		"platform": {


### PR DESCRIPTION
This PR aims to bump squizlabs/php_codesniffer at least on version 3.5.3 to fix deprecations and fatal due to rules not compatible with PHP7.4:
https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.5.3

Unfortunately, consistence/coding-standard supports squizlabs/php_codesniffer ^3.5 only from 3.9.

consistence/coding-standard 3.9 need slevomat/coding-standard: ^5.0

slevomat/coding-standard don't support phpstan/phpdoc-parser ^0.4.2 before ^6.0

Conclusion
=> Bump squizlabs/php_codesniffer to ^3.5.3
=> Allow slevomat/coding-standard on version ^5.0 and ^6.0

If tests pass, I'll try some to tweak with "prefer lowest" to see if some lower version can be removed altogether.