### PR TITLE
PHP8 specific removed create_function error

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
@@ -2,15 +2,20 @@
 
 namespace PHPStan\Rules\Functions;
 
+use PHPStan\Php\PhpVersion;
+
 /**
  * @extends \PHPStan\Testing\RuleTestCase<CallToNonExistentFunctionRule>
  */
 class CallToNonExistentFunctionRuleTest extends \PHPStan\Testing\RuleTestCase
 {
 
+	/** @var int */
+	private $phpVersion = 70400;
+
 	protected function getRule(): \PHPStan\Rules\Rule
 	{
-		return new CallToNonExistentFunctionRule($this->createReflectionProvider(), true);
+		return new CallToNonExistentFunctionRule($this->createReflectionProvider(), true, new PhpVersion($this->phpVersion));
 	}
 
 	public function testEmptyFile(): void
@@ -97,4 +102,21 @@ class CallToNonExistentFunctionRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testCallToCreateFunction(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+		// @todo The reflection provider doesn't respect PHP version to
+		//   determine if a function does not exist. The function exists on 7
+		//   but not 8. However, running on 7 it is still returned as existing.
+		// @see https://github.com/phpstan/phpstan/issues/5373
+		$this->phpVersion = 80000;
+		$this->analyse([__DIR__ . '/data/call-to-create-function.php'], [
+			[
+				'create_function not found. This function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. Use anonymous functions instead.',
+				3,
+			],
+		]);
+	}
 }

--- a/tests/PHPStan/Rules/Functions/data/call-to-create-function.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-create-function.php
@@ -1,0 +1,4 @@
+<?php
+
+$newfunc = create_function('$a,$b', 'return "ln($a) + ln($b) = " . log($a * $b);');
+echo $newfunc(2, M_E);


### PR DESCRIPTION
Part of https://github.com/phpstan/phpstan/issues/5368

This handles an improved error message when running on PHP8 to explain why the function no longer exists.﻿
