### PR TITLE
Incorrect return type for SplFileObject::fgetcsv

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11291,7 +11291,7 @@ return [
 'SplFileObject::eof' => ['bool'],
 'SplFileObject::fflush' => ['bool'],
 'SplFileObject::fgetc' => ['string|false'],
-'SplFileObject::fgetcsv' => ['array|false|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'SplFileObject::fgetcsv' => ['array|false', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'SplFileObject::fgets' => ['string|false'],
 'SplFileObject::fgetss' => ['string|false', 'allowable_tags='=>'string'],
 'SplFileObject::flock' => ['bool', 'operation'=>'int', '&w_wouldblock='=>'int'],


### PR DESCRIPTION
Return type should be `array|false` instead of `array|false|null`. See https://www.php.net/manual/en/splfileobject.fgetcsv#refsect1-splfileobject.fgetcsv-returnvalues