### PR TITLE
Invalidate array type info when using array_{push,pop,shift,unshift}

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1374,14 +1374,14 @@ class NodeScopeResolver
 						}
 					}
 
-					$scope = $scope->specifyExpressionType(
+					$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType(
 						$arrayArg,
 						TypeCombinator::union(...$resultArrayTypes)
 					);
 				} else {
 					$arrays = TypeUtils::getAnyArrays($scope->getType($arrayArg));
 					if (count($arrays) > 0) {
-						$scope = $scope->specifyExpressionType($arrayArg, TypeCombinator::union(...$arrays));
+						$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, TypeCombinator::union(...$arrays));
 					}
 				}
 			}
@@ -1421,7 +1421,7 @@ class NodeScopeResolver
 						$arrayType = $arrayType->setOffsetValueType(null, $argType);
 					}
 
-					$scope = $scope->specifyExpressionType($arrayArg, TypeCombinator::intersect($arrayType, new NonEmptyArrayType()));
+					$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, TypeCombinator::intersect($arrayType, new NonEmptyArrayType()));
 				} elseif (count($constantArrays) > 0) {
 					$defaultArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
 					foreach ($argumentTypes as $argType) {
@@ -1443,7 +1443,7 @@ class NodeScopeResolver
 						$arrayTypes[] = $arrayType;
 					}
 
-					$scope = $scope->specifyExpressionType(
+					$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType(
 						$arrayArg,
 						TypeCombinator::union(...$arrayTypes)
 					);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9762,6 +9762,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2443.php');
 	}
 
+	public function dataBug2750(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2750.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -9787,6 +9792,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug2822
 	 * @dataProvider dataBug2835
 	 * @dataProvider dataBug2443
+	 * @dataProvider dataBug2750
 	 * @param ConstantStringType $expectedType
 	 * @param Type $actualType
 	 */

--- a/tests/PHPStan/Analyser/data/bug-2750.php
+++ b/tests/PHPStan/Analyser/data/bug-2750.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Analyser\Bug2750;
+
+use function PHPStan\Analyser\assertType;
+
+function (array $input) {
+	\assert(count($input) > 0);
+	assertType('int<1, max>', count($input));
+	array_shift($input);
+	assertType('int', count($input));
+
+	\assert(count($input) > 0);
+	assertType('int<1, max>', count($input));
+	array_pop($input);
+	assertType('int', count($input));
+
+	\assert(count($input) > 0);
+	assertType('int<1, max>', count($input));
+	array_unshift($input, 'test');
+	assertType('int', count($input));
+
+	\assert(count($input) > 0);
+	assertType('int<1, max>', count($input));
+	array_push($input, 'nope');
+	assertType('int', count($input));
+};


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/2750

Seems to me like it's probably worth something more generic like - if the method has side effects and argument is passed by reference invalidate the argument.