### PR TITLE
Fix mixed with subtraction not being a super type of never

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -83,11 +83,6 @@ class ArrayType implements Type
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
 		if ($type instanceof self) {
-			// Any array is always a super type of an empty array.
-			if ($type->keyType->equals(new NeverType())) {
-				return TrinaryLogic::createYes();
-			}
-
 			return $this->getItemType()->isSuperTypeOf($type->getItemType())
 				->and($this->keyType->isSuperTypeOf($type->keyType));
 		}

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -103,8 +103,8 @@ class ArrayType implements Type
 
 	public function describe(VerbosityLevel $level): string
 	{
-		$isMixedKeyType = $this->keyType instanceof MixedType && !$this->keyType instanceof TemplateType;
-		$isMixedItemType = $this->itemType instanceof MixedType && !$this->itemType instanceof TemplateType;
+		$isMixedKeyType = $this->keyType instanceof MixedType && $this->keyType->describe(VerbosityLevel::precise()) === 'mixed';
+		$isMixedItemType = $this->itemType instanceof MixedType && $this->itemType->describe(VerbosityLevel::precise()) === 'mixed';
 
 		$valueHandler = function () use ($level, $isMixedKeyType, $isMixedItemType): string {
 			if ($isMixedKeyType || $this->keyType instanceof NeverType) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -83,6 +83,11 @@ class ArrayType implements Type
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
 		if ($type instanceof self) {
+			// Any array is always a super type of an empty array.
+			if ($type->keyType->equals(new NeverType())) {
+				return TrinaryLogic::createYes();
+			}
+
 			return $this->getItemType()->isSuperTypeOf($type->getItemType())
 				->and($this->keyType->isSuperTypeOf($type->keyType));
 		}

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -88,7 +88,7 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
-		if ($this->subtractedType === null) {
+		if ($this->subtractedType === null || $type instanceof NeverType) {
 			return TrinaryLogic::createYes();
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9757,6 +9757,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2835.php');
 	}
 
+	public function dataBug2443(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2443.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -9781,6 +9786,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataListType
 	 * @dataProvider dataBug2822
 	 * @dataProvider dataBug2835
+	 * @dataProvider dataBug2443
 	 * @param ConstantStringType $expectedType
 	 * @param Type $actualType
 	 */

--- a/tests/PHPStan/Analyser/data/bug-2443.php
+++ b/tests/PHPStan/Analyser/data/bug-2443.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Analyser\Bug2443;
+
+use function PHPStan\Analyser\assertType;
+
+/**
+ * @param array<int,mixed> $a
+ */
+function (array $a): void
+{
+	assertType('bool', array_filter($a) !== []);
+	assertType('bool', [] !== array_filter($a));
+
+	assertType('bool', array_filter($a) === []);
+	assertType('bool', [] === array_filter($a));
+};

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -4,7 +4,10 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -47,6 +50,23 @@ class ArrayTypeTest extends \PHPStan\Testing\TestCase
 			],
 			[
 				new ArrayType(new IntegerType(), new StringType()),
+				new ConstantArrayType([], []),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new ArrayType(new MixedType(), new MixedType(false, new UnionType([
+					new NullType(),
+					new ConstantBooleanType(false),
+					new ConstantIntegerType(0),
+					new ConstantFloatType(0.0),
+					new ConstantStringType(''),
+					new ConstantArrayType([], []),
+				]))),
+				new ConstantArrayType([], []),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new ArrayType(new MixedType(), new MixedType(false, new NullType())),
 				new ConstantArrayType([], []),
 				TrinaryLogic::createYes(),
 			],

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -121,6 +121,26 @@ class MixedTypeTest extends \PHPStan\Testing\TestCase
 				new MixedType(false, new ObjectType('stdClass')),
 				TrinaryLogic::createMaybe(),
 			],
+			[
+				new MixedType(),
+				new NeverType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(false, new NullType()),
+				new NeverType(),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(),
+				new UnionType([new StringType(), new IntegerType()]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new MixedType(false, new NullType()),
+				new UnionType([new StringType(), new IntegerType()]),
+				TrinaryLogic::createYes(),
+			],
 		];
 	}
 


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/2443

The return of `array_filter($foo)` has a type of `array<mixed,mixed~0|0.0|''|false|null|array{}>` which was not being regarded as a super type of an empty array.

I've also adjusted the `ArrayType::describe()` method to ensure mixed types with a subtracted type is explained.