### PR TITLE
Add missing parameter to thumbnailImage

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -4997,7 +4997,7 @@ return [
 'Imagick::swirlImage' => ['bool', 'degrees'=>'float'],
 'Imagick::textureImage' => ['bool', 'texture_wand'=>'imagick'],
 'Imagick::thresholdImage' => ['bool', 'threshold'=>'float', 'channel='=>'int'],
-'Imagick::thumbnailImage' => ['bool', 'columns'=>'int', 'rows'=>'int', 'bestfit='=>'bool', 'fill='=>'bool'],
+'Imagick::thumbnailImage' => ['bool', 'columns'=>'int', 'rows'=>'int', 'bestfit='=>'bool', 'fill='=>'bool', 'legacy='=>'bool'],
 'Imagick::tintImage' => ['bool', 'tint'=>'mixed', 'opacity'=>'mixed'],
 'Imagick::transformImage' => ['Imagick', 'crop'=>'string', 'geometry'=>'string'],
 'Imagick::transformImageColorspace' => ['bool', 'colorspace'=>'int'],


### PR DESCRIPTION
The function map is missing the `$legacy` parameter for `Imagick::thumbnailImage`.

The phpstorm stub has the following description for it:

```
* @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
```

Additionally, the description to the function describes it as:

```
* If legacy is true, the calculations are done with the small rounding bug that existed in Imagick before 3.4.0.<br>
* If false, the calculations should produce the same results as ImageMagick CLI does.<br>
```