### PR TITLE
Add test case for multiple inheritance in interfaces

### DIFF
--- a/tests/PHPStan/Levels/data/methodCalls.php
+++ b/tests/PHPStan/Levels/data/methodCalls.php
@@ -234,3 +234,34 @@ class ExtraArguments
 	}
 
 }
+
+interface FooInterface
+{
+    public function doFoo(): void;
+}
+
+interface BarInterface
+{
+    public function doBar(): void;
+}
+
+interface BazInterface
+{
+    public function doBaz(): void;
+}
+
+interface QuxInterface extends FooInterface, BarInterface, BazInterface
+{
+    public function doFooBarBazQux(): void;
+}
+
+class QuxDecorator
+{
+    public function __construct(string $quxClass)
+    {
+        /** @var QuxInterface $qux */
+        $qux = new $quxClass();
+
+        $qux->doFoo();
+    }
+}


### PR DESCRIPTION
This PR attempts to expose an issue I have. I guess it's related to multiple interface inheritance.
In my case, even it the inheritance seems right, I get the following error:
```
Call to an undefined method FooInterface::doFoo()
```
I'd like to confirm the scenario and its causes before opening an issue, in order to confirm my case is valid and provide more details.