### PR TITLE
is_a(): support class-string in parameter $class

### DIFF
--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -57,6 +57,9 @@ class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtens
 		} elseif ($classNameArgExprType instanceof ConstantStringType) {
 			$objectType = new ObjectType($classNameArgExprType->getValue());
 			$types = $this->typeSpecifier->create($node->args[0]->value, $objectType, $context);
+		} elseif ($classNameArgExprType instanceof GenericClassStringType) {
+			$objectType = $classNameArgExprType->getGenericType();
+			$types = $this->typeSpecifier->create($node->args[0]->value, $objectType, $context);
 		} elseif ($context->true()) {
 			$objectType = new ObjectWithoutClassType();
 			$types = $this->typeSpecifier->create($node->args[0]->value, $objectType, $context);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -9981,6 +9981,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/is-numeric.php');
 	}
 
+	public function dataIsA(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/is-a.php');
+	}
+
 	public function dataBug3142(): array
 	{
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-3142.php');
@@ -10537,6 +10542,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataExtDs
 	 * @dataProvider dataArrowFunctionReturnTypeInference
 	 * @dataProvider dataIsNumeric
+	 * @dataProvider dataIsA
 	 * @dataProvider dataBug3142
 	 * @dataProvider dataArrayShapeKeysStrings
 	 * @dataProvider dataBug1216

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -17,7 +17,9 @@ use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\VarLikeIdentifier;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
@@ -57,6 +59,8 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 		$this->scope = $this->scope->assignVariable('stringOrFalse', new UnionType([new StringType(), new ConstantBooleanType(false)]));
 		$this->scope = $this->scope->assignVariable('array', new ArrayType(new MixedType(), new MixedType()));
 		$this->scope = $this->scope->assignVariable('foo', new MixedType());
+		$this->scope = $this->scope->assignVariable('classString', new ClassStringType());
+		$this->scope = $this->scope->assignVariable('genericClassString', new GenericClassStringType(new ObjectType('Bar')));
 	}
 
 	/**
@@ -436,6 +440,22 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 				]),
 				['$foo' => 'static(DateTime)'],
 				['$foo' => '~static(DateTime)'],
+			],
+			[
+				new FuncCall(new Name('is_a'), [
+					new Arg(new Variable('foo')),
+					new Arg(new Variable('classString')),
+				]),
+				['$foo' => 'object'],
+				[],
+			],
+			[
+				new FuncCall(new Name('is_a'), [
+					new Arg(new Variable('foo')),
+					new Arg(new Variable('genericClassString')),
+				]),
+				['$foo' => 'Bar'],
+				['$foo' => '~Bar'],
 			],
 			[
 				new FuncCall(new Name('is_a'), [

--- a/tests/PHPStan/Analyser/data/is-a.php
+++ b/tests/PHPStan/Analyser/data/is-a.php
@@ -1,0 +1,28 @@
+<?php
+
+function (object $foo) {
+	if (is_a($foo, Foo::class)) {
+		\PHPStan\Analyser\assertType('Foo', $foo);
+	}
+};
+
+function (object $foo) {
+	/** @var class-string<Foo> $fooClassString */
+	$fooClassString = 'Foo';
+
+	if (is_a($foo, $fooClassString)) {
+		\PHPStan\Analyser\assertType('Foo', $foo);
+	}
+};
+
+function (string $foo) {
+	if (is_a($foo, Foo::class, true)) {
+		\PHPStan\Analyser\assertType('class-string<Foo>', $foo);
+	}
+};
+
+function (string $foo, string $someString) {
+	if (is_a($foo, $someString, true)) {
+		\PHPStan\Analyser\assertType('class-string<object>', $foo);
+	}
+};


### PR DESCRIPTION
Follow-up to #392, should fix phpstan/phpstan#2799