### PR TITLE
Fix return values for date_parse()

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1549,7 +1549,7 @@ return [
 'date_isodate_set' => ['DateTime|false', 'object'=>'DateTime', 'year'=>'int', 'week'=>'int', 'day='=>'int|mixed'],
 'date_modify' => ['DateTime|false', 'object'=>'DateTime', 'modify'=>'string'],
 'date_offset_get' => ['int', 'obj'=>'DateTimeInterface'],
-'date_parse' => ['array', 'date'=>'string'],
+'date_parse' => ['array|false', 'date'=>'string'],
 'date_parse_from_format' => ['array', 'format'=>'string', 'date'=>'string'],
 'date_sub' => ['DateTime|false', 'object'=>'DateTime', 'interval'=>'DateInterval'],
 'date_sun_info' => ['array', 'time'=>'int', 'latitude'=>'float', 'longitude'=>'float'],


### PR DESCRIPTION
date_parse() returns an array on success, `false` on failure.