### PR TITLE
Do not show memory limit warning on previous crash

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -261,12 +261,6 @@ class CommandHelper
 
 		$memoryLimitFile = $container->getParameter('memoryLimitFile');
 		if ($manageMemoryLimitFile && file_exists($memoryLimitFile)) {
-			$memoryLimitFileContents = FileReader::read($memoryLimitFile);
-			$errorOutput->writeLineFormatted('PHPStan crashed in the previous run probably because of excessive memory consumption.');
-			$errorOutput->writeLineFormatted(sprintf('It consumed around %s of memory.', $memoryLimitFileContents));
-			$errorOutput->writeLineFormatted('');
-			$errorOutput->writeLineFormatted('');
-			$errorOutput->writeLineFormatted('To avoid this issue, allow to use more memory with the --memory-limit option.');
 			@unlink($memoryLimitFile);
 		}
 


### PR DESCRIPTION
PR for discussion, I think we should not show that warning as I get it many times with issues not related with memory limit.

I think we should actually check if the read/consumed memory is close (like above 75%) of allowed memory limit.