### PR TITLE
GitLab 13.x expects severity field in code quality reports

### DIFF
--- a/src/Command/ErrorFormatter/GitlabErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GitlabErrorFormatter.php
@@ -37,6 +37,7 @@ class GitlabErrorFormatter implements ErrorFormatter
 						]
 					)
 				),
+				'severity' => $fileSpecificError->canBeIgnored() ? 'major' : 'blocker',
 				'location' => [
 					'path' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
 					'lines' => [
@@ -45,10 +46,6 @@ class GitlabErrorFormatter implements ErrorFormatter
 				],
 			];
 
-			if (!$fileSpecificError->canBeIgnored()) {
-				$error['severity'] = 'blocker';
-			}
-
 			$errorsArray[] = $error;
 		}
 
@@ -56,6 +53,7 @@ class GitlabErrorFormatter implements ErrorFormatter
 			$errorsArray[] = [
 				'description' => $notFileSpecificError,
 				'fingerprint' => hash('sha256', $notFileSpecificError),
+				'severity' => 'major',
 				'location' => [
 					'path' => '',
 					'lines' => [

--- a/tests/PHPStan/Command/ErrorFormatter/GitlabFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GitlabFormatterTest.php
@@ -27,6 +27,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Foo",
         "fingerprint": "e82b7e1f1d4255352b19ecefa9116a12f129c7edb4351cf2319285eccdb1565e",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode 😃/project/folder with unicode 😃/file name with \"spaces\" and unicode 😃.php",
             "lines": {
@@ -46,6 +47,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "first generic error",
         "fingerprint": "53ed216d77c9a9b21d9535322457ca7d7b037d6596d76484b3481f161adfd96f",
+        "severity": "major",
         "location": {
             "path": "",
             "lines": {
@@ -65,6 +67,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Bar\nBar2",
         "fingerprint": "034b4afbfb347494c14e396ed8327692f58be4cd27e8aff5f19f4194934db7c9",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode 😃/project/folder with unicode 😃/file name with \"spaces\" and unicode 😃.php",
             "lines": {
@@ -75,6 +78,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Foo",
         "fingerprint": "e82b7e1f1d4255352b19ecefa9116a12f129c7edb4351cf2319285eccdb1565e",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode 😃/project/folder with unicode 😃/file name with \"spaces\" and unicode 😃.php",
             "lines": {
@@ -85,6 +89,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Foo",
         "fingerprint": "93c79740ed8c6fbaac2087e54d6f6f67fc0918e3ff77840530f32e19857ef63c",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
             "lines": {
@@ -95,6 +100,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Bar\nBar2",
         "fingerprint": "829f6c782152fdac840b39208c5b519d18e51bff2c601b6197812fffb8bcd9ed",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
             "lines": {
@@ -114,6 +120,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "first generic error",
         "fingerprint": "53ed216d77c9a9b21d9535322457ca7d7b037d6596d76484b3481f161adfd96f",
+        "severity": "major",
         "location": {
             "path": "",
             "lines": {
@@ -124,6 +131,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "second generic error",
         "fingerprint": "f49870714e8ce889212aefb50f718f88ae63d00dd01c775b7bac86c4466e96f0",
+        "severity": "major",
         "location": {
             "path": "",
             "lines": {
@@ -143,6 +151,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Bar\nBar2",
         "fingerprint": "034b4afbfb347494c14e396ed8327692f58be4cd27e8aff5f19f4194934db7c9",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/folder with unicode \ud83d\ude03/file name with \"spaces\" and unicode \ud83d\ude03.php",
             "lines": {
@@ -153,6 +162,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Foo",
         "fingerprint": "e82b7e1f1d4255352b19ecefa9116a12f129c7edb4351cf2319285eccdb1565e",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/folder with unicode \ud83d\ude03/file name with \"spaces\" and unicode \ud83d\ude03.php",
             "lines": {
@@ -163,6 +173,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Foo",
         "fingerprint": "93c79740ed8c6fbaac2087e54d6f6f67fc0918e3ff77840530f32e19857ef63c",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
             "lines": {
@@ -173,6 +184,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "Bar\nBar2",
         "fingerprint": "829f6c782152fdac840b39208c5b519d18e51bff2c601b6197812fffb8bcd9ed",
+        "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
             "lines": {
@@ -183,6 +195,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "first generic error",
         "fingerprint": "53ed216d77c9a9b21d9535322457ca7d7b037d6596d76484b3481f161adfd96f",
+        "severity": "major",
         "location": {
             "path": "",
             "lines": {
@@ -193,6 +206,7 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
     {
         "description": "second generic error",
         "fingerprint": "f49870714e8ce889212aefb50f718f88ae63d00dd01c775b7bac86c4466e96f0",
+        "severity": "major",
         "location": {
             "path": "",
             "lines": {


### PR DESCRIPTION
Added the severity field in gitlab formatted code quality reports. Since GitLab 13.x it's a required property. See: https://docs.gitlab.com/13.11/ee/user/project/merge_requests/code_quality.html#implementing-a-custom-tool

If the field is missing, GitLab isn't able to parse the report (silently fails) and doesn't show any errors/degradations.

