### PR TITLE
Fix accepted types for fputcsv fields parameter

### DIFF
--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -6,12 +6,14 @@ use PHPStan\Reflection\FunctionVariant;
 use PHPStan\Reflection\Native\NativeFunctionReflection;
 use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringAlwaysAcceptingObjectWithToStringType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 
 class NativeFunctionReflectionProvider
@@ -63,6 +65,26 @@ class NativeFunctionReflectionProvider
 							new BooleanType(),
 						]);
 					}
+
+					if (
+						$parameterSignature->getName() === 'fields'
+						&& $lowerCasedFunctionName === 'fputcsv'
+					) {
+						$type = new ArrayType(
+							new UnionType([
+								new StringType(),
+								new IntegerType(),
+							]),
+							new UnionType([
+								new StringAlwaysAcceptingObjectWithToStringType(),
+								new IntegerType(),
+								new FloatType(),
+								new NullType(),
+								new BooleanType(),
+							])
+						);
+					}
+
 					return new NativeParameterReflection(
 						$parameterSignature->getName(),
 						$parameterSignature->isOptional(),

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -411,6 +411,28 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testFputCsv(): void
+	{
+		$this->analyse([__DIR__ . '/data/fputcsv-fields-parameter.php'], [
+			[
+				'Parameter #2 $fields of function fputcsv expects array<int|string, bool|float|int|string|null>, array<int, Fputcsv\Person> given.',
+				30,
+			],
+		]);
+	}
+
+
+	public function testPutCsvWithStringable(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test skipped under 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/fputcsv-fields-parameter-php8.php'], [
+			// No issues expected
+		]);
+	}
+
 	public function testFunctionWithNumericParameterThatCreatedByAddition(): void
 	{
 		$this->analyse([__DIR__ . '/data/function-with-int-parameter-that-created-by-addition.php'], [

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -415,8 +415,8 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/fputcsv-fields-parameter.php'], [
 			[
-				'Parameter #2 $fields of function fputcsv expects array<int|string, bool|float|int|string|null>, array<int, Person> given.',
-				33,
+				'Parameter #2 $fields of function fputcsv expects array<int|string, bool|float|int|string|null>, array<int, Fputcsv\Person> given.',
+				35,
 			],
 		]);
 	}
@@ -425,7 +425,7 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 	public function testPutCsvWithStringable(): void
 	{
 		if (PHP_VERSION_ID < 80000) {
-			$this->markTestSkipped('Test skipped under 8.0');
+			$this->markTestSkipped('Test skipped on lower version than 8.0 (needs Stringable interface, added in PHP8)');
 		}
 
 		$this->analyse([__DIR__ . '/data/fputcsv-fields-parameter-php8.php'], [

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -415,8 +415,8 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/fputcsv-fields-parameter.php'], [
 			[
-				'Parameter #2 $fields of function fputcsv expects array<int|string, bool|float|int|string|null>, array<int, Fputcsv\Person> given.',
-				30,
+				'Parameter #2 $fields of function fputcsv expects array<int|string, bool|float|int|string|null>, array<int, Person> given.',
+				33,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter-php8.php
+++ b/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter-php8.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Fputcsv;
+
+
+$handle = fopen("/tmp/output.csv", "w");
+if ($handle === false) die();
+
+class StringablePerson implements \Stringable {
+	public function __toString(): string {
+		return "stringable name";
+	}
+}
+
+// This is valid. StringablePerson should be treated as a string
+fputcsv($handle, [new StringablePerson()]);

--- a/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter-php8.php
+++ b/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter-php8.php
@@ -1,16 +1,17 @@
 <?php declare(strict_types = 1);
 
-namespace Fputcsv;
-
-
-$handle = fopen("/tmp/output.csv", "w");
-if ($handle === false) die();
-
 class StringablePerson implements \Stringable {
 	public function __toString(): string {
 		return "stringable name";
 	}
 }
 
-// This is valid. StringablePerson should be treated as a string
-fputcsv($handle, [new StringablePerson()]);
+class CsvWriterPhp8
+{
+	/** @param resource $handle */
+	public function write($handle): void
+	{
+		// This is valid. StringablePerson should be treated as a string
+		fputcsv($handle, [new StringablePerson()]);
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter-php8.php
+++ b/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter-php8.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+namespace FputcsvPhp8;
+
 class StringablePerson implements \Stringable {
 	public function __toString(): string {
 		return "stringable name";

--- a/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter.php
+++ b/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter.php
@@ -1,33 +1,38 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
-namespace Fputcsv;
+class Person
+{
+}
 
-
-$handle = fopen("/tmp/output.csv", "w");
-if ($handle === false) die();
-
-class Person {}
-
-class PersonWithToString {
-	public function __toString(): string {
+class PersonWithToString
+{
+	public function __toString(): string
+	{
 		return "to string name";
 	}
 }
 
-// These are all valid scalers
-fputcsv($handle, [
-	"string",
-	1,
-	3.5,
-	true,
-	false,
-	null, // Yes this is accepted by fputcsv,
-]);
+class CsvWriter
+{
+	/** @param resource $handle */
+	public function writeCsv($handle): void
+	{
+		// These are all valid scalers
+		fputcsv($handle, [
+			"string",
+			1,
+			3.5,
+			true,
+			false,
+			null, // Yes this is accepted by fputcsv,
+		]);
 
-// Arrays can have string for keys (which are ignored)
-fputcsv($handle, [ "foo" => "bar", ]);
+		// Arrays can have string for keys (which are ignored)
+		fputcsv($handle, ["foo" => "bar",]);
 
-fputcsv($handle, [ new Person, ]); // Problem on this line
+		fputcsv($handle, [new Person,]); // Problem on this line
 
-// This is valid. PersonWithToString should be cast to string by fputcsv
-fputcsv($handle, [new PersonWithToString()]);
+		// This is valid. PersonWithToString should be cast to string by fputcsv
+		fputcsv($handle, [new PersonWithToString()]);
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter.php
+++ b/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace Fputcsv;
+
 class Person
 {
 }

--- a/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter.php
+++ b/tests/PHPStan/Rules/Functions/data/fputcsv-fields-parameter.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Fputcsv;
+
+
+$handle = fopen("/tmp/output.csv", "w");
+if ($handle === false) die();
+
+class Person {}
+
+class PersonWithToString {
+	public function __toString(): string {
+		return "to string name";
+	}
+}
+
+// These are all valid scalers
+fputcsv($handle, [
+	"string",
+	1,
+	3.5,
+	true,
+	false,
+	null, // Yes this is accepted by fputcsv,
+]);
+
+// Arrays can have string for keys (which are ignored)
+fputcsv($handle, [ "foo" => "bar", ]);
+
+fputcsv($handle, [ new Person, ]); // Problem on this line
+
+// This is valid. PersonWithToString should be cast to string by fputcsv
+fputcsv($handle, [new PersonWithToString()]);


### PR DESCRIPTION
Correctly fix type for `fputcsv` function parameter `$fields`. Fix attempt made in #448 

- [X] Update code
- [X] Add tests
- [x] Fix failing test