### PR TITLE
IsSuperTypeOf refactorings

### DIFF
--- a/src/Type/Generic/TemplateMixedType.php
+++ b/src/Type/Generic/TemplateMixedType.php
@@ -90,14 +90,8 @@ final class TemplateMixedType extends MixedType implements TemplateType
 			return $type->isSubTypeOf($this);
 		}
 
-		$isSuperTypeOf = $this->getBound()->isSuperTypeOf($type);
-		if ($isSuperTypeOf->yes()) {
-			return TrinaryLogic::createMaybe();
-		}
-		if ($isSuperTypeOf->maybe()) {
-			return TrinaryLogic::createNo();
-		}
-		return $isSuperTypeOf;
+		return $this->getBound()->isSuperTypeOf($type)
+			->and(TrinaryLogic::createMaybe());
 	}
 
 	public function isSuperTypeOfMixed(MixedType $type): TrinaryLogic

--- a/src/Type/Generic/TemplateObjectType.php
+++ b/src/Type/Generic/TemplateObjectType.php
@@ -95,14 +95,8 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 			return $type->isSubTypeOf($this);
 		}
 
-		$isSuperTypeOf = $this->getBound()->isSuperTypeOf($type);
-		if ($isSuperTypeOf->yes()) {
-			return TrinaryLogic::createMaybe();
-		}
-		if ($isSuperTypeOf->maybe()) {
-			return TrinaryLogic::createNo();
-		}
-		return $isSuperTypeOf;
+		return $this->getBound()->isSuperTypeOf($type)
+			->and(TrinaryLogic::createMaybe());
 	}
 
 	public function isSubTypeOf(Type $type): TrinaryLogic
@@ -116,15 +110,24 @@ final class TemplateObjectType extends ObjectType implements TemplateType
 		}
 
 		if (!$type instanceof TemplateType) {
-			return $type->isSuperTypeOf($this->getBound());
+			if ($this->getBound()->equals($type)) {
+				return TrinaryLogic::createYes();
+			}
+
+			return $type->isSuperTypeOf($this->getBound())
+				->and(TrinaryLogic::createMaybe());
 		}
 
 		if ($this->equals($type)) {
 			return TrinaryLogic::createYes();
 		}
 
-		return $type->getBound()->isSuperTypeOf($this->getBound())
-			->and(TrinaryLogic::createMaybe());
+		if ($type->getBound()->isSuperTypeOf($this->getBound())->no() &&
+			$this->getBound()->isSuperTypeOf($type->getBound())->no()) {
+			return TrinaryLogic::createNo();
+		}
+
+		return TrinaryLogic::createMaybe();
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): TrinaryLogic

--- a/tests/PHPStan/Rules/Classes/data/impossible-instanceof.php
+++ b/tests/PHPStan/Rules/Classes/data/impossible-instanceof.php
@@ -392,3 +392,15 @@ class CheckInstanceofInIterableForeach
 	}
 
 }
+
+class CheckInstanceofWithTemplates
+{
+	/**
+	 * @template T of \Exception
+	 * @param T $e
+	 */
+	public function test(\Throwable $t, $e): void {
+		if ($t instanceof $e) return;
+		if ($e instanceof $t) return;
+	}
+}

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -19,47 +19,47 @@ class ConstantStringTypeTest extends TestCase
 	public function dataIsSuperTypeOf(): array
 	{
 		return [
-			[
+			0 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			1 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new ObjectType(\Throwable::class)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			2 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new ObjectType(\InvalidArgumentException::class)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			3 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new ObjectType(\stdClass::class)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			4 => [
 				new ConstantStringType(\Exception::class),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			5 => [
 				new ConstantStringType(\Exception::class),
 				new ConstantStringType(\InvalidArgumentException::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			6 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			7 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new ObjectType(\stdClass::class)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			8 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
@@ -69,7 +69,7 @@ class ConstantStringTypeTest extends TestCase
 				)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			9 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
@@ -79,7 +79,7 @@ class ConstantStringTypeTest extends TestCase
 				)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			10 => [
 				new ConstantStringType(\InvalidArgumentException::class),
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
@@ -89,7 +89,7 @@ class ConstantStringTypeTest extends TestCase
 				)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			11 => [
 				new ConstantStringType(\Throwable::class),
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
@@ -99,7 +99,7 @@ class ConstantStringTypeTest extends TestCase
 				)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			12 => [
 				new ConstantStringType(\stdClass::class),
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
@@ -109,17 +109,17 @@ class ConstantStringTypeTest extends TestCase
 				)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			13 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new StaticType(\Exception::class)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			14 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new StaticType(\InvalidArgumentException::class)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			15 => [
 				new ConstantStringType(\Exception::class),
 				new GenericClassStringType(new StaticType(\Throwable::class)),
 				TrinaryLogic::createMaybe(),

--- a/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
@@ -19,62 +19,57 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 	public function dataIsSuperTypeOf(): array
 	{
 		return [
-			[
+			0 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new ClassStringType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			1 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new StringType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			2 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				TrinaryLogic::createYes(),
 			],
-			[
+			3 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new GenericClassStringType(new ObjectType(\Throwable::class)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			4 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new GenericClassStringType(new ObjectType(\InvalidArgumentException::class)),
 				TrinaryLogic::createYes(),
 			],
-			[
+			5 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new GenericClassStringType(new ObjectType(\stdClass::class)),
 				TrinaryLogic::createNo(),
 			],
-			[
+			6 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			7 => [
 				new GenericClassStringType(new ObjectType(\Throwable::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			8 => [
 				new GenericClassStringType(new ObjectType(\InvalidArgumentException::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createNo(),
 			],
-			[
-				new GenericClassStringType(new ObjectType(\Exception::class)),
-				new ConstantStringType(\Exception::class),
-				TrinaryLogic::createYes(),
-			],
-			[
+			9 => [
 				new GenericClassStringType(new ObjectType(\stdClass::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			10 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
 					'T',
@@ -84,7 +79,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			11 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
 					'T',
@@ -94,7 +89,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			12 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
 					'T',
@@ -104,7 +99,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType(\stdClass::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			13 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
 					'T',
@@ -114,7 +109,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType(\InvalidArgumentException::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			14 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
 					'T',
@@ -124,17 +119,17 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType(\Throwable::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			15 => [
 				new GenericClassStringType(new StaticType(\Exception::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			16 => [
 				new GenericClassStringType(new StaticType(\InvalidArgumentException::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			17 => [
 				new GenericClassStringType(new StaticType(\Throwable::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
@@ -158,37 +153,37 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 	public function dataAccepts(): array
 	{
 		return [
-			[
+			0 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new ConstantStringType(\Throwable::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			1 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new ConstantStringType(\Exception::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			2 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new ConstantStringType(\InvalidArgumentException::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			3 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new StringType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			4 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new ObjectType(\Exception::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			5 => [
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				new GenericClassStringType(new ObjectType(\Exception::class)),
 				TrinaryLogic::createYes(),
 			],
-			[
+			6 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithFunction('foo'),
 					'T',
@@ -198,7 +193,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType('NonexistentClass'),
 				TrinaryLogic::createNo(),
 			],
-			[
+			7 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithClass('Foo'),
 					'T',
@@ -211,7 +206,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createYes(),
 			],
-			[
+			8 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithClass('Foo'),
 					'T',
@@ -221,7 +216,7 @@ class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
 				new ClassStringType(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			9 => [
 				new GenericClassStringType(TemplateTypeFactory::create(
 					TemplateTypeScope::createWithClass('Foo'),
 					'T',

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -11,132 +11,132 @@ class MixedTypeTest extends \PHPStan\Testing\TestCase
 	public function dataIsSuperTypeOf(): array
 	{
 		return [
-			[
+			0 => [
 				new MixedType(),
 				new MixedType(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			1 => [
 				new MixedType(),
 				new IntegerType(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			2 => [
 				new MixedType(false, new IntegerType()),
 				new IntegerType(),
 				TrinaryLogic::createNo(),
 			],
-			[
+			3 => [
 				new MixedType(false, new IntegerType()),
 				new ConstantIntegerType(1),
 				TrinaryLogic::createNo(),
 			],
-			[
+			4 => [
 				new MixedType(false, new ConstantIntegerType(1)),
 				new IntegerType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			5 => [
 				new MixedType(false, new ConstantIntegerType(1)),
 				new MixedType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			6 => [
 				new MixedType(),
 				new MixedType(false, new ConstantIntegerType(1)),
 				TrinaryLogic::createYes(),
 			],
-			[
+			7 => [
 				new MixedType(false, new ConstantIntegerType(1)),
 				new MixedType(false, new ConstantIntegerType(1)),
 				TrinaryLogic::createYes(),
 			],
-			[
+			8 => [
 				new MixedType(false, new IntegerType()),
 				new MixedType(false, new ConstantIntegerType(1)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			9 => [
 				new MixedType(false, new ConstantIntegerType(1)),
 				new MixedType(false, new IntegerType()),
 				TrinaryLogic::createYes(),
 			],
-			[
+			10 => [
 				new MixedType(false, new StringType()),
 				new MixedType(false, new IntegerType()),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			11 => [
 				new MixedType(),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			12 => [
 				new MixedType(false, new ObjectWithoutClassType()),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createNo(),
 			],
-			[
+			13 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			14 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new ObjectWithoutClassType(new ObjectType('Exception')),
 				TrinaryLogic::createYes(),
 			],
-			[
+			15 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new ObjectWithoutClassType(new ObjectType('InvalidArgumentException')),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			16 => [
 				new MixedType(false, new ObjectType('InvalidArgumentException')),
 				new ObjectWithoutClassType(new ObjectType('Exception')),
 				TrinaryLogic::createYes(),
 			],
-			[
+			17 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new ObjectType('Exception'),
 				TrinaryLogic::createNo(),
 			],
-			[
+			18 => [
 				new MixedType(false, new ObjectType('InvalidArgumentException')),
 				new ObjectType('Exception'),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			19 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new ObjectType('InvalidArgumentException'),
 				TrinaryLogic::createNo(),
 			],
-			[
+			20 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new MixedType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			21 => [
 				new MixedType(false, new ObjectType('Exception')),
 				new MixedType(false, new ObjectType('stdClass')),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			22 => [
 				new MixedType(),
 				new NeverType(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			23 => [
 				new MixedType(false, new NullType()),
 				new NeverType(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			24 => [
 				new MixedType(),
 				new UnionType([new StringType(), new IntegerType()]),
 				TrinaryLogic::createYes(),
 			],
-			[
+			25 => [
 				new MixedType(false, new NullType()),
 				new UnionType([new StringType(), new IntegerType()]),
 				TrinaryLogic::createYes(),

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -332,7 +332,7 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 					new ObjectType(\DateTime::class),
 					TemplateTypeVariance::createInvariant()
 				),
-				TrinaryLogic::createYes(),
+				TrinaryLogic::createMaybe(),
 			],
 			48 => [
 				new ObjectType(\DateTime::class),

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -66,52 +66,52 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 	public function dataIsSuperTypeOf(): array
 	{
 		return [
-			[
+			0 => [
 				new ObjectType('UnknownClassA'),
 				new ObjectType('UnknownClassB'),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			1 => [
 				new ObjectType(\ArrayAccess::class),
 				new ObjectType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			2 => [
 				new ObjectType(\Countable::class),
 				new ObjectType(\Countable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			3 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new ObjectType(\DateTimeImmutable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			4 => [
 				new ObjectType(\Traversable::class),
 				new ObjectType(\ArrayObject::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			5 => [
 				new ObjectType(\Traversable::class),
 				new ObjectType(\Iterator::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			6 => [
 				new ObjectType(\ArrayObject::class),
 				new ObjectType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			7 => [
 				new ObjectType(\Iterator::class),
 				new ObjectType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			8 => [
 				new ObjectType(\ArrayObject::class),
 				new ObjectType(\DateTimeImmutable::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			9 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new UnionType([
 					new ObjectType(\DateTimeImmutable::class),
@@ -119,7 +119,7 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			10 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new UnionType([
 					new ObjectType(\ArrayObject::class),
@@ -127,57 +127,57 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createNo(),
 			],
-			[
+			11 => [
 				new ObjectType(\LogicException::class),
 				new ObjectType(\InvalidArgumentException::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			12 => [
 				new ObjectType(\InvalidArgumentException::class),
 				new ObjectType(\LogicException::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			13 => [
 				new ObjectType(\ArrayAccess::class),
 				new StaticType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			14 => [
 				new ObjectType(\Countable::class),
 				new StaticType(\Countable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			15 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new StaticType(\DateTimeImmutable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			16 => [
 				new ObjectType(\Traversable::class),
 				new StaticType(\ArrayObject::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			17 => [
 				new ObjectType(\Traversable::class),
 				new StaticType(\Iterator::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			18 => [
 				new ObjectType(\ArrayObject::class),
 				new StaticType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			19 => [
 				new ObjectType(\Iterator::class),
 				new StaticType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			20 => [
 				new ObjectType(\ArrayObject::class),
 				new StaticType(\DateTimeImmutable::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			21 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new UnionType([
 					new StaticType(\DateTimeImmutable::class),
@@ -185,7 +185,7 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			22 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new UnionType([
 					new StaticType(\ArrayObject::class),
@@ -193,42 +193,42 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createNo(),
 			],
-			[
+			23 => [
 				new ObjectType(\LogicException::class),
 				new StaticType(\InvalidArgumentException::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			24 => [
 				new ObjectType(\InvalidArgumentException::class),
 				new StaticType(\LogicException::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			25 => [
 				new ObjectType(\stdClass::class),
 				new ClosureType([], new MixedType(), false),
 				TrinaryLogic::createNo(),
 			],
-			[
+			26 => [
 				new ObjectType(\Closure::class),
 				new ClosureType([], new MixedType(), false),
 				TrinaryLogic::createYes(),
 			],
-			[
+			27 => [
 				new ObjectType(\Countable::class),
 				new IterableType(new MixedType(), new MixedType()),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			28 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new HasMethodType('format'),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			29 => [
 				new ObjectType(\Closure::class),
 				new HasMethodType('format'),
 				TrinaryLogic::createNo(),
 			],
-			[
+			30 => [
 				new ObjectType(\DateTimeImmutable::class),
 				new UnionType([
 					new HasMethodType('format'),
@@ -236,17 +236,17 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			31 => [
 				new ObjectType(\DateInterval::class),
 				new HasPropertyType('d'),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			32 => [
 				new ObjectType(\Closure::class),
 				new HasPropertyType('d'),
 				TrinaryLogic::createNo(),
 			],
-			[
+			33 => [
 				new ObjectType(\DateInterval::class),
 				new UnionType([
 					new HasPropertyType('d'),
@@ -254,67 +254,67 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			34 => [
 				new ObjectType('Exception'),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			35 => [
 				new ObjectType('Exception'),
 				new ObjectWithoutClassType(new ObjectType('Exception')),
 				TrinaryLogic::createNo(),
 			],
-			[
+			36 => [
 				new ObjectType('Exception'),
 				new ObjectWithoutClassType(new ObjectType(\InvalidArgumentException::class)),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			37 => [
 				new ObjectType(\InvalidArgumentException::class),
 				new ObjectWithoutClassType(new ObjectType('Exception')),
 				TrinaryLogic::createNo(),
 			],
-			[
+			38 => [
 				new ObjectType(\Throwable::class, new ObjectType(\InvalidArgumentException::class)),
 				new ObjectType(\InvalidArgumentException::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			39 => [
 				new ObjectType(\Throwable::class, new ObjectType(\InvalidArgumentException::class)),
 				new ObjectType('Exception'),
 				TrinaryLogic::createYes(),
 			],
-			[
+			40 => [
 				new ObjectType(\Throwable::class, new ObjectType('Exception')),
 				new ObjectType(\InvalidArgumentException::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			41 => [
 				new ObjectType(\Throwable::class, new ObjectType('Exception')),
 				new ObjectType('Exception'),
 				TrinaryLogic::createNo(),
 			],
-			[
+			42 => [
 				new ObjectType(\Throwable::class, new ObjectType('Exception')),
 				new ObjectType(\Throwable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			43 => [
 				new ObjectType(\Throwable::class),
 				new ObjectType(\Throwable::class, new ObjectType('Exception')),
 				TrinaryLogic::createYes(),
 			],
-			[
+			44 => [
 				new ObjectType(\Throwable::class),
 				new ObjectType(\Throwable::class, new ObjectType('Exception')),
 				TrinaryLogic::createYes(),
 			],
-			[
+			45 => [
 				new ObjectType('Exception'),
 				new ObjectType(\Throwable::class, new ObjectType('Exception')),
 				TrinaryLogic::createNo(),
 			],
-			[
+			46 => [
 				new ObjectType(\DateTimeInterface::class),
 				TemplateTypeFactory::create(
 					TemplateTypeScope::createWithClass(\DateTimeInterface::class),
@@ -324,7 +324,7 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				),
 				TrinaryLogic::createYes(),
 			],
-			[
+			47 => [
 				new ObjectType(\DateTimeInterface::class),
 				TemplateTypeFactory::create(
 					TemplateTypeScope::createWithClass(\DateTime::class),
@@ -334,7 +334,7 @@ class ObjectTypeTest extends \PHPStan\Testing\TestCase
 				),
 				TrinaryLogic::createYes(),
 			],
-			[
+			48 => [
 				new ObjectType(\DateTime::class),
 				TemplateTypeFactory::create(
 					TemplateTypeScope::createWithClass(\DateTimeInterface::class),

--- a/tests/PHPStan/Type/StaticTypeTest.php
+++ b/tests/PHPStan/Type/StaticTypeTest.php
@@ -59,52 +59,52 @@ class StaticTypeTest extends \PHPStan\Testing\TestCase
 	public function dataIsSuperTypeOf(): array
 	{
 		return [
-			[
+			0 => [
 				new StaticType('UnknownClassA'),
 				new ObjectType('UnknownClassB'),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			1 => [
 				new StaticType(\ArrayAccess::class),
 				new ObjectType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			2 => [
 				new StaticType(\Countable::class),
 				new ObjectType(\Countable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			3 => [
 				new StaticType(\DateTimeImmutable::class),
 				new ObjectType(\DateTimeImmutable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			4 => [
 				new StaticType(\Traversable::class),
 				new ObjectType(\ArrayObject::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			5 => [
 				new StaticType(\Traversable::class),
 				new ObjectType(\Iterator::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			6 => [
 				new StaticType(\ArrayObject::class),
 				new ObjectType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			7 => [
 				new StaticType(\Iterator::class),
 				new ObjectType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			8 => [
 				new StaticType(\ArrayObject::class),
 				new ObjectType(\DateTimeImmutable::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			9 => [
 				new StaticType(\DateTimeImmutable::class),
 				new UnionType([
 					new ObjectType(\DateTimeImmutable::class),
@@ -112,7 +112,7 @@ class StaticTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			10 => [
 				new StaticType(\DateTimeImmutable::class),
 				new UnionType([
 					new ObjectType(\ArrayObject::class),
@@ -120,57 +120,57 @@ class StaticTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createNo(),
 			],
-			[
+			11 => [
 				new StaticType(\LogicException::class),
 				new ObjectType(\InvalidArgumentException::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			12 => [
 				new StaticType(\InvalidArgumentException::class),
 				new ObjectType(\LogicException::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			13 => [
 				new StaticType(\ArrayAccess::class),
 				new StaticType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			14 => [
 				new StaticType(\Countable::class),
 				new StaticType(\Countable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			15 => [
 				new StaticType(\DateTimeImmutable::class),
 				new StaticType(\DateTimeImmutable::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			16 => [
 				new StaticType(\Traversable::class),
 				new StaticType(\ArrayObject::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			17 => [
 				new StaticType(\Traversable::class),
 				new StaticType(\Iterator::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			18 => [
 				new StaticType(\ArrayObject::class),
 				new StaticType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			19 => [
 				new StaticType(\Iterator::class),
 				new StaticType(\Traversable::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			20 => [
 				new StaticType(\ArrayObject::class),
 				new StaticType(\DateTimeImmutable::class),
 				TrinaryLogic::createNo(),
 			],
-			[
+			21 => [
 				new StaticType(\DateTimeImmutable::class),
 				new UnionType([
 					new StaticType(\DateTimeImmutable::class),
@@ -178,7 +178,7 @@ class StaticTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createYes(),
 			],
-			[
+			22 => [
 				new StaticType(\DateTimeImmutable::class),
 				new UnionType([
 					new StaticType(\DateTimeImmutable::class),
@@ -186,7 +186,7 @@ class StaticTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			23 => [
 				new StaticType(\DateTimeImmutable::class),
 				new UnionType([
 					new StaticType(\ArrayObject::class),
@@ -194,32 +194,32 @@ class StaticTypeTest extends \PHPStan\Testing\TestCase
 				]),
 				TrinaryLogic::createNo(),
 			],
-			[
+			24 => [
 				new StaticType(\LogicException::class),
 				new StaticType(\InvalidArgumentException::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			25 => [
 				new StaticType(\InvalidArgumentException::class),
 				new StaticType(\LogicException::class),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			26 => [
 				new StaticType(\stdClass::class),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			27 => [
 				new ObjectWithoutClassType(),
 				new StaticType(\stdClass::class),
 				TrinaryLogic::createYes(),
 			],
-			[
+			28 => [
 				new ThisType(\stdClass::class),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			29 => [
 				new ObjectWithoutClassType(),
 				new ThisType(\stdClass::class),
 				TrinaryLogic::createYes(),

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -134,8 +134,8 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 			4 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new ObjectType('DateTimeInterface'),
-				TrinaryLogic::createNo(), // (T of DateTime) isSuperTypeTo DateTimeInterface
-				TrinaryLogic::createYes(), // DateTimeInterface isSuperTypeTo (T of DateTime)
+				TrinaryLogic::createMaybe(), // (T of DateTime) isSuperTypeTo DateTimeInterface
+				TrinaryLogic::createMaybe(), // DateTimeInterface isSuperTypeTo (T of DateTime)
 			],
 			5 => [
 				$templateType('T', new ObjectType('DateTime')),
@@ -173,8 +173,8 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 					new NullType(),
 					new ObjectType('DateTimeInterface'),
 				]),
-				TrinaryLogic::createNo(), // (T of DateTime) isSuperTypeTo (DateTimeInterface|null)
-				TrinaryLogic::createYes(), // (DateTimeInterface|null) isSuperTypeTo (T of DateTime)
+				TrinaryLogic::createMaybe(), // (T of DateTime) isSuperTypeTo (DateTimeInterface|null)
+				TrinaryLogic::createMaybe(), // (DateTimeInterface|null) isSuperTypeTo (T of DateTime)
 			],
 			10 => [
 				$templateType('T', null),
@@ -187,6 +187,12 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createMaybe(),
 				TrinaryLogic::createYes(),
+			],
+			12 => [
+				$templateType('T', new ObjectType(\Throwable::class)),
+				new ObjectType(\Exception::class),
+				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createMaybe(),
 			],
 		];
 	}

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -107,49 +107,49 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 		};
 
 		return [
-			[
+			0 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new ObjectType('DateTime'),
 				TrinaryLogic::createMaybe(), // (T of DateTime) isSuperTypeTo DateTime
 				TrinaryLogic::createYes(), // DateTime isSuperTypeTo (T of DateTime)
 			],
-			[
+			1 => [
 				$templateType('T', new ObjectType('DateTime')),
 				$templateType('T', new ObjectType('DateTime')),
 				TrinaryLogic::createYes(),
 				TrinaryLogic::createYes(),
 			],
-			[
+			2 => [
 				$templateType('T', new ObjectType('DateTime'), 'a'),
 				$templateType('T', new ObjectType('DateTime'), 'b'),
 				TrinaryLogic::createMaybe(),
 				TrinaryLogic::createMaybe(),
 			],
-			[
+			3 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new StringType(),
 				TrinaryLogic::createNo(), // (T of DateTime) isSuperTypeTo string
 				TrinaryLogic::createNo(), // string isSuperTypeTo (T of DateTime)
 			],
-			[
+			4 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new ObjectType('DateTimeInterface'),
 				TrinaryLogic::createNo(), // (T of DateTime) isSuperTypeTo DateTimeInterface
 				TrinaryLogic::createYes(), // DateTimeInterface isSuperTypeTo (T of DateTime)
 			],
-			[
+			5 => [
 				$templateType('T', new ObjectType('DateTime')),
 				$templateType('T', new ObjectType('DateTimeInterface')),
 				TrinaryLogic::createMaybe(), // (T of DateTime) isSuperTypeTo (T of DateTimeInterface)
 				TrinaryLogic::createMaybe(), // (T of DateTimeInterface) isSuperTypeTo (T of DateTime)
 			],
-			[
+			6 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new NullType(),
 				TrinaryLogic::createNo(), // (T of DateTime) isSuperTypeTo null
 				TrinaryLogic::createNo(), // null isSuperTypeTo (T of DateTime)
 			],
-			[
+			7 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new UnionType([
 					new NullType(),
@@ -158,7 +158,7 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 				TrinaryLogic::createMaybe(), // (T of DateTime) isSuperTypeTo (DateTime|null)
 				TrinaryLogic::createYes(), // (DateTime|null) isSuperTypeTo (T of DateTime)
 			],
-			[
+			8 => [
 				$templateType('T', new ObjectType('DateTimeInterface')),
 				new UnionType([
 					new NullType(),
@@ -167,7 +167,7 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 				TrinaryLogic::createMaybe(), // (T of DateTimeInterface) isSuperTypeTo (DateTime|null)
 				TrinaryLogic::createMaybe(), // (DateTime|null) isSuperTypeTo (T of DateTimeInterface)
 			],
-			[
+			9 => [
 				$templateType('T', new ObjectType('DateTime')),
 				new UnionType([
 					new NullType(),
@@ -176,13 +176,13 @@ class TemplateTypeTest extends \PHPStan\Testing\TestCase
 				TrinaryLogic::createNo(), // (T of DateTime) isSuperTypeTo (DateTimeInterface|null)
 				TrinaryLogic::createYes(), // (DateTimeInterface|null) isSuperTypeTo (T of DateTime)
 			],
-			[
+			10 => [
 				$templateType('T', null),
 				new MixedType(true),
 				TrinaryLogic::createMaybe(), // T isSuperTypeTo mixed
 				TrinaryLogic::createYes(), // mixed isSuperTypeTo T
 			],
-			[
+			11 => [
 				$templateType('T', new ObjectWithoutClassType()),
 				new ObjectWithoutClassType(),
 				TrinaryLogic::createMaybe(),


### PR DESCRIPTION
Here we go again... [the last time](https://github.com/phpstan/phpstan-src/pull/85) I've changed ObjectType::isSuperTypeOf too, but in the end I've removed since it seemed too big change and you have suggested (my feeling, can't find it now) that it is not probably correct. This time I did it again and later remembered the previous trial... and this time I've finished this change. /shrug