### PR TITLE
BaselineNeonErrorFormatter: Sort errors by normalized relative path, …

### DIFF
--- a/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
@@ -40,7 +40,7 @@ class BaselineNeonErrorFormatter implements ErrorFormatter
 			if (!$fileSpecificError->canBeIgnored()) {
 				continue;
 			}
-			$fileErrors[$fileSpecificError->getFilePath()][] = $fileSpecificError->getMessage();
+			$fileErrors[$this->relativePathHelper->getRelativePath($fileSpecificError->getFilePath())][] = $fileSpecificError->getMessage();
 		}
 		ksort($fileErrors, SORT_STRING);
 
@@ -61,7 +61,7 @@ class BaselineNeonErrorFormatter implements ErrorFormatter
 				$errorsToOutput[] = [
 					'message' => Helpers::escape('#^' . preg_quote($message, '#') . '$#'),
 					'count' => $count,
-					'path' => Helpers::escape($this->relativePathHelper->getRelativePath($file)),
+					'path' => Helpers::escape($file),
 				];
 			}
 		}

--- a/src/File/SimpleRelativePathHelper.php
+++ b/src/File/SimpleRelativePathHelper.php
@@ -15,10 +15,10 @@ class SimpleRelativePathHelper implements RelativePathHelper
 	public function getRelativePath(string $filename): string
 	{
 		if ($this->currentWorkingDirectory !== '' && strpos($filename, $this->currentWorkingDirectory) === 0) {
-			return substr($filename, strlen($this->currentWorkingDirectory) + 1);
+			return str_replace('\\', '/', substr($filename, strlen($this->currentWorkingDirectory) + 1));
 		}
 
-		return $filename;
+		return str_replace('\\', '/', $filename);
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -207,6 +207,9 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			new Error('Second error in a different file', 'TestfileB', 4),
 			new Error('Error #1 in a different file', 'TestfileB', 5),
 			new Error('Second error in a different file', 'TestfileB', 6),
+			new Error('Error with Windows path separators', 'TestFiles\\TestA', 1),
+			new Error('Error with Unix path separators', 'TestFiles/TestA', 1),
+			new Error('Error without path separators', 'TestFilesFoo', 1),
 		];
 		yield [$errors];
 		mt_srand(0);
@@ -241,6 +244,21 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			trim(Neon::encode([
 				'parameters' => [
 					'ignoreErrors' => [
+						[
+							'message' => '#^Error with Unix path separators$#',
+							'count' => 1,
+							'path' => 'TestFiles/TestA',
+						],
+						[
+							'message' => '#^Error with Windows path separators$#',
+							'count' => 1,
+							'path' => 'TestFiles/TestA',
+						],
+						[
+							'message' => '#^Error without path separators$#',
+							'count' => 1,
+							'path' => 'TestFilesFoo',
+						],
 						[
 							'message' => '#^A different error \\#1$#',
 							'count' => 1,

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -207,9 +207,9 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			new Error('Second error in a different file', 'TestfileB', 4),
 			new Error('Error #1 in a different file', 'TestfileB', 5),
 			new Error('Second error in a different file', 'TestfileB', 6),
-			new Error('Error with Windows path separators', 'TestFiles\\TestA', 1),
-			new Error('Error with Unix path separators', 'TestFiles/TestA', 1),
-			new Error('Error without path separators', 'TestFilesFoo', 1),
+			new Error('Error with Windows directory separators', 'TestFiles\\TestA', 1),
+			new Error('Error with Unix directory separators', 'TestFiles/TestA', 1),
+			new Error('Error without directory separators', 'TestFilesFoo', 1),
 		];
 		yield [$errors];
 		mt_srand(0);
@@ -245,17 +245,17 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 				'parameters' => [
 					'ignoreErrors' => [
 						[
-							'message' => '#^Error with Unix path separators$#',
+							'message' => '#^Error with Unix directory separators$#',
 							'count' => 1,
 							'path' => 'TestFiles/TestA',
 						],
 						[
-							'message' => '#^Error with Windows path separators$#',
+							'message' => '#^Error with Windows directory separators$#',
 							'count' => 1,
 							'path' => 'TestFiles/TestA',
 						],
 						[
-							'message' => '#^Error without path separators$#',
+							'message' => '#^Error without directory separators$#',
 							'count' => 1,
 							'path' => 'TestFilesFoo',
 						],


### PR DESCRIPTION
…instead of original absolute path

while in theory the net result should be the same (because the leading part of the path would be the same), / and \ have a different sorting order, so output gets sorted differently on Windows than on Linux.
This fixes phpstan/phpstan#5085.