### PR TITLE
random_int() return type and parameters rule

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -1,0 +1,3 @@
+parameters:
+	featureToggles:
+		randomIntParameters: true

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -27,6 +27,7 @@ rules:
 	- PHPStan\Rules\Functions\InnerFunctionRule
 	- PHPStan\Rules\Functions\NonExistentDefinedFunctionRule
 	- PHPStan\Rules\Functions\PrintfParametersRule
+	- PHPStan\Rules\Functions\RandomIntParametersRule
 	- PHPStan\Rules\Methods\ExistingClassesInTypehintsRule
 	- PHPStan\Rules\Properties\AccessPropertiesInAssignRule
 	- PHPStan\Rules\Properties\AccessStaticPropertiesInAssignRule

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -27,7 +27,6 @@ rules:
 	- PHPStan\Rules\Functions\InnerFunctionRule
 	- PHPStan\Rules\Functions\NonExistentDefinedFunctionRule
 	- PHPStan\Rules\Functions\PrintfParametersRule
-	- PHPStan\Rules\Functions\RandomIntParametersRule
 	- PHPStan\Rules\Methods\ExistingClassesInTypehintsRule
 	- PHPStan\Rules\Properties\AccessPropertiesInAssignRule
 	- PHPStan\Rules\Properties\AccessStaticPropertiesInAssignRule

--- a/conf/config.level5.neon
+++ b/conf/config.level5.neon
@@ -14,3 +14,5 @@ parameters:
 services:
 	-
 		class: PHPStan\Rules\Functions\RandomIntParametersRule
+		arguments:
+			reportMaybes: %reportMaybes%

--- a/conf/config.level5.neon
+++ b/conf/config.level5.neon
@@ -1,6 +1,16 @@
 includes:
 	- config.level4.neon
 
+conditionalTags:
+	PHPStan\Rules\Functions\RandomIntParametersRule:
+		phpstan.rules.rule: %featureToggles.randomIntParameters%
+
 parameters:
 	checkFunctionArgumentTypes: true
 	checkArgumentsPassedByReference: true
+	featureToggles:
+		randomIntParameters: false
+
+services:
+	-
+		class: PHPStan\Rules\Functions\RandomIntParametersRule

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -718,6 +718,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\RandomIntFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\RangeFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Rules/Functions/RandomIntParametersRule.php
+++ b/src/Rules/Functions/RandomIntParametersRule.php
@@ -57,11 +57,7 @@ class RandomIntParametersRule implements \PHPStan\Rules\Rule
 			}
 
 			if (!$maxPermittedType->isSuperTypeOf($maxType)->yes()) {
-				$message = 'Cannot call random_int() when $min parameter (%s) can be greater than $max parameter (%s).';
-
-				if ($maxType->isSuperTypeOf($minType)->no()) {
-					$message = 'Cannot call random_int() when $min parameter (%s) is greater than $max parameter (%s).';
-				}
+				$message = 'Parameter #1 $min (%s) of function random_int expects lower number than parameter #2 $max (%s).';
 
 				return [
 					RuleErrorBuilder::message(sprintf(

--- a/src/Rules/Functions/RandomIntParametersRule.php
+++ b/src/Rules/Functions/RandomIntParametersRule.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\FuncCall>
+ */
+class RandomIntParametersRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!($node->name instanceof \PhpParser\Node\Name)) {
+			return [];
+		}
+
+		if (strtolower((string) $node->name) !== 'random_int') {
+			return [];
+		}
+
+		$minType = $scope->getType($node->args[0]->value)->toInteger();
+		$maxType = $scope->getType($node->args[1]->value)->toInteger();
+
+		if ($minType instanceof ConstantIntegerType
+			&& $maxType instanceof ConstantIntegerType
+			&& $minType->getValue() > $maxType->getValue()
+		) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'Cannot call random_int() with $min parameter (%d) greater than $max parameter (%d).',
+					$minType->getValue(),
+					$maxType->getValue()
+				))->build(),
+			];
+		}
+
+		if ($minType instanceof IntegerRangeType
+			&& $maxType instanceof ConstantIntegerType
+			&& $minType->getMax() > $maxType->getValue()
+		) {
+			$message = $minType->getMin() > $maxType->getValue()
+				? 'Cannot call random_int() with $min parameter (%s) greater than $max parameter (%d).'
+				: 'Cannot call random_int() when $min parameter (%s) can be greater than $max parameter (%d).';
+
+			return [
+				RuleErrorBuilder::message(sprintf(
+					$message,
+					$minType->describe(VerbosityLevel::value()),
+					$maxType->getValue()
+				))->build(),
+			];
+		}
+
+		if ($minType instanceof ConstantIntegerType
+			&& $maxType instanceof IntegerRangeType
+			&& $minType->getValue() > $maxType->getMin()
+		) {
+			$message = $minType->getValue() > $maxType->getMax()
+				? 'Cannot call random_int() with $max parameter (%s) less than $min parameter (%d).'
+				: 'Cannot call random_int() when $max parameter (%s) can be less than $min parameter (%d).';
+
+			return [
+				RuleErrorBuilder::message(sprintf(
+					$message,
+					$maxType->describe(VerbosityLevel::value()),
+					$minType->getValue()
+				))->build(),
+			];
+		}
+
+		if ($minType instanceof IntegerRangeType
+			&& $maxType instanceof IntegerRangeType
+			&& $minType->getMax() > $maxType->getMin()
+		) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'Cannot call random_int() with intersecting $min (%s) and $max (%s) parameters.',
+					$minType->describe(VerbosityLevel::value()),
+					$maxType->describe(VerbosityLevel::value())
+				))->build(),
+			];
+		}
+
+		return [];
+	}
+
+}

--- a/src/Rules/Functions/RandomIntParametersRule.php
+++ b/src/Rules/Functions/RandomIntParametersRule.php
@@ -43,8 +43,9 @@ class RandomIntParametersRule implements \PHPStan\Rules\Rule
 
 		$minType = $scope->getType($node->args[0]->value)->toInteger();
 		$maxType = $scope->getType($node->args[1]->value)->toInteger();
+		$integerType = new IntegerType();
 
-		if ($minType->equals(new IntegerType()) || $maxType->equals(new IntegerType())) {
+		if ($minType->equals($integerType) || $maxType->equals($integerType)) {
 			return [];
 		}
 

--- a/src/Rules/Functions/RandomIntParametersRule.php
+++ b/src/Rules/Functions/RandomIntParametersRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Functions;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\IntegerRangeType;
@@ -15,6 +16,14 @@ use PHPStan\Type\VerbosityLevel;
  */
 class RandomIntParametersRule implements \PHPStan\Rules\Rule
 {
+
+	/** @var ReflectionProvider */
+	private $reflectionProvider;
+
+	public function __construct(ReflectionProvider $reflectionProvider)
+	{
+		$this->reflectionProvider = $reflectionProvider;
+	}
 
 	public function getNodeType(): string
 	{
@@ -27,7 +36,7 @@ class RandomIntParametersRule implements \PHPStan\Rules\Rule
 			return [];
 		}
 
-		if (strtolower((string) $node->name) !== 'random_int') {
+		if ($this->reflectionProvider->resolveFunctionName($node->name, $scope) !== 'random_int') {
 			return [];
 		}
 

--- a/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class RandomIntFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'random_int';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		if (count($functionCall->args) < 2) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$minType = $scope->getType($functionCall->args[0]->value)->toInteger();
+		$maxType = $scope->getType($functionCall->args[1]->value)->toInteger();
+
+		return $this->createRange($minType, $maxType);
+	}
+
+	private function createRange(Type $minType, Type $maxType): Type
+	{
+		$minValue = array_reduce($minType instanceof UnionType ? $minType->getTypes() : [$minType], static function (int $carry, Type $type): int {
+			if ($type instanceof IntegerRangeType) {
+				$value = $type->getMin();
+			} elseif ($type instanceof ConstantIntegerType) {
+				$value = $type->getValue();
+			} else {
+				$value = PHP_INT_MIN;
+			}
+
+			return min($value, $carry);
+		}, PHP_INT_MAX);
+
+		$maxValue = array_reduce($maxType instanceof UnionType ? $maxType->getTypes() : [$maxType], static function (int $carry, Type $type): int {
+			if ($type instanceof IntegerRangeType) {
+				$value = $type->getMax();
+			} elseif ($type instanceof ConstantIntegerType) {
+				$value = $type->getValue();
+			} else {
+				$value = PHP_INT_MAX;
+			}
+
+			return max($value, $carry);
+		}, PHP_INT_MIN);
+
+		return IntegerRangeType::fromInterval($minValue, $maxValue);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9672,6 +9672,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/integer-range-types.php');
 	}
 
+	public function dataRandomInt(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/random-int.php');
+	}
+
 	public function dataClosureReturnTypes(): array
 	{
 		return $this->gatherAssertTypes(__DIR__ . '/data/closure-return-type-extensions.php');
@@ -9769,6 +9774,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataGenericClassStringType
 	 * @dataProvider dataInstanceOf
 	 * @dataProvider dataIntegerRangeTypes
+	 * @dataProvider dataRandomInt
 	 * @dataProvider dataClosureReturnTypes
 	 * @dataProvider dataArrayKey
 	 * @dataProvider dataIntersectionStatic

--- a/tests/PHPStan/Analyser/data/random-int.php
+++ b/tests/PHPStan/Analyser/data/random-int.php
@@ -1,0 +1,39 @@
+<?php
+
+use function PHPStan\Analyser\assertType;
+
+function (int $min) {
+	\assert($min === 10 || $min === 15);
+	assertType('int<10, 20>', random_int($min, 20));
+};
+
+function (int $min) {
+	\assert($min <= 0);
+	assertType('int<min, 20>', random_int($min, 20));
+};
+
+function (int $max) {
+	\assert($min >= 0);
+	assertType('int<0, max>', random_int(0, $max));
+};
+
+function (int $i) {
+	assertType('int', random_int($i, $i));
+};
+
+assertType('0', random_int(0, 0));
+assertType('int', random_int(PHP_INT_MIN, PHP_INT_MAX));
+assertType('int<0, max>', random_int(0, PHP_INT_MAX));
+assertType('int<min, 0>', random_int(PHP_INT_MIN, 0));
+assertType('int<-1, 1>', random_int(-1, 1));
+assertType('int<0, 30>', random_int(0, random_int(0, 30)));
+assertType('int<0, 100>', random_int(random_int(0, 10), 100));
+
+assertType('*NEVER*', random_int(10, 1));
+assertType('*NEVER*', random_int(2, random_int(0, 1)));
+assertType('int<0, 1>', random_int(0, random_int(0, 1)));
+assertType('*NEVER*', random_int(random_int(0, 1), -1));
+assertType('int<0, 1>', random_int(random_int(0, 1), 1));
+
+assertType('int<-5, 5>', random_int(random_int(-5, 0), random_int(0, 5)));
+assertType('int', random_int(random_int(PHP_INT_MIN, 0), random_int(0, PHP_INT_MAX)));

--- a/tests/PHPStan/Levels/data/acceptTypes-5.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-5.json
@@ -183,5 +183,20 @@
         "message": "Parameter #1 $one of method Levels\\AcceptTypes\\ArrayShapes::doBar() expects array('foo' => callable(): mixed), array('bar' => 'date') given.",
         "line": 576,
         "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (-1).",
+        "line": 662,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $min (int<11, max>) of function random_int expects lower number than parameter #2 $max (10).",
+        "line": 669,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $min (340) of function random_int expects lower number than parameter #2 $max (int<min, 339>).",
+        "line": 676,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/acceptTypes-7.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-7.json
@@ -113,5 +113,20 @@
         "message": "Parameter #1 $static of method Levels\\AcceptTypes\\RequireObjectWithoutClassType::requireStatic() expects Levels\\AcceptTypes\\RequireObjectWithoutClassType, object given.",
         "line": 639,
         "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $min (int<-1, 1>) of function random_int expects lower number than parameter #2 $max (int<0, 1>).",
+        "line": 681,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $min (int<-1, 0>) of function random_int expects lower number than parameter #2 $max (int<-1, 1>).",
+        "line": 682,
+        "ignorable": true
+    },
+    {
+        "message": "Parameter #1 $min (int<-1, 1>) of function random_int expects lower number than parameter #2 $max (int<-1, 1>).",
+        "line": 683,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/acceptTypes.php
+++ b/tests/PHPStan/Levels/data/acceptTypes.php
@@ -653,3 +653,34 @@ class RequireObjectWithoutClassType
 	}
 
 }
+
+class RandomInt
+{
+
+	public function doThings(): int
+	{
+		return random_int(0, -1);
+	}
+
+	public function doInputMin(int $input): int
+	{
+		assert($input > 10);
+
+		return random_int($input, 10);
+	}
+
+	public function doInputMax(int $input): int
+	{
+		assert($input < 340);
+
+		return random_int(340, $input);
+	}
+
+	public function doStuff(): void
+	{
+		random_int(random_int(-1, 1), random_int(0, 1));
+		random_int(random_int(-1, 0), random_int(-1, 1));
+		random_int(random_int(-1, 1), random_int(-1, 1));
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<RandomIntParametersRule>
+ */
+class RandomIntParametersRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new RandomIntParametersRule();
+	}
+
+	public function testFile(): void
+	{
+		$this->analyse([__DIR__ . '/data/random-int.php'], [
+			[
+				'Cannot call random_int() with $min parameter (1) greater than $max parameter (0).',
+				8,
+			],
+			[
+				'Cannot call random_int() with $min parameter (0) greater than $max parameter (-1).',
+				9,
+			],
+			[
+				'Cannot call random_int() with $max parameter (int<-10, -1>) less than $min parameter (0).',
+				11,
+			],
+			[
+				'Cannot call random_int() when $max parameter (int<-10, 10>) can be less than $min parameter (0).',
+				12,
+			],
+			[
+				'Cannot call random_int() with $min parameter (int<1, 10>) greater than $max parameter (0).',
+				15,
+			],
+			[
+				'Cannot call random_int() when $min parameter (int<-10, 10>) can be greater than $max parameter (0).',
+				16,
+			],
+			[
+				'Cannot call random_int() with intersecting $min (int<-5, 1>) and $max (int<0, 5>) parameters.',
+				19,
+			],
+			[
+				'Cannot call random_int() with intersecting $min (int<-5, 0>) and $max (int<-1, 5>) parameters.',
+				20,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
@@ -10,7 +10,7 @@ class RandomIntParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		return new RandomIntParametersRule();
+		return new RandomIntParametersRule($this->createReflectionProvider());
 	}
 
 	public function testFile(): void

--- a/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
@@ -10,46 +10,46 @@ class RandomIntParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		return new RandomIntParametersRule($this->createReflectionProvider());
+		return new RandomIntParametersRule($this->createReflectionProvider(), true);
 	}
 
 	public function testFile(): void
 	{
 		$this->analyse([__DIR__ . '/data/random-int.php'], [
 			[
-				'Cannot call random_int() when $min parameter (1) is greater than $max parameter (0).',
+				'Parameter #1 $min (1) of function random_int expects lower number than parameter #2 $max (0).',
 				8,
 			],
 			[
-				'Cannot call random_int() when $min parameter (0) is greater than $max parameter (-1).',
+				'Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (-1).',
 				9,
 			],
 			[
-				'Cannot call random_int() when $min parameter (0) is greater than $max parameter (int<-10, -1>).',
+				'Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (int<-10, -1>).',
 				11,
 			],
 			[
-				'Cannot call random_int() when $min parameter (0) can be greater than $max parameter (int<-10, 10>).',
+				'Parameter #1 $min (0) of function random_int expects lower number than parameter #2 $max (int<-10, 10>).',
 				12,
 			],
 			[
-				'Cannot call random_int() when $min parameter (int<1, 10>) is greater than $max parameter (0).',
+				'Parameter #1 $min (int<1, 10>) of function random_int expects lower number than parameter #2 $max (0).',
 				15,
 			],
 			[
-				'Cannot call random_int() when $min parameter (int<-10, 10>) can be greater than $max parameter (0).',
+				'Parameter #1 $min (int<-10, 10>) of function random_int expects lower number than parameter #2 $max (0).',
 				16,
 			],
 			[
-				'Cannot call random_int() when $min parameter (int<-5, 1>) can be greater than $max parameter (int<0, 5>).',
+				'Parameter #1 $min (int<-5, 1>) of function random_int expects lower number than parameter #2 $max (int<0, 5>).',
 				19,
 			],
 			[
-				'Cannot call random_int() when $min parameter (int<-5, 0>) can be greater than $max parameter (int<-1, 5>).',
+				'Parameter #1 $min (int<-5, 0>) of function random_int expects lower number than parameter #2 $max (int<-1, 5>).',
 				20,
 			],
 			[
-				'Cannot call random_int() when $min parameter (int<0, 10>) can be greater than $max parameter (int<0, 10>).',
+				'Parameter #1 $min (int<0, 10>) of function random_int expects lower number than parameter #2 $max (int<0, 10>).',
 				31,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/RandomIntParametersRuleTest.php
@@ -17,23 +17,23 @@ class RandomIntParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/random-int.php'], [
 			[
-				'Cannot call random_int() with $min parameter (1) greater than $max parameter (0).',
+				'Cannot call random_int() when $min parameter (1) is greater than $max parameter (0).',
 				8,
 			],
 			[
-				'Cannot call random_int() with $min parameter (0) greater than $max parameter (-1).',
+				'Cannot call random_int() when $min parameter (0) is greater than $max parameter (-1).',
 				9,
 			],
 			[
-				'Cannot call random_int() with $max parameter (int<-10, -1>) less than $min parameter (0).',
+				'Cannot call random_int() when $min parameter (0) is greater than $max parameter (int<-10, -1>).',
 				11,
 			],
 			[
-				'Cannot call random_int() when $max parameter (int<-10, 10>) can be less than $min parameter (0).',
+				'Cannot call random_int() when $min parameter (0) can be greater than $max parameter (int<-10, 10>).',
 				12,
 			],
 			[
-				'Cannot call random_int() with $min parameter (int<1, 10>) greater than $max parameter (0).',
+				'Cannot call random_int() when $min parameter (int<1, 10>) is greater than $max parameter (0).',
 				15,
 			],
 			[
@@ -41,12 +41,16 @@ class RandomIntParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 				16,
 			],
 			[
-				'Cannot call random_int() with intersecting $min (int<-5, 1>) and $max (int<0, 5>) parameters.',
+				'Cannot call random_int() when $min parameter (int<-5, 1>) can be greater than $max parameter (int<0, 5>).',
 				19,
 			],
 			[
-				'Cannot call random_int() with intersecting $min (int<-5, 0>) and $max (int<-1, 5>) parameters.',
+				'Cannot call random_int() when $min parameter (int<-5, 0>) can be greater than $max parameter (int<-1, 5>).',
 				20,
+			],
+			[
+				'Cannot call random_int() when $min parameter (int<0, 10>) can be greater than $max parameter (int<0, 10>).',
+				31,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/random-int.php
+++ b/tests/PHPStan/Rules/Functions/data/random-int.php
@@ -28,5 +28,6 @@ random_int($x, $y);
 random_int(0, $x);
 random_int($x, random_int(0, PHP_INT_MAX));
 random_int(random_int(PHP_INT_MIN, 0), $x);
+random_int(random_int(0, 10), random_int(0, 10)); // Equal args are okay except ranges.
 
 random_int(PHP_INT_MAX, PHP_INT_MIN); // @todo this should error

--- a/tests/PHPStan/Rules/Functions/data/random-int.php
+++ b/tests/PHPStan/Rules/Functions/data/random-int.php
@@ -1,0 +1,32 @@
+<?php
+
+random_int(0, 0);
+random_int(0, 1);
+random_int(-1, 0);
+random_int(-1, 1);
+
+random_int(1, 0);
+random_int(0, -1);
+
+random_int(0, random_int(-10, -1));
+random_int(0, random_int(-10, 10));
+random_int(0, random_int(0, 10)); // ok
+
+random_int(random_int(1, 10), 0);
+random_int(random_int(-10, 10), 0);
+random_int(random_int(-10, 0), 0); // ok
+
+random_int(random_int(-5, 1), random_int(0, 5));
+random_int(random_int(-5, 0), random_int(-1, 5));
+
+/** @var int */
+$x = foo();
+/** @var int */
+$y = bar();
+
+random_int($x, $y);
+random_int(0, $x);
+random_int($x, random_int(0, PHP_INT_MAX));
+random_int(random_int(PHP_INT_MIN, 0), $x);
+
+random_int(PHP_INT_MAX, PHP_INT_MIN); // @todo this should error


### PR DESCRIPTION
This PR adds a return type extension which teaches PHPStan that `random_int()` will return an integer between the min/max parameters. The code I've written to get the lower/upper bounds could probably be extracted to be reused as it should handle crazy types like `int<0,10>|20|25|int<30,100>` which I don't think PHPStan will even create currently.

Secondly there is a rule which performs validation of the input parameters to ensure `$min <= $max` always holds true. Not sure on what level this should be configured or if it belongs in the strict rules repo.

Unfortunately it's not possible to validate `random_int(PHP_INT_MAX, PHP_INT_MIN)` as the min/max constants are just converted to a plain integer type, perhaps there is scope for `{Min,Max}IntegerType` classes.