### PR TITLE
github: Highlight stub files with php syntax highlighter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.php text eol=lf
 *.stub linguist-language=PHP
+*.neon linguist-language=YAML
 
 tests/PHPStan/Command/ErrorFormatter/data/WindowsNewlines.php eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.php text eol=lf
+*.stub linguist-language=PHP
 
 tests/PHPStan/Command/ErrorFormatter/data/WindowsNewlines.php eol=crlf


### PR DESCRIPTION
https://github.com/github/linguist#overrides

I merged this PR to my fork's master, so you can preview how it will look like: https://github.com/adaamz/phpstan-src/blob/master/stubs/ArrayObject.stub