### PR TITLE
Fix usage of void return type with arrow functions

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -155,6 +155,7 @@ class FunctionCallParametersCheck
 			$scope->getType($funcCall) instanceof VoidType
 			&& !$scope->isInFirstLevelStatement()
 			&& !$funcCall instanceof \PhpParser\Node\Expr\New_
+			&& !$funcCall->getAttribute('parent') instanceof \PhpParser\Node\Expr\ArrowFunction
 		) {
 			$errors[] = RuleErrorBuilder::message($messages[7])->build();
 		}

--- a/src/Rules/FunctionReturnTypeCheck.php
+++ b/src/Rules/FunctionReturnTypeCheck.php
@@ -72,7 +72,7 @@ class FunctionReturnTypeCheck
 
 		$returnValueType = $scope->getType($returnValue);
 
-		if ($isVoidSuperType->yes()) {
+		if (!$scope->isInAnonymousFunction() && $isVoidSuperType->yes()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
 					$voidMessage,

--- a/tests/PHPStan/Rules/Functions/ArrowFunctionReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrowFunctionReturnTypeRuleTest.php
@@ -32,11 +32,11 @@ class ArrowFunctionReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/arrow-functions-return-type.php'], [
 			[
 				'Anonymous function should return string but returns int.',
-				12,
+				13,
 			],
 			[
 				'Anonymous function should return int but returns string.',
-				14,
+				15,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -443,4 +443,10 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testAnonymousFunctionVoidReturnValue(): void
+	{
+		require_once __DIR__ . '/data/anonymous-function-void-return-value.php';
+		$this->analyse([__DIR__ . '/data/anonymous-function-void-return-value.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/anonymous-function-void-return-value.php
+++ b/tests/PHPStan/Rules/Functions/data/anonymous-function-void-return-value.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Derp;
+
+function runner(callable $callback): void
+{
+	$callback();
+}
+
+function run(): void
+{
+	runner(fn() => noop());
+}
+
+function noop(): void
+{
+	return;
+}

--- a/tests/PHPStan/Rules/Functions/data/arrow-functions-return-type.php
+++ b/tests/PHPStan/Rules/Functions/data/arrow-functions-return-type.php
@@ -8,10 +8,16 @@ class Foo
 	public function doFoo(int $i)
 	{
 		fn() => $i;
+		fn() => self::noop();
 		fn(): int => $i;
 		fn(): string => $i;
 		fn(int $a): int => $a;
 		fn(string $a): int => $a;
+	}
+
+	public static function noop(): void
+	{
+		return;
 	}
 
 }


### PR DESCRIPTION
This PR is an attempt to fix the following issues:  phpstan/phpstan#3781 phpstan/phpstan#3348

[Here's a simple demo to reproduce what the issues are describing](https://phpstan.org/r/d351c920-f706-45cc-a035-9b398bba4bb9), you can see we have two errors to remove.

The PR is a draft because there's one thing left I can't seem to be able to do [here](https://github.com/nesk/phpstan-src/blob/d3942bf708270cdaaffc3638deccec5c82480fe7/src/Rules/FunctionReturnTypeCheck.php#L75):

```php
if (!$scope->isInAnonymousFunction() && $isVoidSuperType->yes()) {
```

I'm checking if the function is anonymous instead of checking if it's an arrow function, because I can't find _how_ to do this. A bit of help here would be great. 🙂