### PR TITLE
encode newlines in GithubErrorFormatter

### DIFF
--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -41,6 +41,9 @@ class GithubErrorFormatter implements ErrorFormatter
 			});
 
 			$message = $fileSpecificError->getMessage();
+			// newlines need to be encoded
+			// see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448
+			$message = str_replace("\n", '%0A', $message);
 
 			$line = sprintf('::error %s::%s', implode(',', $metas), $message);
 

--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -52,6 +52,10 @@ class GithubErrorFormatter implements ErrorFormatter
 		}
 
 		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
+			// newlines need to be encoded
+			// see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448
+			$notFileSpecificError = str_replace("\n", '%0A', $notFileSpecificError);
+
 			$line = sprintf('::error ::%s', $notFileSpecificError);
 
 			$output->writeRaw($line);
@@ -59,6 +63,10 @@ class GithubErrorFormatter implements ErrorFormatter
 		}
 
 		foreach ($analysisResult->getWarnings() as $warning) {
+			// newlines need to be encoded
+			// see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448
+			$warning = str_replace("\n", '%0A', $warning);
+			
 			$line = sprintf('::warning ::%s', $warning);
 
 			$output->writeRaw($line);

--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -66,7 +66,7 @@ class GithubErrorFormatter implements ErrorFormatter
 			// newlines need to be encoded
 			// see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448
 			$warning = str_replace("\n", '%0A', $warning);
-			
+
 			$line = sprintf('::warning ::%s', $warning);
 
 			$output->writeRaw($line);

--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -67,8 +67,8 @@ abstract class ErrorFormatterTestCase extends \PHPStan\Testing\TestCase
 		$fileErrors = array_slice([
 			new Error('Foo', self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 4),
 			new Error('Foo', self::DIRECTORY_PATH . '/foo.php', 1),
-			new Error('Bar', self::DIRECTORY_PATH . '/foo.php', 5),
-			new Error('Bar', self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 2),
+			new Error("Bar\nBar2", self::DIRECTORY_PATH . '/foo.php', 5),
+			new Error("Bar\nBar2", self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 2),
 		], 0, $numFileErrors);
 
 		$genericErrors = array_slice([

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -42,7 +42,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			[
 				[
-					'message' => '#^Bar$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -57,7 +57,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'foo.php',
 				],
 				[
-					'message' => '#^Bar$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'foo.php',
 				],
@@ -71,12 +71,12 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			2,
 			[
 				[
-					'message' => '#^Bar$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],
 				[
-					'message' => '#^Foo$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],
@@ -86,7 +86,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'foo.php',
 				],
 				[
-					'message' => '#^Bar$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'foo.php',
 				],

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -76,7 +76,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],
 				[
-					'message' => "#^Bar\nBar2$#",
+					'message' => '#^Foo$#',
 					'count' => 1,
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -59,12 +59,12 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 <file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
-  <error line="2" column="1" severity="error" message="Bar"/>
+  <error line="2" column="1" severity="error" message="Bar Bar2"/>
   <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 <file name="foo.php">
   <error line="1" column="1" severity="error" message="Foo"/>
-  <error line="5" column="1" severity="error" message="Bar"/>
+  <error line="5" column="1" severity="error" message="Bar Bar2"/>
 </file>
 </checkstyle>
 ',
@@ -93,12 +93,12 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 			'<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 <file name="folder with unicode 😃/file name with &quot;spaces&quot; and unicode 😃.php">
-  <error line="2" column="1" severity="error" message="Bar"/>
+  <error line="2" column="1" severity="error" message="Bar Bar2"/>
   <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 <file name="foo.php">
   <error line="1" column="1" severity="error" message="Foo"/>
-  <error line="5" column="1" severity="error" message="Bar"/>
+  <error line="5" column="1" severity="error" message="Bar Bar2"/>
 </file>
 <file>
   <error message="first generic error" severity="error"/>

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -64,6 +64,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
   Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
  ------ -----------------------------------------------------------------
   2      Bar
+         Bar2
   4      Foo
  ------ -----------------------------------------------------------------
 
@@ -72,14 +73,15 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
  ------ ---------
   1      Foo
   5      Bar
+         Bar2
  ------ ---------
 
  [ERROR] Found 4 errors
 
-::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar%0ABar2
 ::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
 ::error file=foo.php,line=1,col=0::Foo
-::error file=foo.php,line=5,col=0::Bar
+::error file=foo.php,line=5,col=0::Bar%0ABar2
 ',
 		];
 
@@ -111,6 +113,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
   Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
  ------ -----------------------------------------------------------------
   2      Bar
+         Bar2
   4      Foo
  ------ -----------------------------------------------------------------
 
@@ -119,6 +122,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
  ------ ---------
   1      Foo
   5      Bar
+         Bar2
  ------ ---------
 
  -- ----------------------
@@ -130,10 +134,10 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 
  [ERROR] Found 6 errors
 
-::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar
+::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar%0ABar2
 ::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
 ::error file=foo.php,line=1,col=0::Foo
-::error file=foo.php,line=5,col=0::Bar
+::error file=foo.php,line=5,col=0::Bar%0ABar2
 ::error ::first generic error
 ::error ::second generic error
 ',

--- a/tests/PHPStan/Command/ErrorFormatter/GitlabFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GitlabFormatterTest.php
@@ -63,8 +63,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
 			0,
 			'[
     {
-        "description": "Bar",
-        "fingerprint": "d112f1651daa597592156359ef28c9a4b81a8a96dbded1c0f1009f5bbc2bda97",
+        "description": "Bar\nBar2",
+        "fingerprint": "034b4afbfb347494c14e396ed8327692f58be4cd27e8aff5f19f4194934db7c9",
         "location": {
             "path": "with space/and unicode 😃/project/folder with unicode 😃/file name with \"spaces\" and unicode 😃.php",
             "lines": {
@@ -93,8 +93,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "Bar",
-        "fingerprint": "d83022ee5bc7c71b6a4988ec47a377c9998b929d12d86fc71b745ec2b04c81e5",
+        "description": "Bar\nBar2",
+        "fingerprint": "829f6c782152fdac840b39208c5b519d18e51bff2c601b6197812fffb8bcd9ed",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
             "lines": {
@@ -141,8 +141,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
 			2,
 			'[
     {
-        "description": "Bar",
-        "fingerprint": "d112f1651daa597592156359ef28c9a4b81a8a96dbded1c0f1009f5bbc2bda97",
+        "description": "Bar\nBar2",
+        "fingerprint": "034b4afbfb347494c14e396ed8327692f58be4cd27e8aff5f19f4194934db7c9",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/folder with unicode \ud83d\ude03/file name with \"spaces\" and unicode \ud83d\ude03.php",
             "lines": {
@@ -171,8 +171,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "Bar",
-        "fingerprint": "d83022ee5bc7c71b6a4988ec47a377c9998b929d12d86fc71b745ec2b04c81e5",
+        "description": "Bar\nBar2",
+        "fingerprint": "829f6c782152fdac840b39208c5b519d18e51bff2c601b6197812fffb8bcd9ed",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
             "lines": {

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -86,7 +86,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 			"errors":2,
 			"messages":[
 				{
-					"message": "Bar",
+					"message": "Bar\nBar2",
 					"line": 2,
 					"ignorable": true
 				},
@@ -106,7 +106,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 					"ignorable": true
 				},
 				{
-					"message": "Bar",
+					"message": "Bar\nBar2",
 					"line": 5,
 					"ignorable": true
 				}
@@ -152,7 +152,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 			"errors":2,
 			"messages":[
 				{
-					"message": "Bar",
+					"message": "Bar\nBar2",
 					"line": 2,
 					"ignorable": true
 				},
@@ -172,7 +172,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 					"ignorable": true
 				},
 				{
-					"message": "Bar",
+					"message": "Bar\nBar2",
 					"line": 5,
 					"ignorable": true
 				}

--- a/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
@@ -69,7 +69,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 			'<?xml version="1.0" encoding="UTF-8"?>
 <testsuite failures="4" name="phpstan" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
-    <failure type="ERROR" message="Bar" />
+    <failure type="ERROR" message="Bar Bar2" />
   </testcase>
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4">
     <failure type="ERROR" message="Foo" />
@@ -78,7 +78,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
     <failure type="ERROR" message="Foo"/>
   </testcase>
   <testcase name="foo.php:5">
-    <failure type="ERROR" message="Bar"/>
+    <failure type="ERROR" message="Bar Bar2"/>
   </testcase>
 </testsuite>
 ',
@@ -107,7 +107,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 			'<?xml version="1.0" encoding="UTF-8"?>
 <testsuite failures="6" name="phpstan" tests="6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:2">
-    <failure type="ERROR" message="Bar" />
+    <failure type="ERROR" message="Bar Bar2" />
   </testcase>
   <testcase name="folder with unicode &#x1F603;/file name with &quot;spaces&quot; and unicode &#x1F603;.php:4">
     <failure type="ERROR" message="Foo" />
@@ -116,7 +116,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
     <failure type="ERROR" message="Foo"/>
   </testcase>
   <testcase name="foo.php:5">
-    <failure type="ERROR" message="Bar"/>
+    <failure type="ERROR" message="Bar Bar2"/>
   </testcase>
   <testcase name="General error">
     <failure type="ERROR" message="first generic error" />

--- a/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
@@ -38,10 +38,10 @@ class RawErrorFormatterTest extends ErrorFormatterTestCase
 			1,
 			4,
 			0,
-			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar' . "\n" .
+			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar' . "\nBar2\n" .
 			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo' . "\n" .
 			'/data/folder/with space/and unicode 😃/project/foo.php:1:Foo' . "\n" .
-			'/data/folder/with space/and unicode 😃/project/foo.php:5:Bar' . "\n",
+			'/data/folder/with space/and unicode 😃/project/foo.php:5:Bar' . "\nBar2\n",
 		];
 
 		yield [
@@ -60,10 +60,10 @@ class RawErrorFormatterTest extends ErrorFormatterTestCase
 			2,
 			'?:?:first generic error' . "\n" .
 		'?:?:second generic error' . "\n" .
-		'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar' . "\n" .
+		'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar' . "\nBar2\n" .
 		'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo' . "\n" .
 		'/data/folder/with space/and unicode 😃/project/foo.php:1:Foo' . "\n" .
-		'/data/folder/with space/and unicode 😃/project/foo.php:5:Bar' . "\n",
+		'/data/folder/with space/and unicode 😃/project/foo.php:5:Bar' . "\nBar2\n",
 		];
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -62,6 +62,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
  ------ -----------------------------------------------------------------
   2      Bar
+         Bar2
   4      Foo
  ------ -----------------------------------------------------------------
 
@@ -70,6 +71,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  ------ ---------
   1      Foo
   5      Bar
+         Bar2
  ------ ---------
 
  [ERROR] Found 4 errors
@@ -103,6 +105,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   Line   folder with unicode 😃/file name with "spaces" and unicode 😃.php
  ------ -----------------------------------------------------------------
   2      Bar
+         Bar2
   4      Foo
  ------ -----------------------------------------------------------------
 
@@ -111,6 +114,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  ------ ---------
   1      Foo
   5      Bar
+         Bar2
  ------ ---------
 
  -- ----------------------

--- a/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
@@ -44,10 +44,10 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			4,
 			0,
 			'##teamcity[inspectionType id=\'phpstan\' name=\'phpstan\' category=\'phpstan\' description=\'phpstan Inspection\']
-##teamcity[inspection typeId=\'phpstan\' message=\'Bar\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'2\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'2\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'4\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'foo.php\' line=\'1\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
-##teamcity[inspection typeId=\'phpstan\' message=\'Bar\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ',
 		];
 
@@ -68,10 +68,10 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			4,
 			2,
 			'##teamcity[inspectionType id=\'phpstan\' name=\'phpstan\' category=\'phpstan\' description=\'phpstan Inspection\']
-##teamcity[inspection typeId=\'phpstan\' message=\'Bar\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'2\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'2\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'4\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'foo.php\' line=\'1\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
-##teamcity[inspection typeId=\'phpstan\' message=\'Bar\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'first generic error\' file=\'./\' SEVERITY=\'ERROR\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'second generic error\' file=\'./\' SEVERITY=\'ERROR\']
 ',


### PR DESCRIPTION
when using https://github.com/phpstan/phpstan-deprecation-rules phpstan emits multi-line error messages.
these do not get rendered properly on github.com - we only see the first line.

I guess this is related because newlines are not properly escaped.
see https://github.com/actions/starter-workflows/issues/68#issuecomment-581479448

![grafik](https://user-images.githubusercontent.com/120441/92321288-0071ba00-f029-11ea-916e-c8b7ada78e0d.png)

inspired by a similar fix in `cs2pr`: https://github.com/staabm/annotate-pull-request-from-checkstyle/pull/49