### PR TITLE
Introduce ErrorFormatter for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
           cd compiler && \
           composer install --no-interaction && \
           vendor/bin/phpunit -c tests/phpunit.xml tests && \
-          ../bin/phpstan analyse -l 8 src tests && \
+          ../bin/phpstan analyse -l 8 src tests --error-format github && \
           php bin/compile && \
           ../tmp/phpstan.phar
 

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1214,3 +1214,9 @@ services:
 		class: PHPStan\Command\ErrorFormatter\GitlabErrorFormatter
 		arguments:
 			relativePathHelper: @simpleRelativePathHelper
+
+	errorFormatter.github:
+		class: PHPStan\Command\ErrorFormatter\GithubErrorFormatter
+		arguments:
+			relativePathHelper: @simpleRelativePathHelper
+			tableErrorformatter: '@errorFormatter.table'

--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -48,6 +48,13 @@ class GithubErrorFormatter implements ErrorFormatter
 			$output->writeLineFormatted('');
 		}
 
+		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
+			$line = sprintf('::error ::%s', $notFileSpecificError);
+
+			$output->writeRaw($line);
+			$output->writeLineFormatted('');
+		}
+
 		return $analysisResult->hasErrors() ? 1 : 0;
 	}
 

--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -55,6 +55,13 @@ class GithubErrorFormatter implements ErrorFormatter
 			$output->writeLineFormatted('');
 		}
 
+		foreach ($analysisResult->getWarnings() as $warning) {
+			$line = sprintf('::warning ::%s', $warning);
+
+			$output->writeRaw($line);
+			$output->writeLineFormatted('');
+		}
+
 		return $analysisResult->hasErrors() ? 1 : 0;
 	}
 

--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+use PHPStan\File\RelativePathHelper;
+
+/**
+ * Allow errors to be reported in pull-requests diff when run in a GitHub Action
+ * @see https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message
+ */
+class GithubErrorFormatter implements ErrorFormatter
+{
+
+	private RelativePathHelper $relativePathHelper;
+
+	private TableErrorFormatter $tableErrorformatter;
+
+	public function __construct(
+		RelativePathHelper $relativePathHelper,
+		TableErrorFormatter $tableErrorformatter
+	)
+	{
+		$this->relativePathHelper = $relativePathHelper;
+		$this->tableErrorformatter = $tableErrorformatter;
+	}
+
+	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+	{
+		$this->tableErrorformatter->formatErrors($analysisResult, $output);
+
+		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+			$metas = [
+				'file' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
+				'line' => $fileSpecificError->getLine(),
+				'col' => 0,
+			];
+			array_walk($metas, static function (&$value, string $key): void {
+				$value = sprintf('%s=%s', $key, (string) $value);
+			});
+
+			$message = $fileSpecificError->getMessage();
+
+			$line = sprintf('::error %s::%s', implode(',', $metas), $message);
+
+			$output->writeRaw($line);
+			$output->writeLineFormatted('');
+		}
+
+		return $analysisResult->hasErrors() ? 1 : 0;
+	}
+
+}

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\File\FuzzyRelativePathHelper;
+use PHPStan\Testing\ErrorFormatterTestCase;
+
+class GithubErrorFormatterTest extends ErrorFormatterTestCase
+{
+
+	public function dataFormatterOutputProvider(): iterable
+	{
+		yield [
+			'No errors',
+			0,
+			0,
+			0,
+			'
+ [OK] No errors
+
+',
+		];
+
+		yield [
+			'One file error',
+			1,
+			1,
+			0,
+			' ------ -----------------------------------------------------------------
+  Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
+ ------ -----------------------------------------------------------------
+  4      Foo
+ ------ -----------------------------------------------------------------
+
+ [ERROR] Found 1 error
+
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
+',
+		];
+
+		yield [
+			'One generic error',
+			1,
+			0,
+			1,
+			' -- ---------------------
+     Error
+ -- ---------------------
+     first generic error
+ -- ---------------------
+
+ [ERROR] Found 1 error
+
+',
+		];
+
+		yield [
+			'Multiple file errors',
+			1,
+			4,
+			0,
+			' ------ -----------------------------------------------------------------
+  Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
+ ------ -----------------------------------------------------------------
+  2      Bar
+  4      Foo
+ ------ -----------------------------------------------------------------
+
+ ------ ---------
+  Line   foo.php
+ ------ ---------
+  1      Foo
+  5      Bar
+ ------ ---------
+
+ [ERROR] Found 4 errors
+
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
+::error file=foo.php,line=1,col=0::Foo
+::error file=foo.php,line=5,col=0::Bar
+',
+		];
+
+		yield [
+			'Multiple generic errors',
+			1,
+			0,
+			2,
+			' -- ----------------------
+     Error
+ -- ----------------------
+     first generic error
+     second generic error
+ -- ----------------------
+
+ [ERROR] Found 2 errors
+
+',
+		];
+
+		yield [
+			'Multiple file, multiple generic errors',
+			1,
+			4,
+			2,
+			' ------ -----------------------------------------------------------------
+  Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
+ ------ -----------------------------------------------------------------
+  2      Bar
+  4      Foo
+ ------ -----------------------------------------------------------------
+
+ ------ ---------
+  Line   foo.php
+ ------ ---------
+  1      Foo
+  5      Bar
+ ------ ---------
+
+ -- ----------------------
+     Error
+ -- ----------------------
+     first generic error
+     second generic error
+ -- ----------------------
+
+ [ERROR] Found 6 errors
+
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
+::error file=foo.php,line=1,col=0::Foo
+::error file=foo.php,line=5,col=0::Bar
+',
+		];
+	}
+
+	/**
+	 * @dataProvider dataFormatterOutputProvider
+	 *
+	 * @param string $message
+	 * @param int    $exitCode
+	 * @param int    $numFileErrors
+	 * @param int    $numGenericErrors
+	 * @param string $expected
+	 */
+	public function testFormatErrors(
+		string $message,
+		int $exitCode,
+		int $numFileErrors,
+		int $numGenericErrors,
+		string $expected
+	): void
+	{
+		$relativePathHelper = new FuzzyRelativePathHelper(self::DIRECTORY_PATH, [], '/');
+		$formatter = new GithubErrorFormatter(
+			$relativePathHelper,
+			new TableErrorFormatter($relativePathHelper, false)
+		);
+
+		$this->assertSame($exitCode, $formatter->formatErrors(
+			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
+			$this->getOutput()
+		), sprintf('%s: response code do not match', $message));
+
+		$this->assertEquals($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+	}
+
+}

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -51,6 +51,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 
  [ERROR] Found 1 error
 
+::error ::first generic error
 ',
 		];
 
@@ -96,6 +97,8 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 
  [ERROR] Found 2 errors
 
+::error ::first generic error
+::error ::second generic error
 ',
 		];
 
@@ -131,6 +134,8 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 ::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
 ::error file=foo.php,line=1,col=0::Foo
 ::error file=foo.php,line=5,col=0::Bar
+::error ::first generic error
+::error ::second generic error
 ',
 		];
 	}


### PR DESCRIPTION
This PR allows PHPStan to report errors on the GitHub interface when used with GitHub Actions, in pull-requests changes. We started using this formatter at PrestaShop to help our contributor to find the required changes easily (https://github.com/PrestaShop/php-dev-tools/pull/24).

![image](https://user-images.githubusercontent.com/6768917/85944684-a66dbd80-b930-11ea-8fb7-6c0c4f9f6007.png)

Note the only displayed errors are targeting a specific line of a file, generic errors (= Not file specific) are not concerned. For developers looking at the complete report in the log, the class `TableErrorFormatter` is used so they can read the default view.