### PR TITLE
Increase result cache hit rate by not throwing away ResultCache files if metadata does not match

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -386,7 +386,7 @@ services:
 	-
 		implement: PHPStan\Analyser\ResultCache\ResultCacheManagerFactory
 		arguments:
-			cacheFilePath: %tmpDir%/resultCache.php
+			resultCachePath: %tmpDir%
 			tempResultCachePath: %tempResultCachePath%
 			allCustomConfigFiles: %allCustomConfigFiles%
 			analysedPaths: %analysedPaths%
@@ -398,7 +398,7 @@ services:
 	-
 		class: PHPStan\Analyser\ResultCache\ResultCacheClearer
 		arguments:
-			cacheFilePath: %tmpDir%/resultCache.php
+			resultCachePath: %tmpDir%
 			tempResultCachePath: %tempResultCachePath%
 
 	-

--- a/src/Analyser/ResultCache/ResultCacheClearer.php
+++ b/src/Analyser/ResultCache/ResultCacheClearer.php
@@ -7,26 +7,24 @@ use Symfony\Component\Finder\Finder;
 class ResultCacheClearer
 {
 
-	private string $cacheFilePath;
+	private string $resultCachePath;
 
 	private string $tempResultCachePath;
 
-	public function __construct(string $cacheFilePath, string $tempResultCachePath)
+	public function __construct(string $resultCachePath, string $tempResultCachePath)
 	{
-		$this->cacheFilePath = $cacheFilePath;
+		$this->resultCachePath = $resultCachePath;
 		$this->tempResultCachePath = $tempResultCachePath;
 	}
 
 	public function clear(): string
 	{
-		$dir = dirname($this->cacheFilePath);
-		if (!is_file($this->cacheFilePath)) {
-			return $dir;
+		$finder = new Finder();
+		foreach ($finder->files()->name('resultCache*.php')->in($this->tempResultCachePath) as $tmpResultCacheFile) {
+			@unlink($tmpResultCacheFile->getPathname());
 		}
 
-		@unlink($this->cacheFilePath);
-
-		return $dir;
+		return $this->resultCachePath;
 	}
 
 	public function clearTemporaryCaches(): void

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -608,6 +608,6 @@ php;
 
 	private function buildCacheFilePath(): string
 	{
-		return $this->resultCachePath . '/resultCache' . $this->getMetaAsString() . 'php';
+		return $this->resultCachePath . '/resultCache' . $this->getMetaAsString() . '.php';
 	}
 }

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -19,7 +19,7 @@ class ResultCacheManager
 
 	private ExportedNodeFetcher $exportedNodeFetcher;
 
-	private string $cacheFilePath;
+	private string $resultCachePath;
 
 	private string $tempResultCachePath;
 
@@ -47,7 +47,7 @@ class ResultCacheManager
 
 	/**
 	 * @param ExportedNodeFetcher $exportedNodeFetcher
-	 * @param string $cacheFilePath
+	 * @param string $resultCachePath
 	 * @param string $tempResultCachePath
 	 * @param string[] $allCustomConfigFiles
 	 * @param string[] $analysedPaths
@@ -59,7 +59,7 @@ class ResultCacheManager
 	 */
 	public function __construct(
 		ExportedNodeFetcher $exportedNodeFetcher,
-		string $cacheFilePath,
+		string $resultCachePath,
 		string $tempResultCachePath,
 		array $allCustomConfigFiles,
 		array $analysedPaths,
@@ -71,7 +71,7 @@ class ResultCacheManager
 	)
 	{
 		$this->exportedNodeFetcher = $exportedNodeFetcher;
-		$this->cacheFilePath = $cacheFilePath;
+		$this->resultCachePath = $resultCachePath;
 		$this->tempResultCachePath = $tempResultCachePath;
 		$this->allCustomConfigFiles = $allCustomConfigFiles;
 		$this->analysedPaths = $analysedPaths;
@@ -96,7 +96,7 @@ class ResultCacheManager
 			return new ResultCache($allAnalysedFiles, true, time(), [], [], []);
 		}
 
-		$cacheFilePath = $this->cacheFilePath;
+		$cacheFilePath = $this->buildCacheFilePath();
 		if ($resultCacheName !== null) {
 			$tmpCacheFile = $this->tempResultCachePath . '/' . $resultCacheName . '.php';
 			if (is_file($tmpCacheFile)) {
@@ -488,7 +488,7 @@ php;
 
 		ksort($exportedNodes);
 
-		$file = $this->cacheFilePath;
+		$file = $this->buildCacheFilePath();
 		if ($resultCacheName !== null) {
 			$file = $this->tempResultCachePath . '/' . $resultCacheName . '.php';
 		}
@@ -528,6 +528,11 @@ php;
 			'stubFiles' => $this->getStubFiles(),
 			'level' => $this->usedLevel,
 		];
+	}
+
+	private function getMetaAsString(): string
+	{
+		return sha1(serialize($this->getMeta()));
 	}
 
 	/**
@@ -601,4 +606,8 @@ php;
 		return $stubFiles;
 	}
 
+	private function buildCacheFilePath(): string
+	{
+		return $this->resultCachePath . '/resultCache' . $this->getMetaAsString() . 'php';
+	}
 }


### PR DESCRIPTION
I would like to propose the following change to increase the result cache hitrate.

## Current Situation

Currently the `ResultCache.php` will first be ignored and then overwritten whenever the cache metadata get changed (`\PHPStan\Analyser\ResultCache\ResultCacheManager::getMeta()`).

```
$ phpstan analyse -vvv -l3
Result cache not used because the cache file does not exist.
Result cache is saved.

$ phpstan analyse -vvv -l3
Result cache is used.

$ phpstan analyse -vvv -l4
Result cache not used because the metadata do not match.
Result cache is saved.

$ phpstan analyse -vvv -l4
Result cache is used.

$ phpstan analyse -vvv -l3
Result cache not used because the metadata do not match.
Result cache is saved.
```

Especially in our CI pipeline this is a major reason for cache misses.
We run a phpstan run for every merge request. All runs use a shared phpstan-tmp directory so the result cache can be reused.
When a single branch has a metadata change phpstan will invalidate and delete the result cache for all other branches too.
So having to branches with different metadata will delete the result cache of the other one.

## Proposed solution

I propose to encode the metadata information as a cache-key directly in the result file path.

```
$ phpstan analyse -vvv -l3
Result cache not used because the cache file does not exist.
Result cache is saved.

$ phpstan analyse -vvv -l3
Result cache is used.

$ phpstan analyse -vvv -l4
Result cache not used because the cache file does not exist.
Result cache is saved.

$ phpstan analyse -vvv -l4
Result cache is used.

$ phpstan analyse -vvv -l3
Result cache is used.
```

