### PR TITLE
Add return type extension for strval()

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1398,6 +1398,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\StrvalFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\StrWordCountFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/StrvalFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrvalFunctionReturnTypeExtension.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+
+class StrvalFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'strval';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope
+	): Type
+	{
+		if (count($functionCall->args) === 0) {
+			return new NullType();
+		}
+		$argType = $scope->getType($functionCall->args[0]->value);
+		return $argType->toString();
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -430,6 +430,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5219.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/strval.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/strval.php
+++ b/tests/PHPStan/Analyser/data/strval.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace StrvalTest;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param class-string<\stdClass> $class
+ */
+function test(string $class)
+{
+	assertType('\'foo\'', strval('foo'));
+	assertType('\'\'', strval(null));
+	assertType('\'\'|\'1\'', strval(rand(0, 1) === 0));
+	assertType('string&numeric', strval(rand()));
+	assertType('string&numeric', strval(rand() * 0.1));
+	assertType('string&numeric', strval(strval(rand())));
+	assertType('class-string<stdClass>', strval($class));
+}


### PR DESCRIPTION
The most useful case here is that it returns `string&numeric` for `strval(rand())`.