### PR TITLE
Change function signature for substr so it can return false

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11802,7 +11802,7 @@ return [
 'strtr' => ['string', 'str'=>'string', 'from'=>'string', 'to'=>'string'],
 'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array'],
 'strval' => ['string', 'var'=>'mixed'],
-'substr' => ['string', 'string'=>'string', 'start'=>'int', 'length='=>'int'],
+'substr' => ['string|false', 'string'=>'string', 'start'=>'int', 'length='=>'int'],
 'substr_compare' => ['int|false', 'main_str'=>'string', 'str'=>'string', 'offset'=>'int', 'length='=>'int', 'case_sensitivity='=>'bool'],
 'substr_count' => ['int', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int', 'length='=>'int'],
 'substr_replace' => ['string|array', 'str'=>'string|array', 'repl'=>'mixed', 'start'=>'mixed', 'length='=>'mixed'],


### PR DESCRIPTION
[`substr` can return false](https://www.php.net/manual/en/function.substr.php#refsect1-function.substr-returnvalues), such as when the offset is larger than the length of the input string.

Therefore, the error reported by phpstan in the following example is incorrect: https://phpstan.org/r/ebf7f0c9-87c2-408f-9789-e4fa6566b86f

This pull request addresses that by recognising that `substr` can return `false`.