### PR TITLE
Update XSLTProcessor::transformToXML signature

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -13231,7 +13231,7 @@ return [
 'XsltProcessor::setSecurityPrefs' => ['int', 'securityPrefs'=>'int'],
 'XSLTProcessor::transformToDoc' => ['DOMDocument', 'doc'=>'DOMNode'],
 'XSLTProcessor::transformToURI' => ['int', 'doc'=>'DOMDocument', 'uri'=>'string'],
-'XSLTProcessor::transformToXML' => ['string|false', 'doc'=>'DOMDocument'],
+'XSLTProcessor::transformToXML' => ['string|false', 'doc'=>'DOMDocument|SimpleXMLElement'],
 'Yaconf::get' => ['mixed', 'name'=>'string', 'default_value='=>'mixed'],
 'Yaconf::has' => ['bool', 'name'=>'string'],
 'Yaf_Action_Abstract::__construct' => ['void', 'request'=>'Yaf_Request_Abstract', 'response'=>'Yaf_Response_Abstract', 'view'=>'Yaf_View_Interface', 'invokeArgs='=>'?array'],


### PR DESCRIPTION
According to documentation `XSLTProcessor::transformToXML` accepts two types of argument.

> Parameters
> document
> The DOMDocument or SimpleXMLElement object to be transformed.

Source: https://www.php.net/manual/en/xsltprocessor.transformtoxml.php
