### PR TITLE
Improve specified type in comparisons

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -366,7 +366,8 @@ class TypeSpecifier
 			);
 
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Smaller || $expr instanceof Node\Expr\BinaryOp\SmallerOrEqual) {
-			$offset = $expr instanceof Node\Expr\BinaryOp\Smaller ? 1 : 0;
+			$orEqual = $expr instanceof Node\Expr\BinaryOp\SmallerOrEqual;
+			$offset = $orEqual ? 0 : 1;
 			$leftType = $scope->getType($expr->left);
 			$rightType = $scope->getType($expr->right);
 
@@ -426,12 +427,6 @@ class TypeSpecifier
 						$context
 					));
 				}
-
-				$result = $result->unionWith($this->createRangeTypes(
-					$expr->right,
-					IntegerRangeType::fromInterval($leftType->getValue(), null, $offset),
-					$context
-				));
 			}
 
 			if ($rightType instanceof ConstantIntegerType) {
@@ -454,12 +449,22 @@ class TypeSpecifier
 						$context
 					));
 				}
+			}
 
-				$result = $result->unionWith($this->createRangeTypes(
-					$expr->left,
-					IntegerRangeType::fromInterval(null, $rightType->getValue(), -$offset),
-					$context
-				));
+			if ($context->truthy()) {
+				if (!$expr->left instanceof Node\Scalar) {
+					$result = $result->unionWith($this->create($expr->left, $rightType->getSmallerType($orEqual), TypeSpecifierContext::createTruthy()));
+				}
+				if (!$expr->right instanceof Node\Scalar) {
+					$result = $result->unionWith($this->create($expr->right, $leftType->getGreaterType($orEqual), TypeSpecifierContext::createTruthy()));
+				}
+			} elseif ($context->falsey()) {
+				if (!$expr->left instanceof Node\Scalar) {
+					$result = $result->unionWith($this->create($expr->left, $rightType->getGreaterType(!$orEqual), TypeSpecifierContext::createTruthy()));
+				}
+				if (!$expr->right instanceof Node\Scalar) {
+					$result = $result->unionWith($this->create($expr->right, $leftType->getSmallerType(!$orEqual), TypeSpecifierContext::createTruthy()));
+				}
 			}
 
 			return $result;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -453,17 +453,41 @@ class TypeSpecifier
 
 			if ($context->truthy()) {
 				if (!$expr->left instanceof Node\Scalar) {
-					$result = $result->unionWith($this->create($expr->left, $rightType->getSmallerType($orEqual), TypeSpecifierContext::createTruthy()));
+					$result = $result->unionWith(
+						$this->create(
+							$expr->left,
+							$orEqual ? $rightType->getSmallerOrEqualType() : $rightType->getSmallerType(),
+							TypeSpecifierContext::createTruthy()
+						)
+					);
 				}
 				if (!$expr->right instanceof Node\Scalar) {
-					$result = $result->unionWith($this->create($expr->right, $leftType->getGreaterType($orEqual), TypeSpecifierContext::createTruthy()));
+					$result = $result->unionWith(
+						$this->create(
+							$expr->right,
+							$orEqual ? $leftType->getGreaterOrEqualType() : $leftType->getGreaterType(),
+							TypeSpecifierContext::createTruthy()
+						)
+					);
 				}
 			} elseif ($context->falsey()) {
 				if (!$expr->left instanceof Node\Scalar) {
-					$result = $result->unionWith($this->create($expr->left, $rightType->getGreaterType(!$orEqual), TypeSpecifierContext::createTruthy()));
+					$result = $result->unionWith(
+						$this->create(
+							$expr->left,
+							$orEqual ? $rightType->getGreaterType() : $rightType->getGreaterOrEqualType(),
+							TypeSpecifierContext::createTruthy()
+						)
+					);
 				}
 				if (!$expr->right instanceof Node\Scalar) {
-					$result = $result->unionWith($this->create($expr->right, $leftType->getSmallerType(!$orEqual), TypeSpecifierContext::createTruthy()));
+					$result = $result->unionWith(
+						$this->create(
+							$expr->right,
+							$orEqual ? $leftType->getSmallerType() : $leftType->getSmallerOrEqualType(),
+							TypeSpecifierContext::createTruthy()
+						)
+					);
 				}
 			}
 

--- a/src/Type/Constant/ConstantBooleanType.php
+++ b/src/Type/Constant/ConstantBooleanType.php
@@ -4,6 +4,9 @@ namespace PHPStan\Type\Constant;
 
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\Traits\ConstantScalarTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -28,6 +31,38 @@ class ConstantBooleanType extends BooleanType implements ConstantScalarType
 	public function describe(VerbosityLevel $level): string
 	{
 		return $this->value ? 'true' : 'false';
+	}
+
+	public function getSmallerType(bool $orEqual = false): Type
+	{
+		if ($orEqual) {
+			if ($this->value) {
+				return new MixedType();
+			}
+			return StaticTypeFactory::falsey();
+		}
+
+		if ($this->value) {
+			return StaticTypeFactory::falsey();
+		}
+
+		return new NeverType();
+	}
+
+	public function getGreaterType(bool $orEqual = false): Type
+	{
+		if ($orEqual) {
+			if ($this->value) {
+				return StaticTypeFactory::truthy();
+			}
+			return new MixedType();
+		}
+
+		if ($this->value) {
+			return new NeverType();
+		}
+
+		return StaticTypeFactory::truthy();
 	}
 
 	public function toBoolean(): BooleanType

--- a/src/Type/Constant/ConstantBooleanType.php
+++ b/src/Type/Constant/ConstantBooleanType.php
@@ -33,36 +33,36 @@ class ConstantBooleanType extends BooleanType implements ConstantScalarType
 		return $this->value ? 'true' : 'false';
 	}
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
-		if ($orEqual) {
-			if ($this->value) {
-				return new MixedType();
-			}
-			return StaticTypeFactory::falsey();
-		}
-
 		if ($this->value) {
 			return StaticTypeFactory::falsey();
 		}
-
 		return new NeverType();
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getSmallerOrEqualType(): Type
 	{
-		if ($orEqual) {
-			if ($this->value) {
-				return StaticTypeFactory::truthy();
-			}
+		if ($this->value) {
 			return new MixedType();
 		}
+		return StaticTypeFactory::falsey();
+	}
 
+	public function getGreaterType(): Type
+	{
 		if ($this->value) {
 			return new NeverType();
 		}
-
 		return StaticTypeFactory::truthy();
+	}
+
+	public function getGreaterOrEqualType(): Type
+	{
+		if ($this->value) {
+			return StaticTypeFactory::truthy();
+		}
+		return new MixedType();
 	}
 
 	public function toBoolean(): BooleanType

--- a/src/Type/Constant/ConstantFloatType.php
+++ b/src/Type/Constant/ConstantFloatType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Traits\ConstantNumericComparisonTypeTrait;
 use PHPStan\Type\Traits\ConstantScalarTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -15,6 +16,7 @@ class ConstantFloatType extends FloatType implements ConstantScalarType
 
 	use ConstantScalarTypeTrait;
 	use ConstantScalarToBooleanTrait;
+	use ConstantNumericComparisonTypeTrait;
 
 	private float $value;
 

--- a/src/Type/Constant/ConstantIntegerType.php
+++ b/src/Type/Constant/ConstantIntegerType.php
@@ -7,6 +7,7 @@ use PHPStan\Type\CompoundType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\Traits\ConstantNumericComparisonTypeTrait;
 use PHPStan\Type\Traits\ConstantScalarTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -16,6 +17,7 @@ class ConstantIntegerType extends IntegerType implements ConstantScalarType
 
 	use ConstantScalarTypeTrait;
 	use ConstantScalarToBooleanTrait;
+	use ConstantNumericComparisonTypeTrait;
 
 	private int $value;
 

--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -302,40 +302,60 @@ class ConstantStringType extends StringType implements ConstantScalarType
 		return new StringType();
 	}
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
 		$subtractedTypes = [
-			IntegerRangeType::createAllGreaterThan((float) $this->value, !$orEqual),
+			new ConstantBooleanType(true),
+			IntegerRangeType::createAllGreaterThanOrEqualTo((float) $this->value),
 		];
 
-		if ($this->value === '' && !$orEqual) {
+		if ($this->value === '') {
 			$subtractedTypes[] = new NullType();
 			$subtractedTypes[] = new StringType();
 		}
 
-		$boolValue = (bool) $this->value;
-		if (!$boolValue && !$orEqual) {
+		if (!(bool) $this->value) {
 			$subtractedTypes[] = new ConstantBooleanType(false);
 		}
-		if (!$boolValue || !$orEqual) {
+
+		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
+	}
+
+	public function getSmallerOrEqualType(): Type
+	{
+		$subtractedTypes = [
+			IntegerRangeType::createAllGreaterThan((float) $this->value),
+		];
+
+		if (!(bool) $this->value) {
 			$subtractedTypes[] = new ConstantBooleanType(true);
 		}
 
 		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getGreaterType(): Type
 	{
 		$subtractedTypes = [
-			IntegerRangeType::createAllSmallerThan((float) $this->value, !$orEqual),
+			new ConstantBooleanType(false),
+			IntegerRangeType::createAllSmallerThanOrEqualTo((float) $this->value),
 		];
 
-		$boolValue = (bool) $this->value;
-		if ($boolValue || !$orEqual) {
-			$subtractedTypes[] = new ConstantBooleanType(false);
-		}
-		if ($boolValue && !$orEqual) {
+		if ((bool) $this->value) {
 			$subtractedTypes[] = new ConstantBooleanType(true);
+		}
+
+		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
+	}
+
+	public function getGreaterOrEqualType(): Type
+	{
+		$subtractedTypes = [
+			IntegerRangeType::createAllSmallerThan((float) $this->value),
+		];
+
+		if ((bool) $this->value) {
+			$subtractedTypes[] = new ConstantBooleanType(false);
 		}
 
 		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -351,6 +351,20 @@ class IntersectionType implements CompoundType
 		});
 	}
 
+	public function getSmallerType(bool $orEqual = false): Type
+	{
+		return $this->intersectTypes(static function (Type $type) use ($orEqual): Type {
+			return $type->getSmallerType($orEqual);
+		});
+	}
+
+	public function getGreaterType(bool $orEqual = false): Type
+	{
+		return $this->intersectTypes(static function (Type $type) use ($orEqual): Type {
+			return $type->getGreaterType($orEqual);
+		});
+	}
+
 	public function toBoolean(): BooleanType
 	{
 		$type = $this->intersectTypes(static function (Type $type): BooleanType {

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -351,17 +351,31 @@ class IntersectionType implements CompoundType
 		});
 	}
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
-		return $this->intersectTypes(static function (Type $type) use ($orEqual): Type {
-			return $type->getSmallerType($orEqual);
+		return $this->intersectTypes(static function (Type $type): Type {
+			return $type->getSmallerType();
 		});
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getSmallerOrEqualType(): Type
 	{
-		return $this->intersectTypes(static function (Type $type) use ($orEqual): Type {
-			return $type->getGreaterType($orEqual);
+		return $this->intersectTypes(static function (Type $type): Type {
+			return $type->getSmallerOrEqualType();
+		});
+	}
+
+	public function getGreaterType(): Type
+	{
+		return $this->intersectTypes(static function (Type $type): Type {
+			return $type->getGreaterType();
+		});
+	}
+
+	public function getGreaterOrEqualType(): Type
+	{
+		return $this->intersectTypes(static function (Type $type): Type {
+			return $type->getGreaterOrEqualType();
 		});
 	}
 

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -157,29 +157,26 @@ class NullType implements ConstantScalarType
 		return TrinaryLogic::createNo();
 	}
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
-		if ($orEqual) {
-			// All falsey types except '0'
-			return new UnionType([
-				new NullType(),
-				new ConstantBooleanType(false),
-				new ConstantIntegerType(0),
-				new ConstantFloatType(0.0),
-				new ConstantStringType(''),
-				new ConstantArrayType([], []),
-			]);
-		}
-
 		return new NeverType();
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getSmallerOrEqualType(): Type
 	{
-		if ($orEqual) {
-			return new MixedType();
-		}
+		// All falsey types except '0'
+		return new UnionType([
+			new NullType(),
+			new ConstantBooleanType(false),
+			new ConstantIntegerType(0),
+			new ConstantFloatType(0.0),
+			new ConstantStringType(''),
+			new ConstantArrayType([], []),
+		]);
+	}
 
+	public function getGreaterType(): Type
+	{
 		// All truthy types, but also '0'
 		return new MixedType(false, new UnionType([
 			new NullType(),
@@ -189,6 +186,11 @@ class NullType implements ConstantScalarType
 			new ConstantStringType(''),
 			new ConstantArrayType([], []),
 		]));
+	}
+
+	public function getGreaterOrEqualType(): Type
+	{
+		return new MixedType();
 	}
 
 	/**

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -4,6 +4,8 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
@@ -153,6 +155,40 @@ class NullType implements ConstantScalarType
 	public function isNumericString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
+	}
+
+	public function getSmallerType(bool $orEqual = false): Type
+	{
+		if ($orEqual) {
+			// All falsey types except '0'
+			return new UnionType([
+				new NullType(),
+				new ConstantBooleanType(false),
+				new ConstantIntegerType(0),
+				new ConstantFloatType(0.0),
+				new ConstantStringType(''),
+				new ConstantArrayType([], []),
+			]);
+		}
+
+		return new NeverType();
+	}
+
+	public function getGreaterType(bool $orEqual = false): Type
+	{
+		if ($orEqual) {
+			return new MixedType();
+		}
+
+		// All truthy types, but also '0'
+		return new MixedType(false, new UnionType([
+			new NullType(),
+			new ConstantBooleanType(false),
+			new ConstantIntegerType(0),
+			new ConstantFloatType(0.0),
+			new ConstantStringType(''),
+			new ConstantArrayType([], []),
+		]));
 	}
 
 	/**

--- a/src/Type/Traits/ConstantNumericComparisonTypeTrait.php
+++ b/src/Type/Traits/ConstantNumericComparisonTypeTrait.php
@@ -12,37 +12,58 @@ use PHPStan\Type\TypeCombinator;
 trait ConstantNumericComparisonTypeTrait
 {
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
 		$subtractedTypes = [
-			IntegerRangeType::createAllGreaterThan($this->value, !$orEqual),
+			new ConstantBooleanType(true),
+			IntegerRangeType::createAllGreaterThanOrEqualTo($this->value),
 		];
 
-		$boolValue = (bool) $this->value;
-		if (!$boolValue && !$orEqual) {
+		if (!(bool) $this->value) {
 			$subtractedTypes[] = new NullType();
 			$subtractedTypes[] = new ConstantBooleanType(false);
 		}
-		if (!$boolValue || !$orEqual) {
+
+		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
+	}
+
+	public function getSmallerOrEqualType(): Type
+	{
+		$subtractedTypes = [
+			IntegerRangeType::createAllGreaterThan($this->value),
+		];
+
+		if (!(bool) $this->value) {
 			$subtractedTypes[] = new ConstantBooleanType(true);
 		}
 
 		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getGreaterType(): Type
 	{
 		$subtractedTypes = [
-			IntegerRangeType::createAllSmallerThan($this->value, !$orEqual),
+			new NullType(),
+			new ConstantBooleanType(false),
+			IntegerRangeType::createAllSmallerThanOrEqualTo($this->value),
 		];
 
-		$boolValue = (bool) $this->value;
-		if ($boolValue || !$orEqual) {
+		if ((bool) $this->value) {
+			$subtractedTypes[] = new ConstantBooleanType(true);
+		}
+
+		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
+	}
+
+	public function getGreaterOrEqualType(): Type
+	{
+		$subtractedTypes = [
+			IntegerRangeType::createAllSmallerThan($this->value),
+		];
+
+		if ((bool) $this->value) {
 			$subtractedTypes[] = new NullType();
 			$subtractedTypes[] = new ConstantBooleanType(false);
-		}
-		if ($boolValue && !$orEqual) {
-			$subtractedTypes[] = new ConstantBooleanType(true);
 		}
 
 		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));

--- a/src/Type/Traits/ConstantNumericComparisonTypeTrait.php
+++ b/src/Type/Traits/ConstantNumericComparisonTypeTrait.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+trait ConstantNumericComparisonTypeTrait
+{
+
+	public function getSmallerType(bool $orEqual = false): Type
+	{
+		$subtractedTypes = [
+			IntegerRangeType::createAllGreaterThan($this->value, !$orEqual),
+		];
+
+		$boolValue = (bool) $this->value;
+		if (!$boolValue && !$orEqual) {
+			$subtractedTypes[] = new NullType();
+			$subtractedTypes[] = new ConstantBooleanType(false);
+		}
+		if (!$boolValue || !$orEqual) {
+			$subtractedTypes[] = new ConstantBooleanType(true);
+		}
+
+		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
+	}
+
+	public function getGreaterType(bool $orEqual = false): Type
+	{
+		$subtractedTypes = [
+			IntegerRangeType::createAllSmallerThan($this->value, !$orEqual),
+		];
+
+		$boolValue = (bool) $this->value;
+		if ($boolValue || !$orEqual) {
+			$subtractedTypes[] = new NullType();
+			$subtractedTypes[] = new ConstantBooleanType(false);
+		}
+		if ($boolValue && !$orEqual) {
+			$subtractedTypes[] = new ConstantBooleanType(true);
+		}
+
+		return TypeCombinator::remove(new MixedType(), TypeCombinator::union(...$subtractedTypes));
+	}
+
+}

--- a/src/Type/Traits/UndecidedComparisonTypeTrait.php
+++ b/src/Type/Traits/UndecidedComparisonTypeTrait.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 
 trait UndecidedComparisonTypeTrait
@@ -11,6 +12,16 @@ trait UndecidedComparisonTypeTrait
 	public function isSmallerThan(Type $otherType, bool $orEqual = false): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getSmallerType(bool $orEqual = false): Type
+	{
+		return new MixedType();
+	}
+
+	public function getGreaterType(bool $orEqual = false): Type
+	{
+		return new MixedType();
 	}
 
 }

--- a/src/Type/Traits/UndecidedComparisonTypeTrait.php
+++ b/src/Type/Traits/UndecidedComparisonTypeTrait.php
@@ -14,12 +14,22 @@ trait UndecidedComparisonTypeTrait
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
 		return new MixedType();
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getSmallerOrEqualType(): Type
+	{
+		return new MixedType();
+	}
+
+	public function getGreaterType(): Type
+	{
+		return new MixedType();
+	}
+
+	public function getGreaterOrEqualType(): Type
 	{
 		return new MixedType();
 	}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -89,9 +89,13 @@ interface Type
 
 	public function isNumericString(): TrinaryLogic;
 
-	public function getSmallerType(bool $orEqual = false): Type;
+	public function getSmallerType(): Type;
 
-	public function getGreaterType(bool $orEqual = false): Type;
+	public function getSmallerOrEqualType(): Type;
+
+	public function getGreaterType(): Type;
+
+	public function getGreaterOrEqualType(): Type;
 
 	/**
 	 * Infers template types

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -89,6 +89,10 @@ interface Type
 
 	public function isNumericString(): TrinaryLogic;
 
+	public function getSmallerType(bool $orEqual = false): Type;
+
+	public function getGreaterType(bool $orEqual = false): Type;
+
 	/**
 	 * Infers template types
 	 *

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -447,17 +447,31 @@ class UnionType implements CompoundType
 		});
 	}
 
-	public function getSmallerType(bool $orEqual = false): Type
+	public function getSmallerType(): Type
 	{
-		return $this->unionTypes(static function (Type $type) use ($orEqual): Type {
-			return $type->getSmallerType($orEqual);
+		return $this->unionTypes(static function (Type $type): Type {
+			return $type->getSmallerType();
 		});
 	}
 
-	public function getGreaterType(bool $orEqual = false): Type
+	public function getSmallerOrEqualType(): Type
 	{
-		return $this->unionTypes(static function (Type $type) use ($orEqual): Type {
-			return $type->getGreaterType($orEqual);
+		return $this->unionTypes(static function (Type $type): Type {
+			return $type->getSmallerOrEqualType();
+		});
+	}
+
+	public function getGreaterType(): Type
+	{
+		return $this->unionTypes(static function (Type $type): Type {
+			return $type->getGreaterType();
+		});
+	}
+
+	public function getGreaterOrEqualType(): Type
+	{
+		return $this->unionTypes(static function (Type $type): Type {
+			return $type->getGreaterOrEqualType();
 		});
 	}
 

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -447,6 +447,20 @@ class UnionType implements CompoundType
 		});
 	}
 
+	public function getSmallerType(bool $orEqual = false): Type
+	{
+		return $this->unionTypes(static function (Type $type) use ($orEqual): Type {
+			return $type->getSmallerType($orEqual);
+		});
+	}
+
+	public function getGreaterType(bool $orEqual = false): Type
+	{
+		return $this->unionTypes(static function (Type $type) use ($orEqual): Type {
+			return $type->getGreaterType($orEqual);
+		});
+	}
+
 	public function isGreaterThan(Type $otherType, bool $orEqual = false): TrinaryLogic
 	{
 		return $this->unionResults(static function (Type $type) use ($otherType, $orEqual): TrinaryLogic {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -704,10 +704,10 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new LNumber(3)
 				),
 				[
-					'$n' => '~int<3, max>',
+					'$n' => 'mixed~int<3, max>|true',
 				],
 				[
-					'$n' => '~int<min, 2>',
+					'$n' => 'mixed~int<min, 2>|false|null',
 				],
 			],
 			[
@@ -715,16 +715,24 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new Variable('n'),
 					new LNumber(PHP_INT_MIN)
 				),
-				[], // would be nice to specify that $n cannot be an int
-				[],
+				[
+					'$n' => 'mixed~int<' . PHP_INT_MIN . ', max>|true',
+				],
+				[
+					'$n' => 'mixed~false|null',
+				],
 			],
 			[
 				new Expr\BinaryOp\Greater(
 					new Variable('n'),
 					new LNumber(PHP_INT_MAX)
 				),
-				[], // would be nice to specify that $n cannot be an int
-				[],
+				[
+					'$n' => 'mixed~bool|int<min, ' . PHP_INT_MAX . '>|null',
+				],
+				[
+					'$n' => 'mixed',
+				],
 			],
 			[
 				new Expr\BinaryOp\SmallerOrEqual(
@@ -732,10 +740,10 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new LNumber(PHP_INT_MIN)
 				),
 				[
-					'$n' => '~int<' . (PHP_INT_MIN + 1) . ', max>',
+					'$n' => 'mixed~int<' . (PHP_INT_MIN + 1) . ', max>',
 				],
 				[
-					'$n' => '~int<min, ' . PHP_INT_MIN . '>',
+					'$n' => 'mixed~bool|int<min, ' . PHP_INT_MIN . '>|null',
 				],
 			],
 			[
@@ -744,10 +752,10 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new LNumber(PHP_INT_MAX)
 				),
 				[
-					'$n' => '~int<min, ' . (PHP_INT_MAX - 1) . '>',
+					'$n' => 'mixed~int<min, ' . (PHP_INT_MAX - 1) . '>|false|null',
 				],
 				[
-					'$n' => '~int<' . PHP_INT_MAX . ', max>',
+					'$n' => 'mixed~int<' . PHP_INT_MAX . ', max>|true',
 				],
 			],
 			[
@@ -762,10 +770,10 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					)
 				),
 				[
-					'$n' => '~int<min, 2>|int<6, max>',
+					'$n' => 'mixed~int<min, 2>|int<6, max>|false|null',
 				],
 				[
-					'$n' => '~int<3, 5>',
+					'$n' => 'mixed~int<3, 5>|true',
 				],
 			],
 			[
@@ -780,8 +788,8 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					)
 				),
 				[
+					'$n' => 'mixed~int<6, max>',
 					'$foo' => self::SURE_NOT_FALSEY,
-					'$n' => '~int<6, max>',
 				],
 				[],
 			],

--- a/tests/PHPStan/Analyser/data/comparison-operators.php
+++ b/tests/PHPStan/Analyser/data/comparison-operators.php
@@ -93,3 +93,267 @@ class ComparisonOperators
 		}
 	}
 }
+
+class ComparisonOperatorsInTypeSpecifier
+{
+
+	public function null(?int $i, ?float $f, ?string $s, ?bool $b): void
+	{
+		if ($i > null) {
+			assertType('int<min, -1>|int<1, max>', $i);
+		}
+		if ($i >= null) {
+			assertType('int|null', $i);
+		}
+		if ($i < null) {
+			assertType('*NEVER*', $i);
+		}
+		if ($i <= null) {
+			assertType('0|null', $i);
+		}
+
+		if ($f > null) {
+			assertType('float', $f);
+		}
+		if ($f >= null) {
+			assertType('float|null', $f);
+		}
+		if ($f < null) {
+			assertType('*NEVER*', $f);
+		}
+		if ($f <= null) {
+			assertType('0.0|null', $f);
+		}
+
+		if ($s > null) {
+			assertType('string', $s);
+		}
+		if ($s >= null) {
+			assertType('string|null', $s);
+		}
+		if ($s < null) {
+			assertType('*NEVER*', $s);
+		}
+		if ($s <= null) {
+			assertType('\'\'|null', $s);
+		}
+
+		if ($b > null) {
+			assertType('true', $b);
+		}
+		if ($b >= null) {
+			assertType('bool|null', $b);
+		}
+		if ($b < null) {
+			assertType('*NEVER*', $b);
+		}
+		if ($b <= null) {
+			assertType('false|null', $b);
+		}
+	}
+
+	public function bool(?bool $b): void
+	{
+		if ($b > false) {
+			assertType('true', $b);
+		}
+		if ($b >= false) {
+			assertType('bool|null', $b);
+		}
+		if ($b < false) {
+			assertType('*NEVER*', $b);
+		}
+		if ($b <= false) {
+			assertType('false|null', $b);
+		}
+
+		if ($b > true) {
+			assertType('*NEVER*', $b);
+		}
+		if ($b >= true) {
+			assertType('true', $b);
+		}
+		if ($b < true) {
+			assertType('false|null', $b);
+		}
+		if ($b <= true) {
+			assertType('bool|null', $b);
+		}
+	}
+
+	public function string(?string $s): void
+	{
+		if ($s < '') {
+			assertType('*NEVER*', $s);
+		}
+		if ($s <= '') {
+			assertType('string|null', $s); // Would be nice to have ''|null
+		}
+	}
+
+	public function intPositive10(?int $i, ?float $f): void
+	{
+		if ($i > 10) {
+			assertType('int<11, max>', $i);
+		}
+		if ($i >= 10) {
+			assertType('int<10, max>', $i);
+		}
+		if ($i < 10) {
+			assertType('int<min, 9>|null', $i);
+		}
+		if ($i <= 10) {
+			assertType('int<min, 10>|null', $i);
+		}
+
+		if ($f > 10) {
+			assertType('float', $f);
+		}
+		if ($f >= 10) {
+			assertType('float', $f);
+		}
+		if ($f < 10) {
+			assertType('float|null', $f);
+		}
+		if ($f <= 10) {
+			assertType('float|null', $f);
+		}
+	}
+
+	public function intNegative10(?int $i, ?float $f): void
+	{
+		if ($i > -10) {
+			assertType('int<-9, max>', $i);
+		}
+		if ($i >= -10) {
+			assertType('int<-10, max>', $i);
+		}
+		if ($i < -10) {
+			assertType('int<min, -11>|null', $i);
+		}
+		if ($i <= -10) {
+			assertType('int<min, -10>|null', $i);
+		}
+
+		if ($f > -10) {
+			assertType('float', $f);
+		}
+		if ($f >= -10) {
+			assertType('float', $f);
+		}
+		if ($f < -10) {
+			assertType('float|null', $f);
+		}
+		if ($f <= -10) {
+			assertType('float|null', $f);
+		}
+	}
+
+	public function intZero(?int $i, ?float $f): void
+	{
+		if ($i > 0) {
+			assertType('int<1, max>', $i);
+		}
+		if ($i >= 0) {
+			assertType('int<0, max>|null', $i);
+		}
+		if ($i < 0) {
+			assertType('int<min, -1>', $i);
+		}
+		if ($i <= 0) {
+			assertType('int<min, 0>|null', $i);
+		}
+
+		if ($f > 0) {
+			assertType('float', $f);
+		}
+		if ($f >= 0) {
+			assertType('float|null', $f);
+		}
+		if ($f < 0) {
+			assertType('float', $f);
+		}
+		if ($f <= 0) {
+			assertType('float|null', $f);
+		}
+	}
+
+	public function float10(?int $i): void
+	{
+		if ($i > 10.0) {
+			assertType('int<11, max>', $i);
+		}
+		if ($i >= 10.0) {
+			assertType('int<10, max>', $i);
+		}
+		if ($i < 10.0) {
+			assertType('int<min, 9>|null', $i);
+		}
+		if ($i <= 10.0) {
+			assertType('int<min, 10>|null', $i);
+		}
+
+		if ($i > 10.1) {
+			assertType('int<11, max>', $i);
+		}
+		if ($i >= 10.1) {
+			assertType('int<11, max>', $i);
+		}
+		if ($i < 10.1) {
+			assertType('int<min, 10>|null', $i);
+		}
+		if ($i <= 10.1) {
+			assertType('int<min, 10>|null', $i);
+		}
+	}
+
+	public function floatZero(?int $i): void
+	{
+		if ($i > 0.0) {
+			assertType('int<1, max>', $i);
+		}
+		if ($i >= 0.0) {
+			assertType('int<0, max>|null', $i);
+		}
+		if ($i < 0.0) {
+			assertType('int<min, -1>', $i);
+		}
+		if ($i <= 0.0) {
+			assertType('int<min, 0>|null', $i);
+		}
+	}
+
+	public function ranges(int $a, ?int $b): void
+	{
+		if ($a >= 17 && $a <= 42) {
+			if ($b < $a) {
+				assertType('int<min, 41>|null', $b);
+			}
+			if ($b <= $a) {
+				assertType('int<min, 42>|null', $b);
+			}
+			if ($b > $a) {
+				assertType('int<18, max>', $b);
+			}
+			if ($b >= $a) {
+				assertType('int<17, max>', $b);
+			}
+		}
+
+		if ($a >= -17 && $a <= 42) {
+			if ($b < $a) {
+				assertType('int<min, 41>|null', $b);
+			}
+			if ($b <= $a) {
+				assertType('int<min, 42>|null', $b);
+			}
+			if ($b > $a) {
+				assertType('int<-16, max>', $b);
+			}
+			if ($b >= $a) {
+				assertType('int<-17, max>|null', $b);
+			}
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -397,4 +397,10 @@ class CallStaticMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testBug577(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/bug-577.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-577.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-577.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug577;
+
+class Test
+{
+	public static function step1(?int $foo): void
+	{
+		if ($foo > 1) {
+			static::step2($foo);
+		}
+	}
+
+	public static function step2(int $bar): void
+	{
+		var_dump($bar);
+	}
+}

--- a/tests/e2e/baseline.neon
+++ b/tests/e2e/baseline.neon
@@ -161,7 +161,7 @@ parameters:
 			path: PHP-Parser/lib/PhpParser/ParserAbstract.php
 
 		-
-			message: "#^Comparison operation \"\\<\" between array\\|float\\|int\\<0, max\\> and int results in an error\\.$#"
+			message: "#^Comparison operation \"\\<\" between \\(array\\|float\\|int\\<0, max\\>\\) and int results in an error\\.$#"
 			count: 2
 			path: PHP-Parser/lib/PhpParser/ParserAbstract.php
 


### PR DESCRIPTION
Note that this PR has a side-effect that might need to be addressed, consider this code:

```PHP
$array = rand() === 0 ? hash_algos() : false;
for ($i = 0; $i < count($array); $i++) {
	echo $array[$i] . "\n"; // <-- this line
}
```

The change in output is as follows:
```diff
- Cannot access offset int on array|false.
+ Cannot access offset int<min, 9223372036854775806> on array|false.
```
While technically correct, this is not very pretty.

Perhaps this can be fixed by adjusting how `IntegerRangeType` is represented. Currently, `int<0, max>` (return value of `count()`) is internally represented by `min=0, max=PHP_INT_MAX`, which is technically a bounded interval. If it were to use `min=0, max=null` instead, then the intended meaning of an open interval can be represented more accurately and the new code in this PR could make use of that information. If this sounds good I'll have a go at it.