### PR TITLE
Fixed getmxrr argument names

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3337,7 +3337,7 @@ return [
 'getimagesize' => ['array|false', 'imagefile'=>'string', '&w_info='=>'array'],
 'getimagesizefromstring' => ['array|false', 'data'=>'string', '&w_info='=>'array'],
 'getlastmod' => ['int|false'],
-'getmxrr' => ['bool', 'hostname'=>'string', '&w_mxhosts'=>'array', '&w_weight='=>'array'],
+'getmxrr' => ['bool', 'hostname'=>'string', '&hosts'=>'array', '&weight='=>'array'],
 'getmygid' => ['int|false'],
 'getmyinode' => ['int|false'],
 'getmypid' => ['int|false'],


### PR DESCRIPTION
https://www.php.net/manual/en/function.getmxrr.php:

`getmxrr(string $hostname, array &$hosts, array &$weights = null): bool`


See https://github.com/rectorphp/rector-src/pull/262#issuecomment-866804060