### PR TITLE
Bump branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "0.12-dev"
+			"dev-master": "0.13-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
I am assuming the recent changes including dropping PHP 7.1, 7.2, and 7.3 mean that the next release will not be in the 0.12.x series, but 0.13.0?