### PR TITLE
Report callables with no prototypes

### DIFF
--- a/conf/config.level6.neon
+++ b/conf/config.level6.neon
@@ -4,6 +4,7 @@ includes:
 parameters:
 	checkGenericClassInNonGenericObjectType: true
 	checkMissingIterableValueType: true
+	checkMissingCallablePrototype: true
 	checkMissingVarTagTypehint: true
 	checkMissingTypehints: true
 

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -36,6 +36,7 @@ parameters:
 	checkGenericClassInNonGenericObjectType: false
 	checkInternalClassCaseSensitivity: false
 	checkMissingIterableValueType: false
+	checkMissingCallablePrototype: false
 	checkMissingVarTagTypehint: false
 	checkArgumentsPassedByReference: false
 	checkMaybeUndefinedVariables: false
@@ -186,6 +187,7 @@ parametersSchema:
 	checkGenericClassInNonGenericObjectType: bool()
 	checkInternalClassCaseSensitivity: bool()
 	checkMissingIterableValueType: bool()
+	checkMissingCallablePrototype: bool()
 	checkMissingVarTagTypehint: bool()
 	checkArgumentsPassedByReference: bool()
 	checkMaybeUndefinedVariables: bool()
@@ -727,6 +729,7 @@ services:
 		arguments:
 			checkMissingIterableValueType: %checkMissingIterableValueType%
 			checkGenericClassInNonGenericObjectType: %checkGenericClassInNonGenericObjectType%
+			checkMissingCallablePrototype: %checkMissingCallablePrototype%
 
 	-
 		class: PHPStan\Rules\NullsafeCheck

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -36,8 +36,8 @@ class AnalyserRunner
 	/**
 	 * @param string[] $files
 	 * @param string[] $allAnalysedFiles
-	 * @param \Closure|null $preFileCallback
-	 * @param \Closure|null $postFileCallback
+	 * @param (\Closure(string $file): void)|null $preFileCallback
+	 * @param (\Closure(int): void)|null $postFileCallback
 	 * @param bool $debug
 	 * @param bool $allowParallel
 	 * @param string|null $projectConfigFile

--- a/src/Rules/Functions/MissingFunctionParameterTypehintRule.php
+++ b/src/Rules/Functions/MissingFunctionParameterTypehintRule.php
@@ -92,6 +92,15 @@ final class MissingFunctionParameterTypehintRule implements \PHPStan\Rules\Rule
 			))->tip(MissingTypehintCheck::TURN_OFF_NON_GENERIC_CHECK_TIP)->build();
 		}
 
+		foreach ($this->missingTypehintCheck->getCallablesWithMissingPrototype($parameterType) as $callableType) {
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Function %s() has parameter $%s with no prototype specified for callable type %s.',
+				$functionReflection->getName(),
+				$parameterReflection->getName(),
+				$callableType->describe(VerbosityLevel::typeOnly())
+			))->build();
+		}
+
 		return $messages;
 	}
 

--- a/src/Rules/Functions/MissingFunctionReturnTypehintRule.php
+++ b/src/Rules/Functions/MissingFunctionReturnTypehintRule.php
@@ -65,6 +65,14 @@ final class MissingFunctionReturnTypehintRule implements \PHPStan\Rules\Rule
 			))->tip(MissingTypehintCheck::TURN_OFF_NON_GENERIC_CHECK_TIP)->build();
 		}
 
+		foreach ($this->missingTypehintCheck->getCallablesWithMissingPrototype($returnType) as $callableType) {
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Function %s() return type has no prototype specified for callable type %s.',
+				$functionReflection->getName(),
+				$callableType->describe(VerbosityLevel::typeOnly())
+			))->build();
+		}
+
 		return $messages;
 	}
 

--- a/src/Rules/Methods/MissingMethodParameterTypehintRule.php
+++ b/src/Rules/Methods/MissingMethodParameterTypehintRule.php
@@ -92,6 +92,16 @@ final class MissingMethodParameterTypehintRule implements \PHPStan\Rules\Rule
 			))->tip(MissingTypehintCheck::TURN_OFF_NON_GENERIC_CHECK_TIP)->build();
 		}
 
+		foreach ($this->missingTypehintCheck->getCallablesWithMissingPrototype($parameterType) as $callableType) {
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Method %s::%s() has parameter $%s with no prototype specified for callable type %s.',
+				$methodReflection->getDeclaringClass()->getDisplayName(),
+				$methodReflection->getName(),
+				$parameterReflection->getName(),
+				$callableType->describe(VerbosityLevel::typeOnly())
+			))->build();
+		}
+
 		return $messages;
 	}
 

--- a/src/Rules/Methods/MissingMethodReturnTypehintRule.php
+++ b/src/Rules/Methods/MissingMethodReturnTypehintRule.php
@@ -70,6 +70,15 @@ final class MissingMethodReturnTypehintRule implements \PHPStan\Rules\Rule
 			))->tip(MissingTypehintCheck::TURN_OFF_NON_GENERIC_CHECK_TIP)->build();
 		}
 
+		foreach ($this->missingTypehintCheck->getCallablesWithMissingPrototype($returnType) as $callableType) {
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Method %s::%s() return type has no prototype specified for callable type %s.',
+				$methodReflection->getDeclaringClass()->getDisplayName(),
+				$methodReflection->getName(),
+				$callableType->describe(VerbosityLevel::typeOnly())
+			))->build();
+		}
+
 		return $messages;
 	}
 

--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -3,10 +3,10 @@
 namespace PHPStan\Rules;
 
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\CallableType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
-use PHPStan\Type\CallableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -143,14 +143,15 @@ class MissingTypehintCheck
 	 * @param \PHPStan\Type\Type $type
 	 * @return \PHPStan\Type\Type[]
 	 */
-	public function getCallablesWithMissingPrototype(Type $type): array{
+	public function getCallablesWithMissingPrototype(Type $type): array
+	{
 		if (!$this->checkMissingCallablePrototype) {
 			return [];
 		}
 
 		$result = [];
-		TypeTraverser::map($type, function (Type $type, callable $traverse) use (&$result): Type {
-			if(
+		TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$result): Type {
+			if (
 				($type instanceof CallableType && $type->isCommonCallable()) ||
 				($type instanceof ObjectType && $type->getClassName() === \Closure::class)) {
 				$result[] = $type;

--- a/src/Rules/Properties/MissingPropertyTypehintRule.php
+++ b/src/Rules/Properties/MissingPropertyTypehintRule.php
@@ -67,6 +67,15 @@ final class MissingPropertyTypehintRule implements \PHPStan\Rules\Rule
 			))->tip(MissingTypehintCheck::TURN_OFF_NON_GENERIC_CHECK_TIP)->build();
 		}
 
+		foreach ($this->missingTypehintCheck->getCallablesWithMissingPrototype($propertyType) as $callableType) {
+			$messages[] = RuleErrorBuilder::message(sprintf(
+				'Property %s::$%s type has no prototype specified for callable type %s.',
+				$propertyReflection->getDeclaringClass()->getDisplayName(),
+				$node->name->name,
+				$callableType->describe(VerbosityLevel::typeOnly())
+			))->build();
+		}
+
 		return $messages;
 	}
 

--- a/src/Rules/Properties/MissingPropertyTypehintRule.php
+++ b/src/Rules/Properties/MissingPropertyTypehintRule.php
@@ -71,7 +71,7 @@ final class MissingPropertyTypehintRule implements \PHPStan\Rules\Rule
 			$messages[] = RuleErrorBuilder::message(sprintf(
 				'Property %s::$%s type has no prototype specified for callable type %s.',
 				$propertyReflection->getDeclaringClass()->getDisplayName(),
-				$node->name->name,
+				$node->getName(),
 				$callableType->describe(VerbosityLevel::typeOnly())
 			))->build();
 		}

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -298,6 +298,11 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return TrinaryLogic::createNo();
 	}
 
+	public function isCommonCallable(): bool
+	{
+		return $this->isCommonCallable;
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 * @return Type

--- a/tests/PHPStan/Analyser/data/Foo-callable.php
+++ b/tests/PHPStan/Analyser/data/Foo-callable.php
@@ -7,7 +7,7 @@ namespace RecursionCallable;
 class Foo
 {
 	/**
-	 * @param Foo|callable $xxx
+	 * @param Foo|(callable(): mixed) $xxx
 	 */
 	public function abc($xxx): void
 	{

--- a/tests/PHPStan/Levels/data/acceptTypes-6.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-6.json
@@ -151,12 +151,12 @@
     },
     {
         "message": "Method Levels\\AcceptTypes\\ArrayShapes::doFoo() has parameter $callables with no prototype specified for callable type callable.",
-        "line": 561,
+        "line": 570,
         "ignorable": true
     },
     {
         "message": "Method Levels\\AcceptTypes\\ArrayShapes::doFoo() has parameter $iterable with no prototype specified for callable type callable.",
-        "line": 561,
+        "line": 570,
         "ignorable": true
     },
     {
@@ -166,7 +166,7 @@
     },
     {
         "message": "Method Levels\\AcceptTypes\\ArrayShapes::doBar() has parameter $one with no prototype specified for callable type callable.",
-        "line": 594,
+        "line": 603,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/acceptTypes-6.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-6.json
@@ -55,6 +55,11 @@
         "ignorable": true
     },
     {
+        "message": "Method Levels\\AcceptTypes\\Foo::expectCallable() has parameter $callable with no prototype specified for callable type callable.",
+        "line": 148,
+        "ignorable": true
+    },
+    {
         "message": "Method Levels\\AcceptTypes\\Foo::iterableCountable() has no return typehint specified.",
         "line": 160,
         "ignorable": true
@@ -145,8 +150,23 @@
         "ignorable": true
     },
     {
+        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doFoo() has parameter $callables with no prototype specified for callable type callable.",
+        "line": 561,
+        "ignorable": true
+    },
+    {
+        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doFoo() has parameter $iterable with no prototype specified for callable type callable.",
+        "line": 561,
+        "ignorable": true
+    },
+    {
         "message": "Method Levels\\AcceptTypes\\ArrayShapes::doBar() has no return typehint specified.",
         "line": 603,
+        "ignorable": true
+    },
+    {
+        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doBar() has parameter $one with no prototype specified for callable type callable.",
+        "line": 594,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/casts.php
+++ b/tests/PHPStan/Levels/data/casts.php
@@ -7,7 +7,7 @@ class Foo
 
 	/**
 	 * @param mixed[] $array
-	 * @param mixed[]|callable $arrayOrCallable
+	 * @param mixed[]|(callable(): mixed) $arrayOrCallable
 	 * @param mixed[]|float|int $arrayOrFloatOrInt
 	 */
 	public function doFoo(

--- a/tests/PHPStan/Levels/data/echo_.php
+++ b/tests/PHPStan/Levels/data/echo_.php
@@ -8,7 +8,7 @@ class Foo
 {
 	/**
 	 * @param mixed[] $array
-	 * @param mixed[]|callable $arrayOrCallable
+	 * @param mixed[]|(callable(): mixed) $arrayOrCallable
 	 * @param mixed[]|float|int $arrayOrFloatOrInt
 	 * @param mixed[]|string $arrayOrString
 	 */

--- a/tests/PHPStan/Levels/data/encapsedString.php
+++ b/tests/PHPStan/Levels/data/encapsedString.php
@@ -7,7 +7,7 @@ class Foo
 
 	/**
 	 * @param mixed[] $array
-	 * @param mixed[]|callable $arrayOrCallable
+	 * @param mixed[]|(callable(): mixed) $arrayOrCallable
 	 * @param mixed[]|float|int $arrayOrFloatOrInt
 	 * @param mixed[]|string $arrayOrString
 	 */

--- a/tests/PHPStan/Levels/data/print_.php
+++ b/tests/PHPStan/Levels/data/print_.php
@@ -8,7 +8,7 @@ class Foo
 {
 	/**
 	 * @param mixed[] $array
-	 * @param mixed[]|callable $arrayOrCallable
+	 * @param mixed[]|(callable(): mixed) $arrayOrCallable
 	 * @param mixed[]|float|int $arrayOrFloatOrInt
 	 * @param mixed[]|string $arrayOrString
 	 */

--- a/tests/PHPStan/Rules/Classes/MixinRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinRuleTest.php
@@ -24,7 +24,7 @@ class MixinRuleTest extends RuleTestCase
 			$reflectionProvider,
 			new ClassCaseSensitivityCheck($reflectionProvider),
 			new GenericObjectTypeCheck(),
-			new MissingTypehintCheck($reflectionProvider, true, true),
+			new MissingTypehintCheck($reflectionProvider, true, true, true),
 			true
 		);
 	}

--- a/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
@@ -13,7 +13,7 @@ class MissingFunctionParameterTypehintRuleTest extends \PHPStan\Testing\RuleTest
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		$broker = $this->createReflectionProvider();
-		return new MissingFunctionParameterTypehintRule(new MissingTypehintCheck($broker, true, true));
+		return new MissingFunctionParameterTypehintRule(new MissingTypehintCheck($broker, true, true, true));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
@@ -48,6 +48,18 @@ class MissingFunctionReturnTypehintRuleTest extends \PHPStan\Testing\RuleTestCas
 				105,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
+			[
+				'Function MissingFunctionReturnTypehint\closureWithNoPrototype() return type has no prototype specified for callable type Closure.',
+				113,
+			],
+			[
+				'Function MissingFunctionReturnTypehint\callableWithNoPrototype() return type has no prototype specified for callable type callable.',
+				127,
+			],
+			[
+				'Function MissingFunctionReturnTypehint\callableNestedNoPrototype() return type has no prototype specified for callable type callable.',
+				141,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
@@ -13,7 +13,7 @@ class MissingFunctionReturnTypehintRuleTest extends \PHPStan\Testing\RuleTestCas
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		$broker = $this->createReflectionProvider();
-		return new MissingFunctionReturnTypehintRule(new MissingTypehintCheck($broker, true, true));
+		return new MissingFunctionReturnTypehintRule(new MissingTypehintCheck($broker, true, true, true));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Functions/data/missing-function-return-typehint.php
+++ b/tests/PHPStan/Rules/Functions/data/missing-function-return-typehint.php
@@ -106,4 +106,46 @@ namespace MissingFunctionReturnTypehint
 	{
 
 	}
+
+	/**
+	 * @return \Closure
+	 */
+	function closureWithNoPrototype() : \Closure{
+
+	}
+
+	/**
+	 * @return \Closure(int) : void
+	 */
+	function closureWithPrototype() : \Closure{
+
+	}
+
+	/**
+	 * @return callable
+	 */
+	function callableWithNoPrototype() : callable{
+
+	}
+
+	/**
+	 * @return callable(int) : void
+	 */
+	function callableWithPrototype() : callable{
+
+	}
+
+	/**
+	 * @return callable(callable) : void
+	 */
+	function callableNestedNoPrototype() : callable{
+
+	}
+
+	/**
+	 * @return callable(callable(int) : void) : void
+	 */
+	function callableNestedWithPrototype() : callable{
+
+	}
 }

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -13,7 +13,7 @@ class MissingMethodParameterTypehintRuleTest extends \PHPStan\Testing\RuleTestCa
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		$broker = $this->createReflectionProvider();
-		return new MissingMethodParameterTypehintRule(new MissingTypehintCheck($broker, true, true));
+		return new MissingMethodParameterTypehintRule(new MissingTypehintCheck($broker, true, true, true));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -13,7 +13,7 @@ class MissingMethodReturnTypehintRuleTest extends \PHPStan\Testing\RuleTestCase
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		$broker = $this->createReflectionProvider();
-		return new MissingMethodReturnTypehintRule(new MissingTypehintCheck($broker, true, true));
+		return new MissingMethodReturnTypehintRule(new MissingTypehintCheck($broker, true, true, true));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -23,7 +23,7 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 			$broker,
 			new ClassCaseSensitivityCheck($broker),
 			new GenericObjectTypeCheck(),
-			new MissingTypehintCheck($broker, true, true),
+			new MissingTypehintCheck($broker, true, true, true),
 			true,
 			true
 		);

--- a/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -13,7 +13,7 @@ class MissingPropertyTypehintRuleTest extends \PHPStan\Testing\RuleTestCase
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		$broker = $this->createReflectionProvider();
-		return new MissingPropertyTypehintRule(new MissingTypehintCheck($broker, true, true));
+		return new MissingPropertyTypehintRule(new MissingTypehintCheck($broker, true, true, true));
 	}
 
 	public function testRule(): void


### PR DESCRIPTION
This pull request implements detection for callables which have no prototypes specified in their PhpDoc.

A new `checkMissingCallablePrototype` is introduced, which is enabled on level 6 and up.

related: phpstan/phpstan#2872