### PR TITLE
Add ArrayAccess rule to AppendedArrayItemTypeRule

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2202,11 +2202,18 @@ class NodeScopeResolver
 	{
 		$nodeCallback($var, $enterExpressionAssign ? $scope->enterExpressionAssign($var) : $scope);
 		$hasYield = false;
+		$arrayDimFetchVarTypeType = $var instanceof ArrayDimFetch ? $scope->getType($var->var) : null;
 		if ($var instanceof Variable && is_string($var->name)) {
 			$result = $processExprCallback($scope);
 			$hasYield = $result->hasYield();
 			$scope = $result->getScope();
 			$scope = $scope->assignVariable($var->name, $scope->getType($assignedExpr));
+		} elseif ($arrayDimFetchVarTypeType instanceof ObjectType && $arrayDimFetchVarTypeType->isInstanceOf(\ArrayAccess::class)->yes()) {
+			$result = $processExprCallback($scope);
+			$hasYield = $result->hasYield();
+			$scope = $result->getScope();
+			$scope = $scope->assignExpression($var, $scope->getType($assignedExpr));
+
 		} elseif ($var instanceof ArrayDimFetch) {
 			$dimExprStack = [];
 			while ($var instanceof ArrayDimFetch) {

--- a/src/Rules/Arrays/AppendedArrayItemTypeRule.php
+++ b/src/Rules/Arrays/AppendedArrayItemTypeRule.php
@@ -88,7 +88,7 @@ class AppendedArrayItemTypeRule implements \PHPStan\Rules\Rule
 
 			if (!$this->ruleLevelHelper->accepts($tValue, $assignedValueType, $scope->isDeclareStrictTypes())) {
 				$verbosityLevel = VerbosityLevel::typeOnly();
-				if ($varType->getClassName() == \ArrayAccess::class) {
+				if ($varType->getClassName() === \ArrayAccess::class) {
 					$varName = $varType->describe($verbosityLevel);
 				} else {
 					$tKey = GenericTypeVariableResolver::getType($varType, \ArrayAccess::class, 'TKey');

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -596,8 +596,16 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return TrinaryLogic::createNo();
 		}
 
+		if ($this->isInstanceOf(\ArrayAccess::class)->yes()) {
+			$tKey = GenericTypeVariableResolver::getType($this, \ArrayAccess::class, 'TKey');
+			if ($tKey !== null && $tKey->isSuperTypeOf($offsetType)->no()) {
+				return TrinaryLogic::createNo();
+			}
+
+			return TrinaryLogic::createMaybe();
+		}
+
 		return $this->isExtraOffsetAccessibleClass()
-			->or($this->isInstanceOf(\ArrayAccess::class))
 			->and(TrinaryLogic::createMaybe());
 	}
 

--- a/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
@@ -52,6 +52,22 @@ class AppendedArrayItemTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 					'Array (array<AppendedArrayItem\Lorem>) does not accept AppendedArrayItem\Baz.',
 					77,
 				],
+				[
+					'ArrayAccess<int, int> does not accept string.',
+					85,
+				],
+				[
+					'ArrayAccess<int, int> does not accept string.',
+					87,
+				],
+				[
+					'ArrayAccess<int, int> does not accept string.',
+					90,
+				],
+				[
+					'ArrayAccess<int, int> does not accept array<int, string>.',
+					91,
+				],
 			]
 		);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
+++ b/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
@@ -76,3 +76,17 @@ function (Lorem $lorem)
 {
 	$lorem->staticProperty[] = new Baz();
 };
+
+function()
+{
+	/** @var \ArrayAccess<int,int> $arrayAccess */
+	$arrayAccess = [];
+
+	$arrayAccess[] = 'foo';
+	$arrayAccess[] = 1;
+	$arrayAccess[2] = 'bar';
+	$i = 1;
+	$arrayAccess[] = $i;
+	$arrayAccess[] = 'baz';
+	$arrayAccess[] = ['foo'];
+};

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -431,4 +431,69 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('Traversable<mixed,mixed>', $classReflection->getDisplayName());
 	}
 
+	public function dataHasOffsetValueType(): array
+	{
+		return [
+			[
+				new ObjectType(\stdClass::class),
+				new IntegerType(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new ObjectType(\ArrayAccess::class),
+				new IntegerType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new GenericObjectType(\ArrayAccess::class, [new IntegerType(), new MixedType()]),
+				new IntegerType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new GenericObjectType(\ArrayAccess::class, [new IntegerType(), new MixedType()]),
+				new MixedType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new GenericObjectType(\ArrayAccess::class, [new IntegerType(), new MixedType()]),
+				new StringType(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new GenericObjectType(\ArrayAccess::class, [new ObjectType(\DateTimeInterface::class), new MixedType()]),
+				new ObjectType(\DateTime::class),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new GenericObjectType(\ArrayAccess::class, [new ObjectType(\DateTime::class), new MixedType()]),
+				new ObjectType(\DateTimeInterface::class),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new GenericObjectType(\ArrayAccess::class, [new ObjectType(\DateTime::class), new MixedType()]),
+				new ObjectType(\stdClass::class),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataHasOffsetValueType
+	 * @param \PHPStan\Type\ObjectType $type
+	 * @param Type $offsetType
+	 * @param TrinaryLogic $expectedResult
+	 */
+	public function testHasOffsetValueType(
+		ObjectType $type,
+		Type $offsetType,
+		TrinaryLogic $expectedResult
+	): void
+	{
+		$this->assertSame(
+			$expectedResult->describe(),
+			$type->hasOffsetValueType($offsetType)->describe(),
+			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $offsetType->describe(VerbosityLevel::precise()))
+		);
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/2858

`PHPStan\Rules\Arrays\OffsetAccessAssignmentRule` is reporting offset errors of `ArrayAccess` in current version.

This commit changed the handling of the `ArrayDimFetch` in the `NodeScopeResolver`, so I'm not sure if this approach was appropriate, but the existing tests did not fail.