### PR TITLE
Improved try-catch scope resolution

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5656,6 +5656,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/generic-parent.php');
 	}
 
+	public function dataTryCatchV2(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/try-catch-scope-v2.php');
+	}
+
 	/**
 	 * @dataProvider dataArrayFunctions
 	 * @param string $description
@@ -11270,6 +11275,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug4423
 	 * @dataProvider dataGenericUnions
 	 * @dataProvider dataGenericParent
+	 * @dataProvider dataTryCatchV2
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/try-catch-scope-v2.php
+++ b/tests/PHPStan/Analyser/data/try-catch-scope-v2.php
@@ -1,0 +1,81 @@
+<?php
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+
+function () {
+	try {
+		$foo = bar();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+};
+
+function () {
+	try {
+		$foo = bar();
+		throw new \Exception();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+};
+
+function () {
+	try {
+		throw new \Exception();
+		$foo = bar();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+};
+
+function () {
+	try {
+		$foo = bar();
+	} catch (Exception $exception) {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+};
+
+function () {
+	try {
+		$foo = bar();
+	} catch (Exception $exception) {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+		$foo = null;
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+};
+
+function () {
+	try {
+		$foo = bar();
+	} catch (Throwable $exception) {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+		$foo = null;
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+};
+
+function () {
+	try {
+		if (random()) {
+			$foo = bar();
+		}
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+};


### PR DESCRIPTION
Better late than never :)

As discussed on https://github.com/phpstan/phpstan/issues/778, here's an alternate implementation of try/catch/finally scope resolution. It's mostly based around keeping track of the scopes for different flows separately and merging them.

I already added test cases replicating the scenario from the issue but I'll be adding a lot more.

Q: is there a way we could implement `assertUnreachable` or `assertAlwaysTerminating`?