### PR TITLE
Add *syntax* support for `non-empty-string` type

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -137,6 +137,7 @@ class TypeNodeResolver
 				return IntegerRangeType::fromInterval(null, -1);
 
 			case 'string':
+			case 'non-empty-string':
 				return new StringType();
 
 			case 'class-string':


### PR DESCRIPTION
It's just a code to treat it like `string` w/o any real emptiness tracking

Refs https://github.com/phpstan/phpstan/issues/3148