### PR TITLE
Make last parameter of openssl_seal optional

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8118,7 +8118,7 @@ return [
 'openssl_public_decrypt' => ['bool', 'data'=>'string', '&w_decrypted'=>'string', 'key'=>'string|resource', 'padding='=>'int'],
 'openssl_public_encrypt' => ['bool', 'data'=>'string', '&w_crypted'=>'string', 'key'=>'string|resource', 'padding='=>'int'],
 'openssl_random_pseudo_bytes' => ['string|false', 'length'=>'int', '&w_crypto_strong='=>'bool'],
-'openssl_seal' => ['int|false', 'data'=>'string', '&w_sealed_data'=>'string', '&w_env_keys'=>'array', 'pub_key_ids'=>'array', 'method='=>'string', '&rw_iv'=>'string'],
+'openssl_seal' => ['int|false', 'data'=>'string', '&w_sealed_data'=>'string', '&w_env_keys'=>'array', 'pub_key_ids'=>'array', 'method='=>'string', '&rw_iv='=>'string'],
 'openssl_sign' => ['bool', 'data'=>'string', '&w_signature'=>'string', 'priv_key_id'=>'resource|string', 'signature_alg='=>'int|string'],
 'openssl_spki_export' => ['string|null', 'spkac'=>'string'],
 'openssl_spki_export_challenge' => ['string|null', 'spkac'=>'string'],


### PR DESCRIPTION
Fixes issue https://github.com/phpstan/phpstan/issues/3896

Which seemed to have been broken by https://github.com/phpstan/phpstan-src/pull/327

Where are the tests for this? It seems to be untested, so we won't know if there is a regression in this file of function signature definitions.