### PR TITLE
Allow `is_subclass_of` with second parameter of type `class-string`

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -10,16 +10,21 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\VerbosityLevel;
+
+use function get_class;
 
 class ImpossibleCheckTypeHelper
 {
@@ -131,6 +136,14 @@ class ImpossibleCheckTypeHelper
 								return null;
 							}
 						}
+					}
+				} elseif ($functionName === 'is_subclass_of') {
+					$classType = $scope->getType($node->args[1]->value);
+
+					if (get_class($classType) === ClassStringType::class
+						|| ($classType instanceof GenericClassStringType
+							&& $classType->getGenericType() instanceof ObjectWithoutClassType)) {
+						return null;
 					}
 				} elseif ($functionName === 'method_exists' && count($node->args) >= 2) {
 					$objectType = $scope->getType($node->args[0]->value);

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -238,6 +238,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends \PHPStan\Testing\RuleTestC
 					'Call to function property_exists() with CheckTypeFunctionCall\Bug2221 and \'foo\' will always evaluate to true.',
 					786,
 				],
+				[
+					'Call to function is_subclass_of() with \'DateTime\' and class-string<DateTimeInterface> will always evaluate to true.',
+					857,
+				],
 			]
 		);
 	}
@@ -383,6 +387,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends \PHPStan\Testing\RuleTestC
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-3994.php'], []);
+	}
+
+	public function testIsSubclassOfClassStringDoesNotReturnError(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/class-strings.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -845,3 +845,15 @@ class InArray2
 	}
 
 }
+
+class IsSubclassOfMatchingClassString
+{
+	/**
+	 * @param class-string<\DateTimeInterface> $classString
+	 * @return bool
+	 */
+	public function doFoo(string $classString): bool
+	{
+		return is_subclass_of(\DateTime::class, $classString);
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/class-strings.php
+++ b/tests/PHPStan/Rules/Comparison/data/class-strings.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ClassStrings;
+
+use stdClass;
+
+class IsSubclassOfClassStrings
+{
+	/**
+	 * @param class-string $classString
+	 * @return bool
+	 */
+	public function doFoo(string $classString): bool
+	{
+		return is_subclass_of(stdClass::class, $classString);
+	}
+
+	/**
+	 * @param class-string<object> $classString
+	 * @return bool
+	 */
+	public function doBar(string $classString): bool
+	{
+		return is_subclass_of(stdClass::class, $classString);
+	}
+}


### PR DESCRIPTION
The following code should not report an error anymore:

```php
class SomeClass
{
	/**
	 * @param class-string $classString
	 */
	public function foo(string $classString): bool
	{
		return is_subclass_of(DateTimeInterface::class, $classString);
	}

	/**
	 * @param class-string<object> $classString
	 */
	public function bar(string $classString): bool
	{
		return is_subclass_of(DateTimeInterface::class, $classString);
	}
}
```

But this one will still report an error:

```php
class SomeClass
{
	/**
	 * @param class-string<DateTimeInterface> $classString
	 */
	public function foo(string $classString): bool
	{
		return is_subclass_of(DateTimeInterface::class, $classString);
	}
}
```

Closes phpstan/phpstan#2755