### PR TITLE
Fix date_time_set function signature

### DIFF
--- a/src/Reflection/SignatureMap/functionMap.php
+++ b/src/Reflection/SignatureMap/functionMap.php
@@ -1555,7 +1555,7 @@ return [
 'date_sun_info' => ['array', 'time'=>'int', 'latitude'=>'float', 'longitude'=>'float'],
 'date_sunrise' => ['mixed', 'time'=>'int', 'format='=>'int', 'latitude='=>'float', 'longitude='=>'float', 'zenith='=>'float', 'gmt_offset='=>'float'],
 'date_sunset' => ['mixed', 'time'=>'int', 'format='=>'int', 'latitude='=>'float', 'longitude='=>'float', 'zenith='=>'float', 'gmt_offset='=>'float'],
-'date_time_set' => ['DateTime|false', 'object'=>'', 'hour'=>'', 'minute'=>'', 'second'=>'', 'microseconds'=>''],
+'date_time_set' => ['DateTime|false', 'object'=>'', 'hour'=>'', 'minute'=>'', 'second='=>'', 'microseconds='=>''],
 'date_timestamp_get' => ['int', 'obj'=>'DateTimeInterface'],
 'date_timestamp_set' => ['DateTime|false', 'object'=>'DateTime', 'unixtimestamp'=>'int'],
 'date_timezone_get' => ['DateTimeZone', 'obj'=>'DateTimeInterface'],


### PR DESCRIPTION
`date_time_set` has 5 parameters but only 3 are mandatory.
`$second` and `$microseconds` are optional with 0 as the default value.