### PR TITLE
Fix signature for ReflectionProperty::isInitialized

### DIFF
--- a/src/Reflection/SignatureMap/functionMap_php74delta.php
+++ b/src/Reflection/SignatureMap/functionMap_php74delta.php
@@ -46,7 +46,7 @@ return [
 		'sapi_windows_set_ctrl_handler' => ['bool', 'callable'=>'callable', 'add'=>'bool'],
 		'ReflectionProperty::getType' => ['?ReflectionType'],
 		'ReflectionProperty::hasType' => ['bool'],
-		'ReflectionProperty::isInitialized' => ['bool'],
+		'ReflectionProperty::isInitialized' => ['bool', 'object='=>'?object'],
 		'ReflectionReference::fromArrayElement' => ['?ReflectionReference', 'array'=>'array', 'key'=>'int|string'],
 		'ReflectionReference::getId' => ['string'],
 		'SQLite3Stmt::getSQL' => ['string', 'expanded='=>'bool'],


### PR DESCRIPTION
An object is required if the property is non-static.