### PR TITLE
Be stricter about getcsv and str_getcsv return types

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -2937,7 +2937,7 @@ return [
 'ffmpeg_movie::hasAudio' => ['bool'],
 'ffmpeg_movie::hasVideo' => ['bool'],
 'fgetc' => ['string|false', 'fp'=>'resource'],
-'fgetcsv' => ['(?array)|(?false)', 'fp'=>'resource', 'length='=>'int', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'fgetcsv' => ['non-empty-array<int,string>|array{null}|false|null', 'fp'=>'resource', 'length='=>'int', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'fgets' => ['string|false', 'fp'=>'resource', 'length='=>'int'],
 'fgetss' => ['string|false', 'fp'=>'resource', 'length='=>'int', 'allowable_tags='=>'string'],
 'file' => ['array<int,string>|false', 'filename'=>'string', 'flags='=>'int', 'context='=>'resource'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11689,7 +11689,7 @@ return [
 'stomp_version' => ['string'],
 'StompException::getDetails' => ['string'],
 'StompFrame::__construct' => ['void', 'command='=>'string', 'headers='=>'array', 'body='=>'string'],
-'str_getcsv' => ['array', 'input'=>'string', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'str_getcsv' => ['non-empty-array<int,string>|array{null}', 'input'=>'string', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'str_ireplace' => ['string|string[]', 'search'=>'string|array', 'replace'=>'string|array', 'subject'=>'string|array', '&w_replace_count='=>'int'],
 'str_pad' => ['string', 'input'=>'string', 'pad_length'=>'int', 'pad_string='=>'string', 'pad_type='=>'int'],
 'str_repeat' => ['string', 'input'=>'string', 'multiplier'=>'int'],


### PR DESCRIPTION
This is a suggestion...

See: phpstan/phpstan#4993.
Example: https://phpstan.org/r/1c1e8795-2cde-48bb-95b5-25aa6d1925d4

I'm not sure whether `non-empty-array` is valid syntax in the `functionMap.php` file though, since I haven't seen any other examples?

`make tests` didn't produce any errors.