### PR TITLE
Support bound nested templates in @template tags

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10199,6 +10199,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-1924.php');
 	}
 
+	public function dataBug3922(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3922.php');
+	}
+
 	/**
 	 * @dataProvider dataBug2574
 	 * @dataProvider dataBug2577
@@ -10281,6 +10286,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataClassConstantOnExpression
 	 * @dataProvider dataBug3961
 	 * @dataProvider dataBug1924
+	 * @dataProvider dataBug3922
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/bug-3922.php
+++ b/tests/PHPStan/Analyser/data/bug-3922.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bug3922;
+
+use function PHPStan\Analyser\assertType;
+
+interface ViewData
+{
+}
+
+/**
+ * @template TViewData
+ */
+class ViewModel
+{
+}
+
+/**
+ * @template TViewData of ViewData
+ * @template TModel of ViewModel<TViewData>
+ */
+abstract class BaseRepository
+{
+	/**
+	 * @param TViewData $a
+	 * @param TModel $b
+	 */
+	public function method($a, $b)
+	{
+		assertType('TViewData of Bug3922\ViewData (class Bug3922\BaseRepository, argument)', $a);
+		assertType('TModel of Bug3922\ViewModel<TViewData> (class Bug3922\BaseRepository, argument)', $b);
+	}
+}
+
+class StudentViewData implements ViewData
+{
+}
+
+class TeacherViewData implements ViewData
+{
+}
+
+/**
+ * @extends ViewModel<StudentViewData>
+ */
+class StudentModel extends ViewModel
+{
+}
+
+/**
+ * @extends ViewModel<TeacherViewData>
+ */
+class TeacherModel extends ViewModel
+{
+}
+
+/**
+ * @extends BaseRepository<StudentViewData, StudentModel>
+ */
+class StudentRepository extends BaseRepository
+{
+}
+
+/**
+ * @extends BaseRepository<StudentViewData, TeacherModel>
+ */
+class TeacherRepository extends BaseRepository
+{
+}

--- a/tests/PHPStan/Rules/Generics/data/class-template.php
+++ b/tests/PHPStan/Rules/Generics/data/class-template.php
@@ -66,3 +66,25 @@ new /** @template TypeAlias */ class
 {
 
 };
+
+interface BaseViewData
+{
+
+}
+
+/**
+ * @template T
+ */
+class BaseModel
+{
+
+}
+
+/**
+ * @template TViewData of BaseViewData
+ * @template TModel of BaseModel<TViewData>
+ */
+class BaseRepository
+{
+
+}

--- a/tests/PHPStan/Rules/Generics/data/interface-template.php
+++ b/tests/PHPStan/Rules/Generics/data/interface-template.php
@@ -33,3 +33,25 @@ interface Lorem
 {
 
 }
+
+interface BaseViewData
+{
+
+}
+
+/**
+ * @template T
+ */
+interface BaseModel
+{
+
+}
+
+/**
+ * @template TViewData of BaseViewData
+ * @template TModel of BaseModel<TViewData>
+ */
+interface BaseRepository
+{
+
+}


### PR DESCRIPTION
This is my personal attempt at supporting bound nested templates in the `@template` tag to fix phpstan/phpstan#3922. Tests are broken and/or missing and the code itself is not complete, but it would be cool to have an opinion on the way I decided to take to understand if it makes sense and it's feasible or if I have to change approach. I have to admit that the code of PHPStan is not easy to understand and I'm having a really hard time figuring out the internals of how it works in some parts, so any help to get this feature done would be appreciated