### PR TITLE
use tab for indentation instead of spaces

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -56,8 +56,8 @@ parameters:
 	ignoreErrors: []
 	internalErrorsCountLimit: 50
 	cache:
-	    nodesByFileCountMax: 512
-	    nodesByStringCountMax: 512
+		nodesByFileCountMax: 512
+		nodesByStringCountMax: 512
 	reportUnmatchedIgnoredErrors: true
 	scopeClass: PHPStan\Analyser\MutatingScope
 	typeAliases:


### PR DESCRIPTION
Fix indentation with spaces in `config.neon` file