### PR TITLE
Populate scope w/ variables above `use` statements

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -338,6 +338,8 @@ class NodeScopeResolver
 			|| $stmt instanceof If_
 			|| $stmt instanceof While_
 			|| $stmt instanceof Switch_
+			|| $stmt instanceof Node\Stmt\Use_
+			|| $stmt instanceof Node\Stmt\GroupUse
 		) {
 			$scope = $this->processStmtVarAnnotation($scope, $stmt, null);
 		} elseif (

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -358,7 +358,6 @@ class FileTypeMapper
 					foreach ($node->uses as $use) {
 						$uses[strtolower($use->getAlias()->name)] = (string) $use->name;
 					}
-					return null;
 				} elseif ($node instanceof \PhpParser\Node\Stmt\GroupUse) {
 					$prefix = (string) $node->prefix;
 					foreach ($node->uses as $use) {
@@ -368,7 +367,6 @@ class FileTypeMapper
 
 						$uses[strtolower($use->getAlias()->name)] = sprintf('%s\\%s', $prefix, (string) $use->name);
 					}
-					return null;
 				} elseif ($node instanceof Node\Stmt\ClassMethod) {
 					$functionName = $node->name->name;
 					if (array_key_exists($functionName, $traitMethodAliases)) {


### PR DESCRIPTION
Test case 1:
```php
<?php

/**
 * @var stdClass $this
 * @var stdClass $user
 */

use stdClass;

echo $this->foo;

\PHPStan\dumpType($this);
\PHPStan\dumpType($user);

if ($user->last_visit_date === null) {
    return;
}
```

Test case 2:
```php
<?php

/**
 * @var LogicException $this
 */

use \Symfony\Component\Console\Exception\LogicException;

\PHPStan\dumpType($this);
```