### PR TITLE
RuleLevelHelper: Don't wipe out TemplateMixedType

### DIFF
--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -59,6 +59,7 @@ class RuleLevelHelper
 		if (
 			$this->checkExplicitMixed
 			&& $acceptedType instanceof MixedType
+			&& !$acceptedType instanceof TemplateMixedType
 			&& $acceptedType->isExplicitMixed()
 		) {
 			$acceptedType = new StrictMixedType();

--- a/tests/PHPStan/Rules/Methods/data/check-explicit-mixed.php
+++ b/tests/PHPStan/Rules/Methods/data/check-explicit-mixed.php
@@ -67,3 +67,24 @@ class Bar
 	}
 
 }
+
+/**
+ * @template T
+ */
+class Baz{
+	/** @var T */
+	private $t;
+
+	/**
+	 * @param T $t
+	 */
+	public function acceptsT($t): void
+	{
+
+	}
+
+	public function doFoo(): void
+	{
+		$this->acceptsT($this->t);
+	}
+}


### PR DESCRIPTION
this caused a variety of interesting bugs with generics in explicit-mixed mode.

This fixes phpstan/phpstan#3566.