### PR TITLE
Fixed foreach key/value type inference for objects implementing Iterator

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -504,7 +504,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		if ($this->isInstanceOf(\Iterator::class)->yes()) {
 			$tKey = GenericTypeVariableResolver::getType($this, \Iterator::class, 'TKey');
-			if ($tKey !== null) {
+			if ($tKey !== null && !$tKey instanceof MixedType) {
 				return $tKey;
 			}
 			return ParametersAcceptorSelector::selectSingle($classReflection->getNativeMethod('key')->getVariants())->getReturnType();
@@ -539,7 +539,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		if ($this->isInstanceOf(\Iterator::class)->yes()) {
 			$tValue = GenericTypeVariableResolver::getType($this, \Iterator::class, 'TValue');
-			if ($tValue !== null) {
+			if ($tValue !== null && !$tValue instanceof MixedType) {
 				return $tValue;
 			}
 			return ParametersAcceptorSelector::selectSingle(

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -504,7 +504,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		if ($this->isInstanceOf(\Iterator::class)->yes()) {
 			$tKey = GenericTypeVariableResolver::getType($this, \Iterator::class, 'TKey');
-			if($tKey !== null){
+			if ($tKey !== null) {
 				return $tKey;
 			}
 			return ParametersAcceptorSelector::selectSingle($classReflection->getNativeMethod('key')->getVariants())->getReturnType();
@@ -539,7 +539,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		if ($this->isInstanceOf(\Iterator::class)->yes()) {
 			$tValue = GenericTypeVariableResolver::getType($this, \Iterator::class, 'TValue');
-			if($tValue !== null){
+			if ($tValue !== null) {
 				return $tValue;
 			}
 			return ParametersAcceptorSelector::selectSingle(

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -503,6 +503,10 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		if ($this->isInstanceOf(\Iterator::class)->yes()) {
+			$tKey = GenericTypeVariableResolver::getType($this, \Iterator::class, 'TKey');
+			if($tKey !== null){
+				return $tKey;
+			}
 			return ParametersAcceptorSelector::selectSingle($classReflection->getNativeMethod('key')->getVariants())->getReturnType();
 		}
 
@@ -534,6 +538,10 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		if ($this->isInstanceOf(\Iterator::class)->yes()) {
+			$tValue = GenericTypeVariableResolver::getType($this, \Iterator::class, 'TValue');
+			if($tValue !== null){
+				return $tValue;
+			}
 			return ParametersAcceptorSelector::selectSingle(
 				$classReflection->getNativeMethod('current')->getVariants()
 			)->getReturnType();

--- a/stubs/iterable.stub
+++ b/stubs/iterable.stub
@@ -34,12 +34,12 @@ interface Iterator extends Traversable
 {
 
 	/**
-	 * @return TValue
+	 * @return TValue|null
 	 */
 	public function current();
 
 	/**
-	 * @return TKey
+	 * @return TKey|null
 	 */
 	public function key();
 


### PR DESCRIPTION
current() and key() are allowed to return NULL when they decide they aren't valid anymore, and various PHP iterators (for example RegexIterator) will return null when its underlying iterator is no longer valid. However, userland code won't receive NULL unless valid() returns true.

I'm not sure how this should be tested.