### PR TITLE
Make "<x>, <y> given" visually easier to read

### DIFF
--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -185,7 +185,7 @@ class InstantiationRule implements \PHPStan\Rules\Rule
 				'Class ' . $classReflection->getDisplayName() . ' constructor invoked with %d parameters, at least %d required.',
 				'Class ' . $classReflection->getDisplayName() . ' constructor invoked with %d parameter, %d-%d required.',
 				'Class ' . $classReflection->getDisplayName() . ' constructor invoked with %d parameters, %d-%d required.',
-				'Parameter #%d %s of class ' . $classReflection->getDisplayName() . ' constructor expects %s, %s given.',
+				'Parameter #%d %s of class ' . $classReflection->getDisplayName() . ' constructor expects %s but %s given.',
 				'', // constructor does not have a return type
 				'Parameter #%d %s of class ' . $classReflection->getDisplayName() . ' constructor is passed by reference, so it expects variables only',
 				'Unable to resolve the template type %s in instantiation of class ' . $classReflection->getDisplayName(),

--- a/src/Rules/Functions/CallCallablesRule.php
+++ b/src/Rules/Functions/CallCallablesRule.php
@@ -123,7 +123,7 @@ class CallCallablesRule implements \PHPStan\Rules\Rule
 					ucfirst($callableDescription) . ' invoked with %d parameters, at least %d required.',
 					ucfirst($callableDescription) . ' invoked with %d parameter, %d-%d required.',
 					ucfirst($callableDescription) . ' invoked with %d parameters, %d-%d required.',
-					'Parameter #%d %s of ' . $callableDescription . ' expects %s, %s given.',
+					'Parameter #%d %s of ' . $callableDescription . ' expects %s but %s given.',
 					'Result of ' . $callableDescription . ' (void) is used.',
 					'Parameter #%d %s of ' . $callableDescription . ' is passed by reference, so it expects variables only.',
 					'Unable to resolve the template type %s in call to ' . $callableDescription,

--- a/src/Rules/Functions/CallToFunctionParametersRule.php
+++ b/src/Rules/Functions/CallToFunctionParametersRule.php
@@ -59,7 +59,7 @@ class CallToFunctionParametersRule implements \PHPStan\Rules\Rule
 				'Function ' . $function->getName() . ' invoked with %d parameters, at least %d required.',
 				'Function ' . $function->getName() . ' invoked with %d parameter, %d-%d required.',
 				'Function ' . $function->getName() . ' invoked with %d parameters, %d-%d required.',
-				'Parameter #%d %s of function ' . $function->getName() . ' expects %s, %s given.',
+				'Parameter #%d %s of function ' . $function->getName() . ' expects %s but %s given.',
 				'Result of function ' . $function->getName() . ' (void) is used.',
 				'Parameter #%d %s of function ' . $function->getName() . ' is passed by reference, so it expects variables only.',
 				'Unable to resolve the template type %s in call to function ' . $function->getName(),

--- a/src/Rules/Generators/YieldFromTypeRule.php
+++ b/src/Rules/Generators/YieldFromTypeRule.php
@@ -83,7 +83,7 @@ class YieldFromTypeRule implements Rule
 		if (!$this->ruleLevelHelper->accepts($returnType->getIterableKeyType(), $exprType->getIterableKeyType(), $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($returnType->getIterableKeyType());
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Generator expects key type %s, %s given.',
+				'Generator expects key type %s but %s given.',
 				$returnType->getIterableKeyType()->describe($verbosityLevel),
 				$exprType->getIterableKeyType()->describe($verbosityLevel)
 			))->line($node->expr->getLine())->build();
@@ -91,7 +91,7 @@ class YieldFromTypeRule implements Rule
 		if (!$this->ruleLevelHelper->accepts($returnType->getIterableValueType(), $exprType->getIterableValueType(), $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($returnType->getIterableValueType());
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Generator expects value type %s, %s given.',
+				'Generator expects value type %s but %s given.',
 				$returnType->getIterableValueType()->describe($verbosityLevel),
 				$exprType->getIterableValueType()->describe($verbosityLevel)
 			))->line($node->expr->getLine())->build();
@@ -120,13 +120,13 @@ class YieldFromTypeRule implements Rule
 		$isSuperType = $exprSendType->isSuperTypeOf($thisSendType);
 		if ($isSuperType->no()) {
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Generator expects delegated TSend type %s, %s given.',
+				'Generator expects delegated TSend type %s but %s given.',
 				$exprSendType->describe(VerbosityLevel::typeOnly()),
 				$thisSendType->describe(VerbosityLevel::typeOnly())
 			))->build();
 		} elseif ($this->reportMaybes && !$isSuperType->yes()) {
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Generator expects delegated TSend type %s, %s given.',
+				'Generator expects delegated TSend type %s but %s given.',
 				$exprSendType->describe(VerbosityLevel::typeOnly()),
 				$thisSendType->describe(VerbosityLevel::typeOnly())
 			))->build();

--- a/src/Rules/Generators/YieldTypeRule.php
+++ b/src/Rules/Generators/YieldTypeRule.php
@@ -66,7 +66,7 @@ class YieldTypeRule implements Rule
 		if (!$this->ruleLevelHelper->accepts($returnType->getIterableKeyType(), $keyType, $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($returnType->getIterableKeyType());
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Generator expects key type %s, %s given.',
+				'Generator expects key type %s but %s given.',
 				$returnType->getIterableKeyType()->describe($verbosityLevel),
 				$keyType->describe($verbosityLevel)
 			))->build();
@@ -74,7 +74,7 @@ class YieldTypeRule implements Rule
 		if (!$this->ruleLevelHelper->accepts($returnType->getIterableValueType(), $valueType, $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($returnType->getIterableValueType());
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Generator expects value type %s, %s given.',
+				'Generator expects value type %s but %s given.',
 				$returnType->getIterableValueType()->describe($verbosityLevel),
 				$valueType->describe($verbosityLevel)
 			))->build();

--- a/src/Rules/Methods/CallMethodsRule.php
+++ b/src/Rules/Methods/CallMethodsRule.php
@@ -154,7 +154,7 @@ class CallMethodsRule implements \PHPStan\Rules\Rule
 				'Method ' . $messagesMethodName . ' invoked with %d parameters, at least %d required.',
 				'Method ' . $messagesMethodName . ' invoked with %d parameter, %d-%d required.',
 				'Method ' . $messagesMethodName . ' invoked with %d parameters, %d-%d required.',
-				'Parameter #%d %s of method ' . $messagesMethodName . ' expects %s, %s given.',
+				'Parameter #%d %s of method ' . $messagesMethodName . ' expects %s but %s given.',
 				'Result of method ' . $messagesMethodName . ' (void) is used.',
 				'Parameter #%d %s of method ' . $messagesMethodName . ' is passed by reference, so it expects variables only.',
 				'Unable to resolve the template type %s in call to method ' . $messagesMethodName,

--- a/src/Rules/Methods/CallStaticMethodsRule.php
+++ b/src/Rules/Methods/CallStaticMethodsRule.php
@@ -279,7 +279,7 @@ class CallStaticMethodsRule implements \PHPStan\Rules\Rule
 				$displayMethodName . ' invoked with %d parameters, at least %d required.',
 				$displayMethodName . ' invoked with %d parameter, %d-%d required.',
 				$displayMethodName . ' invoked with %d parameters, %d-%d required.',
-				'Parameter #%d %s of ' . $lowercasedMethodName . ' expects %s, %s given.',
+				'Parameter #%d %s of ' . $lowercasedMethodName . ' expects %s but %s given.',
 				'Result of ' . $lowercasedMethodName . ' (void) is used.',
 				'Parameter #%d %s of ' . $lowercasedMethodName . ' is passed by reference, so it expects variables only.',
 				'Unable to resolve the template type %s in call to method ' . $lowercasedMethodName,


### PR DESCRIPTION
When this appears in my terminal, it's hard to read, I don't know what was actually given and expected without concentrated attempts to read it.

```
expects Ds\Map<string, Ds\Map<string, My\Ns\Something1\Domain\Value\Name>>, Ds\Map<string,
         Ds\Set<My\Ns\Something1\Domain\Value\2>> given.
```

I propose to add a separator, `but` so I know what's happening without effort

```
expects Ds\Map<string, Ds\Map<string, My\Ns\Something1\Domain\Value\Name>> but Ds\Map<string,
         Ds\Set<My\Ns\Something1\Domain\Value\2>> given.
````