### PR TITLE
functionMap: Fix return type of array_flip

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -274,7 +274,7 @@ return [
 'array_fill' => ['array', 'start_key'=>'int', 'num'=>'int', 'val'=>'mixed'],
 'array_fill_keys' => ['array', 'keys'=>'array', 'val'=>'mixed'],
 'array_filter' => ['array', 'input'=>'array', 'callback='=>'callable(mixed,mixed):bool|callable(mixed):bool', 'flag='=>'int'],
-'array_flip' => ['array', 'input'=>'array'],
+'array_flip' => ['array|null', 'input'=>'array'],
 'array_intersect' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],
 'array_intersect_assoc' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],
 'array_intersect_key' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],


### PR DESCRIPTION
According to [the php docs for `array_flip`](https://www.php.net/manual/en/function.array-flip.php) it can return `false`. So, I suggest changing the return type signature from `array` to `array|false` in `resources/functionMap.php`.

~`make tests` and `make phpstan` are currently failing for me, so this hasn't been tested:~

```
PHP Fatal error:  Uncaught Nette\MemberAccessException: Cannot read an undeclared property PHPStan\DependencyInjection\Configurator::$parameters. in /home/pms/Code/phpstan-src/vendor/nette/utils/src/Utils/ObjectHelpers.php:31
```
**Update**: I've resolved the above problem. (I had run `composer update` after `composer install`, which was a mistake!)

`make phpstan` and `make tests` now both work for me and succeed (Tests: 10115, Assertions: 80094, Skipped: 150.).