### PR TITLE
updated mb_convert_encoding mapping

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6309,7 +6309,7 @@ return [
 'mb_check_encoding' => ['bool', 'var='=>'string', 'encoding='=>'string'],
 'mb_chr' => ['string|false', 'cp'=>'int', 'encoding='=>'string'],
 'mb_convert_case' => ['string', 'sourcestring'=>'string', 'mode'=>'int', 'encoding='=>'string'],
-'mb_convert_encoding' => ['string', 'str'=>'string', 'to_encoding'=>'string', 'from_encoding='=>'mixed'],
+'mb_convert_encoding' => ['string|array', 'val'=>'string|array', 'to_encoding'=>'string', 'from_encoding='=>'mixed'],
 'mb_convert_kana' => ['string', 'str'=>'string', 'option='=>'string', 'encoding='=>'string'],
 'mb_convert_variables' => ['string|false', 'to_encoding'=>'string', 'from_encoding'=>'array|string', '&rw_vars'=>'string|array|object', '&...rw_vars='=>'string|array|object'],
 'mb_decode_mimeheader' => ['string', 'string'=>'string'],


### PR DESCRIPTION
Issue reference: https://github.com/phpstan/phpstan/issues/3336

`mb_convert_encoding` accepts array|string since php 7.2

https://www.php.net/manual/en/function.mb-convert-encoding.php