### PR TITLE
Fix for: Optional array key is not recognized with !empty

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -682,23 +682,7 @@ class TypeSpecifier
 					}
 				}
 				if ($expr instanceof Expr\Isset_) {
-					if (
-						$var instanceof ArrayDimFetch
-						&& $var->dim !== null
-						&& !$scope->getType($var->var) instanceof MixedType
-					) {
-						$type = $this->create(
-							$var->var,
-							new HasOffsetType($scope->getType($var->dim)),
-							$context,
-							false,
-							$scope
-						)->unionWith(
-							$this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope)
-						);
-					} else {
-						$type = $this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope);
-					}
+					$type = $this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope);
 				} else {
 					$type = $this->create(
 						$var,
@@ -709,6 +693,22 @@ class TypeSpecifier
 						TypeSpecifierContext::createFalse(),
 						false,
 						$scope
+					);
+				}
+
+				if (
+					$var instanceof ArrayDimFetch
+					&& $var->dim !== null
+					&& !$scope->getType($var->var) instanceof MixedType
+				) {
+					$type = $this->create(
+						$var->var,
+						new HasOffsetType($scope->getType($var->dim)),
+						$context,
+						false,
+						$scope
+					)->unionWith(
+						$type
 					);
 				}
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -280,8 +280,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends \PHPStan\Testing\RuleTest
 
 	public function testBug3297(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-3297.php'], [
-		]);
+		$this->analyse([__DIR__ . '/data/bug-3297.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -278,4 +278,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends \PHPStan\Testing\RuleTest
 		]);
 	}
 
+	public function testBug3297(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-3297.php'], [
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-3297.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-3297.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Bug3297;
+
+class Foo
+{
+	/** @param array{opt?: string} $param */
+	public function bar(array $param): void
+	{
+		if (!empty($param['opt'])) {
+			echo $param['opt'];
+		}
+	}
+}


### PR DESCRIPTION
Fix for: https://github.com/phpstan/phpstan/issues/3297

Seems like array key handling was implemented only for `isset()`

I factored it out so that it would be applied also for `!empty()`, added a test (used example from the issue).