### PR TITLE
ClassReflection: make getTraits recursive

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -674,9 +674,13 @@ class ClassReflection implements ReflectionWithFilename
 	 */
 	public function getTraits(bool $recursive = false): array
 	{
+		$traits = $recursive ?
+			$this->collectTraits($this->getNativeReflection()) :
+			array_values($this->getNativeReflection()->getTraits());
+
 		$traits = array_map(function (\ReflectionClass $trait): ClassReflection {
 			return $this->reflectionProvider->getClass($trait->getName());
-		}, $this->collectTraits($this->getNativeReflection()));
+		}, $traits);
 
 		if ($recursive) {
 			$parentClass = $this->getNativeReflection()->getParentClass();

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -676,7 +676,7 @@ class ClassReflection implements ReflectionWithFilename
 	{
 		return array_map(function (\ReflectionClass $trait): ClassReflection {
 			return $this->reflectionProvider->getClass($trait->getName());
-		}, $this->getNativeReflection()->getTraits());
+		}, $this->collectTraits($this->getNativeReflection()));
 	}
 
 	/**

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -344,6 +344,11 @@ class ClassReflection implements ReflectionWithFilename
 		$traits = [];
 		$traitsLeftToAnalyze = $class->getTraits();
 
+		// TOOD is this desired?
+		// if ($parentClass = $class->getParentClass()) {
+		// 	$traits = $this->collectTraits($parentClass);
+		// }
+
 		while (count($traitsLeftToAnalyze) !== 0) {
 			$trait = reset($traitsLeftToAnalyze);
 			$traits[] = $trait;

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -670,13 +670,19 @@ class ClassReflection implements ReflectionWithFilename
 	}
 
 	/**
-	 * @return \PHPStan\Reflection\ClassReflection[]
+	 * @return array<string, \PHPStan\Reflection\ClassReflection>
 	 */
 	public function getTraits(bool $recursive = false): array
 	{
-		$traits = $recursive ?
-			$this->collectTraits($this->getNativeReflection()) :
-			array_values($this->getNativeReflection()->getTraits());
+		$traits = [];
+
+		if ($recursive) {
+			foreach ($this->collectTraits($this->getNativeReflection()) as $trait) {
+				$traits[$trait->getName()] = $trait;
+			}
+		} else {
+			$traits = $this->getNativeReflection()->getTraits();
+		}
 
 		$traits = array_map(function (\ReflectionClass $trait): ClassReflection {
 			return $this->reflectionProvider->getClass($trait->getName());

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -223,7 +223,7 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 	/**
 	 * @dataProvider dataNestedRecursiveTraits
 	 * @param class-string $className
-	 * @param class-string[] $expected
+	 * @param array<class-string, class-string> $expected
 	 * @param bool $recursive
 	 */
 	public function testGetTraits(string $className, array $expected, bool $recursive): void

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -220,41 +220,96 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 		$this->assertTrue($constant->isDeprecated()->yes());
 	}
 
-	public function testGetTraits(): void
+	/**
+	 * @dataProvider dataNestedRecursiveTraits
+	 * @param class-string $className
+	 * @param class-string[] $expected
+	 * @param bool $recursive
+	 */
+	public function testGetTraits(string $className, array $expected, bool $recursive = false): void
 	{
 		$reflectionProvider = $this->createBroker();
 
-		$classes = [
-			\NestedTraits\NoTrait::class => [],
-			\NestedTraits\Foo::class => [
-				\NestedTraits\FooTrait::class,
+		$this->assertSame(
+			array_map(
+				static fn(ClassReflection $classReflection) => $classReflection->getNativeReflection()->getName(),
+				$reflectionProvider->getClass($className)->getTraits($recursive)
+			),
+			$expected
+		);
+	}
+
+	public function dataNestedRecursiveTraits(): array
+	{
+		return [
+			[
+				\NestedTraits\NoTrait::class,
+				[],
 			],
-			\NestedTraits\Bar::class => [
-				\NestedTraits\BarTrait::class,
-				\NestedTraits\FooTrait::class,
+			[
+				\NestedTraits\NoTrait::class,
+				[],
+				true,
 			],
-			\NestedTraits\Baz::class => [
-				\NestedTraits\BazTrait::class,
-				\NestedTraits\BarTrait::class,
-				\NestedTraits\FooTrait::class,
+			[
+				\NestedTraits\Foo::class,
+				[
+					\NestedTraits\FooTrait::class,
+				],
 			],
-			\NestedTraits\BazChild::class => [
-				// TOOD is this expected?
-				// \NestedTraits\BazTrait::class,
-				// \NestedTraits\BarTrait::class,
-				// \NestedTraits\FooTrait::class,
+			[
+				\NestedTraits\Foo::class,
+				[
+					\NestedTraits\FooTrait::class,
+				],
+				true,
+			],
+			[
+				\NestedTraits\Bar::class,
+				[
+					\NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class,
+				],
+			],
+			[
+				\NestedTraits\Bar::class,
+				[
+					\NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class,
+				],
+				true,
+			],
+			[
+				\NestedTraits\Baz::class,
+				[
+					\NestedTraits\BazTrait::class,
+					\NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class,
+				],
+			],
+			[
+				\NestedTraits\Baz::class,
+				[
+					\NestedTraits\BazTrait::class,
+					\NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class,
+				],
+				true,
+			],
+			[
+				\NestedTraits\BazChild::class,
+				[],
+			],
+			[
+				\NestedTraits\BazChild::class,
+				[
+					\NestedTraits\BazTrait::class,
+					\NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class,
+				],
+				true,
 			],
 		];
-
-		foreach ($classes as $class => $expectedTraits) {
-			$this->assertSame(
-				array_map(
-					static fn(ClassReflection $classReflection) => $classReflection->getNativeReflection()->getName(),
-					$reflectionProvider->getClass($class)->getTraits()
-				),
-				$expectedTraits
-			);
-		}
 	}
 
 }

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -220,4 +220,41 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 		$this->assertTrue($constant->isDeprecated()->yes());
 	}
 
+	public function testGetTraits(): void
+	{
+		$reflectionProvider = $this->createBroker();
+
+		$classes = [
+			\NestedTraits\NoTrait::class => [],
+			\NestedTraits\Foo::class => [
+				\NestedTraits\FooTrait::class,
+			],
+			\NestedTraits\Bar::class => [
+				\NestedTraits\BarTrait::class,
+				\NestedTraits\FooTrait::class,
+			],
+			\NestedTraits\Baz::class => [
+				\NestedTraits\BazTrait::class,
+				\NestedTraits\BarTrait::class,
+				\NestedTraits\FooTrait::class,
+			],
+			\NestedTraits\BazChild::class => [
+				// TOOD is this expected?
+				// \NestedTraits\BazTrait::class,
+				// \NestedTraits\BarTrait::class,
+				// \NestedTraits\FooTrait::class,
+			],
+		];
+
+		foreach ($classes as $class => $expectedTraits) {
+			$this->assertSame(
+				array_map(
+					static fn(ClassReflection $classReflection) => $classReflection->getNativeReflection()->getName(),
+					$reflectionProvider->getClass($class)->getTraits()
+				),
+				$expectedTraits
+			);
+		}
+	}
+
 }

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -226,13 +226,15 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 	 * @param class-string[] $expected
 	 * @param bool $recursive
 	 */
-	public function testGetTraits(string $className, array $expected, bool $recursive = false): void
+	public function testGetTraits(string $className, array $expected, bool $recursive): void
 	{
 		$reflectionProvider = $this->createBroker();
 
 		$this->assertSame(
 			array_map(
-				static fn(ClassReflection $classReflection) => $classReflection->getNativeReflection()->getName(),
+				static function (ClassReflection $classReflection): string {
+					return $classReflection->getNativeReflection()->getName();
+				},
 				$reflectionProvider->getClass($className)->getTraits($recursive)
 			),
 			$expected
@@ -245,6 +247,7 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 			[
 				\NestedTraits\NoTrait::class,
 				[],
+				false,
 			],
 			[
 				\NestedTraits\NoTrait::class,
@@ -256,6 +259,7 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 				[
 					\NestedTraits\FooTrait::class,
 				],
+				false,
 			],
 			[
 				\NestedTraits\Foo::class,
@@ -270,6 +274,7 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 					\NestedTraits\BarTrait::class,
 					\NestedTraits\FooTrait::class,
 				],
+				false,
 			],
 			[
 				\NestedTraits\Bar::class,
@@ -286,6 +291,7 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 					\NestedTraits\BarTrait::class,
 					\NestedTraits\FooTrait::class,
 				],
+				false,
 			],
 			[
 				\NestedTraits\Baz::class,
@@ -299,6 +305,7 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 			[
 				\NestedTraits\BazChild::class,
 				[],
+				false,
 			],
 			[
 				\NestedTraits\BazChild::class,

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -272,7 +272,6 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 				\NestedTraits\Bar::class,
 				[
 					\NestedTraits\BarTrait::class,
-					\NestedTraits\FooTrait::class,
 				],
 				false,
 			],
@@ -288,8 +287,6 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 				\NestedTraits\Baz::class,
 				[
 					\NestedTraits\BazTrait::class,
-					\NestedTraits\BarTrait::class,
-					\NestedTraits\FooTrait::class,
 				],
 				false,
 			],

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -257,45 +257,45 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 			[
 				\NestedTraits\Foo::class,
 				[
-					\NestedTraits\FooTrait::class,
+					\NestedTraits\FooTrait::class => \NestedTraits\FooTrait::class,
 				],
 				false,
 			],
 			[
 				\NestedTraits\Foo::class,
 				[
-					\NestedTraits\FooTrait::class,
+					\NestedTraits\FooTrait::class => \NestedTraits\FooTrait::class,
 				],
 				true,
 			],
 			[
 				\NestedTraits\Bar::class,
 				[
-					\NestedTraits\BarTrait::class,
+					\NestedTraits\BarTrait::class => \NestedTraits\BarTrait::class,
 				],
 				false,
 			],
 			[
 				\NestedTraits\Bar::class,
 				[
-					\NestedTraits\BarTrait::class,
-					\NestedTraits\FooTrait::class,
+					\NestedTraits\BarTrait::class => \NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class => \NestedTraits\FooTrait::class,
 				],
 				true,
 			],
 			[
 				\NestedTraits\Baz::class,
 				[
-					\NestedTraits\BazTrait::class,
+					\NestedTraits\BazTrait::class => \NestedTraits\BazTrait::class,
 				],
 				false,
 			],
 			[
 				\NestedTraits\Baz::class,
 				[
-					\NestedTraits\BazTrait::class,
-					\NestedTraits\BarTrait::class,
-					\NestedTraits\FooTrait::class,
+					\NestedTraits\BazTrait::class => \NestedTraits\BazTrait::class,
+					\NestedTraits\BarTrait::class => \NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class => \NestedTraits\FooTrait::class,
 				],
 				true,
 			],
@@ -307,9 +307,9 @@ class ClassReflectionTest extends \PHPStan\Testing\TestCase
 			[
 				\NestedTraits\BazChild::class,
 				[
-					\NestedTraits\BazTrait::class,
-					\NestedTraits\BarTrait::class,
-					\NestedTraits\FooTrait::class,
+					\NestedTraits\BazTrait::class => \NestedTraits\BazTrait::class,
+					\NestedTraits\BarTrait::class => \NestedTraits\BarTrait::class,
+					\NestedTraits\FooTrait::class => \NestedTraits\FooTrait::class,
 				],
 				true,
 			],

--- a/tests/PHPStan/Reflection/data/NestedTraits.php
+++ b/tests/PHPStan/Reflection/data/NestedTraits.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace NestedTraits;
+
+trait FooTrait
+{
+}
+
+trait BarTrait
+{
+    use FooTrait;
+}
+
+trait BazTrait
+{
+    use BarTrait;
+}
+
+class NoTrait
+{
+}
+
+class Foo
+{
+    use FooTrait;
+}
+
+class Bar
+{
+    use BarTrait;
+}
+
+class Baz
+{
+    use BazTrait;
+}
+
+class BazChild extends Baz
+{
+}


### PR DESCRIPTION
Changes the `ClassReflection::getTraits` function to be recursive according to the suggestion from @ondrejmirtes at https://github.com/nunomaduro/larastan/issues/837#issuecomment-860205446 