### PR TITLE
composer: allow symfony/service-contracts that allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"react/stream": "^1.1",
 		"symfony/console": "^4.3",
 		"symfony/finder": "^4.3",
-		"symfony/service-contracts": "1.1.8"
+		"symfony/service-contracts": "1.1.9"
 	},
 	"replace": {
 		"phpstan/phpstan": "self.version"


### PR DESCRIPTION
We're trying to install src to downgrade it, but this packages blocks it on PHP 8:

- https://packagist.org/packages/symfony/service-contracts#v1.1.8


![image](https://user-images.githubusercontent.com/924196/117295705-75291c80-ae74-11eb-9ac9-c744e410eb06.png)

<br>

The very next patch version luckily allows PHP 8 :)

- https://packagist.org/packages/symfony/service-contracts#v1.1.9
 
![image](https://user-images.githubusercontent.com/924196/117295733-7eb28480-ae74-11eb-8d0a-173f2e33f824.png)
