### PR TITLE
Fix function signatures for preg_replace_callback[_array] for PHP 7.4+

### DIFF
--- a/resources/functionMap_php74delta.php
+++ b/resources/functionMap_php74delta.php
@@ -43,6 +43,8 @@ return [
 		'password_algos' => ['array<int, string>'],
 		'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'string|null', 'options='=>'array'],
 		'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'string|null', 'options='=>'array'],
+		'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int', 'flags='=>'int'],
+		'preg_replace_callback_array' => ['string|array|null', 'pattern'=>'array<string,callable>', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int', 'flags='=>'int'],
 		'sapi_windows_set_ctrl_handler' => ['bool', 'callable'=>'callable', 'add='=>'bool'],
 		'ReflectionProperty::getType' => ['?ReflectionType'],
 		'ReflectionProperty::hasType' => ['bool'],


### PR DESCRIPTION
Current function signatures for `preg_replace_callback` and `preg_replace_callback_array` do not include the `$flags` argument introduced in PHP 7.4 (see https://www.php.net/manual/en/function.preg-replace-callback.php and https://www.php.net/manual/en/function.preg-replace-callback-array.php). This pull request should (hopefully) fix that.