### PR TITLE
populate missing callable prototypes

### DIFF
--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -215,6 +215,7 @@ class FileTypeMapper
 	private function createResolvedPhpDocMap(string $fileName): array
 	{
 		$phpDocMap = $this->createFilePhpDocMap($fileName, null, null);
+		$resolvedPhpDocMap = [];
 
 		try {
 			$this->inProcess[$fileName] = $phpDocMap;
@@ -222,14 +223,14 @@ class FileTypeMapper
 			foreach ($phpDocMap as $phpDocKey => $resolveCallback) {
 				$this->inProcess[$fileName][$phpDocKey] = false;
 				$this->inProcess[$fileName][$phpDocKey] = $data = $resolveCallback();
-				$phpDocMap[$phpDocKey] = $data;
+				$resolvedPhpDocMap[$phpDocKey] = $data;
 			}
 
 		} finally {
 			unset($this->inProcess[$fileName]);
 		}
 
-		return $phpDocMap;
+		return $resolvedPhpDocMap;
 	}
 
 	/**

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -45,7 +45,7 @@ class FileTypeMapper
 	/** @var \PHPStan\PhpDoc\NameScopedPhpDocString[][] */
 	private $memoryCache = [];
 
-	/** @var (false|callable|\PHPStan\PhpDoc\NameScopedPhpDocString)[][] */
+	/** @var (false|(callable(): \PHPStan\PhpDoc\NameScopedPhpDocString)|\PHPStan\PhpDoc\NameScopedPhpDocString)[][] */
 	private $inProcess = [];
 
 	/** @var array<string, ResolvedPhpDocBlock> */
@@ -237,7 +237,7 @@ class FileTypeMapper
 	 * @param string|null $lookForTrait
 	 * @param string|null $traitUseClass
 	 * @param array<string, string> $traitMethodAliases
-	 * @return callable[]
+	 * @return (callable(): \PHPStan\PhpDoc\NameScopedPhpDocString)[]
 	 */
 	private function createFilePhpDocMap(
 		string $fileName,
@@ -246,7 +246,7 @@ class FileTypeMapper
 		array $traitMethodAliases = []
 	): array
 	{
-		/** @var callable[] $phpDocMap */
+		/** @var (callable(): \PHPStan\PhpDoc\NameScopedPhpDocString)[] $phpDocMap */
 		$phpDocMap = [];
 
 		/** @var (callable(): TemplateTypeMap)[] $typeMapStack */

--- a/src/Type/RecursionGuard.php
+++ b/src/Type/RecursionGuard.php
@@ -8,6 +8,12 @@ class RecursionGuard
 	/** @var true[] */
 	private static $context = [];
 
+	/**
+	 * @param Type $type
+	 * @param callable(): Type $callback
+	 *
+	 * @return Type
+	 */
 	public static function run(Type $type, callable $callback): Type
 	{
 		$key = $type->describe(VerbosityLevel::value());


### PR DESCRIPTION
The missing prototype on the `@var` tag inside `createFilePhpDocMap()` had to be spotted by eye, but the others were detected by #120.

It might be a good idea to have a rule checking for missing generics & prototypes in @var.