### PR TITLE
Fix scale parameter check in bc math return type extension

### DIFF
--- a/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
+++ b/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
@@ -60,7 +60,7 @@ class BcMathStringOrNullReturnTypeExtension implements \PHPStan\Type\DynamicFunc
 		$thirdArgument = $scope->getType($functionCall->args[2]->value);
 		$thirdArgumentIsNumeric = ($thirdArgument instanceof ConstantScalarType && is_numeric($thirdArgument->getValue())) || $thirdArgument instanceof IntegerType;
 
-		if ($thirdArgument instanceof ConstantScalarType && ($this->isZero($thirdArgument->getValue()) || !is_numeric($thirdArgument->getValue()))) {
+		if ($thirdArgument instanceof ConstantScalarType && !is_numeric($thirdArgument->getValue())) {
 			return new NullType();
 		}
 

--- a/tests/PHPStan/Analyser/data/bcmath-dynamic-return.php
+++ b/tests/PHPStan/Analyser/data/bcmath-dynamic-return.php
@@ -23,6 +23,8 @@ $nonNumeric = 'foo';
 \PHPStan\Analyser\assertType('null', bcdiv('10', 0.0)); // Warning: Division by zero
 \PHPStan\Analyser\assertType('string', bcdiv('10', '1'));
 \PHPStan\Analyser\assertType('string', bcdiv('10', '-1'));
+\PHPStan\Analyser\assertType('string', bcdiv('10', '2', 0));
+\PHPStan\Analyser\assertType('string', bcdiv('10', '2', 1));
 \PHPStan\Analyser\assertType('string', bcdiv('10', $iNeg));
 \PHPStan\Analyser\assertType('string', bcdiv('10', $iPos));
 \PHPStan\Analyser\assertType('string', bcdiv($iPos, $iPos));
@@ -38,6 +40,8 @@ $nonNumeric = 'foo';
 \PHPStan\Analyser\assertType('null', bcmod($iPos, '0')); // Warning: Division by zero
 \PHPStan\Analyser\assertType('null', bcmod('10', $nonNumeric));
 \PHPStan\Analyser\assertType('string', bcmod('10', '1'));
+\PHPStan\Analyser\assertType('string', bcmod('10', '2', 0));
+\PHPStan\Analyser\assertType('string', bcmod('5.7', '1.3', 1));
 \PHPStan\Analyser\assertType('string', bcmod('10', 2.2));
 \PHPStan\Analyser\assertType('string', bcmod('10', $iUnknown));
 \PHPStan\Analyser\assertType('string', bcmod('10', '-1'));


### PR DESCRIPTION
I believe that the "zero" check is incorrect for the third parameter.

There is a fallback to zero when the scale parametter is omitted and the default scale has not been set with the bcscale() function.

I added test cases covering the third parameter of the bcdiv and bcmod functions.

My changes should not break any of the existing tests. However, I would like to ask the extension author @eigan for a comment.

Problem example: https://phpstan.org/r/ef05165e-ca1e-4eb3-a26d-23d08c3d7b46