### PR TITLE
Fix php warning for "*" ignore path when open_basedir is set

### DIFF
--- a/src/Analyser/IgnoredErrorHelper.php
+++ b/src/Analyser/IgnoredErrorHelper.php
@@ -65,7 +65,7 @@ class IgnoredErrorHelper
 							'index' => $i,
 							'ignoreError' => $ignoreError,
 						];
-					} elseif (is_file($ignoreError['path'])) {
+					} elseif (@is_file($ignoreError['path'])) {
 						$normalizedPath = $this->fileHelper->normalizePath($ignoreError['path']);
 						$ignoreError['path'] = $normalizedPath;
 						$ignoreErrorsByFile[$normalizedPath][] = [


### PR DESCRIPTION
without this PR phpstan produces this output:

```
Note: Using configuration file C:\debug\vendor\atk4\data\phpstan.neon.dist.
Warning: is_file(): open_basedir restriction in effect. File(*) is not within the allowed path(s): (C:\debug;C:\Program Files\PHP\shared-ro;C:\ProgramData\phpw-temp) in phar://C:\debug/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/IgnoredErrorHelper.php on line 50
 137/137 [============================] 100%

 [OK] No errors
```