### PR TITLE
functionMap: fixed return type of password_hash() on php 7.1-7.3

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8248,7 +8248,7 @@ return [
 'parsekit_func_arginfo' => ['array', 'function'=>'mixed'],
 'passthru' => ['void', 'command'=>'string', '&w_return_value='=>'int'],
 'password_get_info' => ['array', 'hash'=>'string'],
-'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
+'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int|string', 'options='=>'array'],
 'password_make_salt' => ['bool', 'password'=>'string', 'hash'=>'string'],
 'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'int', 'options='=>'array'],
 'password_verify' => ['bool', 'password'=>'string', 'hash'=>'string'],


### PR DESCRIPTION
I hope this will fix https://github.com/phpstan/phpstan/issues/4960

I was not able to test the change itself, because I did not found a way on how to run phpstan-src locally with php7.3