### PR TITLE
make second two arguments optional in mysqli_begin_transaction

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -7213,7 +7213,7 @@ return [
 'mysqli::use_result' => ['mysqli_result|false'],
 'mysqli_affected_rows' => ['int', 'link'=>'mysqli'],
 'mysqli_autocommit' => ['bool', 'link'=>'mysqli', 'mode'=>'bool'],
-'mysqli_begin_transaction' => ['bool', 'link'=>'mysqli', 'flags'=>'int', 'name'=>'string'],
+'mysqli_begin_transaction' => ['bool', 'link'=>'mysqli', 'flags='=>'int', 'name='=>'string'],
 'mysqli_change_user' => ['bool', 'link'=>'mysqli', 'user'=>'string', 'password'=>'string', 'database'=>'string'],
 'mysqli_character_set_name' => ['string', 'link'=>'mysqli'],
 'mysqli_close' => ['bool', 'link'=>'mysqli'],


### PR DESCRIPTION
When using the procedural `mysqli_begin_transaction` function, the second two arguments are not marked as optional (contrary to the object oriented style and the docs).

demo: https://phpstan.org/r/c4459296-8924-4154-9e6f-e274c85271d4