### PR TITLE
apply php configurations when fork child workers

### DIFF
--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -25,7 +25,7 @@ class ProcessHelper
 	): string
 	{
 		$processCommandArray = [
-			escapeshellarg(PHP_BINARY),
+            sprintf('%s -c %s', escapeshellarg(PHP_BINARY), escapeshellarg(php_ini_loaded_file())),
 		];
 
 		if ($input->getOption('memory-limit') === null) {

--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -25,7 +25,7 @@ class ProcessHelper
 	): string
 	{
 		$phpIni = php_ini_loaded_file();
-		$phpCmd = ($phpIni === false) ? escapeshellarg(PHP_BINARY) : sprintf('%s -c %s', escapeshellarg(PHP_BINARY), $phpIni);
+		$phpCmd = $phpIni === false ? escapeshellarg(PHP_BINARY) : sprintf('%s -c %s', escapeshellarg(PHP_BINARY), escapeshellarg($phpIni));
 
 		$processCommandArray = [
 			$phpCmd,

--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -24,8 +24,11 @@ class ProcessHelper
 		InputInterface $input
 	): string
 	{
+		$phpIni = php_ini_loaded_file();
+		$phpCmd = ($phpIni === false) ? escapeshellarg(PHP_BINARY) : sprintf('%s -c %s', escapeshellarg(PHP_BINARY), $phpIni);
+
 		$processCommandArray = [
-            sprintf('%s -c %s', escapeshellarg(PHP_BINARY), escapeshellarg(php_ini_loaded_file())),
+			$phpCmd,
 		];
 
 		if ($input->getOption('memory-limit') === null) {


### PR DESCRIPTION
Currently, ProcessHelper only copy command-line arguments of phpstan, but ignore those of php itself.
In some cases, the custom configuration for php: --configuration (-c in short), is very usefull.

for example:
If a custom php.ini is specified when starting phpstan like:
php74 -c my-php.ini analyze --level 0 ...

# my-php.ini
extension=yaf
yaf.use_namespace = On
...

phpstan creates child workers to analyze, however, it only copies its own the command-line arguments, not those of php itself (-c my-php.ini). 
In workers, "yaf.use_namespace" could not take effect, the reference to "Yaf\Application" will generate "Yaf\Application not found" error message.
