### PR TITLE
Add config option to exclude mixin classes

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -39,6 +39,7 @@ parameters:
 	reportMaybes: false
 	reportMaybesInMethodSignatures: false
 	reportStaticMethodSignatures: false
+	mixinExcludeClasses: []
 	parallel:
 		jobSize: 20
 		processTimeout: 60.0
@@ -215,6 +216,7 @@ parametersSchema:
 	tmpDir: string()
 	currentWorkingDirectory: string()
 	cliArgumentsVariablesRegistered: bool()
+	mixinExcludeClasses: listOf(string())
 
 	# irrelevant Nette parameters
 	debugMode: bool()
@@ -480,11 +482,15 @@ services:
 		class: PHPStan\Reflection\Mixin\MixinMethodsClassReflectionExtension
 		tags:
 			- phpstan.broker.methodsClassReflectionExtension
+		arguments:
+			mixinExcludeClasses: %mixinExcludeClasses%
 
 	-
 		class: PHPStan\Reflection\Mixin\MixinPropertiesClassReflectionExtension
 		tags:
 			- phpstan.broker.propertiesClassReflectionExtension
+		arguments:
+			mixinExcludeClasses: %mixinExcludeClasses%
 
 	-
 		class: PHPStan\Reflection\Php\PhpClassReflectionExtension

--- a/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
@@ -6,9 +6,21 @@ use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\TypeUtils;
 
 class MixinMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
+
+	/** @var string[] */
+	private $mixinExcludeClasses;
+
+	/**
+	 * @param string[] $mixinExcludeClasses
+	 */
+	public function __construct(array $mixinExcludeClasses)
+	{
+		$this->mixinExcludeClasses = $mixinExcludeClasses;
+	}
 
 	public function hasMethod(ClassReflection $classReflection, string $methodName): bool
 	{
@@ -29,6 +41,10 @@ class MixinMethodsClassReflectionExtension implements MethodsClassReflectionExte
 	{
 		$mixinTypes = $classReflection->getResolvedMixinTypes();
 		foreach ($mixinTypes as $type) {
+			if (count(array_intersect(TypeUtils::getDirectClassNames($type), $this->mixinExcludeClasses)) > 0) {
+				continue;
+			}
+
 			if (!$type->hasMethod($methodName)->yes()) {
 				continue;
 			}

--- a/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
@@ -6,9 +6,21 @@ use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\TypeUtils;
 
 class MixinPropertiesClassReflectionExtension implements PropertiesClassReflectionExtension
 {
+
+	/** @var string[] */
+	private $mixinExcludeClasses;
+
+	/**
+	 * @param string[] $mixinExcludeClasses
+	 */
+	public function __construct(array $mixinExcludeClasses)
+	{
+		$this->mixinExcludeClasses = $mixinExcludeClasses;
+	}
 
 	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
 	{
@@ -29,6 +41,10 @@ class MixinPropertiesClassReflectionExtension implements PropertiesClassReflecti
 	{
 		$mixinTypes = $classReflection->getResolvedMixinTypes();
 		foreach ($mixinTypes as $type) {
+			if (count(array_intersect(TypeUtils::getDirectClassNames($type), $this->mixinExcludeClasses)) > 0) {
+				continue;
+			}
+
 			if (!$type->hasProperty($propertyName)->yes()) {
 				continue;
 			}


### PR DESCRIPTION
From the discussion at https://github.com/nunomaduro/larastan/issues/555

This PR adds a config option to blacklist classes for `@mixin` annotation.

I did not find an easy way to test this. Because the config file needs to be changed. So, if you can point me how to test this, I will do it.