### PR TITLE
RedisCluster::__construct expects #1 parameter to be string or null

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -9456,7 +9456,7 @@ return [
 'RedisArray::_hosts' => ['array'],
 'RedisArray::_rehash' => ['', 'callable='=>'callable'],
 'RedisArray::_target' => ['string', 'key'=>'string'],
-'RedisCluster::__construct' => ['void', 'name'=>'string', 'seeds'=>'array', 'timeout='=>'float', 'readTimeout='=>'float', 'persistent='=>'bool|false', 'auth='=>'string|null'],
+'RedisCluster::__construct' => ['void', 'name'=>'string|null', 'seeds'=>'array', 'timeout='=>'float', 'readTimeout='=>'float', 'persistent='=>'bool|false', 'auth='=>'string|null'],
 'RedisCluster::_masters' => ['array'],
 'RedisCluster::_prefix' => ['string', 'value'=>'mixed'],
 'RedisCluster::_serialize' => ['mixed', 'value'=>'mixed'],


### PR DESCRIPTION
RedisCluster::__construct expects #1 parameter to be string or null.

https://github.com/zgb7mtr/phpredis_cluster_phpdoc/blob/master/src/RedisCluster.php#L96