### PR TITLE
NeonAdapter: throw more meaningful error which contains the filename

### DIFF
--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -30,8 +30,8 @@ class NeonAdapter implements Adapter
 		$contents = FileReader::read($file);
 		try {
 			return $this->process((array) Neon::decode($contents), '', $file);
-		} catch (Nette\Neon\Exception $e) {
-			throw new Nette\Neon\Exception(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
+		} catch (\Nette\Neon\Exception $e) {
+			throw new \Nette\Neon\Exception(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
 		}
 	}
 

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -8,6 +8,7 @@ use Nette\DI\Definitions\Reference;
 use Nette\DI\Definitions\Statement;
 use Nette\Neon\Entity;
 use Nette\Neon\Neon;
+use Nette\Neon\Exception as NeonExcepton;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
 
@@ -28,8 +29,11 @@ class NeonAdapter implements Adapter
 	public function load(string $file): array
 	{
 		$contents = FileReader::read($file);
-
-		return $this->process((array) Neon::decode($contents), '', $file);
+		try {
+			return $this->process((array) Neon::decode($contents), '', $file);
+		} catch (NeonExcepton $e) {
+			throw new \Nette\DI\InvalidConfigurationException(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
+		}
 	}
 
 	/**

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -8,7 +8,6 @@ use Nette\DI\Definitions\Reference;
 use Nette\DI\Definitions\Statement;
 use Nette\Neon\Entity;
 use Nette\Neon\Neon;
-use Nette\Neon\Exception as NeonExcepton;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
 
@@ -31,8 +30,8 @@ class NeonAdapter implements Adapter
 		$contents = FileReader::read($file);
 		try {
 			return $this->process((array) Neon::decode($contents), '', $file);
-		} catch (NeonExcepton $e) {
-			throw new NeonExcepton(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
+		} catch (Nette\Neon\Exception $e) {
+			throw new Nette\Neon\Exception(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
 		}
 	}
 

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -32,7 +32,7 @@ class NeonAdapter implements Adapter
 		try {
 			return $this->process((array) Neon::decode($contents), '', $file);
 		} catch (NeonExcepton $e) {
-			throw new \Nette\DI\InvalidConfigurationException(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
+			throw new NeonExcepton(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
 		}
 	}
 


### PR DESCRIPTION
before this change a error looks like

```
$ ../phpstan-src/bin/phpstan analyse -c phpstan.neon.dist --error-format baselineNeon  -vvv

In Decoder.php line 370:

  [Nette\Neon\Exception]
  Unexpected 'NULL' on line 2, column 1.
```

after this change we get a error message which also contains the actual path to the neon-file which contains the error.. its not always the one which gets passed by cli arg :)

```
$ ../phpstan-src/bin/phpstan analyse -c phpstan.neon.dist --error-format baselineNeon  -vvv

In NeonAdapter.php line 35:

  [Nette\Neon\Exception]
  Error while loading C:\dvl\Zend\DefaultWorkspace13\php-clxmobilenet/phpstan-baseline.neon: Unexpected 'NULL' on line 2, column 1.
```