### PR TITLE
Log used memory only if fatal error would be not displayed

### DIFF
--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -212,6 +212,10 @@ class AnalyseApplication
 
 	private function updateMemoryLimitFile(): void
 	{
+		if (in_array(strtolower((string) ini_get('display_errors')), ['1', 'on'], true) && (error_reporting() & \E_ERROR) !== 0) { // log only if fatal error can be displayed
+			return;
+		}
+
 		$bytes = memory_get_peak_usage(true);
 		$megabytes = ceil($bytes / 1024 / 1024);
 		file_put_contents($this->memoryLimitFile, sprintf('%d MB', $megabytes));


### PR DESCRIPTION
When error reporting is enabled, php displays something like:
```
Fatal error: Allowed memory size of 201326592 bytes exhausted (tried to allocate 20480 bytes) in phar://C:/.../vendor/phpstan/phpstan/phpstan.phar/vendor/nikic/php-parser/lib/PhpParser/NodeAbstract.php on line 148
```

and nothing should be logger not displayed on the next phpstan run.