### PR TITLE
Fix intersection in generics

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -513,7 +513,12 @@ class IntersectionType implements CompoundType
 		$types = TemplateTypeMap::createEmpty();
 
 		foreach ($this->types as $type) {
-			$types = $types->intersect($templateType->inferTemplateTypes($type));
+			$inferred = $templateType->inferTemplateTypes($type);
+			if ($inferred->isEmpty() && $templateType instanceof TemplateType) {
+				$inferred = new TemplateTypeMap([$templateType->getName() => $type]);
+			}
+
+			$types = $types->intersect($inferred);
 		}
 
 		return $types;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -478,6 +478,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5129.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4970.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5322.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5336.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/splfixedarray-iterator-types.php');
 
 		if (PHP_VERSION_ID >= 70400 || self::$useStaticReflectionProvider) {

--- a/tests/PHPStan/Analyser/data/bug-5336.php
+++ b/tests/PHPStan/Analyser/data/bug-5336.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bug5336;
+
+use function PHPStan\Testing\assertType;
+
+interface Stub
+{
+}
+
+interface ProxyQueryInterface
+{
+}
+
+/**
+ * @phpstan-template T of ProxyQueryInterface
+ */
+class Pager
+{
+	/**
+	 * @var T
+	 */
+	private $query;
+
+	/**
+	 * @phpstan-param T $query
+	 */
+	public function __construct(ProxyQueryInterface $query) {
+		$this->query = $query;
+	}
+}
+
+abstract class Test
+{
+	/**
+	 * @var Pager<ProxyQueryInterface&Stub>
+	 */
+	private $pager;
+
+	/**
+	 * @template T of object
+	 * @param class-string<T> $originalClassName
+	 * @return T&Stub
+	 */
+	abstract public function createStub(string $originalClassName): Stub;
+
+	public function sayHello(): void
+	{
+		$query = $this->createStub(ProxyQueryInterface::class);
+		$this->pager = new Pager($query);
+		assertType('Bug5336\Pager<Bug5336\ProxyQueryInterface&Bug5336\Stub>', $this->pager);
+	}
+}


### PR DESCRIPTION
Without the fix I get 
```
------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   bug-5336.php                                                                                                                                         
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
  23     Property Bug5336\Pager::$query is never read, only written.                                                                                          
  50     Property Bug5336\Test::$pager (Bug5336\Pager<Bug5336\ProxyQueryInterface&Bug5336\Stub>) does not accept Bug5336\Pager<Bug5336\ProxyQueryInterface>.  
  51     Expected type Bug5336\Pager<Bug5336\ProxyQueryInterface&Bug5336\Stub>, actual: Bug5336\Pager<Bug5336\ProxyQueryInterface>                            
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------- 
```
on the file.

With the fix I get
```
------ ------------------------------------------------------------- 
  Line   bug-5336.php                                                 
 ------ ------------------------------------------------------------- 
  23     Property Bug5336\Pager::$query is never read, only written.  
 ------ ------------------------------------------------------------- 
```

The fix I made in `IntersectionType::inferTemplateTypesOn` might be improved... 
More important, I don't know if the fix should be added to `IntersectionType::inferTemplateTypes` too (and what's the diff between both methods).

Close https://github.com/phpstan/phpstan/issues/5336