### PR TITLE
Static analyse if date_create_from_format will fail or not

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -963,6 +963,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\DateTimeDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\DsMapDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\Php;
 
@@ -17,6 +17,7 @@ use PHPStan\Type\TypeUtils;
 
 class DateTimeDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
 		return in_array($functionReflection->getName(), ['date_create_from_format', 'date_create_immutable_from_format'], true);
@@ -40,4 +41,5 @@ class DateTimeDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExt
 		$className = $functionReflection->getName() === 'date_create_from_format' ? DateTime::class : DateTimeImmutable::class;
 		return $isValid ? new ObjectType($className) : new ConstantBooleanType(false);
 	}
+
 }

--- a/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Php;
+
+use DateTime;
+use DateTimeImmutable;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeUtils;
+
+class DateTimeDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), ['date_create_from_format', 'date_create_immutable_from_format'], true);
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+
+		$format = $scope->getType($functionCall->args[0]->value);
+		$datetime = $scope->getType($functionCall->args[1]->value);
+
+		if (!$format instanceof ConstantStringType || !$datetime instanceof ConstantStringType) {
+			return $defaultReturnType;
+		}
+
+		$formatValue = TypeUtils::getConstantStrings($format)[0]->getValue();
+		$datetimeValue = TypeUtils::getConstantStrings($datetime)[0]->getValue();
+		$isValid = (DateTime::createFromFormat($formatValue, $datetimeValue) !== false);
+
+		$className = $functionReflection->getName() === 'date_create_from_format' ? DateTime::class : DateTimeImmutable::class;
+		return $isValid ? new ObjectType($className) : new ConstantBooleanType(false);
+	}
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -381,6 +381,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-aliases.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4650.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2906.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeDynamicReturnTypes.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
+++ b/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace DateTimeDynamicReturnTypes;
+
+use DateTime;
+use DateTimeImmutable;
+use function date_create_from_format;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function createDynamic(string $format, string $datetime): void {
+		assertType('DateTime|false', date_create_from_format($format, $datetime));
+		assertType('DateTimeImmutable|false', date_create_immutable_from_format($format, $datetime));
+
+		assertType('DateTime|false', DateTime::createFromFormat($format, $datetime));
+		assertType('DateTimeImmutable|false', DateTimeImmutable::createFromFormat($format, $datetime));
+	}
+
+	public function staticInvalidFormat(): void {
+		assertType('false', date_create_from_format('Foobar', '2022-02-20'));
+		assertType('false', date_create_immutable_from_format('Foobar', '2022-02-20'));
+
+		assertType('false', DateTime::createFromFormat('Foobar', '2022-02-20'));
+		assertType('false', DateTimeImmutable::createFromFormat('Foobar', '2022-02-20'));
+	}
+
+	public function staticInvalidDatetime(): void {
+		assertType('false', date_create_from_format('Y-m-d', '2022/02/20'));
+		assertType('false', date_create_immutable_from_format('Y-m-d', '2022/02/20'));
+
+		assertType('false', DateTime::createFromFormat('Y-m-d', '2022/02/20'));
+		assertType('false', DateTimeImmutable::createFromFormat('Y-m-d', '2022/02/20'));
+	}
+
+	public function staticValidStrings(): void {
+		assertType('DateTime', date_create_from_format('Y-m-d', '2020-10-12'));
+		assertType('DateTimeImmutable', date_create_immutable_from_format('Y-m-d', '2020-10-12'));
+
+		assertType('DateTime', DateTime::createFromFormat('Y-m-d', '2020-10-12'));
+		assertType('DateTimeImmutable', DateTimeImmutable::createFromFormat('Y-m-d', '2020-10-12'));
+	}
+}

--- a/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
+++ b/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace DateTimeDynamicReturnTypes;
 
@@ -9,35 +9,25 @@ use function PHPStan\Testing\assertType;
 
 class Foo
 {
+
 	public function createDynamic(string $format, string $datetime): void {
 		assertType('DateTime|false', date_create_from_format($format, $datetime));
 		assertType('DateTimeImmutable|false', date_create_immutable_from_format($format, $datetime));
-
-		assertType('DateTime|false', DateTime::createFromFormat($format, $datetime));
-		assertType('DateTimeImmutable|false', DateTimeImmutable::createFromFormat($format, $datetime));
 	}
 
 	public function staticInvalidFormat(): void {
 		assertType('false', date_create_from_format('Foobar', '2022-02-20'));
 		assertType('false', date_create_immutable_from_format('Foobar', '2022-02-20'));
-
-		assertType('false', DateTime::createFromFormat('Foobar', '2022-02-20'));
-		assertType('false', DateTimeImmutable::createFromFormat('Foobar', '2022-02-20'));
 	}
 
 	public function staticInvalidDatetime(): void {
 		assertType('false', date_create_from_format('Y-m-d', '2022/02/20'));
 		assertType('false', date_create_immutable_from_format('Y-m-d', '2022/02/20'));
-
-		assertType('false', DateTime::createFromFormat('Y-m-d', '2022/02/20'));
-		assertType('false', DateTimeImmutable::createFromFormat('Y-m-d', '2022/02/20'));
 	}
 
 	public function staticValidStrings(): void {
 		assertType('DateTime', date_create_from_format('Y-m-d', '2020-10-12'));
 		assertType('DateTimeImmutable', date_create_immutable_from_format('Y-m-d', '2020-10-12'));
-
-		assertType('DateTime', DateTime::createFromFormat('Y-m-d', '2020-10-12'));
-		assertType('DateTimeImmutable', DateTimeImmutable::createFromFormat('Y-m-d', '2020-10-12'));
 	}
+
 }

--- a/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
+++ b/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
@@ -30,4 +30,12 @@ class Foo
 		assertType('DateTimeImmutable', date_create_immutable_from_format('Y-m-d', '2020-10-12'));
 	}
 
+	public function localVariables(): void {
+		$format = 'Y-m-d';
+		$datetime = '2020-10-12';
+
+		assertType('DateTime', date_create_from_format($format, $datetime));
+		assertType('DateTimeImmutable', date_create_immutable_from_format($format, $datetime));
+	}
+
 }


### PR DESCRIPTION
Both `date_create_from_format` and its immutable cousin `date_create_immutable_from_format` can return `DateTime`/`DateTimeImmutable` objects or `false` on error.

In situations where both `$format` and `$datetime` parameters are known (static strings) we can check for results via phpstan and therefore prevent both unnecessary checks during runtime and false positives in phpstan (baseline).

~As `DateTime::createFromFormat()` and `DateTimeImmutable::createFromFormat()` are both aliases for these functions they are covered as well.~ OOP variants should work but seem not to do...