### PR TITLE
regenerated windows baseline on windows host

### DIFF
--- a/tests/PHPStan/Command/ErrorFormatter/data/windowsBaseline.neon
+++ b/tests/PHPStan/Command/ErrorFormatter/data/windowsBaseline.neon
@@ -11,7 +11,7 @@ parameters:
 			path: UnixNewlines.php
 
 		-
-			message: "#^PHPDoc tag @param has invalid value \\(\\)\\: Unexpected token \"\\\\r\\\\n\\\\t \\*\", expected type at offset 110$#"
+			message: "#^PHPDoc tag @param has invalid value \\(\\)\\: Unexpected token \"\\\\r\\\\n     \\*\", expected type at offset 122$#"
 			count: 1
 			path: UnixNewlines.php
 


### PR DESCRIPTION
regenerated the windows baseline on a windows host.

the previous baseline file seems to be generated on a unix/mac host, just with changed line-endings.

with this PR we can see that the errors itself are also different, which lead to different problems phpstan-src does not yet cover.

the PR is meant to provide a failing testcase. I tried to whole day get a fix implemented but failed.

hopefully someone can work on a fix, as I don't have a clue how this should be handled properly.

refs https://github.com/phpstan/phpstan/issues/3039#issuecomment-593449369