### PR TITLE
[FIX] SimpleXmlElement construct can throw exceptions

### DIFF
--- a/resources/functionMetadata.php
+++ b/resources/functionMetadata.php
@@ -522,7 +522,7 @@ return [
 	'ResourceBundle::getErrorMessage' => ['hasSideEffects' => false],
 	'ResourceBundle::getIterator' => ['hasSideEffects' => false],
 	'SQLiteException::__construct' => ['hasSideEffects' => false],
-	'SimpleXMLElement::__construct' => ['hasSideEffects' => false],
+	'SimpleXMLElement::__construct' => ['hasSideEffects' => true],
 	'SimpleXMLElement::children' => ['hasSideEffects' => false],
 	'SimpleXMLElement::count' => ['hasSideEffects' => false],
 	'SimpleXMLElement::current' => ['hasSideEffects' => false],


### PR DESCRIPTION
See https://www.php.net/manual/fr/simplexmlelement.construct.php

Example: `new SimpleXmlElement('foo')`