### PR TITLE
Add false as return type of shell_exec

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -10205,7 +10205,7 @@ return [
 'shapeObj::toWkt' => ['string'],
 'shapeObj::union' => ['shapeObj', 'shape'=>'shapeObj'],
 'shapeObj::within' => ['int', 'shape2'=>'shapeObj'],
-'shell_exec' => ['?string', 'cmd'=>'string'],
+'shell_exec' => ['string|false|null', 'cmd'=>'string'],
 'shm_attach' => ['resource|false', 'key'=>'int', 'memsize='=>'int', 'perm='=>'int'],
 'shm_detach' => ['bool', 'shm_identifier'=>'resource'],
 'shm_get_var' => ['mixed', 'id'=>'resource', 'variable_key'=>'int'],


### PR DESCRIPTION
The doc is only talking about string|null, but
false is possible when the pipe can't be etablished
@see php/php-src#7306 (comment)

For the information, it was also merged in psalm https://github.com/vimeo/psalm/pull/6178