### PR TITLE
Add DynamicReturnType for call_user_func

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -711,6 +711,16 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\CallUserFuncArrayDynamicFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
+		class: PHPStan\Type\Php\CallUserFuncDynamicFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ClosureBindDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/src/Type/Php/CallUserFuncArrayDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CallUserFuncArrayDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+class CallUserFuncArrayDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'call_user_func_array';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$args = $functionCall->args;
+
+		if (
+			count($args) < 2
+			|| !$args[1]->value instanceof Array_
+		) {
+			return $this->getNativeReturnType($functionReflection, $args, $scope);
+		}
+
+		$callback = $args[0]->value;
+		$params = $this->prepareParamsForFuncCall($args[1]->value);
+
+		$callableType = $scope->getType($callback);
+
+		if ($callableType->isCallable()->no()) {
+			return $this->getNativeReturnType($functionReflection, $params, $scope);
+		}
+
+		return ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$params,
+			$callableType->getCallableParametersAcceptors($scope)
+		)->getReturnType();
+	}
+
+	/**
+	 * @param array<Arg> $params
+	 */
+	private function getNativeReturnType(FunctionReflection $functionReflection, array $params, Scope $scope): Type
+	{
+		return ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$params,
+			$functionReflection->getVariants()
+		)->getReturnType();
+	}
+
+	/**
+	 * @return array<Arg>
+	 */
+	private function prepareParamsForFuncCall(Array_ $paramsArg): array
+	{
+		$result = [];
+
+		foreach ($paramsArg->items as $item) {
+			$result[] = new Arg($item->value, $item->byRef, $item->unpack);
+		}
+
+		return $result;
+	}
+
+}

--- a/src/Type/Php/CallUserFuncDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CallUserFuncDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+class CallUserFuncDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'call_user_func';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$args = $functionCall->args;
+
+		if (count($args) === 0) {
+			return $this->getNativeReturnType($functionReflection, $args, $scope);
+		}
+
+		$callback = array_shift($args)->value;
+		$params = $args;
+
+		$callableType = $scope->getType($callback);
+
+		if ($callableType->isCallable()->no()) {
+			return $this->getNativeReturnType($functionReflection, $params, $scope);
+		}
+
+		return ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$params,
+			$callableType->getCallableParametersAcceptors($scope)
+		)->getReturnType();
+	}
+
+	/**
+	 * @param array<Arg> $params
+	 */
+	private function getNativeReturnType(FunctionReflection $functionReflection, array $params, Scope $scope): Type
+	{
+		return ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$params,
+			$functionReflection->getVariants()
+		)->getReturnType();
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9964,6 +9964,16 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/mixed-typehint.php');
 	}
 
+	public function dataCallUserFunc(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/call-user-func.php');
+	}
+
+	public function dataCallUserFuncArray(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/call-user-func-array.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10019,6 +10029,8 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug3336
 	 * @dataProvider dataCatchWithoutVariable
 	 * @dataProvider dataMixedTypehint
+	 * @dataProvider dataCallUserFunc
+	 * @dataProvider dataCallUserFuncArray
 	 * @param ConstantStringType $expectedType
 	 * @param Type $actualType
 	 */

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4938,6 +4938,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$mappedStrings[0]',
 			],
 			[
+				'array(mixed, mixed, mixed)',
+				'$mappedStringsViaFoo',
+			],
+			[
 				'1|2|3',
 				'$filteredIntegers[0]',
 			],

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -7,6 +7,10 @@ $mappedStrings = array_map(function (): string {
 
 }, $integers);
 
+function foo(): string {}
+
+$mappedStringsViaFoo = array_map('foo', $integers);
+
 $filteredIntegers = array_filter($integers, function (): bool {
 
 });

--- a/tests/PHPStan/Analyser/data/call-user-func-array.php
+++ b/tests/PHPStan/Analyser/data/call-user-func-array.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace CallUserFuncArray;
+
+use function PHPStan\Analyser\assertType;
+
+
+@assertType('mixed', call_user_func_array());
+
+$foo = function () {};
+assertType('mixed', call_user_func_array($foo, []));
+$fooReturnsBool = function (): bool { return TRUE; };
+assertType('bool', call_user_func_array($fooReturnsBool, []));
+
+function foo() {}
+assertType('mixed', call_user_func_array('\\CallUserFuncArray\\foo', []));
+function fooReturnsBool(): bool { return TRUE; }
+assertType('mixed', call_user_func_array('\\CallUserFuncArray\\fooReturnsBool', [])); // bool, not supported
+
+/**
+ * @return bool
+ */
+function fooReturnsBoolInPhpDoc() { return TRUE; }
+assertType('mixed', call_user_func_array('\\CallUserFuncArray\\fooReturnsBoolInPhpDoc', [])); // bool, not supported
+
+/**
+ * @var callable(): bool $returnsBoolInVarPhpDoc
+ */
+$returnsBoolInVarPhpDoc = function () {};
+assertType('bool', call_user_func_array($returnsBoolInVarPhpDoc, []));
+
+/**
+ * @return bool
+ */
+$returnsBoolInReturnPhpDoc = function () { return TRUE; };
+assertType('mixed', call_user_func_array($returnsBoolInReturnPhpDoc, [])); // bool, not supported
+
+class Foo {
+
+	function returnsBool(): bool { return TRUE; }
+
+	/**
+	 * @return bool
+	 */
+	function returnsBoolInReturnPhpDoc() { return TRUE; }
+
+}
+
+$foo = new Foo();
+assertType('bool', call_user_func_array([$foo, 'returnsBool'], []));
+assertType('bool', call_user_func_array([$foo, 'returnsBoolInReturnPhpDoc'], []));
+
+/**
+ * @template T
+ * @param T $a
+ * @return T
+ */
+function returnsGeneric($a) { return $a; }
+assertType('bool', call_user_func_array('\\CallUserFuncArray\\returnsGeneric', [TRUE]));
+assertType('string', call_user_func_array('\\CallUserFuncArray\\returnsGeneric', ['a']));
+
+class FooGeneric {
+
+	/**
+	 * @template T
+	 * @param T $a
+	 * @return T
+	 */
+	function returnsGeneric($a) { return $a; }
+
+}
+
+$fooGeneric = new FooGeneric();
+assertType('bool', call_user_func_array([$fooGeneric, 'returnsGeneric'], [TRUE]));
+assertType('string', call_user_func_array([$fooGeneric, 'returnsGeneric'], ['a']));

--- a/tests/PHPStan/Analyser/data/call-user-func.php
+++ b/tests/PHPStan/Analyser/data/call-user-func.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace CallUserFunc;
+
+use function PHPStan\Analyser\assertType;
+
+
+@assertType('mixed', call_user_func());
+
+$foo = function () {};
+assertType('mixed', call_user_func($foo));
+$fooReturnsBool = function (): bool { return TRUE; };
+assertType('bool', call_user_func($fooReturnsBool));
+
+function foo() {}
+assertType('mixed', call_user_func('\\CallUserFunc\\foo'));
+function fooReturnsBool(): bool { return TRUE; }
+assertType('mixed', call_user_func('\\CallUserFunc\\fooReturnsBool')); // bool, not supported
+
+/**
+ * @return bool
+ */
+function fooReturnsBoolInPhpDoc() { return TRUE; }
+assertType('mixed', call_user_func('\\CallUserFunc\\fooReturnsBoolInPhpDoc')); // bool, not supported
+
+/**
+ * @var callable(): bool $returnsBoolInVarPhpDoc
+ */
+$returnsBoolInVarPhpDoc = function () {};
+assertType('bool', call_user_func($returnsBoolInVarPhpDoc));
+
+/**
+ * @return bool
+ */
+$returnsBoolInReturnPhpDoc = function () { return TRUE; };
+assertType('mixed', call_user_func($returnsBoolInReturnPhpDoc)); // bool, not supported
+
+class Foo {
+
+	function returnsBool(): bool { return TRUE; }
+
+	/**
+	 * @return bool
+	 */
+	function returnsBoolInReturnPhpDoc() { return TRUE; }
+
+}
+
+$foo = new Foo();
+assertType('bool', call_user_func([$foo, 'returnsBool']));
+assertType('bool', call_user_func([$foo, 'returnsBoolInReturnPhpDoc']));
+
+/**
+ * @template T
+ * @param T $a
+ * @return T
+ */
+function returnsGeneric($a) { return $a; }
+assertType('bool', call_user_func('\\CallUserFunc\\returnsGeneric', TRUE));
+assertType('string', call_user_func('\\CallUserFunc\\returnsGeneric', 'a'));
+
+class FooGeneric {
+
+	/**
+	 * @template T
+	 * @param T $a
+	 * @return T
+	 */
+	function returnsGeneric($a) { return $a; }
+
+}
+
+$fooGeneric = new FooGeneric();
+assertType('bool', call_user_func([$fooGeneric, 'returnsGeneric'], TRUE));
+assertType('string', call_user_func([$fooGeneric, 'returnsGeneric'], 'a'));


### PR DESCRIPTION
Honestly, I wonder 2 things :)

1. Is there some deeper reason why this isn't implemented yet :) ?
2. How should I write tests to cover this?

I will appreciate a bit of help, but I would like to polish this to highest standard. I would like to also include `call_user_func_array`.