### PR TITLE
Fix: phpdoc cache collision with identical aliases & variable names

### DIFF
--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -216,7 +216,7 @@ class FileTypeMapper
 	private function getResolvedPhpDocMap(string $fileName): array
 	{
 		if (!isset($this->memoryCache[$fileName])) {
-			$cacheKey = sprintf('%s-phpdocstring-v7-generic-traits', $fileName);
+			$cacheKey = sprintf('%s-phpdocstring-v8-generic-traits', $fileName);
 			$variableCacheKey = implode(',', array_map(static function (array $file): string {
 				return sprintf('%s-%d', $file['filename'], $file['modifiedTime']);
 			}, $this->getCachedDependentFilesWithTimestamps($fileName)));

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -216,7 +216,7 @@ class FileTypeMapper
 	private function getResolvedPhpDocMap(string $fileName): array
 	{
 		if (!isset($this->memoryCache[$fileName])) {
-			$cacheKey = sprintf('%s-phpdocstring-v8-generic-traits', $fileName);
+			$cacheKey = sprintf('%s-phpdocstring-v9-generic-traits', $fileName);
 			$variableCacheKey = implode(',', array_map(static function (array $file): string {
 				return sprintf('%s-%d', $file['filename'], $file['modifiedTime']);
 			}, $this->getCachedDependentFilesWithTimestamps($fileName)));
@@ -594,7 +594,11 @@ class FileTypeMapper
 		}
 		$docComment = $this->docKeys[$cacheKey];
 
-		return md5(sprintf('%s-%s-%s-%s-%s', $file, $class, $trait, $function, $docComment));
+		if ($class === null && $trait === null && $function === null) {
+			return md5(sprintf('%s-%s', $file, $docComment));
+		}
+
+		return md5(sprintf('%s-%s-%s-%s', $class, $trait, $function, $docComment));
 	}
 
 	/**

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -216,7 +216,7 @@ class FileTypeMapper
 	private function getResolvedPhpDocMap(string $fileName): array
 	{
 		if (!isset($this->memoryCache[$fileName])) {
-			$cacheKey = sprintf('%s-phpdocstring-v9-generic-traits', $fileName);
+			$cacheKey = sprintf('%s-phpdocstring-v8-alias-collision', $fileName);
 			$variableCacheKey = implode(',', array_map(static function (array $file): string {
 				return sprintf('%s-%d', $file['filename'], $file['modifiedTime']);
 			}, $this->getCachedDependentFilesWithTimestamps($fileName)));

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -87,7 +87,7 @@ class FileTypeMapper
 			throw new \PHPStan\ShouldNotHappenException();
 		}
 
-		$phpDocKey = $this->getPhpDocKey($className, $traitName, $functionName, $docComment);
+		$phpDocKey = $this->getPhpDocKey($fileName, $className, $traitName, $functionName, $docComment);
 		if (isset($this->resolvedPhpDocBlockCache[$phpDocKey])) {
 			return $this->resolvedPhpDocBlockCache[$phpDocKey];
 		}
@@ -349,7 +349,7 @@ class FileTypeMapper
 					$className = $classStack[count($classStack) - 1] ?? null;
 					$typeMapCb = $typeMapStack[count($typeMapStack) - 1] ?? null;
 
-					$phpDocKey = $this->getPhpDocKey($className, $lookForTrait, $functionName, $phpDocString);
+					$phpDocKey = $this->getPhpDocKey($fileName, $className, $lookForTrait, $functionName, $phpDocString);
 					$phpDocMap[$phpDocKey] = static function () use ($phpDocString, $namespace, $uses, $className, $functionName, $typeMapCb, $resolvableTemplateTypes): NameScopedPhpDocString {
 						$nameScope = new NameScope(
 							$namespace,
@@ -581,6 +581,7 @@ class FileTypeMapper
 	}
 
 	private function getPhpDocKey(
+		string $file,
 		?string $class,
 		?string $trait,
 		?string $function,
@@ -593,7 +594,7 @@ class FileTypeMapper
 		}
 		$docComment = $this->docKeys[$cacheKey];
 
-		return md5(sprintf('%s-%s-%s-%s', $class, $trait, $function, $docComment));
+		return md5(sprintf('%s-%s-%s-%s-%s', $file, $class, $trait, $function, $docComment));
 	}
 
 	/**

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -170,4 +170,15 @@ class FileTypeMapperTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('CyclicPhpDocs\Foo|iterable<CyclicPhpDocs\Foo>', $returnTag->getType()->describe(VerbosityLevel::precise()));
 	}
 
+	public function testFilesWithIdenticalPhpDocsUsingDifferentAliases(): void
+	{
+		/** @var FileTypeMapper $fileTypeMapper */
+		$fileTypeMapper = self::getContainer()->getByType(FileTypeMapper::class);
+
+		$doc1 = $fileTypeMapper->getResolvedPhpDoc(__DIR__ . '/data/alias-collision1.php', null, null, null, '/** @var Foo $x */');
+		$doc2 = $fileTypeMapper->getResolvedPhpDoc(__DIR__ . '/data/alias-collision2.php', null, null, null, '/** @var Foo $x */');
+
+		$this->assertSame('Namespace1\Foo', $doc1->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
+		$this->assertSame('Namespace2\Foo', $doc2->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
+	}
 }

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -181,4 +181,5 @@ class FileTypeMapperTest extends \PHPStan\Testing\TestCase
 		$this->assertSame('Namespace1\Foo', $doc1->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
 		$this->assertSame('Namespace2\Foo', $doc2->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
 	}
+
 }

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -178,8 +178,8 @@ class FileTypeMapperTest extends \PHPStan\Testing\TestCase
 		$doc1 = $fileTypeMapper->getResolvedPhpDoc(__DIR__ . '/data/alias-collision1.php', null, null, null, '/** @var Foo $x */');
 		$doc2 = $fileTypeMapper->getResolvedPhpDoc(__DIR__ . '/data/alias-collision2.php', null, null, null, '/** @var Foo $x */');
 
-		$this->assertSame('Namespace1\Foo', $doc1->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
-		$this->assertSame('Namespace2\Foo', $doc2->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
+		$this->assertSame('AliasCollisionNamespace1\Foo', $doc1->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
+		$this->assertSame('AliasCollisionNamespace2\Foo', $doc2->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/data/alias-collision1.php
+++ b/tests/PHPStan/Type/data/alias-collision1.php
@@ -1,0 +1,6 @@
+<?php
+
+use Namespace1\Foo;
+
+/** @var Foo $x */
+$x = $GLOBALS['x1'];

--- a/tests/PHPStan/Type/data/alias-collision1.php
+++ b/tests/PHPStan/Type/data/alias-collision1.php
@@ -1,6 +1,6 @@
 <?php
 
-use Namespace1\Foo;
+use AliasCollisionNamespace1\Foo;
 
 /** @var Foo $x */
 $x = $GLOBALS['x1'];

--- a/tests/PHPStan/Type/data/alias-collision2.php
+++ b/tests/PHPStan/Type/data/alias-collision2.php
@@ -1,6 +1,6 @@
 <?php
 
-use Namespace2\Foo;
+use AliasCollisionNamespace2\Foo;
 
 /** @var Foo $x */
 $x = $GLOBALS['x2'];

--- a/tests/PHPStan/Type/data/alias-collision2.php
+++ b/tests/PHPStan/Type/data/alias-collision2.php
@@ -1,0 +1,6 @@
+<?php
+
+use Namespace2\Foo;
+
+/** @var Foo $x */
+$x = $GLOBALS['x2'];


### PR DESCRIPTION
`/** @var Foo $x */` in the global scope was cached once for all files, but it can have different semantics depending on the imports used in each file.

I can't provide a playground link because the bug requires multiple files. Please see the test coverage I added for an example.