### PR TITLE
Change message 'typehint' to 'type' and 'typehint type' to 'type'.

### DIFF
--- a/src/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRule.php
@@ -31,7 +31,7 @@ class ExistingClassesInArrowFunctionTypehintsRule implements \PHPStan\Rules\Rule
 			$node->getParams(),
 			$node->getReturnType(),
 			'Parameter $%s of anonymous function has invalid type %s.',
-			'Return type of anonymous function has invalid type %s.',
+			'Anonymous function has invalid return type %s.',
 			'Anonymous function uses native union types but they\'re supported only on PHP 8.0 and later.'
 		);
 	}

--- a/src/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRule.php
@@ -30,8 +30,8 @@ class ExistingClassesInArrowFunctionTypehintsRule implements \PHPStan\Rules\Rule
 			$scope,
 			$node->getParams(),
 			$node->getReturnType(),
-			'Parameter $%s of anonymous function has invalid typehint type %s.',
-			'Return typehint of anonymous function has invalid type %s.',
+			'Parameter $%s of anonymous function has invalid type %s.',
+			'Return type of anonymous function has invalid type %s.',
 			'Anonymous function uses native union types but they\'re supported only on PHP 8.0 and later.'
 		);
 	}

--- a/src/Rules/Functions/ExistingClassesInClosureTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInClosureTypehintsRule.php
@@ -31,8 +31,8 @@ class ExistingClassesInClosureTypehintsRule implements \PHPStan\Rules\Rule
 			$scope,
 			$node->getParams(),
 			$node->getReturnType(),
-			'Parameter $%s of anonymous function has invalid typehint type %s.',
-			'Return typehint of anonymous function has invalid type %s.',
+			'Parameter $%s of anonymous function has invalid type %s.',
+			'Return type of anonymous function has invalid type %s.',
 			'Anonymous function uses native union types but they\'re supported only on PHP 8.0 and later.'
 		);
 	}

--- a/src/Rules/Functions/ExistingClassesInClosureTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInClosureTypehintsRule.php
@@ -32,7 +32,7 @@ class ExistingClassesInClosureTypehintsRule implements \PHPStan\Rules\Rule
 			$node->getParams(),
 			$node->getReturnType(),
 			'Parameter $%s of anonymous function has invalid type %s.',
-			'Return type of anonymous function has invalid type %s.',
+			'Anonymous function has invalid return type %s.',
 			'Anonymous function uses native union types but they\'re supported only on PHP 8.0 and later.'
 		);
 	}

--- a/src/Rules/Functions/ExistingClassesInTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInTypehintsRule.php
@@ -38,11 +38,11 @@ class ExistingClassesInTypehintsRule implements \PHPStan\Rules\Rule
 			$node->getOriginalNode(),
 			$scope->getFunction(),
 			sprintf(
-				'Parameter $%%s of function %s() has invalid typehint type %%s.',
+				'Parameter $%%s of function %s() has invalid type %%s.',
 				$functionName
 			),
 			sprintf(
-				'Return typehint of function %s() has invalid type %%s.',
+				'Return type of function %s() has invalid type %%s.',
 				$functionName
 			),
 			sprintf('Function %s() uses native union types but they\'re supported only on PHP 8.0 and later.', $functionName),

--- a/src/Rules/Functions/ExistingClassesInTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInTypehintsRule.php
@@ -42,7 +42,7 @@ class ExistingClassesInTypehintsRule implements \PHPStan\Rules\Rule
 				$functionName
 			),
 			sprintf(
-				'Return type of function %s() has invalid type %%s.',
+				'Function %s() has invalid return type %%s.',
 				$functionName
 			),
 			sprintf('Function %s() uses native union types but they\'re supported only on PHP 8.0 and later.', $functionName),

--- a/src/Rules/Functions/MissingFunctionParameterTypehintRule.php
+++ b/src/Rules/Functions/MissingFunctionParameterTypehintRule.php
@@ -64,7 +64,7 @@ final class MissingFunctionParameterTypehintRule implements \PHPStan\Rules\Rule
 		if ($parameterType instanceof MixedType && !$parameterType->isExplicitMixed()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Function %s() has parameter $%s with no typehint specified.',
+					'Function %s() has parameter $%s with no type specified.',
 					$functionReflection->getName(),
 					$parameterReflection->getName()
 				))->build(),

--- a/src/Rules/Functions/MissingFunctionReturnTypehintRule.php
+++ b/src/Rules/Functions/MissingFunctionReturnTypehintRule.php
@@ -44,7 +44,7 @@ final class MissingFunctionReturnTypehintRule implements \PHPStan\Rules\Rule
 		if ($returnType instanceof MixedType && !$returnType->isExplicitMixed()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Function %s() has no return typehint specified.',
+					'Function %s() has no return type specified.',
 					$functionReflection->getName()
 				))->build(),
 			];

--- a/src/Rules/Methods/ExistingClassesInTypehintsRule.php
+++ b/src/Rules/Methods/ExistingClassesInTypehintsRule.php
@@ -45,7 +45,7 @@ class ExistingClassesInTypehintsRule implements \PHPStan\Rules\Rule
 				$methodReflection->getName()
 			),
 			sprintf(
-				'Return type of method %s::%s() has invalid type %%s.',
+				'Method %s::%s() has invalid return type %%s.',
 				$scope->getClassReflection()->getDisplayName(),
 				$methodReflection->getName()
 			),

--- a/src/Rules/Methods/ExistingClassesInTypehintsRule.php
+++ b/src/Rules/Methods/ExistingClassesInTypehintsRule.php
@@ -40,12 +40,12 @@ class ExistingClassesInTypehintsRule implements \PHPStan\Rules\Rule
 			$methodReflection,
 			$node->getOriginalNode(),
 			sprintf(
-				'Parameter $%%s of method %s::%s() has invalid typehint type %%s.',
+				'Parameter $%%s of method %s::%s() has invalid type %%s.',
 				$scope->getClassReflection()->getDisplayName(),
 				$methodReflection->getName()
 			),
 			sprintf(
-				'Return typehint of method %s::%s() has invalid type %%s.',
+				'Return type of method %s::%s() has invalid type %%s.',
 				$scope->getClassReflection()->getDisplayName(),
 				$methodReflection->getName()
 			),

--- a/src/Rules/Methods/MissingMethodParameterTypehintRule.php
+++ b/src/Rules/Methods/MissingMethodParameterTypehintRule.php
@@ -61,7 +61,7 @@ final class MissingMethodParameterTypehintRule implements \PHPStan\Rules\Rule
 		if ($parameterType instanceof MixedType && !$parameterType->isExplicitMixed()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Method %s::%s() has parameter $%s with no typehint specified.',
+					'Method %s::%s() has parameter $%s with no type specified.',
 					$methodReflection->getDeclaringClass()->getDisplayName(),
 					$methodReflection->getName(),
 					$parameterReflection->getName()

--- a/src/Rules/Methods/MissingMethodReturnTypehintRule.php
+++ b/src/Rules/Methods/MissingMethodReturnTypehintRule.php
@@ -42,7 +42,7 @@ final class MissingMethodReturnTypehintRule implements \PHPStan\Rules\Rule
 		if ($returnType instanceof MixedType && !$returnType->isExplicitMixed()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Method %s::%s() has no return typehint specified.',
+					'Method %s::%s() has no return type specified.',
 					$methodReflection->getDeclaringClass()->getDisplayName(),
 					$methodReflection->getName()
 				))->build(),

--- a/src/Rules/Properties/MissingPropertyTypehintRule.php
+++ b/src/Rules/Properties/MissingPropertyTypehintRule.php
@@ -39,7 +39,7 @@ final class MissingPropertyTypehintRule implements \PHPStan\Rules\Rule
 		if ($propertyType instanceof MixedType && !$propertyType->isExplicitMixed()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Property %s::$%s has no typehint specified.',
+					'Property %s::$%s has no type specified.',
 					$propertyReflection->getDeclaringClass()->getDisplayName(),
 					$node->getName()
 				))->build(),

--- a/src/Rules/TooWideTypehints/TooWideArrowFunctionReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideArrowFunctionReturnTypehintRule.php
@@ -49,7 +49,7 @@ class TooWideArrowFunctionReturnTypehintRule implements Rule
 			}
 
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Anonymous function never returns %s so it can be removed from the return typehint.',
+				'Anonymous function never returns %s so it can be removed from the return type.',
 				$type->describe(VerbosityLevel::getRecommendedLevelByType($type))
 			))->build();
 		}

--- a/src/Rules/TooWideTypehints/TooWideClosureReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideClosureReturnTypehintRule.php
@@ -71,7 +71,7 @@ class TooWideClosureReturnTypehintRule implements Rule
 			}
 
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Anonymous function never returns %s so it can be removed from the return typehint.',
+				'Anonymous function never returns %s so it can be removed from the return type.',
 				$type->describe(VerbosityLevel::getRecommendedLevelByType($type))
 			))->build();
 		}

--- a/src/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRule.php
@@ -79,7 +79,7 @@ class TooWideFunctionReturnTypehintRule implements Rule
 			}
 
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Function %s() never returns %s so it can be removed from the return typehint.',
+				'Function %s() never returns %s so it can be removed from the return type.',
 				$function->getName(),
 				$type->describe(VerbosityLevel::getRecommendedLevelByType($type))
 			))->build();

--- a/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php
@@ -103,7 +103,7 @@ class TooWideMethodReturnTypehintRule implements Rule
 			}
 
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Method %s::%s() never returns %s so it can be removed from the return typehint.',
+				'Method %s::%s() never returns %s so it can be removed from the return type.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
 				$type->describe(VerbosityLevel::getRecommendedLevelByType($type))

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -134,9 +134,9 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/anonymous-class-wrong-filename-regression.php');
 		$this->assertCount(5, $errors);
-		$this->assertStringContainsString('Return typehint of method', $errors[0]->getMessage());
+		$this->assertStringContainsString('Return type of method', $errors[0]->getMessage());
 		$this->assertSame(16, $errors[0]->getLine());
-		$this->assertStringContainsString('Return typehint of method', $errors[1]->getMessage());
+		$this->assertStringContainsString('Return type of method', $errors[1]->getMessage());
 		$this->assertSame(16, $errors[1]->getLine());
 		$this->assertSame('Instantiated class AnonymousClassWrongFilename\Bar not found.', $errors[2]->getMessage());
 		$this->assertSame(18, $errors[2]->getLine());
@@ -168,7 +168,7 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 		$this->assertCount(2, $errors);
 		$this->assertSame('Property y\x::$baz has unknown class x\baz as its type.', $errors[0]->getMessage());
 		$this->assertSame(15, $errors[0]->getLine());
-		$this->assertSame('Parameter $baz of method y\x::__construct() has invalid typehint type x\baz.', $errors[1]->getMessage());
+		$this->assertSame('Parameter $baz of method y\x::__construct() has invalid type x\baz.', $errors[1]->getMessage());
 		$this->assertSame(16, $errors[1]->getLine());
 	}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -134,9 +134,11 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/anonymous-class-wrong-filename-regression.php');
 		$this->assertCount(5, $errors);
-		$this->assertStringContainsString('Return type of method', $errors[0]->getMessage());
+		$this->assertStringContainsString('Method', $errors[0]->getMessage());
+		$this->assertStringContainsString('has invalid return type', $errors[0]->getMessage());
 		$this->assertSame(16, $errors[0]->getLine());
-		$this->assertStringContainsString('Return type of method', $errors[1]->getMessage());
+		$this->assertStringContainsString('Method', $errors[1]->getMessage());
+		$this->assertStringContainsString('has invalid return type', $errors[1]->getMessage());
 		$this->assertSame(16, $errors[1]->getLine());
 		$this->assertSame('Instantiated class AnonymousClassWrongFilename\Bar not found.', $errors[2]->getMessage());
 		$this->assertSame(18, $errors[2]->getLine());

--- a/tests/PHPStan/Command/ErrorFormatter/data/unixBaseline.neon
+++ b/tests/PHPStan/Command/ErrorFormatter/data/unixBaseline.neon
@@ -1,12 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method BaselineIntegration\\\\WindowsNewlines\\:\\:phpdocWithNewlines\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method BaselineIntegration\\\\WindowsNewlines\\:\\:phpdocWithNewlines\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: WindowsNewlines.php
 
 		-
-			message: "#^Method BaselineIntegration\\\\WindowsNewlines\\:\\:phpdocWithNewlines\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			message: "#^Method BaselineIntegration\\\\WindowsNewlines\\:\\:phpdocWithNewlines\\(\\) has parameter \\$object with no type specified\\.$#"
 			count: 1
 			path: WindowsNewlines.php
 

--- a/tests/PHPStan/Command/ErrorFormatter/data/windowsBaseline.neon
+++ b/tests/PHPStan/Command/ErrorFormatter/data/windowsBaseline.neon
@@ -1,12 +1,12 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method BaselineIntegration\\\\UnixNewlines\\:\\:phpdocWithNewlines\\(\\) has no return typehint specified\\.$#"
+			message: "#^Method BaselineIntegration\\\\UnixNewlines\\:\\:phpdocWithNewlines\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: UnixNewlines.php
 
 		-
-			message: "#^Method BaselineIntegration\\\\UnixNewlines\\:\\:phpdocWithNewlines\\(\\) has parameter \\$object with no typehint specified\\.$#"
+			message: "#^Method BaselineIntegration\\\\UnixNewlines\\:\\:phpdocWithNewlines\\(\\) has parameter \\$object with no type specified\\.$#"
 			count: 1
 			path: UnixNewlines.php
 

--- a/tests/PHPStan/Generics/data/functions-6.json
+++ b/tests/PHPStan/Generics/data/functions-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Function PHPStan\\Generics\\Functions\\testF() has no return typehint specified.",
+        "message": "Function PHPStan\\Generics\\Functions\\testF() has no return type specified.",
         "line": 27,
         "ignorable": true
     },

--- a/tests/PHPStan/Generics/data/pick-6.json
+++ b/tests/PHPStan/Generics/data/pick-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Function PHPStan\\Generics\\Pick\\test() has no return typehint specified.",
+        "message": "Function PHPStan\\Generics\\Pick\\test() has no return type specified.",
         "line": 22,
         "ignorable": true
     }

--- a/tests/PHPStan/Generics/data/varyingAcceptor-6.json
+++ b/tests/PHPStan/Generics/data/varyingAcceptor-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Function PHPStan\\Generics\\VaryingAcceptor\\testApply() has no return typehint specified.",
+        "message": "Function PHPStan\\Generics\\VaryingAcceptor\\testApply() has no return type specified.",
         "line": 30,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/acceptTypes-6.json
+++ b/tests/PHPStan/Levels/data/acceptTypes-6.json
@@ -1,151 +1,151 @@
 [
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doFoo() has no return type specified.",
         "line": 15,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doBar() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doBar() has no return type specified.",
         "line": 30,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doBaz() has no return type specified.",
         "line": 41,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doLorem() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doLorem() has no return type specified.",
         "line": 60,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doIpsum() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doIpsum() has no return type specified.",
         "line": 68,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doFooArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doFooArray() has no return type specified.",
         "line": 80,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doBarArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doBarArray() has no return type specified.",
         "line": 98,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doBazArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doBazArray() has no return type specified.",
         "line": 103,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::doBazArrayUnionItemTypes() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::doBazArrayUnionItemTypes() has no return type specified.",
         "line": 127,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::callableArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::callableArray() has no return type specified.",
         "line": 138,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::expectCallable() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::expectCallable() has no return type specified.",
         "line": 148,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::iterableCountable() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::iterableCountable() has no return type specified.",
         "line": 160,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Foo::benevolentUnionNotReported() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Foo::benevolentUnionNotReported() has no return type specified.",
         "line": 176,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doFoo() has no return type specified.",
         "line": 208,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doFooUnionClosures() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doFooUnionClosures() has no return type specified.",
         "line": 254,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doBar() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doBar() has no return type specified.",
         "line": 332,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\ClosureAccepts::doBaz() has no return type specified.",
         "line": 342,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doFoo() has no return type specified.",
         "line": 409,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doBar() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doBar() has no return type specified.",
         "line": 418,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doBaz() has no return type specified.",
         "line": 423,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doLorem() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doLorem() has no return type specified.",
         "line": 437,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doIpsum() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doIpsum() has no return type specified.",
         "line": 445,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doFooArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doFooArray() has no return type specified.",
         "line": 490,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::doBarArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::doBarArray() has no return type specified.",
         "line": 502,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::testUnions() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::testUnions() has no return type specified.",
         "line": 524,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::testUnions2() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::testUnions2() has no return type specified.",
         "line": 535,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::requireArray() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::requireArray() has no return type specified.",
         "line": 549,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\Baz::requireFoo() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\Baz::requireFoo() has no return type specified.",
         "line": 554,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doFoo() has no return type specified.",
         "line": 570,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doBar() has no return typehint specified.",
+        "message": "Method Levels\\AcceptTypes\\ArrayShapes::doBar() has no return type specified.",
         "line": 603,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/arrayAccess-6.json
+++ b/tests/PHPStan/Levels/data/arrayAccess-6.json
@@ -1,26 +1,26 @@
 [
     {
-        "message": "Method Levels\\ArrayAccess\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\ArrayAccess\\Foo::doFoo() has no return type specified.",
         "line": 11,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ArrayAccess\\Foo::doBar() has no return typehint specified.",
+        "message": "Method Levels\\ArrayAccess\\Foo::doBar() has no return type specified.",
         "line": 22,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ArrayAccess\\Foo::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\ArrayAccess\\Foo::doBaz() has no return type specified.",
         "line": 30,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ArrayAccess\\Foo::doLorem() has no return typehint specified.",
+        "message": "Method Levels\\ArrayAccess\\Foo::doLorem() has no return type specified.",
         "line": 38,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ArrayAccess\\Foo::doLorem() has parameter $mixed with no typehint specified.",
+        "message": "Method Levels\\ArrayAccess\\Foo::doLorem() has parameter $mixed with no type specified.",
         "line": 38,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/arrayDimFetches-6.json
+++ b/tests/PHPStan/Levels/data/arrayDimFetches-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Method Levels\\ArrayDimFetches\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\ArrayDimFetches\\Foo::doFoo() has no return type specified.",
         "line": 12,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ArrayDimFetches\\Foo::doBar() has no return typehint specified.",
+        "message": "Method Levels\\ArrayDimFetches\\Foo::doBar() has no return type specified.",
         "line": 31,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/binaryOps-6.json
+++ b/tests/PHPStan/Levels/data/binaryOps-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method Levels\\BinaryOps\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\BinaryOps\\Foo::doFoo() has no return type specified.",
         "line": 14,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/callableCalls-6.json
+++ b/tests/PHPStan/Levels/data/callableCalls-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Method Levels\\CallableCalls\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\CallableCalls\\Foo::doFoo() has no return type specified.",
         "line": 14,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\CallableCalls\\Foo::doBar() has no return typehint specified.",
+        "message": "Method Levels\\CallableCalls\\Foo::doBar() has no return type specified.",
         "line": 41,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/callableVariance-6.json
+++ b/tests/PHPStan/Levels/data/callableVariance-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Function Levels\\CallableVariance\\d() has no return typehint specified.",
+        "message": "Function Levels\\CallableVariance\\d() has no return type specified.",
         "line": 68,
         "ignorable": true
     },
     {
-        "message": "Function Levels\\CallableVariance\\testD() has no return typehint specified.",
+        "message": "Function Levels\\CallableVariance\\testD() has no return type specified.",
         "line": 79,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/casts-6.json
+++ b/tests/PHPStan/Levels/data/casts-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method Levels\\Casts\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\Casts\\Foo::doFoo() has no return type specified.",
         "line": 13,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/clone-6.json
+++ b/tests/PHPStan/Levels/data/clone-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method Levels\\Cloning\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\Cloning\\Foo::doFoo() has no return type specified.",
         "line": 18,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/comparison-6.json
+++ b/tests/PHPStan/Levels/data/comparison-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method Levels\\Comparison\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\Comparison\\Foo::doFoo() has no return type specified.",
         "line": 18,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/constantAccesses-6.json
+++ b/tests/PHPStan/Levels/data/constantAccesses-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Method Levels\\ConstantAccesses\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\ConstantAccesses\\Foo::doFoo() has no return type specified.",
         "line": 14,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ConstantAccesses\\Baz::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\ConstantAccesses\\Baz::doBaz() has no return type specified.",
         "line": 42,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/inferPropertyType-6.json
+++ b/tests/PHPStan/Levels/data/inferPropertyType-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Property InferPropertyType\\Foo::$bar has no typehint specified.",
+        "message": "Property InferPropertyType\\Foo::$bar has no type specified.",
         "line": 10,
         "ignorable": true
     },
     {
-        "message": "Method InferPropertyType\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method InferPropertyType\\Foo::doFoo() has no return type specified.",
         "line": 18,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/iterable-6.json
+++ b/tests/PHPStan/Levels/data/iterable-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method Levels\\Iterables\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\Iterables\\Foo::doFoo() has no return type specified.",
         "line": 15,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/methodCalls-6.json
+++ b/tests/PHPStan/Levels/data/methodCalls-6.json
@@ -1,71 +1,71 @@
 [
     {
-        "message": "Method Levels\\MethodCalls\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\Foo::doFoo() has no return type specified.",
         "line": 8,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\Bar::doBar() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\Bar::doBar() has no return type specified.",
         "line": 23,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\Baz::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\Baz::doBaz() has no return type specified.",
         "line": 45,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\ClassWithMagicMethod::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\ClassWithMagicMethod::doFoo() has no return type specified.",
         "line": 70,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\ClassWithMagicMethod::__call() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\ClassWithMagicMethod::__call() has no return type specified.",
         "line": 79,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\AnotherClassWithMagicMethod::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\AnotherClassWithMagicMethod::doFoo() has no return type specified.",
         "line": 89,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\AnotherClassWithMagicMethod::__callStatic() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\AnotherClassWithMagicMethod::__callStatic() has no return type specified.",
         "line": 98,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\Ipsum::doLorem() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\Ipsum::doLorem() has no return type specified.",
         "line": 158,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\FooException::commonMethod() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\FooException::commonMethod() has no return type specified.",
         "line": 182,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\FooException::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\FooException::doFoo() has no return type specified.",
         "line": 187,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\BarException::commonMethod() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\BarException::commonMethod() has no return type specified.",
         "line": 197,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\BarException::doBar() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\BarException::doBar() has no return type specified.",
         "line": 202,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\TestExceptions::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\TestExceptions::doFoo() has no return type specified.",
         "line": 212,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\MethodCalls\\ExtraArguments::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\MethodCalls\\ExtraArguments::doFoo() has no return type specified.",
         "line": 234,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/object-6.json
+++ b/tests/PHPStan/Levels/data/object-6.json
@@ -1,16 +1,16 @@
 [
     {
-        "message": "Method Levels\\ObjectTests\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\ObjectTests\\Foo::doFoo() has no return type specified.",
         "line": 11,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ObjectTests\\Foo::doBar() has no return typehint specified.",
+        "message": "Method Levels\\ObjectTests\\Foo::doBar() has no return type specified.",
         "line": 23,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\ObjectTests\\Foo::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\ObjectTests\\Foo::doBaz() has no return type specified.",
         "line": 35,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/propertyAccesses-6.json
+++ b/tests/PHPStan/Levels/data/propertyAccesses-6.json
@@ -1,41 +1,41 @@
 [
     {
-        "message": "Method Levels\\PropertyAccesses\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\Foo::doFoo() has no return type specified.",
         "line": 11,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\Bar::doBar() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\Bar::doBar() has no return type specified.",
         "line": 29,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\Baz::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\Baz::doBaz() has no return type specified.",
         "line": 50,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\ClassWithMagicMethod::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\ClassWithMagicMethod::doFoo() has no return type specified.",
         "line": 74,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\ClassWithMagicMethod::__set() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\ClassWithMagicMethod::__set() has no return type specified.",
         "line": 83,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\AnotherClassWithMagicMethod::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\AnotherClassWithMagicMethod::doFoo() has no return type specified.",
         "line": 93,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\AnotherClassWithMagicMethod::__get() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\AnotherClassWithMagicMethod::__get() has no return type specified.",
         "line": 98,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\Ipsum::doBaz() has no return typehint specified.",
+        "message": "Method Levels\\PropertyAccesses\\Ipsum::doBaz() has no return type specified.",
         "line": 158,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/stubValidator-0.json
+++ b/tests/PHPStan/Levels/data/stubValidator-0.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method StubValidator\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method StubValidator\\Foo::doFoo() has no return type specified.",
         "line": 15,
         "ignorable": true
     },
@@ -10,7 +10,7 @@
         "ignorable": true
     },
     {
-        "message": "Function StubValidator\\someFunction() has no return typehint specified.",
+        "message": "Function StubValidator\\someFunction() has no return type specified.",
         "line": 22,
         "ignorable": true
     },
@@ -20,12 +20,12 @@
         "ignorable": true
     },
     {
-        "message": "Method class@anonymous/stubValidator/stubs.php:27::doFoo() has no return typehint specified.",
+        "message": "Method class@anonymous/stubValidator/stubs.php:27::doFoo() has no return type specified.",
         "line": 30,
         "ignorable": true
     },
     {
-        "message": "Parameter $foo of method class@anonymous/stubValidator/stubs.php:27::doFoo() has invalid typehint type StubValidator\\Foooooooo.",
+        "message": "Parameter $foo of method class@anonymous/stubValidator/stubs.php:27::doFoo() has invalid type StubValidator\\Foooooooo.",
         "line": 30,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/stubs-functions-6.json
+++ b/tests/PHPStan/Levels/data/stubs-functions-6.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Function StubsIntegrationTest\\foo() has no return typehint specified.",
+        "message": "Function StubsIntegrationTest\\foo() has no return type specified.",
         "line": 5,
         "ignorable": true
     },
     {
-        "message": "Function StubsIntegrationTest\\foo() has parameter $i with no typehint specified.",
+        "message": "Function StubsIntegrationTest\\foo() has parameter $i with no type specified.",
         "line": 5,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/stubs-methods-6.json
+++ b/tests/PHPStan/Levels/data/stubs-methods-6.json
@@ -1,26 +1,26 @@
 [
     {
-        "message": "Method StubsIntegrationTest\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method StubsIntegrationTest\\Foo::doFoo() has no return type specified.",
         "line": 8,
         "ignorable": true
     },
     {
-        "message": "Method StubsIntegrationTest\\Foo::doFoo() has parameter $i with no typehint specified.",
+        "message": "Method StubsIntegrationTest\\Foo::doFoo() has parameter $i with no type specified.",
         "line": 8,
         "ignorable": true
     },
     {
-        "message": "Method StubsIntegrationTest\\InterfaceWithStubPhpDoc2::doFoo() has no return typehint specified.",
+        "message": "Method StubsIntegrationTest\\InterfaceWithStubPhpDoc2::doFoo() has no return type specified.",
         "line": 151,
         "ignorable": true
     },
     {
-        "message": "Method StubsIntegrationTest\\YetAnotherFoo::doFoo() has no return typehint specified.",
+        "message": "Method StubsIntegrationTest\\YetAnotherFoo::doFoo() has no return type specified.",
         "line": 197,
         "ignorable": true
     },
     {
-        "message": "Method StubsIntegrationTest\\YetAnotherFoo::doFoo() has parameter $j with no typehint specified.",
+        "message": "Method StubsIntegrationTest\\YetAnotherFoo::doFoo() has parameter $j with no type specified.",
         "line": 197,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/throwValues-6.json
+++ b/tests/PHPStan/Levels/data/throwValues-6.json
@@ -1,6 +1,6 @@
 [
     {
-        "message": "Method Levels\\ThrowValues\\Foo::doFoo() has no return typehint specified.",
+        "message": "Method Levels\\ThrowValues\\Foo::doFoo() has no return type specified.",
         "line": 30,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/typehints-0.json
+++ b/tests/PHPStan/Levels/data/typehints-0.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Parameter $lorem of method Levels\\Typehints\\Foo::doFoo() has invalid typehint type Levels\\Typehints\\Lorem.",
+        "message": "Parameter $lorem of method Levels\\Typehints\\Foo::doFoo() has invalid type Levels\\Typehints\\Lorem.",
         "line": 8,
         "ignorable": true
     },
     {
-        "message": "Return typehint of method Levels\\Typehints\\Foo::doFoo() has invalid type Levels\\Typehints\\Ipsum.",
+        "message": "Return type of method Levels\\Typehints\\Foo::doFoo() has invalid type Levels\\Typehints\\Ipsum.",
         "line": 8,
         "ignorable": true
     },

--- a/tests/PHPStan/Levels/data/typehints-2.json
+++ b/tests/PHPStan/Levels/data/typehints-2.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Parameter $lorem of method Levels\\Typehints\\Foo::doBar() has invalid typehint type Levels\\Typehints\\Lorem.",
+        "message": "Parameter $lorem of method Levels\\Typehints\\Foo::doBar() has invalid type Levels\\Typehints\\Lorem.",
         "line": 17,
         "ignorable": true
     },
     {
-        "message": "Return typehint of method Levels\\Typehints\\Foo::doBar() has invalid type Levels\\Typehints\\Ipsum.",
+        "message": "Return type of method Levels\\Typehints\\Foo::doBar() has invalid type Levels\\Typehints\\Ipsum.",
         "line": 17,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/unreachable-6-alwaysTrue.json
+++ b/tests/PHPStan/Levels/data/unreachable-6-alwaysTrue.json
@@ -1,61 +1,61 @@
 [
     {
-        "message": "Method Levels\\Unreachable\\Foo::doStrictComparison() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doStrictComparison() has no return type specified.",
         "line": 8,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doInstanceOf() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doInstanceOf() has no return type specified.",
         "line": 18,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doTypeSpecifyingFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doTypeSpecifyingFunction() has no return type specified.",
         "line": 27,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doOtherFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doOtherFunction() has no return type specified.",
         "line": 36,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doOtherValue() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doOtherValue() has no return type specified.",
         "line": 45,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doBooleanAnd() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doBooleanAnd() has no return type specified.",
         "line": 54,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doStrictComparison() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doStrictComparison() has no return type specified.",
         "line": 71,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doInstanceOf() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doInstanceOf() has no return type specified.",
         "line": 77,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doTypeSpecifyingFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doTypeSpecifyingFunction() has no return type specified.",
         "line": 82,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doOtherFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doOtherFunction() has no return type specified.",
         "line": 87,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doOtherValue() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doOtherValue() has no return type specified.",
         "line": 92,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doBooleanAnd() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doBooleanAnd() has no return type specified.",
         "line": 97,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/unreachable-6.json
+++ b/tests/PHPStan/Levels/data/unreachable-6.json
@@ -1,61 +1,61 @@
 [
     {
-        "message": "Method Levels\\Unreachable\\Foo::doStrictComparison() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doStrictComparison() has no return type specified.",
         "line": 8,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doInstanceOf() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doInstanceOf() has no return type specified.",
         "line": 18,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doTypeSpecifyingFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doTypeSpecifyingFunction() has no return type specified.",
         "line": 27,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doOtherFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doOtherFunction() has no return type specified.",
         "line": 36,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doOtherValue() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doOtherValue() has no return type specified.",
         "line": 45,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Foo::doBooleanAnd() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Foo::doBooleanAnd() has no return type specified.",
         "line": 54,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doStrictComparison() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doStrictComparison() has no return type specified.",
         "line": 71,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doInstanceOf() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doInstanceOf() has no return type specified.",
         "line": 77,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doTypeSpecifyingFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doTypeSpecifyingFunction() has no return type specified.",
         "line": 82,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doOtherFunction() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doOtherFunction() has no return type specified.",
         "line": 87,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doOtherValue() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doOtherValue() has no return type specified.",
         "line": 92,
         "ignorable": true
     },
     {
-        "message": "Method Levels\\Unreachable\\Bar::doBooleanAnd() has no return typehint specified.",
+        "message": "Method Levels\\Unreachable\\Bar::doBooleanAnd() has no return type specified.",
         "line": 97,
         "ignorable": true
     }

--- a/tests/PHPStan/Parallel/ParallelAnalyserIntegrationTest.php
+++ b/tests/PHPStan/Parallel/ParallelAnalyserIntegrationTest.php
@@ -58,7 +58,7 @@ class ParallelAnalyserIntegrationTest extends TestCase
 					'errors' => 1,
 					'messages' => [
 						[
-							'message' => 'Method ParallelAnalyserIntegrationTest\\Bar::doFoo() has no return typehint specified.',
+							'message' => 'Method ParallelAnalyserIntegrationTest\\Bar::doFoo() has no return type specified.',
 							'line' => 8,
 							'ignorable' => true,
 						],
@@ -68,7 +68,7 @@ class ParallelAnalyserIntegrationTest extends TestCase
 					'errors' => 2,
 					'messages' => [
 						[
-							'message' => 'Method ParallelAnalyserIntegrationTest\\Foo::doFoo() has no return typehint specified.',
+							'message' => 'Method ParallelAnalyserIntegrationTest\\Foo::doFoo() has no return type specified.',
 							'line' => 8,
 							'ignorable' => true,
 						],

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -32,7 +32,7 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends \PHPStan\Testing\R
 				10,
 			],
 			[
-				'Return type of anonymous function has invalid type ArrowFunctionExistingClassesInTypehints\Baz.',
+				'Anonymous function has invalid return type ArrowFunctionExistingClassesInTypehints\Baz.',
 				10,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -28,11 +28,11 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends \PHPStan\Testing\R
 		}
 		$this->analyse([__DIR__ . '/data/arrow-function-typehints.php'], [
 			[
-				'Parameter $bar of anonymous function has invalid typehint type ArrowFunctionExistingClassesInTypehints\Bar.',
+				'Parameter $bar of anonymous function has invalid type ArrowFunctionExistingClassesInTypehints\Bar.',
 				10,
 			],
 			[
-				'Return typehint of anonymous function has invalid type ArrowFunctionExistingClassesInTypehints\Baz.',
+				'Return type of anonymous function has invalid type ArrowFunctionExistingClassesInTypehints\Baz.',
 				10,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -25,11 +25,11 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 	{
 		$this->analyse([__DIR__ . '/data/closure-typehints.php'], [
 			[
-				'Return typehint of anonymous function has invalid type TestClosureFunctionTypehints\NonexistentClass.',
+				'Return type of anonymous function has invalid type TestClosureFunctionTypehints\NonexistentClass.',
 				10,
 			],
 			[
-				'Parameter $bar of anonymous function has invalid typehint type TestClosureFunctionTypehints\BarFunctionTypehints.',
+				'Parameter $bar of anonymous function has invalid type TestClosureFunctionTypehints\BarFunctionTypehints.',
 				15,
 			],
 			[
@@ -41,11 +41,11 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 				30,
 			],
 			[
-				'Parameter $trait of anonymous function has invalid typehint type TestClosureFunctionTypehints\SomeTrait.',
+				'Parameter $trait of anonymous function has invalid type TestClosureFunctionTypehints\SomeTrait.',
 				45,
 			],
 			[
-				'Return typehint of anonymous function has invalid type TestClosureFunctionTypehints\SomeTrait.',
+				'Return type of anonymous function has invalid type TestClosureFunctionTypehints\SomeTrait.',
 				50,
 			],
 		]);
@@ -55,11 +55,11 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 	{
 		$this->analyse([__DIR__ . '/data/closure-7.1-typehints.php'], [
 			[
-				'Parameter $bar of anonymous function has invalid typehint type TestClosureFunctionTypehintsPhp71\NonexistentClass.',
+				'Parameter $bar of anonymous function has invalid type TestClosureFunctionTypehintsPhp71\NonexistentClass.',
 				35,
 			],
 			[
-				'Return typehint of anonymous function has invalid type TestClosureFunctionTypehintsPhp71\NonexistentClass.',
+				'Return type of anonymous function has invalid type TestClosureFunctionTypehintsPhp71\NonexistentClass.',
 				35,
 			],
 		]);
@@ -80,7 +80,7 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 		}
 		$this->analyse([__DIR__ . '/data/void-parameter-typehint.php'], [
 			[
-				'Parameter $param of anonymous function has invalid typehint type void.',
+				'Parameter $param of anonymous function has invalid type void.',
 				5,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -25,7 +25,7 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 	{
 		$this->analyse([__DIR__ . '/data/closure-typehints.php'], [
 			[
-				'Return type of anonymous function has invalid type TestClosureFunctionTypehints\NonexistentClass.',
+				'Anonymous function has invalid return type TestClosureFunctionTypehints\NonexistentClass.',
 				10,
 			],
 			[
@@ -45,7 +45,7 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 				45,
 			],
 			[
-				'Return type of anonymous function has invalid type TestClosureFunctionTypehints\SomeTrait.',
+				'Anonymous function has invalid return type TestClosureFunctionTypehints\SomeTrait.',
 				50,
 			],
 		]);
@@ -59,7 +59,7 @@ class ExistingClassesInClosureTypehintsRuleTest extends \PHPStan\Testing\RuleTes
 				35,
 			],
 			[
-				'Return type of anonymous function has invalid type TestClosureFunctionTypehintsPhp71\NonexistentClass.',
+				'Anonymous function has invalid return type TestClosureFunctionTypehintsPhp71\NonexistentClass.',
 				35,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -106,7 +106,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				18,
 			],
 			[
-				'Return type of function returnParentWithoutNamespace() has invalid type parent.',
+				'Function returnParentWithoutNamespace() has invalid type parent.',
 				31,
 			],
 			[

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -106,7 +106,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				18,
 			],
 			[
-				'Function returnParentWithoutNamespace() has invalid type parent.',
+				'Function returnParentWithoutNamespace() has invalid return type parent.',
 				31,
 			],
 			[

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -27,15 +27,15 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		require_once __DIR__ . '/data/typehints.php';
 		$this->analyse([__DIR__ . '/data/typehints.php'], [
 			[
-				'Return typehint of function TestFunctionTypehints\foo() has invalid type TestFunctionTypehints\NonexistentClass.',
+				'Return type of function TestFunctionTypehints\foo() has invalid type TestFunctionTypehints\NonexistentClass.',
 				15,
 			],
 			[
-				'Parameter $bar of function TestFunctionTypehints\bar() has invalid typehint type TestFunctionTypehints\BarFunctionTypehints.',
+				'Parameter $bar of function TestFunctionTypehints\bar() has invalid type TestFunctionTypehints\BarFunctionTypehints.',
 				20,
 			],
 			[
-				'Return typehint of function TestFunctionTypehints\returnParent() has invalid type TestFunctionTypehints\parent.',
+				'Return type of function TestFunctionTypehints\returnParent() has invalid type TestFunctionTypehints\parent.',
 				33,
 			],
 			[
@@ -63,27 +63,27 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				56,
 			],
 			[
-				'Parameter $trait of function TestFunctionTypehints\referencesTraitsInNative() has invalid typehint type TestFunctionTypehints\SomeTrait.',
+				'Parameter $trait of function TestFunctionTypehints\referencesTraitsInNative() has invalid type TestFunctionTypehints\SomeTrait.',
 				61,
 			],
 			[
-				'Return typehint of function TestFunctionTypehints\referencesTraitsInNative() has invalid type TestFunctionTypehints\SomeTrait.',
+				'Return type of function TestFunctionTypehints\referencesTraitsInNative() has invalid type TestFunctionTypehints\SomeTrait.',
 				61,
 			],
 			[
-				'Parameter $trait of function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid typehint type TestFunctionTypehints\SomeTrait.',
+				'Parameter $trait of function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid type TestFunctionTypehints\SomeTrait.',
 				70,
 			],
 			[
-				'Return typehint of function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid type TestFunctionTypehints\SomeTrait.',
+				'Return type of function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid type TestFunctionTypehints\SomeTrait.',
 				70,
 			],
 			[
-				'Parameter $string of function TestFunctionTypehints\genericClassString() has invalid typehint type TestFunctionTypehints\SomeNonexistentClass.',
+				'Parameter $string of function TestFunctionTypehints\genericClassString() has invalid type TestFunctionTypehints\SomeNonexistentClass.',
 				78,
 			],
 			[
-				'Parameter $string of function TestFunctionTypehints\genericTemplateClassString() has invalid typehint type TestFunctionTypehints\SomeNonexistentClass.',
+				'Parameter $string of function TestFunctionTypehints\genericTemplateClassString() has invalid type TestFunctionTypehints\SomeNonexistentClass.',
 				87,
 			],
 			[
@@ -98,15 +98,15 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		require_once __DIR__ . '/data/typehintsWithoutNamespace.php';
 		$this->analyse([__DIR__ . '/data/typehintsWithoutNamespace.php'], [
 			[
-				'Return typehint of function fooWithoutNamespace() has invalid type NonexistentClass.',
+				'Return type of function fooWithoutNamespace() has invalid type NonexistentClass.',
 				13,
 			],
 			[
-				'Parameter $bar of function barWithoutNamespace() has invalid typehint type BarFunctionTypehints.',
+				'Parameter $bar of function barWithoutNamespace() has invalid type BarFunctionTypehints.',
 				18,
 			],
 			[
-				'Return typehint of function returnParentWithoutNamespace() has invalid type parent.',
+				'Return type of function returnParentWithoutNamespace() has invalid type parent.',
 				31,
 			],
 			[
@@ -134,19 +134,19 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				54,
 			],
 			[
-				'Parameter $trait of function referencesTraitsInNativeWithoutNamespace() has invalid typehint type SomeTraitWithoutNamespace.',
+				'Parameter $trait of function referencesTraitsInNativeWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
 				59,
 			],
 			[
-				'Return typehint of function referencesTraitsInNativeWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
+				'Return type of function referencesTraitsInNativeWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
 				59,
 			],
 			[
-				'Parameter $trait of function referencesTraitsInPhpDocWithoutNamespace() has invalid typehint type SomeTraitWithoutNamespace.',
+				'Parameter $trait of function referencesTraitsInPhpDocWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
 				68,
 			],
 			[
-				'Return typehint of function referencesTraitsInPhpDocWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
+				'Return type of function referencesTraitsInPhpDocWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
 				68,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -27,7 +27,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		require_once __DIR__ . '/data/typehints.php';
 		$this->analyse([__DIR__ . '/data/typehints.php'], [
 			[
-				'Return type of function TestFunctionTypehints\foo() has invalid type TestFunctionTypehints\NonexistentClass.',
+				'Function TestFunctionTypehints\foo() has invalid return type TestFunctionTypehints\NonexistentClass.',
 				15,
 			],
 			[
@@ -35,7 +35,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				20,
 			],
 			[
-				'Return type of function TestFunctionTypehints\returnParent() has invalid type TestFunctionTypehints\parent.',
+				'Function TestFunctionTypehints\returnParent() has invalid return type TestFunctionTypehints\parent.',
 				33,
 			],
 			[
@@ -67,7 +67,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				61,
 			],
 			[
-				'Return type of function TestFunctionTypehints\referencesTraitsInNative() has invalid type TestFunctionTypehints\SomeTrait.',
+				'Function TestFunctionTypehints\referencesTraitsInNative() has invalid return type TestFunctionTypehints\SomeTrait.',
 				61,
 			],
 			[
@@ -75,7 +75,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				70,
 			],
 			[
-				'Return type of function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid type TestFunctionTypehints\SomeTrait.',
+				'Function TestFunctionTypehints\referencesTraitsInPhpDoc() has invalid return type TestFunctionTypehints\SomeTrait.',
 				70,
 			],
 			[
@@ -98,7 +98,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		require_once __DIR__ . '/data/typehintsWithoutNamespace.php';
 		$this->analyse([__DIR__ . '/data/typehintsWithoutNamespace.php'], [
 			[
-				'Return type of function fooWithoutNamespace() has invalid type NonexistentClass.',
+				'Function fooWithoutNamespace() has invalid return type NonexistentClass.',
 				13,
 			],
 			[
@@ -138,7 +138,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				59,
 			],
 			[
-				'Return type of function referencesTraitsInNativeWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
+				'Function referencesTraitsInNativeWithoutNamespace() has invalid return type SomeTraitWithoutNamespace.',
 				59,
 			],
 			[
@@ -146,7 +146,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				68,
 			],
 			[
-				'Return type of function referencesTraitsInPhpDocWithoutNamespace() has invalid type SomeTraitWithoutNamespace.',
+				'Function referencesTraitsInPhpDocWithoutNamespace() has invalid return type SomeTraitWithoutNamespace.',
 				68,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -159,7 +159,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		}
 		$this->analyse([__DIR__ . '/data/void-parameter-typehint.php'], [
 			[
-				'Parameter $param of function VoidParameterTypehint\doFoo() has invalid typehint type void.',
+				'Parameter $param of function VoidParameterTypehint\doFoo() has invalid type void.',
 				9,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
@@ -21,15 +21,15 @@ class MissingFunctionParameterTypehintRuleTest extends \PHPStan\Testing\RuleTest
 		require_once __DIR__ . '/data/missing-function-parameter-typehint.php';
 		$this->analyse([__DIR__ . '/data/missing-function-parameter-typehint.php'], [
 			[
-				'Function globalFunction() has parameter $b with no typehint specified.',
+				'Function globalFunction() has parameter $b with no type specified.',
 				9,
 			],
 			[
-				'Function globalFunction() has parameter $c with no typehint specified.',
+				'Function globalFunction() has parameter $c with no type specified.',
 				9,
 			],
 			[
-				'Function MissingFunctionParameterTypehint\namespacedFunction() has parameter $d with no typehint specified.',
+				'Function MissingFunctionParameterTypehint\namespacedFunction() has parameter $d with no type specified.',
 				24,
 			],
 			[

--- a/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
@@ -21,11 +21,11 @@ class MissingFunctionReturnTypehintRuleTest extends \PHPStan\Testing\RuleTestCas
 		require_once __DIR__ . '/data/missing-function-return-typehint.php';
 		$this->analyse([__DIR__ . '/data/missing-function-return-typehint.php'], [
 			[
-				'Function globalFunction1() has no return typehint specified.',
+				'Function globalFunction1() has no return type specified.',
 				5,
 			],
 			[
-				'Function MissingFunctionReturnTypehint\namespacedFunction1() has no return typehint specified.',
+				'Function MissingFunctionReturnTypehint\namespacedFunction1() has no return type specified.',
 				30,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -69,11 +69,11 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				53,
 			],
 			[
-				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid return type parent.',
+				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
 				62,
 			],
 			[
-				'Method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
+				'Method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid return type parent.',
 				62,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -65,11 +65,11 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				53,
 			],
 			[
-				'Method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.',
+				'Method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid return type parent.',
 				53,
 			],
 			[
-				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
+				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid return type parent.',
 				62,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -41,7 +41,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				28,
 			],
 			[
-				'Return typehint of method TestMethodTypehints\FooMethodTypehints::lorem() has invalid type TestMethodTypehints\BazMethodTypehints.',
+				'Return type of method TestMethodTypehints\FooMethodTypehints::lorem() has invalid type TestMethodTypehints\BazMethodTypehints.',
 				28,
 			],
 			[
@@ -49,7 +49,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				38,
 			],
 			[
-				'Return typehint of method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid type TestMethodTypehints\BazMethodTypehints.',
+				'Return type of method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid type TestMethodTypehints\BazMethodTypehints.',
 				38,
 			],
 			[
@@ -57,7 +57,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				48,
 			],
 			[
-				'Return typehint of method TestMethodTypehints\FooMethodTypehints::dolor() has invalid type TestMethodTypehints\BazMethodTypehints.',
+				'Return type of method TestMethodTypehints\FooMethodTypehints::dolor() has invalid type TestMethodTypehints\BazMethodTypehints.',
 				48,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -65,7 +65,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				53,
 			],
 			[
-				'Return type of method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.',
+				'Method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.',
 				53,
 			],
 			[
@@ -73,7 +73,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				62,
 			],
 			[
-				'Return type of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
+				'Method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
 				62,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -29,7 +29,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		}
 		$this->analyse([__DIR__ . '/data/typehints.php'], [
 			[
-				'Return typehint of method TestMethodTypehints\FooMethodTypehints::foo() has invalid type TestMethodTypehints\NonexistentClass.',
+				'Return type of method TestMethodTypehints\FooMethodTypehints::foo() has invalid type TestMethodTypehints\NonexistentClass.',
 				8,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -33,11 +33,11 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				8,
 			],
 			[
-				'Parameter $bar of method TestMethodTypehints\FooMethodTypehints::bar() has invalid typehint type TestMethodTypehints\BarMethodTypehints.',
+				'Parameter $bar of method TestMethodTypehints\FooMethodTypehints::bar() has invalid type TestMethodTypehints\BarMethodTypehints.',
 				13,
 			],
 			[
-				'Parameter $bars of method TestMethodTypehints\FooMethodTypehints::lorem() has invalid typehint type TestMethodTypehints\BarMethodTypehints.',
+				'Parameter $bars of method TestMethodTypehints\FooMethodTypehints::lorem() has invalid type TestMethodTypehints\BarMethodTypehints.',
 				28,
 			],
 			[
@@ -45,7 +45,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				28,
 			],
 			[
-				'Parameter $bars of method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid typehint type TestMethodTypehints\BarMethodTypehints.',
+				'Parameter $bars of method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid type TestMethodTypehints\BarMethodTypehints.',
 				38,
 			],
 			[
@@ -53,7 +53,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				38,
 			],
 			[
-				'Parameter $bars of method TestMethodTypehints\FooMethodTypehints::dolor() has invalid typehint type TestMethodTypehints\BarMethodTypehints.',
+				'Parameter $bars of method TestMethodTypehints\FooMethodTypehints::dolor() has invalid type TestMethodTypehints\BarMethodTypehints.',
 				48,
 			],
 			[
@@ -109,15 +109,15 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				94,
 			],
 			[
-				'Parameter $array of method TestMethodTypehints\FooMethodTypehints::unknownTypesInArrays() has invalid typehint type TestMethodTypehints\AnotherNonexistentClass.',
+				'Parameter $array of method TestMethodTypehints\FooMethodTypehints::unknownTypesInArrays() has invalid type TestMethodTypehints\AnotherNonexistentClass.',
 				102,
 			],
 			[
-				'Parameter $cb of method TestMethodTypehints\CallableTypehints::doFoo() has invalid typehint type TestMethodTypehints\Bla.',
+				'Parameter $cb of method TestMethodTypehints\CallableTypehints::doFoo() has invalid type TestMethodTypehints\Bla.',
 				113,
 			],
 			[
-				'Parameter $cb of method TestMethodTypehints\CallableTypehints::doFoo() has invalid typehint type TestMethodTypehints\Ble.',
+				'Parameter $cb of method TestMethodTypehints\CallableTypehints::doFoo() has invalid type TestMethodTypehints\Ble.',
 				113,
 			],
 			[
@@ -148,7 +148,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		}
 		$this->analyse([__DIR__ . '/data/void-parameter-typehint.php'], [
 			[
-				'Parameter $param of method VoidParameterTypehintMethod\Foo::doFoo() has invalid typehint type void.',
+				'Parameter $param of method VoidParameterTypehintMethod\Foo::doFoo() has invalid type void.',
 				8,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -29,7 +29,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 		}
 		$this->analyse([__DIR__ . '/data/typehints.php'], [
 			[
-				'Return type of method TestMethodTypehints\FooMethodTypehints::foo() has invalid type TestMethodTypehints\NonexistentClass.',
+				'Method TestMethodTypehints\FooMethodTypehints::foo() has invalid return type TestMethodTypehints\NonexistentClass.',
 				8,
 			],
 			[
@@ -41,7 +41,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				28,
 			],
 			[
-				'Return type of method TestMethodTypehints\FooMethodTypehints::lorem() has invalid type TestMethodTypehints\BazMethodTypehints.',
+				'Method TestMethodTypehints\FooMethodTypehints::lorem() has invalid return type TestMethodTypehints\BazMethodTypehints.',
 				28,
 			],
 			[
@@ -49,7 +49,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				38,
 			],
 			[
-				'Return type of method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid type TestMethodTypehints\BazMethodTypehints.',
+				'Method TestMethodTypehints\FooMethodTypehints::ipsum() has invalid return type TestMethodTypehints\BazMethodTypehints.',
 				38,
 			],
 			[
@@ -57,7 +57,7 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				48,
 			],
 			[
-				'Return type of method TestMethodTypehints\FooMethodTypehints::dolor() has invalid type TestMethodTypehints\BazMethodTypehints.',
+				'Method TestMethodTypehints\FooMethodTypehints::dolor() has invalid return type TestMethodTypehints\BazMethodTypehints.',
 				48,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -61,19 +61,19 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				48,
 			],
 			[
-				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid typehint type parent.',
+				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.',
 				53,
 			],
 			[
-				'Return typehint of method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.',
+				'Return type of method TestMethodTypehints\FooMethodTypehints::parentWithoutParent() has invalid type parent.',
 				53,
 			],
 			[
-				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid typehint type parent.',
+				'Parameter $parent of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
 				62,
 			],
 			[
-				'Return typehint of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
+				'Return type of method TestMethodTypehints\FooMethodTypehints::phpDocParentWithoutParent() has invalid type parent.',
 				62,
 			],
 			[
@@ -131,11 +131,11 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/typehints-iterable.php'], [
 			[
-				'Parameter $iterable of method TestMethodTypehints\IterableTypehints::doFoo() has invalid typehint type TestMethodTypehints\NonexistentClass.',
+				'Parameter $iterable of method TestMethodTypehints\IterableTypehints::doFoo() has invalid type TestMethodTypehints\NonexistentClass.',
 				11,
 			],
 			[
-				'Parameter $iterable of method TestMethodTypehints\IterableTypehints::doFoo() has invalid typehint type TestMethodTypehints\AnotherNonexistentClass.',
+				'Parameter $iterable of method TestMethodTypehints\IterableTypehints::doFoo() has invalid type TestMethodTypehints\AnotherNonexistentClass.',
 				11,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -23,23 +23,23 @@ class MissingMethodParameterTypehintRuleTest extends \PHPStan\Testing\RuleTestCa
 	{
 		$errors = [
 			[
-				'Method MissingMethodParameterTypehint\FooInterface::getFoo() has parameter $p1 with no typehint specified.',
+				'Method MissingMethodParameterTypehint\FooInterface::getFoo() has parameter $p1 with no type specified.',
 				8,
 			],
 			[
-				'Method MissingMethodParameterTypehint\FooParent::getBar() has parameter $p2 with no typehint specified.',
+				'Method MissingMethodParameterTypehint\FooParent::getBar() has parameter $p2 with no type specified.',
 				15,
 			],
 			[
-				'Method MissingMethodParameterTypehint\Foo::getFoo() has parameter $p1 with no typehint specified.',
+				'Method MissingMethodParameterTypehint\Foo::getFoo() has parameter $p1 with no type specified.',
 				25,
 			],
 			[
-				'Method MissingMethodParameterTypehint\Foo::getBar() has parameter $p2 with no typehint specified.',
+				'Method MissingMethodParameterTypehint\Foo::getBar() has parameter $p2 with no type specified.',
 				33,
 			],
 			[
-				'Method MissingMethodParameterTypehint\Foo::getBaz() has parameter $p3 with no typehint specified.',
+				'Method MissingMethodParameterTypehint\Foo::getBaz() has parameter $p3 with no type specified.',
 				42,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -20,19 +20,19 @@ class MissingMethodReturnTypehintRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/missing-method-return-typehint.php'], [
 			[
-				'Method MissingMethodReturnTypehint\FooInterface::getFoo() has no return typehint specified.',
+				'Method MissingMethodReturnTypehint\FooInterface::getFoo() has no return type specified.',
 				8,
 			],
 			[
-				'Method MissingMethodReturnTypehint\FooParent::getBar() has no return typehint specified.',
+				'Method MissingMethodReturnTypehint\FooParent::getBar() has no return type specified.',
 				15,
 			],
 			[
-				'Method MissingMethodReturnTypehint\Foo::getFoo() has no return typehint specified.',
+				'Method MissingMethodReturnTypehint\Foo::getFoo() has no return type specified.',
 				25,
 			],
 			[
-				'Method MissingMethodReturnTypehint\Foo::getBar() has no return typehint specified.',
+				'Method MissingMethodReturnTypehint\Foo::getBar() has no return type specified.',
 				33,
 			],
 			[

--- a/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -20,15 +20,15 @@ class MissingPropertyTypehintRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/missing-property-typehint.php'], [
 			[
-				'Property MissingPropertyTypehint\MyClass::$prop1 has no typehint specified.',
+				'Property MissingPropertyTypehint\MyClass::$prop1 has no type specified.',
 				7,
 			],
 			[
-				'Property MissingPropertyTypehint\MyClass::$prop2 has no typehint specified.',
+				'Property MissingPropertyTypehint\MyClass::$prop2 has no type specified.',
 				9,
 			],
 			[
-				'Property MissingPropertyTypehint\MyClass::$prop3 has no typehint specified.',
+				'Property MissingPropertyTypehint\MyClass::$prop3 has no type specified.',
 				14,
 			],
 			[

--- a/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -65,7 +65,7 @@ class MissingPropertyTypehintRuleTest extends \PHPStan\Testing\RuleTestCase
 		}
 		$this->analyse([__DIR__ . '/data/promoted-properties-missing-typehint.php'], [
 			[
-				'Property PromotedPropertiesMissingTypehint\Foo::$lorem has no typehint specified.',
+				'Property PromotedPropertiesMissingTypehint\Foo::$lorem has no type specified.',
 				15,
 			],
 			[

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideArrowFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideArrowFunctionReturnTypehintRuleTest.php
@@ -23,7 +23,7 @@ class TooWideArrowFunctionReturnTypehintRuleTest extends RuleTestCase
 		}
 		$this->analyse([__DIR__ . '/data/tooWideArrowFunctionReturnType.php'], [
 			[
-				'Anonymous function never returns null so it can be removed from the return typehint.',
+				'Anonymous function never returns null so it can be removed from the return type.',
 				14,
 			],
 		]);

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideClosureReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideClosureReturnTypehintRuleTest.php
@@ -20,7 +20,7 @@ class TooWideClosureReturnTypehintRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/tooWideClosureReturnType.php'], [
 			[
-				'Anonymous function never returns null so it can be removed from the return typehint.',
+				'Anonymous function never returns null so it can be removed from the return type.',
 				20,
 			],
 		]);

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRuleTest.php
@@ -29,19 +29,19 @@ class TooWideFunctionReturnTypehintRuleTest extends RuleTestCase
 				15,
 			],
 			[
-				'Function TooWideFunctionReturnType\ipsum() never returns null so it can be removed from the return typehint.',
+				'Function TooWideFunctionReturnType\ipsum() never returns null so it can be removed from the return type.',
 				27,
 			],
 			[
-				'Function TooWideFunctionReturnType\dolor2() never returns null so it can be removed from the return typehint.',
+				'Function TooWideFunctionReturnType\dolor2() never returns null so it can be removed from the return type.',
 				41,
 			],
 			[
-				'Function TooWideFunctionReturnType\dolor4() never returns int so it can be removed from the return typehint.',
+				'Function TooWideFunctionReturnType\dolor4() never returns int so it can be removed from the return type.',
 				59,
 			],
 			[
-				'Function TooWideFunctionReturnType\dolor6() never returns null so it can be removed from the return typehint.',
+				'Function TooWideFunctionReturnType\dolor6() never returns null so it can be removed from the return type.',
 				79,
 			],
 		]);

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRuleTest.php
@@ -21,11 +21,11 @@ class TooWideFunctionReturnTypehintRuleTest extends RuleTestCase
 		require_once __DIR__ . '/data/tooWideFunctionReturnType.php';
 		$this->analyse([__DIR__ . '/data/tooWideFunctionReturnType.php'], [
 			[
-				'Function TooWideFunctionReturnType\bar() never returns string so it can be removed from the return typehint.',
+				'Function TooWideFunctionReturnType\bar() never returns string so it can be removed from the return type.',
 				11,
 			],
 			[
-				'Function TooWideFunctionReturnType\baz() never returns null so it can be removed from the return typehint.',
+				'Function TooWideFunctionReturnType\baz() never returns null so it can be removed from the return type.',
 				15,
 			],
 			[

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodReturnTypehintRuleTest.php
@@ -28,19 +28,19 @@ class TooWideMethodReturnTypehintRuleTest extends RuleTestCase
 				18,
 			],
 			[
-				'Method TooWideMethodReturnType\Foo::dolor() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Foo::dolor() never returns null so it can be removed from the return type.',
 				34,
 			],
 			[
-				'Method TooWideMethodReturnType\Foo::dolor2() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Foo::dolor2() never returns null so it can be removed from the return type.',
 				48,
 			],
 			[
-				'Method TooWideMethodReturnType\Foo::dolor4() never returns int so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Foo::dolor4() never returns int so it can be removed from the return type.',
 				66,
 			],
 			[
-				'Method TooWideMethodReturnType\Foo::dolor6() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Foo::dolor6() never returns null so it can be removed from the return type.',
 				86,
 			],
 		]);
@@ -82,7 +82,7 @@ class TooWideMethodReturnTypehintRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-5095.php'], [
 			[
-				'Method Bug5095\Parser::unaryOperatorFor() never returns \'not\' so it can be removed from the return typehint.',
+				'Method Bug5095\Parser::unaryOperatorFor() never returns \'not\' so it can be removed from the return type.',
 				21,
 			],
 		]);

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodReturnTypehintRuleTest.php
@@ -20,11 +20,11 @@ class TooWideMethodReturnTypehintRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/tooWideMethodReturnType-private.php'], [
 			[
-				'Method TooWideMethodReturnType\Foo::bar() never returns string so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Foo::bar() never returns string so it can be removed from the return type.',
 				14,
 			],
 			[
-				'Method TooWideMethodReturnType\Foo::baz() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Foo::baz() never returns null so it can be removed from the return type.',
 				18,
 			],
 			[
@@ -50,15 +50,15 @@ class TooWideMethodReturnTypehintRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/tooWideMethodReturnType-public-protected.php'], [
 			[
-				'Method TooWideMethodReturnType\Bar::bar() never returns string so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Bar::bar() never returns string so it can be removed from the return type.',
 				14,
 			],
 			[
-				'Method TooWideMethodReturnType\Bar::baz() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Bar::baz() never returns null so it can be removed from the return type.',
 				18,
 			],
 			[
-				'Method TooWideMethodReturnType\Bazz::lorem() never returns string so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Bazz::lorem() never returns string so it can be removed from the return type.',
 				35,
 			],
 		]);
@@ -68,11 +68,11 @@ class TooWideMethodReturnTypehintRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/tooWideMethodReturnType-public-protected-inheritance.php'], [
 			[
-				'Method TooWideMethodReturnType\Baz::baz() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\Baz::baz() never returns null so it can be removed from the return type.',
 				27,
 			],
 			[
-				'Method TooWideMethodReturnType\BarClass::doFoo() never returns null so it can be removed from the return typehint.',
+				'Method TooWideMethodReturnType\BarClass::doFoo() never returns null so it can be removed from the return type.',
 				51,
 			],
 		]);


### PR DESCRIPTION
Not sure if you've chosen to keep 'typehint' rather than 'type', but it is my own personal windmill so here is a PR to avoid using legacy description of types.

Some of them were changed from:
> Return typehint of anonymous function has invalid type %s

To:
> Return type of anonymous function has invalid type %s

But they might be better as:
> Return type of anonymous function is invalid type %s

But I didn't do that change.

Also, didn't touch the internal classnames as they don't get shown to endusers in the error messages.