### PR TITLE
proc_open() accepts list<string> for $command in 7.4+

### DIFF
--- a/resources/functionMap_php74delta.php
+++ b/resources/functionMap_php74delta.php
@@ -55,6 +55,7 @@ return [
 		'strip_tags' => ['string', 'str'=>'string', 'allowable_tags='=>'string|array<int, string>'],
 		'WeakReference::create' => ['WeakReference', 'referent'=>'object'],
 		'WeakReference::get' => ['?object'],
+		'proc_open' => ['resource|false', 'command'=>'string|list<string>', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
 	],
 	'old' => [
 		'implode\'2' => ['string', 'pieces'=>'array', 'glue'=>'string'],

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -797,4 +797,18 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testProcOpen(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->analyse([__DIR__ . '/data/proc_open.php'], [
+			[
+				'Parameter #1 $command of function proc_open expects array<int, string>|string, array<string, string> given.',
+				6,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/proc_open.php
+++ b/tests/PHPStan/Rules/Functions/data/proc_open.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+
+proc_open('echo "hello world"', [], $pipes);
+proc_open(['echo', 'hello world'], [], $pipes);
+
+proc_open(['something' => 'bogus', 'in' => 'here'], [], $pipes);


### PR DESCRIPTION
I'm not sure if this needs to be added somewhere for 8.0 as well? The stubs will have it correct, but won't be as detailed about the type.