### PR TITLE
Memoize expensive calls to docComments.

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -89,6 +89,9 @@ class ClassReflection implements ReflectionWithFilename
 	/** @var string|false|null */
 	private $filename;
 
+	/** @var string|false|null */
+	private $reflectionDocComment;
+
 	/**
 	 * @param \PHPStan\Reflection\ReflectionProvider $reflectionProvider
 	 * @param \PHPStan\Type\FileTypeMapper $fileTypeMapper
@@ -933,12 +936,15 @@ class ClassReflection implements ReflectionWithFilename
 			return null;
 		}
 
-		$docComment = $this->reflection->getDocComment();
-		if ($docComment === false) {
+		if ($this->reflectionDocComment === null) {
+			$this->reflectionDocComment = $this->reflection->getDocComment();
+		}
+
+		if ($this->reflectionDocComment === false) {
 			return null;
 		}
 
-		return $this->fileTypeMapper->getResolvedPhpDoc($fileName, $this->getName(), null, null, $docComment);
+		return $this->fileTypeMapper->getResolvedPhpDoc($fileName, $this->getName(), null, null, $this->reflectionDocComment);
 	}
 
 	private function getFirstExtendsTag(): ?ExtendsTag

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -53,6 +53,9 @@ class FileTypeMapper
 	/** @var array<string, bool> */
 	private array $alreadyProcessedDependentFiles = [];
 
+	/** @var array<string, string> */
+	private array $docKeys = [];
+
 	public function __construct(
 		ReflectionProviderProvider $reflectionProviderProvider,
 		Parser $phpParser,
@@ -518,7 +521,11 @@ class FileTypeMapper
 		string $docComment
 	): string
 	{
-		$docComment = \Nette\Utils\Strings::replace($docComment, '#\s+#', ' ');
+		$cacheKey = md5($docComment);
+		if (!isset($this->docKeys[$cacheKey])) {
+			$this->docKeys[$cacheKey] = \Nette\Utils\Strings::replace($docComment, '#\s+#', ' ');
+		}
+		$docComment = $this->docKeys[$cacheKey];
 
 		return md5(sprintf('%s-%s-%s-%s', $class, $trait, $function, $docComment));
 	}


### PR DESCRIPTION
I ran multiple tests using Blackfire. Memoizing these expensive calls reduces both RAM consumption & execution time.

This is an example with running on https://github.com/pyguerder/phpstan-propel2-example/blob/master/generated-classes/App/AnalyzeMe2.php only: https://blackfire.io/profiles/compare/7f25525d-0676-40b8-a809-a92692106be6/graph

And this is an example running on my main project (154 classes): https://blackfire.io/profiles/compare/7cc0ea82-3727-4a95-b948-112678bc0991/graph

@ondrejmirtes can you please have a look at this?

Thanks in advance, best regards