### PR TITLE
Require PHP 7.4 in phpstan-src

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
+
       - name: "Validate Composer"
         run: "composer validate"
 
@@ -47,6 +51,10 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Transform source code"
+        if: matrix.php-version != '7.4'
+        run: php bin/transform-source.php
 
       - name: "Lint"
         run: "vendor/bin/phing lint"
@@ -71,6 +79,10 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
+
       - name: "Validate Composer"
         run: "composer validate"
 
@@ -83,6 +95,10 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Transform source code"
+        if: matrix.php-version != '7.4'
+        run: php bin/transform-source.php
 
       - name: "Composer Normalize"
         run: "vendor/bin/phing composer-normalize-check"
@@ -112,6 +128,10 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
 
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
@@ -153,6 +173,10 @@ jobs:
           extensions: ds,mbstring
           ini-values: memory_limit=512M
 
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
+
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
         with:
@@ -162,6 +186,10 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Transform source code"
+        if: matrix.php-version != '7.4'
+        run: php bin/transform-source.php
 
       - name: "Tests"
         run: "vendor/bin/phing tests"
@@ -182,6 +210,10 @@ jobs:
           php-version: "7.4"
           tools: pecl
           extensions: ds
+
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
 
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
@@ -229,6 +261,10 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring
 
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
+
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
         with:
@@ -238,6 +274,10 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Transform source code"
+        if: matrix.php-version != '7.4'
+        run: php bin/transform-source.php
 
       - name: "PHPStan"
         run: "vendor/bin/phing phpstan"
@@ -267,6 +307,10 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring
 
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
+
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
         with:
@@ -276,6 +320,10 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Transform source code"
+        if: matrix.php-version != '7.4'
+        run: php bin/transform-source.php
 
       - name: "PHPStan with static PHP-Parser"
         run: "vendor/bin/phing phpstan-static-php-parser"
@@ -301,6 +349,10 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring
+
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
 
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
@@ -362,6 +414,10 @@ jobs:
           extensions: mbstring
           ini-values: memory_limit=256M
 
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
+
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
         with:
@@ -396,6 +452,9 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
+      - name: "Change PHP version in composer.json"
+        run: php bin/change-composer-json.php
+
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
         with:
@@ -405,6 +464,9 @@ jobs:
 
       - name: "Install dependencies"
         run: "composer update --no-interaction --no-progress --no-suggest"
+
+      - name: "Transform source code"
+        run: php bin/transform-source.php
 
       - name: "Tests"
         run: |
@@ -434,6 +496,10 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
 
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"
@@ -477,6 +543,10 @@ jobs:
           php-version: "7.4"
           tools: ${{ matrix.tools }}
           extensions: ${{ matrix.extensions }}
+
+      - name: "Change PHP version in composer.json"
+        #if: matrix.php-version != '7.4'
+        run: php bin/change-composer-json.php
 
       - name: "Cache dependencies"
         uses: "actions/cache@v1.1.2"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Any contributions are welcome.
 
 ### Building
 
+PHPStan's source code is developed on PHP 7.4. For distribution in `phpstan/phpstan` package and as a PHAR file, the source code is transformed to run on PHP 7.1 and higher.
+
 Initially you need to run `composer install`, or `composer update` in case you aren't working in a directory which was built before.
 
 Afterwards you can either run the whole build including linting and coding standards using

--- a/bin/change-composer-json.php
+++ b/bin/change-composer-json.php
@@ -1,0 +1,8 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+$composerPath = __DIR__ . '/../composer.json';
+$json = json_decode(file_get_contents($composerPath), true);
+$json['require']['php'] = '^7.1';
+
+file_put_contents($composerPath, json_encode($json, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));

--- a/bin/transform-source.php
+++ b/bin/transform-source.php
@@ -1,0 +1,122 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+ini_set('memory_limit', '512M');
+
+use PhpParser\Lexer;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\UnionType;
+use PhpParser\Parser;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\PrettyPrinter;
+use PhpParser\Node;
+
+class PhpPatcher extends NodeVisitorAbstract
+{
+
+	public function leaveNode(Node $node)
+	{
+		if (!$node instanceof Node\Stmt\Property) {
+			return null;
+		}
+		if ($node->type === null) {
+			return null;
+		}
+		$docComment = $node->getDocComment();
+		if ($docComment !== null) {
+			$node->type = null;
+			return $node;
+		}
+
+		$node->setDocComment(new \PhpParser\Comment\Doc(sprintf('/** @var %s */', $this->printType($node->type))));
+		$node->type = null;
+
+		return $node;
+	}
+
+	/**
+	 * @param Identifier|Name|NullableType|UnionType $type
+	 * @return string
+	 */
+	private function printType($type): string
+	{
+		if ($type instanceof NullableType) {
+			return '?' . $this->printType($type->type);
+		}
+
+		if ($type instanceof UnionType) {
+			throw new \Exception('UnionType not yet supported');
+		}
+
+		if ($type instanceof Name) {
+			$name = $type->toString();
+			if ($type->isFullyQualified()) {
+				return '\\' . $name;
+			}
+
+			return $name;
+		}
+
+		if ($type instanceof Identifier) {
+			return $type->name;
+		}
+
+		throw new \Exception('Unsupported type class');
+	}
+
+}
+
+(function () {
+	$dir = __DIR__ . '/../src';
+
+	$lexer = new Lexer\Emulative([
+		'usedAttributes' => [
+			'comments',
+			'startLine', 'endLine',
+			'startTokenPos', 'endTokenPos',
+		],
+	]);
+	$parser = new Parser\Php7($lexer, [
+		'useIdentifierNodes' => true,
+		'useConsistentVariableNodes' => true,
+		'useExpressionStatements' => true,
+		'useNopStatements' => false,
+	]);
+	$nameResolver = new NodeVisitor\NameResolver(null, [
+		'replaceNodes' => false
+	]);
+
+	$printer = new PrettyPrinter\Standard();
+
+	$traverser = new NodeTraverser();
+	$traverser->addVisitor(new NodeVisitor\CloningVisitor());
+	$traverser->addVisitor($nameResolver);
+	$traverser->addVisitor(new PhpPatcher($printer));
+
+	$it = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($dir),
+		RecursiveIteratorIterator::LEAVES_ONLY
+	);
+	foreach ($it as $file) {
+		$fileName = $file->getPathname();
+		if (!preg_match('/\.php$/', $fileName)) {
+			continue;
+		}
+
+		$code = \PHPStan\File\FileReader::read($fileName);
+		$origStmts = $parser->parse($code);
+		$newCode = $printer->printFormatPreserving(
+			$traverser->traverse($origStmts),
+			$origStmts,
+			$lexer->getTokens()
+		);
+
+		\PHPStan\File\FileWriter::write($fileName, $newCode);
+	}
+})();

--- a/compiler/src/Console/CompileCommand.php
+++ b/compiler/src/Console/CompileCommand.php
@@ -62,6 +62,7 @@ final class CompileCommand extends Command
 		);
 		$this->fixComposerJson($this->buildDir);
 		$this->renamePhpStormStubs();
+		$this->transformSource();
 
 		$this->processFactory->create(['php', 'box.phar', 'compile', '--no-parallel'], $this->dataDir);
 
@@ -74,6 +75,7 @@ final class CompileCommand extends Command
 
 		unset($json['replace']);
 		$json['name'] = 'phpstan/phpstan';
+		$json['require']['php'] = '^7.1';
 
 		// simplify autoload (remove not packed build directory]
 		$json['autoload']['psr-4']['PHPStan\\'] = 'src/';
@@ -181,6 +183,16 @@ php;
 		}
 
 		$output->writeln(sprintf('Patching failed: %s', implode("\n", $outputLines)));
+	}
+
+	private function transformSource(): void
+	{
+		exec(escapeshellarg(__DIR__ . '/../../../bin/transform-source.php'), $outputLines, $exitCode);
+		if ($exitCode === 0) {
+			return;
+		}
+
+		throw new \PHPStan\ShouldNotHappenException(implode("\n", $outputLines));
 	}
 
 }

--- a/compiler/tests/Console/CompileCommandTest.php
+++ b/compiler/tests/Console/CompileCommandTest.php
@@ -15,12 +15,12 @@ final class CompileCommandTest extends TestCase
 	public function testCommand(): void
 	{
 		$filesystem = $this->createMock(Filesystem::class);
-		$filesystem->expects(self::once())->method('read')->with('bar/composer.json')->willReturn('{"name":"phpstan/phpstan-src","replace":{"phpstan/phpstan": "self.version"},"require":{"php":"~7.1"},"require-dev":1,"autoload-dev":2,"autoload":{"psr-4":{"PHPStan\\\\":[3]}}}');
+		$filesystem->expects(self::once())->method('read')->with('bar/composer.json')->willReturn('{"name":"phpstan/phpstan-src","replace":{"phpstan/phpstan": "self.version"},"require":{"php":"^7.4"},"require-dev":1,"autoload-dev":2,"autoload":{"psr-4":{"PHPStan\\\\":[3]}}}');
 		$filesystem->expects(self::once())->method('write')->with('bar/composer.json', <<<EOT
 {
     "name": "phpstan/phpstan",
     "require": {
-        "php": "~7.1"
+        "php": "^7.1"
     },
     "require-dev": 1,
     "autoload-dev": 2,

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 		"MIT"
 	],
 	"require": {
-		"php": "^7.1",
+		"php": "^7.4",
 		"clue/ndjson-react": "^1.0",
 		"composer/xdebug-handler": "^1.3.0",
 		"hoa/compiler": "3.17.08.08",

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -7,11 +7,9 @@ use PHPStan\Rules\Registry;
 class Analyser
 {
 
-	/** @var \PHPStan\Analyser\FileAnalyser */
-	private $fileAnalyser;
+	private \PHPStan\Analyser\FileAnalyser $fileAnalyser;
 
-	/** @var \PHPStan\Rules\Registry */
-	private $registry;
+	private Registry $registry;
 
 	/** @var \PHPStan\Analyser\NodeScopeResolver */
 	private $nodeScopeResolver;


### PR DESCRIPTION
This PR introduces some basic PHP 7.4 syntax into the phpstan-src repository.

Some notes:

* PHP 7.1+ is still supported in the `phpstan/phpstan` distribution which should be used by everyone when they're not working on PHPStan's source code itself.
* I'm doing this so that I can use newer versions of dependencies. For example `roave/better-reflection` is planning to switch to PHP 7.4 so PHPStan should get ready for that.
* I can also take advantage of latest PHP features during PHPStan development itself.

People depending on phpstan-src in their build workflow like @TomasVotruba should call the `bin/transform-source.php` script to get the sources transformed for PHP 7.1+.