### PR TITLE
Mark slow tests as slow

### DIFF
--- a/src/Testing/LevelsTestCase.php
+++ b/src/Testing/LevelsTestCase.php
@@ -25,6 +25,7 @@ abstract class LevelsTestCase extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * @dataProvider dataTopics
+	 * @group slow
 	 * @param string $topic
 	 */
 	public function testLevels(

--- a/tests/PHPStan/Analyser/traitsCachingIssue/TraitsCachingIssueIntegrationTest.php
+++ b/tests/PHPStan/Analyser/traitsCachingIssue/TraitsCachingIssueIntegrationTest.php
@@ -65,6 +65,7 @@ class TraitsCachingIssueIntegrationTest extends TestCase
 
 	/**
 	 * @dataProvider dataCachingIssue
+	 * @group slow
 	 * @param bool $changeOne
 	 * @param bool $changeTwo
 	 * @param string[] $expectedErrors


### PR DESCRIPTION
This way passing `--exclude slow` to PHPUnit makes the tests go from 2.7 minutes to 15 seconds.