### PR TITLE
Add LIBXML_VERSION & LIBXML_DOTTED_VERSION dynamic constants

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -83,6 +83,8 @@ parameters:
 		- '#^Soap(?:Client|Var|Server|Fault|Param|Header)$#'
 	dynamicConstantNames:
 		- ICONV_IMPL
+		- LIBXML_VERSION
+		- LIBXML_DOTTED_VERSION
 		- PHP_VERSION
 		- PHP_MAJOR_VERSION
 		- PHP_MINOR_VERSION


### PR DESCRIPTION
Both `LIBXML_VERSION` & `LIBXML_DOTTED_VERSION` are dynamic constants from a PHP extension that should not be inferred from the current version of the runtime.

Related issue https://github.com/phpstan/phpstan/issues/3291