### PR TITLE
Add check the array is not empty

### DIFF
--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -17,12 +17,75 @@ function dummy(): void
  */
 function dummy2(array $ints): void
 {
+	if (count($ints) === 0) {
+		assertType('false', min($ints));
+		assertType('false', max($ints));
+	} else {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	}
+	if (count($ints) === 1) {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	} else {
+		assertType('int|false', min($ints));
+		assertType('int|false', max($ints));
+	}
 	if (count($ints) !== 0) {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	} else {
 		assertType('false', min($ints));
 		assertType('false', max($ints));
+	}
+	if (count($ints) !== 1) {
+		assertType('int|false', min($ints));
+		assertType('int|false', max($ints));
+	} else {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	}
+	if (count($ints) > 0) {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	} else {
+		assertType('false', min($ints));
+		assertType('false', max($ints));
+	}
+	if (count($ints) >= 1) {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	} else {
+		assertType('false', min($ints));
+		assertType('false', max($ints));
+	}
+	if (count($ints) >= 2) {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	} else {
+		assertType('int|false', min($ints));
+		assertType('int|false', max($ints));
+	}
+	if (count($ints) <= 0) {
+		assertType('false', min($ints));
+		assertType('false', max($ints));
+	} else {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	}
+	if (count($ints) < 1) {
+		assertType('false', min($ints));
+		assertType('false', max($ints));
+	} else {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
+	}
+	if (count($ints) < 2) {
+		assertType('int|false', min($ints));
+		assertType('int|false', max($ints));
+	} else {
+		assertType('int', min($ints));
+		assertType('int', max($ints));
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/3155

I made this the same way as identical compare works (`count($foo) !== 0`) but I don't understand what is context and why the checks needed such `$context->null()`, `$context->truthy()` and why changing context may be needed `$newContext = $newContext->negate()`.