### PR TITLE
Fix resolving type of isset($arr['key'])

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10194,6 +10194,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3961.php');
 	}
 
+	public function dataBug1924(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-1924.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10275,6 +10280,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataNotEmptyArray
 	 * @dataProvider dataClassConstantOnExpression
 	 * @dataProvider dataBug3961
+	 * @dataProvider dataBug1924
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/bug-1924.php
+++ b/tests/PHPStan/Analyser/data/bug-1924.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bug1924;
+
+use function PHPStan\Analyser\assertType;
+
+class Bug1924
+{
+
+	function getArrayOrNull(): ?array
+	{
+		return rand(0, 1) ? [1, 2, 3] : null;
+	}
+
+	function foo(): void
+	{
+		$arr = [
+			'a' => $this->getArrayOrNull(),
+			'b' => $this->getArrayOrNull(),
+		];
+		assertType('array(\'a\' => array|null, \'b\' => array|null)', $arr);
+
+		$cond = isset($arr['a']) && isset($arr['b']);
+		assertType('bool', $cond);
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/boolean-and.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-and.php
@@ -149,3 +149,18 @@ class AndInIfCondition
 		}
 	}
 }
+
+function getMaybeArray() : ?array {
+	if (rand(0, 1)) { return [1, 2, 3]; }
+	return null;
+}
+
+function bug1924() {
+	$arr = [
+		'a' => getMaybeArray(),
+		'b' => getMaybeArray(),
+	];
+
+	if (isset($arr['a']) && isset($arr['b'])) {
+	}
+}


### PR DESCRIPTION
It was buggy when $arr['key'] might be null.

Fixes phpstan/phpstan#1924