### PR TITLE
Add ./phpstan to match phpstan repo

### DIFF
--- a/phpstan
+++ b/phpstan
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+
+declare (strict_types=1);
+
+require_once __DIR__ . '/bin/phpstan';


### PR DESCRIPTION
It allows `phpstan-src` to be used (launched by `vendor/phpstan/phpstan-src/phpstan`) as the compiled `phpstan` for development purposes.