### PR TITLE
Add missing parameter to cropThumbnailImage

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -4688,7 +4688,7 @@ return [
 'Imagick::convolveImage' => ['bool', 'kernel'=>'array', 'channel='=>'int'],
 'Imagick::count' => ['void', 'mode='=>'string'],
 'Imagick::cropImage' => ['bool', 'width'=>'int', 'height'=>'int', 'x'=>'int', 'y'=>'int'],
-'Imagick::cropThumbnailImage' => ['bool', 'width'=>'int', 'height'=>'int'],
+'Imagick::cropThumbnailImage' => ['bool', 'width'=>'int', 'height'=>'int', 'legacy='=>'bool'],
 'Imagick::current' => ['Imagick'],
 'Imagick::cycleColormapImage' => ['bool', 'displace'=>'int'],
 'Imagick::decipherImage' => ['bool', 'passphrase'=>'string'],


### PR DESCRIPTION
The function map is missing the `$legacy` parameter for `Imagick::cropThumbnailImage`.

The phpstorm stub has the following description for it:

```
* @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
```

Additionally, the description to the function describes it as:

```
* If legacy is true, uses the incorrect behaviour that was present until Imagick 3.4.0.
* If false it uses the correct behaviour.
```