### PR TITLE
Fix grammar error

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -197,7 +197,7 @@ class CommandHelper
 					}
 					$includedFilePath = sprintf('%s/%s', $extensionConfig['install_path'], $includedFile);
 					if (!file_exists($includedFilePath) || !is_readable($includedFilePath)) {
-						$errorOutput->writeLineFormatted(sprintf('Config file %s does not exists or isn\'t readable', $includedFilePath));
+						$errorOutput->writeLineFormatted(sprintf('Config file %s does not exist or isn\'t readable', $includedFilePath));
 						throw new \PHPStan\Command\InceptionNotSuccessfulException();
 					}
 					$additionalConfigFiles[] = $includedFilePath;


### PR DESCRIPTION
This change fixes the grammar of an error message I was seeing in PHPStorm 2020.3 EAP (Build \#PS-203.5251.40) with PHPStan Inspection enabled.

Note: this does not fix the actual error, just the error message. I still need to look into what is causing the error.