### PR TITLE
Check array key type in PHPdoc

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -310,7 +310,13 @@ class TypeNodeResolver
 			}
 
 			if (count($genericTypes) === 2) { // array<KeyType, ValueType>
-				return new ArrayType($genericTypes[0], $genericTypes[1]);
+				$keyType = $genericTypes[0];
+				$valueType = $genericTypes[1];
+
+				$allowedArrayKeyTypes = new UnionType([new IntegerType(), new StringType()]);
+				$keyType = TypeCombinator::intersect($allowedArrayKeyTypes, $keyType);
+
+				return new ArrayType($keyType, $valueType);
 			}
 
 		} elseif ($mainTypeName === 'list') {

--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
@@ -13,6 +13,7 @@ use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverserHelper;
 use PHPStan\Type\VerbosityLevel;
 
 /**
@@ -67,6 +68,7 @@ class IncompatiblePhpDocTypeRule implements \PHPStan\Rules\Rule
 
 		foreach ($resolvedPhpDoc->getParamTags() as $parameterName => $phpDocParamTag) {
 			$phpDocParamType = $phpDocParamTag->getType();
+
 			if (!isset($nativeParameterTypes[$parameterName])) {
 				$errors[] = RuleErrorBuilder::message(sprintf(
 					'PHPDoc tag @param references unknown parameter: $%s',
@@ -76,6 +78,7 @@ class IncompatiblePhpDocTypeRule implements \PHPStan\Rules\Rule
 			} elseif (
 				$phpDocParamType instanceof ErrorType
 				|| ($phpDocParamType instanceof NeverType && !$phpDocParamType->isExplicit())
+				|| TypeTraverserHelper::hasUnresolveableType($phpDocParamType)
 			) {
 				$errors[] = RuleErrorBuilder::message(sprintf(
 					'PHPDoc tag @param for parameter $%s contains unresolvable type.',
@@ -138,6 +141,7 @@ class IncompatiblePhpDocTypeRule implements \PHPStan\Rules\Rule
 			if (
 				$phpDocReturnType instanceof ErrorType
 				|| ($phpDocReturnType instanceof NeverType && !$phpDocReturnType->isExplicit())
+				|| TypeTraverserHelper::hasUnresolveableType($phpDocReturnType)
 			) {
 				$errors[] = RuleErrorBuilder::message('PHPDoc tag @return contains unresolvable type.')->build();
 

--- a/src/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRule.php
@@ -9,6 +9,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\TypeTraverserHelper;
 use PHPStan\Type\VerbosityLevel;
 
 /**
@@ -48,6 +49,7 @@ class IncompatiblePropertyPhpDocTypeRule implements Rule
 		if (
 			$phpDocType instanceof ErrorType
 			|| ($phpDocType instanceof NeverType && !$phpDocType->isExplicit())
+			|| TypeTraverserHelper::hasUnresolveableType($phpDocType)
 		) {
 			$messages[] = RuleErrorBuilder::message(sprintf(
 				'PHPDoc tag @var for property %s::$%s contains unresolvable type.',

--- a/src/Rules/PhpDoc/InvalidPhpDocVarTagTypeRule.php
+++ b/src/Rules/PhpDoc/InvalidPhpDocVarTagTypeRule.php
@@ -14,6 +14,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\TypeTraverserHelper;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
@@ -89,13 +90,16 @@ class InvalidPhpDocVarTagTypeRule implements Rule
 		$errors = [];
 		foreach ($resolvedPhpDoc->getVarTags() as $name => $varTag) {
 			$varTagType = $varTag->getType();
+
 			$identifier = 'PHPDoc tag @var';
 			if (is_string($name)) {
 				$identifier .= sprintf(' for variable $%s', $name);
 			}
+
 			if (
 				$varTagType instanceof ErrorType
 				|| ($varTagType instanceof NeverType && !$varTagType->isExplicit())
+				|| TypeTraverserHelper::hasUnresolveableType($varTagType)
 			) {
 				$errors[] = RuleErrorBuilder::message(sprintf('%s contains unresolvable type.', $identifier))->line($docComment->getStartLine())->build();
 				continue;

--- a/src/Type/TypeTraverserHelper.php
+++ b/src/Type/TypeTraverserHelper.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+class TypeTraverserHelper
+{
+
+	public static function hasUnresolveableType(Type $baseType): bool
+	{
+		$hasUnresolveableType = false;
+
+		TypeTraverser::map($baseType, static function (Type $type, callable $traverse) use (&$hasUnresolveableType): Type {
+			if (
+				$type instanceof ErrorType
+				|| ($type instanceof NeverType && !$type->isExplicit())
+			) {
+				$hasUnresolveableType = true;
+
+				return $type;
+			}
+
+			return $traverse($type);
+		});
+
+		return $hasUnresolveableType;
+	}
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -130,6 +130,22 @@ class IncompatiblePhpDocTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @param for parameter $x is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.',
 				242,
 			],
+			[
+				'PHPDoc tag @param for parameter $floatKey contains unresolvable type.',
+				250,
+			],
+			[
+				'PHPDoc tag @return contains unresolvable type.',
+				258,
+			],
+			[
+				'PHPDoc tag @param for parameter $floatKey contains unresolvable type.',
+				266,
+			],
+			[
+				'PHPDoc tag @return contains unresolvable type.',
+				274,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
@@ -55,6 +55,14 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends \PHPStan\Testing\RuleTestCa
 				'PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$unknownClassConstant2 contains unresolvable type.',
 				45,
 			],
+			[
+				'PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$arrayFloatKey contains unresolvable type.',
+				48,
+			],
+			[
+				'PHPDoc tag @var for property InvalidPhpDoc\FooWithProperty::$arrayMultiFloatKey contains unresolvable type.',
+				51,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -91,6 +91,18 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 				61,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
+			[
+				'PHPDoc tag @var for variable $test contains unresolvable type.',
+				66,
+			],
+			[
+				'PHPDoc tag @var for variable $test contains unresolvable type.',
+				72,
+			],
+			[
+				'PHPDoc tag @var for variable $test contains unresolvable type.',
+				78,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-property-phpdoc.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-property-phpdoc.php
@@ -44,4 +44,10 @@ class FooWithProperty
 	/** @var self::BLABLA */
 	private $unknownClassConstant2;
 
+	/** @var array<float, string> */
+	private $arrayFloatKey;
+
+	/** @var array<string, array<float, string>> */
+	private $arrayMultiFloatKey;
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-types.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-types.php
@@ -243,3 +243,35 @@ function genericGenerics($t, $u, $v, $w, $x)
 {
 
 }
+
+/**
+ * @param array<float, string> $floatKey
+ */
+function paramArrayFloatKey(array $floatKey)
+{
+
+}
+
+/**
+ * @return array<float, string>
+ */
+function returnArrayFloatKey(): array
+{
+
+}
+
+/**
+ * @param array<string, array<float, string>> $floatKey
+ */
+function paramMultiArrayFloatKey(array $floatKey)
+{
+
+}
+
+/**
+ * @return array<string, array<float, string>>
+ */
+function returnMultiArrayFloatKey(): array
+{
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/invalid-var-tag-type.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/invalid-var-tag-type.php
@@ -59,6 +59,24 @@ class Foo
 
 		/** @var \InvalidPhpDocDefinitions\FooGeneric $test */
 		$test = doFoo();
+
+		/** @var array<int|string, string> $test */
+		$test = [];
+
+		/** @var array<null, string> $test */
+		$test = [];
+
+		/** @var array<mixed, string> $test */
+		$test = [];
+
+		/** @var array<float, string> $test */
+		$test = [];
+
+		/** @var array<float|string, string> $test */
+		$test = [];
+
+		/** @var array<string, array<float, mixed>> $test */
+		$test = [];
 	}
 
 }


### PR DESCRIPTION
A take at https://github.com/phpstan/phpstan/issues/3753. I couldn't find an existing way to retain the original type information in a `NeverType`, but it helps the clarity of the error message. An alternative would be to check the type in `InvalidPhpDocVarTagTypeRule`, instead of in `TypeNodeResolver`.

If this is the correct aproach, I'll add the same checks to `IncompatiblePhpDocTypeRule`.