### PR TITLE
Update return type hint for stream_bucket_make_writeable

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11703,7 +11703,7 @@ return [
 'strcoll' => ['int', 'str1'=>'string', 'str2'=>'string'],
 'strcspn' => ['int', 'str'=>'string', 'mask'=>'string', 'start='=>'int', 'length='=>'int'],
 'stream_bucket_append' => ['void', 'brigade'=>'resource', 'bucket'=>'object'],
-'stream_bucket_make_writeable' => ['object', 'brigade'=>'resource'],
+'stream_bucket_make_writeable' => ['object|null', 'brigade'=>'resource'],
 'stream_bucket_new' => ['resource', 'stream'=>'resource', 'buffer'=>'string'],
 'stream_bucket_prepend' => ['void', 'brigade'=>'resource', 'bucket'=>'object'],
 'stream_context_create' => ['resource', 'options='=>'array', 'params='=>'array'],


### PR DESCRIPTION
Official php-doc https://www.php.net/manual/en/function.stream-bucket-make-writeable.php is incorrect. I have sent a PR to php-docs https://github.com/php/doc-en/pull/636 to correct it.

Updated to match https://github.com/php/php-src/blob/dd83ced6bd600e0dd5b09cf26fe4302344521e97/ext/standard/basic_functions.stub.php#L1456

Closes https://github.com/phpstan/phpstan/issues/5087