### PR TITLE
Remove workaround of yaml highlighting for neon files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 *.php text eol=lf
 *.stub linguist-language=PHP
-*.neon linguist-language=YAML
 
 tests/PHPStan/Command/ErrorFormatter/data/WindowsNewlines.php eol=crlf


### PR DESCRIPTION
Since https://github.com/github/linguist/pull/4845 is merged, we can remove this workaround

example in my fork https://github.com/adaamz/phpstan-src/blob/master/conf/config.stubValidator.neon