### PR TITLE
Support `@psalm-pure` and `@phpstan-pure` annotations

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2442,6 +2442,7 @@ class MutatingScope implements Scope
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
+	 * @param bool|null $isPure
 	 * @return self
 	 */
 	public function enterClassMethod(
@@ -2454,7 +2455,7 @@ class MutatingScope implements Scope
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure
+		?bool $isPure = null
 	): self
 	{
 		if (!$this->isInClass()) {
@@ -2535,6 +2536,7 @@ class MutatingScope implements Scope
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
+	 * @param bool|null $isPure
 	 * @return self
 	 */
 	public function enterFunction(
@@ -2547,7 +2549,7 @@ class MutatingScope implements Scope
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure
+		?bool $isPure = null
 	): self
 	{
 		return $this->enterFunctionLike(

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2453,7 +2453,8 @@ class MutatingScope implements Scope
 		?string $deprecatedDescription,
 		bool $isDeprecated,
 		bool $isInternal,
-		bool $isFinal
+		bool $isFinal,
+		bool $isPure
 	): self
 	{
 		if (!$this->isInClass()) {
@@ -2476,7 +2477,8 @@ class MutatingScope implements Scope
 				$deprecatedDescription,
 				$isDeprecated,
 				$isInternal,
-				$isFinal
+				$isFinal,
+				$isPure
 			),
 			!$classMethod->isStatic()
 		);
@@ -2544,7 +2546,8 @@ class MutatingScope implements Scope
 		?string $deprecatedDescription,
 		bool $isDeprecated,
 		bool $isInternal,
-		bool $isFinal
+		bool $isFinal,
+		bool $isPure
 	): self
 	{
 		return $this->enterFunctionLike(
@@ -2562,7 +2565,8 @@ class MutatingScope implements Scope
 				$deprecatedDescription,
 				$isDeprecated,
 				$isInternal,
-				$isFinal
+				$isFinal,
+				$isPure
 			),
 			false
 		);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -393,7 +393,7 @@ class NodeScopeResolver
 					}
 				}
 			}
-			[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal] = $this->getPhpDocs($scope, $stmt);
+			[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure] = $this->getPhpDocs($scope, $stmt);
 
 			foreach ($stmt->params as $param) {
 				$this->processParamNode($param, $scope, $nodeCallback);
@@ -412,7 +412,8 @@ class NodeScopeResolver
 				$deprecatedDescription,
 				$isDeprecated,
 				$isInternal,
-				$isFinal
+				$isFinal,
+				$isPure
 			);
 			$nodeCallback(new InFunctionNode($stmt), $functionScope);
 
@@ -440,7 +441,7 @@ class NodeScopeResolver
 					}
 				}
 			}
-			[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal] = $this->getPhpDocs($scope, $stmt);
+			[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure] = $this->getPhpDocs($scope, $stmt);
 
 			foreach ($stmt->params as $param) {
 				$this->processParamNode($param, $scope, $nodeCallback);
@@ -474,7 +475,8 @@ class NodeScopeResolver
 				$deprecatedDescription,
 				$isDeprecated,
 				$isInternal,
-				$isFinal
+				$isFinal,
+				$isPure
 			);
 
 			if ($stmt->name->toLowerString() === '__construct') {
@@ -2893,7 +2895,7 @@ class NodeScopeResolver
 	/**
 	 * @param Scope $scope
 	 * @param Node\FunctionLike $functionLike
-	 * @return array{TemplateTypeMap, Type[], ?Type, ?Type, ?string, bool, bool, bool}
+	 * @return array{TemplateTypeMap, Type[], ?Type, ?Type, ?string, bool, bool, bool, bool}
 	 */
 	public function getPhpDocs(Scope $scope, Node\FunctionLike $functionLike): array
 	{
@@ -2905,6 +2907,7 @@ class NodeScopeResolver
 		$isDeprecated = false;
 		$isInternal = false;
 		$isFinal = false;
+		$isPure = false;
 		$docComment = $functionLike->getDocComment() !== null
 			? $functionLike->getDocComment()->getText()
 			: null;
@@ -3001,9 +3004,10 @@ class NodeScopeResolver
 			$isDeprecated = $resolvedPhpDoc->isDeprecated();
 			$isInternal = $resolvedPhpDoc->isInternal();
 			$isFinal = $resolvedPhpDoc->isFinal();
+			$isPure = $resolvedPhpDoc->isPure();
 		}
 
-		return [$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal];
+		return [$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure];
 	}
 
 	private function getPhpDocReturnType(ResolvedPhpDocBlock $resolvedPhpDoc, Type $nativeReturnType): ?Type

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2895,7 +2895,7 @@ class NodeScopeResolver
 	/**
 	 * @param Scope $scope
 	 * @param Node\FunctionLike $functionLike
-	 * @return array{TemplateTypeMap, Type[], ?Type, ?Type, ?string, bool, bool, bool, bool}
+	 * @return array{TemplateTypeMap, Type[], ?Type, ?Type, ?string, bool, bool, bool, bool|null}
 	 */
 	public function getPhpDocs(Scope $scope, Node\FunctionLike $functionLike): array
 	{

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -398,6 +398,17 @@ class PhpDocNodeResolver
 		return false;
 	}
 
+	public function resolveIsImpure(PhpDocNode $phpDocNode): bool
+	{
+		foreach ($phpDocNode->getTags() as $phpDocTagNode) {
+			if (in_array($phpDocTagNode->name, ['@impure', '@phpstan-impure'], true)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private function shouldSkipType(string $tagName, Type $type): bool
 	{
 		if (strpos($tagName, '@psalm-') !== 0) {

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -390,7 +390,7 @@ class PhpDocNodeResolver
 	public function resolveIsPure(PhpDocNode $phpDocNode): bool
 	{
 		foreach ($phpDocNode->getTags() as $phpDocTagNode) {
-			if (in_array($phpDocTagNode->name, ['@psalm-pure', '@phpstan-pure'], true)) {
+			if (in_array($phpDocTagNode->name, ['@pure', '@psalm-pure', '@phpstan-pure'], true)) {
 				return true;
 			}
 		}

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -387,6 +387,17 @@ class PhpDocNodeResolver
 		return count($finalTags) > 0;
 	}
 
+	public function resolveIsPure(PhpDocNode $phpDocNode): bool
+	{
+		foreach ($phpDocNode->getTags() as $phpDocTagNode) {
+			if (in_array($phpDocTagNode->name, ['@psalm-pure', '@phpstan-pure'], true)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private function shouldSkipType(string $tagName, Type $type): bool
 	{
 		if (strpos($tagName, '@psalm-') !== 0) {

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -70,6 +70,8 @@ class ResolvedPhpDocBlock
 
 	private ?bool $isFinal = null;
 
+	private ?bool $isPure = null;
+
 	private function __construct()
 	{
 	}
@@ -129,6 +131,7 @@ class ResolvedPhpDocBlock
 		$self->isDeprecated = false;
 		$self->isInternal = false;
 		$self->isFinal = false;
+		$self->isPure = false;
 
 		return $self;
 	}
@@ -164,6 +167,8 @@ class ResolvedPhpDocBlock
 		$result->isDeprecated = $result->deprecatedTag !== null;
 		$result->isInternal = $this->isInternal();
 		$result->isFinal = $this->isFinal();
+		$result->isPure = $this->isPure();
+
 		return $result;
 	}
 
@@ -204,6 +209,7 @@ class ResolvedPhpDocBlock
 		$self->isDeprecated = $this->isDeprecated;
 		$self->isInternal = $this->isInternal;
 		$self->isFinal = $this->isFinal;
+		$self->isPure = $this->isPure;
 
 		return $self;
 	}
@@ -415,6 +421,16 @@ class ResolvedPhpDocBlock
 	public function getTemplateTypeMap(): TemplateTypeMap
 	{
 		return $this->templateTypeMap;
+	}
+
+	public function isPure(): bool
+	{
+		if ($this->isPure === null) {
+			$this->isPure = $this->phpDocNodeResolver->resolveIsPure(
+				$this->phpDocNode
+			);
+		}
+		return $this->isPure;
 	}
 
 	/**

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -167,7 +167,7 @@ class ResolvedPhpDocBlock
 		$result->isDeprecated = $result->deprecatedTag !== null;
 		$result->isInternal = $this->isInternal();
 		$result->isFinal = $this->isFinal();
-		$result->isPure = $this->isPure();
+		$result->isPure = $this->isPure() ?? false;
 
 		return $result;
 	}
@@ -423,14 +423,18 @@ class ResolvedPhpDocBlock
 		return $this->templateTypeMap;
 	}
 
-	public function isPure(): bool
+	public function isPure(): ?bool
 	{
 		if ($this->isPure === null) {
 			$this->isPure = $this->phpDocNodeResolver->resolveIsPure(
 				$this->phpDocNode
 			);
 		}
-		return $this->isPure;
+		if (!$this->isPure) {
+			return null;
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -270,6 +270,7 @@ class BetterReflectionProvider implements ReflectionProvider
 		$isDeprecated = false;
 		$isInternal = false;
 		$isFinal = false;
+		$isPure = false;
 		$resolvedPhpDoc = $this->stubPhpDocProvider->findFunctionPhpDoc($reflectionFunction->getName());
 		if ($resolvedPhpDoc === null && $reflectionFunction->getFileName() !== false && $reflectionFunction->getDocComment() !== false) {
 			$fileName = $reflectionFunction->getFileName();
@@ -286,6 +287,7 @@ class BetterReflectionProvider implements ReflectionProvider
 			$isDeprecated = $resolvedPhpDoc->isDeprecated();
 			$isInternal = $resolvedPhpDoc->isInternal();
 			$isFinal = $resolvedPhpDoc->isFinal();
+			$isPure = $resolvedPhpDoc->isPure();
 		}
 
 		return $this->functionReflectionFactory->create(
@@ -300,6 +302,7 @@ class BetterReflectionProvider implements ReflectionProvider
 			$isDeprecated,
 			$isInternal,
 			$isFinal,
+			$isPure,
 			$reflectionFunction->getFileName()
 		);
 	}

--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -302,8 +302,8 @@ class BetterReflectionProvider implements ReflectionProvider
 			$isDeprecated,
 			$isInternal,
 			$isFinal,
-			$isPure,
-			$reflectionFunction->getFileName()
+			$reflectionFunction->getFileName(),
+			$isPure
 		);
 	}
 

--- a/src/Reflection/FunctionReflectionFactory.php
+++ b/src/Reflection/FunctionReflectionFactory.php
@@ -32,6 +32,7 @@ interface FunctionReflectionFactory
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
+		bool $isPure,
 		$filename
 	): PhpFunctionReflection;
 

--- a/src/Reflection/FunctionReflectionFactory.php
+++ b/src/Reflection/FunctionReflectionFactory.php
@@ -20,6 +20,7 @@ interface FunctionReflectionFactory
 	 * @param bool $isInternal
 	 * @param bool $isFinal
 	 * @param string|false $filename
+	 * @param bool|null $isPure
 	 * @return PhpFunctionReflection
 	 */
 	public function create(
@@ -32,8 +33,8 @@ interface FunctionReflectionFactory
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure,
-		$filename
+		$filename,
+		?bool $isPure = null
 	): PhpFunctionReflection;
 
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -680,8 +680,8 @@ class PhpClassReflectionExtension
 			$isDeprecated,
 			$isInternal,
 			$isFinal,
-			$isPure,
-			$stubPhpDocString
+			$stubPhpDocString,
+			$isPure
 		);
 	}
 

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -598,6 +598,7 @@ class PhpClassReflectionExtension
 		$isDeprecated = false;
 		$isInternal = false;
 		$isFinal = false;
+		$isPure = false;
 		if (
 			$methodReflection instanceof NativeBuiltinMethodReflection
 			&& $methodReflection->isConstructor()
@@ -664,6 +665,7 @@ class PhpClassReflectionExtension
 			$isDeprecated = $resolvedPhpDoc->isDeprecated();
 			$isInternal = $resolvedPhpDoc->isInternal();
 			$isFinal = $resolvedPhpDoc->isFinal();
+			$isPure = $resolvedPhpDoc->isPure();
 		}
 
 		return $this->methodReflectionFactory->create(
@@ -678,6 +680,7 @@ class PhpClassReflectionExtension
 			$isDeprecated,
 			$isInternal,
 			$isFinal,
+			$isPure,
 			$stubPhpDocString
 		);
 	}
@@ -933,7 +936,7 @@ class PhpClassReflectionExtension
 			$constructor,
 			$namespace
 		)->enterClass($declaringClass);
-		[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal] = $this->nodeScopeResolver->getPhpDocs($classScope, $methodNode);
+		[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure] = $this->nodeScopeResolver->getPhpDocs($classScope, $methodNode);
 		$methodScope = $classScope->enterClassMethod(
 			$methodNode,
 			$templateTypeMap,
@@ -943,7 +946,8 @@ class PhpClassReflectionExtension
 			$deprecatedDescription,
 			$isDeprecated,
 			$isInternal,
-			$isFinal
+			$isFinal,
+			$isPure
 		);
 
 		$propertyTypes = [];

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -44,7 +44,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 
 	private bool $isFinal;
 
-	private bool $isPure;
+	private ?bool $isPure;
 
 	/** @var FunctionVariantWithPhpDocs[]|null */
 	private ?array $variants = null;
@@ -62,6 +62,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
+	 * @param bool|null $isPure
 	 */
 	public function __construct(
 		FunctionLike $functionLike,
@@ -76,7 +77,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		bool $isDeprecated = false,
 		bool $isInternal = false,
 		bool $isFinal = false,
-		bool $isPure = false
+		?bool $isPure = null
 	)
 	{
 		$this->functionLike = $functionLike;
@@ -217,8 +218,8 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		if ($this->getReturnType() instanceof VoidType) {
 			return TrinaryLogic::createYes();
 		}
-		if ($this->isPure) {
-			return TrinaryLogic::createNo();
+		if ($this->isPure !== null) {
+			return TrinaryLogic::createFromBoolean(!$this->isPure);
 		}
 
 		return TrinaryLogic::createMaybe();

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -44,6 +44,8 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 
 	private bool $isFinal;
 
+	private bool $isPure;
+
 	/** @var FunctionVariantWithPhpDocs[]|null */
 	private ?array $variants = null;
 
@@ -73,7 +75,8 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		?string $deprecatedDescription = null,
 		bool $isDeprecated = false,
 		bool $isInternal = false,
-		bool $isFinal = false
+		bool $isFinal = false,
+		bool $isPure = false
 	)
 	{
 		$this->functionLike = $functionLike;
@@ -88,6 +91,7 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		$this->isDeprecated = $isDeprecated;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
+		$this->isPure = $isPure;
 	}
 
 	protected function getFunctionLike(): FunctionLike
@@ -213,6 +217,10 @@ class PhpFunctionFromParserNodeReflection implements \PHPStan\Reflection\Functio
 		if ($this->getReturnType() instanceof VoidType) {
 			return TrinaryLogic::createYes();
 		}
+		if ($this->isPure) {
+			return TrinaryLogic::createNo();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -49,6 +49,8 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 
 	private bool $isFinal;
 
+	private bool $isPure;
+
 	/** @var string|false */
 	private $filename;
 
@@ -83,6 +85,7 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
+		bool $isPure,
 		$filename
 	)
 	{
@@ -98,6 +101,7 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 		$this->deprecatedDescription = $deprecatedDescription;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
+		$this->isPure = $isPure;
 		$this->filename = $filename;
 	}
 
@@ -283,6 +287,10 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 		if ($this->getReturnType() instanceof VoidType) {
 			return TrinaryLogic::createYes();
 		}
+		if ($this->isPure) {
+			return TrinaryLogic::createNo();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -49,10 +49,10 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 
 	private bool $isFinal;
 
-	private bool $isPure;
-
 	/** @var string|false */
 	private $filename;
+
+	private ?bool $isPure;
 
 	/** @var FunctionVariantWithPhpDocs[]|null */
 	private ?array $variants = null;
@@ -71,6 +71,7 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 	 * @param bool $isInternal
 	 * @param bool $isFinal
 	 * @param string|false $filename
+	 * @param bool|null $isPure
 	 */
 	public function __construct(
 		\ReflectionFunction $reflection,
@@ -85,8 +86,8 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure,
-		$filename
+		$filename,
+		?bool $isPure = null
 	)
 	{
 		$this->reflection = $reflection;
@@ -101,8 +102,8 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 		$this->deprecatedDescription = $deprecatedDescription;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
-		$this->isPure = $isPure;
 		$this->filename = $filename;
+		$this->isPure = $isPure;
 	}
 
 	public function getName(): string
@@ -287,8 +288,8 @@ class PhpFunctionReflection implements FunctionReflection, ReflectionWithFilenam
 		if ($this->getReturnType() instanceof VoidType) {
 			return TrinaryLogic::createYes();
 		}
-		if ($this->isPure) {
-			return TrinaryLogic::createNo();
+		if ($this->isPure !== null) {
+			return TrinaryLogic::createFromBoolean(!$this->isPure);
 		}
 
 		return TrinaryLogic::createMaybe();

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -35,6 +35,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 	 * @param bool $isDeprecated
 	 * @param bool $isInternal
 	 * @param bool $isFinal
+	 * @param bool|null $isPure
 	 */
 	public function __construct(
 		ClassReflection $declaringClass,
@@ -50,7 +51,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure
+		?bool $isPure = null
 	)
 	{
 		$name = strtolower($classMethod->name->name);

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -49,7 +49,8 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		?string $deprecatedDescription,
 		bool $isDeprecated,
 		bool $isInternal,
-		bool $isFinal
+		bool $isFinal,
+		bool $isPure
 	)
 	{
 		$name = strtolower($classMethod->name->name);
@@ -87,7 +88,8 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 			$deprecatedDescription,
 			$isDeprecated,
 			$isInternal,
-			$isFinal || $classMethod->isFinal()
+			$isFinal || $classMethod->isFinal(),
+			$isPure
 		);
 		$this->declaringClass = $declaringClass;
 	}

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -70,7 +70,7 @@ class PhpMethodReflection implements MethodReflection
 
 	private bool $isFinal;
 
-	private bool $isPure;
+	private ?bool $isPure;
 
 	private ?string $stubPhpDocString;
 
@@ -110,8 +110,8 @@ class PhpMethodReflection implements MethodReflection
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure,
-		?string $stubPhpDocString
+		?string $stubPhpDocString,
+		?bool $isPure = null
 	)
 	{
 		$this->declaringClass = $declaringClass;
@@ -129,8 +129,8 @@ class PhpMethodReflection implements MethodReflection
 		$this->isDeprecated = $isDeprecated;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
-		$this->isPure = $isPure;
 		$this->stubPhpDocString = $stubPhpDocString;
+		$this->isPure = $isPure;
 	}
 
 	public function getDeclaringClass(): ClassReflection
@@ -454,8 +454,8 @@ class PhpMethodReflection implements MethodReflection
 		if ($this->getReturnType() instanceof VoidType) {
 			return TrinaryLogic::createYes();
 		}
-		if ($this->isPure) {
-			return TrinaryLogic::createNo();
+		if ($this->isPure !== null) {
+			return TrinaryLogic::createFromBoolean(!$this->isPure);
 		}
 
 		return TrinaryLogic::createMaybe();

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -70,6 +70,8 @@ class PhpMethodReflection implements MethodReflection
 
 	private bool $isFinal;
 
+	private bool $isPure;
+
 	private ?string $stubPhpDocString;
 
 	/** @var FunctionVariantWithPhpDocs[]|null */
@@ -108,6 +110,7 @@ class PhpMethodReflection implements MethodReflection
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
+		bool $isPure,
 		?string $stubPhpDocString
 	)
 	{
@@ -126,6 +129,7 @@ class PhpMethodReflection implements MethodReflection
 		$this->isDeprecated = $isDeprecated;
 		$this->isInternal = $isInternal;
 		$this->isFinal = $isFinal;
+		$this->isPure = $isPure;
 		$this->stubPhpDocString = $stubPhpDocString;
 	}
 
@@ -450,6 +454,10 @@ class PhpMethodReflection implements MethodReflection
 		if ($this->getReturnType() instanceof VoidType) {
 			return TrinaryLogic::createYes();
 		}
+		if ($this->isPure) {
+			return TrinaryLogic::createNo();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 

--- a/src/Reflection/Php/PhpMethodReflectionFactory.php
+++ b/src/Reflection/Php/PhpMethodReflectionFactory.php
@@ -22,6 +22,7 @@ interface PhpMethodReflectionFactory
 	 * @param bool $isInternal
 	 * @param bool $isFinal
 	 * @param string|null $stubPhpDocString
+	 * @param bool|null $isPure
 	 *
 	 * @return \PHPStan\Reflection\Php\PhpMethodReflection
 	 */
@@ -37,8 +38,8 @@ interface PhpMethodReflectionFactory
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
-		bool $isPure,
-		?string $stubPhpDocString
+		?string $stubPhpDocString,
+		?bool $isPure = null
 	): PhpMethodReflection;
 
 }

--- a/src/Reflection/Php/PhpMethodReflectionFactory.php
+++ b/src/Reflection/Php/PhpMethodReflectionFactory.php
@@ -37,6 +37,7 @@ interface PhpMethodReflectionFactory
 		bool $isDeprecated,
 		bool $isInternal,
 		bool $isFinal,
+		bool $isPure,
 		?string $stubPhpDocString
 	): PhpMethodReflection;
 

--- a/src/Reflection/Runtime/RuntimeReflectionProvider.php
+++ b/src/Reflection/Runtime/RuntimeReflectionProvider.php
@@ -259,6 +259,7 @@ class RuntimeReflectionProvider implements ReflectionProvider
 		$isDeprecated = false;
 		$isInternal = false;
 		$isFinal = false;
+		$isPure = false;
 		$resolvedPhpDoc = $this->stubPhpDocProvider->findFunctionPhpDoc($reflectionFunction->getName());
 		if ($resolvedPhpDoc === null && $reflectionFunction->getFileName() !== false && $reflectionFunction->getDocComment() !== false) {
 			$fileName = $reflectionFunction->getFileName();
@@ -275,6 +276,7 @@ class RuntimeReflectionProvider implements ReflectionProvider
 			$isDeprecated = $resolvedPhpDoc->isDeprecated();
 			$isInternal = $resolvedPhpDoc->isInternal();
 			$isFinal = $resolvedPhpDoc->isFinal();
+			$isPure = $resolvedPhpDoc->isPure();
 		}
 
 		$functionReflection = $this->functionReflectionFactory->create(
@@ -289,6 +291,7 @@ class RuntimeReflectionProvider implements ReflectionProvider
 			$isDeprecated,
 			$isInternal,
 			$isFinal,
+			$isPure,
 			$reflectionFunction->getFileName()
 		);
 		$this->customFunctionReflections[$lowerCasedFunctionName] = $functionReflection;

--- a/src/Reflection/Runtime/RuntimeReflectionProvider.php
+++ b/src/Reflection/Runtime/RuntimeReflectionProvider.php
@@ -291,8 +291,8 @@ class RuntimeReflectionProvider implements ReflectionProvider
 			$isDeprecated,
 			$isInternal,
 			$isFinal,
-			$isPure,
-			$reflectionFunction->getFileName()
+			$reflectionFunction->getFileName(),
+			$isPure
 		);
 		$this->customFunctionReflections[$lowerCasedFunctionName] = $functionReflection;
 

--- a/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
+++ b/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
@@ -29,6 +29,7 @@ class InvalidPHPStanDocTagRule implements \PHPStan\Rules\Rule
 		'@phpstan-ignore-next-line',
 		'@phpstan-ignore-line',
 		'@phpstan-method',
+		'@phpstan-pure',
 	];
 
 	private Lexer $phpDocLexer;

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -291,6 +291,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			 * @param bool $isInternal
 			 * @param bool $isFinal
 			 * @param string|null $stubPhpDocString
+			 * @param bool|null $isPure
 			 * @return PhpMethodReflection
 			 */
 			public function create(
@@ -305,8 +306,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 				bool $isDeprecated,
 				bool $isInternal,
 				bool $isFinal,
-				bool $isPure,
-				?string $stubPhpDocString
+				?string $stubPhpDocString,
+				?bool $isPure = null
 			): PhpMethodReflection
 			{
 				return new PhpMethodReflection(
@@ -325,8 +326,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 					$isDeprecated,
 					$isInternal,
 					$isFinal,
-					$isPure,
-					$stubPhpDocString
+					$stubPhpDocString,
+					$isPure
 				);
 			}
 
@@ -494,6 +495,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 			 * @param bool $isInternal
 			 * @param bool $isFinal
 			 * @param string|false $filename
+			 * @param bool|null $isPure
 			 * @return PhpFunctionReflection
 			 */
 			public function create(
@@ -506,8 +508,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 				bool $isDeprecated,
 				bool $isInternal,
 				bool $isFinal,
-				bool $isPure,
-				$filename
+				$filename,
+				?bool $isPure = null
 			): PhpFunctionReflection
 			{
 				return new PhpFunctionReflection(
@@ -523,8 +525,8 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 					$isDeprecated,
 					$isInternal,
 					$isFinal,
-					$isPure,
-					$filename
+					$filename,
+					$isPure
 				);
 			}
 

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -305,6 +305,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 				bool $isDeprecated,
 				bool $isInternal,
 				bool $isFinal,
+				bool $isPure,
 				?string $stubPhpDocString
 			): PhpMethodReflection
 			{
@@ -324,6 +325,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 					$isDeprecated,
 					$isInternal,
 					$isFinal,
+					$isPure,
 					$stubPhpDocString
 				);
 			}
@@ -504,6 +506,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 				bool $isDeprecated,
 				bool $isInternal,
 				bool $isFinal,
+				bool $isPure,
 				$filename
 			): PhpFunctionReflection
 			{
@@ -520,6 +523,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 					$isDeprecated,
 					$isInternal,
 					$isFinal,
+					$isPure,
 					$filename
 				);
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10700,6 +10700,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-4343.php');
 	}
 
+	public function dataImpureMethod(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/impure-method.php');
+	}
+
 	/**
 	 * @param string $file
 	 * @return array<string, mixed[]>
@@ -10905,6 +10910,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug4188
 	 * @dataProvider dataBug4339
 	 * @dataProvider dataBug4343
+	 * @dataProvider dataImpureMethod
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/impure-method.php
+++ b/tests/PHPStan/Analyser/data/impure-method.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace ImpureMethod;
+
+use function PHPStan\Analyser\assertType;
+
+class Foo
+{
+
+	/** @var int */
+	private $fooProp;
+
+	public function voidMethod(): void
+	{
+		$this->fooProp = rand(0, 1);
+	}
+
+	public function ordinaryMethod(): int
+	{
+		return 1;
+	}
+
+	/**
+	 * @phpstan-impure
+	 * @return int
+	 */
+	public function impureMethod(): int
+	{
+		$this->fooProp = rand(0, 1);
+
+		return $this->fooProp;
+	}
+
+	/**
+	 * @impure
+	 * @return int
+	 */
+	public function impureMethod2(): int
+	{
+		$this->fooProp = rand(0, 1);
+
+		return $this->fooProp;
+	}
+
+	public function doFoo(): void
+	{
+		$this->fooProp = 1;
+		assertType('1', $this->fooProp);
+
+		$this->voidMethod();
+		assertType('int', $this->fooProp);
+	}
+
+	public function doBar(): void
+	{
+		$this->fooProp = 1;
+		assertType('1', $this->fooProp);
+
+		$this->ordinaryMethod();
+		assertType('1', $this->fooProp);
+	}
+
+	public function doBaz(): void
+	{
+		$this->fooProp = 1;
+		assertType('1', $this->fooProp);
+
+		$this->impureMethod();
+		assertType('int', $this->fooProp);
+	}
+
+	public function doLorem(): void
+	{
+		$this->fooProp = 1;
+		assertType('1', $this->fooProp);
+
+		$this->impureMethod2();
+		assertType('int', $this->fooProp);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionStamentWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionStamentWithoutSideEffectsRuleTest.php
@@ -28,14 +28,19 @@ class CallToFunctionStamentWithoutSideEffectsRuleTest extends RuleTestCase
 
 	public function testPhpDoc(): void
 	{
+		require_once __DIR__ . '/data/function-call-statement-no-side-effects-phpdoc-definition.php';
 		$this->analyse([__DIR__ . '/data/function-call-statement-no-side-effects-phpdoc.php'], [
 			[
 				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure1() on a separate line has no effect.',
-				15,
+				8,
 			],
 			[
 				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure2() on a separate line has no effect.',
-				16,
+				9,
+			],
+			[
+				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure3() on a separate line has no effect.',
+				10,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionStamentWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionStamentWithoutSideEffectsRuleTest.php
@@ -26,4 +26,18 @@ class CallToFunctionStamentWithoutSideEffectsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhpDoc(): void
+	{
+		$this->analyse([__DIR__ . '/data/function-call-statement-no-side-effects-phpdoc.php'], [
+			[
+				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure1() on a separate line has no effect.',
+				15,
+			],
+			[
+				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure2() on a separate line has no effect.',
+				16,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc-definition.php
+++ b/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc-definition.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FunctionCallStatementNoSideEffectsPhpDoc;
+
+function regular(string $a): string {return $a;}
+
+/**
+ * @phpstan-pure
+ */
+function pure1(string $a): string {return $a;}
+
+/**
+ * @psalm-pure
+ */
+function pure2(string $a): string {return $a;}
+
+/**
+ * @pure
+ */
+function pure3(string $a): string {return $a;}

--- a/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc.php
@@ -2,15 +2,10 @@
 
 namespace FunctionCallStatementNoSideEffectsPhpDoc;
 
-function regular(string $a): string {return $a;}
-/**
- * @phpstan-pure
- */
-function pure1(string $a): string {return $a;}
-/**
- * @psalm-pure
- */
-function pure2(string $a): string {return $a;}
-regular('test');
-pure1('test');
-pure2('test');
+function(): void
+{
+	regular('test');
+	pure1('test');
+	pure2('test');
+	pure3('test');
+};

--- a/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FunctionCallStatementNoSideEffectsPhpDoc;
+
+function regular(string $a): string {return $a;}
+/**
+ * @phpstan-pure
+ */
+function pure1(string $a): string {return $a;}
+/**
+ * @psalm-pure
+ */
+function pure2(string $a): string {return $a;}
+regular('test');
+pure1('test');
+pure2('test');

--- a/tests/PHPStan/Rules/Methods/CallToMethodStamentWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStamentWithoutSideEffectsRuleTest.php
@@ -54,4 +54,18 @@ class CallToMethodStamentWithoutSideEffectsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4232.php'], []);
 	}
 
+	public function testPhpDoc(): void
+	{
+		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects-phpdoc.php'], [
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bzz::pure1() on a separate line has no effect.',
+				17,
+			],
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bzz::pure2() on a separate line has no effect.',
+				18,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/CallToMethodStamentWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStamentWithoutSideEffectsRuleTest.php
@@ -59,11 +59,15 @@ class CallToMethodStamentWithoutSideEffectsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects-phpdoc.php'], [
 			[
 				'Call to method MethodCallStatementNoSideEffects\Bzz::pure1() on a separate line has no effect.',
-				17,
+				39,
 			],
 			[
 				'Call to method MethodCallStatementNoSideEffects\Bzz::pure2() on a separate line has no effect.',
-				18,
+				40,
+			],
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bzz::pure3() on a separate line has no effect.',
+				41,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStamentWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStamentWithoutSideEffectsRuleTest.php
@@ -44,11 +44,15 @@ class CallToStaticMethodStamentWithoutSideEffectsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects-phpdoc.php'], [
 			[
 				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure1() on a separate line has no effect.',
-				17,
+				39,
 			],
 			[
 				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure2() on a separate line has no effect.',
-				18,
+				40,
+			],
+			[
+				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure3() on a separate line has no effect.',
+				41,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStamentWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStamentWithoutSideEffectsRuleTest.php
@@ -39,4 +39,18 @@ class CallToStaticMethodStamentWithoutSideEffectsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhpDoc(): void
+	{
+		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects-phpdoc.php'], [
+			[
+				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure1() on a separate line has no effect.',
+				17,
+			],
+			[
+				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure2() on a separate line has no effect.',
+				18,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/method-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Methods/data/method-call-statement-no-side-effects-phpdoc.php
@@ -2,17 +2,41 @@
 
 namespace MethodCallStatementNoSideEffects;
 
-class Bzz {
-	function regular(string $a): string {return $a;}
+class Bzz
+{
+	function regular(string $a): string
+	{
+		return $a;
+	}
+
 	/**
 	 * @phpstan-pure
 	 */
-	function pure1(string $a): string {return $a;}
+	function pure1(string $a): string
+	{
+		return $a;
+	}
+
 	/**
 	 * @psalm-pure
 	 */
-	function pure2(string $a): string {return $a;}
+	function pure2(string $a): string
+	{
+		return $a;
+	}
+
+	/**
+	 * @psalm-pure
+	 */
+	function pure3(string $a): string
+	{
+		return $a;
+	}
 }
-(new Bzz())->regular('test');
-(new Bzz())->pure1('test');
-(new Bzz())->pure2('test');
+
+function(): void {
+	(new Bzz())->regular('test');
+	(new Bzz())->pure1('test');
+	(new Bzz())->pure2('test');
+	(new Bzz())->pure3('test');
+};

--- a/tests/PHPStan/Rules/Methods/data/method-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Methods/data/method-call-statement-no-side-effects-phpdoc.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace MethodCallStatementNoSideEffects;
+
+class Bzz {
+	function regular(string $a): string {return $a;}
+	/**
+	 * @phpstan-pure
+	 */
+	function pure1(string $a): string {return $a;}
+	/**
+	 * @psalm-pure
+	 */
+	function pure2(string $a): string {return $a;}
+}
+(new Bzz())->regular('test');
+(new Bzz())->pure1('test');
+(new Bzz())->pure2('test');

--- a/tests/PHPStan/Rules/Methods/data/static-method-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Methods/data/static-method-call-statement-no-side-effects-phpdoc.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace StaticMethodCallStatementNoSideEffects;
+
+class BzzStatic {
+	static function regular(string $a): string {return $a;}
+	/**
+	 * @phpstan-pure
+	 */
+	static function pure1(string $a): string {return $a;}
+	/**
+	 * @psalm-pure
+	 */
+	static function pure2(string $a): string {return $a;}
+}
+BzzStatic::regular('test');
+BzzStatic::pure1('test');
+BzzStatic::pure2('test');

--- a/tests/PHPStan/Rules/Methods/data/static-method-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Methods/data/static-method-call-statement-no-side-effects-phpdoc.php
@@ -2,17 +2,41 @@
 
 namespace StaticMethodCallStatementNoSideEffects;
 
-class BzzStatic {
-	static function regular(string $a): string {return $a;}
+class BzzStatic
+{
+	static function regular(string $a): string
+	{
+		return $a;
+	}
+
 	/**
 	 * @phpstan-pure
 	 */
-	static function pure1(string $a): string {return $a;}
+	static function pure1(string $a): string
+	{
+		return $a;
+	}
+
 	/**
 	 * @psalm-pure
 	 */
-	static function pure2(string $a): string {return $a;}
+	static function pure2(string $a): string
+	{
+		return $a;
+	}
+
+	/**
+	 * @pure
+	 */
+	static function pure3(string $a): string
+	{
+		return $a;
+	}
 }
-BzzStatic::regular('test');
-BzzStatic::pure1('test');
-BzzStatic::pure2('test');
+
+function(): void {
+	BzzStatic::regular('test');
+	BzzStatic::pure1('test');
+	BzzStatic::pure2('test');
+	BzzStatic::pure3('test');
+};


### PR DESCRIPTION
1. `CallToFunctionStamentWithoutSideEffectsRuleTest` doesn't find errors and I don't know how to fix it. Running analysis with `bin/phpstan` finds them correctly.
2. This needs more rules to check the bodies of `@pure` functions/methods for purity. I think this might be postponed for now and solved in the future.
3. This needs documenting, but I'd rather prefer not to write it myself. I'm not a native speaker :)