### PR TITLE
is_a(): specify class-string types if allow_string: true

### DIFF
--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -11,13 +11,14 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
-use PHPStan\Type\StringType;
 
 class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
@@ -65,7 +66,11 @@ class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtens
 
 		if (isset($node->args[2]) && $context->true()) {
 			if (!$scope->getType($node->args[2]->value)->isSuperTypeOf(new ConstantBooleanType(true))->no()) {
-				$types = $types->intersectWith($this->typeSpecifier->create($node->args[0]->value, new StringType(), $context));
+				$types = $types->intersectWith($this->typeSpecifier->create(
+					$node->args[0]->value,
+					isset($objectType) ? new GenericClassStringType($objectType) : new ClassStringType(),
+					$context
+				));
 			}
 		}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -443,7 +443,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new Arg(new String_('Foo')),
 					new Arg(new Expr\ConstFetch(new Name('true'))),
 				]),
-				['$foo' => 'Foo|string'],
+				['$foo' => 'class-string<Foo>|Foo'],
 				['$foo' => '~Foo'],
 			],
 			[
@@ -452,7 +452,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new Arg(new Variable('className')),
 					new Arg(new Expr\ConstFetch(new Name('true'))),
 				]),
-				['$foo' => 'object|string'],
+				['$foo' => 'class-string<object>|object'],
 				[],
 			],
 			[
@@ -461,7 +461,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new Arg(new String_('Foo')),
 					new Arg(new Variable('unknown')),
 				]),
-				['$foo' => 'Foo|string'],
+				['$foo' => 'class-string<Foo>|Foo'],
 				['$foo' => '~Foo'],
 			],
 			[
@@ -470,7 +470,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					new Arg(new Variable('className')),
 					new Arg(new Variable('unknown')),
 				]),
-				['$foo' => 'object|string'],
+				['$foo' => 'class-string<object>|object'],
 				[],
 			],
 			[


### PR DESCRIPTION
`is_a($foo, Foo::class, true)` is now able to narrow `$foo` to `class-string<Foo>` instead of just `string`