### PR TITLE
Friend functions

### DIFF
--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -21,6 +21,7 @@ rules:
 	- PHPStan\Rules\Generics\MethodTemplateTypeRule
 	- PHPStan\Rules\Generics\MethodSignatureVarianceRule
 	- PHPStan\Rules\Generics\TraitTemplateTypeRule
+	- PHPStan\Rules\Methods\FriendMethodCallRule
 	- PHPStan\Rules\Methods\IncompatibleDefaultParameterTypeRule
 	- PHPStan\Rules\Operators\InvalidBinaryOperationRule
 	- PHPStan\Rules\Operators\InvalidUnaryOperationRule

--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -28,6 +28,7 @@ rules:
 	- PHPStan\Rules\Operators\InvalidComparisonOperationRule
 	- PHPStan\Rules\PhpDoc\IncompatiblePhpDocTypeRule
 	- PHPStan\Rules\PhpDoc\IncompatiblePropertyPhpDocTypeRule
+	- PHPStan\Rules\PhpDoc\InvalidFriendTagTargetRule
 	- PHPStan\Rules\PhpDoc\InvalidPhpDocTagValueRule
 	- PHPStan\Rules\PhpDoc\InvalidPHPStanDocTagRule
 	- PHPStan\Rules\PhpDoc\InvalidThrowsPhpDocValueRule

--- a/src/PhpDoc/Tag/FriendTag.php
+++ b/src/PhpDoc/Tag/FriendTag.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc\Tag;
+
+use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\VerbosityLevel;
+
+class FriendTag
+{
+
+	private \PHPStan\Type\TypeWithClassName $type;
+
+	private ?string $method;
+
+	public function __construct(TypeWithClassName $type, ?string $method)
+	{
+		$this->type = $type;
+		$this->method = $method;
+	}
+
+	public function getType(): TypeWithClassName
+	{
+		return $this->type;
+	}
+
+	public function getMethod(): ?string
+	{
+		return $this->method;
+	}
+
+	public function __toString(): string
+	{
+		$string = $this->type->describe(VerbosityLevel::precise());
+		if ($this->method !== null) {
+			$string .= '::' . $this->method;
+		}
+		return $string;
+	}
+
+}

--- a/src/Rules/Methods/FriendMethodCallRule.php
+++ b/src/Rules/Methods/FriendMethodCallRule.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\MethodCall>
+ */
+class FriendMethodCallRule implements \PHPStan\Rules\Rule
+{
+
+	private FileTypeMapper $fileTypeMapper;
+
+	public function __construct(FileTypeMapper $fileTypeMapper)
+	{
+		$this->fileTypeMapper = $fileTypeMapper;
+	}
+
+	public function getNodeType(): string
+	{
+		return MethodCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Identifier) {
+			return [];
+		}
+		$methodName = $node->name->name;
+		$callee = $scope->getType($node->var);
+		if (!$callee->hasMethod($methodName)->yes()) {
+			return [];
+		}
+		$method = $callee->getMethod($methodName, $scope);
+		if (!$scope->canCallMethod($method)) {
+			return [];
+		}
+		$docComment = $method->getDocComment();
+		if ($docComment === null || $method->getDeclaringClass()->getFileName() === false) {
+			return [];
+		}
+		$friends = $this->fileTypeMapper->getResolvedPhpDoc(
+			$method->getDeclaringClass()->getFileName(),
+			$method->getDeclaringClass()->getName(),
+			null,
+			$method->getName(),
+			$docComment
+		)->getFriends();
+		if (\count($friends) === 0) {
+			return [];
+		}
+
+		if (!$scope->isInClass()) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'You may not not call %s::%s() from the global scope as the method lists allowed callers through friends.',
+					$method->getDeclaringClass()->getName(),
+					$method->getName()
+				))->build(),
+			];
+		}
+
+		$callerClass = $scope->getClassReflection();
+		$callerMethod = $scope->getFunctionName();
+		foreach ($friends as $friend) {
+			$type = $friend->getType();
+			if ($callerClass->getName() !== $type->getClassName()) {
+				continue;
+			}
+			if ($friend->getMethod() !== null && $friend->getMethod() !== $callerMethod) {
+				continue;
+			}
+			return []; // caller is whitelisted
+		}
+
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'%s::%s() may not call %s::%s() as it is not listed as a friend.',
+				$callerClass->getName(),
+				$callerMethod,
+				$method->getDeclaringClass()->getName(),
+				$method->getName()
+			))->build(),
+		];
+	}
+
+}

--- a/src/Rules/PhpDoc/InvalidFriendTagTargetRule.php
+++ b/src/Rules/PhpDoc/InvalidFriendTagTargetRule.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\ClassMethod>
+ */
+class InvalidFriendTagTargetRule implements \PHPStan\Rules\Rule
+{
+
+	private FileTypeMapper $fileTypeMapper;
+
+	private ReflectionProvider $reflectionProvider;
+
+	public function __construct(FileTypeMapper $fileTypeMapper, ReflectionProvider $reflectionProvider)
+	{
+		$this->fileTypeMapper = $fileTypeMapper;
+		$this->reflectionProvider = $reflectionProvider;
+	}
+
+	public function getNodeType(): string
+	{
+		return \PhpParser\Node\Stmt\ClassMethod::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$docComment = $node->getDocComment();
+		if ($docComment === null) {
+			return [];
+		}
+		$resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+			$scope->getFile(),
+			$scope->isInClass() ? $scope->getClassReflection()->getName() : null,
+			$scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
+			$node->name->name,
+			$docComment->getText()
+		);
+		$errors = [];
+		foreach ($resolvedPhpDoc->getFriends() as $friendTag) {
+			$className = $friendTag->getType()->getClassName();
+			if (!$this->reflectionProvider->hasClass($className)) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'Class %s specified by a @friend tag does not exist.',
+					$className
+				))->build();
+				continue;
+			}
+			$reflection = $this->reflectionProvider->getClass($className);
+			$methodName = $friendTag->getMethod();
+			if ($methodName === null || $reflection->hasMethod($methodName)) {
+				continue;
+			}
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'Method %s::%s() specified by a @friend tag does not exist.',
+				$className,
+				$methodName
+			))->build();
+		}
+		return $errors;
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/FriendMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/FriendMethodCallRuleTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<FriendMethodCallRule>
+ */
+class FriendMethodCallRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new FriendMethodCallRule(self::getContainer()->getByType(FileTypeMapper::class));
+	}
+
+	public function testFriendMethodCall(): void
+	{
+		$this->analyse([ __DIR__ . '/data/friend-method-call.php'], [
+			[
+				'You may not not call FriendMethodCallTest\Foo::friendWithEntireBar() from the global scope as the method lists allowed callers through friends.',
+				6,
+			],
+			[
+				'FriendMethodCallTest\Bar::notBaz() may not call FriendMethodCallTest\Foo::friendWithBarBaz() as it is not listed as a friend.',
+				34,
+			],
+			[
+				'FriendMethodCallTest\BarBar::baz() may not call FriendMethodCallTest\Foo::friendWithEntireBar() as it is not listed as a friend.',
+				44,
+			],
+			[
+				'FriendMethodCallTest\BarBar::baz() may not call FriendMethodCallTest\Foo::friendWithBarBaz() as it is not listed as a friend.',
+				45,
+			],
+			[
+				'FriendMethodCallTest\BarBar::notBaz() may not call FriendMethodCallTest\Foo::friendWithEntireBar() as it is not listed as a friend.',
+				52,
+			],
+			[
+				'FriendMethodCallTest\BarBar::notBaz() may not call FriendMethodCallTest\Foo::friendWithBarBaz() as it is not listed as a friend.',
+				53,
+			],
+			[
+				'FriendMethodCallTest\Qux::smh() may not call FriendMethodCallTest\Foo::friendWithEntireBar() as it is not listed as a friend.',
+				63,
+			],
+			[
+				'FriendMethodCallTest\Qux::smh() may not call FriendMethodCallTest\Foo::friendWithBarBaz() as it is not listed as a friend.',
+				64,
+			],
+			[
+				'FriendMethodCallTest\SelfFriend::caller() may not call FriendMethodCallTest\SelfFriend::notFriend() as it is not listed as a friend.',
+				72,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/friend-method-call.php
+++ b/tests/PHPStan/Rules/Methods/data/friend-method-call.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace FriendMethodCallTest;
+
+$foo = new Foo();
+$foo->friendWithEntireBar();
+
+class Foo
+{
+	public function casual() {  }
+
+	/** @friend Bar */
+	public function friendWithEntireBar() {  }
+
+	/** @friend Bar::baz */
+	public function friendWithBarBaz() {  }
+}
+
+class Bar
+{
+	public function baz()
+	{
+		$foo = new Foo();
+		$foo->casual();
+		$foo->friendWithEntireBar();
+		$foo->friendWithBarBaz();
+	}
+
+	public function notBaz()
+	{
+		$foo = new Foo();
+		$foo->casual();
+		$foo->friendWithEntireBar();
+		$foo->friendWithBarBaz();
+	}
+}
+
+class BarBar
+{
+	public function baz()
+	{
+		$foo = new Foo();
+		$foo->casual();
+		$foo->friendWithEntireBar();
+		$foo->friendWithBarBaz();
+	}
+
+	public function notBaz()
+	{
+		$foo = new Foo();
+		$foo->casual();
+		$foo->friendWithEntireBar();
+		$foo->friendWithBarBaz();
+	}
+}
+
+class Qux
+{
+	public function smh()
+	{
+		$foo = new Foo();
+		$foo->casual();
+		$foo->friendWithEntireBar();
+		$foo->friendWithBarBaz();
+	}
+}
+
+class SelfFriend
+{
+	public function caller()
+	{
+		$this->notFriend();
+		$this->friendWithSelfFriend();
+		$this->friendWithSelf();
+		$this->friendWithStatic();
+	}
+
+	/** @friend Foo */
+	public function notFriend() {  }
+
+	/** @friend SelfFriend */
+	public function friendWithSelfFriend() {  }
+
+	/** @friend self */
+	public function friendWithSelf() {  }
+
+	/** @friend static */
+	public function friendWithStatic() {  }
+}

--- a/tests/PHPStan/Rules/PhpDoc/InvalidFriendTagTargetRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidFriendTagTargetRuleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<InvalidFriendTagTargetRule>
+ */
+class InvalidFriendTagTargetRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new InvalidFriendTagTargetRule(
+			self::getContainer()->getByType(FileTypeMapper::class),
+			$this->createReflectionProvider()
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/invalid-friends.php'], [
+			[
+				'Class InvalidFriends\Bar specified by a @friend tag does not exist.',
+				11,
+			],
+			[
+				'Method InvalidFriends\Foo::notExists() specified by a @friend tag does not exist.',
+				11,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/invalid-friends.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/invalid-friends.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace InvalidFriends;
+
+class Foo
+{
+	/**
+	 * @friend Bar
+	 * @friend Foo::notExists
+	 */
+	public function bar() {  }
+}

--- a/tests/PHPStan/Type/data/friend-phpdocs.php
+++ b/tests/PHPStan/Type/data/friend-phpdocs.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace FriendPhpDocs;
+
+use LogicException;
+use RuntimeException;
+
+interface Foo
+{
+	public function noFriends();
+
+	/**
+	 * @friend Bar
+	 */
+	public function classAsFriend();
+
+	/**
+	 * @friend Bar::baz
+	 */
+	public function methodAsFriend();
+
+	/**
+	 * @friend Bar
+	 * @friend Bar::baz
+	 */
+	public function multipleFriends();
+
+	/**
+	 * @friend
+	 * @friend bool
+	 */
+	public function invalidFriends();
+}
+
+interface Bar
+{
+	public function baz();
+}


### PR DESCRIPTION
First (completed) version of friend functions, closes https://github.com/phpstan/phpstan/issues/3565

As for "What if we're in the same class for example?" I took the whitelist approach - if a user specifies `@friend` tag then they want to control who may access given method and it makes sense to restrict calls from same class as well. For instance from my original example, I wouldn't want anybody to call `Category::addProduct` from anywhere but the `Product::addCategory`. Also being friends is not inherited like showcased in the test.

Open issues that come to my mind:
- [x] There's one issue reported by PHPStan I'm not sure how to approach
- [x] Should `FriendTag` creation be hardened somehow?
- [x] I'm not fond of filtering `FriendTag`s that contain `TypeWithClassName` in the rule class. Do you see a better place or is it ok?
- [x] Implement a rule for validating `@friend` annotations