### PR TITLE
Use ReturnTypeExtension for mb_str_split

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -10,9 +10,9 @@
  * This contains the information needed to convert the function signatures for php 8.0 to php 7.4 (and vice versa)
  *
  * This has two sections.
- * The 'new' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php7.3 or have different signatures in php 7.4.
+ * The 'new' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php7.4 or have different signatures in php 8.0.
  *   If they were just updated, the function/method will be present in the 'added' signatures.
- * The 'old' signatures contains the signatures that are different in php 7.3.
+ * The 'old' signatures contains the signatures that are different in php 7.4.
  *   Functions are expected to be removed only in major releases of php.
  *
  * @see FunctionSignatureMap.php
@@ -68,6 +68,7 @@ return [
 		'imagerotate' => ['false|object', 'src_im'=>'resource', 'angle'=>'float', 'bgdcolor'=>'int', 'ignoretransparent='=>'int'],
 		'imagescale' => ['false|object', 'im'=>'resource', 'new_width'=>'int', 'new_height='=>'int', 'method='=>'int'],
 		'mb_decode_numericentity' => ['string|false', 'string'=>'string', 'convmap'=>'array', 'encoding='=>'string'],
+		'mb_str_split' => ['array<int,string>', 'str'=>'string', 'split_length='=>'int', 'encoding='=>'string'],
 		'mktime' => ['int|false', 'hour'=>'int', 'minute='=>'int', 'second='=>'int', 'month='=>'int', 'day='=>'int', 'year='=>'int'],
 		'parse_str' => ['void', 'encoded_string'=>'string', '&w_result'=>'array'],
 		'password_hash' => ['string', 'password'=>'string', 'algo'=>'string|int|null', 'options='=>'array'],

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -21,7 +21,7 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
-		return $functionReflection->getName() === 'str_split';
+		return in_array($functionReflection->getName(), ['str_split', 'mb_str_split'], true);
 	}
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9553,6 +9553,68 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		);
 	}
 
+	public function dataPhp74Functions(): array
+	{
+		return [
+			[
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
+				'$mbStrSplitConstantStringWithoutDefinedParameters',
+			],
+			[
+				"array('a', 'b', 'c', 'd', 'e', 'f')",
+				'$mbStrSplitConstantStringWithoutDefinedSplitLength',
+			],
+			[
+				'array<int, string>',
+				'$mbStrSplitStringWithoutDefinedSplitLength',
+			],
+			[
+				"array('a', 'b', 'c', 'd', 'e', 'f')",
+				'$mbStrSplitConstantStringWithOneSplitLength',
+			],
+			[
+				"array('abcdef')",
+				'$mbStrSplitConstantStringWithGreaterSplitLengthThanStringLength',
+			],
+			[
+				'false',
+				'$mbStrSplitConstantStringWithFailureSplitLength',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
+				'$mbStrSplitConstantStringWithInvalidSplitLengthType',
+			],
+			[
+				'array<int, string>',
+				'$mbStrSplitConstantStringWithVariableStringAndConstantSplitLength',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
+				'$mbStrSplitConstantStringWithVariableStringAndVariableSplitLength',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataPhp74Functions
+	 * @param string $description
+	 * @param string $expression
+	 */
+	public function testPhp74Functions(
+		string $description,
+		string $expression
+	): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4');
+		}
+		$this->assertTypes(
+			__DIR__ . '/data/php74_functions.php',
+			$description,
+			$expression
+		);
+	}
+
 	public function dataUnionMethods(): array
 	{
 		return [

--- a/tests/PHPStan/Analyser/data/php74_functions.php
+++ b/tests/PHPStan/Analyser/data/php74_functions.php
@@ -1,0 +1,15 @@
+<?php
+
+// mb_str_split
+/** @var string $string */
+$string = doFoo();
+$mbStrSplitConstantStringWithoutDefinedParameters = mb_str_split();
+$mbStrSplitConstantStringWithoutDefinedSplitLength = mb_str_split('abcdef');
+$mbStrSplitStringWithoutDefinedSplitLength = mb_str_split($string);
+$mbStrSplitConstantStringWithOneSplitLength = mb_str_split('abcdef', 1);
+$mbStrSplitConstantStringWithGreaterSplitLengthThanStringLength = mb_str_split('abcdef', 999);
+$mbStrSplitConstantStringWithFailureSplitLength = mb_str_split('abcdef', 0);
+$mbStrSplitConstantStringWithInvalidSplitLengthType = mb_str_split('abcdef', []);
+$mbStrSplitConstantStringWithVariableStringAndConstantSplitLength = mb_str_split(doFoo() ? 'abcdef' : 'ghijkl', 1);
+$mbStrSplitConstantStringWithVariableStringAndVariableSplitLength = mb_str_split(doFoo() ? 'abcdef' : 'ghijkl', doFoo() ? 1 : 2);
+die;


### PR DESCRIPTION
Shouldn't `mb_str_split` work as `str_split` ? @ondrejmirtes 

I can add tests if you think it's right.