### PR TITLE
Fix 2914: Fix a test on merging inherited PHPDocs

### DIFF
--- a/src/PhpDoc/PhpDocBlock.php
+++ b/src/PhpDoc/PhpDocBlock.php
@@ -346,12 +346,6 @@ class PhpDocBlock
 			if ($parentReflection->isPrivate()) {
 				return null;
 			}
-			if (
-				!$parentReflection->getDeclaringClass()->isTrait()
-				&& $parentReflection->getDeclaringClass()->getName() !== $classReflection->getName()
-			) {
-				return null;
-			}
 
 			if ($parentReflection instanceof PhpPropertyReflection || $parentReflection instanceof ResolvedPropertyReflection) {
 				$traitReflection = $parentReflection->getDeclaringTrait();

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -1280,3 +1280,43 @@ function arrayOfGenericClassStrings(array $a): void
 {
 	assertType('array<class-string<PHPStan\Generics\FunctionsAssertType\Foo>>', $a);
 }
+
+/**
+ * @template T
+ */
+class TagMergingGrandparent
+{
+	/** @var T */
+	public $property;
+
+	/**
+	 * @param T $one
+	 * @param int $two
+	 */
+	public function method($one, $two): void {}
+}
+
+/**
+ * @template TT
+ * @extends TagMergingGrandparent<TT>
+ */
+class TagMergingParent extends TagMergingGrandparent
+{
+	/**
+	 * @param TT $one
+	 */
+	public function method($one, $two): void {}
+}
+
+/**
+ * @extends TagMergingParent<float>
+ */
+class TagMergingChild extends TagMergingParent
+{
+	public function method($one, $two): void
+	{
+		assertType('float', $one);
+		assertType('int', $two);
+		assertType('float', $this->property);
+	}
+}

--- a/tests/PHPStan/Analyser/data/inherit-phpdoc-merging-var.php
+++ b/tests/PHPStan/Analyser/data/inherit-phpdoc-merging-var.php
@@ -66,7 +66,7 @@ class Six extends Five
 
 	public function method(): void
 	{
-		// assertType('InheritDocMergingVar\B', $this->property);
+		assertType('InheritDocMergingVar\B', $this->property);
 	}
 }
 


### PR DESCRIPTION
I fixed the test.

> BTW have you considered what should be done about `@template T` and for example `@param T` tags? They can't be simply merged, the scope of the types (TemplateTypeScope) needs to change to reflect the child class.

I took care of that already. I just added a test to generics.php on that. If you mean something else then please provide a test that breaks.