### PR TITLE
Make DateTimeInterface::format return string|false

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1632,7 +1632,7 @@ return [
 'DateTimeImmutable::setTimezone' => ['static', 'timezone'=>'DateTimeZone'],
 'DateTimeImmutable::sub' => ['static', 'interval'=>'DateInterval'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
-'DateTimeInterface::format' => ['string', 'format'=>'string'],
+'DateTimeInterface::format' => ['string|false', 'format'=>'string'],
 'DateTimeInterface::getOffset' => ['int'],
 'DateTimeInterface::getTimestamp' => ['int'],
 'DateTimeInterface::getTimezone' => ['DateTimeZone'],


### PR DESCRIPTION
While the official signature (`public DateTimeInterface::format ( string $format ) : string`) doesn't contain the `false` part, in [return value description](https://www.php.net/manual/en/datetime.format.php#refsect1-datetime.format-returnvalues) you can read:

`Returns the formatted date string on success or FALSE on failure.`