### PR TITLE
Handle dynamic return types for bc math functions

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -802,6 +802,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\BcMathStringOrNullReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ClosureBindDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
+++ b/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
@@ -43,15 +43,14 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 		}
 
 		$secondArgument = $scope->getType($functionCall->args[1]->value);
-		$secondArgumentIsConstant = $secondArgument instanceof ConstantScalarType;
-		$secondArgumentIsNumeric = ($secondArgumentIsConstant && is_numeric($secondArgument->getValue())) || $secondArgument instanceof IntegerType;
+		$secondArgumentIsNumeric = ($secondArgument instanceof ConstantScalarType && is_numeric($secondArgument->getValue())) || $secondArgument instanceof IntegerType;
 
-		if ($secondArgumentIsConstant && ($this->isZero($secondArgument->getValue()) || !$secondArgumentIsNumeric)) {
+		if ($secondArgument instanceof ConstantScalarType && ($this->isZero($secondArgument->getValue()) || !$secondArgumentIsNumeric)) {
 			return new NullType();
 		}
 
 		if (isset($functionCall->args[2]) === false) {
-			if ($secondArgumentIsConstant || $secondArgumentIsNumeric) {
+			if ($secondArgument instanceof ConstantScalarType || $secondArgumentIsNumeric) {
 				return new StringType();
 			}
 
@@ -59,14 +58,13 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 		}
 
 		$thirdArgument = $scope->getType($functionCall->args[2]->value);
-		$thirdArgumentIsConstant = $thirdArgument instanceof ConstantScalarType;
-		$thirdArgumentIsNumeric = ($thirdArgumentIsConstant && is_numeric($thirdArgument->getValue())) || $thirdArgument instanceof IntegerType;
+		$thirdArgumentIsNumeric = ($thirdArgument instanceof ConstantScalarType && is_numeric($thirdArgument->getValue())) || $thirdArgument instanceof IntegerType;
 
-		if ($thirdArgumentIsConstant && ($this->isZero($thirdArgument->getValue()) || !is_numeric($thirdArgument->getValue()))) {
+		if ($thirdArgument instanceof ConstantScalarType && ($this->isZero($thirdArgument->getValue()) || !is_numeric($thirdArgument->getValue()))) {
 			return new NullType();
 		}
 
-		if (($secondArgumentIsConstant || $secondArgumentIsNumeric) && $thirdArgumentIsNumeric) {
+		if (($secondArgument instanceof ConstantScalarType || $secondArgumentIsNumeric) && $thirdArgumentIsNumeric) {
 			return new StringType();
 		}
 
@@ -92,9 +90,8 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 
 		$firstArgument = $scope->getType($functionCall->args[0]->value);
 
-		$firstArgumentIsConstant = $firstArgument instanceof ConstantScalarType;
-		$firstArgumentIsPositive = $firstArgumentIsConstant && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() >= 0;
-		$firstArgumentIsNegative = $firstArgumentIsConstant && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() < 0;
+		$firstArgumentIsPositive = $firstArgument instanceof ConstantScalarType && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() >= 0;
+		$firstArgumentIsNegative = $firstArgument instanceof ConstantScalarType && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() < 0;
 
 		if ($firstArgument instanceof UnaryMinus ||
 			($firstArgumentIsNegative)) {
@@ -110,9 +107,8 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 		}
 
 		$secondArgument = $scope->getType($functionCall->args[1]->value);
-		$secondArgumentIsConstant = $secondArgument instanceof ConstantScalarType;
-		$secondArgumentIsValid = $secondArgumentIsConstant && is_numeric($secondArgument->getValue()) && !$this->isZero($secondArgument->getValue());
-		$secondArgumentIsNonNumeric = $secondArgumentIsConstant && !is_numeric($secondArgument->getValue());
+		$secondArgumentIsValid = $secondArgument instanceof ConstantScalarType && is_numeric($secondArgument->getValue()) && !$this->isZero($secondArgument->getValue());
+		$secondArgumentIsNonNumeric = $secondArgument instanceof ConstantScalarType && !is_numeric($secondArgument->getValue());
 
 		if ($secondArgumentIsNonNumeric) {
 			return new NullType();
@@ -142,8 +138,7 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 		$exponent = $scope->getType($functionCall->args[1]->value);
 		$exponentIsNegative = IntegerRangeType::fromInterval(null, 0)->isSuperTypeOf($exponent)->yes();
 
-		$exponentIsConstant = $exponent instanceof ConstantScalarType;
-		if ($exponentIsConstant) {
+		if ($exponent instanceof ConstantScalarType) {
 			$exponentIsNegative = is_numeric($exponent->getValue()) && $exponent->getValue() < 0;
 		}
 
@@ -153,15 +148,14 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 
 		if (isset($functionCall->args[2])) {
 			$modulus = $scope->getType($functionCall->args[2]->value);
-			$modulusIsConstant = $modulus instanceof ConstantScalarType;
-			$modulusIsZero = $modulusIsConstant && $this->isZero($modulus->getValue());
-			$modulusIsNonNumeric = $modulusIsConstant && !is_numeric($modulus->getValue());
+			$modulusIsZero = $modulus instanceof ConstantScalarType && $this->isZero($modulus->getValue());
+			$modulusIsNonNumeric = $modulus instanceof ConstantScalarType && !is_numeric($modulus->getValue());
 
 			if ($modulusIsZero || $modulusIsNonNumeric) {
 				return new ConstantBooleanType(false);
 			}
 
-			if ($modulusIsConstant) {
+			if ($modulus instanceof ConstantScalarType) {
 				return new StringType();
 			}
 		}

--- a/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
+++ b/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
@@ -1,0 +1,191 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\UnaryMinus;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use function in_array;
+use function is_numeric;
+
+class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), ['bcdiv', 'bcmod', 'bcpowmod', 'bcsqrt'], true);
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		if ($functionReflection->getName() === 'bcsqrt') {
+			return $this->getTypeForBcSqrt($functionCall, $scope);
+		}
+
+		if ($functionReflection->getName() === 'bcpowmod') {
+			return $this->getTypeForBcPowMod($functionCall, $scope);
+		}
+
+		$defaultReturnType = new UnionType([new StringType(), new NullType()]);
+
+		if (isset($functionCall->args[1]) === false) {
+			return $defaultReturnType;
+		}
+
+		$secondArgument = $scope->getType($functionCall->args[1]->value);
+		$secondArgumentIsConstant = $secondArgument instanceof ConstantScalarType;
+		$secondArgumentIsNumeric = ($secondArgumentIsConstant && is_numeric($secondArgument->getValue())) || $secondArgument instanceof IntegerType;
+
+		if ($secondArgumentIsConstant && ($this->isZero($secondArgument->getValue()) || !$secondArgumentIsNumeric)) {
+			return new NullType();
+		}
+
+		if (isset($functionCall->args[2]) === false) {
+			if ($secondArgumentIsConstant || $secondArgumentIsNumeric) {
+				return new StringType();
+			}
+
+			return $defaultReturnType;
+		}
+
+		$thirdArgument = $scope->getType($functionCall->args[2]->value);
+		$thirdArgumentIsConstant = $thirdArgument instanceof ConstantScalarType;
+		$thirdArgumentIsNumeric = ($thirdArgumentIsConstant && is_numeric($thirdArgument->getValue())) || $thirdArgument instanceof IntegerType;
+
+		if ($thirdArgumentIsConstant && ($this->isZero($thirdArgument->getValue()) || !is_numeric($thirdArgument->getValue()))) {
+			return new NullType();
+		}
+
+		if (($secondArgumentIsConstant || $secondArgumentIsNumeric) && $thirdArgumentIsNumeric) {
+			return new StringType();
+		}
+
+		return $defaultReturnType;
+	}
+
+	/**
+	 * bcsqrt
+	 * https://www.php.net/manual/en/function.bcsqrt.php
+	 * > Returns the square root as a string, or NULL if operand is negative.
+	 *
+	 * @param FuncCall $functionCall
+	 * @param Scope $scope
+	 * @return NullType|StringType|UnionType
+	 */
+	private function getTypeForBcSqrt(FuncCall $functionCall, Scope $scope)
+	{
+		$defaultReturnType = new UnionType([new StringType(), new NullType()]);
+
+		if (isset($functionCall->args[0]) === false) {
+			return $defaultReturnType;
+		}
+
+		$firstArgument = $scope->getType($functionCall->args[0]->value);
+
+		$firstArgumentIsConstant = $firstArgument instanceof ConstantScalarType;
+		$firstArgumentIsPositive = $firstArgumentIsConstant && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() >= 0;
+		$firstArgumentIsNegative = $firstArgumentIsConstant && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() < 0;
+
+		if ($firstArgument instanceof UnaryMinus ||
+			($firstArgumentIsNegative)) {
+			return new NullType();
+		}
+
+		if (isset($functionCall->args[1]) === false) {
+			if ($firstArgumentIsPositive) {
+				return new StringType();
+			}
+
+			return $defaultReturnType;
+		}
+
+		$secondArgument = $scope->getType($functionCall->args[1]->value);
+		$secondArgumentIsConstant = $secondArgument instanceof ConstantScalarType;
+		$secondArgumentIsValid = $secondArgumentIsConstant && is_numeric($secondArgument->getValue()) && !$this->isZero($secondArgument->getValue());
+		$secondArgumentIsNonNumeric = $secondArgumentIsConstant && !is_numeric($secondArgument->getValue());
+
+		if ($secondArgumentIsNonNumeric) {
+			return new NullType();
+		}
+
+		if ($firstArgumentIsPositive && $secondArgumentIsValid) {
+			return new StringType();
+		}
+
+		return $defaultReturnType;
+	}
+
+	/**
+	 * bcpowmod()
+	 * https://www.php.net/manual/en/function.bcpowmod.php
+	 * > Returns the result as a string, or FALSE if modulus is 0 or exponent is negative.
+	 * @param FuncCall $functionCall
+	 * @param Scope $scope
+	 * @return BooleanType|StringType|UnionType
+	 */
+	private function getTypeForBcPowMod(FuncCall $functionCall, Scope $scope)
+	{
+		if (isset($functionCall->args[1]) === false) {
+			return new UnionType([new StringType(), new ConstantBooleanType(false)]);
+		}
+
+		$exponent = $scope->getType($functionCall->args[1]->value);
+		$exponentIsNegative = IntegerRangeType::fromInterval(null, 0)->isSuperTypeOf($exponent)->yes();
+
+		$exponentIsConstant = $exponent instanceof ConstantScalarType;
+		if ($exponentIsConstant) {
+			$exponentIsNegative = is_numeric($exponent->getValue()) && $exponent->getValue() < 0;
+		}
+
+		if ($exponentIsNegative) {
+			return new ConstantBooleanType(false);
+		}
+
+		if (isset($functionCall->args[2])) {
+			$modulus = $scope->getType($functionCall->args[2]->value);
+			$modulusIsConstant = $modulus instanceof ConstantScalarType;
+			$modulusIsZero = $modulusIsConstant && $this->isZero($modulus->getValue());
+			$modulusIsNonNumeric = $modulusIsConstant && !is_numeric($modulus->getValue());
+
+			if ($modulusIsZero || $modulusIsNonNumeric) {
+				return new ConstantBooleanType(false);
+			}
+
+			if ($modulusIsConstant) {
+				return new StringType();
+			}
+		}
+
+		return new UnionType([new StringType(), new ConstantBooleanType(false)]);
+	}
+
+	/**
+	 * Utility to help us determine if value is zero. Handles cases where we pass "0.000" too.
+	 *
+	 * @param mixed $value
+	 * @return bool
+	 */
+	private function isZero($value): bool
+	{
+		if (is_numeric($value) === false) {
+			return false;
+		}
+
+		if ($value > 0 || $value < 0) {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10093,6 +10093,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/preg_split.php');
 	}
 
+	public function dataBcMathDynamicReturn(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bcmath-dynamic-return.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10158,6 +10163,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataNativeStaticReturnType
 	 * @dataProvider dataClassPhpDocs
 	 * @dataProvider dataNonEmptyArrayKeyType
+	 * @dataProvider dataBcMathDynamicReturn
 	 * @dataProvider dataBug3133
 	 * @dataProvider dataBug2550
 	 * @dataProvider dataBug2899

--- a/tests/PHPStan/Analyser/data/bcmath-dynamic-return.php
+++ b/tests/PHPStan/Analyser/data/bcmath-dynamic-return.php
@@ -1,0 +1,93 @@
+<?php
+
+// Verification for constant types: https://3v4l.org/96GSj
+
+/** @var mixed $mixed */
+$mixed = getMixed();
+
+/** @var int $iUnknown */
+$iUnknown = getInt();
+
+/** @var string $string */
+$string = getString();
+
+$iNeg = -5;
+$iPos = 5;
+$nonNumeric = 'foo';
+
+
+//  bcdiv ( string $dividend , string $divisor [, int $scale = 0 ] ) : string
+// Returns the result of the division as a string, or NULL if divisor is 0.
+\PHPStan\Analyser\assertType('null', bcdiv('10', '0')); // Warning: Division by zero
+\PHPStan\Analyser\assertType('null', bcdiv('10', '0.0')); // Warning: Division by zero
+\PHPStan\Analyser\assertType('null', bcdiv('10', 0.0)); // Warning: Division by zero
+\PHPStan\Analyser\assertType('string', bcdiv('10', '1'));
+\PHPStan\Analyser\assertType('string', bcdiv('10', '-1'));
+\PHPStan\Analyser\assertType('string', bcdiv('10', $iNeg));
+\PHPStan\Analyser\assertType('string', bcdiv('10', $iPos));
+\PHPStan\Analyser\assertType('string', bcdiv($iPos, $iPos));
+\PHPStan\Analyser\assertType('string|null', bcdiv('10', $mixed));
+\PHPStan\Analyser\assertType('string', bcdiv('10', $iPos, $iPos));
+\PHPStan\Analyser\assertType('string', bcdiv('10', $iUnknown));
+\PHPStan\Analyser\assertType('null', bcdiv('10', $iPos, $nonNumeric)); // Warning: expects parameter 3 to be int, string given in
+\PHPStan\Analyser\assertType('null', bcdiv('10', $nonNumeric)); // Warning: bcmath function argument is not well-formed
+
+//  bcmod ( string $dividend , string $divisor [, int $scale = 0 ] ) : string
+// Returns the modulus as a string, or NULL if divisor is 0.
+\PHPStan\Analyser\assertType('null', bcmod('10', '0'));
+\PHPStan\Analyser\assertType('null', bcmod($iPos, '0')); // Warning: Division by zero
+\PHPStan\Analyser\assertType('null', bcmod('10', $nonNumeric));
+\PHPStan\Analyser\assertType('string', bcmod('10', '1'));
+\PHPStan\Analyser\assertType('string', bcmod('10', 2.2));
+\PHPStan\Analyser\assertType('string', bcmod('10', $iUnknown));
+\PHPStan\Analyser\assertType('string', bcmod('10', '-1'));
+\PHPStan\Analyser\assertType('string', bcmod($iPos, '-1'));
+\PHPStan\Analyser\assertType('string', bcmod('10', $iNeg));
+\PHPStan\Analyser\assertType('string', bcmod('10', $iPos));
+\PHPStan\Analyser\assertType('string', bcmod('10', -$iNeg));
+\PHPStan\Analyser\assertType('string', bcmod('10', -$iPos));
+\PHPStan\Analyser\assertType('string|null', bcmod('10', $mixed));
+
+//  bcpowmod ( string $base , string $exponent , string $modulus [, int $scale = 0 ] ) : string
+// Returns the result as a string, or FALSE if modulus is 0 or exponent is negative.
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '-2', '0')); // exponent negative, and modulus is 0
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '-2', '1')); // exponent negative
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '2', $nonNumeric)); // Warning: bcmath function argument is not well-formed
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '-2', '-1')); // exponent negative
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '-2', -1.3)); // exponent negative
+\PHPStan\Analyser\assertType('false', bcpowmod('10', -$iPos, '-1')); // exponent negative
+\PHPStan\Analyser\assertType('false', bcpowmod('10', -$iPos, '1')); // exponent negative
+\PHPStan\Analyser\assertType('false', bcpowmod('10', $nonNumeric, $nonNumeric)); // Warning: bcmath function argument is not well-formed
+\PHPStan\Analyser\assertType('false', bcpowmod($iPos, $nonNumeric, $nonNumeric));
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '2', '0')); // modulus is 0
+\PHPStan\Analyser\assertType('false', bcpowmod('10', 2.3, '0')); // modulus is 0
+\PHPStan\Analyser\assertType('false', bcpowmod('10', '0', '0')); // modulus is 0
+\PHPStan\Analyser\assertType('string', bcpowmod('10', '0', '-2'));
+\PHPStan\Analyser\assertType('string', bcpowmod('10', '2', '2'));
+\PHPStan\Analyser\assertType('string', bcpowmod('10', $iUnknown, '2'));
+\PHPStan\Analyser\assertType('string', bcpowmod($iPos, '2', '2'));
+\PHPStan\Analyser\assertType('string|false', bcpowmod('10', $mixed, $mixed));
+\PHPStan\Analyser\assertType('string', bcpowmod('10', '2', '2'));
+\PHPStan\Analyser\assertType('string', bcpowmod('10', -$iNeg, '2'));
+\PHPStan\Analyser\assertType('string', bcpowmod('10', $nonNumeric, '2')); // Warning: bcmath function argument is not well-formed
+\PHPStan\Analyser\assertType('string|false', bcpowmod('10', $iUnknown, $iUnknown));
+
+//  bcsqrt ( string $operand [, int $scale = 0 ] ) : string
+// Returns the square root as a string, or NULL if operand is negative.
+\PHPStan\Analyser\assertType('string', bcsqrt('10', $iNeg));
+\PHPStan\Analyser\assertType('string', bcsqrt('10', 1));
+\PHPStan\Analyser\assertType('string', bcsqrt('0.00', 1));
+\PHPStan\Analyser\assertType('string', bcsqrt(0.0, 1));
+\PHPStan\Analyser\assertType('string', bcsqrt('0', 1));
+\PHPStan\Analyser\assertType('string|null', bcsqrt($iUnknown, $iUnknown));
+\PHPStan\Analyser\assertType('string', bcsqrt('10', $iPos));
+\PHPStan\Analyser\assertType('null', bcsqrt('-10', 0)); // Warning: Square root of negative number
+\PHPStan\Analyser\assertType('null', bcsqrt($iNeg, 0));
+\PHPStan\Analyser\assertType('null', bcsqrt('10', $nonNumeric)); // Warning: Second argument must be ?int (Fatal in PHP8)
+\PHPStan\Analyser\assertType('string', bcsqrt('10'));
+\PHPStan\Analyser\assertType('string|null', bcsqrt($iUnknown));
+\PHPStan\Analyser\assertType('null', bcsqrt('-10')); // Warning: Square root of negative number
+
+\PHPStan\Analyser\assertType('string|null', bcsqrt($nonNumeric, -1)); // Warning: bcmath function argument is not well-formed
+\PHPStan\Analyser\assertType('string|null', bcsqrt('10', $mixed));
+\PHPStan\Analyser\assertType('string', bcsqrt($iPos));


### PR DESCRIPTION
Not sure if this should be split into multiple extensions, kept it at one because they all had very similar logic.