### PR TITLE
Implement `stream_eof` in `FileReadTrapStreamWrapper`, disable OpCache on PHP < 7.4, #4881

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -11,6 +11,11 @@ use Symfony\Component\Console\Helper\ProgressBar;
 (function () {
 	error_reporting(E_ALL);
 	ini_set('display_errors', 'stderr');
+    if (version_compare(PHP_VERSION, '7.4.0', '<')) {
+		// PHP earlier than 7.4.x with OpCache triggers a bug when we intercept
+		// custom autoloaders' reads to discover file paths. See PHPStan #4881.
+		ini_set('opcache.enable', 'Off');
+	}
 	gc_disable(); // performance boost
 
 	define('__PHPSTAN_RUNNING__', true);


### PR DESCRIPTION
## Overview

This PR resolves [PHPStan issue #4881](https://github.com/phpstan/phpstan/issues/4881) which had two parts:

1. PHP emitted warnings about a missing `stream_eof()` implementation, and
2. PHP on versions prior to 7.4 segfaulted with `zend_mm_heap corrupted` error messages, likely due to an OpCache issue.

We address item 1 by implementing more of the stream wrapper.

We address item 2 by disabling OpCache for PHPStan when the version of PHP is earlier than 7.4.x.

## Testing

Thanks to the diligent work of @alfredbez and others in the issue 4881 thread, we have [a repository](https://github.com/alfredbez/phpstan-0-12-84-error/) which allows for a Dockerized reproduction of the issue.

**Before**
```
$ docker run -it --rm -v $(pwd):/app -w /app spryker/php:7.3 vendor/bin/phpstan
Note: Using configuration file /app/phpstan.neon.dist.
PHP Warning:  include(): PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrapper::stream_eof is not implemented! Assuming EOF in phar:///app/vendor/phpstan/phpstan/phpstan.phar/vendor/composer/ClassLoader.php on line 478
Warning: include(): PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrapper::stream_eof is not implemented! Assuming EOF in phar:///app/vendor/phpstan/phpstan/phpstan.phar/vendor/composer/ClassLoader.php on line 478
zend_mm_heap corrupted
```

**After**
```
$ docker run -it --rm -v $(pwd):/app -v $(pwd)/../phpstan-src:/opt/phpstan-src -w /app spryker/php:7.3 bash -c "cp /opt/phpstan-src/tmp/phpstan.phar vendor/phpstan/phpstan/phpstan.phar && vendor/bin/phpstan"
Note: Using configuration file /app/phpstan.neon.dist.
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%



 [OK] No errors

```

## e2e tests
It seems that the code triggering the EOF warnings relies on having PHPStan itself in `composer.json`, I was not sure how to craft a companion PR in the `phpstan/phpstan` repository that would do this without introducing a circular dependency.