### PR TITLE
min() and max() may return false if array size could be zero

### DIFF
--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\ErrorType;
@@ -37,8 +38,15 @@ class MinMaxFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunction
 		if (count($functionCall->args) === 1) {
 			$argType = $scope->getType($functionCall->args[0]->value);
 			if ($argType->isArray()->yes()) {
+				$isIterable = $argType->isIterableAtLeastOnce();
+				if ($isIterable->no()) {
+					return new ConstantBooleanType(false);
+				}
 				$iterableValueType = $argType->getIterableValueType();
 				$argumentTypes = [];
+				if (!$isIterable->yes()) {
+					$argumentTypes[] = new ConstantBooleanType(false);
+				}
 				if ($iterableValueType instanceof UnionType) {
 					foreach ($iterableValueType->getTypes() as $innerType) {
 						$argumentTypes[] = $innerType;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10009,6 +10009,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/mixedType.php');
 	}
 
+	public function dataMinMaxReturnTypeWithArrays(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/minmax-arrays.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10070,6 +10075,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBitwiseNot
 	 * @dataProvider dataGraphicsDrawReturnTypes
 	 * @dataProvider dataNativeUnionTypes
+	 * @dataProvider dataMinMaxReturnTypeWithArrays
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -31,6 +31,6 @@ function dummy2(array $ints): void
  */
 function dummy3(array $ints): void
 {
-	assertType('(int|false)', min($ints));
-	assertType('(int|false)', max($ints));
+	assertType('int|false', min($ints));
+	assertType('int|false', max($ints));
 }

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace MinMaxArrays;
+
+use function PHPStan\Analyser\assertType;
+
+function dummy(): void
+{
+	assertType('1', min([1]));
+	assertType('false', min([]));
+	assertType('1', max([1]));
+	assertType('false', max([]));
+}
+
+/**
+ * @param int[] $ints
+ */
+function dummy2(array $ints): void
+{
+	if (count($ints) !== 0) {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	} else {
+		assertType('false', min($ints));
+		assertType('false', max($ints));
+	}
+}
+
+/**
+ * @param int[] $ints
+ */
+function dummy3(array $ints): void
+{
+	assertType('(int|false)', min($ints));
+	assertType('(int|false)', max($ints));
+}


### PR DESCRIPTION
Working on tests, just thought it would be nice to get some feedback on this 👍 

https://phpstan.org/r/4d4d5332-d1ad-45b2-bbdd-43c8cb87ff61
https://3v4l.org/f0kNk

I'm not 100% sure this is the right way to address the issue since in 8.0 this starts throwing a `ValueError` instead. But, since most of us are still using 7, I think this should be useful anyway.