### PR TITLE
Native properties on universal object crates

### DIFF
--- a/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
+++ b/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
@@ -71,6 +71,12 @@ class UniversalObjectCratesClassReflectionExtension
 
 	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
+		if ($classReflection->hasNativeProperty($propertyName)) {
+			$property = $classReflection->getNativeProperty($propertyName);
+
+			return new UniversalObjectCrateProperty($classReflection, $property->getReadableType(), $property->getWritableType());
+		}
+
 		if ($classReflection->hasNativeMethod('__get')) {
 			$readableType = ParametersAcceptorSelector::selectSingle($classReflection->getNativeMethod('__get')->getVariants())->getReturnType();
 		} else {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -116,9 +116,11 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 	public function testUniversalObjectCrateIssue(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/universal-object-crate.php');
-		$this->assertCount(1, $errors);
+		$this->assertCount(2, $errors);
 		$this->assertSame('Parameter #1 $i of method UniversalObjectCrate\Foo::doBaz() expects int, string given.', $errors[0]->getMessage());
 		$this->assertSame(19, $errors[0]->getLine());
+		$this->assertSame('Parameter #1 $i of method UniversalObjectCrate\Foo::doBaz() expects int, string given.', $errors[1]->getMessage());
+		$this->assertSame(36, $errors[1]->getLine());
 	}
 
 	public function testCustomFunctionWithNameEquivalentInSignatureMap(): void

--- a/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Reflection\Php;
 
 use PHPStan\Broker\Broker;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 
@@ -40,6 +42,30 @@ class UniversalObjectCratesClassReflectionExtensionTest extends \PHPStan\Testing
 			new StringType(),
 			$extension
 				->getProperty($broker->getClass('UniversalObjectCreates\DifferentGetSetTypes'), 'foo')
+				->getWritableType()
+		);
+	}
+
+	public function testNativeProperty(): void
+	{
+		require_once __DIR__ . '/data/universal-object-crates.php';
+
+		$broker = self::getContainer()->getByType(Broker::class);
+		$extension = new UniversalObjectCratesClassReflectionExtension([
+			'UniversalObjectCreates\NativeProperty',
+		]);
+		$extension->setBroker($broker);
+
+		$this->assertEquals(
+			new ArrayType(new MixedType(), new MixedType()),
+			$extension
+				->getProperty($broker->getClass('UniversalObjectCreates\NativeProperty'), 'nativeProperty')
+				->getReadableType()
+		);
+		$this->assertEquals(
+			new ArrayType(new MixedType(), new MixedType()),
+			$extension
+				->getProperty($broker->getClass('UniversalObjectCreates\NativeProperty'), 'nativeProperty')
 				->getWritableType()
 		);
 	}

--- a/tests/PHPStan/Reflection/Php/data/universal-object-crates.php
+++ b/tests/PHPStan/Reflection/Php/data/universal-object-crates.php
@@ -8,7 +8,7 @@ class DifferentGetSetTypes
 
 	public function __get($name): DifferentGetSetTypesValue
 	{
-		$this->values[$name] ?: new DifferentGetSetTypesValue();
+		return $this->values[$name] ?: new DifferentGetSetTypesValue();
 	}
 
 	public function __set($name, string $value): void

--- a/tests/PHPStan/Reflection/Php/data/universal-object-crates.php
+++ b/tests/PHPStan/Reflection/Php/data/universal-object-crates.php
@@ -24,3 +24,14 @@ class DifferentGetSetTypesValue
 {
 	public $value = null;
 }
+
+class NativeProperty
+{
+	/** @var array */
+	public $nativeProperty;
+
+	public function __get($name): int
+	{
+		return 42;
+	}
+}


### PR DESCRIPTION
It occurred to me that native properties were not taken in account on universal object crates. This fixes that.