### PR TITLE
ceil() never returns int

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -933,7 +933,7 @@ return [
 'CallbackFilterIterator::next' => ['void'],
 'CallbackFilterIterator::rewind' => ['void'],
 'CallbackFilterIterator::valid' => ['bool'],
-'ceil' => ['float|int', 'number'=>'float'],
+'ceil' => ['float', 'number'=>'float'],
 'chdb::__construct' => ['void', 'pathname'=>'string'],
 'chdb::get' => ['string', 'key'=>'string'],
 'chdb_create' => ['bool', 'pathname'=>'string', 'data'=>'array'],


### PR DESCRIPTION
However, note that prior to PHP 8 `floor()` and `ceil()` returned `false` when given something other than `float|int`. Is it worth creating a return type extension for this?