### PR TITLE
add memoize cache on ClassReflection::isGeneric()

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -61,6 +61,9 @@ class ClassReflection implements ReflectionWithFilename
 	private $isDeprecated;
 
 	/** @var bool|null */
+	private $isGeneric;
+
+	/** @var bool|null */
 	private $isInternal;
 
 	/** @var bool|null */
@@ -709,7 +712,11 @@ class ClassReflection implements ReflectionWithFilename
 
 	public function isGeneric(): bool
 	{
-		return count($this->getTemplateTags()) > 0;
+		if ($this->isGeneric === null) {
+			$this->isGeneric = count($this->getTemplateTags()) > 0;
+		}
+
+		return $this->isGeneric;
 	}
 
 	/**


### PR DESCRIPTION
isGeneric is called way too much and has no cache, causing the parsing of getTemplateTags again and again.

![image](https://user-images.githubusercontent.com/84887/73285806-de909900-41f6-11ea-8042-c17a21bf1112.png)


![image](https://user-images.githubusercontent.com/84887/73285704-b6a13580-41f6-11ea-8885-e55eb4e775a9.png)
