### PR TITLE
CallableType: accept [class-string, constant-string] array as callable

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -13,6 +13,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -367,6 +368,8 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				return ConstantArrayTypeAndMethod::createUnknown();
 			}
 			$type = new ObjectType($broker->getClass($classOrObject->getValue())->getName());
+		} elseif ($classOrObject instanceof GenericClassStringType) {
+			$type = $classOrObject->getGenericType();
 		} elseif ((new \PHPStan\Type\ObjectWithoutClassType())->isSuperTypeOf($classOrObject)->yes()) {
 			$type = $classOrObject;
 		} else {

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -6,6 +6,10 @@ use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\HasMethodType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -336,6 +340,17 @@ class CallableTypeTest extends \PHPStan\Testing\TestCase
 			[
 				new CallableType(),
 				TypeCombinator::intersect(new ArrayType(new MixedType(), new MixedType()), new CallableType()),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new CallableType(),
+				new ConstantArrayType([
+					new ConstantIntegerType(0),
+					new ConstantIntegerType(1),
+				], [
+					new GenericClassStringType(new ObjectType(\Closure::class)),
+					new ConstantStringType('bind'),
+				]),
 				TrinaryLogic::createYes(),
 			],
 		];

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -5,12 +5,14 @@ namespace PHPStan\Type\Constant;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -708,6 +710,17 @@ class ConstantArrayTypeTest extends \PHPStan\Testing\TestCase
 				new ConstantStringType('bind'),
 			]),
 			TrinaryLogic::createNo(),
+		];
+
+		yield 'class-string' => [
+			new ConstantArrayType([
+				new ConstantIntegerType(0),
+				new ConstantIntegerType(1),
+			], [
+				new GenericClassStringType(new ObjectType(\Closure::class)),
+				new ConstantStringType('bind'),
+			]),
+			TrinaryLogic::createYes(),
 		];
 	}
 


### PR DESCRIPTION
Should fix phpstan/phpstan#2880. Constant array type of `[class-string, constant-string]` wasn't considered callable.