### PR TITLE
MethodReturnStatementsNode: add getClassMethod

### DIFF
--- a/src/Node/MethodReturnStatementsNode.php
+++ b/src/Node/MethodReturnStatementsNode.php
@@ -47,6 +47,11 @@ class MethodReturnStatementsNode extends NodeAbstract implements ReturnStatement
 		return $this->statementResult;
 	}
 
+	public function getClassMethod(): ClassMethod
+	{
+		return $this->classMethod;
+	}
+
 	public function returnsByRef(): bool
 	{
 		return $this->classMethod->byRef;


### PR DESCRIPTION
This method would be very handy in my case, do you think we can expose it?

I'm trying to analyse all methods with extra analysis on their returns, but I also need to check the class and method even when void is returned.