### PR TITLE
Fixed isset always false in global scope

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -489,7 +489,7 @@ class MutatingScope implements Scope
 					$variableType = $this->resolveType($var);
 					$isNullSuperType = (new NullType())->isSuperTypeOf($variableType);
 					$has = $this->hasVariableType($var->name);
-					if ($has->no() || $isNullSuperType->yes()) {
+					if (($this->inFirstLevelStatement && $has->no()) || $isNullSuperType->yes()) {
 						return new ConstantBooleanType(false);
 					}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -3238,6 +3238,45 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	public function dataIssetInGlobalScope(): array
+	{
+		return [
+			[
+				'bool',
+				'isset($bar)',
+			],
+			[
+				'bool',
+				'!isset($bar)',
+			],
+			[
+				'bool',
+				'!isset($bar)',
+			],
+			[
+				'bool',
+				'!isset($bar) || $bar instanceof stdClass',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataIssetInGlobalScope
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testIssetInGlobalScope(
+		string $description,
+		string $expression
+	): void
+	{
+		$this->assertTypes(
+			__DIR__ . '/data/isset-in-global-scope.php',
+			$description,
+			$expression
+		);
+	}
+
 	public function dataVarStatementAnnotation(): array
 	{
 		return [

--- a/tests/PHPStan/Analyser/data/isset-in-global-scope.php
+++ b/tests/PHPStan/Analyser/data/isset-in-global-scope.php
@@ -1,0 +1,5 @@
+<?php
+
+assert(!isset($bar) || $bar instanceof stdClass);
+
+die;


### PR DESCRIPTION
The `MutatingScope` does not think that an `isset` on a unknown variable is always false when the scope is `inFirstLevelStatement`.

Fix https://github.com/phpstan/phpstan/issues/2013