### PR TITLE
Language Server POC

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -4,6 +4,7 @@
 use PHPStan\Command\AnalyseCommand;
 use PHPStan\Command\ClearResultCacheCommand;
 use PHPStan\Command\DumpDependenciesCommand;
+use PHPStan\Command\LanguageServerCommand;
 use PHPStan\Command\WorkerCommand;
 
 (function () {
@@ -89,5 +90,6 @@ use PHPStan\Command\WorkerCommand;
 	$application->add(new DumpDependenciesCommand($reversedComposerAutoloaderProjectPaths));
 	$application->add(new WorkerCommand($reversedComposerAutoloaderProjectPaths));
 	$application->add(new ClearResultCacheCommand($reversedComposerAutoloaderProjectPaths));
+	$application->add(new LanguageServerCommand($reversedComposerAutoloaderProjectPaths));
 	$application->run();
 })();

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"ondrejmirtes/better-reflection": "4.3.25",
 		"phpdocumentor/reflection-docblock": "4.3.4",
 		"phpstan/phpdoc-parser": "^0.4.9",
+		"phpactor/language-server": "dev-lsp-prot-1",
 		"react/child-process": "^0.6.1",
 		"react/event-loop": "^1.1",
 		"react/socket": "^1.3",

--- a/src/Command/LanguageServerCommand.php
+++ b/src/Command/LanguageServerCommand.php
@@ -1,108 +1,111 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Command;
 
-use PHPStan\LanguageServer\PhpstanDispatcherFactory;
 use Phpactor\LanguageServer\LanguageServerBuilder;
+use PHPStan\LanguageServer\PhpstanDispatcherFactory;
 use Psr\Log\AbstractLogger;
-use Psr\Log\LoggerInterface;
-use RuntimeException;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Logger\ConsoleLogger;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class LanguageServerCommand extends Command
 {
-    const OPT_ADDRESS = 'address';
 
-    /**
-     * @var array<string>
-     */
-    private array $composerAutoloaderProjectPaths;
+	const OPT_ADDRESS = 'address';
 
-    private const NAME = 'language-server';
+	/** @var array<string> */
+	private array $composerAutoloaderProjectPaths;
 
-    /**
-     * @param array<string> $composerAutoloaderProjectPaths
-     */
-    public function __construct(
-        array $composerAutoloaderProjectPaths
-    )
-    {
-        parent::__construct();
-        $this->composerAutoloaderProjectPaths = $composerAutoloaderProjectPaths;
-    }
+	private const NAME = 'language-server';
 
-    protected function configure(): void
-    {
-        $this->setName(self::NAME)
-            ->setDescription('Start the Phpstan language server')
-            ->setDefinition([
-                new InputOption(self::OPT_ADDRESS, null, InputOption::VALUE_REQUIRED, 'TCP address (ommit to use stdio)'),
-                new InputOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'Path to project configuration file'),
-                new InputOption('autoload-file', 'a', InputOption::VALUE_REQUIRED, 'Project\'s additional autoload file path'),
-            ]);
-    }
+	/**
+	 * @param array<string> $composerAutoloaderProjectPaths
+	 */
+	public function __construct(
+		array $composerAutoloaderProjectPaths
+	)
+	{
+		parent::__construct();
+		$this->composerAutoloaderProjectPaths = $composerAutoloaderProjectPaths;
+	}
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $autoloadFile = $input->getOption('autoload-file');
-        $configuration = $input->getOption('configuration');
+	protected function configure(): void
+	{
+		$this->setName(self::NAME)
+			->setDescription('Start the Phpstan language server')
+			->setDefinition([
+				new InputOption(self::OPT_ADDRESS, null, InputOption::VALUE_REQUIRED, 'TCP address (ommit to use stdio)'),
+				new InputOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'Path to project configuration file'),
+				new InputOption('autoload-file', 'a', InputOption::VALUE_REQUIRED, 'Project\'s additional autoload file path'),
+			]);
+	}
 
-        if (
-            (!is_string($autoloadFile) && $autoloadFile !== null)
-            || (!is_string($configuration) && $configuration !== null)
-        ) {
-            throw new \PHPStan\ShouldNotHappenException();
-        }
+	protected function execute(InputInterface $input, OutputInterface $output): int
+	{
+		$autoloadFile = $input->getOption('autoload-file');
+		$configuration = $input->getOption('configuration');
 
-        try {
-            $inceptionResult = CommandHelper::begin(
-                $input,
-                $output,
-                ['.'],
-                null,
-                null,
-                $autoloadFile,
-                $this->composerAutoloaderProjectPaths,
-                $configuration,
-                null,
-                '7',
-                false,
-                false
-            );
-        } catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
-            return 1;
-        }
+		if (
+			(!is_string($autoloadFile) && $autoloadFile !== null)
+			|| (!is_string($configuration) && $configuration !== null)
+		) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
 
-        $container = $inceptionResult->getContainer();
-        assert($output instanceof ConsoleOutput);
+		try {
+			$inceptionResult = CommandHelper::begin(
+				$input,
+				$output,
+				['.'],
+				null,
+				null,
+				$autoloadFile,
+				$this->composerAutoloaderProjectPaths,
+				$configuration,
+				null,
+				'7',
+				false,
+				false
+			);
+		} catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
+			return 1;
+		}
 
-        $logger = new class extends AbstractLogger {
-            public function log($level, $message, array $context = array()) {
-                fwrite(STDERR, sprintf(
-                    '[%s] %s ::: %s', $level, $message, json_encode($context, JSON_PRETTY_PRINT)
-                ) . "\n");
-            }
-        };
+		$container = $inceptionResult->getContainer();
+		assert($output instanceof ConsoleOutput);
 
-        $builder = LanguageServerBuilder::create(
-            new PhpstanDispatcherFactory($inceptionResult, $logger),
-            $logger
-        );
+		$logger = new class extends AbstractLogger {
 
-        if ($address = $input->getOption(self::OPT_ADDRESS)) {
-            if (!is_string($address)) {
-                throw new RuntimeException('Address must be a string');
-            }
-            $builder->tcpServer($address);
-        }
+			public function log($level, $message, array $context = []): void
+			{
+				fwrite(STDERR, sprintf(
+					'[%s] %s ::: %s',
+					$level,
+					$message,
+					json_encode($context, JSON_PRETTY_PRINT)
+				) . "\n");
+			}
 
-        $builder->build()->run();
+		};
 
-        return 0;
-    }
+		$builder = LanguageServerBuilder::create(
+			new PhpstanDispatcherFactory($inceptionResult, $logger),
+			$logger
+		);
+
+		if ($address = $input->getOption(self::OPT_ADDRESS)) {
+			if (!is_string($address)) {
+				throw new \RuntimeException('Address must be a string');
+			}
+			$builder->tcpServer($address);
+		}
+
+		$builder->build()->run();
+
+		return 0;
+	}
+
 }

--- a/src/Command/LanguageServerCommand.php
+++ b/src/Command/LanguageServerCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace PHPStan\Command;
+
+use PHPStan\LanguageServer\PhpstanDispatcherFactory;
+use Phpactor\LanguageServer\LanguageServerBuilder;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+class LanguageServerCommand extends Command
+{
+    const OPT_ADDRESS = 'address';
+
+    private array $composerAutoloaderProjectPaths;
+    private const NAME = 'language-server';
+
+    public function __construct(
+        array $composerAutoloaderProjectPaths
+    )
+    {
+        parent::__construct();
+        $this->composerAutoloaderProjectPaths = $composerAutoloaderProjectPaths;
+    }
+
+    protected function configure()
+    {
+        $this->setName(self::NAME)
+            ->setDescription('Start the Phpstan language server')
+            ->setDefinition([
+                new InputOption(self::OPT_ADDRESS, null, InputOption::VALUE_REQUIRED, 'TCP address (ommit to use stdio)'),
+                new InputOption('configuration', 'c', InputOption::VALUE_REQUIRED, 'Path to project configuration file'),
+                new InputOption('autoload-file', 'a', InputOption::VALUE_REQUIRED, 'Project\'s additional autoload file path'),
+            ]);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $autoloadFile = $input->getOption('autoload-file');
+        $configuration = $input->getOption('configuration');
+
+        if (
+            (!is_string($autoloadFile) && $autoloadFile !== null)
+            || (!is_string($configuration) && $configuration !== null)
+        ) {
+            throw new \PHPStan\ShouldNotHappenException();
+        }
+
+        try {
+            $inceptionResult = CommandHelper::begin(
+                $input,
+                $output,
+                ['.'],
+                null,
+                null,
+                $autoloadFile,
+                $this->composerAutoloaderProjectPaths,
+                $configuration,
+                null,
+                '7',
+                false,
+                false
+            );
+        } catch (\PHPStan\Command\InceptionNotSuccessfulException $e) {
+            return 1;
+        }
+
+        $container = $inceptionResult->getContainer();
+        assert($output instanceof ConsoleOutput);
+
+        $logger = new class extends AbstractLogger {
+            public function log($level, $message, array $context = array()) {
+                fwrite(STDERR, sprintf(
+                    '[%s] %s ::: %s', $level, $message, json_encode($context, JSON_PRETTY_PRINT)
+                ) . "\n");
+            }
+        };
+
+        $builder = LanguageServerBuilder::create(
+            new PhpstanDispatcherFactory($inceptionResult, $logger),
+            $logger
+        );
+
+        if ($address = $input->getOption(self::OPT_ADDRESS)) {
+            $builder->tcpServer((string)$address);
+        }
+
+        $builder->build()->run();
+
+        return 0;
+    }
+}

--- a/src/Command/LanguageServerCommand.php
+++ b/src/Command/LanguageServerCommand.php
@@ -6,6 +6,7 @@ use PHPStan\LanguageServer\PhpstanDispatcherFactory;
 use Phpactor\LanguageServer\LanguageServerBuilder;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
@@ -17,9 +18,16 @@ class LanguageServerCommand extends Command
 {
     const OPT_ADDRESS = 'address';
 
+    /**
+     * @var array<string>
+     */
     private array $composerAutoloaderProjectPaths;
+
     private const NAME = 'language-server';
 
+    /**
+     * @param array<string> $composerAutoloaderProjectPaths
+     */
     public function __construct(
         array $composerAutoloaderProjectPaths
     )
@@ -28,7 +36,7 @@ class LanguageServerCommand extends Command
         $this->composerAutoloaderProjectPaths = $composerAutoloaderProjectPaths;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName(self::NAME)
             ->setDescription('Start the Phpstan language server')
@@ -87,7 +95,10 @@ class LanguageServerCommand extends Command
         );
 
         if ($address = $input->getOption(self::OPT_ADDRESS)) {
-            $builder->tcpServer((string)$address);
+            if (!is_string($address)) {
+                throw new RuntimeException('Address must be a string');
+            }
+            $builder->tcpServer($address);
         }
 
         $builder->build()->run();

--- a/src/LanguageServer/DiagnosticsHandler.php
+++ b/src/LanguageServer/DiagnosticsHandler.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace PHPStan\LanguageServer;
+
+use Amp\Promise;
+use Amp\Success;
+use PHPStan\Command\AnalyseApplication;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\InceptionResult;
+use Phpactor\LanguageServerProtocol\Diagnostic;
+use Phpactor\LanguageServerProtocol\DiagnosticSeverity;
+use Phpactor\LanguageServerProtocol\DidChangeTextDocumentNotification;
+use Phpactor\LanguageServerProtocol\DidChangeTextDocumentParams;
+use Phpactor\LanguageServerProtocol\DidOpenTextDocumentNotification;
+use Phpactor\LanguageServerProtocol\DidOpenTextDocumentParams;
+use Phpactor\LanguageServerProtocol\DidSaveTextDocumentNotification;
+use Phpactor\LanguageServerProtocol\DidSaveTextDocumentParams;
+use Phpactor\LanguageServerProtocol\Position;
+use Phpactor\LanguageServerProtocol\Range;
+use Phpactor\LanguageServerProtocol\SaveOptions;
+use Phpactor\LanguageServerProtocol\ServerCapabilities;
+use Phpactor\LanguageServerProtocol\TextDocumentSyncKind;
+use Phpactor\LanguageServerProtocol\TextDocumentSyncOptions;
+use Phpactor\LanguageServer\Core\Handler\CanRegisterCapabilities;
+use Phpactor\LanguageServer\Core\Handler\Handler;
+use Phpactor\LanguageServer\Core\Server\RpcClient;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class DiagnosticsHandler implements Handler, CanRegisterCapabilities
+{
+    private RpcClient $client;
+    private AnalyseApplication $analyser;
+    private InceptionResult $result;
+
+    public function __construct(RpcClient $client, AnalyseApplication $analyser, InceptionResult $result)
+    {
+        $this->client = $client;
+        $this->analyser = $analyser;
+        $this->result = $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function methods(): array
+    {
+        return [
+            DidSaveTextDocumentNotification::METHOD => 'didSave',
+        ];
+    }
+
+    /**
+     * @return Promise<null>
+     */
+    public function didSave(DidSaveTextDocumentParams $didSave): Promise
+    {
+        $result = $this->analyser->analyse(
+            [
+                str_replace('file://', '', $didSave->textDocument->uri)
+            ],
+            false,
+            $this->result->getStdOutput(),
+            $this->result->getErrorOutput(),
+            true,
+            true,
+            null,
+            new ArrayInput([])
+        );
+
+        $this->client->notification('textDocument/publishDiagnostics', [
+            'uri' => $didSave->textDocument->uri,
+            'version' => $didSave->textDocument->version,
+            'diagnostics' => $this->buildDiagnostics($result)
+        ]);
+
+        return new Success(null);
+    }
+
+    public function registerCapabiltiies(ServerCapabilities $capabilities): void
+    {
+        $syncOptions = new TextDocumentSyncOptions();
+        $syncOptions->save = new SaveOptions(true);
+        $syncOptions->willSave = true;
+        $syncOptions->change = TextDocumentSyncKind::FULL;
+        $capabilities->textDocumentSync = $syncOptions;
+    }
+
+    /**
+     * @return array<Diagnostic>
+     */
+    private function buildDiagnostics(AnalysisResult $result): array
+    {
+        $diagnostics = [];
+        var_dump($result);
+        foreach ($result->getFileSpecificErrors() as $error) {
+
+            $diagnostics[] = new Diagnostic(
+                new Range(
+                    new Position($error->getLine() - 1, 0),
+                    new Position($error->getLine() - 1, 100)
+                ),
+                $error->getMessage(),
+                DiagnosticSeverity::ERROR
+            );
+        }
+
+        return $diagnostics;
+    }
+}

--- a/src/LanguageServer/DiagnosticsHandler.php
+++ b/src/LanguageServer/DiagnosticsHandler.php
@@ -40,7 +40,7 @@ class DiagnosticsHandler implements Handler, CanRegisterCapabilities
     }
 
     /**
-     * {@inheritDoc}
+     * @return array<string,string>
      */
     public function methods(): array
     {
@@ -91,7 +91,6 @@ class DiagnosticsHandler implements Handler, CanRegisterCapabilities
     private function buildDiagnostics(AnalysisResult $result): array
     {
         $diagnostics = [];
-        var_dump($result);
         foreach ($result->getFileSpecificErrors() as $error) {
 
             $diagnostics[] = new Diagnostic(

--- a/src/LanguageServer/PhpstanDispatcherFactory.php
+++ b/src/LanguageServer/PhpstanDispatcherFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PHPStan\LanguageServer;
+
+use PHPStan\Command\AnalyseApplication;
+use PHPStan\Command\InceptionResult;
+use Phpactor\LanguageServerProtocol\InitializeParams;
+use Phpactor\LanguageServer\Adapter\Psr\NullEventDispatcher;
+use Phpactor\LanguageServer\Core\Dispatcher\ArgumentResolver\LanguageSeverProtocolParamsResolver;
+use Phpactor\LanguageServer\Core\Dispatcher\Dispatcher;
+use Phpactor\LanguageServer\Core\Dispatcher\DispatcherFactory;
+use Phpactor\LanguageServer\Core\Dispatcher\Dispatcher\MiddlewareDispatcher;
+use Phpactor\LanguageServer\Core\Handler\HandlerMethodResolver;
+use Phpactor\LanguageServer\Core\Handler\HandlerMethodRunner;
+use Phpactor\LanguageServer\Core\Handler\Handlers;
+use Phpactor\LanguageServer\Core\Server\ResponseWatcher\DeferredResponseWatcher;
+use Phpactor\LanguageServer\Core\Server\RpcClient;
+use Phpactor\LanguageServer\Core\Server\RpcClient\JsonRpcClient;
+use Phpactor\LanguageServer\Core\Server\Transmitter\MessageTransmitter;
+use Phpactor\LanguageServer\Core\Session\Workspace;
+use Phpactor\LanguageServer\Handler\TextDocument\TextDocumentHandler;
+use Phpactor\LanguageServer\Middleware\ErrorHandlingMiddleware;
+use Phpactor\LanguageServer\Middleware\HandlerMiddleware;
+use Phpactor\LanguageServer\Middleware\InitializeMiddleware;
+use Psr\Log\LoggerInterface;
+
+class PhpstanDispatcherFactory implements DispatcherFactory
+{
+    private InceptionResult $result;
+
+    private LoggerInterface $logger;
+
+	public function __construct(InceptionResult $result, LoggerInterface $logger)
+	{
+        $this->result = $result;
+        $this->logger = $logger;
+	}
+
+    public function create(MessageTransmitter $transmitter, InitializeParams $initializeParams): Dispatcher
+    {
+		$watcher = new DeferredResponseWatcher();
+		$client = new JsonRpcClient($transmitter, $watcher);
+
+		$handlers = new Handlers([
+			new DiagnosticsHandler(
+				$client,
+				$this->result->getContainer()->getByType(AnalyseApplication::class),
+				$this->result
+			)
+		]);
+
+		$argumentResolver = new LanguageSeverProtocolParamsResolver();
+
+		return new MiddlewareDispatcher(
+			new ErrorHandlingMiddleware($this->logger),
+			new InitializeMiddleware($handlers, new NullEventDispatcher()),
+			new HandlerMiddleware(
+				new HandlerMethodRunner(
+					$handlers,
+					new HandlerMethodResolver(),
+					$argumentResolver,
+				)
+			)
+		);
+    }
+}

--- a/src/LanguageServer/PhpstanDispatcherFactory.php
+++ b/src/LanguageServer/PhpstanDispatcherFactory.php
@@ -55,7 +55,6 @@ class PhpstanDispatcherFactory implements DispatcherFactory
 			new HandlerMiddleware(
 				new HandlerMethodRunner(
 					$handlers,
-					new HandlerMethodResolver(),
 					$argumentResolver,
 				)
 			)

--- a/src/LanguageServer/PhpstanDispatcherFactory.php
+++ b/src/LanguageServer/PhpstanDispatcherFactory.php
@@ -1,43 +1,41 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace PHPStan\LanguageServer;
 
-use PHPStan\Command\AnalyseApplication;
-use PHPStan\Command\InceptionResult;
-use Phpactor\LanguageServerProtocol\InitializeParams;
 use Phpactor\LanguageServer\Adapter\Psr\NullEventDispatcher;
 use Phpactor\LanguageServer\Core\Dispatcher\ArgumentResolver\LanguageSeverProtocolParamsResolver;
 use Phpactor\LanguageServer\Core\Dispatcher\Dispatcher;
-use Phpactor\LanguageServer\Core\Dispatcher\DispatcherFactory;
 use Phpactor\LanguageServer\Core\Dispatcher\Dispatcher\MiddlewareDispatcher;
+use Phpactor\LanguageServer\Core\Dispatcher\DispatcherFactory;
 use Phpactor\LanguageServer\Core\Handler\HandlerMethodResolver;
 use Phpactor\LanguageServer\Core\Handler\HandlerMethodRunner;
 use Phpactor\LanguageServer\Core\Handler\Handlers;
 use Phpactor\LanguageServer\Core\Server\ResponseWatcher\DeferredResponseWatcher;
-use Phpactor\LanguageServer\Core\Server\RpcClient;
 use Phpactor\LanguageServer\Core\Server\RpcClient\JsonRpcClient;
 use Phpactor\LanguageServer\Core\Server\Transmitter\MessageTransmitter;
-use Phpactor\LanguageServer\Core\Session\Workspace;
-use Phpactor\LanguageServer\Handler\TextDocument\TextDocumentHandler;
 use Phpactor\LanguageServer\Middleware\ErrorHandlingMiddleware;
 use Phpactor\LanguageServer\Middleware\HandlerMiddleware;
 use Phpactor\LanguageServer\Middleware\InitializeMiddleware;
+use Phpactor\LanguageServerProtocol\InitializeParams;
+use PHPStan\Command\AnalyseApplication;
+use PHPStan\Command\InceptionResult;
 use Psr\Log\LoggerInterface;
 
 class PhpstanDispatcherFactory implements DispatcherFactory
 {
-    private InceptionResult $result;
 
-    private LoggerInterface $logger;
+	private InceptionResult $result;
+
+	private LoggerInterface $logger;
 
 	public function __construct(InceptionResult $result, LoggerInterface $logger)
 	{
-        $this->result = $result;
-        $this->logger = $logger;
+		$this->result = $result;
+		$this->logger = $logger;
 	}
 
-    public function create(MessageTransmitter $transmitter, InitializeParams $initializeParams): Dispatcher
-    {
+	public function create(MessageTransmitter $transmitter, InitializeParams $initializeParams): Dispatcher
+	{
 		$watcher = new DeferredResponseWatcher();
 		$client = new JsonRpcClient($transmitter, $watcher);
 
@@ -46,7 +44,7 @@ class PhpstanDispatcherFactory implements DispatcherFactory
 				$client,
 				$this->result->getContainer()->getByType(AnalyseApplication::class),
 				$this->result
-			)
+			),
 		]);
 
 		$argumentResolver = new LanguageSeverProtocolParamsResolver();
@@ -62,5 +60,6 @@ class PhpstanDispatcherFactory implements DispatcherFactory
 				)
 			)
 		);
-    }
+	}
+
 }

--- a/src/LanguageServer/PhpstanDispatcherFactory.php
+++ b/src/LanguageServer/PhpstanDispatcherFactory.php
@@ -23,7 +23,6 @@ use Psr\Log\LoggerInterface;
 
 class PhpstanDispatcherFactory implements DispatcherFactory
 {
-
 	private InceptionResult $result;
 
 	private LoggerInterface $logger;
@@ -39,13 +38,13 @@ class PhpstanDispatcherFactory implements DispatcherFactory
 		$watcher = new DeferredResponseWatcher();
 		$client = new JsonRpcClient($transmitter, $watcher);
 
-		$handlers = new Handlers([
+		$handlers = new Handlers(
 			new DiagnosticsHandler(
 				$client,
 				$this->result->getContainer()->getByType(AnalyseApplication::class),
 				$this->result
 			),
-		]);
+		);
 
 		$argumentResolver = new LanguageSeverProtocolParamsResolver();
 


### PR DESCRIPTION
This PR is a POC for a built-in Language Server for PHPStan  (as hinted at in [this ticket](https://github.com/phpstan/phpstan/issues/3262)) which supports **diagnostics**

I've been somewhat busy this week refactoring the Phpactor Language Server Platform and thought it would be interesting to try and integrate it with PHPStan.

Currently this is a naive implementation which works on document _save_ but has issues with the PHPStan (internal) cache.

Any final implementation should:

- Lint in real-time.
- Dispatching a (non-blocking and stateless) worker.
- Lints should be de-duplicated and queued.

See [phpactor-phpstan](https://github.com/phpactor/language-server-phpstan-extension/blob/master/lib/Handler/PhpstanHandler.php) for an approach which uses a sub-process (and runs as a background service)

Anyway, just playing about - let me know if this is interesting and/or feel free to close. I'd create a new PR anyway (this one is from `dantleech:master` :/ )