### PR TITLE
Sending strings to range() should resolve to array with strings

### DIFF
--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -12,6 +12,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -98,6 +99,14 @@ class RangeFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionR
 			|| $stepType instanceof FloatType
 		) {
 			return new ArrayType(new IntegerType(), new FloatType());
+		}
+
+		if (
+			$startType instanceof StringType
+			&& $endType instanceof StringType
+			&& $stepType instanceof IntegerType
+		) {
+			return new ArrayType(new IntegerType(), new StringType());
 		}
 
 		return new ArrayType(new IntegerType(), new UnionType([new IntegerType(), new FloatType()]));

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -6012,6 +6012,18 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array<int, int>',
 				'range(0, 50)',
 			],
+			[
+				'array<int, string>',
+				'range("a", "d")',
+			],
+			[
+				'array<int, float>',
+				'range("a", "d", 1.1)',
+			],
+			[
+				'array<int, float>',
+				'range("a", 2, 1.1)',
+			],
 		];
 	}
 


### PR DESCRIPTION
Was resolving to array<int, float|int>.

Fixes phpstan/phpstan#2378

I tried your suggestion in https://github.com/phpstan/phpstan/issues/2378#issuecomment-523173173 It looked like you wanted to refactor the entire method? Your suggestion only works with int and strings, range() can return floats too. I didnt understand how I would use your provided suggestion with a third type (float). Tried some things, but tests ended up failing :(