### PR TITLE
Fix JustNullableTypeTrait.equals()

### DIFF
--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -44,7 +44,7 @@ trait JustNullableTypeTrait
 
 	public function equals(Type $type): bool
 	{
-		return get_class($type) === self::class;
+		return get_class($type) === static::class;
 	}
 
 	public function traverse(callable $cb): Type

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10121,6 +10121,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3548.php');
 	}
 
+	public function dataBug3866(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3866.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10194,6 +10199,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug3875
 	 * @dataProvider dataBug2611
 	 * @dataProvider dataBug3548
+	 * @dataProvider dataBug3866
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/bug-3866.php
+++ b/tests/PHPStan/Analyser/data/bug-3866.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bug3866;
+
+use DateTimeImmutable;
+use Ds\Set;
+use Iterator;
+use function PHPStan\Analyser\assertType;
+
+abstract class PHPStanBug
+{
+	public function test(): void
+	{
+		/** @var Set<class-string> $set */
+		$set = new Set();
+		foreach ($this->a() as $item) {
+			$set->add(\get_class($item));
+		}
+		foreach ($this->b() as $item) {
+			$set->add(\get_class($item));
+		}
+		foreach ($this->c() as $item) {
+			$set->add($item);
+		}
+		assertType('Ds\Set<class-string>', $set);
+		$set->sort();
+	}
+
+	/**
+	 * @return Iterator<object>
+	 */
+	abstract public function a(): Iterator;
+
+	/**
+	 * @return Iterator<object>
+	 */
+	private function b(): Iterator
+	{
+		yield new DateTimeImmutable();
+	}
+
+	/**
+	 * @return Iterator<class-string<object>>
+	 */
+	private function c(): Iterator
+	{
+		yield DateTimeImmutable::class;
+	}
+}
+


### PR DESCRIPTION
equals() wrongly returned false for two instances of ClassStringType.  This
lead to an exponential explosion of very large UnionType objects with all
identical types inside.

Fixes https://github.com/phpstan/phpstan/issues/3866