### PR TITLE
Failing test for #4657

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4000,6 +4000,7 @@ class MutatingScope implements Scope
 		array $byRefUses
 	): self
 	{
+		$nativeExpressionTypes = $this->nativeExpressionTypes;
 		$variableTypes = $this->variableTypes;
 		if (count($byRefUses) === 0) {
 			return $this;
@@ -4014,6 +4015,7 @@ class MutatingScope implements Scope
 
 			if (!$closureScope->hasVariableType($variableName)->yes()) {
 				$variableTypes[$variableName] = VariableTypeHolder::createYes(new NullType());
+				$nativeExpressionTypes[sprintf('$%s', $variableName)] = new NullType();
 				continue;
 			}
 
@@ -4028,6 +4030,7 @@ class MutatingScope implements Scope
 			}
 
 			$variableTypes[$variableName] = VariableTypeHolder::createYes($variableType);
+			$nativeExpressionTypes[sprintf('$%s', $variableName)] = $variableType;
 		}
 
 		return $this->scopeFactory->create(
@@ -4043,7 +4046,7 @@ class MutatingScope implements Scope
 			$this->anonymousFunctionReflection,
 			$this->inFirstLevelStatement,
 			[],
-			$this->nativeExpressionTypes,
+			$nativeExpressionTypes,
 			$this->inFunctionCallsStack,
 			$this->afterExtractCall,
 			$this->parentScope

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5686,6 +5686,11 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		return $this->gatherAssertTypes(__DIR__ . '/data/bug-4213.php');
 	}
 
+	public function dataBug4657(): array
+	{
+		return $this->gatherAssertTypes(__DIR__ . '/data/bug-4657.php');
+	}
+
 	/**
 	 * @dataProvider dataArrayFunctions
 	 * @param string $description
@@ -11306,6 +11311,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug3558
 	 * @dataProvider dataBug3351
 	 * @dataProvider dataBug4213
+	 * @dataProvider dataBug4657
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/data/bug-4657.php
+++ b/tests/PHPStan/Analyser/data/bug-4657.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bug4657;
+
+use DateTime;
+use function PHPStan\Analyser\assertType;
+use function PHPStan\Analyser\assertNativeType;
+
+function (): void {
+	$value = null;
+	$other = null;
+	$callback = function () use (&$value, &$other) : void {
+		$value = new DateTime();
+	};
+	$callback();
+
+	assertType('DateTime|null', $value);
+	assertNativeType('DateTime|null', $value);
+
+	assertType('null', $other);
+	assertNativeType('null', $other);
+};

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -399,4 +399,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends \PHPStan\Testing\RuleTestC
 		$this->analyse([__DIR__ . '/data/bug-2714.php'], []);
 	}
 
+	public function testBug4657(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-4657.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-4657.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4657.php
@@ -3,6 +3,8 @@
 namespace Bug4657;
 
 use DateTime;
+use function PHPStan\Analyser\assertNativeType;
+use function PHPStan\Analyser\assertType;
 
 function (): void {
 	$value = null;
@@ -13,4 +15,7 @@ function (): void {
 
 	// phpstan: Call to static method Webmozart\Assert\Assert::notNull() with DateTime|null will always evaluate to false.
 	assert(!is_null($value));
+
+	assertType('DateTime|null', $value);
+	assertNativeType('DateTime|null', $value);
 };

--- a/tests/PHPStan/Rules/Comparison/data/bug-4657.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4657.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bug4657;
+
+use DateTime;
+
+function (): void {
+	$value = null;
+	$callback = function () use (&$value) : void {
+		$value = new DateTime();
+	};
+	$callback();
+
+	// phpstan: Call to static method Webmozart\Assert\Assert::notNull() with DateTime|null will always evaluate to false.
+	assert(!is_null($value));
+};

--- a/tests/PHPStan/Rules/Comparison/data/bug-4657.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4657.php
@@ -3,8 +3,6 @@
 namespace Bug4657;
 
 use DateTime;
-use function PHPStan\Analyser\assertNativeType;
-use function PHPStan\Analyser\assertType;
 
 function (): void {
 	$value = null;
@@ -13,9 +11,5 @@ function (): void {
 	};
 	$callback();
 
-	// phpstan: Call to static method Webmozart\Assert\Assert::notNull() with DateTime|null will always evaluate to false.
 	assert(!is_null($value));
-
-	assertType('DateTime|null', $value);
-	assertNativeType('DateTime|null', $value);
 };


### PR DESCRIPTION
See https://github.com/phpstan/phpstan/issues/4657

While using the debugger I found that the problem occurs while resolving `is_null($value)`.

This code:
https://github.com/phpstan/phpstan-src/blob/6d523028e399c15dc77aec3affd2ea97ff735925/src/Rules/Comparison/ImpossibleCheckTypeHelper.php#L177-L186
gets $sureTypes = [ Node\Expr\Variable  , Type\NullType ].

When treatPhpDocTypesAsCertain = false, it will call `getNativeType` on the variable. That resolves to `null`.

It's probably because the `$value = null;` declaration on the top.

It does not know that the value is also passed as reference to a callback.

Any advice how to debug this further? 