### PR TITLE
Increase default parallel.processTimeout to 30 minutes

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -78,7 +78,7 @@ parameters:
 	scanDirectories: []
 	parallel:
 		jobSize: 20
-		processTimeout: 60.0
+		processTimeout: 1800.0
 		maximumNumberOfProcesses: 32
 		minimumNumberOfJobsPerProcess: 2
 		buffer: 134217728 # 128 MB


### PR DESCRIPTION
60 seconds is not enought for larger projects.

Improve UX with implicit larget timeout by default. 30 minutes timeout should still be below the typical CI timeouts to catch unexpected errors in phpstan and get them displayed.