### PR TITLE
Add "base64" as key for stream_get_meta_data

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11722,7 +11722,7 @@ return [
 'stream_get_contents' => ['string|false', 'source'=>'resource', 'maxlen='=>'int', 'offset='=>'int'],
 'stream_get_filters' => ['array'],
 'stream_get_line' => ['string|false', 'stream'=>'resource', 'maxlen'=>'int', 'ending='=>'string'],
-'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,base64:bool}', 'fp'=>'resource'],
+'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype?:string,base64?:bool}', 'fp'=>'resource'],
 'stream_get_transports' => ['array'],
 'stream_get_wrappers' => ['array'],
 'stream_is_local' => ['bool', 'stream'=>'resource|string'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11722,7 +11722,7 @@ return [
 'stream_get_contents' => ['string|false', 'source'=>'resource', 'maxlen='=>'int', 'offset='=>'int'],
 'stream_get_filters' => ['array'],
 'stream_get_line' => ['string|false', 'stream'=>'resource', 'maxlen'=>'int', 'ending='=>'string'],
-'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string}', 'fp'=>'resource'],
+'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,base64:bool}', 'fp'=>'resource'],
 'stream_get_transports' => ['array'],
 'stream_get_wrappers' => ['array'],
 'stream_is_local' => ['bool', 'stream'=>'resource|string'],


### PR DESCRIPTION
Given the right "data" url, PHP will add a boolean "base64" key to `stream_get_meta_data`.

See some example code in action: https://3v4l.org/G65j4