### PR TITLE
Fix ClassTemplateTypeRule with anonymous classes

### DIFF
--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -4,6 +4,7 @@ namespace PHPStan\PhpDoc;
 
 use PHPStan\Analyser\FileAnalyser;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Broker\AnonymousClassNameHelper;
 use PHPStan\Broker\Broker;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\DerivativeContainerFactory;
@@ -115,6 +116,7 @@ class StubValidator
 		$classCaseSensitivityCheck = $container->getByType(ClassCaseSensitivityCheck::class);
 		$functionDefinitionCheck = $container->getByType(FunctionDefinitionCheck::class);
 		$missingTypehintCheck = $container->getByType(MissingTypehintCheck::class);
+		$anonymousClassNameHelper = $container->getByType(AnonymousClassNameHelper::class);
 
 		return new Registry([
 			// level 0
@@ -128,7 +130,7 @@ class StubValidator
 
 			// level 2
 			new ClassAncestorsRule($fileTypeMapper, $genericAncestorsCheck),
-			new ClassTemplateTypeRule($fileTypeMapper, $templateTypeCheck),
+			new ClassTemplateTypeRule($fileTypeMapper, $templateTypeCheck, $anonymousClassNameHelper),
 			new FunctionTemplateTypeRule($fileTypeMapper, $templateTypeCheck),
 			new FunctionSignatureVarianceRule($varianceCheck),
 			new InterfaceAncestorsRule($fileTypeMapper, $genericAncestorsCheck),

--- a/src/Rules/Generics/ClassTemplateTypeRule.php
+++ b/src/Rules/Generics/ClassTemplateTypeRule.php
@@ -39,19 +39,13 @@ class ClassTemplateTypeRule implements Rule
 			return [];
 		}
 
-		$className = null;
-		$errorMessageClass = null;
-		if ($node->getAttribute('anonymousClass', false)) {
-			$className = $node->name->name;
-			$errorMessageClass = 'anonymous class';
-		}
-
 		if (isset($node->namespacedName)) {
 			$className = (string) $node->namespacedName;
 			$errorMessageClass = 'class ' . $className;
-		}
-
-		if ($className === null || $errorMessageClass === null) {
+		} elseif ($node->name !== null && (bool) $node->getAttribute('anonymousClass', false)) {
+			$className = $node->name->name;
+			$errorMessageClass = 'anonymous class';
+		} else {
 			throw new \PHPStan\ShouldNotHappenException();
 		}
 

--- a/src/Rules/Generics/ClassTemplateTypeRule.php
+++ b/src/Rules/Generics/ClassTemplateTypeRule.php
@@ -39,6 +39,10 @@ class ClassTemplateTypeRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
+		if (!$node instanceof Node\Stmt\Class_) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
 		$docComment = $node->getDocComment();
 		if ($docComment === null) {
 			return [];
@@ -48,10 +52,6 @@ class ClassTemplateTypeRule implements Rule
 			$className = (string) $node->namespacedName;
 			$errorMessageClass = 'class ' . $className;
 		} elseif ((bool) $node->getAttribute('anonymousClass', false)) {
-			if (!$node instanceof Node\Stmt\Class_) {
-				throw new \PHPStan\ShouldNotHappenException();
-			}
-
 			$className = $this->anonymousClassNameHelper->getAnonymousClassName($node, $scope->getFile());
 			$errorMessageClass = 'anonymous class';
 		} else {

--- a/src/Rules/Generics/ClassTemplateTypeRule.php
+++ b/src/Rules/Generics/ClassTemplateTypeRule.php
@@ -39,10 +39,6 @@ class ClassTemplateTypeRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node instanceof Node\Stmt\Class_) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
-
 		$docComment = $node->getDocComment();
 		if ($docComment === null) {
 			return [];

--- a/src/Rules/Generics/ClassTemplateTypeRule.php
+++ b/src/Rules/Generics/ClassTemplateTypeRule.php
@@ -39,11 +39,22 @@ class ClassTemplateTypeRule implements Rule
 			return [];
 		}
 
-		if (!isset($node->namespacedName)) {
+		$className = null;
+		$errorMessageClass = null;
+		if ($node->getAttribute('anonymousClass', false)) {
+			$className = $node->name->name;
+			$errorMessageClass = 'anonymous class';
+		}
+
+		if (isset($node->namespacedName)) {
+			$className = (string) $node->namespacedName;
+			$errorMessageClass = 'class ' . $className;
+		}
+
+		if ($className === null || $errorMessageClass === null) {
 			throw new \PHPStan\ShouldNotHappenException();
 		}
 
-		$className = (string) $node->namespacedName;
 		$resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
 			$scope->getFile(),
 			$className,
@@ -56,10 +67,10 @@ class ClassTemplateTypeRule implements Rule
 			$node,
 			TemplateTypeScope::createWithClass($className),
 			$resolvedPhpDoc->getTemplateTags(),
-			sprintf('PHPDoc tag @template for class %s cannot have existing class %%s as its name.', $className),
-			sprintf('PHPDoc tag @template for class %s cannot have existing type alias %%s as its name.', $className),
-			sprintf('PHPDoc tag @template %%s for class %s has invalid bound type %%s.', $className),
-			sprintf('PHPDoc tag @template %%s for class %s with bound type %%s is not supported.', $className)
+			sprintf('PHPDoc tag @template for %s cannot have existing class %%s as its name.', $errorMessageClass),
+			sprintf('PHPDoc tag @template for %s cannot have existing type alias %%s as its name.', $errorMessageClass),
+			sprintf('PHPDoc tag @template %%s for %s has invalid bound type %%s.', $errorMessageClass),
+			sprintf('PHPDoc tag @template %%s for %s with bound type %%s is not supported.', $errorMessageClass)
 		);
 	}
 

--- a/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
@@ -46,6 +46,26 @@ class ClassTemplateTypeRuleTest extends RuleTestCase
 				'PHPDoc tag @template for class ClassTemplateType\Ipsum cannot have existing type alias TypeAlias as its name.',
 				40,
 			],
+			[
+				'PHPDoc tag @template for anonymous class cannot have existing class stdClass as its name.',
+				45,
+			],
+			[
+				'PHPDoc tag @template T for anonymous class has invalid bound type ClassTemplateType\Zazzzu.',
+				50,
+			],
+			[
+				'PHPDoc tag @template T for anonymous class with bound type int is not supported.',
+				55,
+			],
+			[
+				'Class ClassTemplateType\Baz referenced with incorrect case: ClassTemplateType\baz.',
+				60,
+			],
+			[
+				'PHPDoc tag @template for anonymous class cannot have existing type alias TypeAlias as its name.',
+				65,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Generics;
 
+use PHPStan\Broker\AnonymousClassNameHelper;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -19,7 +20,8 @@ class ClassTemplateTypeRuleTest extends RuleTestCase
 
 		return new ClassTemplateTypeRule(
 			self::getContainer()->getByType(FileTypeMapper::class),
-			new TemplateTypeCheck($broker, new ClassCaseSensitivityCheck($broker), ['TypeAlias' => 'int'], true)
+			new TemplateTypeCheck($broker, new ClassCaseSensitivityCheck($broker), ['TypeAlias' => 'int'], true),
+			self::getContainer()->getByType(AnonymousClassNameHelper::class)
 		);
 	}
 

--- a/tests/PHPStan/Rules/Generics/data/class-template.php
+++ b/tests/PHPStan/Rules/Generics/data/class-template.php
@@ -41,3 +41,28 @@ class Ipsum
 {
 
 }
+
+new /** @template stdClass */ class
+{
+
+};
+
+new /** @template T of Zazzzu */ class
+{
+
+};
+
+new /** @template T of int */ class
+{
+
+};
+
+new /** @template T of baz */ class
+{
+
+};
+
+new /** @template TypeAlias */ class
+{
+
+};


### PR DESCRIPTION
Fixes [#3661](https://github.com/phpstan/phpstan/issues/3661) and as an added bonus now correctly interprets template annotations on anonymous classes