### PR TITLE
Fix issue in method return type override annotation on same class or from trait

### DIFF
--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -398,7 +398,7 @@ class PhpClassReflectionExtension
 				throw new \PHPStan\ShouldNotHappenException();
 			}
 
-			if ($hierarchyDistances[$annotationMethod->getDeclaringClass()->getName()] < $hierarchyDistances[$methodReflection->getDeclaringClass()->getName()]) {
+			if ($hierarchyDistances[$annotationMethod->getDeclaringClass()->getName()] <= $hierarchyDistances[$methodReflection->getDeclaringClass()->getName()]) {
 				return $annotationMethod;
 			}
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9820,6 +9820,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/is-numeric.php');
 	}
 
+	public function dataBug3142(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3142.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -9855,6 +9860,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataExtDs
 	 * @dataProvider dataArrowFunctionReturnTypeInference
 	 * @dataProvider dataIsNumeric
+	 * @dataProvider dataBug3142
 	 * @param ConstantStringType $expectedType
 	 * @param Type $actualType
 	 */

--- a/tests/PHPStan/Analyser/data/bug-3142.php
+++ b/tests/PHPStan/Analyser/data/bug-3142.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace Analyser\Bug3142;
+
+use function PHPStan\Analyser\assertType;
+
+class ParentClass
+{
+
+	/**
+	 * @return int
+	 */
+	public function sayHi()
+	{
+		return 'hi';
+	}
+
+}
+
+/**
+ * @method string sayHi()
+ * @method string sayHello()
+ */
+class HelloWorld extends ParentClass
+{
+	/**
+	 * @return int
+	 */
+	public function sayHello()
+	{
+		return 'hello';
+	}
+}
+
+$hw = new HelloWorld();
+assertType('string', $hw->sayHi());
+assertType('string', $hw->sayHello());
+
+interface DecoratorInterface
+{
+}
+
+class FooDecorator implements DecoratorInterface
+{
+	public function getCode(): string
+	{
+		return 'FOO';
+	}
+}
+
+trait DecoratorTrait
+{
+	public function getDecorator(): DecoratorInterface
+	{
+		return new FooDecorator();
+	}
+}
+
+/**
+ * @method FooDecorator getDecorator()
+ */
+class Dummy
+{
+	use DecoratorTrait;
+
+	public function getLabel(): string
+	{
+		return $this->getDecorator()->getCode();
+	}
+}
+
+$dummy = new Dummy();
+assertType(FooDecorator::class, $dummy->getDecorator());

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -451,7 +451,7 @@ class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\Te
 				],
 				'conflictingMethod' => [
 					'class' => \AnnotationsMethods\Bar::class,
-					'returnType' => \AnnotationsMethods\Bar::class,
+					'returnType' => \AnnotationsMethods\Foo::class,
 					'isStatic' => false,
 					'isVariadic' => false,
 					'parameters' => [],


### PR DESCRIPTION
Related https://github.com/phpstan/phpstan/issues/1301 and https://github.com/phpstan/phpstan/issues/3142

Trying to reproduce & fix theses issues: 
- https://phpstan.org/r/916a390a-8b70-489e-9f81-4732520d1434
- https://phpstan.org/r/4456d3c9-ccfb-4ee5-8b48-c20d4e264b08

The idea here is to override method return type when a method tag exists on same class.