### PR TITLE
functionMap: fix return type of SQLite3Result::fetchArray()

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -11419,7 +11419,7 @@ return [
 'SQLite3Result::__construct' => ['void'],
 'SQLite3Result::columnName' => ['string', 'column_number'=>'int'],
 'SQLite3Result::columnType' => ['int', 'column_number'=>'int'],
-'SQLite3Result::fetchArray' => ['array', 'mode='=>'int'],
+'SQLite3Result::fetchArray' => ['array|false', 'mode='=>'int'],
 'SQLite3Result::finalize' => ['bool'],
 'SQLite3Result::numColumns' => ['int'],
 'SQLite3Result::reset' => ['bool'],


### PR DESCRIPTION
this function returns `false` when there are no more rows to fetch.