### PR TITLE
Check name startline in autoload source locator

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php
@@ -221,7 +221,7 @@ class AutoloadSourceLocator implements SourceLocator
 					if (count($classNode->getNode()->attrGroups) > 0 && PHP_VERSION_ID < 80000) {
 						$startLine--;
 					}
-					if ($startLine !== $classNode->getNode()->getStartLine()) {
+					if ($classNode->getNode()->name === null || $startLine !== $classNode->getNode()->name->getStartLine()) {
 						continue;
 					}
 				}


### PR DESCRIPTION
This checks the name identifier start line instead of the start line for the ClassLike file as a whole.

Fixes https://github.com/phpstan/phpstan/issues/4194