### PR TITLE
Correct the signature of `mysqli_get_client_version()`

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -7252,7 +7252,7 @@ return [
 'mysqli_get_charset' => ['object', 'link'=>'mysqli'],
 'mysqli_get_client_info' => ['string', 'link='=>'mysqli'],
 'mysqli_get_client_stats' => ['array|false'],
-'mysqli_get_client_version' => ['int', 'link'=>'mysqli'],
+'mysqli_get_client_version' => ['int'],
 'mysqli_get_connection_stats' => ['array|false', 'link'=>'mysqli'],
 'mysqli_get_host_info' => ['string', 'link'=>'mysqli'],
 'mysqli_get_links_stats' => ['array'],


### PR DESCRIPTION
The signature of `mysqli_get_client_version()` incorrectly includes a `$link` parameter which does not exist. The cause of this error is likely due to the documentation on php.net historically being incorrect.

* [phpstan.org playground link](https://phpstan.org/r/b8e41dbb-2aff-4286-bc78-ccc524fc00a5), note the error on the PHP 7.1-7.4 tab
* [PHP 7 source](https://github.com/php/php-src/blob/php-7.4.16/ext/mysqli/mysqli_api.c#L1389-L1395) and [PHP 5 source](https://github.com/php/php-src/blob/php-5.6.40/ext/mysqli/mysqli_api.c#L1435-L1441) showing there is no parameter in this function
* [Link to archive.org for php.net at PHP version 7](https://web.archive.org/web/20200520092518/https://www.php.net/manual/en/mysqli.get-client-version.php) which incorrectly shows the parameter

As of PHP 8 [the documentation on php.net](https://www.php.net/manual/en/mysqli.get-client-version.php) is correct and [the PHPStan stub for PHP 8](https://github.com/phpstan/php-8-stubs/blob/0.1.20/stubs/ext/mysqli/mysqli_get_client_version.php) correctly shows no parameter.