### PR TITLE
Enhancement: Use ergebnis/composer-root-version-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        uses: "ergebnis/composer-root-version-action@0.1.2"
+        uses: "docker://ergebnis/composer-root-version-action:0.1.3"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -82,7 +82,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        uses: "ergebnis/composer-root-version-action@0.1.2"
+        uses: "docker://ergebnis/composer-root-version-action:0.1.3"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -121,7 +121,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        uses: "ergebnis/composer-root-version-action@0.1.2"
+        uses: "docker://ergebnis/composer-root-version-action:0.1.3"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -160,7 +160,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        uses: "ergebnis/composer-root-version-action@0.1.2"
+        uses: "docker://ergebnis/composer-root-version-action:0.1.3"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -199,7 +199,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        uses: "ergebnis/composer-root-version-action@0.1.2"
+        uses: "docker://ergebnis/composer-root-version-action:0.1.3"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        run: "echo \"::set-env name=COMPOSER_ROOT_VERSION::$(jq --raw-output '.extra.\"branch-alias\".\"dev-master\"' composer.json)\""
+        uses: "ergebnis/composer-root-version-action@0.1.2"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -82,7 +82,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        run: "echo \"::set-env name=COMPOSER_ROOT_VERSION::$(jq --raw-output '.extra.\"branch-alias\".\"dev-master\"' composer.json)\""
+        uses: "ergebnis/composer-root-version-action@0.1.2"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -121,7 +121,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        run: "echo \"::set-env name=COMPOSER_ROOT_VERSION::$(jq --raw-output '.extra.\"branch-alias\".\"dev-master\"' composer.json)\""
+        uses: "ergebnis/composer-root-version-action@0.1.2"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -160,7 +160,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        run: "echo \"::set-env name=COMPOSER_ROOT_VERSION::$(jq --raw-output '.extra.\"branch-alias\".\"dev-master\"' composer.json)\""
+        uses: "ergebnis/composer-root-version-action@0.1.2"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
@@ -199,7 +199,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
       - name: "Set COMPOSER_ROOT_VERSION environment variable"
-        run: "echo \"::set-env name=COMPOSER_ROOT_VERSION::$(jq --raw-output '.extra.\"branch-alias\".\"dev-master\"' composer.json)\""
+        uses: "ergebnis/composer-root-version-action@0.1.2"
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"


### PR DESCRIPTION
This PR

* [x] uses [`ergebnis/composer-root-version-action`](https://github.com/ergebnis/composer-root-version-action)

💁‍♂ Not sure, maybe it's overkill and could be simplified a lot.