### PR TITLE
Add case for return rule when returning an iterator without yield from

### DIFF
--- a/src/Rules/Functions/ArrowFunctionReturnTypeRule.php
+++ b/src/Rules/Functions/ArrowFunctionReturnTypeRule.php
@@ -52,6 +52,7 @@ class ArrowFunctionReturnTypeRule implements \PHPStan\Rules\Rule
 			'Anonymous function with return type void returns %s but should not return anything.',
 			'Anonymous function should return %s but returns %s.',
 			'Anonymous function should never return but return statement found.',
+			'Anonymous function should never return an iterable directly when already using yield.',
 			$generatorType->isSuperTypeOf($returnType)->yes()
 		);
 	}

--- a/src/Rules/Functions/ClosureReturnTypeRule.php
+++ b/src/Rules/Functions/ClosureReturnTypeRule.php
@@ -53,6 +53,7 @@ class ClosureReturnTypeRule implements \PHPStan\Rules\Rule
 				'Anonymous function with return type void returns %s but should not return anything.',
 				'Anonymous function should return %s but returns %s.',
 				'Anonymous function should never return but return statement found.',
+				'Anonymous function should never return an iterable directly when already using yield.',
 				count($node->getYieldStatements()) > 0
 			);
 

--- a/src/Rules/Functions/ReturnTypeRule.php
+++ b/src/Rules/Functions/ReturnTypeRule.php
@@ -86,6 +86,10 @@ class ReturnTypeRule implements \PHPStan\Rules\Rule
 				'Function %s() should never return but return statement found.',
 				$function->getName()
 			),
+			sprintf(
+				'Function %s() should never return an iterable directly when already using yield.',
+				$function->getName()
+			),
 			$reflection !== null && $reflection->isGenerator()
 		);
 	}

--- a/src/Rules/Methods/ReturnTypeRule.php
+++ b/src/Rules/Methods/ReturnTypeRule.php
@@ -72,6 +72,11 @@ class ReturnTypeRule implements \PHPStan\Rules\Rule
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName()
 			),
+			sprintf(
+				'Method %s::%s() should never return an iterable directly when already using yield.',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName()
+			),
 			$reflection !== null && $reflection->isGenerator()
 		);
 	}

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -46,20 +46,28 @@ class ReturnTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 				87,
 			],
 			[
+				'Function ReturnTypes\returnFromGeneratorMixed() should never return an iterable directly when already using yield.',
+				141,
+			],
+			[
 				'Function ReturnTypes\returnFromGeneratorString() should return string but empty return statement found.',
 				152,
 			],
 			[
-				'Function ReturnTypes\returnFromGeneratorString() should return string but returns int.',
+				'Function ReturnTypes\returnFromGeneratorString() should never return an iterable directly when already using yield.',
 				155,
 			],
 			[
-				'Function ReturnTypes\returnVoidFromGenerator2() with return type void returns int but should not return anything.',
+				'Function ReturnTypes\returnVoidFromGenerator2() should never return an iterable directly when already using yield.',
 				173,
 			],
 			[
 				'Function ReturnTypes\returnNever() should never return but return statement found.',
 				181,
+			],
+			[
+				'Function ReturnTypes\countTo3Wrong() should never return an iterable directly when already using yield.',
+				188,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/returnTypes.php
+++ b/tests/PHPStan/Rules/Functions/data/returnTypes.php
@@ -180,3 +180,30 @@ function returnNever()
 {
 	return;
 }
+
+function countTo3Wrong(): iterable
+{
+	yield 1;
+
+	return yieldTwoAndThree();
+}
+
+function yieldTwoAndThree(): iterable
+{
+	yield 2;
+	yield from [3];
+}
+
+function countToThreeCorrectly(): iterable
+{
+	yield 1;
+
+	return yield from yieldTwoAndThree();
+}
+
+function countTo3Correctly(): iterable
+{
+	yield 1;
+
+	return (yield from yieldTwoAndThree());
+}

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -176,6 +176,10 @@ class ReturnTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 				552,
 			],
 			[
+				'Method ReturnTypes\GeneratorMethod::doFoo() should never return an iterable directly when already using yield.',
+				596,
+			],
+			[
 				'Method ReturnTypes\ReturnTernary::returnTernary() should return ReturnTypes\Foo but returns false.',
 				625,
 			],
@@ -266,6 +270,10 @@ class ReturnTypeRuleTest extends \PHPStan\Testing\RuleTestCase
 			[
 				'Method ReturnTypes\NeverReturn::doFoo() should never return but return statement found.',
 				1238,
+			],
+			[
+				'Method ReturnTypes\GeneratorMethodThatDoNotWork::countTo3Wrong() should never return an iterable directly when already using yield.',
+				1249,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/data/returnTypes.php
+++ b/tests/PHPStan/Rules/Methods/data/returnTypes.php
@@ -1239,3 +1239,33 @@ class NeverReturn
 	}
 
 }
+
+class GeneratorMethodThatDoNotWork
+{
+	public function countTo3Wrong(): iterable
+	{
+		yield 1;
+
+		return $this->yieldTwoAndThree();
+	}
+
+	public function countToThreeCorrectly(): iterable
+	{
+		yield 1;
+
+		return yield from $this->yieldTwoAndThree();
+	}
+
+	public function countTo3Correctly(): iterable
+	{
+		yield 1;
+
+		return (yield from $this->yieldTwoAndThree());
+	}
+
+	private function yieldTwoAndThree(): iterable
+	{
+		yield 2;
+		yield from [3];
+	}
+}


### PR DESCRIPTION
Static validation tools like phpstan can't warn that the attached snippet won't work. I amend a rule and added a test case that can detect these situations.

It feels like it is too vague in its implementation as I have no clue yet how to get the type of the expression but a function/method that is a generator which has a return statement without an iterable as value is weird in anycase.

Attachment:

When you this code you will only get 1 as output. Any IDE or standalone static code analysis tools did not hint it yet.

```php
function countTo3Wrong(): iterable
{
    yield 1;
    return yieldTwoAndThree();
}

function yieldTwoAndThree(): iterable
{
    yield 2;
    yield from [3];
}

foreach (countTo3Wrong() as $i) {
    echo $i . PHP_EOL;
}
```
