### PR TITLE
Make IntegerRangeType represent open intervals properly

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1461,11 +1461,7 @@ class MutatingScope implements Scope
 				}
 				return TypeCombinator::union(...$newTypes);
 			} elseif ($varType instanceof IntegerRangeType) {
-				$shift = $node instanceof Expr\PreInc ? +1 : -1;
-				return IntegerRangeType::fromInterval(
-					$varType->getMin() === PHP_INT_MIN ? PHP_INT_MIN : $varType->getMin() + $shift,
-					$varType->getMax() === PHP_INT_MAX ? PHP_INT_MAX : $varType->getMax() + $shift
-				);
+				return $varType->shift($node instanceof Expr\PreInc ? +1 : -1);
 			}
 
 			$stringType = new StringType();

--- a/src/Rules/Functions/RandomIntParametersRule.php
+++ b/src/Rules/Functions/RandomIntParametersRule.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\IntegerRangeType;
-use PHPStan\Type\IntegerType;
 use PHPStan\Type\VerbosityLevel;
 
 /**
@@ -45,35 +44,25 @@ class RandomIntParametersRule implements \PHPStan\Rules\Rule
 
 		$minType = $scope->getType($node->args[0]->value)->toInteger();
 		$maxType = $scope->getType($node->args[1]->value)->toInteger();
-		$integerType = new IntegerType();
 
-		if ($minType->equals($integerType) || $maxType->equals($integerType)) {
+		if (
+			!$minType instanceof ConstantIntegerType && !$minType instanceof IntegerRangeType
+			|| !$maxType instanceof ConstantIntegerType && !$maxType instanceof IntegerRangeType
+		) {
 			return [];
 		}
 
-		if ($minType instanceof ConstantIntegerType || $minType instanceof IntegerRangeType) {
-			if ($minType instanceof ConstantIntegerType) {
-				$maxPermittedType = IntegerRangeType::fromInterval($minType->getValue(), PHP_INT_MAX);
-			} else {
-				$maxPermittedType = IntegerRangeType::fromInterval($minType->getMax(), PHP_INT_MAX);
-			}
+		$isSmaller = $maxType->isSmallerThan($minType);
 
-			if (!$maxPermittedType->isSuperTypeOf($maxType)->yes()) {
-				$message = 'Parameter #1 $min (%s) of function random_int expects lower number than parameter #2 $max (%s).';
-
-				// True if sometimes the parameters conflict.
-				$isMaybe = !$maxType->isSuperTypeOf($minType)->no();
-
-				if (!$isMaybe || $this->reportMaybes) {
-					return [
-						RuleErrorBuilder::message(sprintf(
-							$message,
-							$minType->describe(VerbosityLevel::value()),
-							$maxType->describe(VerbosityLevel::value())
-						))->build(),
-					];
-				}
-			}
+		if ($isSmaller->yes() || $isSmaller->maybe() && $this->reportMaybes) {
+			$message = 'Parameter #1 $min (%s) of function random_int expects lower number than parameter #2 $max (%s).';
+			return [
+				RuleErrorBuilder::message(sprintf(
+					$message,
+					$minType->describe(VerbosityLevel::value()),
+					$maxType->describe(VerbosityLevel::value())
+				))->build(),
+			];
 		}
 
 		return [];

--- a/src/Type/Constant/ConstantIntegerType.php
+++ b/src/Type/Constant/ConstantIntegerType.php
@@ -37,7 +37,9 @@ class ConstantIntegerType extends IntegerType implements ConstantScalarType
 		}
 
 		if ($type instanceof IntegerRangeType) {
-			if ($type->getMin() <= $this->value && $this->value <= $type->getMax()) {
+			$min = $type->getMin();
+			$max = $type->getMax();
+			if (($min === null || $min <= $this->value) && ($max === null || $this->value <= $max)) {
 				return TrinaryLogic::createMaybe();
 			}
 

--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -9,67 +9,51 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 class IntegerRangeType extends IntegerType implements CompoundType
 {
 
-	private int $min;
+	private ?int $min;
 
-	private int $max;
+	private ?int $max;
 
 	private function __construct(?int $min, ?int $max)
 	{
 		assert($min === null || $max === null || $min <= $max);
+		assert($min !== null || $max !== null);
 
-		$this->min = $min ?? PHP_INT_MIN;
-		$this->max = $max ?? PHP_INT_MAX;
+		$this->min = $min;
+		$this->max = $max;
 	}
-
 
 	public static function fromInterval(?int $min, ?int $max, int $shift = 0): Type
 	{
-		$min = $min ?? PHP_INT_MIN;
-		$max = $max ?? PHP_INT_MAX;
-
-		if ($shift !== 0) {
-			if ($shift < 0) {
-				if ($max < PHP_INT_MIN - $shift) {
-					return new NeverType();
-				}
-				if ($max !== PHP_INT_MAX) {
-					$max += $shift;
-				}
-				$min = $min < PHP_INT_MIN - $shift ? PHP_INT_MIN : $min + $shift;
-			} else {
-				if ($min > PHP_INT_MAX - $shift) {
-					return new NeverType();
-				}
-				if ($min !== PHP_INT_MIN) {
-					$min += $shift;
-				}
-				$max = $max > PHP_INT_MAX - $shift ? PHP_INT_MAX : $max + $shift;
+		if ($min !== null && $max !== null) {
+			if ($min > $max) {
+				return new NeverType();
+			}
+			if ($min === $max) {
+				return new ConstantIntegerType($min + $shift);
 			}
 		}
 
-		if ($min > $max) {
-			return new NeverType();
-		}
-
-		if ($min === $max) {
-			return new ConstantIntegerType($min);
-		}
-
-		if ($min === PHP_INT_MIN && $max === PHP_INT_MAX) {
+		if ($min === null && $max === null) {
 			return new IntegerType();
 		}
 
-		return new self($min, $max);
+		return (new self($min, $max))->shift($shift);
 	}
 
+	protected static function isDisjoint(?int $minA, ?int $maxA, ?int $minB, ?int $maxB, bool $touchingIsDisjoint = true): bool
+	{
+		$offset = $touchingIsDisjoint ? 0 : 1;
+		return $minA !== null && $maxB !== null && $minA > $maxB + $offset
+			|| $maxA !== null && $minB !== null && $maxA + $offset < $minB;
+	}
 
-	public function getMin(): int
+	public function getMin(): ?int
 	{
 		return $this->min;
 	}
 
 
-	public function getMax(): int
+	public function getMax(): ?int
 	{
 		return $this->max;
 	}
@@ -77,42 +61,49 @@ class IntegerRangeType extends IntegerType implements CompoundType
 
 	public function describe(VerbosityLevel $level): string
 	{
-		if ($this->min === PHP_INT_MIN) {
-			return sprintf('int<min, %d>', $this->max);
+		return sprintf('int<%s, %s>', $this->min ?? 'min', $this->max ?? 'max');
+	}
+
+
+	public function shift(int $amount): Type
+	{
+		if ($amount === 0) {
+			return $this;
 		}
 
-		if ($this->max === PHP_INT_MAX) {
-			return sprintf('int<%d, max>', $this->min);
+		$min = $this->min;
+		$max = $this->max;
+
+		if ($amount < 0) {
+			if ($max !== null) {
+				if ($max < PHP_INT_MIN - $amount) {
+					return new NeverType();
+				}
+				$max += $amount;
+			}
+			if ($min !== null) {
+				$min = $min < PHP_INT_MIN - $amount ? null : $min + $amount;
+			}
+		} else {
+			if ($min !== null) {
+				if ($min > PHP_INT_MAX - $amount) {
+					return new NeverType();
+				}
+				$min += $amount;
+			}
+			if ($max !== null) {
+				$max = $max > PHP_INT_MAX - $amount ? null : $max + $amount;
+			}
 		}
 
-		return sprintf('int<%d, %d>', $this->min, $this->max);
+		return self::fromInterval($min, $max);
 	}
 
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
-		if ($type instanceof self) {
-			if ($this->min > $type->max || $this->max < $type->min) {
-				return TrinaryLogic::createNo();
-			}
-
-			if ($this->min <= $type->min && $this->max >= $type->max) {
-				return TrinaryLogic::createYes();
-			}
-
-			return TrinaryLogic::createMaybe();
-		}
-
-		if ($type instanceof ConstantIntegerType) {
-			if ($this->min <= $type->getValue() && $type->getValue() <= $this->max) {
-				return TrinaryLogic::createYes();
-			}
-
-			return TrinaryLogic::createNo();
-		}
-
 		if ($type instanceof parent) {
-			return TrinaryLogic::createMaybe();
+			return $this->isSuperTypeOf($type);
 		}
 
 		if ($type instanceof CompoundType) {
@@ -125,24 +116,27 @@ class IntegerRangeType extends IntegerType implements CompoundType
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
-		if ($type instanceof self) {
-			if ($this->min > $type->max || $this->max < $type->min) {
+		if ($type instanceof self || $type instanceof ConstantIntegerType) {
+			if ($type instanceof self) {
+				$typeMin = $type->min;
+				$typeMax = $type->max;
+			} else {
+				$typeMin = $type->getValue();
+				$typeMax = $type->getValue();
+			}
+
+			if (self::isDisjoint($this->min, $this->max, $typeMin, $typeMax)) {
 				return TrinaryLogic::createNo();
 			}
 
-			if ($this->min <= $type->min && $this->max >= $type->max) {
+			if (
+				($this->min === null || $typeMin !== null && $this->min <= $typeMin)
+				&& ($this->max === null || $typeMax !== null && $this->max >= $typeMax)
+			) {
 				return TrinaryLogic::createYes();
 			}
 
 			return TrinaryLogic::createMaybe();
-		}
-
-		if ($type instanceof ConstantIntegerType) {
-			if ($this->min <= $type->getValue() && $type->getValue() <= $this->max) {
-				return TrinaryLogic::createYes();
-			}
-
-			return TrinaryLogic::createNo();
 		}
 
 		if ($type instanceof parent) {
@@ -187,18 +181,36 @@ class IntegerRangeType extends IntegerType implements CompoundType
 
 	public function isSmallerThan(Type $otherType, bool $orEqual = false): TrinaryLogic
 	{
-		return TrinaryLogic::extremeIdentity(
-			(new ConstantIntegerType($this->min))->isSmallerThan($otherType, $orEqual),
-			(new ConstantIntegerType($this->max))->isSmallerThan($otherType, $orEqual)
-		);
+		if ($this->min === null) {
+			$minIsSmaller = TrinaryLogic::createYes();
+		} else {
+			$minIsSmaller = (new ConstantIntegerType($this->min))->isSmallerThan($otherType, $orEqual);
+		}
+
+		if ($this->max === null) {
+			$maxIsSmaller = TrinaryLogic::createNo();
+		} else {
+			$maxIsSmaller = (new ConstantIntegerType($this->max))->isSmallerThan($otherType, $orEqual);
+		}
+
+		return TrinaryLogic::extremeIdentity($minIsSmaller, $maxIsSmaller);
 	}
 
 	public function isGreaterThan(Type $otherType, bool $orEqual = false): TrinaryLogic
 	{
-		return TrinaryLogic::extremeIdentity(
-			$otherType->isSmallerThan((new ConstantIntegerType($this->min)), $orEqual),
-			$otherType->isSmallerThan((new ConstantIntegerType($this->max)), $orEqual)
-		);
+		if ($this->min === null) {
+			$minIsSmaller = TrinaryLogic::createNo();
+		} else {
+			$minIsSmaller = $otherType->isSmallerThan((new ConstantIntegerType($this->min)), $orEqual);
+		}
+
+		if ($this->max === null) {
+			$maxIsSmaller = TrinaryLogic::createYes();
+		} else {
+			$maxIsSmaller = $otherType->isSmallerThan((new ConstantIntegerType($this->max)), $orEqual);
+		}
+
+		return TrinaryLogic::extremeIdentity($minIsSmaller, $maxIsSmaller);
 	}
 
 	public function toNumber(): Type
@@ -220,6 +232,136 @@ class IntegerRangeType extends IntegerType implements CompoundType
 		return new ConstantBooleanType(false);
 	}
 
+	/**
+	 * Return the union with another type, but only if it can be expressed in a simpler way than using UnionType
+	 *
+	 * @param Type $otherType
+	 * @return Type|null
+	 */
+	public function tryUnion(Type $otherType): ?Type
+	{
+		if ($otherType instanceof self || $otherType instanceof ConstantIntegerType) {
+			if ($otherType instanceof self) {
+				$otherMin = $otherType->min;
+				$otherMax = $otherType->max;
+			} else {
+				$otherMin = $otherType->getValue();
+				$otherMax = $otherType->getValue();
+			}
+
+			if (self::isDisjoint($this->min, $this->max, $otherMin, $otherMax, false)) {
+				return null;
+			}
+
+			return self::fromInterval(
+				$this->min !== null && $otherMin !== null ? min($this->min, $otherMin) : null,
+				$this->max !== null && $otherMax !== null ? max($this->max, $otherMax) : null
+			);
+		}
+
+		if (get_class($otherType) === parent::class) {
+			return $otherType;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return the intersection with another type, but only if it can be expressed in a simpler way than using
+	 * IntersectionType
+	 *
+	 * @param Type $otherType
+	 * @return Type|null
+	 */
+	public function tryIntersect(Type $otherType): ?Type
+	{
+		if ($otherType instanceof self || $otherType instanceof ConstantIntegerType) {
+			if ($otherType instanceof self) {
+				$otherMin = $otherType->min;
+				$otherMax = $otherType->max;
+			} else {
+				$otherMin = $otherType->getValue();
+				$otherMax = $otherType->getValue();
+			}
+
+			if (self::isDisjoint($this->min, $this->max, $otherMin, $otherMax, false)) {
+				return new NeverType();
+			}
+
+			if ($this->min === null) {
+				$newMin = $otherMin;
+			} elseif ($otherMin === null) {
+				$newMin = $this->min;
+			} else {
+				$newMin = max($this->min, $otherMin);
+			}
+
+			if ($this->max === null) {
+				$newMax = $otherMax;
+			} elseif ($otherMax === null) {
+				$newMax = $this->max;
+			} else {
+				$newMax = min($this->max, $otherMax);
+			}
+
+			return self::fromInterval($newMin, $newMax);
+		}
+
+		if (get_class($otherType) === parent::class) {
+			return $this;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return the different with another type, or null if it cannot be represented.
+	 *
+	 * @param Type $typeToRemove
+	 * @return Type|null
+	 */
+	public function tryRemove(Type $typeToRemove): ?Type
+	{
+		if (get_class($typeToRemove) === parent::class) {
+			return new NeverType();
+		}
+
+		if ($typeToRemove instanceof IntegerRangeType || $typeToRemove instanceof ConstantIntegerType) {
+			if ($typeToRemove instanceof IntegerRangeType) {
+				$removeMin = $typeToRemove->min;
+				$removeMax = $typeToRemove->max;
+			} else {
+				$removeMin = $typeToRemove->getValue();
+				$removeMax = $typeToRemove->getValue();
+			}
+
+			if (
+				$this->min !== null && $removeMax !== null && $removeMax < $this->min
+				|| $this->max !== null && $removeMin !== null && $this->max < $removeMin
+			) {
+				return $this;
+			}
+
+			if ($removeMin !== null && $removeMin !== PHP_INT_MIN) {
+				$lowerPart = self::fromInterval($this->min, $removeMin - 1);
+			} else {
+				$lowerPart = null;
+			}
+			if ($removeMax !== null && $removeMax !== PHP_INT_MAX) {
+				$upperPart = self::fromInterval($removeMax + 1, $this->max);
+			} else {
+				$upperPart = null;
+			}
+
+			if ($lowerPart !== null && $upperPart !== null) {
+				return TypeCombinator::union($lowerPart, $upperPart);
+			}
+
+			return $lowerPart ?? $upperPart;
+		}
+
+		return null;
+	}
 
 	/**
 	 * @param mixed[] $properties

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -87,7 +87,7 @@ class UnionTypeHelper
 			}
 
 			if ($a instanceof IntegerRangeType && $b instanceof IntegerRangeType) {
-				return $a->getMin() <=> $b->getMin();
+				return ($a->getMin() ?? PHP_INT_MIN) <=> ($b->getMin() ?? PHP_INT_MIN);
 			}
 
 			if ($a instanceof ConstantStringType && $b instanceof ConstantStringType) {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -735,7 +735,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					'$n' => '~int<' . (PHP_INT_MIN + 1) . ', max>',
 				],
 				[
-					'$n' => '~' . PHP_INT_MIN,
+					'$n' => '~int<min, ' . PHP_INT_MIN . '>',
 				],
 			],
 			[
@@ -747,7 +747,7 @@ class TypeSpecifierTest extends \PHPStan\Testing\TestCase
 					'$n' => '~int<min, ' . (PHP_INT_MAX - 1) . '>',
 				],
 				[
-					'$n' => '~' . PHP_INT_MAX,
+					'$n' => '~int<' . PHP_INT_MAX . ', max>',
 				],
 			],
 			[


### PR DESCRIPTION
This removes the usage of `PHP_INT_MIN` and `PHP_INT_MAX` to mark open-ended intervals and instead uses `null` for that purpose.  Since using `getMin()` and `getMax()` now became slightly more complicated for callers, a lot of `IntegerRangeType`-related logic has been moved into the class itself.

I especially like that some type combinator logic is now inside the type class, but without too much pressure, since it is allowed to return `null` when it can't handle the situation. Perhaps this could be extended into the entire `Type` hierarchy.