### PR TITLE
DynamicReturnType for array search call not strict

### DIFF
--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\ConstantScalarType;
@@ -87,9 +86,6 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 		}
 
 		$iterableKeyType = TypeCombinator::union(...$arrays)->getIterableKeyType();
-		if ($iterableKeyType instanceof BenevolentUnionType) {
-			$iterableKeyType = new MixedType();
-		}
 
 		return TypeCombinator::union(
 			$iterableKeyType,

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -42,12 +42,14 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 		}
 
 		if ($argsCount < 3) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return TypeCombinator::union($haystackArgType->getIterableKeyType(), new ConstantBooleanType(false));
 		}
 
 		$strictArgType = $scope->getType($functionCall->args[2]->value);
-		if (!($strictArgType instanceof ConstantBooleanType) || $strictArgType->getValue() === false) {
+		if (!($strictArgType instanceof ConstantBooleanType)) {
 			return TypeCombinator::union($haystackArgType->getIterableKeyType(), new ConstantBooleanType(false), new NullType());
+		} elseif ($strictArgType->getValue() === false) {
+			return TypeCombinator::union($haystackArgType->getIterableKeyType(), new ConstantBooleanType(false));
 		}
 
 		$needleArgType = $scope->getType($functionCall->args[0]->value);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5262,6 +5262,14 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_search(9, $generalStringKeys, true)',
 			],
 			[
+				'string|false',
+				'array_search(9, $generalStringKeys, false)',
+			],
+			[
+				'string|false',
+				'array_search(9, $generalStringKeys)',
+			],
+			[
 				'null',
 				'array_search(999, $integer, true)',
 			],
@@ -5274,7 +5282,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_search($mixed, $array, true)',
 			],
 			[
-				'int|string|false|null',
+				'int|string|false',
 				'array_search($mixed, $array, false)',
 			],
 			[
@@ -5298,7 +5306,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_search($generalIntegerOrString, $clonedConditionalArray, true)',
 			],
 			[
-				'int|string|false|null',
+				'int|string|false',
 				'array_search($generalIntegerOrString, $generalIntegerOrStringKeys, false)',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5278,7 +5278,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_search(new stdClass, $generalStringKeys, true)',
 			],
 			[
-				'mixed',
+				'int|string|false',
 				'array_search($mixed, $array, true)',
 			],
 			[
@@ -5342,8 +5342,16 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_search(\'id\', doFoo() ? $thisDoesNotExistAndIsMixedInUnion : false, true)',
 			],
 			[
-				'mixed',
+				'int|string|false',
 				'array_search(1, $generalIntegers, true)',
+			],
+			[
+				'int|string|false',
+				'array_search(1, $generalIntegers, false)',
+			],
+			[
+				'int|string|false',
+				'array_search(1, $generalIntegers)',
 			],
 			[
 				'array<string, int>',


### PR DESCRIPTION
Close https://github.com/phpstan/phpstan/issues/3316

When a call `array_search($foo, $array)` or `array_search($foo, $array, false)` is made we can still restrict the type of the return value thanks to the type of the array keys. 
And I saw no reason to add `null` as a possible return value.

Another thing. During writing/updating the tests, I saw
```
[
    'mixed',
    'array_search(1, $generalIntegers, true)',
],
```
When `$generalIntegers` is typed with `int[]`.

This seems weird to me. There was a check about BenevolentUnionType, I don't see any reason to keep it ; tell me if I'm wrong. So I added a fix.