### PR TITLE
Remove unused coalesce

### DIFF
--- a/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpParameterFromParserNodeReflection.php
@@ -86,7 +86,7 @@ class PhpParameterFromParserNodeReflection implements \PHPStan\Reflection\Parame
 
 	public function getNativeType(): Type
 	{
-		return $this->realType ?? new MixedType();
+		return $this->realType;
 	}
 
 	public function passedByReference(): PassedByReference


### PR DESCRIPTION
`$this->realType` is set in the constructor and cannot be null. The rule added in #36 picked this up.