### PR TITLE
Revert "Register missing SplObjectStorage stub"

### DIFF
--- a/conf/config.stubFiles.neon
+++ b/conf/config.stubFiles.neon
@@ -11,4 +11,3 @@ parameters:
 		- ../stubs/zip.stub
 		- ../stubs/dom.stub
 		- ../stubs/spl.stub
-		- ../stubs/SplObjectStorage.stub


### PR DESCRIPTION
This reverts commit 143741c9c68edcc96845926b551d40eeed2af0d5.

This stub is already registered in bleedingEdge.neon. I'm not totally clear why (something to do with backwards compatibility?) but this should either be in bleedingEdge or here, but not both.