### PR TITLE
Make second parameter of toPHP optional

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -6727,7 +6727,7 @@ return [
 'MongoDB\BSON\Timestamp::__construct' => ['void', 'increment'=>'int', 'timestamp'=>'int'],
 'MongoDB\BSON\Timestamp::__toString' => ['string'],
 'MongoDB\BSON\toJSON' => ['string', 'bson'=>'string'],
-'MongoDB\BSON\toPHP' => ['object', 'bson'=>'string', 'typeMap'=>'array'],
+'MongoDB\BSON\toPHP' => ['object', 'bson'=>'string', 'typeMap='=>'array'],
 'MongoDB\BSON\Unserializable::bsonUnserialize' => ['', 'data'=>'array'],
 'MongoDB\BSON\UTCDateTime::__construct' => ['void', 'milliseconds='=>'int|DateTimeInterface'],
 'MongoDB\BSON\UTCDateTime::__toString' => ['string'],


### PR DESCRIPTION
Second parameter of https://www.php.net/manual/en/function.mongodb.bson-tophp.php is optional.

Ref: https://github.com/phpstan/phpstan/discussions/5100#discussioncomment-807507