### PR TITLE
Assure Gitlab reports have integer line properties

### DIFF
--- a/src/Command/ErrorFormatter/GitlabErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GitlabErrorFormatter.php
@@ -41,7 +41,7 @@ class GitlabErrorFormatter implements ErrorFormatter
 				'location' => [
 					'path' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
 					'lines' => [
-						'begin' => $fileSpecificError->getLine(),
+						'begin' => $fileSpecificError->getLine() ?? 0,
 					],
 				],
 			];


### PR DESCRIPTION
In Gitlab, the MR widget was always showing "No changes to code quality". One of the errors was printed like this:

```json
[
    {
        "description": "Class [...] not found.",
        "fingerprint": "17c1f3ebd05edb28bfbd26b74f917f92fe1c906762ed4fd764375f6f65c30ce3",
        "severity": "blocker",
        "location": {
            "path": "[...].php",
            "lines": {
                "begin": null
            }
        }
    }
]
```

After searching for a while, I found this [on the Gitlab docs](https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html#no-code-quality-appears-on-merge-requests-when-using-custom-tool):
> If your merge requests do not show any code quality changes when using a custom tool, ensure that the line property is an integer.

After fixing this single error, the errors suddenly showed up.

This MR makes sure that the line property is not null.


