### PR TITLE
Add a dynamic return type for number_format

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1147,6 +1147,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\NumberFormatFunctionDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\PathinfoFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/NumberFormatFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/NumberFormatFunctionDynamicReturnTypeExtension.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+final class NumberFormatFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'number_format';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$stringType = new StringType();
+		if (!isset($functionCall->args[3])) {
+			return $stringType;
+		}
+
+		$thousandsType = $scope->getType($functionCall->args[3]->value);
+		$decimalType = $scope->getType($functionCall->args[2]->value);
+
+		if (!$thousandsType instanceof ConstantStringType || $thousandsType->getValue() !== '') {
+			return $stringType;
+		}
+
+		if (!$decimalType instanceof ConstantScalarType || !in_array($decimalType->getValue(), [null, '.', ''], true)) {
+			return $stringType;
+		}
+
+		return new IntersectionType([
+			$stringType,
+			new AccessoryNumericStringType(),
+		]);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -406,6 +406,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/generics-default.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4985.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5000.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/number_format.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/number_format.php
+++ b/tests/PHPStan/Analyser/data/number_format.php
@@ -1,0 +1,18 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+assertType('string', number_format(1002.7));
+assertType('string', number_format(1002.7, 3));
+assertType('string', number_format(1002.7, 3, null));
+assertType('string', number_format(1002.7, 3, '.'));
+assertType('string', number_format(1002.7, 3, '.', ','));
+assertType('string', number_format(1002.7, 3, '.', null));
+assertType('string', number_format(1002.7, 3, '', null));
+assertType('string', number_format(1002.7, 3, 'b', null));
+assertType('string', number_format(1002.7, 3, 'b', ''));
+
+assertType('string&numeric', number_format(1002.7, 3, '.', ''));
+assertType('string&numeric', number_format(1002.7, 3, null, ''));
+assertType('string&numeric', number_format(1002.7, 3, '', ''));
+


### PR DESCRIPTION
If your locale can change, casting a float to string may be unsafe for making numeric strings (before PHP 8).

In that case number_format can be used with specific params to get a numeric string.