### PR TITLE
Fix XMLReader::open() return type

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1233,6 +1233,12 @@ services:
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
+	-
+		class: PHPStan\Type\Php\XMLReaderOpenReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
 	typeSpecifier:
 		class: PHPStan\Analyser\TypeSpecifier
 		factory: @typeSpecifierFactory::create

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -13060,7 +13060,7 @@ return [
 'XMLReader::moveToFirstAttribute' => ['bool'],
 'XMLReader::moveToNextAttribute' => ['bool'],
 'XMLReader::next' => ['bool', 'localname='=>'string'],
-'XMLReader::open' => ['bool', 'uri'=>'string', 'encoding='=>'?string', 'options='=>'int'],
+'XMLReader::open' => ['bool|XMLReader', 'uri'=>'string', 'encoding='=>'?string', 'options='=>'int'],
 'XMLReader::read' => ['bool'],
 'XMLReader::readInnerXML' => ['string'],
 'XMLReader::readOuterXML' => ['string'],

--- a/src/Type/Php/XMLReaderOpenReturnTypeExtension.php
+++ b/src/Type/Php/XMLReaderOpenReturnTypeExtension.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+
+class XMLReaderOpenReturnTypeExtension implements DynamicMethodReturnTypeExtension, DynamicStaticMethodReturnTypeExtension
+{
+
+	private const XML_READER_CLASS = 'XMLReader';
+
+	public function getClass(): string
+	{
+		return self::XML_READER_CLASS;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'open';
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $this->isMethodSupported($methodReflection);
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		return new BooleanType();
+	}
+
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+	{
+		return new UnionType([new ObjectType(self::XML_READER_CLASS), new ConstantBooleanType(false)]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/call-methods.php
+++ b/tests/PHPStan/Rules/Methods/data/call-methods.php
@@ -1669,4 +1669,12 @@ class XmlReaderOpen
 		$xml->open('http://', null);
 	}
 
+	public function openStatically(): void
+	{
+		$xml = \XMLReader::open('http://', null);
+		if ($xml !== false) {
+			$xml->read();
+		}
+	}
+
 }


### PR DESCRIPTION
XMLReader::open() returns an instance of `XMLReader` when called statically (and according to its `ReflectionMethod`, `XMLReader::open()` is actually a static function).

Currently, this method is now unable to use in boths ways without PHPStan reporting errors with strict rules enabled:
- Non-statically: https://phpstan.org/r/3fd6a8b3-3320-4e26-8a81-4f0a4a16c8c9
- Statically: https://phpstan.org/r/6afc7b43-ccd8-4b21-b235-229c46c23603

Actually, an even better fix would be to make the return type dependent on whether the method is called statically or not, is that possible? It returns `XMLReader|false` when called statically or `bool` when called non-statically.