### PR TITLE
Infer private properties in constructor, even if typehinted

### DIFF
--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -303,7 +303,6 @@ class PhpClassReflectionExtension
 			&& $this->inferPrivatePropertyTypeFromConstructor
 			&& $declaringClassReflection->getFileName() !== false
 			&& $propertyReflection->isPrivate()
-			&& (!method_exists($propertyReflection, 'hasType') || !$propertyReflection->hasType())
 			&& $declaringClassReflection->hasConstructor()
 			&& $declaringClassReflection->getConstructor()->getDeclaringClass()->getName() === $declaringClassReflection->getName()
 		) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10439,6 +10439,15 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-2945.php');
 	}
 
+	public function dataInferPrivateTypedPropertyTypeFromConstructor(): array
+	{
+		if (!self::$useStaticReflectionProvider && PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		return $this->gatherAssertTypes(__DIR__ . '/data/infer-private-typed-property-type-from-constructor.php');
+	}
+
 	/**
 	 * @param string $file
 	 * @return array<string, mixed[]>
@@ -10627,6 +10636,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug2997
 	 * @dataProvider dataBug1657
 	 * @dataProvider dataBug2945
+	 * @dataProvider dataInferPrivateTypedPropertyTypeFromConstructor
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args
@@ -10708,41 +10718,6 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	{
 		$this->assertTypes(
 			__DIR__ . '/data/infer-private-property-type-from-constructor.php',
-			$description,
-			$expression
-		);
-	}
-
-	public function dataInferPrivateTypedPropertyTypeFromConstructor(): array
-	{
-		return [
-			[
-				'InferPrivateTypedPropertyTypeFromConstructor\GenericFoo<stdClass>',
-				'$this->genericFoo',
-			],
-			[
-				'array<int, string>',
-				'$this->typedArray',
-			],
-		];
-	}
-
-	/**
-	 * @dataProvider dataInferPrivateTypedPropertyTypeFromConstructor
-	 * @param string $description
-	 * @param string $expression
-	 */
-	public function testInferPrivateTypedPropertyTypeFromConstructor(
-		string $description,
-		string $expression
-	): void
-	{
-		if (!self::$useStaticReflectionProvider && PHP_VERSION_ID < 70400) {
-			$this->markTestSkipped('Test requires PHP 7.4.');
-		}
-
-		$this->assertTypes(
-			__DIR__ . '/data/infer-private-typed-property-type-from-constructor.php',
 			$description,
 			$expression
 		);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10713,6 +10713,41 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	public function dataInferPrivateTypedPropertyTypeFromConstructor(): array
+	{
+		return [
+			[
+				'InferPrivateTypedPropertyTypeFromConstructor\GenericFoo<stdClass>',
+				'$this->genericFoo',
+			],
+			[
+				'array<int, string>',
+				'$this->typedArray',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataInferPrivateTypedPropertyTypeFromConstructor
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testInferPrivateTypedPropertyTypeFromConstructor(
+		string $description,
+		string $expression
+	): void
+	{
+		if (!self::$useStaticReflectionProvider && PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->assertTypes(
+			__DIR__ . '/data/infer-private-typed-property-type-from-constructor.php',
+			$description,
+			$expression
+		);
+	}
+
 	public function dataPropertyNativeTypes(): array
 	{
 		return [

--- a/tests/PHPStan/Analyser/data/infer-private-typed-property-type-from-constructor.php
+++ b/tests/PHPStan/Analyser/data/infer-private-typed-property-type-from-constructor.php
@@ -2,14 +2,30 @@
 
 namespace InferPrivateTypedPropertyTypeFromConstructor;
 
+use function PHPStan\Analyser\assertType;
+
 class Foo
 {
 	private GenericFoo $genericFoo;
+	private int $notIntInConstructorTypehint;
+	private int $notIntInConstructorPhpdoc;
+	private array $typedArrayPhpdoc;
 	private array $typedArray;
 
-	public function __construct(string ...$typedArray)
-	{
+	/**
+	 * @param string $notIntInConstructorPhpdoc
+	 * @param string[] $typedArrayPhpdoc
+	 */
+	public function __construct(
+		$notIntInConstructorPhpdoc,
+		string $notIntInConstructorTypehint,
+		array $typedArrayPhpdoc,
+		string ...$typedArray
+	) {
 		$this->genericFoo = $this->newGenericFoo(\stdClass::class);
+		$this->notIntInConstructorPhpdoc = $notIntInConstructorPhpdoc;
+		$this->notIntInConstructorTypehint = $notIntInConstructorTypehint;
+		$this->typedArrayPhpdoc = $typedArrayPhpdoc;
 		$this->typedArray = $typedArray;
 	}
 
@@ -25,9 +41,13 @@ class Foo
 		return new GenericFoo();
 	}
 
-	public function doFoo()
+	public function method()
 	{
-		die;
+		assertType('InferPrivateTypedPropertyTypeFromConstructor\GenericFoo<stdClass>', $this->genericFoo);
+		assertType('int', $this->notIntInConstructorPhpdoc);
+		assertType('int', $this->notIntInConstructorTypehint);
+		assertType('array<string>', $this->typedArrayPhpdoc);
+		assertType('array<int, string>', $this->typedArray);
 	}
 }
 

--- a/tests/PHPStan/Analyser/data/infer-private-typed-property-type-from-constructor.php
+++ b/tests/PHPStan/Analyser/data/infer-private-typed-property-type-from-constructor.php
@@ -1,0 +1,40 @@
+<?php // lint >= 7.4
+
+namespace InferPrivateTypedPropertyTypeFromConstructor;
+
+class Foo
+{
+	private GenericFoo $genericFoo;
+	private array $typedArray;
+
+	public function __construct(string ...$typedArray)
+	{
+		$this->genericFoo = $this->newGenericFoo(\stdClass::class);
+		$this->typedArray = $typedArray;
+	}
+
+	/**
+	 * @template T
+	 *
+	 * @param class-string<T> $class
+	 *
+	 * @return GenericFoo<T>
+	 */
+	public function newGenericFoo(string $class): GenericFoo
+	{
+		return new GenericFoo();
+	}
+
+	public function doFoo()
+	{
+		die;
+	}
+}
+
+/**
+ * @template T
+ */
+class GenericFoo
+{
+
+}


### PR DESCRIPTION
Hi!

When using the flag `inferPrivatePropertyTypeFromConstructor: true`, the inference is disabled if the property is natively typehinted.

However the inference could provide a more specific type (eg: generic).

A usecase is ORM: 

```php
class UserRepository
{
    private DatabaseClient $db;

    public function __construct(DatabaseClientProvider $dbClientProvider)
    {
        $this->db = $dbClientProvider->for(User::class);
    }

    public function get(string $id): User
    {
         return $this->db->query('...');
    }
}
```

This PR allows PHPStan to infer `DatabaseClient<User>` instead of just `DatabaseClient` for the `$db` property.
