### PR TITLE
callable type with NEVER parameter accepts any closure

### DIFF
--- a/src/Type/CallableTypeHelper.php
+++ b/src/Type/CallableTypeHelper.php
@@ -16,7 +16,7 @@ class CallableTypeHelper
 	{
 		$theirParameters = $theirs->getParameters();
 		$ourParameters = $ours->getParameters();
-		if(count($ourParameters) === 1 && $ourParameters[0] instanceof NeverType){
+		if (count($ourParameters) === 1 && $ourParameters[0]->getType() instanceof NeverType) {
 			//a parameter with NEVER type is impossible to satisfy, meaning that such acceptors are not callable and therefore can accept anything with any number of arguments
 			return TrinaryLogic::createYes();
 		}

--- a/src/Type/CallableTypeHelper.php
+++ b/src/Type/CallableTypeHelper.php
@@ -16,6 +16,10 @@ class CallableTypeHelper
 	{
 		$theirParameters = $theirs->getParameters();
 		$ourParameters = $ours->getParameters();
+		if(count($ourParameters) === 1 && $ourParameters[0] instanceof NeverType){
+			//a parameter with NEVER type is impossible to satisfy, meaning that such acceptors are not callable and therefore can accept anything with any number of arguments
+			return TrinaryLogic::createYes();
+		}
 
 		$result = null;
 		foreach ($theirParameters as $i => $theirParameter) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -41,7 +41,7 @@ class NeverType implements CompoundType
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
-		return TrinaryLogic::createYes();
+		return $type instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createNo();
 	}
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -299,6 +299,13 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
 		$this->assertSame(13, $errors[0]->getLine());
 	}
 
+	public function testUncallableCallable(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/uncallable-callables.php');
+		$this->assertCount(1, $errors);
+		$this->assertStringContainsString('expects *NEVER*, 1 given', $errors[0]->getMessage());
+	}
+
 	/**
 	 * @param string $file
 	 * @return \PHPStan\Analyser\Error[]

--- a/tests/PHPStan/Analyser/data/uncallable-callables.php
+++ b/tests/PHPStan/Analyser/data/uncallable-callables.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace UncallableCallables;
+
+class Test{
+	/**
+	 * @param callable(never) : mixed $c
+	 */
+	public function acceptsAnyCallable(callable $c) : void{
+		$c(1);
+	}
+
+	public function test() : void{
+		$this->acceptsAnyCallable(function() : void{ });
+		$this->acceptsAnyCallable(function(int $a) : void{ });
+		$this->acceptsAnyCallable(function(int $a, string $b) : void{ });
+	}
+}


### PR DESCRIPTION
a closure whose only parameter is NEVER cannot be called. This is useful for marking a callable which should only be analyzed (e.g. via reflection, like [this function](https://github.com/pmmp/PocketMine-MP/blob/38b2d83799ff796c15b784510ff983a8daf0eafe/src/pocketmine/utils/Utils.php#L140)), and not executed.

You can see in the referenced commit that I already attempted to use `mixed...` for this. However, this has problems when there is more than 1 parameter in the passed callable, and I didn't want to make `mixed` any more broken for this.

Instead, I figured it was a better idea to use `never`, which otherwise makes no sense as a parameter type.