### PR TITLE
Add DateInterval extension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1026,6 +1026,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\DateIntervalConstructorThrowTypeExtension
+		tags:
+			- phpstan.dynamicStaticMethodThrowTypeExtension
+
+	-
 		class: PHPStan\Type\Php\DateTimeDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use DateInterval;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeUtils;
+
+class DateIntervalConstructorThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === '__construct' && $methodReflection->getDeclaringClass()->getName() === DateInterval::class;
+	}
+
+	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+	{
+		if (count($methodCall->args) === 0) {
+			return $methodReflection->getThrowType();
+		}
+
+		$arg = $methodCall->args[0]->value;
+		$constantStrings = TypeUtils::getConstantStrings($scope->getType($arg));
+		if (count($constantStrings) === 0) {
+			return $methodReflection->getThrowType();
+		}
+
+		foreach ($constantStrings as $constantString) {
+			try {
+				new \DateInterval($constantString->getValue());
+			} catch (\Exception $e) { // phpcs:ignore
+				return $methodReflection->getThrowType();
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -59,6 +59,10 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - Exception is never thrown in the try block.',
 				180,
 			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				212,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Exceptions/data/unthrown-exception.php
+++ b/tests/PHPStan/Rules/Exceptions/data/unthrown-exception.php
@@ -192,3 +192,35 @@ class TestDateTime
 	}
 
 }
+
+class TestDateInterval
+{
+
+	public function doFoo(): void
+	{
+		try {
+			new \DateInterval('invalid format');
+		} catch (\Exception $e) {
+
+		}
+	}
+
+	public function doBar(): void
+	{
+		try {
+			new \DateInterval('P10D');
+		} catch (\Exception $e) {
+
+		}
+	}
+
+	public function doBaz(string $s): void
+	{
+		try {
+			new \DateInterval($s);
+		} catch (\Exception $e) {
+
+		}
+	}
+
+}


### PR DESCRIPTION
Follow up of the discussion https://github.com/phpstan/phpstan-src/commit/181f75ce89a521aebc0336a61352b821645c738a#r50600099

I try to add some ThrowTypeExtension. This one seems easy.

The others in https://github.com/pepakriz/phpstan-exception-rules/tree/master/src/Extension are
- `DOMDocumentExtension`: This one is half-wrong. It makes the code believe method can throw an `ErrorException` but I discover it only throw a `Warning` and the error handler is transforming this to `ErrorException` when using `APP_DEBUG=true` with Symfony. Still, empty string will throw an error in PHP8.
http://sandbox.onlinephpfunctions.com/code/9a26ff8a86809b4e9848d9635ec0debeee36e355.

- `IntdivExtension`
- `JsonEncodeDecodeExtension`
- `ReflectionExtension`
- `SimpleXMLElementExtension`
- `SplFileObjectExtension`

I'll try to add more after this PR.
First I'd like to understand something @ondrejmirtes. When I'm returning 
```
return $methodReflection->getThrowType();
```
I assume this rely on the fact that the exception which can be thrown by the method is well documented. Where can I check if it is ? Do you rely on Phpstorm stubs ?

Does it means for instance that intdiv is not considered as throwing an exception because the phpdoc does not contains `throws` tag ?
```
/**
 * Integer division
 * @link https://php.net/manual/en/function.intdiv.php
 * @param int $num1 <p>Number to be divided.</p>
 * @param int $num2 <p>Number which divides the <b><i>dividend</i></b></p>
 * @return int <p>
 * If divisor is 0, a {@link DivisionByZeroError} exception is thrown.
 * If the <b><i>dividend</i></b> is <b>PHP_INT_MIN</b> and the <b><i>divisor</i></b> is -1,
 * then an {@link ArithmeticError} exception is thrown.
 * </p>
 * @since 7.0
 */
#[Pure]
function intdiv ($num1, $num2) {}
```