### PR TITLE
Fix fputcsv fields parameter.  Should be string[].

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3004,7 +3004,7 @@ return [
 'fpassthru' => ['int|false', 'fp'=>'resource'],
 'fpm_get_status' => ['array|false'],
 'fprintf' => ['int', 'stream'=>'resource', 'format'=>'string', '...values='=>'string|int|float'],
-'fputcsv' => ['int|false', 'fp'=>'resource', 'fields'=>'array', 'delimiter='=>'string', 'enclosure='=>'string', 'escape_char='=>'string'],
+'fputcsv' => ['int|false', 'fp'=>'resource', 'fields'=>'string[]', 'delimiter='=>'string', 'enclosure='=>'string', 'escape_char='=>'string'],
 'fputs' => ['int|false', 'fp'=>'resource', 'str'=>'string', 'length='=>'int'],
 'fread' => ['string|false', 'fp'=>'resource', 'length'=>'int'],
 'frenchtojd' => ['int', 'month'=>'int', 'day'=>'int', 'year'=>'int'],


### PR DESCRIPTION
The `fields` parameter for `fputcsv` should be an array of strings. See [PHP manual](https://www.php.net/manual/en/function.fputcsv.php).

This PR should fix analysis of [this snippet](https://phpstan.org/r/65420d60-d1fd-4eef-9ba3-e057672082ee) by correctly reporting an error on line `22`.

Running the code in the snippet on PHP 8.0 (`PHP 8.0.0 (cli) (built: Dec  6 2020 06:56:11) ( NTS )`) results in this error:
```
PHP Fatal error:  Uncaught Error: Object of class Person could not be converted to string in /home/vagrant/example/csv.php:24
Stack trace:
#0 /home/vagrant/example/csv.php(24): fputcsv()
#1 {main}
  thrown in /home/vagrant/example/csv.php on line 24
```

NOTE: I've seen  a similar error with PHP 7.3 too.