### PR TITLE
Concat between numeric and empty string produces numeric string

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -912,6 +912,14 @@ class MutatingScope implements Scope
 				return new ErrorType();
 			}
 
+			if ($leftStringType instanceof ConstantStringType && $leftStringType->getValue() === '') {
+				return $rightStringType;
+			}
+
+			if ($rightStringType instanceof ConstantStringType && $rightStringType->getValue() === '') {
+				return $leftStringType;
+			}
+
 			if ($leftStringType instanceof ConstantStringType && $rightStringType instanceof ConstantStringType) {
 				return $leftStringType->append($rightStringType);
 			}

--- a/tests/PHPStan/Analyser/data/cast-to-numeric-string.php
+++ b/tests/PHPStan/Analyser/data/cast-to-numeric-string.php
@@ -22,3 +22,40 @@ function foo(int $a, float $b, $numeric, $numeric2, $number, $positive, $negativ
 	assertType('string&numeric', (string)$negative);
 	assertType("'1'", (string)$constantInt);
 }
+
+/**
+ * @param int|float|numeric-string $numeric
+ * @param numeric $numeric2
+ * @param number $number
+ * @param positive-int $positive
+ * @param negative-int $negative
+ * @param 1 $constantInt
+ */
+function concatEmptyString(int $a, float $b, $numeric, $numeric2, $number, $positive, $negative, $constantInt): void {
+	assertType('string&numeric', '' . $a);
+	assertType('string&numeric', '' . $b);
+	assertType('string&numeric', '' . $numeric);
+	assertType('string&numeric', '' . $numeric2);
+	assertType('string&numeric', '' . $number);
+	assertType('string&numeric', '' . $positive);
+	assertType('string&numeric', '' . $negative);
+	assertType("'1'", '' . $constantInt);
+
+	assertType('string&numeric', $a . '');
+	assertType('string&numeric', $b . '');
+	assertType('string&numeric', $numeric . '');
+	assertType('string&numeric', $numeric2 . '');
+	assertType('string&numeric', $number . '');
+	assertType('string&numeric', $positive . '');
+	assertType('string&numeric', $negative . '');
+	assertType("'1'", $constantInt . '');
+}
+
+function concatAssignEmptyString(int $i, float $f) {
+	$i .= '';
+	assertType('string&numeric', $i);
+
+	$s = '';
+	$s .= $f;
+	assertType('string&numeric', $s);
+}


### PR DESCRIPTION
People often use this as an alternative to casting to a string.