### PR TITLE
 Allow null for file_put_contents $context argument

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -2943,7 +2943,7 @@ return [
 'file' => ['array<int,string>|false', 'filename'=>'string', 'flags='=>'int', 'context='=>'resource'],
 'file_exists' => ['bool', 'filename'=>'string'],
 'file_get_contents' => ['string|false', 'filename'=>'string', 'use_include_path='=>'bool', 'context='=>'?resource', 'offset='=>'int', 'maxlen='=>'int'],
-'file_put_contents' => ['int|false', 'file'=>'string', 'data'=>'mixed', 'flags='=>'int', 'context='=>'resource'],
+'file_put_contents' => ['int|false', 'file'=>'string', 'data'=>'mixed', 'flags='=>'int', 'context='=>'?resource'],
 'fileatime' => ['int|false', 'filename'=>'string'],
 'filectime' => ['int|false', 'filename'=>'string'],
 'filegroup' => ['int|false', 'filename'=>'string'],


### PR DESCRIPTION
Tested on PHP `7.0.0`, `7.1.0`, `7.2.0`, `7.3.0` and `7.4.0`: `null` is allowed, as explained in the doc (https://www.php.net/manual/en/function.file-put-contents.php)