### PR TITLE
Clickable line number when using `editorUrl`

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -76,10 +76,13 @@ class TableErrorFormatter implements ErrorFormatter
 					$message .= "\n💡 " . $tip;
 				}
 				if (is_string($this->editorUrl)) {
-					$message .= "\n✏️  " . str_replace(['%file%', '%line%'], [$file, (string) $error->getLine()], $this->editorUrl);
+					$link = str_replace(['%file%', '%line%'], [$file, (string) $error->getLine()], $this->editorUrl);
+					$line = "<href=" . $link . ">" . $error->getLine() . "</>";
+				} else {
+					$line = (string) $error->getLine();
 				}
 				$rows[] = [
-					(string) $error->getLine(),
+					$line,
 					$message,
 				];
 			}

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -35,44 +35,6 @@ class ErrorsConsoleStyle extends \Symfony\Component\Console\Style\SymfonyStyle
 	}
 
 	/**
-	 * @param string[] $headers
-	 * @param string[][] $rows
-	 */
-	public function table(array $headers, array $rows): void
-	{
-		/** @var int $terminalWidth */
-		$terminalWidth = (new \Symfony\Component\Console\Terminal())->getWidth() - 2;
-		$maxHeaderWidth = strlen($headers[0]);
-		foreach ($rows as $row) {
-			$length = strlen($row[0]);
-			if ($maxHeaderWidth !== 0 && $length <= $maxHeaderWidth) {
-				continue;
-			}
-
-			$maxHeaderWidth = $length;
-		}
-
-		$wrap = static function ($rows) use ($terminalWidth, $maxHeaderWidth): array {
-			return array_map(static function ($row) use ($terminalWidth, $maxHeaderWidth): array {
-				return array_map(static function ($s) use ($terminalWidth, $maxHeaderWidth) {
-					if ($terminalWidth > $maxHeaderWidth + 5) {
-						return wordwrap(
-							$s,
-							$terminalWidth - $maxHeaderWidth - 5,
-							"\n",
-							true
-						);
-					}
-
-					return $s;
-				}, $row);
-			}, $rows);
-		};
-
-		parent::table($headers, $wrap($rows));
-	}
-
-	/**
 	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
 	 * @param int $max
 	 */


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/5013

I like the `editorUrl` feature a lot. Unfortunately, it didn't work on small terminals as the line would be wrapped and breaking the link.

I found out that Symfony has support for [Console Hyperlinks](https://github.com/symfony/symfony/pull/29168). We can use them to make the line number clickable instead.

I think it looks a lot cleaner and more intuitive: 

<img width="1489" alt="Screenshot 2021-05-17 at 19 01 59@2x" src="https://user-images.githubusercontent.com/104180/118528223-61b66500-b742-11eb-8244-dbd5ba40b5c9.png">

⚠️  I had to remove the table wrapper code as the `wordwrap` method doesn't take formatting / decoration into account. I hope this is OK.  
