### PR TITLE
TypeNodeResolver: variadics are always optional

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -451,7 +451,7 @@ class TypeNodeResolver
 				$isVariadic = $isVariadic || $parameterNode->isVariadic;
 				return new NativeParameterReflection(
 					$parameterNode->parameterName,
-					$parameterNode->isOptional,
+					$parameterNode->isOptional || $parameterNode->isVariadic,
 					$this->resolve($parameterNode->type, $nameScope),
 					$parameterNode->isReference ? PassedByReference::createCreatesNewVariable() : PassedByReference::createNo(),
 					$parameterNode->isVariadic,

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -273,6 +273,12 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('Reflection error: Could not locate constant "SOME_UNKNOWN_CONST" while evaluating expression in Bug3379\Foo at line 8', $errors[1]->getMessage());
 	}
 
+	public function testBug3798(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3798.php');
+		$this->assertCount(0, $errors);
+	}
+
 	/**
 	 * @param string $file
 	 * @return \PHPStan\Analyser\Error[]

--- a/tests/PHPStan/Analyser/data/bug-3798.php
+++ b/tests/PHPStan/Analyser/data/bug-3798.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3798;
+
+/** @param callable(int ...$params) : void $c */
+function acceptsVariadicCallable(callable $c) : void{
+	$c();
+	$c(1);
+	$c(1, 2, 3);
+}


### PR DESCRIPTION
this fixes phpstan/phpstan#3798.