### PR TITLE
Add support for `no-return` and `never-returns` types

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -217,6 +217,8 @@ class TypeNodeResolver
 
 			case 'never':
 			case 'never-return':
+			case 'never-returns':
+			case 'no-return':
 				return new NeverType(true);
 
 			case 'list':


### PR DESCRIPTION
Just some aliases used in psalm

```
no-return is the 'return type' for a function that can never actually return,
such as die(), exit(), or a function that always throws an exception.
It may also be written as never-return or never-returns, and is also known as the bottom type.
```

https://psalm.dev/docs/annotating_code/type_syntax/atomic_types/