### PR TITLE
Return `false` for hash_hmac/hash_hmac_file on invalid algorithm

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -875,6 +875,10 @@ services:
 		class: PHPStan\Type\Php\GettimeofdayDynamicFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
+	-
+		class: PHPStan\Type\Php\HashHmacFunctionsReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\SimpleXMLElementClassPropertyReflectionExtension

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3915,7 +3915,7 @@ return [
 'hash_hkdf' => ['string', 'algo'=>'string', 'ikm'=>'string', 'length='=>'int', 'info='=>'string', 'salt='=>'string'],
 'hash_hmac' => ['string', 'algo'=>'string', 'data'=>'string', 'key'=>'string', 'raw_output='=>'bool'],
 'hash_hmac_algos' => ['array<int,string>'],
-'hash_hmac_file' => ['string', 'algo'=>'string', 'filename'=>'string', 'key'=>'string', 'raw_output='=>'bool'],
+'hash_hmac_file' => ['string|false', 'algo'=>'string', 'filename'=>'string', 'key'=>'string', 'raw_output='=>'bool'],
 'hash_init' => ['HashContext', 'algo'=>'string', 'options='=>'int', 'key='=>'string'],
 'hash_pbkdf2' => ['string', 'algo'=>'string', 'password'=>'string', 'salt'=>'string', 'iterations'=>'int', 'length='=>'int', 'raw_output='=>'bool'],
 'hash_update' => ['bool', 'context'=>'HashContext', 'data'=>'string'],

--- a/src/Type/Php/HashHmacFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashHmacFunctionsReturnTypeExtension.php
@@ -15,6 +15,53 @@ use PHPStan\Type\TypeUtils;
 final class HashHmacFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 
+	private const HMAC_ALGORITHMS = [
+		'md2',
+		'md4',
+		'md5',
+		'sha1',
+		'sha224',
+		'sha256',
+		'sha384',
+		'sha512/224',
+		'sha512/256',
+		'sha512',
+		'sha3-224',
+		'sha3-256',
+		'sha3-384',
+		'sha3-512',
+		'ripemd128',
+		'ripemd160',
+		'ripemd256',
+		'ripemd320',
+		'whirlpool',
+		'tiger128,3',
+		'tiger160,3',
+		'tiger192,3',
+		'tiger128,4',
+		'tiger160,4',
+		'tiger192,4',
+		'snefru',
+		'snefru256',
+		'gost',
+		'gost-crypto',
+		'haval128,3',
+		'haval160,3',
+		'haval192,3',
+		'haval224,3',
+		'haval256,3',
+		'haval128,4',
+		'haval160,4',
+		'haval192,4',
+		'haval224,4',
+		'haval256,4',
+		'haval128,5',
+		'haval160,5',
+		'haval192,5',
+		'haval224,5',
+		'haval256,5',
+	];
+
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
 		return in_array($functionReflection->getName(), ['hash_hmac', 'hash_hmac_file'], true);
@@ -34,9 +81,8 @@ final class HashHmacFunctionsReturnTypeExtension implements DynamicFunctionRetur
 			return TypeUtils::toBenevolentUnion($defaultReturnType);
 		}
 		$string = $values[0];
-		$availableAlgorithms = function_exists('hash_hmac_algos') ? hash_hmac_algos() : hash_algos();
 
-		return in_array($string->getValue(), $availableAlgorithms, true) ? $defaultReturnType : new ConstantBooleanType(false);
+		return in_array($string->getValue(), self::HMAC_ALGORITHMS, true) ? $defaultReturnType : new ConstantBooleanType(false);
 	}
 
 }

--- a/src/Type/Php/HashHmacFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashHmacFunctionsReturnTypeExtension.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeUtils;
+
+final class HashHmacFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), ['hash_hmac', 'hash_hmac_file'], true);
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+
+		$argType = $scope->getType($functionCall->args[0]->value);
+		if ($argType instanceof MixedType) {
+			return TypeUtils::toBenevolentUnion($defaultReturnType);
+		}
+
+		$values = TypeUtils::getConstantStrings($argType);
+		if (count($values) !== 1) {
+			return TypeUtils::toBenevolentUnion($defaultReturnType);
+		}
+		$string = $values[0];
+		$availableAlgorithms = function_exists('hash_hmac_algos') ? hash_hmac_algos() : hash_algos();
+
+		return in_array($string->getValue(), $availableAlgorithms, true) ? $defaultReturnType : new ConstantBooleanType(false);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5905,6 +5905,46 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array<int, string>|int|false',
 				'$strWordCountStrTypeIndeterminant',
 			],
+			[
+				'string',
+				'$hashHmacMd5',
+			],
+			[
+				'string',
+				'$hashHmacSha256',
+			],
+			[
+				'false',
+				'$hashHmacNonCryptographic',
+			],
+			[
+				'false',
+				'$hashHmacRandom',
+			],
+			[
+				'string',
+				'$hashHmacVariable',
+			],
+			[
+				'string|false',
+				'$hashHmacFileMd5',
+			],
+			[
+				'string|false',
+				'$hashHmacFileSha256',
+			],
+			[
+				'false',
+				'$hashHmacFileNonCryptographic',
+			],
+			[
+				'false',
+				'$hashHmacFileRandom',
+			],
+			[
+				'(string|false)',
+				'$hashHmacFileVariable',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5914,8 +5914,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$hashHmacSha256',
 			],
 			[
-				// can't be tested correctly in PHP < 7.2
-				(function_exists('hash_hmac_algos') ? 'false' : 'string'),
+				'false',
 				'$hashHmacNonCryptographic',
 			],
 			[
@@ -5935,7 +5934,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$hashHmacFileSha256',
 			],
 			[
-				(function_exists('hash_hmac_algos') ? 'false' : 'string'),
+				'false',
 				'$hashHmacFileNonCryptographic',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5914,7 +5914,8 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$hashHmacSha256',
 			],
 			[
-				'false',
+				// can't be tested correctly in PHP < 7.2
+				(function_exists('hash_hmac_algos') ? 'false' : 'string'),
 				'$hashHmacNonCryptographic',
 			],
 			[
@@ -5934,7 +5935,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$hashHmacFileSha256',
 			],
 			[
-				'false',
+				(function_exists('hash_hmac_algos') ? 'false' : 'string'),
 				'$hashHmacFileNonCryptographic',
 			],
 			[

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -123,4 +123,16 @@ $strWordCountStrType2Extra = str_word_count('string', 2, 'string');
 $integer = doFoo();
 $strWordCountStrTypeIndeterminant = str_word_count('string', $integer);
 
+$hashHmacMd5 = hash_hmac('md5', 'data', 'key');
+$hashHmacSha256 = hash_hmac('sha256', 'data', 'key');
+$hashHmacNonCryptographic = hash_hmac('crc32', 'data', 'key');
+$hashHmacRandom = hash_hmac('random', 'data', 'key');
+$hashHmacVariable = hash_hmac($string, 'data', 'key');
+
+$hashHmacFileMd5 = hash_hmac_file('md5', 'data', 'key');
+$hashHmacFileSha256 = hash_hmac_file('sha256', 'data', 'key');
+$hashHmacFileNonCryptographic = hash_hmac_file('crc32', 'data', 'key');
+$hashHmacFileRandom = hash_hmac_file('random', 'data', 'key');
+$hashHmacFileVariable = hash_hmac_file($string, 'data', 'key');
+
 die;


### PR DESCRIPTION
This PR adds a dynamic function return type extension for both `hash_hmac` and `hash_hmac_file` as both functions can return `false` in certain circumstances. For both functions this means providing an invalid algorithm as first parameter will statically return false, otherwise `string` for `hash_hmac` and `string|false` for `hash_hmac_file` (we can't check for file readability in static analysis, and you should always check for file errors anyway). 

There has been a [PR more than 1.5 years ago](https://github.com/phpstan/phpstan/pull/1852) that tried to fix this within static functions map but that would lead to far more false positives.