### PR TITLE
Don't try to create a directory that already exists

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -238,7 +238,7 @@ class CommandHelper
 		);
 
 		$createDir = static function (string $path) use ($errorOutput): void {
-			if (!@mkdir($path, 0777) && !is_dir($path)) {
+			if (!is_dir($path) && !@mkdir($path, 0777) && !is_dir($path)) {
 				$errorOutput->writeLineFormatted(sprintf('Cannot create a temp directory %s', $path));
 				throw new \PHPStan\Command\InceptionNotSuccessfulException();
 			}


### PR DESCRIPTION
When creating directories, whenever those already exist mkdir is still called and reports an E_WARNING. Although it is supressed, those still end up in the error handler.

When this PR is merged, directories are checked first for existence. If so, mkdir is not called anymore, not triggering the E_WARNING.