### PR TITLE
PDOStatement::fetchColumn can return an int

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -8495,7 +8495,7 @@ return [
 'PDOStatement::execute' => ['bool', 'bound_input_params='=>'?array'],
 'PDOStatement::fetch' => ['mixed', 'how='=>'int', 'orientation='=>'int', 'offset='=>'int'],
 'PDOStatement::fetchAll' => ['array|false', 'how='=>'int', 'fetch_argument='=>'int|string|callable', 'ctor_args='=>'?array'],
-'PDOStatement::fetchColumn' => ['string|null|false', 'column_number='=>'int'],
+'PDOStatement::fetchColumn' => ['string|null|false|int', 'column_number='=>'int'],
 'PDOStatement::fetchObject' => ['mixed', 'class_name='=>'string', 'ctor_args='=>'?array'],
 'PDOStatement::getAttribute' => ['mixed', 'attribute'=>'int'],
 'PDOStatement::getColumnMeta' => ['array', 'column'=>'int'],


### PR DESCRIPTION
One example of arguments that can lead to this is pdo_mysql
with PDO::ATTR_STRINGIFY_FETCHES => false