### PR TITLE
Issue #3964: Add ArraySumFunctionDynamicReturnTypeExtension for array_sum function

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -802,6 +802,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\ArraySumFunctionDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ArrayValuesFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
@@ -5,7 +5,9 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\FloatType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 class ArraySumFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
@@ -17,7 +19,18 @@ class ArraySumFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dynami
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		return $scope->getType($functionCall->args[0]->value)->getIterableValueType();
+		$argType = $scope->getType($functionCall->args[0]->value);
+		$keyType = $argType->getIterableValueType();
+
+		if ($keyType instanceof UnionType) {
+			$floatType = new FloatType();
+
+			if ($keyType->accepts($floatType, true)->yes()) {
+				$keyType = $floatType;
+			}
+		}
+
+		return $keyType;
 	}
 
 }

--- a/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+
+class ArraySumFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'array_sum';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		return $scope->getType($functionCall->args[0]->value)->getIterableValueType();
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10199,7 +10199,15 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-1924.php');
 	}
 
+	public function dataBug3964(): array
+	{
+		require_once __DIR__ . '/data/array-sum.php';
+
+		return $this->gatherAssertTypes(__DIR__ . '/data/array-sum.php');
+	}
+
 	/**
+	 * @dataProvider dataBug3964
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
 	 * @dataProvider dataGenerics

--- a/tests/PHPStan/Analyser/data/array-sum.php
+++ b/tests/PHPStan/Analyser/data/array-sum.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ArraySum;
+
+use function PHPStan\Analyser\assertType;
+
+class Foo
+{
+	public function doSumWithInt(
+		int ...$integers
+	): void
+	{
+		$sum = array_sum($integers);
+
+		assertType('int', $sum);
+	}
+
+	public function doSumWithFloat(
+		float ...$floats
+	): void
+	{
+		$sum = array_sum($floats);
+
+		assertType('float', $sum);
+	}
+
+	/**
+	 * @param array<string, float> $floats
+	 */
+	public function doSumWithUntypedFloatParameter(
+		array $floats
+	): void
+	{
+		$sum = array_sum($floats);
+
+		assertType('float', $sum);
+	}
+
+	/**
+	 * @param array<string, int> $ints
+	 */
+	public function doSumWithUntypedIntParameter(
+		array $ints
+	): void
+	{
+		$sum = array_sum($ints);
+
+		assertType('int', $sum);
+	}
+
+	/**
+	 * @param array<string, int|float> $intOrFloat
+	 */
+	public function doSumWithUntypedIntOrFloatParameter(
+		array $intOrFloat
+	): void
+	{
+		$sum = array_sum($intOrFloat);
+
+		assertType('float', $sum);
+	}
+
+}


### PR DESCRIPTION
This PR:

* [x] Is a work in progress
* [x] Add a new class `ArraySumFunctionDynamicReturnTypeExtension`
* [x] Update the default configuration and include this class by default
* [x] Add tests
* [ ] Update more tests, update the Dynamic Return Type mechanism so untyped `$parameters` would work fine as well. 

Fix https://github.com/phpstan/phpstan/issues/3964