### PR TITLE
Change PDOStatement::fetchAll signature to match the new PHP 8 format

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -143,6 +143,7 @@ return [
 		'xmlwriter_write_element_ns' => ['bool', 'xmlwriter'=>'XMLWriter', 'prefix'=>'string', 'name'=>'string', 'uri'=>'string', 'content'=>'string'],
 		'xmlwriter_write_pi' => ['bool', 'xmlwriter'=>'XMLWriter', 'target'=>'string', 'content'=>'string'],
 		'xmlwriter_write_raw' => ['bool', 'xmlwriter'=>'XMLWriter', 'content'=>'string'],
+		'PDOStatement::fetchAll' => ['array|false', 'fetch_style='=>'int', '...fetch_args='=>'mixed'],
 	],
 	'old' => [
 
@@ -264,5 +265,6 @@ return [
 		'xmlwriter_write_element_ns' => ['bool', 'xmlwriter'=>'resource', 'prefix'=>'string', 'name'=>'string', 'uri'=>'string', 'content'=>'string'],
 		'xmlwriter_write_pi' => ['bool', 'xmlwriter'=>'resource', 'target'=>'string', 'content'=>'string'],
 		'xmlwriter_write_raw' => ['bool', 'xmlwriter'=>'resource', 'content'=>'string'],
+		'PDOStatement::fetchAll' => ['array|false', 'how='=>'int', 'fetch_argument='=>'int|string|callable', 'ctor_args='=>'?array'],
 	]
 ];


### PR DESCRIPTION
The signature for PDOStatement::fetchAll was changed with PHP 8. This was already mentioned in the following bug report: https://github.com/phpstan/phpstan/issues/4150
However, no action was taken upon it.
You can see the changes made to the signature of the PHP source code in the following commit:
https://github.com/php/php-src/commit/cfaa270da5b511e2821aa0a5e036ef5879a56bed

This PR fixes the fetchAll signature for PHP 8.