### PR TITLE
Add ConstantNumericStringType

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantNumericStringType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
@@ -282,9 +283,18 @@ class ArrayType implements Type
 			}
 
 			if ($offsetType instanceof ConstantScalarType) {
-				/** @var int|string $offsetValue */
-				$offsetValue = key([$offsetType->getValue() => null]);
-				return is_int($offsetValue) ? new ConstantIntegerType($offsetValue) : new ConstantStringType($offsetValue);
+				/** @var int|string $castedOffsetValue */
+				$castedOffsetValue = key([$offsetType->getValue() => null]);
+
+				if (is_string($castedOffsetValue)) {
+					return new ConstantStringType($castedOffsetValue);
+				}
+
+				if ($castedOffsetValue !== $offsetType->getValue()) {
+					return new ConstantNumericStringType($castedOffsetValue);
+				}
+
+				return new ConstantIntegerType($castedOffsetValue);
 			}
 
 			if ($offsetType instanceof IntegerType) {

--- a/src/Type/Constant/ConstantNumericStringType.php
+++ b/src/Type/Constant/ConstantNumericStringType.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Constant;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+class ConstantNumericStringType extends ConstantIntegerType
+{
+
+	public function isSuperTypeOf(Type $type): TrinaryLogic
+	{
+		if ($type instanceof self) {
+			return $this->getValue() === $type->getValue() ? TrinaryLogic::createYes() : TrinaryLogic::createNo();
+		}
+
+		if ($type instanceof ConstantStringType) {
+			return (string) $this->getValue() === $type->getValue() ? TrinaryLogic::createYes() : TrinaryLogic::createNo();
+		}
+
+		if ($type instanceof StringType) {
+			return TrinaryLogic::createMaybe();
+		}
+
+		return parent::isSuperTypeOf($type);
+	}
+
+}

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -78,6 +78,10 @@ class IssetRuleTest extends RuleTestCase
 				'Static property IssetRule\FooCoalesce::$staticString (string) in isset() is not nullable.',
 				124,
 			],
+			[
+				'Offset string on array(1, 2, 3) in isset() does not exist.',
+				149,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/data/isset.php
+++ b/tests/PHPStan/Rules/Variables/data/isset.php
@@ -141,3 +141,22 @@ function (SomeMagicProperties $foo, \stdClass $std): void {
 
 	echo isset($std->foo) ? $std->foo : null;
 };
+
+function numericStringOffset(string $code): string
+{
+	$array = [1, 2, 3];
+
+	if (isset($array[$code])) {
+		return (string) $array[$code];
+	}
+
+	$mappings = [
+		'21021200' => '21028800',
+	];
+
+	if (isset($mappings[$code])) {
+		return (string) $mappings[$code];
+	}
+
+	throw new \RuntimeException();
+}

--- a/tests/PHPStan/Type/Constant/ConstantNumericStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantNumericStringTypeTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Constant;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+class ConstantNumericStringTypeTest extends \PHPStan\Testing\TestCase
+{
+
+	public function dataIsSuperTypeOf(): iterable
+	{
+		yield [
+			new ConstantNumericStringType(1),
+			new ConstantNumericStringType(1),
+			TrinaryLogic::createYes(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new ConstantIntegerType(1),
+			TrinaryLogic::createYes(),
+		];
+
+		yield [
+			new ConstantNumericStringType(2),
+			new ConstantStringType('2'),
+			TrinaryLogic::createYes(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new IntegerType(),
+			TrinaryLogic::createMaybe(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new StringType(),
+			TrinaryLogic::createMaybe(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new ConstantNumericStringType(2),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new ConstantIntegerType(2),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new ConstantStringType('2'),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(0),
+			new ConstantStringType('string'),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1234),
+			new ConstantStringType('01234'),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(0),
+			new ConstantStringType(''),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(1),
+			new ConstantBooleanType(true),
+			TrinaryLogic::createNo(),
+		];
+
+		yield [
+			new ConstantNumericStringType(0),
+			new ConstantBooleanType(false),
+			TrinaryLogic::createNo(),
+		];
+	}
+
+	/**
+	 * @dataProvider dataIsSuperTypeOf
+	 * @param ConstantNumericStringType $type
+	 * @param Type $otherType
+	 * @param TrinaryLogic $expectedResult
+	 */
+	public function testIsSuperTypeOf(ConstantNumericStringType $type, Type $otherType, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $type->isSuperTypeOf($otherType);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise()))
+		);
+	}
+
+}


### PR DESCRIPTION
Attempt to fix https://github.com/phpstan/phpstan/issues/3170.

While php treats `[1] === ['0' => 1]` true and we can always use numeric string offset `$array['0']`, the below warning sounds reasonable to me:

```php
$array = [1, 2, 3];

// Offset string on array(1, 2, 3) in isset() does not exist.
echo isset($array[$string]) ? $array[$string] : 0;
```

To keep this current behavior and handle arrays (intentionally) constructed with numeric string differently, this pull request introduces ConstantNumericStringType.



