### PR TITLE
functionMap: fixed return type of getopt()

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -947,6 +947,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\GetoptFunctionDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\GetParentClassDynamicFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3342,7 +3342,7 @@ return [
 'getmyinode' => ['int|false'],
 'getmypid' => ['int|false'],
 'getmyuid' => ['int|false'],
-'getopt' => ['array<string,string>|array<string,false>|array<string,array<int,mixed>>', 'options'=>'string', 'longopts='=>'array', '&w_optind='=>'int'],
+'getopt' => ['array<string,string>|array<string,false>|array<string,array<int,mixed>>|false', 'options'=>'string', 'longopts='=>'array', '&w_optind='=>'int'],
 'getprotobyname' => ['int|false', 'name'=>'string'],
 'getprotobynumber' => ['string|false', 'proto'=>'int'],
 'getrandmax' => ['int'],

--- a/src/Type/Php/GetoptFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetoptFunctionDynamicReturnTypeExtension.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
+
+class GetoptFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'getopt';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		return TypeUtils::toBenevolentUnion(TypeCombinator::union(
+			ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType(),
+			new ConstantBooleanType(false)
+		));
+	}
+
+}

--- a/src/Type/Php/GetoptFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetoptFunctionDynamicReturnTypeExtension.php
@@ -6,10 +6,8 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 
 class GetoptFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -22,10 +20,7 @@ class GetoptFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnT
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		return TypeUtils::toBenevolentUnion(TypeCombinator::union(
-			ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType(),
-			new ConstantBooleanType(false)
-		));
+		return TypeUtils::toBenevolentUnion(ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType());
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -10743,6 +10743,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-4415.php');
 	}
 
+	public function dataGetoptDynamicReturnTypeExtension(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/getopt.php');
+	}
+
 	/**
 	 * @param string $file
 	 * @return array<string, mixed[]>
@@ -10955,6 +10960,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataClosureReturnType
 	 * @dataProvider dataBug4398
 	 * @dataProvider dataBug4415
+	 * @dataProvider dataGetoptDynamicReturnTypeExtension
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/getopt.php
+++ b/tests/PHPStan/Analyser/data/getopt.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Getopt;
+
+use function getopt;
+use function PHPStan\Analyser\assertType;
+
+$opts = getopt("ab:c::", ["longopt1", "longopt2:", "longopt3::"]);
+assertType('(array<string, array<int, mixed>|string|false>|false)', $opts);


### PR DESCRIPTION
this can return FALSE if $argv is not an array for some reason (maybe register_argv_argv was disabled, or maybe it was overwritten by user code).

This isn't currently reported on 7.x, but is reported on 8.0 (due to stubs differences).