### PR TITLE
Update jetbrains/phpstorm-stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"hoa/exception": "^1.0",
 		"hoa/regex": "1.17.01.13",
 		"jean85/pretty-package-versions": "^1.0.3",
-		"jetbrains/phpstorm-stubs": "dev-master#11e2d07705b8b7063a984f49a27d8c3120288e31",
+		"jetbrains/phpstorm-stubs": "dev-master#300365d4b2511899967d6e4c502b27dabfd243a9",
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.0",
 		"nette/finder": "^2.5",


### PR DESCRIPTION
I was waiting for PHPStan 0.12.32 to fix the ext-ds issues introduced in 0.12.31 caused by jetbrains stubs. Unfortunately it seems you forgot to update the stubs before release.