### PR TITLE
Allow passing function returns as arguments by reference

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1179,7 +1179,8 @@ class MutatingScope implements Scope
 			return new ClosureType(
 				$parameters,
 				$this->getFunctionType($node->returnType, $node->returnType === null, false),
-				$isVariadic
+				$isVariadic,
+				$node->byRef
 			);
 		} elseif ($node instanceof New_) {
 			if ($node->class instanceof Name) {

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -423,13 +423,13 @@ class TypeNodeResolver
 		$returnType = $this->resolve($typeNode->returnType, $nameScope);
 
 		if ($mainType instanceof CallableType) {
-			return new CallableType($parameters, $returnType, $isVariadic);
+			return new CallableType($parameters, $returnType, $isVariadic, false); // @todo
 
 		} elseif (
 			$mainType instanceof ObjectType
 			&& $mainType->getClassName() === \Closure::class
 		) {
-			return new ClosureType($parameters, $returnType, $isVariadic);
+			return new ClosureType($parameters, $returnType, $isVariadic, false); // @todo
 		}
 
 		return new ErrorType();

--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -101,7 +101,8 @@ class AnnotationMethodReflection implements MethodReflection
 					null,
 					$this->parameters,
 					$this->isVariadic,
-					$this->returnType
+					$this->returnType,
+					false // @todo
 				),
 			];
 		}
@@ -141,6 +142,11 @@ class AnnotationMethodReflection implements MethodReflection
 	public function getDocComment(): ?string
 	{
 		return null;
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return false;
 	}
 
 }

--- a/src/Reflection/Dummy/DummyConstructorReflection.php
+++ b/src/Reflection/Dummy/DummyConstructorReflection.php
@@ -100,4 +100,9 @@ class DummyConstructorReflection implements MethodReflection
 		return null;
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Dummy/DummyMethodReflection.php
+++ b/src/Reflection/Dummy/DummyMethodReflection.php
@@ -98,4 +98,9 @@ class DummyMethodReflection implements MethodReflection
 		return null;
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -27,4 +27,6 @@ interface FunctionReflection
 
 	public function hasSideEffects(): TrinaryLogic;
 
+	public function isReturnByReference(): bool;
+
 }

--- a/src/Reflection/FunctionVariant.php
+++ b/src/Reflection/FunctionVariant.php
@@ -23,6 +23,9 @@ class FunctionVariant implements ParametersAcceptor
 	/** @var Type */
 	private $returnType;
 
+	/** @var bool */
+	private $isReturnByReference;
+
 	/**
 	 * @param array<int, ParameterReflection> $parameters
 	 * @param bool $isVariadic
@@ -33,7 +36,8 @@ class FunctionVariant implements ParametersAcceptor
 		?TemplateTypeMap $resolvedTemplateTypeMap,
 		array $parameters,
 		bool $isVariadic,
-		Type $returnType
+		Type $returnType,
+		bool $isReturnByReference
 	)
 	{
 		$this->templateTypeMap = $templateTypeMap;
@@ -41,6 +45,7 @@ class FunctionVariant implements ParametersAcceptor
 		$this->parameters = $parameters;
 		$this->isVariadic = $isVariadic;
 		$this->returnType = $returnType;
+		$this->isReturnByReference = $isReturnByReference;
 	}
 
 	public function getTemplateTypeMap(): TemplateTypeMap
@@ -69,6 +74,11 @@ class FunctionVariant implements ParametersAcceptor
 	public function getReturnType(): Type
 	{
 		return $this->returnType;
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return $this->isReturnByReference;
 	}
 
 }

--- a/src/Reflection/FunctionVariantWithPhpDocs.php
+++ b/src/Reflection/FunctionVariantWithPhpDocs.php
@@ -28,6 +28,7 @@ class FunctionVariantWithPhpDocs extends FunctionVariant implements ParametersAc
 		array $parameters,
 		bool $isVariadic,
 		Type $returnType,
+		bool $isReturnByReference = null, // @todo
 		Type $phpDocReturnType,
 		Type $nativeReturnType
 	)
@@ -37,7 +38,8 @@ class FunctionVariantWithPhpDocs extends FunctionVariant implements ParametersAc
 			$resolvedTemplateTypeMap,
 			$parameters,
 			$isVariadic,
-			$returnType
+			$returnType,
+			$isReturnByReference
 		);
 		$this->phpDocReturnType = $phpDocReturnType;
 		$this->nativeReturnType = $nativeReturnType;

--- a/src/Reflection/Generic/ResolvedFunctionVariant.php
+++ b/src/Reflection/Generic/ResolvedFunctionVariant.php
@@ -86,4 +86,9 @@ class ResolvedFunctionVariant implements ParametersAcceptor
 		return $type;
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return $this->parametersAcceptor->isReturnByReference();
+	}
+
 }

--- a/src/Reflection/InaccessibleMethod.php
+++ b/src/Reflection/InaccessibleMethod.php
@@ -50,4 +50,9 @@ class InaccessibleMethod implements ParametersAcceptor
 		return new MixedType();
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return false; // @todo Correct default?
+	}
+
 }

--- a/src/Reflection/MethodReflection.php
+++ b/src/Reflection/MethodReflection.php
@@ -29,4 +29,6 @@ interface MethodReflection extends ClassMemberReflection
 
 	public function hasSideEffects(): TrinaryLogic;
 
+	public function isReturnByReference(): bool;
+
 }

--- a/src/Reflection/Native/NativeFunctionReflection.php
+++ b/src/Reflection/Native/NativeFunctionReflection.php
@@ -82,4 +82,9 @@ class NativeFunctionReflection implements \PHPStan\Reflection\FunctionReflection
 		return $this->hasSideEffects;
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -152,4 +152,9 @@ class NativeMethodReflection implements MethodReflection
 		return $this->reflection->getDocComment();
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return $this->reflection->isReturnByReference();
+	}
+
 }

--- a/src/Reflection/ObjectTypeMethodReflection.php
+++ b/src/Reflection/ObjectTypeMethodReflection.php
@@ -108,7 +108,8 @@ class ObjectTypeMethodReflection implements MethodReflection
 				);
 			}, $acceptor->getParameters()),
 			$acceptor->isVariadic(),
-			$acceptor->getReturnType()
+			$acceptor->getReturnType(),
+			$this->isReturnByReference()
 		);
 	}
 
@@ -140,6 +141,11 @@ class ObjectTypeMethodReflection implements MethodReflection
 	public function hasSideEffects(): TrinaryLogic
 	{
 		return $this->reflection->hasSideEffects();
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return $this->reflection->isReturnByReference();
 	}
 
 }

--- a/src/Reflection/ParametersAcceptor.php
+++ b/src/Reflection/ParametersAcceptor.php
@@ -27,4 +27,6 @@ interface ParametersAcceptor
 
 	public function getReturnType(): Type;
 
+	public function isReturnByReference(): bool;
+
 }

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -254,7 +254,8 @@ class ParametersAcceptorSelector
 			null,
 			$parameters,
 			$isVariadic,
-			$returnType
+			$returnType,
+			false // @todo
 		);
 	}
 

--- a/src/Reflection/Php/BuiltinMethodReflection.php
+++ b/src/Reflection/Php/BuiltinMethodReflection.php
@@ -53,4 +53,6 @@ interface BuiltinMethodReflection
 
 	public function isAbstract(): bool;
 
+	public function isReturnByReference(): bool;
+
 }

--- a/src/Reflection/Php/ClosureCallMethodReflection.php
+++ b/src/Reflection/Php/ClosureCallMethodReflection.php
@@ -89,7 +89,8 @@ final class ClosureCallMethodReflection implements MethodReflection
 				$this->closureType->getResolvedTemplateTypeMap(),
 				$parameters,
 				$this->closureType->isVariadic(),
-				$this->closureType->getReturnType()
+				$this->closureType->getReturnType(),
+				$this->closureType->isReturnByReference()
 			),
 		];
 	}
@@ -122,6 +123,11 @@ final class ClosureCallMethodReflection implements MethodReflection
 	public function hasSideEffects(): TrinaryLogic
 	{
 		return $this->nativeMethodReflection->hasSideEffects();
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return $this->nativeMethodReflection->isReturnByReference();
 	}
 
 }

--- a/src/Reflection/Php/FakeBuiltinMethodReflection.php
+++ b/src/Reflection/Php/FakeBuiltinMethodReflection.php
@@ -119,4 +119,9 @@ class FakeBuiltinMethodReflection implements BuiltinMethodReflection
 		return [];
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Php/NativeBuiltinMethodReflection.php
+++ b/src/Reflection/Php/NativeBuiltinMethodReflection.php
@@ -117,4 +117,9 @@ class NativeBuiltinMethodReflection implements BuiltinMethodReflection
 		return $this->reflection->getParameters();
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return $this->reflection->returnsReference();
+	}
+
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -472,7 +472,8 @@ class PhpClassReflectionExtension
 						);
 					}, $methodSignature->getParameters()),
 					$methodSignature->isVariadic(),
-					$phpDocReturnType ?? $methodSignature->getReturnType()
+					$phpDocReturnType ?? $methodSignature->getReturnType(),
+					false // @todo isReturnByReference
 				);
 			}
 

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -133,6 +133,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 					$this->getParameters(),
 					$this->isVariadic(),
 					$this->getReturnType(),
+					$this->isReturnByReference(),
 					$this->phpDocReturnType ?? new MixedType(),
 					$this->realReturnType
 				),
@@ -234,6 +235,11 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 			return TrinaryLogic::createYes();
 		}
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return false;
 	}
 
 }

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -139,6 +139,7 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 					$this->getParameters(),
 					$this->isVariadic(),
 					$this->getReturnType(),
+					$this->isReturnByReference(),
 					$this->getPhpDocReturnType(),
 					$this->getNativeReturnType()
 				),
@@ -289,6 +290,11 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 			return TrinaryLogic::createYes();
 		}
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return $this->reflection->returnsReference();
 	}
 
 }

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -240,6 +240,7 @@ class PhpMethodReflection implements MethodReflection
 					$this->getParameters(),
 					$this->isVariadic(),
 					$this->getReturnType(),
+					$this->isReturnByReference(),
 					$this->getPhpDocReturnType(),
 					$this->getNativeReturnType()
 				),
@@ -464,6 +465,11 @@ class PhpMethodReflection implements MethodReflection
 			return TrinaryLogic::createYes();
 		}
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return $this->reflection->isReturnByReference();
 	}
 
 }

--- a/src/Reflection/ResolvedFunctionVariant.php
+++ b/src/Reflection/ResolvedFunctionVariant.php
@@ -84,4 +84,9 @@ class ResolvedFunctionVariant implements ParametersAcceptor
 		return $type;
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return $this->parametersAcceptor->isReturnByReference();
+	}
+
 }

--- a/src/Reflection/ResolvedMethodReflection.php
+++ b/src/Reflection/ResolvedMethodReflection.php
@@ -122,4 +122,9 @@ class ResolvedMethodReflection implements MethodReflection
 		return $this->reflection->hasSideEffects();
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return $this->reflection->isReturnByReference();
+	}
+
 }

--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -79,7 +79,8 @@ class NativeFunctionReflectionProvider
 					);
 				}, $functionSignature->getParameters()),
 				$functionSignature->isVariadic(),
-				$returnType
+				$returnType,
+				false // @todo
 			);
 
 			$i++;

--- a/src/Reflection/TrivialParametersAcceptor.php
+++ b/src/Reflection/TrivialParametersAcceptor.php
@@ -37,4 +37,9 @@ class TrivialParametersAcceptor implements ParametersAcceptor
 		return new MixedType();
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return false;
+	}
+
 }

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -93,7 +93,8 @@ class IntersectionTypeMethodReflection implements MethodReflection
 				$acceptor->getResolvedTemplateTypeMap(),
 				$acceptor->getParameters(),
 				$acceptor->isVariadic(),
-				$returnType
+				$returnType,
+				$acceptor->isReturnByReference()
 			);
 		}, $variants);
 	}
@@ -171,6 +172,11 @@ class IntersectionTypeMethodReflection implements MethodReflection
 	public function getDocComment(): ?string
 	{
 		return null;
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return false; // @todo ???
 	}
 
 }

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -93,7 +93,8 @@ class UnionTypeMethodReflection implements MethodReflection
 				$acceptor->getResolvedTemplateTypeMap(),
 				$acceptor->getParameters(),
 				$acceptor->isVariadic(),
-				$returnType
+				$returnType,
+				$acceptor->isReturnByReference()
 			);
 		}, $variants);
 	}
@@ -171,6 +172,17 @@ class UnionTypeMethodReflection implements MethodReflection
 	public function getDocComment(): ?string
 	{
 		return null;
+	}
+
+	public function isReturnByReference(): bool
+	{
+		foreach ($this->methods as $method) {
+			if (!$method->isReturnByReference()) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 }

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -32,6 +32,9 @@ class CallableType implements CompoundType, ParametersAcceptor
 	private $variadic;
 
 	/** @var bool */
+	private $returnByReference;
+
+	/** @var bool */
 	private $isCommonCallable;
 
 	/**
@@ -42,12 +45,14 @@ class CallableType implements CompoundType, ParametersAcceptor
 	public function __construct(
 		?array $parameters = null,
 		?Type $returnType = null,
-		bool $variadic = true
+		bool $variadic = true,
+		bool $returnByReference = false // @todo
 	)
 	{
 		$this->parameters = $parameters ?? [];
 		$this->returnType = $returnType ?? new MixedType();
 		$this->variadic = $variadic;
+		$this->returnByReference = $returnByReference;
 		$this->isCommonCallable = $parameters === null && $returnType === null;
 	}
 
@@ -208,6 +213,11 @@ class CallableType implements CompoundType, ParametersAcceptor
 	public function getReturnType(): Type
 	{
 		return $this->returnType;
+	}
+
+	public function isReturnByReference(): bool
+	{
+		return $this->returnByReference;
 	}
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -35,6 +35,9 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 	/** @var bool */
 	private $variadic;
 
+	/** @var bool */
+	private $returnByReference;
+
 	/**
 	 * @param array<int, \PHPStan\Reflection\ParameterReflection> $parameters
 	 * @param Type $returnType
@@ -43,13 +46,15 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 	public function __construct(
 		array $parameters,
 		Type $returnType,
-		bool $variadic
+		bool $variadic,
+		bool $returnByReference
 	)
 	{
 		$this->objectType = new ObjectType(\Closure::class);
 		$this->parameters = $parameters;
 		$this->returnType = $returnType;
 		$this->variadic = $variadic;
+		$this->returnByReference = $returnByReference;
 	}
 
 	public function getClassName(): string
@@ -306,6 +311,11 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return $this->returnType;
 	}
 
+	public function isReturnByReference(): bool
+	{
+		return $this->returnByReference;
+	}
+
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
 		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
@@ -357,7 +367,8 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 				);
 			}, $this->getParameters()),
 			$cb($this->getReturnType()),
-			$this->isVariadic()
+			$this->isVariadic(),
+			$this->isReturnByReference()
 		);
 	}
 
@@ -375,7 +386,8 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return new self(
 			$properties['parameters'],
 			$properties['returnType'],
-			$properties['variadic']
+			$properties['variadic'],
+			$properties['returnByReference']
 		);
 	}
 

--- a/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
@@ -36,7 +36,8 @@ class ClosureFromCallableDynamicReturnTypeExtension implements \PHPStan\Type\Dyn
 			$closureTypes[] = new ClosureType(
 				$parameters,
 				$variant->getReturnType(),
-				$variant->isVariadic()
+				$variant->isVariadic(),
+				$variant->isReturnByReference() // @todo Bugged in PHP <https://bugs.php.net/bug.php?id=75474>
 			);
 		}
 

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -17,7 +17,7 @@ class InstantiationRuleTest extends \PHPStan\Testing\RuleTestCase
 		$broker = $this->createReflectionProvider();
 		return new InstantiationRule(
 			$broker,
-			new FunctionCallParametersCheck(new RuleLevelHelper($broker, true, false, true), true, true, true, true),
+			new FunctionCallParametersCheck($broker, new RuleLevelHelper($broker, true, false, true), true, true, true, true),
 			new ClassCaseSensitivityCheck($broker)
 		);
 	}

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -16,6 +16,7 @@ class CallCallablesRuleTest extends \PHPStan\Testing\RuleTestCase
 		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true);
 		return new CallCallablesRule(
 			new FunctionCallParametersCheck(
+				$this->createReflectionProvider(),
 				$ruleLevelHelper,
 				true,
 				true,

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -16,7 +16,7 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		$broker = $this->createReflectionProvider();
 		return new CallToFunctionParametersRule(
 			$broker,
-			new FunctionCallParametersCheck(new RuleLevelHelper($broker, true, false, true), true, true, true, true)
+			new FunctionCallParametersCheck($broker, new RuleLevelHelper($broker, true, false, true), true, true, true, true)
 		);
 	}
 
@@ -213,15 +213,15 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		$this->analyse([__DIR__ . '/data/passed-by-reference.php'], [
 			[
 				'Parameter #1 $foo of function PassedByReference\foo is passed by reference, so it expects variables only.',
-				32,
+				60,
 			],
 			[
 				'Parameter #1 $foo of function PassedByReference\foo is passed by reference, so it expects variables only.',
-				33,
+				61,
 			],
 			[
 				'Parameter #1 $array_arg of function reset expects array, null given.',
-				39,
+				67,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/passed-by-reference.php
+++ b/tests/PHPStan/Rules/Functions/data/passed-by-reference.php
@@ -7,6 +7,13 @@ function foo(&$foo)
 
 }
 
+function &getRef(): string
+{
+	static $ref = 'testing';
+
+	return $ref;
+}
+
 class Bar
 {
 
@@ -16,8 +23,28 @@ class Bar
 
 	public function doBar()
 	{
+		$bar = 'Bar';
+
 		foo($this->barProperty); // ok
 		foo(self::$staticBarProperty); // ok
+		foo($this->getInstanceRef()); // ok
+		foo(self::getStaticRef()); // ok
+		foo($bar::getStaticRef()); // ok
+
+		$method = [$bar, 'getStaticRef'];
+		foo($method());
+		$method = "$bar::getStaticRef";
+		foo($method());
+	}
+
+	public function &getInstanceRef()
+	{
+		return $this->barProperty;
+	}
+
+	public static function &getStaticRef()
+	{
+		return self::$staticBarProperty;
 	}
 
 }
@@ -28,6 +55,8 @@ function () {
 
 	$arr = [1, 2, 3];
 	foo($arr[0]); // ok
+
+	foo(getRef()); // ok
 
 	foo(rand());
 	foo(null);

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -27,7 +27,7 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 		$ruleLevelHelper = new RuleLevelHelper($broker, $this->checkNullables, $this->checkThisOnly, $this->checkUnionTypes);
 		return new CallMethodsRule(
 			$broker,
-			new FunctionCallParametersCheck($ruleLevelHelper, true, true, true, true),
+			new FunctionCallParametersCheck($broker, $ruleLevelHelper, true, true, true, true),
 			$ruleLevelHelper,
 			true,
 			true

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -21,7 +21,7 @@ class CallStaticMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 		$ruleLevelHelper = new RuleLevelHelper($broker, true, $this->checkThisOnly, true);
 		return new CallStaticMethodsRule(
 			$broker,
-			new FunctionCallParametersCheck($ruleLevelHelper, true, true, true, true),
+			new FunctionCallParametersCheck($broker, $ruleLevelHelper, true, true, true, true),
 			$ruleLevelHelper,
 			new ClassCaseSensitivityCheck($broker),
 			true,


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/757

Not quite an easy fix this, as there does not appear to be anyway in PHPStan to tell if a function returns a reference.

I've made it a boolean method in the reflection API currently but I'm actually wondering if it should be described via a type. I assumed that a function can either return a reference or not, which is true of userland code but then I checked `call_user_func()` and co and sure enough they will return a reference if that is what you return. https://3v4l.org/goJWZ

If this approach is fine I'm a bit stumped on how to deal with dynamic method calls.

#### TODO

* [ ] Handle `call_user_func()` and `call_user_func_array()` magic references