### PR TITLE
Throw points (work in progress)

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -31,6 +31,7 @@ parameters:
 		- ../tests/e2e/magic-setter/*
 		- ../tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
 		- ../tests/PHPStan/Command/IgnoredRegexValidatorTest.php
+		- ../src/Command/IgnoredRegexValidator.php
 	featureToggles:
 		readComposerPhpVersion: false
 	ignoreErrors:

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -58,6 +58,7 @@ parameters:
 	checkTooWideReturnTypesInProtectedAndPublicMethods: false
 	checkUninitializedProperties: false
 	inferPrivatePropertyTypeFromConstructor: false
+	functionsHaveCompleteThrowsAnnotations: false
 	reportMaybes: false
 	reportMaybesInMethodSignatures: false
 	reportStaticMethodSignatures: false
@@ -214,6 +215,7 @@ parametersSchema:
 	checkTooWideReturnTypesInProtectedAndPublicMethods: bool()
 	checkUninitializedProperties: bool()
 	inferPrivatePropertyTypeFromConstructor: bool()
+	functionsHaveCompleteThrowsAnnotations: bool()
 	tipsOfTheDay: bool()
 	reportMaybes: bool()
 	reportMaybesInMethodSignatures: bool()
@@ -412,6 +414,7 @@ services:
 			polluteScopeWithAlwaysIterableForeach: %polluteScopeWithAlwaysIterableForeach%
 			earlyTerminatingMethodCalls: %earlyTerminatingMethodCalls%
 			earlyTerminatingFunctionCalls: %earlyTerminatingFunctionCalls%
+			functionsHaveCompleteThrowsAnnotations: %functionsHaveCompleteThrowsAnnotations%
 
 	-
 		implement: PHPStan\Analyser\ResultCache\ResultCacheManagerFactory

--- a/src/Analyser/ExpressionResult.php
+++ b/src/Analyser/ExpressionResult.php
@@ -9,6 +9,9 @@ class ExpressionResult
 
 	private bool $hasYield;
 
+	/** @var ThrowPoint[] $throwPoints */
+	private array $throwPoints;
+
 	/** @var (callable(): MutatingScope)|null */
 	private $truthyScopeCallback;
 
@@ -22,18 +25,21 @@ class ExpressionResult
 	/**
 	 * @param MutatingScope $scope
 	 * @param bool $hasYield
+	 * @param ThrowPoint[] $throwPoints
 	 * @param (callable(): MutatingScope)|null $truthyScopeCallback
 	 * @param (callable(): MutatingScope)|null $falseyScopeCallback
 	 */
 	public function __construct(
 		MutatingScope $scope,
 		bool $hasYield,
+		array $throwPoints,
 		?callable $truthyScopeCallback = null,
 		?callable $falseyScopeCallback = null
 	)
 	{
 		$this->scope = $scope;
 		$this->hasYield = $hasYield;
+		$this->throwPoints = $throwPoints;
 		$this->truthyScopeCallback = $truthyScopeCallback;
 		$this->falseyScopeCallback = $falseyScopeCallback;
 	}
@@ -46,6 +52,14 @@ class ExpressionResult
 	public function hasYield(): bool
 	{
 		return $this->hasYield;
+	}
+
+	/**
+	 * @return ThrowPoint[]
+	 */
+	public function getThrowPoints(): array
+	{
+		return $this->throwPoints;
 	}
 
 	public function getTruthyScope(): MutatingScope

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2759,7 +2759,7 @@ class NodeScopeResolver
 		$nodeCallback($var, $enterExpressionAssign ? $scope->enterExpressionAssign($var) : $scope);
 		$hasYield = false;
 		$throwPoints = [];
-		if ($var instanceof Variable) {
+		if ($var instanceof Variable && is_string($var->name)) {
 			$result = $processExprCallback($scope);
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -155,6 +155,8 @@ class NodeScopeResolver
 	/** @var array<int, string> */
 	private array $earlyTerminatingFunctionCalls;
 
+	private bool $functionsHaveCompleteThrowsAnnotations;
+
 	/** @var bool[] filePath(string) => bool(true) */
 	private array $analysedFiles = [];
 
@@ -171,6 +173,7 @@ class NodeScopeResolver
 	 * @param bool $polluteScopeWithAlwaysIterableForeach
 	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])
 	 * @param array<int, string> $earlyTerminatingFunctionCalls
+	 * @param bool $functionsHaveCompleteThrowsAnnotations
 	 */
 	public function __construct(
 		ReflectionProvider $reflectionProvider,
@@ -186,7 +189,8 @@ class NodeScopeResolver
 		bool $polluteCatchScopeWithTryAssignments,
 		bool $polluteScopeWithAlwaysIterableForeach,
 		array $earlyTerminatingMethodCalls,
-		array $earlyTerminatingFunctionCalls
+		array $earlyTerminatingFunctionCalls,
+		bool $functionsHaveCompleteThrowsAnnotations
 	)
 	{
 		$this->reflectionProvider = $reflectionProvider;
@@ -203,6 +207,7 @@ class NodeScopeResolver
 		$this->polluteScopeWithAlwaysIterableForeach = $polluteScopeWithAlwaysIterableForeach;
 		$this->earlyTerminatingMethodCalls = $earlyTerminatingMethodCalls;
 		$this->earlyTerminatingFunctionCalls = $earlyTerminatingFunctionCalls;
+		$this->functionsHaveCompleteThrowsAnnotations = $functionsHaveCompleteThrowsAnnotations;
 	}
 
 	/**
@@ -1649,7 +1654,7 @@ class NodeScopeResolver
 				if (!$throwType instanceof VoidType) {
 					$throwPoints[] = new ThrowPoint($scope, $throwType);
 				}
-			} else {
+			} elseif (!$this->functionsHaveCompleteThrowsAnnotations) {
 				$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 			}
 
@@ -1820,7 +1825,7 @@ class NodeScopeResolver
 						if (!$throwType instanceof VoidType) {
 							$throwPoints[] = new ThrowPoint($scope, $methodReflection->getThrowType());
 						}
-					} else {
+					} elseif (!$this->functionsHaveCompleteThrowsAnnotations) {
 						$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 					}
 				}
@@ -1882,7 +1887,7 @@ class NodeScopeResolver
 							if (!$throwType instanceof VoidType) {
 								$throwPoints[] = new ThrowPoint($scope, $throwType);
 							}
-						} else {
+						} elseif (!$this->functionsHaveCompleteThrowsAnnotations) {
 							$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 						}
 						if (
@@ -2245,8 +2250,7 @@ class NodeScopeResolver
 							if (!$throwType instanceof VoidType) {
 								$throwPoints[] = new ThrowPoint($scope, $throwType);
 							}
-						} else {
-							// todo setting
+						} elseif (!$this->functionsHaveCompleteThrowsAnnotations) {
 							$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 						}
 					}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2602,7 +2602,7 @@ class NodeScopeResolver
 				$statementResult
 			), $closureScope);
 
-			return new ExpressionResult($scope, false, $statementResult->getThrowPoints());
+			return new ExpressionResult($scope, false, []);
 		}
 
 		$count = 0;
@@ -2631,7 +2631,7 @@ class NodeScopeResolver
 			$statementResult
 		), $closureScope);
 
-		return new ExpressionResult($scope->processClosureScope($closureScope, null, $byRefUses), false, $statementResult->getThrowPoints());
+		return new ExpressionResult($scope->processClosureScope($closureScope, null, $byRefUses), false, []);
 	}
 
 	private function lookForArrayDestructuringArray(MutatingScope $scope, Expr $expr, Type $valueType): MutatingScope

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2289,6 +2289,8 @@ class NodeScopeResolver
 							$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 						}
 					}
+				} else {
+					$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 				}
 			}
 			$result = $this->processArgs($constructorReflection, $parametersAcceptor, $expr->args, $scope, $nodeCallback, $context);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -655,7 +655,7 @@ class NodeScopeResolver
 			return new StatementResult($result->getScope(), $result->hasYield(), true, [
 				new StatementExitPoint($stmt, $scope),
 			], [
-				new ThrowPoint($stmt, $result->getScope(), $scope->getType($stmt->expr)),
+				new ThrowPoint($result->getScope(), $scope->getType($stmt->expr)),
 			]);
 		} elseif ($stmt instanceof If_) {
 			$conditionType = $scope->getType($stmt->cond)->toBoolean();
@@ -1645,10 +1645,10 @@ class NodeScopeResolver
 			if (isset($functionReflection) && $functionReflection->getThrowType() !== null) {
 				$throwType = $functionReflection->getThrowType();
 				if (!$throwType instanceof VoidType) {
-					$throwPoints[] = new ThrowPoint($expr, $scope, $throwType);
+					$throwPoints[] = new ThrowPoint($scope, $throwType);
 				}
 			} else {
-				$throwPoints[] = new ThrowPoint($expr, $scope, new ObjectType(\Throwable::class));
+				$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 			}
 
 			if (
@@ -1816,10 +1816,10 @@ class NodeScopeResolver
 					if ($methodReflection->getThrowType() !== null) {
 						$throwType = $methodReflection->getThrowType();
 						if (!$throwType instanceof VoidType) {
-							$throwPoints[] = new ThrowPoint($expr, $scope, $methodReflection->getThrowType());
+							$throwPoints[] = new ThrowPoint($scope, $methodReflection->getThrowType());
 						}
 					} else {
-						$throwPoints[] = new ThrowPoint($expr, $scope, new ObjectType(\Throwable::class));
+						$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 					}
 				}
 			}
@@ -1878,10 +1878,10 @@ class NodeScopeResolver
 						if ($methodReflection->getThrowType() !== null) {
 							$throwType = $methodReflection->getThrowType();
 							if (!$throwType instanceof VoidType) {
-								$throwPoints[] = new ThrowPoint($expr, $scope, $throwType);
+								$throwPoints[] = new ThrowPoint($scope, $throwType);
 							}
 						} else {
-							$throwPoints[] = new ThrowPoint($expr, $scope, new ObjectType(\Throwable::class));
+							$throwPoints[] = new ThrowPoint($scope, new ObjectType(\Throwable::class));
 						}
 						if (
 							$classReflection->getName() === 'Closure'

--- a/src/Analyser/StatementResult.php
+++ b/src/Analyser/StatementResult.php
@@ -17,23 +17,29 @@ class StatementResult
 	/** @var StatementExitPoint[] */
 	private array $exitPoints;
 
+	/** @var ThrowPoint[] */
+	private array $throwPoints;
+
 	/**
 	 * @param MutatingScope $scope
 	 * @param bool $hasYield
 	 * @param bool $isAlwaysTerminating
 	 * @param StatementExitPoint[] $exitPoints
+	 * @param ThrowPoint[] $throwPoints
 	 */
 	public function __construct(
 		MutatingScope $scope,
 		bool $hasYield,
 		bool $isAlwaysTerminating,
-		array $exitPoints
+		array $exitPoints,
+		array $throwPoints
 	)
 	{
 		$this->scope = $scope;
 		$this->hasYield = $hasYield;
 		$this->isAlwaysTerminating = $isAlwaysTerminating;
 		$this->exitPoints = $exitPoints;
+		$this->throwPoints = $throwPoints;
 	}
 
 	public function getScope(): MutatingScope
@@ -65,14 +71,14 @@ class StatementResult
 
 			$num = $statement->num;
 			if (!$num instanceof LNumber) {
-				return new self($this->scope, $this->hasYield, false, $this->exitPoints);
+				return new self($this->scope, $this->hasYield, false, $this->exitPoints, []);
 			}
 
 			if ($num->value !== 1) {
 				continue;
 			}
 
-			return new self($this->scope, $this->hasYield, false, $this->exitPoints);
+			return new self($this->scope, $this->hasYield, false, $this->exitPoints, []);
 		}
 
 		return $this;
@@ -157,6 +163,14 @@ class StatementResult
 		}
 
 		return $exitPoints;
+	}
+
+	/**
+	 * @return ThrowPoint[]
+	 */
+	public function getThrowPoints(): array
+	{
+		return $this->throwPoints;
 	}
 
 }

--- a/src/Analyser/StatementResult.php
+++ b/src/Analyser/StatementResult.php
@@ -71,14 +71,14 @@ class StatementResult
 
 			$num = $statement->num;
 			if (!$num instanceof LNumber) {
-				return new self($this->scope, $this->hasYield, false, $this->exitPoints, []);
+				return new self($this->scope, $this->hasYield, false, $this->exitPoints, $this->throwPoints);
 			}
 
 			if ($num->value !== 1) {
 				continue;
 			}
 
-			return new self($this->scope, $this->hasYield, false, $this->exitPoints, []);
+			return new self($this->scope, $this->hasYield, false, $this->exitPoints, $this->throwPoints);
 		}
 
 		return $this;

--- a/src/Analyser/ThrowPoint.php
+++ b/src/Analyser/ThrowPoint.php
@@ -2,37 +2,19 @@
 
 namespace PHPStan\Analyser;
 
-use PhpParser\Node;
 use PHPStan\Type\Type;
 
 class ThrowPoint
 {
 
-	/** @var Node\Expr|Node\Stmt $node */
-	private Node $node;
-
 	private MutatingScope $scope;
 
 	private Type $type;
 
-	/**
-	 * @param Node\Expr|Node\Stmt $node
-	 * @param MutatingScope $scope
-	 * @param Type $type
-	 */
-	public function __construct(Node $node, MutatingScope $scope, Type $type)
+	public function __construct(MutatingScope $scope, Type $type)
 	{
-		$this->node = $node;
 		$this->scope = $scope;
 		$this->type = $type;
-	}
-
-	/**
-	 * @return Node\Expr|Node\Stmt
-	 */
-	public function getNode(): Node
-	{
-		return $this->node;
 	}
 
 	public function getScope(): MutatingScope

--- a/src/Analyser/ThrowPoint.php
+++ b/src/Analyser/ThrowPoint.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node;
+use PHPStan\Type\Type;
+
+class ThrowPoint
+{
+
+	/** @var Node\Expr|Node\Stmt $node */
+	private Node $node;
+
+	private MutatingScope $scope;
+
+	private Type $type;
+
+	/**
+	 * @param Node\Expr|Node\Stmt $node
+	 * @param MutatingScope $scope
+	 * @param Type $type
+	 */
+	public function __construct(Node $node, MutatingScope $scope, Type $type)
+	{
+		$this->node = $node;
+		$this->scope = $scope;
+		$this->type = $type;
+	}
+
+	/**
+	 * @return Node\Expr|Node\Stmt
+	 */
+	public function getNode(): Node
+	{
+		return $this->node;
+	}
+
+	public function getScope(): MutatingScope
+	{
+		return $this->scope;
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
+	}
+
+}

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -83,7 +83,8 @@ abstract class RuleTestCase extends \PHPStan\Testing\TestCase
 				$this->shouldPolluteCatchScopeWithTryAssignments(),
 				$this->shouldPolluteScopeWithAlwaysIterableForeach(),
 				[],
-				[]
+				[],
+				false
 			);
 			$fileAnalyser = new FileAnalyser(
 				$this->createScopeFactory($broker, $typeSpecifier),

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -514,7 +514,8 @@ class AnalyserTest extends \PHPStan\Testing\TestCase
 			false,
 			true,
 			[],
-			[]
+			[],
+			false
 		);
 		$lexer = new \PhpParser\Lexer(['usedAttributes' => ['comments', 'startLine', 'endLine', 'startTokenPos', 'endTokenPos']]);
 		$fileAnalyser = new FileAnalyser(

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5809,6 +5809,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/try-catch-finally.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/variable.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/while.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/try-catch.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -12001,7 +12001,8 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 					'doBar',
 				],
 			],
-			['baz']
+			['baz'],
+			false
 		);
 		$resolver->setAnalysedFiles(array_map(static function (string $file) use ($fileHelper): string {
 			return $fileHelper->normalizePath($file);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5784,6 +5784,33 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/invalidate-object-argument-function.php');
 	}
 
+	public function dataThrowPoints(): iterable
+	{
+		require_once __DIR__ . '/data/throw-points/helpers.php';
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/php8/null-safe-method-call.php');
+		}
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/and.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/array.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/array-dim-fetch.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/assign.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/assign-op.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/do-while.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/for.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/foreach.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/func-call.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/if.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/method-call.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/or.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/property-fetch.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/static-call.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/switch.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/throw.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/try-catch-finally.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/variable.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/while.php');
+	}
+
 	/**
 	 * @dataProvider dataArrayFunctions
 	 * @param string $description
@@ -11423,6 +11450,7 @@ class NodeScopeResolverTest extends \PHPStan\Testing\TestCase
 	 * @dataProvider dataBug4190
 	 * @dataProvider dataClearStatCache
 	 * @dataProvider dataInvalidateObjectStateAfterPassingToImpureFunction
+	 * @dataProvider dataThrowPoints
 	 * @param string $assertType
 	 * @param string $file
 	 * @param mixed ...$args

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -144,7 +144,7 @@ class StatementResultTest extends \PHPStan\Testing\TestCase
 				true,
 			],
 			[
-				'try { return; } catch (Exception $e) { }',
+				'try { maybeThrow(); return; } catch (Exception $e) { }',
 				false,
 			],
 			[
@@ -156,7 +156,7 @@ class StatementResultTest extends \PHPStan\Testing\TestCase
 				true,
 			],
 			[
-				'try { break; } catch (Exception $e) { break; } catch (OtherException $e) { }',
+				'try { maybeThrow(); break; } catch (Exception $e) { break; } catch (OtherException $e) { }',
 				false,
 			],
 			[
@@ -324,15 +324,15 @@ class StatementResultTest extends \PHPStan\Testing\TestCase
 				true,
 			],
 			[
-				'while ($string !== null) { $string = null; try { return true; } catch (\Exception $e) { doFoo(); } }',
+				'while ($string !== null) { $string = null; try { maybeThrow(); return true; } catch (\Exception $e) { doFoo(); } }',
 				false,
 			],
 			[
-				'while ($string !== null) { $string = null; try { return true; } catch (\Exception $e) { doFoo(); } }',
+				'while ($string !== null) { $string = null; try { maybeThrow(); return true; } catch (\Exception $e) { doFoo(); } }',
 				false,
 			],
 			[
-				'try { return true; } catch (\Exception $e) { doFoo(); }',
+				'try { maybeThrow(); return true; } catch (\Exception $e) { doFoo(); }',
 				false,
 			],
 			[

--- a/tests/PHPStan/Analyser/data/finally-with-early-termination.php
+++ b/tests/PHPStan/Analyser/data/finally-with-early-termination.php
@@ -5,6 +5,7 @@ namespace FinallyNamespace;
 try {
 	$integerOrString = 1;
 	$fooOrBarException = null;
+	maybeThrows();
 	return 1;
 } catch (FooException $e) {
 	$integerOrString = 1;

--- a/tests/PHPStan/Analyser/data/finally.php
+++ b/tests/PHPStan/Analyser/data/finally.php
@@ -16,6 +16,7 @@ function () {
 	try {
 		$integerOrString = 1;
 		$fooOrBarException = null;
+		maybeThrows();
 	} catch (FooException $e) {
 		$integerOrString = 1;
 		$fooOrBarException = $e;

--- a/tests/PHPStan/Analyser/data/if.php
+++ b/tests/PHPStan/Analyser/data/if.php
@@ -38,8 +38,8 @@ function () {
 	$exceptionFromTry = null;
 	try {
 		$inTry = 1;
-		$inTryNotInCatch = 1;
 		$fooObjectFromTryCatch = new InTryCatchFoo();
+		$inTryNotInCatch = 1;
 		$mixedVarFromTryCatch = 1;
 		$nullableIntegerFromTryCatch = 1;
 		$anotherNullableIntegerFromTryCatch = null;
@@ -59,7 +59,7 @@ function () {
 
 	$exceptionFromTryCatch = null;
 	try {
-
+		maybeThrows();
 	} catch (\SomeConcreteException $exceptionFromTryCatch) {
 		return;
 	} catch (\AnotherException $exceptionFromTryCatch) {

--- a/tests/PHPStan/Analyser/data/throw-points/and.php
+++ b/tests/PHPStan/Analyser/data/throw-points/and.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ThrowPoints\And_;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		$foo = (doesntThrow() && doesntThrow());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = (doesntThrow() && maybeThrows());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = (doesntThrow() and doesntThrow());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = (doesntThrow() and maybeThrows());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/array-dim-fetch.php
+++ b/tests/PHPStan/Analyser/data/throw-points/array-dim-fetch.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ThrowPoints\ArrayDimFetch;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		[][doesntThrow()];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[][maybeThrows()];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/array.php
+++ b/tests/PHPStan/Analyser/data/throw-points/array.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace ThrowPoints\Array_;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		[];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[doesntThrow()];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[maybeThrows()];
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		[doesntThrow(), $foo = 1];
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[maybeThrows(), $foo = 1];
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		[doesntThrow() => 1, $foo = 1];
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[maybeThrows() => 1, $foo = 1];
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/assign-op.php
+++ b/tests/PHPStan/Analyser/data/throw-points/assign-op.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace ThrowPoints\Assign;
+
+use PHPStan\TrinaryLogic;
+use stdClass;
+use function PHPStan\Analyser\assertType;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		$foo .= doesntThrow();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo .= maybeThrows();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[0] .= doesntThrow();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[0] .= maybeThrows();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[doesntThrow()] .= 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[maybeThrows()] .= 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = new stdClass();
+		$foo->bar = 'a';
+		$foo->bar .= [doesntThrow(), 'b'][1];
+	} finally {
+		assertType('\'ab\'', $foo->bar);
+	}
+};
+
+function () {
+	try {
+		$foo = new stdClass();
+		$foo->bar = 'a';
+		$foo->bar .= [maybeThrows(), 'b'][1];
+	} finally {
+		assertType('\'a\'|\'ab\'', $foo->bar);
+	}
+};
+
+function () {
+	try {
+		$obj = new stdClass();
+		$obj->{doesntThrow()} .= ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$obj = new stdClass();
+		$obj->{maybeThrows()} .= ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		Foo::$bar = 'a';
+		Foo::$bar .= [doesntThrow(), 'b'][1];
+	} finally {
+		assertType('\'ab\'', Foo::$bar);
+	}
+};
+
+function () {
+	try {
+		Foo::$bar = 'a';
+		Foo::$bar .= [maybeThrows(), 'b'][1];
+	} finally {
+		assertType('\'a\'|\'ab\'', Foo::$bar);
+	}
+};
+
+function () {
+	try {
+		Foo::${doesntThrow()} .= ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		Foo::${maybeThrows()} .= ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/assign.php
+++ b/tests/PHPStan/Analyser/data/throw-points/assign.php
@@ -9,6 +9,14 @@ use function PHPStan\Analyser\assertVariableCertainty;
 use function ThrowPoints\Helpers\doesntThrow;
 use function ThrowPoints\Helpers\maybeThrows;
 
+class Foo
+{
+
+	/** @var bool */
+	public static $bar = true;
+
+}
+
 function () {
 	try {
 		$foo = doesntThrow();

--- a/tests/PHPStan/Analyser/data/throw-points/assign.php
+++ b/tests/PHPStan/Analyser/data/throw-points/assign.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace ThrowPoints\Assign;
+
+use PHPStan\TrinaryLogic;
+use stdClass;
+use function PHPStan\Analyser\assertType;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		$foo = doesntThrow();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = maybeThrows();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[0] = doesntThrow();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[0] = maybeThrows();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[doesntThrow()] = 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo[maybeThrows()] = 0;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = new stdClass();
+		$foo->bar = false;
+		$foo->bar = (doesntThrow() || true);
+	} finally {
+		assertType('true', $foo->bar);
+	}
+};
+
+function () {
+	try {
+		$foo = new stdClass();
+		$foo->bar = false;
+		$foo->bar = (maybeThrows() || true);
+	} finally {
+		assertType('bool', $foo->bar);
+	}
+};
+
+function () {
+	try {
+		$obj = new stdClass();
+		$obj->{doesntThrow()} = ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$obj = new stdClass();
+		$obj->{maybeThrows()} = ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		Foo::$bar = false;
+		Foo::$bar = (doesntThrow() || true);
+	} finally {
+		assertType('true', Foo::$bar);
+	}
+};
+
+function () {
+	try {
+		Foo::$bar = false;
+		Foo::$bar = (maybeThrows() || true);
+	} finally {
+		assertType('bool', Foo::$bar);
+	}
+};
+
+function () {
+	try {
+		Foo::${doesntThrow()} = ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		Foo::${maybeThrows()} = ($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		[$foo] = doesntThrow();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[$foo] = maybeThrows();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		[$foo[doesntThrow()]] = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		[$foo[maybeThrows()]] = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/do-while.php
+++ b/tests/PHPStan/Analyser/data/throw-points/do-while.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ThrowPoints\DoWhile;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		do {
+			maybeThrows();
+		} while (random_int(0, 1));
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		do {
+			maybeThrows();
+		} while (false);
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/for.php
+++ b/tests/PHPStan/Analyser/data/throw-points/for.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ThrowPoints\For_;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		for (;random_int(0, 1);) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/foreach.php
+++ b/tests/PHPStan/Analyser/data/throw-points/foreach.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ThrowPoints\Foreach_;
+
+use Exception;
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function (iterable $iterable) {
+	try {
+		foreach ($iterable as $v) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		foreach ([] as $v) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+

--- a/tests/PHPStan/Analyser/data/throw-points/func-call.php
+++ b/tests/PHPStan/Analyser/data/throw-points/func-call.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ThrowPoints\FuncCall;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+use function ThrowPoints\Helpers\throws;
+
+function () {
+	try {
+		throws();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		maybeThrows();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		doesntThrow();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		doesntThrow()($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		maybeThrows()($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		doesntThrow(doesntThrow(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		doesntThrow(maybeThrows(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/helpers.php
+++ b/tests/PHPStan/Analyser/data/throw-points/helpers.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace ThrowPoints\Helpers;
+
+use Exception;
+
+/**
+ * @return mixed
+ * @throws Exception
+ */
+function throws(...$args)
+{
+}
+
+/**
+ * @return mixed
+ */
+function maybeThrows(...$args)
+{
+}
+
+/**
+ * @return mixed
+ * @throws void
+ */
+function doesntThrow(...$args)
+{
+}
+
+class ThrowPointTestObject
+{
+	/**
+	 * @return mixed
+	 * @throws Exception
+	 */
+	public function throws(...$args)
+	{
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public function maybeThrows(...$args)
+	{
+	}
+
+	/**
+	 * @return mixed
+	 * @throws void
+	 */
+	public function doesntThrow(...$args)
+	{
+	}
+
+	/**
+	 * @return mixed
+	 * @throws Exception
+	 */
+	public static function staticThrows(...$args)
+	{
+	}
+
+	/**
+	 * @return mixed
+	 */
+	public static function staticMaybeThrows(...$args)
+	{
+	}
+
+	/**
+	 * @return mixed
+	 * @throws void
+	 */
+	public static function staticDoesntThrow(...$args)
+	{
+	}
+}

--- a/tests/PHPStan/Analyser/data/throw-points/if.php
+++ b/tests/PHPStan/Analyser/data/throw-points/if.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ThrowPoints\If_;
+
+use Exception;
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		if (random_int(0, 1)) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		if (random_int(0, 1)) {
+		} else {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		if (random_int(0, 1)) {
+		} elseif (random_int(0, 1)) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/method-call.php
+++ b/tests/PHPStan/Analyser/data/throw-points/method-call.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace ThrowPoints\MethodCall;
+
+use PHPStan\TrinaryLogic;
+use ThrowPoints\Helpers\ThrowPointTestObject;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->throws();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->maybeThrows();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->doesntThrow();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		doesntThrow()->{$foo = 1}($bar = 2);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+		assertVariableCertainty(TrinaryLogic::createYes(), $bar);
+	}
+};
+
+function () {
+	try {
+		maybeThrows()->{$foo = 1}($bar = 2);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $bar);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->{doesntThrow()}($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->{maybeThrows()}($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->doesntThrow(doesntThrow(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj->doesntThrow(maybeThrows(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/or.php
+++ b/tests/PHPStan/Analyser/data/throw-points/or.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ThrowPoints\And_;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		$foo = (doesntThrow() || doesntThrow());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = (doesntThrow() || maybeThrows());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = (doesntThrow() or doesntThrow());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = (doesntThrow() or maybeThrows());
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/php8/null-safe-method-call.php
+++ b/tests/PHPStan/Analyser/data/throw-points/php8/null-safe-method-call.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace ThrowPoints\NullSafeMethodCall;
+
+use PHPStan\TrinaryLogic;
+use ThrowPoints\Helpers\ThrowPointTestObject;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->throws();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->maybeThrows();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->doesntThrow();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		doesntThrow()?->{$foo = 1}($bar = 2);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+		assertVariableCertainty(TrinaryLogic::createYes(), $bar);
+	}
+};
+
+function () {
+	try {
+		maybeThrows()?->{$foo = 1}($bar = 2);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $bar);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->{doesntThrow()}($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->{maybeThrows()}($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->doesntThrow(doesntThrow(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	$obj = new ThrowPointTestObject();
+	try {
+		$obj?->doesntThrow(maybeThrows(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/property-fetch.php
+++ b/tests/PHPStan/Analyser/data/throw-points/property-fetch.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ThrowPoints\PropertyFetch;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		doesntThrow()->foo;
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		maybeThrows()->foo;
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/static-call.php
+++ b/tests/PHPStan/Analyser/data/throw-points/static-call.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ThrowPoints\StaticCall;
+
+use PHPStan\TrinaryLogic;
+use ThrowPoints\Helpers\ThrowPointTestObject;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		ThrowPointTestObject::staticThrows();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		ThrowPointTestObject::staticMaybeThrows();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		ThrowPointTestObject::staticDoesntThrow();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		ThrowPointTestObject::{doesntThrow()}($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		ThrowPointTestObject::{maybeThrows()}($foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		ThrowPointTestObject::staticDoesntThrow(doesntThrow(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		ThrowPointTestObject::staticDoesntThrow(maybeThrows(), $foo = 1);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/switch.php
+++ b/tests/PHPStan/Analyser/data/throw-points/switch.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ThrowPoints\Switch_;
+
+use Exception;
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		switch (random_int(0, 1)) {
+			case 0:
+				maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		switch (random_int(0, 1)) {
+			default:
+				maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		switch (random_int(0, 1)) {
+			default:
+				throw new Exception();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/throw.php
+++ b/tests/PHPStan/Analyser/data/throw-points/throw.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ThrowPoints\Throw_;
+
+use Exception;
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+
+function () {
+	try {
+		throw new Exception();
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	}
+};
+
+function () {
+	try {
+		if (random_int(0, 1)) {
+			throw new Exception();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		$foo = 1;
+		throw new Exception();
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/try-catch-finally.php
+++ b/tests/PHPStan/Analyser/data/throw-points/try-catch-finally.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ThrowPoints\TryCatch;
+
+use Exception;
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		try {
+		} finally {
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		try {
+			maybeThrows();
+		} finally {
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		try {
+			maybeThrows();
+		} catch (Exception $exception) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		try {
+		} finally {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/try-catch.php
+++ b/tests/PHPStan/Analyser/data/throw-points/try-catch.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace ThrowPoints\TryCatch;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertType;
+use function PHPStan\Analyser\assertVariableCertainty;
+
+class MyInvalidArgumentException extends \InvalidArgumentException
+{
+
+}
+
+class MyRuntimeException extends \RuntimeException
+{
+
+}
+
+class Foo
+{
+
+	/** @throws void */
+	public static function createInvalidArgumentException(): \InvalidArgumentException
+	{
+
+	}
+
+	/** @throws void */
+	public static function createMyInvalidArgumentException(): MyInvalidArgumentException
+	{
+
+	}
+
+	/** @throws void */
+	public static function createRuntimeException(): \RuntimeException
+	{
+
+	}
+
+	/** @throws void */
+	public static function createMyRuntimeException(): MyRuntimeException
+	{
+
+	}
+
+	/** @throws void */
+	public static function myRand(): int
+	{
+
+	}
+
+}
+
+function (): void {
+	try {
+		if (Foo::myRand() === 0) {
+			$foo = 1;
+			throw Foo::createInvalidArgumentException();
+		}
+		if (Foo::myRand() === 1) {
+			$foo = 2;
+			throw Foo::createMyInvalidArgumentException();
+		}
+
+		if (Foo::myRand() === 2) {
+			$baz = 1;
+			throw Foo::createRuntimeException();
+		}
+		if (Foo::myRand() === 3) {
+			$baz = 2;
+			throw Foo::createMyRuntimeException();
+		}
+
+		$bar = 1;
+	} catch (\InvalidArgumentException $e) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+		assertType('1|2', $foo);
+
+		assertVariableCertainty(TrinaryLogic::createNo(), $bar);
+		assertVariableCertainty(TrinaryLogic::createNo(), $baz);
+	} catch (\RuntimeException $e) {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+		assertVariableCertainty(TrinaryLogic::createNo(), $bar);
+		assertVariableCertainty(TrinaryLogic::createYes(), $baz);
+		assertType('1|2', $baz);
+	} catch (\Throwable $e) {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+		assertVariableCertainty(TrinaryLogic::createYes(), $bar);
+		assertVariableCertainty(TrinaryLogic::createNo(), $baz);
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+		assertType('1|2', $foo);
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $bar);
+		assertType('1', $bar);
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $baz);
+		assertType('1|2', $baz);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/variable.php
+++ b/tests/PHPStan/Analyser/data/throw-points/variable.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ThrowPoints\Variable;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\doesntThrow;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		${doesntThrow()};
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};
+
+function () {
+	try {
+		${maybeThrows()};
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};

--- a/tests/PHPStan/Analyser/data/throw-points/while.php
+++ b/tests/PHPStan/Analyser/data/throw-points/while.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ThrowPoints\While_;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Analyser\assertVariableCertainty;
+use function ThrowPoints\Helpers\maybeThrows;
+
+function () {
+	try {
+		while (random_int(0, 1)) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+};
+
+function () {
+	try {
+		while (false) {
+			maybeThrows();
+		}
+		$foo = 1;
+	} finally {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	}
+};

--- a/tests/PHPStan/Rules/Missing/data/missing-return.php
+++ b/tests/PHPStan/Rules/Missing/data/missing-return.php
@@ -232,7 +232,7 @@ class TryCatchFinally
 	public function doBaz(): int
 	{
 		try {
-			return 1;
+			maybeThrow(); return 1;
 		} catch (\Exception $e) {
 			return 1;
 		} catch (\Throwable $e) {

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -160,10 +160,6 @@ class DefinedVariableRuleTest extends \PHPStan\Testing\RuleTestCase
 				251,
 			],
 			[
-				'Variable $variableDefinedInTry might not be defined.',
-				260,
-			],
-			[
 				'Variable $variableAvailableInAllCatches might not be defined.',
 				266,
 			],

--- a/tests/PHPStan/Rules/Variables/data/defined-variables.php
+++ b/tests/PHPStan/Rules/Variables/data/defined-variables.php
@@ -252,7 +252,7 @@ function () {
 
 	try {
 		$variableDefinedInTry = 1;
-		$variableDefinedInTryAndAllCatches = 1;
+		$variableDefinedInTryAndAllCatches = 1; maybeThrow();
 	} catch (\FooException $e) {
 		$variableDefinedInTryAndAllCatches = 1;
 		$variableAvailableInAllCatches = 1;


### PR DESCRIPTION
As discussed in https://github.com/phpstan/phpstan-src/pull/472 I've begun implementing the 'throw points' logic in NodeScopeResolver. As you suspected @ondrejmirtes `assertVariableCertainty` does the trick.

So far I've only implemented throw points at a statement level, so all expressions are still behaving as if they are nothrow, only an explicit `throw` statement creates a point. I just started extending the implementation to the expression level and I am running into an issue. I am trying to get this test to pass:

```
/**
 * @throws Exception
 */
function throws()
{
}

function () {
	try {
		throws();
		$foo = 1;
	} finally {
		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
	}
};
```

But I can't seem to get `throws()` to resolve... when processing the `FuncCall` node, `$functionReflection` is always null. I'm not sure how get it to work, I hope I won't have to go messing around in `TestCase::createBroker`...