### PR TITLE
Add option to check internal class capitalization

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -26,6 +26,7 @@ parameters:
 	checkFunctionArgumentTypes: false
 	checkFunctionNameCase: false
 	checkGenericClassInNonGenericObjectType: false
+	checkInternalClassCaseSensitivity: false
 	checkMissingIterableValueType: false
 	checkMissingVarTagTypehint: false
 	checkArgumentsPassedByReference: false
@@ -167,6 +168,7 @@ parametersSchema:
 	checkFunctionArgumentTypes: bool()
 	checkFunctionNameCase: bool()
 	checkGenericClassInNonGenericObjectType: bool()
+	checkInternalClassCaseSensitivity: bool()
 	checkMissingIterableValueType: bool()
 	checkMissingVarTagTypehint: bool()
 	checkArgumentsPassedByReference: bool()
@@ -584,6 +586,8 @@ services:
 
 	-
 		class: PHPStan\Rules\ClassCaseSensitivityCheck
+		arguments:
+			checkInternalClassCaseSensitivity: %checkInternalClassCaseSensitivity%
 
 	-
 		class: PHPStan\Rules\Comparison\ConstantConditionRuleHelper

--- a/src/Rules/ClassCaseSensitivityCheck.php
+++ b/src/Rules/ClassCaseSensitivityCheck.php
@@ -10,9 +10,12 @@ class ClassCaseSensitivityCheck
 
 	private \PHPStan\Reflection\ReflectionProvider $reflectionProvider;
 
-	public function __construct(ReflectionProvider $reflectionProvider)
+	private bool $checkInternalClassCaseSensitivity;
+
+	public function __construct(ReflectionProvider $reflectionProvider, bool $checkInternalClassCaseSensitivity = false)
 	{
 		$this->reflectionProvider = $reflectionProvider;
+		$this->checkInternalClassCaseSensitivity = $checkInternalClassCaseSensitivity;
 	}
 
 	/**
@@ -28,7 +31,7 @@ class ClassCaseSensitivityCheck
 				continue;
 			}
 			$classReflection = $this->reflectionProvider->getClass($className);
-			if ($classReflection->isBuiltin()) {
+			if (!$this->checkInternalClassCaseSensitivity && $classReflection->isBuiltin()) {
 				continue; // skip built-in classes
 			}
 			$realClassName = $classReflection->getName();

--- a/tests/PHPStan/Rules/Namespaces/ExistingNamesInUseRuleTest.php
+++ b/tests/PHPStan/Rules/Namespaces/ExistingNamesInUseRuleTest.php
@@ -13,7 +13,7 @@ class ExistingNamesInUseRuleTest extends \PHPStan\Testing\RuleTestCase
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
 		$broker = $this->createReflectionProvider();
-		return new ExistingNamesInUseRule($broker, new ClassCaseSensitivityCheck($broker), true);
+		return new ExistingNamesInUseRule($broker, new ClassCaseSensitivityCheck($broker, true), true);
 	}
 
 	public function testRule(): void
@@ -37,6 +37,10 @@ class ExistingNamesInUseRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				'Interface Uses\Lorem referenced with incorrect case: Uses\LOREM.',
 				10,
+			],
+			[
+				'Class DateTime referenced with incorrect case: DATETIME.',
+				11,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Namespaces/data/uses.php
+++ b/tests/PHPStan/Rules/Namespaces/data/uses.php
@@ -8,3 +8,4 @@ use function Uses\foo as fooFunction, Uses\bar;
 use const Uses\MY_CONSTANT, Uses\OTHER_CONSTANT;
 use function Uses\Foo;
 use Uses\LOREM;
+use DATETIME;


### PR DESCRIPTION
Currently PHPStan has option  `checkFunctionNameCase` which checks the case sensitivity of function names in code. This checks the cases of both user defined and built in PHP functions.

PHPStan also has an option `checkClassCaseSensitivity`, but that option does not check the capitalization of built in classes. The reasoning for this is that using internal classes with incorrect capitalization does not actually result in bugs, but usage of user defined classes can result in bugs especially due to class loader behavior.

This PR adds a new option `checkInternalClassCaseSensitivity` which, when enabled, also checks the capitalization of internal classes for consistency.