### PR TITLE
Revert (partially) #231 "constant arrays without an explicit class string should not…

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -352,7 +352,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			return ConstantArrayTypeAndMethod::createUnknown();
 		}
 
-		if ($classOrObject instanceof ConstantStringType && $classOrObject->isClassString()) {
+		if ($classOrObject instanceof ConstantStringType) {
 			$broker = Broker::getInstance();
 			if (!$broker->hasClass($classOrObject->getValue())) {
 				return ConstantArrayTypeAndMethod::createUnknown();

--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -45,11 +45,6 @@ class ConstantStringType extends StringType implements ConstantScalarType
 		return $this->value;
 	}
 
-	public function isClassString(): bool
-	{
-		return $this->isClassString;
-	}
-
 	public function describe(VerbosityLevel $level): string
 	{
 		return $level->handle(

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -591,7 +591,6 @@ class ConstantArrayTypeTest extends \PHPStan\Testing\TestCase
 
 	/**
 	 * @dataProvider dataIsCallable
-	 * @group solo
 	 */
 	public function testIsCallable(ConstantArrayType $type, TrinaryLogic $expectedResult): void
 	{
@@ -641,18 +640,15 @@ class ConstantArrayTypeTest extends \PHPStan\Testing\TestCase
 			TrinaryLogic::createNo(),
 		];
 
-		/**
-		 * @see https://github.com/phpstan/phpstan/issues/3428
-		 */
 		yield 'existing static method but not a class string' => [
 			new ConstantArrayType([
 				new ConstantIntegerType(0),
 				new ConstantIntegerType(1),
 			], [
 				new ConstantStringType('Closure'),
-				new ConstantStringType('foobar'),
+				new ConstantStringType('bind'),
 			]),
-			TrinaryLogic::createMaybe(),
+			TrinaryLogic::createYes(),
 		];
 
 		yield 'existing static method but with string keys' => [


### PR DESCRIPTION
…resolve the class name"

This reverts commit 28ed92404db4306f44c99ed120d44bab2afe4670.

:bulb: I kept the tests for `isCallable` in `ConstantArrayTypeTest`, with of course a slight change for the assertions against `['Closure', 'bind']`.

#### Conflicts:
- tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php