### PR TITLE
Add DOMDocument class to list of exclusions for ReflectionProvider

### DIFF
--- a/build/composer-require-checker.json
+++ b/build/composer-require-checker.json
@@ -21,6 +21,7 @@
     "pcntl",
     "mbstring",
     "hash",
-    "tokenizer"
+    "tokenizer",
+    "dom"
   ]
 }

--- a/src/Reflection/ReflectionProvider/ClassBlacklistReflectionProvider.php
+++ b/src/Reflection/ReflectionProvider/ClassBlacklistReflectionProvider.php
@@ -63,6 +63,10 @@ class ClassBlacklistReflectionProvider implements ReflectionProvider
 		if ($classReflection->isSubclassOf(\DateInterval::class)
 			|| $classReflection->isSubclassOf(\DatePeriod::class)
 			|| $classReflection->isSubclassOf(\DOMDocument::class)
+			|| $classReflection->isSubclassOf(\DOMNode::class)
+			|| $classReflection->isSubclassOf(\DOMNamedNodeMap::class)
+			|| $classReflection->isSubclassOf(\DOMNodeList::class)
+			|| $classReflection->isSubclassOf(\DOMCharacterData::class)
 		) {
 			return false;
 		}

--- a/src/Reflection/ReflectionProvider/ClassBlacklistReflectionProvider.php
+++ b/src/Reflection/ReflectionProvider/ClassBlacklistReflectionProvider.php
@@ -62,7 +62,8 @@ class ClassBlacklistReflectionProvider implements ReflectionProvider
 		$classReflection = $this->reflectionProvider->getClass($className);
 		if ($classReflection->isSubclassOf(\DateInterval::class)
 			|| $classReflection->isSubclassOf(\DatePeriod::class)
-			|| $classReflection->isSubclassOf(\DOMDocument::class)) {
+			|| $classReflection->isSubclassOf(\DOMDocument::class)
+		) {
 			return false;
 		}
 

--- a/src/Reflection/ReflectionProvider/ClassBlacklistReflectionProvider.php
+++ b/src/Reflection/ReflectionProvider/ClassBlacklistReflectionProvider.php
@@ -60,7 +60,9 @@ class ClassBlacklistReflectionProvider implements ReflectionProvider
 		}
 
 		$classReflection = $this->reflectionProvider->getClass($className);
-		if ($classReflection->isSubclassOf(\DateInterval::class) || $classReflection->isSubclassOf(\DatePeriod::class)) {
+		if ($classReflection->isSubclassOf(\DateInterval::class)
+			|| $classReflection->isSubclassOf(\DatePeriod::class)
+			|| $classReflection->isSubclassOf(\DOMDocument::class)) {
 			return false;
 		}
 

--- a/tests/PHPStan/Analyser/data/bug-3468.php
+++ b/tests/PHPStan/Analyser/data/bug-3468.php
@@ -9,3 +9,11 @@ class NewInterval extends \DateInterval
 function (NewInterval $ni): void {
 	$ni->f = 0.1;
 };
+
+class NewDocument extends \DOMDocument
+{
+}
+
+function (NewDocument $nd): void {
+	$element = $nd->documentElement;
+};


### PR DESCRIPTION
As stated in https://github.com/phpstan/phpstan/issues/3477, the `DOMDocument` class does not have the proper signatures when analyzed via Reflection.

This PR adds it to the list of exclusions in the `ReflectionProvider`.

Fixes https://github.com/phpstan/phpstan/issues/3477