### PR TITLE
Correct hash function stub return type

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -896,6 +896,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\HashFunctionsReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\SimpleXMLElementClassPropertyReflectionExtension
 		tags:
 			- phpstan.broker.propertiesClassReflectionExtension

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3906,7 +3906,7 @@ return [
 'HaruPage::stroke' => ['bool', 'close_path='=>'bool'],
 'HaruPage::textOut' => ['bool', 'x'=>'float', 'y'=>'float', 'text'=>'string'],
 'HaruPage::textRect' => ['bool', 'left'=>'float', 'top'=>'float', 'right'=>'float', 'bottom'=>'float', 'text'=>'string', 'align='=>'int'],
-'hash' => ['string', 'algo'=>'string', 'data'=>'string', 'raw_output='=>'bool'],
+'hash' => ['string|false', 'algo'=>'string', 'data'=>'string', 'raw_output='=>'bool'],
 'hash_algos' => ['array'],
 'hash_copy' => ['HashContext', 'context'=>'HashContext'],
 'hash_equals' => ['bool', 'known_string'=>'string', 'user_string'=>'string'],

--- a/src/Type/Php/HashFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashFunctionsReturnTypeExtension.php
@@ -23,11 +23,7 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		if ($functionReflection->getName() === 'hash') {
-			$defaultReturnType = new StringType();
-		} else {
-			$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
-		}
+		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
 		if (!isset($functionCall->args[0])) {
 			return $defaultReturnType;
@@ -44,7 +40,7 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 		$string = $values[0];
 
-		return in_array($string->getValue(), hash_algos(), true) ? $defaultReturnType : new ConstantBooleanType(false);
+		return in_array($string->getValue(), hash_algos(), true) ? new StringType() : new ConstantBooleanType(false);
 	}
 
 }

--- a/src/Type/Php/HashFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashFunctionsReturnTypeExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeUtils;
+
+final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'hash';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		if ($functionReflection->getName() === 'hash') {
+			$defaultReturnType = new StringType();
+		} else {
+			$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		if (!isset($functionCall->args[0])) {
+			return $defaultReturnType;
+		}
+
+		$argType = $scope->getType($functionCall->args[0]->value);
+		if ($argType instanceof MixedType) {
+			return TypeUtils::toBenevolentUnion($defaultReturnType);
+		}
+
+		$values = TypeUtils::getConstantStrings($argType);
+		if (count($values) !== 1) {
+			return TypeUtils::toBenevolentUnion($defaultReturnType);
+		}
+		$string = $values[0];
+
+		return in_array($string->getValue(), hash_algos(), true) ? $defaultReturnType : new ConstantBooleanType(false);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5966,6 +5966,10 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'false',
 				'$hashRandom',
 			],
+			[
+				'string',
+				'$hashMixed',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5954,6 +5954,18 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'(string|false)',
 				'$hashHmacFileVariable',
 			],
+			[
+				'string',
+				'$hash',
+			],
+			[
+				'string',
+				'$hashRaw',
+			],
+			[
+				'false',
+				'$hashRandom',
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -138,4 +138,7 @@ $hashHmacFileVariable = hash_hmac_file($string, 'data', 'key');
 $hash = hash('sha256', 'data', false);
 $hashRaw = hash('sha256', 'data', true);
 $hashRandom = hash('random', 'data', false);
+/** @var mixed $mixed */
+$mixed = doFoo();
+$hashMixed = hash('md5', $mixed, false);
 die;

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -135,4 +135,7 @@ $hashHmacFileNonCryptographic = hash_hmac_file('crc32', 'data', 'key');
 $hashHmacFileRandom = hash_hmac_file('random', 'data', 'key');
 $hashHmacFileVariable = hash_hmac_file($string, 'data', 'key');
 
+$hash = hash('sha256', 'data', false);
+$hashRaw = hash('sha256', 'data', true);
+$hashRandom = hash('random', 'data', false);
 die;


### PR DESCRIPTION
Correct return type of the `hash` function. [The PHP docs](https://www.php.net/manual/en/function.hash.php) say that this function only returns a string, however this is not true. It can also return a boolean `false` if you pass in the name of a non-existent hash algorithm. For example:

    var_dump(@hash('foo', 'bar', true));
    bool(false)