### PR TITLE
Improve type specifier for identical operator

### DIFF
--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -86,6 +86,10 @@ class UnionTypeHelper
 				return 0;
 			}
 
+			if ($a instanceof IntegerRangeType && $b instanceof IntegerRangeType) {
+				return $a->getMin() <=> $b->getMin();
+			}
+
 			if ($a instanceof ConstantStringType && $b instanceof ConstantStringType) {
 				return strcasecmp($a->getValue(), $b->getValue());
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -7591,17 +7591,17 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	{
 		return [
 			[
-				'int',
+				'int<min, 10>',
 				'$i',
 				"'begin'",
 			],
 			[
-				'int',
+				'int<min, 10>',
 				'$i',
 				"'end'",
 			],
 			[
-				'int',
+				'int<min, 10>',
 				'$i',
 				"'afterLoop'",
 			],
@@ -8921,7 +8921,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				"'afterFirst'",
 			],
 			[
-				'int',
+				'int<min, -1>|int<1, max>',
 				'$a',
 				"'afterSecond'",
 			],
@@ -8936,12 +8936,12 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				"'afterSecond'",
 			],
 			[
-				'int',
+				'int<min, -1>|int<1, max>',
 				'$a',
 				"'afterThird'",
 			],
 			[
-				'int',
+				'int<min, -1>|int<1, max>',
 				'$b',
 				"'afterThird'",
 			],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -2343,7 +2343,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'@$stringOrNull ?: 12',
 			],
 			[
-				'int<1, max>|int<min, -1>',
+				'int<min, -1>|int<1, max>',
 				'$integer ?: 12',
 			],
 			[
@@ -5244,7 +5244,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 				'array_filter($union)',
 			],
 			[
-				'array<int, int<1, max>|int<min, -1>|true>',
+				'array<int, int<min, -1>|int<1, max>|true>',
 				'array_filter($withPossiblyFalsey)',
 			],
 			[

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -702,7 +702,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					)
 				),
 				[
-					'$n' => '~int<6, max>|int<min, 2>',
+					'$n' => '~int<min, 2>|int<6, max>',
 				],
 				[
 					'$n' => '~int<3, 5>',

--- a/tests/PHPStan/Analyser/data/bug-2648.php
+++ b/tests/PHPStan/Analyser/data/bug-2648.php
@@ -37,7 +37,7 @@ class Foo
 				assertType('int<0, max>', count($list));
 
 				if (count($list) === 1) {
-					assertType('int<1, max>', count($list));
+					assertType('1', count($list));
 					break;
 				}
 			}

--- a/tests/PHPStan/Analyser/data/bug-2954.php
+++ b/tests/PHPStan/Analyser/data/bug-2954.php
@@ -6,7 +6,7 @@ use function PHPStan\Analyser\assertType;
 
 function (int $x) {
 	if ($x === 0) return;
-	assertType('int<1, max>|int<min, -1>', $x);
+	assertType('int<min, -1>|int<1, max>', $x);
 
 	$x++;
 	assertType('int', $x);
@@ -14,7 +14,7 @@ function (int $x) {
 
 function (int $x) {
 	if ($x === 0) return;
-	assertType('int<1, max>|int<min, -1>', $x);
+	assertType('int<min, -1>|int<1, max>', $x);
 
 	++$x;
 	assertType('int', $x);
@@ -22,7 +22,7 @@ function (int $x) {
 
 function (int $x) {
 	if ($x === 0) return;
-	assertType('int<1, max>|int<min, -1>', $x);
+	assertType('int<min, -1>|int<1, max>', $x);
 
 	$x--;
 	assertType('int', $x);
@@ -30,7 +30,7 @@ function (int $x) {
 
 function (int $x) {
 	if ($x === 0) return;
-	assertType('int<1, max>|int<min, -1>', $x);
+	assertType('int<min, -1>|int<1, max>', $x);
 
 	--$x;
 	assertType('int', $x);

--- a/tests/PHPStan/Analyser/data/bug-3009.php
+++ b/tests/PHPStan/Analyser/data/bug-3009.php
@@ -15,14 +15,14 @@ class HelloWorld
 			return null;
 		}
 
-		assertType('array(?\'scheme\' => string, ?\'host\' => string, ?\'port\' => int, ?\'user\' => string, ?\'pass\' => string, ?\'path\' => string, ?\'query\' => string, ?\'fragment\' => string)', $redirectUrlParts);
+		assertType('array(?\'scheme\' => string, ?\'port\' => int, ?\'user\' => string, ?\'pass\' => string, ?\'path\' => string, ?\'query\' => string, ?\'fragment\' => string)', $redirectUrlParts);
 
 		if (true === array_key_exists('query', $redirectUrlParts)) {
-			assertType('array(?\'scheme\' => string, ?\'host\' => string, ?\'port\' => int, ?\'user\' => string, ?\'pass\' => string, ?\'path\' => string, \'query\' => string, ?\'fragment\' => string)', $redirectUrlParts);
+			assertType('array(?\'scheme\' => string, ?\'port\' => int, ?\'user\' => string, ?\'pass\' => string, ?\'path\' => string, \'query\' => string, ?\'fragment\' => string)', $redirectUrlParts);
 			$redirectServer['QUERY_STRING'] = $redirectUrlParts['query'];
 		}
 
-		assertType('array(?\'scheme\' => string, ?\'host\' => string, ?\'port\' => int, ?\'user\' => string, ?\'pass\' => string, ?\'path\' => string, ?\'query\' => string, ?\'fragment\' => string)', $redirectUrlParts);
+		assertType('array(?\'scheme\' => string, ?\'port\' => int, ?\'user\' => string, ?\'pass\' => string, ?\'path\' => string, ?\'query\' => string, ?\'fragment\' => string)', $redirectUrlParts);
 
 		return 'foo';
 	}

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -21,18 +21,18 @@ function (int $i) {
 		assertType('int<min, 1>', $i);
 	}
 
-	assertType('int<3, max>|int<min, 1>', $i);
+	assertType('int<min, 1>|int<3, max>', $i);
 
 	if ($i < 3 && $i > 5) {
 		assertType('*NEVER*', $i);
 	} else {
-		assertType('int<3, max>|int<min, 1>', $i);
+		assertType('int<min, 1>|int<3, max>', $i);
 	}
 
 	if ($i > 3 && $i < 5) {
 		assertType('4', $i);
 	} else {
-		assertType('3|int<5, max>|int<min, 1>', $i);
+		assertType('3|int<min, 1>|int<5, max>', $i);
 	}
 
 	if ($i >= 3 && $i <= 5) {

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -159,11 +159,11 @@ class StrictComparisonOfDifferentTypesRuleTest extends \PHPStan\Testing\RuleTest
 					438,
 				],
 				[
-					'Strict comparison using === between int<2, max>|int<min, 0>|string and 1.0 will always evaluate to false.',
+					'Strict comparison using === between int<min, 0>|int<2, max>|string and 1.0 will always evaluate to false.',
 					464,
 				],
 				[
-					'Strict comparison using === between int<2, max>|int<min, 0>|string and stdClass will always evaluate to false.',
+					'Strict comparison using === between int<min, 0>|int<2, max>|string and stdClass will always evaluate to false.',
 					466,
 				],
 				[
@@ -333,11 +333,11 @@ class StrictComparisonOfDifferentTypesRuleTest extends \PHPStan\Testing\RuleTest
 					438,
 				],
 				[
-					'Strict comparison using === between int<2, max>|int<min, 0>|string and 1.0 will always evaluate to false.',
+					'Strict comparison using === between int<min, 0>|int<2, max>|string and 1.0 will always evaluate to false.',
 					464,
 				],
 				[
-					'Strict comparison using === between int<2, max>|int<min, 0>|string and stdClass will always evaluate to false.',
+					'Strict comparison using === between int<min, 0>|int<2, max>|string and stdClass will always evaluate to false.',
 					466,
 				],
 				[

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1428,6 +1428,14 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 			],
 			[
 				[
+					IntegerRangeType::fromInterval(7, 9),
+					IntegerRangeType::fromInterval(1, 3),
+				],
+				UnionType::class,
+				'int<1, 3>|int<7, 9>',
+			],
+			[
+				[
 					IntegerRangeType::fromInterval(1, 3),
 					new ConstantIntegerType(3),
 				],
@@ -3204,7 +3212,7 @@ class TypeCombinatorTest extends \PHPStan\Testing\TestCase
 				new BenevolentUnionType([new IntegerType(), new StringType()]),
 				new ConstantIntegerType(1),
 				UnionType::class,
-				'int<2, max>|int<min, 0>|string',
+				'int<min, 0>|int<2, max>|string',
 			],
 			[
 				new BenevolentUnionType([new IntegerType(), new StringType()]),


### PR DESCRIPTION
This started as a small change and became much bigger than originally intended. So I'm pushing this early as a draft to get comments and see if this is going in a useful direction or not.  Or if maybe this is a too big change for pre-1.0.

The intention here was
- Make type inference in conditions more precise in general
- Remove hard-coded things for certain functions (like `count()` and then just improve count-related extensions)
- Probably this would help fix phpstan/phpstan#2816 cleanly
- Future work would be to do the same for the `==` operator which would benefit switch-statements and fix phpstan/phpstan#1861

However I also hit some limitations, mostly that `TypeSpecifierContext` can only tell me if something was true/truthy/false/falsey, but not what exact type something evaluated to. Hence I added `TypeSpecifier::specifyTypesInExpression()`. But it would be nice to have more precise information available in extensions as well (`MethodTypeSpecifyingExtension` & co.)

Let me know what you think.