### PR TITLE
Add failing test with @method annotation.

### DIFF
--- a/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
@@ -32,6 +32,15 @@ class ThrowsAnnotationsTest extends \PHPStan\Testing\TestCase
 				],
 			],
 			[
+				\ThrowsAnnotations\FooWithMethodAnnotation::class,
+				[
+					'withoutThrows' => null,
+					'throwsRuntime' => \RuntimeException::class,
+					'staticThrowsRuntime' => \RuntimeException::class,
+
+				],
+			],
+			[
 				\ThrowsAnnotations\FooInterface::class,
 				[
 					'withoutThrows' => null,

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-throws.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-throws.php
@@ -75,6 +75,16 @@ class PhpstanFoo
 
 }
 
+/**
+ * @method void withoutThrows()
+ * @method void throwsRuntime()
+ * @method void staticThrowsRuntime()
+ */
+class FooWithMethodAnnotation extends Foo
+{
+
+}
+
 interface FooInterface
 {
 


### PR DESCRIPTION
Hi,

When someone use the `@method annotation`, the throws annotation is lost. It should be kept IMHO.