### PR TITLE
update phpunit.xml to adjust to changed keywords in phpunit 9.3+

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="tests/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
 	bootstrap="tests/bootstrap-runtime-reflection.php"
 	cacheResult="false"
 	colors="true"
@@ -11,6 +11,16 @@
 	beStrictAboutOutputDuringTests="true"
 	beStrictAboutTodoAnnotatedTests="true"
 	verbose="false">
+	<coverage processUncoveredFiles="true">
+		<include>
+			<directory suffix=".php">src</directory>
+		</include>
+		<report>
+			<clover outputFile="tests/tmp/clover.xml"/>
+			<text outputFile="php://stdout" showUncoveredFiles="true" showOnlySummary="true"/>
+		</report>
+	</coverage>
+
 	<testsuites>
 		<testsuite name="PHPStan">
 			<directory suffix="Test.php">tests/PHPStan</directory>
@@ -22,16 +32,5 @@
 			<group>exec</group>
 		</exclude>
 	</groups>
-
-	<filter>
-		<whitelist processUncoveredFilesFromWhitelist="true">
-			<directory suffix=".php">src</directory>
-		</whitelist>
-	</filter>
-
-	<logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true" showOnlySummary="true"/>
-		<log type="coverage-clover" target="tests/tmp/clover.xml"/>
-	</logging>
+	<logging/>
 </phpunit>
-

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+	xsi:noNamespaceSchemaLocation="tests/phpunit.xsd"
 	bootstrap="tests/bootstrap-runtime-reflection.php"
 	cacheResult="false"
 	colors="true"

--- a/tests/phpunit.xsd
+++ b/tests/phpunit.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 	<xs:annotation>
 		<xs:documentation source="https://phpunit.de/documentation.html">
-			This Schema file defines the rules by which the XML configuration file of PHPUnit 7.5 may be structured.
+			This Schema file defines the rules by which the XML configuration file of PHPUnit 9.5 may be structured.
 		</xs:documentation>
 		<xs:appinfo source="https://phpunit.de/documentation.html"/>
 	</xs:annotation>
@@ -11,30 +11,33 @@
 			<xs:documentation>Root Element</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-	<xs:complexType name="filtersType">
-		<xs:sequence>
-			<xs:element name="whitelist" type="whiteListType" minOccurs="0"/>
-		</xs:sequence>
+	<xs:complexType name="coverageType">
+		<xs:all>
+			<xs:element name="include" minOccurs="0" maxOccurs="1">
+				<xs:complexType>
+					<xs:group ref="pathGroup"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="exclude" minOccurs="0" maxOccurs="1">
+				<xs:complexType>
+					<xs:group ref="pathGroup"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="report" minOccurs="0" maxOccurs="1">
+				<xs:complexType>
+					<xs:group ref="coverageReportGroup"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:all>
+		<xs:attribute name="cacheDirectory" type="xs:anyURI"/>
+		<xs:attribute name="pathCoverage" type="xs:boolean" default="false"/>
+		<xs:attribute name="includeUncoveredFiles" type="xs:boolean" default="true"/>
+		<xs:attribute name="processUncoveredFiles" type="xs:boolean" default="false"/>
+		<xs:attribute name="ignoreDeprecatedCodeUnits" type="xs:boolean" default="false"/>
+		<xs:attribute name="disableCodeCoverageIgnore" type="xs:boolean" default="false"/>
 	</xs:complexType>
-	<xs:complexType name="filterType">
-		<xs:sequence>
-			<xs:choice maxOccurs="unbounded" minOccurs="0">
-				<xs:group ref="pathGroup"/>
-				<xs:element name="exclude">
-					<xs:complexType>
-						<xs:group ref="pathGroup"/>
-					</xs:complexType>
-				</xs:element>
-			</xs:choice>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="whiteListType">
-		<xs:complexContent>
-			<xs:extension base="filterType">
-				<xs:attribute name="addUncoveredFilesFromWhitelist" default="true" type="xs:boolean"/>
-				<xs:attribute name="processUncoveredFilesFromWhitelist" default="false" type="xs:boolean"/>
-			</xs:extension>
-		</xs:complexContent>
+	<xs:complexType name="loggingType">
+		<xs:group ref="loggingGroup"/>
 	</xs:complexType>
 	<xs:complexType name="groupsType">
 		<xs:choice>
@@ -122,39 +125,6 @@
 			</xs:simpleType>
 		</xs:union>
 	</xs:simpleType>
-	<xs:complexType name="loggersType">
-		<xs:sequence>
-			<xs:element name="log" type="loggerType" maxOccurs="unbounded"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="loggerType">
-		<xs:attribute name="type">
-			<xs:simpleType>
-				<xs:restriction base="xs:string">
-					<xs:enumeration value="coverage-html"/>
-					<xs:enumeration value="coverage-text"/>
-					<xs:enumeration value="coverage-clover"/>
-					<xs:enumeration value="coverage-crap4j"/>
-					<xs:enumeration value="coverage-xml"/>
-					<xs:enumeration value="coverage-php"/>
-					<xs:enumeration value="json"/>
-					<xs:enumeration value="plain"/>
-					<xs:enumeration value="tap"/>
-					<xs:enumeration value="teamcity"/>
-					<xs:enumeration value="junit"/>
-					<xs:enumeration value="testdox-html"/>
-					<xs:enumeration value="testdox-text"/>
-					<xs:enumeration value="testdox-xml"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-		<xs:attribute name="target" type="xs:anyURI"/>
-		<xs:attribute name="lowUpperBound" type="xs:nonNegativeInteger" default="35"/>
-		<xs:attribute name="highLowerBound" type="xs:nonNegativeInteger" default="70"/>
-		<xs:attribute name="showUncoveredFiles" type="xs:boolean" default="false"/>
-		<xs:attribute name="showOnlySummary" type="xs:boolean" default="false"/>
-		<xs:attribute name="threshold" type="xs:nonNegativeInteger" default="30"/>
-	</xs:complexType>
 	<xs:group name="pathGroup">
 		<xs:sequence>
 			<xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -176,14 +146,22 @@
 		<xs:restriction base="xs:string">
 			<xs:enumeration value="default"/>
 			<xs:enumeration value="defects"/>
-			<xs:enumeration value="duration"/>
 			<xs:enumeration value="depends"/>
 			<xs:enumeration value="depends,defects"/>
-			<xs:enumeration value="random"/>
-			<xs:enumeration value="reverse"/>
+			<xs:enumeration value="depends,duration"/>
 			<xs:enumeration value="depends,random"/>
 			<xs:enumeration value="depends,reverse"/>
-			<xs:enumeration value="depends,duration"/>
+			<xs:enumeration value="depends,size"/>
+			<xs:enumeration value="duration"/>
+			<xs:enumeration value="no-depends"/>
+			<xs:enumeration value="no-depends,defects"/>
+			<xs:enumeration value="no-depends,duration"/>
+			<xs:enumeration value="no-depends,random"/>
+			<xs:enumeration value="no-depends,reverse"/>
+			<xs:enumeration value="no-depends,size"/>
+			<xs:enumeration value="random"/>
+			<xs:enumeration value="reverse"/>
+			<xs:enumeration value="size"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:complexType name="fileFilterType">
@@ -231,18 +209,16 @@
 		<xs:attribute name="backupGlobals" type="xs:boolean" default="false"/>
 		<xs:attribute name="backupStaticAttributes" type="xs:boolean" default="false"/>
 		<xs:attribute name="bootstrap" type="xs:anyURI"/>
-		<xs:attribute name="cacheResult" type="xs:boolean" default="false"/>
+		<xs:attribute name="cacheResult" type="xs:boolean" default="true"/>
 		<xs:attribute name="cacheResultFile" type="xs:anyURI"/>
-		<xs:attribute name="cacheTokens" type="xs:boolean" default="false"/>
 		<xs:attribute name="colors" type="xs:boolean" default="false"/>
 		<xs:attribute name="columns" type="columnsType" default="80"/>
 		<xs:attribute name="convertDeprecationsToExceptions" type="xs:boolean" default="true"/>
 		<xs:attribute name="convertErrorsToExceptions" type="xs:boolean" default="true"/>
 		<xs:attribute name="convertNoticesToExceptions" type="xs:boolean" default="true"/>
 		<xs:attribute name="convertWarningsToExceptions" type="xs:boolean" default="true"/>
-		<xs:attribute name="disableCodeCoverageIgnore" type="xs:boolean" default="false"/>
 		<xs:attribute name="forceCoversAnnotation" type="xs:boolean" default="false"/>
-		<xs:attribute name="printerClass" type="xs:string" default="PHPUnit\TextUI\ResultPrinter"/>
+		<xs:attribute name="printerClass" type="xs:string" default="PHPUnit\TextUI\DefaultResultPrinter"/>
 		<xs:attribute name="printerFile" type="xs:anyURI"/>
 		<xs:attribute name="processIsolation" type="xs:boolean" default="false"/>
 		<xs:attribute name="stopOnDefect" type="xs:boolean" default="false"/>
@@ -252,7 +228,10 @@
 		<xs:attribute name="stopOnIncomplete" type="xs:boolean" default="false"/>
 		<xs:attribute name="stopOnRisky" type="xs:boolean" default="false"/>
 		<xs:attribute name="stopOnSkipped" type="xs:boolean" default="false"/>
+		<xs:attribute name="failOnEmptyTestSuite" type="xs:boolean" default="false"/>
+		<xs:attribute name="failOnIncomplete" type="xs:boolean" default="false"/>
 		<xs:attribute name="failOnRisky" type="xs:boolean" default="false"/>
+		<xs:attribute name="failOnSkipped" type="xs:boolean" default="false"/>
 		<xs:attribute name="failOnWarning" type="xs:boolean" default="false"/>
 		<xs:attribute name="beStrictAboutChangesToGlobalState" type="xs:boolean" default="false"/>
 		<xs:attribute name="beStrictAboutOutputDuringTests" type="xs:boolean" default="false"/>
@@ -262,7 +241,6 @@
 		<xs:attribute name="beStrictAboutCoversAnnotation" type="xs:boolean" default="false"/>
 		<xs:attribute name="defaultTimeLimit" type="xs:integer" default="0"/>
 		<xs:attribute name="enforceTimeLimit" type="xs:boolean" default="false"/>
-		<xs:attribute name="ignoreDeprecatedCodeUnitsFromCodeCoverage" type="xs:boolean" default="false"/>
 		<xs:attribute name="timeoutForSmallTests" type="xs:integer" default="1"/>
 		<xs:attribute name="timeoutForMediumTests" type="xs:integer" default="10"/>
 		<xs:attribute name="timeoutForLargeTests" type="xs:integer" default="60"/>
@@ -270,20 +248,22 @@
 		<xs:attribute name="testSuiteLoaderFile" type="xs:anyURI"/>
 		<xs:attribute name="defaultTestSuite" type="xs:string" default=""/>
 		<xs:attribute name="verbose" type="xs:boolean" default="false"/>
+		<xs:attribute name="testdox" type="xs:boolean" default="false"/>
 		<xs:attribute name="stderr" type="xs:boolean" default="false"/>
 		<xs:attribute name="reverseDefectList" type="xs:boolean" default="false"/>
 		<xs:attribute name="registerMockObjectsFromTestArgumentsRecursively" type="xs:boolean" default="false"/>
 		<xs:attribute name="extensionsDirectory" type="xs:string"/>
 		<xs:attribute name="executionOrder" type="executionOrderType" default="default"/>
-		<xs:attribute name="resolveDependencies" type="xs:boolean" default="false"/>
+		<xs:attribute name="resolveDependencies" type="xs:boolean" default="true"/>
+		<xs:attribute name="noInteraction" type="xs:boolean" default="false"/>
 	</xs:attributeGroup>
 	<xs:group name="configGroup">
 		<xs:all>
 			<xs:element ref="testSuiteFacet" minOccurs="0"/>
 			<xs:element name="groups" type="groupsType" minOccurs="0"/>
 			<xs:element name="testdoxGroups" type="groupsType" minOccurs="0"/>
-			<xs:element name="filter" type="filtersType" minOccurs="0"/>
-			<xs:element name="logging" type="loggersType" minOccurs="0"/>
+			<xs:element name="coverage" type="coverageType" minOccurs="0"/>
+			<xs:element name="logging" type="loggingType" minOccurs="0"/>
 			<xs:element name="extensions" type="extensionsType" minOccurs="0"/>
 			<xs:element name="listeners" type="listenersType" minOccurs="0"/>
 			<xs:element name="php" type="phpType" minOccurs="0"/>
@@ -303,5 +283,46 @@
 			<xs:element name="exclude" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 		<xs:attribute name="name" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:group name="coverageReportGroup">
+		<xs:all>
+			<xs:element name="clover" type="logToFileType" minOccurs="0"/>
+			<xs:element name="cobertura" type="logToFileType" minOccurs="0"/>
+			<xs:element name="crap4j" type="coverageReportCrap4JType" minOccurs="0" />
+			<xs:element name="html" type="coverageReportHtmlType" minOccurs="0" />
+			<xs:element name="php" type="logToFileType" minOccurs="0" />
+			<xs:element name="text" type="coverageReportTextType" minOccurs="0" />
+			<xs:element name="xml" type="logToDirectoryType" minOccurs="0" />
+		</xs:all>
+	</xs:group>
+	<xs:group name="loggingGroup">
+		<xs:all>
+			<xs:element name="junit" type="logToFileType" minOccurs="0" />
+			<xs:element name="teamcity" type="logToFileType" minOccurs="0" />
+			<xs:element name="testdoxHtml" type="logToFileType" minOccurs="0" />
+			<xs:element name="testdoxText" type="logToFileType" minOccurs="0" />
+			<xs:element name="testdoxXml" type="logToFileType" minOccurs="0" />
+			<xs:element name="text" type="logToFileType" minOccurs="0"/>
+		</xs:all>
+	</xs:group>
+	<xs:complexType name="logToFileType">
+		<xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="logToDirectoryType">
+		<xs:attribute name="outputDirectory" type="xs:anyURI" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="coverageReportCrap4JType">
+		<xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+		<xs:attribute name="threshold" type="xs:integer"/>
+	</xs:complexType>
+	<xs:complexType name="coverageReportHtmlType">
+		<xs:attribute name="outputDirectory" type="xs:anyURI" use="required"/>
+		<xs:attribute name="lowUpperBound" type="xs:integer" default="50"/>
+		<xs:attribute name="highLowerBound" type="xs:integer" default="90"/>
+	</xs:complexType>
+	<xs:complexType name="coverageReportTextType">
+		<xs:attribute name="outputFile" type="xs:anyURI" use="required"/>
+		<xs:attribute name="showUncoveredFiles" type="xs:boolean" default="false"/>
+		<xs:attribute name="showOnlySummary" type="xs:boolean" default="false"/>
 	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
PHPUnit will no longer use keywords like `whitelist` -> this PR used the phpunit build-in `--migrate-configuration`  flag