### PR TITLE
Imporve printf function rule

### DIFF
--- a/src/Rules/Functions/PrintfFormatStringHelper.php
+++ b/src/Rules/Functions/PrintfFormatStringHelper.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use Nette\Utils\Strings;
+
+/**
+ * Get information about PHP printf() format strings.
+ */
+class PrintfFormatStringHelper
+{
+
+	/** @var string */
+	private $format;
+
+	/** @var array<int,array{string,int,string}> */
+	private $placeholders;
+
+	public function __construct(string $format)
+	{
+		$this->format = $format;
+	}
+
+	/**
+	 * Get the number of arguments required to format the string.
+	 */
+	public function getNumberOfRequiredArguments(): int
+	{
+		$placeholders = $this->getPlaceholders();
+
+		return $placeholders === [] ? 0 : max(array_column($placeholders, 1));
+	}
+
+	/**
+	 * Get the placeholders in the format string.
+	 *
+	 * The result is an array of placeholders each an array containing 3 elements:
+	 * 0: Format specifier (underscore is used to denote an invalid specifier)
+	 * 1: Argument number (from 1)
+	 * 2: The placeholder from starting percent to specifier
+	 *
+	 * @return array<int,array{string,int,string}>
+	 */
+	public function getPlaceholders(): array
+	{
+		if ($this->placeholders === null) {
+			$this->placeholders = $this->parsePlaceholders();
+		}
+
+		return $this->placeholders;
+	}
+
+	/**
+	 * @return array<int,array{string,int,string}>
+	 */
+	private function parsePlaceholders(): array
+	{
+		$formatLength = strlen($this->format);
+		$pos = 0;
+
+		$currentArgument = 0;
+		$argumentNumber = 0;
+		$placeholders = [];
+
+		for ($pos = 0; $pos <= $formatLength; $pos++) {
+			$nextPos = strpos($this->format, '%', $pos);
+
+			// https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L418
+			if ($nextPos === false) {
+				break;
+			}
+
+			$pos = $nextPos;
+
+			\assert($this->format[$pos] === '%');
+			$pos++;
+
+			// Hit the end of the string at the starting percent.
+			if ($pos === $formatLength) {
+				$argumentNumber = $currentArgument++;
+				$placeholders[] = ['_', $argumentNumber, substr($this->format, $nextPos, $pos - $nextPos)];
+				break;
+			}
+
+			// https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L429
+			if ($this->format[$pos] === '%') {
+				continue;
+			}
+
+			// https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L443
+			if (Strings::match($this->format[$pos], '/^[a-zA-Z]$/') !== null) {
+				$argumentNumber = $currentArgument++;
+				$placeholders[] = [$this->format[$pos], $argumentNumber, substr($this->format, $nextPos, $pos - $nextPos + 1)];
+			} else {
+				// Argument... https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L447
+				if (null !== $matches = Strings::match(substr($this->format, $pos), '/^([0-9]+)\$/')) {
+					$argumentNumber = ((int) $matches[1]) - 1;
+					$pos += strlen($matches[0]);
+				} else {
+					$argumentNumber = $currentArgument++;
+				}
+
+				// Modifiers... https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L465
+				while (null !== $matches = Strings::match(substr($this->format, $pos), '/^([0 ]|-|\+|\'.)/')) {
+					$pos += strlen($matches[0]);
+				}
+
+				// Width... https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L491
+				if (null !== $matches = Strings::match(substr($this->format, $pos), '/^([0-9]+)/')) {
+					$pos += strlen($matches[0]);
+				}
+
+				// Precision... https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L506
+				if (null !== $matches = Strings::match(substr($this->format, $pos), '/^\.([0-9]+)?/')) {
+					$pos += strlen($matches[0]);
+				}
+
+				// No idea what this is about...
+				// https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L533
+				if (($this->format[$pos] ?? '') === 'l') {
+					$pos++;
+				}
+
+				// https://github.com/php/php-src/blob/e30f52b919e04d3a057b6759e7d66c01da550bf8/ext/standard/formatted_print.c#L540
+				switch ($this->format[$pos] ?? '') {
+					case 's':
+					case 'd':
+					case 'u':
+					case 'g':
+					case 'G':
+					case 'e':
+					case 'E':
+					case 'f':
+					case 'F':
+					case 'c':
+					case 'o':
+					case 'x':
+					case 'X':
+					case 'b':
+						$placeholders[] = [$this->format[$pos], $argumentNumber, substr($this->format, $nextPos, $pos - $nextPos + 1)];
+						break;
+
+					case '%':
+					default:
+						$placeholders[] = ['_', $argumentNumber, substr($this->format, $nextPos, $pos - $nextPos + 1)];
+						break;
+				}
+			}
+		}
+
+		$placeholders = array_map(static function (array $placeholder): array {
+			// Up to this point the arguments have been zero indexed.
+			$placeholder[1]++;
+
+			return $placeholder;
+		}, $placeholders);
+
+		return $placeholders;
+	}
+
+}

--- a/src/Rules/Functions/PrintfParametersRule.php
+++ b/src/Rules/Functions/PrintfParametersRule.php
@@ -14,6 +14,14 @@ use PHPStan\Type\TypeUtils;
 class PrintfParametersRule implements \PHPStan\Rules\Rule
 {
 
+	/** @var bool */
+	private $reportInvalidPlaceholders;
+
+	public function __construct(bool $reportInvalidPlaceholders = false)
+	{
+		$this->reportInvalidPlaceholders = $reportInvalidPlaceholders;
+	}
+
 	public function getNodeType(): string
 	{
 		return FuncCall::class;
@@ -25,25 +33,12 @@ class PrintfParametersRule implements \PHPStan\Rules\Rule
 			return [];
 		}
 
-		$functionsArgumentPositions = [
-			'printf' => 0,
-			'sprintf' => 0,
-			'sscanf' => 1,
-			'fscanf' => 1,
-		];
-		$minimumNumberOfArguments = [
-			'printf' => 1,
-			'sprintf' => 1,
-			'sscanf' => 3,
-			'fscanf' => 3,
-		];
-
 		$name = strtolower((string) $node->name);
-		if (!isset($functionsArgumentPositions[$name])) {
+		if (!in_array($name, ['printf', 'sprintf'], true)) {
 			return [];
 		}
 
-		$formatArgumentPosition = $functionsArgumentPositions[$name];
+		$formatArgumentPosition = 0;
 
 		$args = $node->args;
 		foreach ($args as $arg) {
@@ -52,76 +47,55 @@ class PrintfParametersRule implements \PHPStan\Rules\Rule
 			}
 		}
 		$argsCount = count($args);
-		if ($argsCount < $minimumNumberOfArguments[$name]) {
+		if ($argsCount < 1) {
 			return []; // caught by CallToFunctionParametersRule
 		}
 
+		$errors = [];
 		$formatArgType = $scope->getType($args[$formatArgumentPosition]->value);
-		$placeHoldersCount = null;
+		$placeholdersCount = null;
 		foreach (TypeUtils::getConstantStrings($formatArgType) as $formatString) {
-			$format = $formatString->getValue();
-			$tempPlaceHoldersCount = $this->getPlaceholdersCount($name, $format);
-			if ($placeHoldersCount === null) {
-				$placeHoldersCount = $tempPlaceHoldersCount;
-			} elseif ($tempPlaceHoldersCount > $placeHoldersCount) {
-				$placeHoldersCount = $tempPlaceHoldersCount;
+			$formatStringObj = new PrintfFormatStringHelper($formatString->getValue());
+			$placeholdersCount = max($placeholdersCount ?? 0, $formatStringObj->getNumberOfRequiredArguments());
+
+			if (!$this->reportInvalidPlaceholders) {
+				continue;
+			}
+
+			foreach ($formatStringObj->getPlaceholders() as $placeholder) {
+				if ($placeholder[0] !== '_') {
+					continue;
+				}
+
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'Call to %s with invalid format string, `%s`, contains invalid placeholder, `%s`.',
+					$name,
+					$formatString->getValue(),
+					$placeholder[2]
+				))->build();
 			}
 		}
 
-		if ($placeHoldersCount === null) {
-			return [];
+		if ($placeholdersCount === null) {
+			return $errors;
 		}
 
 		$argsCount -= $formatArgumentPosition;
 
-		if ($argsCount !== $placeHoldersCount + 1) {
-			return [
-				RuleErrorBuilder::message(sprintf(
-					sprintf(
-						'%s, %s.',
-						$placeHoldersCount === 1 ? 'Call to %s contains %d placeholder' : 'Call to %s contains %d placeholders',
-						$argsCount - 1 === 1 ? '%d value given' : '%d values given'
-					),
-					$name,
-					$placeHoldersCount,
-					$argsCount - 1
-				))->build(),
-			];
+		if ($argsCount !== $placeholdersCount + 1) {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				sprintf(
+					'%s, %s.',
+					$placeholdersCount === 1 ? 'Call to %s contains %d placeholder' : 'Call to %s contains %d placeholders',
+					$argsCount - 1 === 1 ? '%d value given' : '%d values given'
+				),
+				$name,
+				$placeholdersCount,
+				$argsCount - 1
+			))->build();
 		}
 
-		return [];
-	}
-
-	private function getPlaceholdersCount(string $functionName, string $format): int
-	{
-		$specifiers = in_array($functionName, ['sprintf', 'printf'], true) ? '[bcdeEfFgGosuxX]' : '(?:[cdDeEfinosuxX]|\[[^\]]+\])';
-		$pattern = '~(?<before>%*)%(?:(?<position>\d+)\$)?[-+]?(?:[ 0]|(?:\'[^%]))?-?\d*(?:\.\d*)?' . $specifiers . '~';
-
-		$matches = \Nette\Utils\Strings::matchAll($format, $pattern, PREG_SET_ORDER);
-
-		if (count($matches) === 0) {
-			return 0;
-		}
-
-		$placeholders = array_filter($matches, static function (array $match): bool {
-			return strlen($match['before']) % 2 === 0;
-		});
-
-		if (count($placeholders) === 0) {
-			return 0;
-		}
-
-		$maxPositionedNumber = 0;
-		$maxOrdinaryNumber = 0;
-		foreach ($placeholders as $placeholder) {
-			if (isset($placeholder['position']) && $placeholder['position'] !== '') {
-				$maxPositionedNumber = max((int) $placeholder['position'], $maxPositionedNumber);
-			} else {
-				$maxOrdinaryNumber++;
-			}
-		}
-
-		return max($maxPositionedNumber, $maxOrdinaryNumber);
+		return $errors;
 	}
 
 }

--- a/src/Rules/Functions/ScanfParametersRule.php
+++ b/src/Rules/Functions/ScanfParametersRule.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\TypeUtils;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\FuncCall>
+ */
+class ScanfParametersRule implements \PHPStan\Rules\Rule
+{
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!($node->name instanceof \PhpParser\Node\Name)) {
+			return [];
+		}
+
+		$name = strtolower((string) $node->name);
+
+		if (!in_array($name, ['sscanf', 'fscanf'], true)) {
+			return [];
+		}
+
+		$formatArgumentPosition = 1;
+
+		$args = $node->args;
+		foreach ($args as $arg) {
+			if ($arg->unpack) {
+				return [];
+			}
+		}
+		$argsCount = count($args);
+		if ($argsCount < 3) {
+			return []; // caught by CallToFunctionParametersRule
+		}
+
+		$formatArgType = $scope->getType($args[$formatArgumentPosition]->value);
+		$placeHoldersCount = null;
+		foreach (TypeUtils::getConstantStrings($formatArgType) as $formatString) {
+			$format = $formatString->getValue();
+			$tempPlaceHoldersCount = $this->getPlaceholdersCount($format);
+			if ($placeHoldersCount === null) {
+				$placeHoldersCount = $tempPlaceHoldersCount;
+			} elseif ($tempPlaceHoldersCount > $placeHoldersCount) {
+				$placeHoldersCount = $tempPlaceHoldersCount;
+			}
+		}
+
+		if ($placeHoldersCount === null) {
+			return [];
+		}
+
+		$argsCount -= $formatArgumentPosition;
+
+		if ($argsCount !== $placeHoldersCount + 1) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					sprintf(
+						'%s, %s.',
+						$placeHoldersCount === 1 ? 'Call to %s contains %d placeholder' : 'Call to %s contains %d placeholders',
+						$argsCount - 1 === 1 ? '%d value given' : '%d values given'
+					),
+					$name,
+					$placeHoldersCount,
+					$argsCount - 1
+				))->build(),
+			];
+		}
+
+		return [];
+	}
+
+	private function getPlaceholdersCount(string $format): int
+	{
+		$specifiers = '(?:[cdDeEfinosuxX]|\[[^\]]+\])';
+		$pattern = '~(?<before>%*)%(?:(?<position>\d+)\$)?[-+]?(?:[ 0]|(?:\'[^%]))?-?\d*(?:\.\d*)?' . $specifiers . '~';
+
+		$matches = \Nette\Utils\Strings::matchAll($format, $pattern, PREG_SET_ORDER);
+
+		if (count($matches) === 0) {
+			return 0;
+		}
+
+		$placeholders = array_filter($matches, static function (array $match): bool {
+			return strlen($match['before']) % 2 === 0;
+		});
+
+		if (count($placeholders) === 0) {
+			return 0;
+		}
+
+		$maxPositionedNumber = 0;
+		$maxOrdinaryNumber = 0;
+		foreach ($placeholders as $placeholder) {
+			if (isset($placeholder['position']) && $placeholder['position'] !== '') {
+				$maxPositionedNumber = max((int) $placeholder['position'], $maxPositionedNumber);
+			} else {
+				$maxOrdinaryNumber++;
+			}
+		}
+
+		return max($maxPositionedNumber, $maxOrdinaryNumber);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/PrintfFormatStringHelperTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfFormatStringHelperTest.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+class PrintfFormatStringHelperTest extends \PHPUnit\Framework\TestCase
+{
+
+	/**
+	 * @dataProvider dataGetPlaceholders
+	 * @param array<int,array{string,int,string}> $expected
+	 */
+	public function testGetPlaceholders(array $expected, string $input): void
+	{
+		self::assertSame($expected, (new PrintfFormatStringHelper($input))->getPlaceholders());
+	}
+
+	public function dataGetPlaceholders(): iterable
+	{
+		yield [
+			[],
+			'',
+		];
+
+		yield [
+			[['E', 1, '%.E']],
+			'%.E',
+		];
+
+		yield [
+			[['s', 1, '%s']],
+			'%s',
+		];
+
+		yield [
+			[['s', 1, '%s'], ['s', 2, '%s']],
+			'Hello %s and %s!',
+		];
+
+		yield [
+			[],
+			'%%',
+		];
+
+		yield [
+			[['_', 1, '%']],
+			'%%%',
+		];
+
+		yield [
+			[['_', 1, '% %']],
+			'%%% %',
+		];
+
+		yield [
+			[['_', 1, '% %']],
+			'%%% %s',
+		];
+
+		yield [
+			[['_', 1, '% %'], ['u', 2, '%u']],
+			'%%% %s%u',
+		];
+
+		yield [
+			[['_', 1, '% %'], ['_', 2, '%']],
+			'%%% %%%%',
+		];
+
+		yield [
+			[],
+			'%%%% %%%%',
+		];
+
+		yield [
+			[['f', 1, '%f']],
+			'How many %%%f percent',
+		];
+
+		yield [
+			[['d', 1, '%041d'], ['d', 2, '% 25d'], ['d', 3, '%\'x39d']],
+			'%041d % 25d %\'x39d',
+		];
+		yield [
+			[['s', 1, '%s']],
+			'foo%sbar',
+		];
+		yield [
+			[['d', 1, '%1$\'y-10d']],
+			's%1$\'y-10d bar',
+		];
+		yield [
+			[['s', 1, '%s'], ['d', 2, '%d'], ['c', 6, '%06$\'c10.2c']],
+			'%s %d foo %06$\'c10.2c foo',
+		];
+		yield [
+			[['s', 1, '%s'], ['d', 1, '%1$\'x242d'], ['s', 2, '%2$s'], ['s', 10, '%10$s']],
+			'this %% is my %s and %1$\'x242d here %2$s is %10$s',
+		];
+		yield [
+			[['g', 1, '%g'], ['s', 2, '%2$s'], ['f', 1, '%1$f'], ['u', 2, '%u']],
+			'%g %2$s-%1$f %u',
+		];
+		yield [
+			[['_', 1, '%']],
+			'1000%',
+		];
+
+		yield [
+			[['_', 19, '%19$']],
+			'%19$',
+		];
+
+		yield [
+			[['s', 5, '%5$s'], ['u', 1, '%u']],
+			'%5$s%u',
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetNumberOfRequiredArguments
+	 */
+	public function testGetNumberOfRequiredArguments(int $expected, string $input): void
+	{
+		self::assertSame($expected, self::howManyArgs($input)); // Check that the expected amount matches what PHP thinks
+		self::assertSame($expected, (new PrintfFormatStringHelper($input))->getNumberOfRequiredArguments());
+	}
+
+	public function dataGetNumberOfRequiredArguments(): iterable
+	{
+		foreach ($this->dataGetPlaceholders() as $data) {
+			$args = array_column($data[0], 1);
+
+			yield [$args !== [] ? max($args) : 0, $data[1]];
+		}
+	}
+
+	/**
+	 * Count the number of arguments PHP requires for a format string.
+	 */
+	private static function howManyArgs(string $format): int
+	{
+		// @todo PHP 8 can parse the exception which says how many arguments are required.
+		$num = 0;
+
+		while (self::isEnoughArgs($format, $num) === false) {
+			$num++;
+		}
+
+		return $num;
+	}
+
+	private static function isEnoughArgs(string $format, int $numArgs): bool
+	{
+		return @sprintf($format, ...array_fill(0, $numArgs, '')) !== false;
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
@@ -10,7 +10,7 @@ class PrintfParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		return new PrintfParametersRule();
+		return new PrintfParametersRule(true);
 	}
 
 	public function testFile(): void
@@ -27,6 +27,10 @@ class PrintfParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				'Call to sprintf contains 1 placeholder, 2 values given.',
 				8,
+			],
+			[
+				'Call to sprintf with invalid format string, `%2$s %1$s %% %1$s %%%`, contains invalid placeholder, `%`.',
+				9,
 			],
 			[
 				'Call to sprintf contains 2 placeholders, 1 value given.',
@@ -61,14 +65,6 @@ class PrintfParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 				18,
 			],
 			[
-				'Call to sscanf contains 2 placeholders, 1 value given.',
-				21,
-			],
-			[
-				'Call to fscanf contains 2 placeholders, 1 value given.',
-				25,
-			],
-			[
 				'Call to sprintf contains 2 placeholders, 1 value given.',
 				27,
 			],
@@ -87,6 +83,42 @@ class PrintfParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				'Call to sprintf contains 2 placeholders, 3 values given.',
 				54,
+			],
+			[
+				'Call to sprintf with invalid format string, `%`, contains invalid placeholder, `%`.',
+				57,
+			],
+			[
+				'Call to sprintf contains 1 placeholder, 0 values given.',
+				57,
+			],
+			[
+				'Call to sprintf contains 4 placeholders, 2 values given.',
+				59,
+			],
+			[
+				'Call to sprintf with invalid format string, `%2$s %1$s %% %s %s %s %s %%% %%%%`, contains invalid placeholder, `% %`.',
+				60,
+			],
+			[
+				'Call to sprintf with invalid format string, `%2$s %1$s %% %s %s %s %s %%% %%%%`, contains invalid placeholder, `%`.',
+				60,
+			],
+			[
+				'Call to sprintf contains 6 placeholders, 4 values given.',
+				60,
+			],
+			[
+				'Call to sprintf with invalid format string, `%s foo %%%`, contains invalid placeholder, `%`.',
+				65,
+			],
+			[
+				'Call to sprintf with invalid format string, `how %s many %?`, contains invalid placeholder, `%?`.',
+				65,
+			],
+			[
+				'Call to sprintf contains 2 placeholders, 1 value given.',
+				65,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/ScanfParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ScanfParametersRuleTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<ScanfParametersRule>
+ */
+class ScanfParametersRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): \PHPStan\Rules\Rule
+	{
+		return new ScanfParametersRule();
+	}
+
+	public function testFile(): void
+	{
+		$this->analyse([__DIR__ . '/data/scanf.php'], [
+			[
+				'Call to sscanf contains 2 placeholders, 1 value given.',
+				5,
+			],
+			[
+				'Call to fscanf contains 2 placeholders, 1 value given.',
+				9,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/printf.php
+++ b/tests/PHPStan/Rules/Functions/data/printf.php
@@ -9,20 +9,20 @@ sprintf('foo %s', 'foo', 'bar'); // one parameter over
 sprintf('%2$s %1$s %% %1$s %%%', 'one'); // one parameter missing
 sprintf('%2$s %%'); // two parameters required
 sprintf('%2$s %1$s %1$s %s %s %s %s'); // four parameters required
-sprintf('%2$s %1$s %% %s %s %s %s %%% %%%%', 'one', 'two', 'three', 'four'); // ok
+sprintf('%2$s %1$s %% %s %s %s %s %%%4$s %%%%', 'one', 'two', 'three', 'four'); // ok
 sprintf("%'.9d %1$'.9d %0.3f %d %d %d", 123, 456);
 sprintf('%-4s', 'foo'); // ok
 sprintf('%%s %s', 'foo', 'bar'); // one parameter over
 sprintf('https://%s/staticmaps/%dx%d/%d/%Fx%F.png'); // six parameters required
 sprintf('%%0%dd%%0%dd'); // two parameters required
 sprintf('%%%s%%'); // one required
-sscanf($str, '%d%d'); // correct - result returned as an array
-sscanf($str, '%d', $number); // correct
-sscanf($str, '%d%d', $number); // one parameter missing
-sscanf($str, '%20[^,],%d', $string, $number); // ok
-fscanf($resource, '%d%d'); // correct - result returned as an array
-fscanf($resource, '%d', $number); // correct
-fscanf($resource, '%d%d', $number); // one parameter missing
+
+
+
+
+
+
+
 sprintf('%+02d', 1); // ok
 sprintf('%+02d %d', 1); // one parameter missing
 sprintf('%-02d', 1); // ok
@@ -30,14 +30,14 @@ sprintf('%-02d %d', 1); // one parameter missing
 sprintf('<info>% -20s</info> : %s', 'id', 42); // ok
 sprintf('%-s', 'x'); // ok
 sprintf('%%s'); // ok
-sscanf($str, "%20[^\n]\n%d", $string, $number); // ok
-sscanf($str, "%20[^\n]\r\n%d", $string, $number); // ok
-sscanf($str, "%20[^abcde]a%d", $string, $number); // ok
+
+
+
 printf("%.E", 3.14159); // ok
 sprintf("%.E", 3.14159); // ok
-sscanf($str, '%.E', $number); // ok
-fscanf($str, '%.E', $number); // ok
-sscanf($str, '%[A-Z]%d', $char, $number); // ok
+
+
+
 sprintf('%s %s %s', ...[1]); // do not detect unpacked arguments
 sprintf('%s %s %s', ...[1, 2, 3]); // ok
 
@@ -52,3 +52,14 @@ if (rand(0, 1) === 0) {
 sprintf($variousPlaceholderCount, 'bar');
 sprintf($variousPlaceholderCount, 'bar', 'baz');
 sprintf($variousPlaceholderCount, 'bar', 'baz', 'lorem');
+
+// #2342
+sprintf('%');
+sprintf('%%');
+sprintf('%2$s %1$s %% %s %s %s %s', 'one', 'two'); // 4 args
+sprintf('%2$s %1$s %% %s %s %s %s %%% %%%%', 'one', 'two', 'three', 'four'); // 6 args, placeholders are in squares %%[% %]%%[%]
+$multipleBrokenFormats = 'how %s many %?';
+if (rand(0, 1) === 0) {
+	$multipleBrokenFormats = '%s foo %%%';
+}
+sprintf($multipleBrokenFormats, 'testing');

--- a/tests/PHPStan/Rules/Functions/data/scanf.php
+++ b/tests/PHPStan/Rules/Functions/data/scanf.php
@@ -1,0 +1,17 @@
+<?php
+
+sscanf($str, '%d%d'); // correct - result returned as an array
+sscanf($str, '%d', $number); // correct
+sscanf($str, '%d%d', $number); // one parameter missing
+sscanf($str, '%20[^,],%d', $string, $number); // ok
+fscanf($resource, '%d%d'); // correct - result returned as an array
+fscanf($resource, '%d', $number); // correct
+fscanf($resource, '%d%d', $number); // one parameter missing
+
+sscanf($str, "%20[^\n]\n%d", $string, $number); // ok
+sscanf($str, "%20[^\n]\r\n%d", $string, $number); // ok
+sscanf($str, "%20[^abcde]a%d", $string, $number); // ok
+
+sscanf($str, '%.E', $number); // ok
+fscanf($str, '%.E', $number); // ok
+sscanf($str, '%[A-Z]%d', $char, $number); // ok


### PR DESCRIPTION
This started out as a simple fix for https://github.com/phpstan/phpstan/issues/2342 and quickly snowballed.

I've added a new class `PrintfFormatStringHelper` which represents a format string for the `printf` family of functions, it parses the format string following the algorithm in the PHP source code. It might be possible to do in regex but the edge cases had me going around in circles, plus this should be easier to update if PHP ever changes anything. There might be a more appropriate namespace for this class, I just put it alongside the `PrintfParametersRule` for now.

The code handling the `{f,s}scanf()` functions has been split out in to it's own rule as these functions are implemented entirely separately in PHP, I've simplified the code slightly but left it untouched otherwise.

Fixes https://github.com/phpstan/phpstan/issues/2342

### TODO

* [ ] Enable `printf` format validation in bleeding edge
* [ ] Remove giant gaps in the `printf.php` file (left behind to avoid renumbering the tests at this point)
* [ ] See if `SprintfFunctionDynamicReturnTypeExtension` can use the new code