### PR TITLE
Fix inferred union types for Ds Map::get() and Map::remove()

### DIFF
--- a/src/Type/Php/DsMapDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DsMapDynamicReturnTypeExtension.php
@@ -35,11 +35,11 @@ final class DsMapDynamicReturnTypeExtension implements DynamicMethodReturnTypeEx
 			)->getReturnType();
 		}
 
-		if (! $returnType instanceof UnionType) {
-			return $returnType;
+		if ($returnType instanceof UnionType) {
+			return new UnionType(array_slice($returnType->getTypes(), 0, -1));
 		}
 
-		return $returnType->getTypes()[0];
+		return $returnType;
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/ext-ds.php
+++ b/tests/PHPStan/Analyser/data/ext-ds.php
@@ -16,6 +16,30 @@ class B
 
 class Foo
 {
+	/** @param Map<int, int|string> $a */
+	public function mapGetUnionType(Map $a) : void
+	{
+		assertType('int|string', $a->get(1));
+	}
+
+	/** @param Map<int, int|string> $a */
+	public function mapGetUnionTypeWithDefaultValue(Map $a) : void
+	{
+		assertType('int|string|null', $a->get(1, null));
+	}
+
+	/** @param Map<int, int|string> $a */
+	public function mapRemoveUnionType(Map $a) : void
+	{
+		assertType('int|string', $a->remove(1));
+	}
+
+	/** @param Map<int, int|string> $a */
+	public function mapRemoveUnionTypeWithDefaultValue(Map $a) : void
+	{
+		assertType('int|string|null', $a->remove(1, null));
+	}
+
 	public function mapMerge() : void
 	{
 		$a = new Map([1 => new A()]);

--- a/tests/PHPStan/Analyser/data/ext-ds.php
+++ b/tests/PHPStan/Analyser/data/ext-ds.php
@@ -16,6 +16,18 @@ class B
 
 class Foo
 {
+	/** @param Map<int, int> $a */
+	public function mapGet(Map $a) : void
+	{
+		assertType('int', $a->get(1));
+	}
+
+	/** @param Map<int, int> $a */
+	public function mapGetWithDefaultValue(Map $a) : void
+	{
+		assertType('int|null', $a->get(1, null));
+	}
+
 	/** @param Map<int, int|string> $a */
 	public function mapGetUnionType(Map $a) : void
 	{


### PR DESCRIPTION
👋 can you guide me with this please?

I'm passing `Map<int, int|string>` into the function.

However, return type of `get(0)` call on the map is resolved as `int`. I'd expect `int|string`.

```php
/** @param Map<int, int|string> $a */
public function mapGetUnionType(Map $a) : void
{
	assertType('int|string', $a->get(0));
}
```

```
Expected :'int|string'
Actual   :'int'
```

Map stub is 

```php
/**
 * @template TKey
 * @template TValue
 * @implements Collection<TKey, TValue>
 */
final class Map implements Collection
{
    /**
     * @param iterable<TKey, TValue>|null $values
     */
    public function __construct(?iterable $values = null)
    {
    }
```

So I believe I'm saying that `TValue` is `int|string`.

`Map::get()`'s signature is 

```php
/**
 * @template TDefault
 * @param TKey $key
 * @param TDefault $default
 * @return TValue|TDefault
 * @throws OutOfBoundsException
 */
public function get($key, $default = null)
```

so `get(0)` should return `TValue` (`int|string`). Or not? Thanks!