### PR TITLE
Fix type inference in assignment with side-effects

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2329,8 +2329,8 @@ class NodeScopeResolver
 		if ($var instanceof Variable && is_string($var->name)) {
 			$result = $processExprCallback($scope);
 			$hasYield = $result->hasYield();
-			$scope = $result->getScope();
-			$scope = $scope->assignVariable($var->name, $scope->getType($assignedExpr));
+			$type = $scope->getType($assignedExpr);
+			$scope = $result->getScope()->assignVariable($var->name, $type);
 		} elseif ($var instanceof ArrayDimFetch) {
 			$dimExprStack = [];
 			while ($var instanceof ArrayDimFetch) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10106,6 +10106,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bcmath-dynamic-return.php');
 	}
 
+	public function dataBug3875(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3875.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10176,6 +10181,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug2550
 	 * @dataProvider dataBug2899
 	 * @dataProvider dataPregSplitReturnType
+	 * @dataProvider dataBug3875
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10116,6 +10116,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2611.php');
 	}
 
+	public function dataBug3548(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3548.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10188,6 +10193,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataPregSplitReturnType
 	 * @dataProvider dataBug3875
 	 * @dataProvider dataBug2611
+	 * @dataProvider dataBug3548
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10111,6 +10111,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3875.php');
 	}
 
+	public function dataBug2611(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2611.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10182,6 +10187,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug2899
 	 * @dataProvider dataPregSplitReturnType
 	 * @dataProvider dataBug3875
+	 * @dataProvider dataBug2611
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5497,6 +5497,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'int|string|null',
 				'key($generalIntegerOrStringKeysMixedValues)',
 			],
+			[
+				'\'foo\'',
+				'$poppedFoo',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -171,4 +171,7 @@ foreach ($array as $val) {
 	$mergedInts = array_merge($mergedInts, $generalIntegers);
 }
 
+$fooArray = ['foo'];
+$poppedFoo = array_pop($fooArray);
+
 die;

--- a/tests/PHPStan/Analyser/data/bug-2611.php
+++ b/tests/PHPStan/Analyser/data/bug-2611.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bug2611;
+
+use function PHPStan\Analyser\assertType;
+
+/**
+ * @param \Traversable|array $collection
+ * @return array
+ */
+function flatten($collection)
+{
+	$stack = [$collection];
+	$result = [];
+
+	while (!empty($stack)) {
+		$item = \array_shift($stack);
+		assertType('mixed', $item);
+
+		if (\is_array($item) || $item instanceof \Traversable) {
+			foreach ($item as $element) {
+				\array_unshift($stack, $element);
+			}
+		} else {
+			\array_unshift($result, $item);
+		}
+	}
+
+	return $result;
+}

--- a/tests/PHPStan/Analyser/data/bug-3548.php
+++ b/tests/PHPStan/Analyser/data/bug-3548.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug3548;
+
+use function PHPStan\Analyser\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param int[] $arr
+	 */
+	public function shift(array $arr): int {
+		if (count($arr) === 0) {
+			throw new \Exception("oops");
+		}
+		$name = array_shift($arr);
+		assertType('int', $name);
+		return $name;
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-3875.php
+++ b/tests/PHPStan/Analyser/data/bug-3875.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bug3875;
+
+use function PHPStan\Analyser\assertType;
+
+function foo(): void
+{
+	$queue = ['foo'];
+	$list = [];
+	do {
+		$current = array_pop($queue);
+		assertType('\'foo\'', $current);
+		if ($current === null) {
+			break;
+		}
+		$list[] = $current;
+	} while ($queue);
+}


### PR DESCRIPTION
The type of the assigned expression needs to be evaluated in the old scope, not
the new scope.

Fixes https://github.com/phpstan/phpstan/issues/3875