### PR TITLE
Skip not deprecated methods

### DIFF
--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -108,7 +108,7 @@ class IntersectionTypeMethodReflection implements MethodReflection
 	{
 		$descriptions = [];
 		foreach ($this->methods as $method) {
-			if ($method->isDeprecated()->yes()) {
+			if (!$method->isDeprecated()->yes()) {
 				continue;
 			}
 			$description = $method->getDeprecatedDescription();

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -108,7 +108,7 @@ class UnionTypeMethodReflection implements MethodReflection
 	{
 		$descriptions = [];
 		foreach ($this->methods as $method) {
-			if ($method->isDeprecated()->yes()) {
+			if (!$method->isDeprecated()->yes()) {
 				continue;
 			}
 			$description = $method->getDeprecatedDescription();

--- a/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Type;
+
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
+
+class IntersectionTypeMethodReflectionTest extends \PHPStan\Testing\TestCase
+{
+
+	public function testCollectsDeprecatedMessages(): void
+	{
+		$reflection = new IntersectionTypeMethodReflection(
+			'foo',
+			[
+				$this->createDeprecatedMethod(TrinaryLogic::createYes(), 'Deprecated'),
+				$this->createDeprecatedMethod(TrinaryLogic::createMaybe(), 'Maybe deprecated'),
+				$this->createDeprecatedMethod(TrinaryLogic::createNo(), 'Not deprecated'),
+			]
+		);
+
+		$this->assertSame('Deprecated', $reflection->getDeprecatedDescription());
+	}
+
+	public function testMultipleDeprecationsAreJoined(): void
+	{
+		$reflection = new IntersectionTypeMethodReflection(
+			'foo',
+			[
+				$this->createDeprecatedMethod(TrinaryLogic::createYes(), 'Deprecated #1'),
+				$this->createDeprecatedMethod(TrinaryLogic::createYes(), 'Deprecated #2'),
+			]
+		);
+
+		$this->assertSame('Deprecated #1 Deprecated #2', $reflection->getDeprecatedDescription());
+	}
+
+	private function createDeprecatedMethod(TrinaryLogic $deprecated, ?string $deprecationText): MethodReflection
+	{
+		$method = $this->createMock(MethodReflection::class);
+		$method->method('isDeprecated')->willReturn($deprecated);
+		$method->method('getDeprecatedDescription')->willReturn($deprecationText);
+		return $method;
+	}
+
+}

--- a/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Type;
+
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
+
+class UnionTypeMethodReflectionTest extends \PHPStan\Testing\TestCase
+{
+
+	public function testCollectsDeprecatedMessages(): void
+	{
+		$reflection = new UnionTypeMethodReflection(
+			'foo',
+			[
+				$this->createDeprecatedMethod(TrinaryLogic::createYes(), 'Deprecated'),
+				$this->createDeprecatedMethod(TrinaryLogic::createMaybe(), 'Maybe deprecated'),
+				$this->createDeprecatedMethod(TrinaryLogic::createNo(), 'Not deprecated'),
+			]
+		);
+
+		$this->assertSame('Deprecated', $reflection->getDeprecatedDescription());
+	}
+
+	public function testMultipleDeprecationsAreJoined(): void
+	{
+		$reflection = new UnionTypeMethodReflection(
+			'foo',
+			[
+				$this->createDeprecatedMethod(TrinaryLogic::createYes(), 'Deprecated #1'),
+				$this->createDeprecatedMethod(TrinaryLogic::createYes(), 'Deprecated #2'),
+			]
+		);
+
+		$this->assertSame('Deprecated #1 Deprecated #2', $reflection->getDeprecatedDescription());
+	}
+
+	private function createDeprecatedMethod(TrinaryLogic $deprecated, ?string $deprecationText): MethodReflection
+	{
+		$method = $this->createMock(MethodReflection::class);
+		$method->method('isDeprecated')->willReturn($deprecated);
+		$method->method('getDeprecatedDescription')->willReturn($deprecationText);
+		return $method;
+	}
+
+}


### PR DESCRIPTION
While roaming around the codebase I have found these two places that seem to not work correctly. Looks like no test was asserting the result so the question is whether shall I write one?