### PR TITLE
Only consider class-strings when resolving dependencies

### DIFF
--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -6,7 +6,6 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\Closure;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Foreach_;
@@ -269,6 +268,7 @@ class DependencyResolver
 		}
 
 		$item = $arrayNode->items[0];
-		return $item->value instanceof ClassConstFetch && $item->value->name->name === "class";
+		return $item->value instanceof ClassConstFetch && $item->value->name->name === 'class';
 	}
+
 }


### PR DESCRIPTION
@ondrejmirtes here is the change you suggested in https://github.com/phpstan/phpstan-src/pull/236. Tests seemed to be ok when I ran them locally with https://github.com/phpstan/phpstan-src/pull/238 included.