### PR TITLE
IntlDateFormatter::parse can define variable by reference

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5529,7 +5529,7 @@ return [
 'IntlDateFormatter::getTimeZoneId' => ['string'],
 'IntlDateFormatter::isLenient' => ['bool'],
 'IntlDateFormatter::localtime' => ['array', 'text_to_parse'=>'string', '&w_parse_pos='=>'int'],
-'IntlDateFormatter::parse' => ['int|false', 'text_to_parse'=>'string', '&rw_parse_pos='=>'int'],
+'IntlDateFormatter::parse' => ['int|false', 'text_to_parse'=>'string', '&w_parse_pos='=>'int'],
 'IntlDateFormatter::setCalendar' => ['bool', 'calendar'=>''],
 'IntlDateFormatter::setLenient' => ['bool', 'lenient'=>'bool'],
 'IntlDateFormatter::setPattern' => ['bool', 'pattern'=>'string'],


### PR DESCRIPTION
fix https://phpstan.org/r/6b576779-bff4-4b12-a6ac-dfd9d71bb22e
applied same solution of https://github.com/phpstan/phpstan/issues/2026