### PR TITLE
Fix signature for MongoDB\Driver\ReadPreference constructor

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6783,7 +6783,7 @@ return [
 'MongoDB\Driver\ReadConcern::__construct' => ['void', 'level='=>'string'],
 'MongoDB\Driver\ReadConcern::bsonSerialize' => ['object'],
 'MongoDB\Driver\ReadConcern::getLevel' => ['null|string'],
-'MongoDB\Driver\ReadPreference::__construct' => ['void', 'readPreference'=>'string', 'tagSets='=>'array', 'options='=>'array'],
+'MongoDB\Driver\ReadPreference::__construct' => ['void', 'mode'=>'string|int', 'tagSets='=>'array', 'options='=>'array'],
 'MongoDB\Driver\ReadPreference::bsonSerialize' => ['object'],
 'MongoDB\Driver\ReadPreference::getMode' => ['int'],
 'MongoDB\Driver\ReadPreference::getTagSets' => ['array'],


### PR DESCRIPTION
Hi,

The first argument name is `mode` and accepts `string|int`, see https://www.php.net/manual/mongodb-driver-readpreference.construct.php