### PR TITLE
Fix: Allow generation of baseline without errors

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -198,12 +198,6 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 		);
 
 		if ($generateBaselineFile !== null) {
-			if (!$analysisResult->hasErrors()) {
-				$inceptionResult->getStdOutput()->getStyle()->error('No errors were found during the analysis. Baseline could not be generated.');
-
-				return $inceptionResult->handleReturn(1);
-			}
-
 			$baselineFileDirectory = dirname($generateBaselineFile);
 			$baselineErrorFormatter = new BaselineNeonErrorFormatter(new ParentDirectoryRelativePathHelper($baselineFileDirectory));
 


### PR DESCRIPTION
This PR

* [x] allows generation of the baseline when the analysis result does not contain any errors

Follows f4a9d5f2f71e4615f03d2f6ca8f8fe184a936846.

💁‍♂ This would be nice to have, for example, when tooling to generate the baseline is already in place, and we either start at or get to a point where `phpstan` could not find any errors.