### PR TITLE
Fix type-less variadic argument in anonymous function

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2541,24 +2541,20 @@ class MutatingScope implements Scope
 	{
 		$variableTypes = [];
 		foreach ($closure->params as $i => $parameter) {
-			if ($parameter->type === null) {
-				if ($callableParameters === null) {
-					$parameterType = new MixedType();
-				} elseif (isset($callableParameters[$i])) {
-					$parameterType = $callableParameters[$i]->getType();
-				} elseif (count($callableParameters) > 0) {
-					$lastParameter = $callableParameters[count($callableParameters) - 1];
-					if ($lastParameter->isVariadic()) {
-						$parameterType = $lastParameter->getType();
-					} else {
-						$parameterType = new MixedType();
-					}
+			if ($callableParameters === null || $parameter->type !== null) {
+				$isNullable = $this->isParameterValueNullable($parameter);
+				$parameterType = $this->getFunctionType($parameter->type, $isNullable, $parameter->variadic);
+			} elseif (isset($callableParameters[$i])) {
+				$parameterType = $callableParameters[$i]->getType();
+			} elseif (count($callableParameters) > 0) {
+				$lastParameter = $callableParameters[count($callableParameters) - 1];
+				if ($lastParameter->isVariadic()) {
+					$parameterType = $lastParameter->getType();
 				} else {
 					$parameterType = new MixedType();
 				}
 			} else {
-				$isNullable = $this->isParameterValueNullable($parameter);
-				$parameterType = $this->getFunctionType($parameter->type, $isNullable, $parameter->variadic);
+				$parameterType = new MixedType();
 			}
 
 			if (!$parameter->var instanceof Variable || !is_string($parameter->var->name)) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -4662,6 +4662,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'$str',
 			],
 			[
+				'array<int, mixed>',
+				'$arr',
+			],
+			[
 				'1',
 				'$integer',
 			],

--- a/tests/PHPStan/Analyser/data/anonymous-function.php
+++ b/tests/PHPStan/Analyser/data/anonymous-function.php
@@ -4,7 +4,7 @@ namespace AnonymousFunction;
 
 function () {
 	$integer = 1;
-	function (string $str) use ($integer, $bar) {
+	function (string $str, ...$arr) use ($integer, $bar) {
 		die;
 	};
 };


### PR DESCRIPTION
Type inferrence was ignoring the variadicity of the argument which wrongly
resulted in type mixed instead of array<int, mixed>.

Fixes https://github.com/phpstan/phpstan/issues/3559