### PR TITLE
Recurse into generic objects parameters

### DIFF
--- a/src/Rules/Generics/GenericObjectTypeCheck.php
+++ b/src/Rules/Generics/GenericObjectTypeCheck.php
@@ -97,14 +97,6 @@ class GenericObjectTypeCheck
 	 */
 	private function getGenericTypes(Type $phpDocType): array
 	{
-		if ($phpDocType instanceof GenericObjectType) {
-			$resolvedType = TemplateTypeHelper::resolveToBounds($phpDocType);
-			if (!$resolvedType instanceof GenericObjectType) {
-				throw new \PHPStan\ShouldNotHappenException();
-			}
-			return [$resolvedType];
-		}
-
 		$genericObjectTypes = [];
 		TypeTraverser::map($phpDocType, static function (Type $type, callable $traverse) use (&$genericObjectTypes): Type {
 			if ($type instanceof GenericObjectType) {
@@ -113,6 +105,7 @@ class GenericObjectTypeCheck
 					throw new \PHPStan\ShouldNotHappenException();
 				}
 				$genericObjectTypes[] = $resolvedType;
+				$traverse($type);
 				return $type;
 			}
 			$traverse($type);

--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -73,7 +73,6 @@ class MissingTypehintCheck
 					}
 					$iterablesWithMissingValueTypehint[] = $type;
 				}
-				$traverse($type);
 				return $type;
 			}
 			return $traverse($type);

--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -73,6 +73,7 @@ class MissingTypehintCheck
 					}
 					$iterablesWithMissingValueTypehint[] = $type;
 				}
+				$traverse($type);
 				return $type;
 			}
 			return $traverse($type);
@@ -94,6 +95,7 @@ class MissingTypehintCheck
 		$objectTypes = [];
 		TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$objectTypes): Type {
 			if ($type instanceof GenericObjectType) {
+				$traverse($type);
 				return $type;
 			}
 			if ($type instanceof TemplateType) {

--- a/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
@@ -43,6 +43,11 @@ class MissingFunctionReturnTypehintRuleTest extends \PHPStan\Testing\RuleTestCas
 				89,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
+			[
+				'Function MissingFunctionReturnTypehint\genericGenericMissingTemplateArgs() return type with generic class MissingFunctionReturnTypehint\GenericClass does not specify its types: A, B',
+				105,
+				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/missing-function-parameter-typehint.php
+++ b/tests/PHPStan/Rules/Functions/data/missing-function-parameter-typehint.php
@@ -158,4 +158,19 @@ namespace MissingFunctionParameterTypehint
 
 	}
 
+	/**
+	 * @param GenericClass<GenericClass<int, int>, GenericClass<int, int>> $class
+	 */
+	function genericGenericValidArgs(GenericClass $class)
+	{
+
+	}
+
+	/**
+	 * @param GenericClass<GenericClass, GenericClass> $class
+	 */
+	function genericGenericMissingTemplateArgs(GenericClass $class)
+	{
+
+	}
 }

--- a/tests/PHPStan/Rules/Functions/data/missing-function-parameter-typehint.php
+++ b/tests/PHPStan/Rules/Functions/data/missing-function-parameter-typehint.php
@@ -158,19 +158,4 @@ namespace MissingFunctionParameterTypehint
 
 	}
 
-	/**
-	 * @param GenericClass<GenericClass<int, int>, GenericClass<int, int>> $class
-	 */
-	function genericGenericValidArgs(GenericClass $class)
-	{
-
-	}
-
-	/**
-	 * @param GenericClass<GenericClass, GenericClass> $class
-	 */
-	function genericGenericMissingTemplateArgs(GenericClass $class)
-	{
-
-	}
 }

--- a/tests/PHPStan/Rules/Functions/data/missing-function-return-typehint.php
+++ b/tests/PHPStan/Rules/Functions/data/missing-function-return-typehint.php
@@ -90,4 +90,20 @@ namespace MissingFunctionReturnTypehint
 	{
 
 	}
+
+	/**
+	 * @return GenericClass<GenericClass<int, int>, GenericClass<int, int>>
+	 */
+	function genericGenericValidArgs(): GenericClass
+	{
+
+	}
+
+	/**
+	 * @return GenericClass<GenericClass, int>
+	 */
+	function genericGenericMissingTemplateArgs(): GenericClass
+	{
+
+	}
 }

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -130,6 +130,18 @@ class IncompatiblePhpDocTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @param for parameter $x is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.',
 				242,
 			],
+			[
+				'Type stdClass in generic type InvalidPhpDocDefinitions\FooGeneric<int, stdClass> in PHPDoc tag @return is not subtype of template type U of Exception of class InvalidPhpDocDefinitions\FooGeneric.',
+				250,
+			],
+			[
+				'Generic type InvalidPhpDocDefinitions\FooGeneric<int> in PHPDoc tag @return does not specify all template types of class InvalidPhpDocDefinitions\FooGeneric: T, U',
+				266,
+			],
+			[
+				'PHPDoc tag @return contains generic type InvalidPhpDocDefinitions\Foo<int, Exception> but class InvalidPhpDocDefinitions\Foo is not generic.',
+				274,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-types.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-types.php
@@ -243,3 +243,35 @@ function genericGenerics($t, $u, $v, $w, $x)
 {
 
 }
+
+/**
+ * @return \InvalidPhpDocDefinitions\FooGeneric<\InvalidPhpDocDefinitions\FooGeneric<int, \stdClass>, \Exception>
+ */
+function genericNestedWrongTemplateArgs()
+{
+
+}
+
+/**
+ * @return \InvalidPhpDocDefinitions\FooGeneric<\InvalidPhpDocDefinitions\FooGeneric<int, \Exception>, \Exception>
+ */
+function genericNestedOkTemplateArgs()
+{
+
+}
+
+/**
+ * @return \InvalidPhpDocDefinitions\FooGeneric<\InvalidPhpDocDefinitions\FooGeneric<int>, \Exception>
+ */
+function genericNestedWrongArgCount()
+{
+
+}
+
+/**
+ * @return \InvalidPhpDocDefinitions\FooGeneric<\InvalidPhpDocDefinitions\Foo<int, \Exception>, \Exception>
+ */
+function genericNestedNonTemplateArgs()
+{
+
+}


### PR DESCRIPTION
This fixes phpstan/phpstan#3767: types like `GenericType<OtherGenericType>` with invalid nested generic parameters not being analysed and reported.

I'm aware that this breaks some iterable special-cases such as intersection of iterable<int>&Traversable. I'm not entirely sure how to address this, so I could use some advice.

I also don't know if I missed any cases, although I don't think I did.

I'm also not sure how this should be tested. There doesn't seem to be any test unit dedicated to `MissingTypehintCheck`.