### PR TITLE
mime_content_type can receive a stream too

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -6518,7 +6518,7 @@ return [
 'mhash_get_hash_name' => ['string', 'hash'=>'int'],
 'mhash_keygen_s2k' => ['string', 'hash'=>'int', 'input_password'=>'string', 'salt'=>'string', 'bytes'=>'int'],
 'microtime' => ['mixed', 'get_as_float='=>'bool'],
-'mime_content_type' => ['string|false', 'filename_or_stream'=>'string'],
+'mime_content_type' => ['string|false', 'filename_or_stream'=>'string|resource'],
 'min' => ['', '...arg1'=>'array'],
 'min\'1' => ['', 'arg1'=>'', 'arg2'=>'', '...args='=>''],
 'ming_keypress' => ['int', 'char'=>'string'],


### PR DESCRIPTION
Here's a playground demo: https://phpstan.org/r/477b6374-021f-4323-aeba-32688a1765d9
And here's an 3v4l of the same code: https://3v4l.org/78q2J

I'm not entirely certain of the syntax this `src/Reflection/SignatureMap/functionMap.php` file needs, but it should do the trick.