### PR TITLE
Fix support for classes named after pseudotypes in phpdoc

### DIFF
--- a/src/Analyser/NameScope.php
+++ b/src/Analyser/NameScope.php
@@ -47,6 +47,11 @@ class NameScope
 		return $this->uses;
 	}
 
+	public function hasUseAlias(string $name): bool
+	{
+		return isset($this->uses[strtolower($name)]);
+	}
+
 	public function getClassName(): ?string
 	{
 		return $this->className;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5619,6 +5619,23 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		];
 	}
 
+	public function dataPseudoTypeOverrides(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-pseudotype-override.php');
+	}
+
+	public function dataPseudoTypeNamespace(): array
+	{
+		require_once __DIR__ . '/data/phpdoc-pseudotype-namespace.php';
+
+		return $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-pseudotype-namespace.php');
+	}
+
+	public function dataPseudoTypeGlobal(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-pseudotype-global.php');
+	}
+
 	/**
 	 * @dataProvider dataArrayFunctions
 	 * @param string $description
@@ -11220,6 +11237,9 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataNestedGenericIncompleteConstructor
 	 * @dataProvider dataIteratorIterator
 	 * @dataProvider dataBug4642
+	 * @dataProvider dataPseudoTypeGlobal
+	 * @dataProvider dataPseudoTypeNamespace
+	 * @dataProvider dataPseudoTypeOverrides
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/phpdoc-pseudotype-global.php
+++ b/tests/PHPStan/Analyser/data/phpdoc-pseudotype-global.php
@@ -1,0 +1,30 @@
+<?php
+
+use function PHPStan\Analyser\assertType;
+
+function () {
+	/** @var Number $number */
+	$number = doFoo();
+
+	/** @var Boolean $boolean */
+	$boolean = doFoo();
+
+	/** @var Numeric $numeric */
+	$numeric = doFoo();
+
+	/** @var Never $never */
+	$never = doFoo();
+
+	/** @var Resource $resource */
+	$resource = doFoo();
+
+	/** @var Double $double */
+	$double = doFoo();
+
+	assertType('float|int', $number);
+	assertType('float|int|(string&numeric)', $numeric);
+	assertType('bool', $boolean);
+	assertType('resource', $resource);
+	assertType('*NEVER*', $never);
+	assertType('float', $double);
+};

--- a/tests/PHPStan/Analyser/data/phpdoc-pseudotype-namespace.php
+++ b/tests/PHPStan/Analyser/data/phpdoc-pseudotype-namespace.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpdocPseudoTypesNamespace;
+
+use function PHPStan\Analyser\assertType;
+
+class Number {}
+class Numeric {}
+class Boolean {}
+class Resource {}
+class Never {}
+class Double {}
+
+function () {
+	/** @var Number $number */
+	$number = doFoo();
+
+	/** @var Boolean $boolean */
+	$boolean = doFoo();
+
+	/** @var Numeric $numeric */
+	$numeric = doFoo();
+
+	/** @var Never $never */
+	$never = doFoo();
+
+	/** @var Resource $resource */
+	$resource = doFoo();
+
+	/** @var Double $double */
+	$double = doFoo();
+
+	assertType('PhpdocPseudoTypesNamespace\Number', $number);
+	assertType('PhpdocPseudoTypesNamespace\Numeric', $numeric);
+	assertType('PhpdocPseudoTypesNamespace\Boolean', $boolean);
+	assertType('PhpdocPseudoTypesNamespace\Resource', $resource);
+	assertType('PhpdocPseudoTypesNamespace\Never', $never);
+	assertType('PhpdocPseudoTypesNamespace\Double', $double);
+};

--- a/tests/PHPStan/Analyser/data/phpdoc-pseudotype-override.php
+++ b/tests/PHPStan/Analyser/data/phpdoc-pseudotype-override.php
@@ -1,0 +1,37 @@
+<?php
+
+use Foo\Number;
+use Foo\Numeric;
+use Foo\Boolean;
+use Foo\Resource;
+use Foo\Never;
+use Foo\Double;
+
+use function PHPStan\Analyser\assertType;
+
+function () {
+	/** @var Number $number */
+	$number = doFoo();
+
+	/** @var Boolean $boolean */
+	$boolean = doFoo();
+
+	/** @var Numeric $numeric */
+	$numeric = doFoo();
+
+	/** @var Never $never */
+	$never = doFoo();
+
+	/** @var Resource $resource */
+	$resource = doFoo();
+
+	/** @var Double $double */
+	$double = doFoo();
+
+	assertType('Foo\Number', $number);
+	assertType('Foo\Numeric', $numeric);
+	assertType('Foo\Boolean', $boolean);
+	assertType('Foo\Resource', $resource);
+	assertType('Foo\Never', $never);
+	assertType('Foo\Double', $double);
+};


### PR DESCRIPTION
The non-standard pseudotype `int|float` will be used only if the resolved class does not exist.

Closes https://github.com/phpstan/phpstan/issues/4039