### PR TITLE
Change MutatingScope:getNodeKey() to public

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -449,7 +449,7 @@ class MutatingScope implements Scope
 		return $this->resolvedTypes[$key];
 	}
 
-	private function getNodeKey(Expr $node): string
+	public function getNodeKey(Expr $node): string
 	{
 		/** @var string|null $key */
 		$key = $node->getAttribute('phpstan_cache_printer');


### PR DESCRIPTION
This PR changes `MutatingScope` `getNodeKey()` function's vibility to public.
It allows to be used in extensions.

https://github.com/phpstan/phpstan-src/blob/676706279ccbd2505862f87b8d585961ad3c3de7/src/Analyser/MutatingScope.php#L452