### PR TITLE
BaselineNeonErrorFormatter: Sort output by file and pattern, ignoring…

### DIFF
--- a/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
@@ -7,6 +7,8 @@ use Nette\Neon\Neon;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
+use const SORT_STRING;
+use function ksort;
 use function preg_quote;
 
 class BaselineNeonErrorFormatter implements ErrorFormatter
@@ -40,6 +42,7 @@ class BaselineNeonErrorFormatter implements ErrorFormatter
 			}
 			$fileErrors[$fileSpecificError->getFilePath()][] = $fileSpecificError->getMessage();
 		}
+		ksort($fileErrors, SORT_STRING);
 
 		$errorsToOutput = [];
 		foreach ($fileErrors as $file => $errorMessages) {
@@ -52,6 +55,7 @@ class BaselineNeonErrorFormatter implements ErrorFormatter
 
 				$fileErrorsCounts[$errorMessage]++;
 			}
+			ksort($fileErrorsCounts, SORT_STRING);
 
 			foreach ($fileErrorsCounts as $message => $count) {
 				$errorsToOutput[] = [

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -55,12 +55,12 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],
 				[
-					'message' => '#^Foo$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'foo.php',
 				],
 				[
-					'message' => "#^Bar\nBar2$#",
+					'message' => '#^Foo$#',
 					'count' => 1,
 					'path' => 'foo.php',
 				],
@@ -84,12 +84,12 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'folder with unicode 😃/file name with "spaces" and unicode 😃.php',
 				],
 				[
-					'message' => '#^Foo$#',
+					'message' => "#^Bar\nBar2$#",
 					'count' => 1,
 					'path' => 'foo.php',
 				],
 				[
-					'message' => "#^Bar\nBar2$#",
+					'message' => '#^Foo$#',
 					'count' => 1,
 					'path' => 'foo.php',
 				],

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -197,7 +197,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 	}
 
 	/**
-	 * @return \Generator<int, list<Error>, void, void>
+	 * @return \Generator<int, array{list<Error>}, void, void>
 	 */
 	public function outputOrderingProvider(): \Generator
 	{


### PR DESCRIPTION
… line numbers

since line numbers aren't retained in ignoreErrors, allowing them to influence the ordering just produces spurious changes to baselines when moving code (and possibly other, weirder cases).

This fixes phpstan/phpstan#4737, barring possible bugs in PHP's own sorting algorithm.