### PR TITLE
Replace excludes analyse by exclude paths

### DIFF
--- a/src/Analyser/IgnoredErrorHelperResult.php
+++ b/src/Analyser/IgnoredErrorHelperResult.php
@@ -139,7 +139,7 @@ class IgnoredErrorHelperResult
 			if ($shouldBeIgnored) {
 				if (!$error->canBeIgnored()) {
 					$addErrors[] = sprintf(
-						'Error message "%s" cannot be ignored, use excludes_analyse instead.',
+						'Error message "%s" cannot be ignored, use excludePaths instead.',
 						$error->getMessage()
 					);
 					return true;

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -65,7 +65,7 @@ class AnalyserTest extends \PHPStan\Testing\TestCase
 		$this->assertCount(2, $result);
 		assert($result[0] instanceof Error);
 		$this->assertSame('Class PHPStan\Tests\Baz was not found while trying to analyse it - autoloading is probably not configured properly.', $result[0]->getMessage());
-		$this->assertSame('Error message "Class PHPStan\Tests\Baz was not found while trying to analyse it - autoloading is probably not configured properly." cannot be ignored, use excludes_analyse instead.', $result[1]);
+		$this->assertSame('Error message "Class PHPStan\Tests\Baz was not found while trying to analyse it - autoloading is probably not configured properly." cannot be ignored, use excludePaths instead.', $result[1]);
 	}
 
 	public function testIgnoreErrorByPath(): void


### PR DESCRIPTION
Adjust error cannot be ignored. Indeed `excludes_analyse` is deprecated and replaced by `excludePaths` 

Before:

![2021-02-22_12-40](https://user-images.githubusercontent.com/9253091/108707456-4d324a00-7510-11eb-8ffc-586be9505baf.png)

![2021-02-22_12-39](https://user-images.githubusercontent.com/9253091/108707659-a69a7900-7510-11eb-84b6-858a18b3a363.png)