### PR TITLE
github-actions: declare timeout for job execution

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -16,6 +16,7 @@ jobs:
     name: "Backward Compatibility"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -16,6 +16,7 @@ jobs:
     name: "Compiler Tests"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,6 +16,7 @@ jobs:
     name: "Result cache E2E tests"
 
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -46,6 +47,7 @@ jobs:
   e2e-tests:
     name: "E2E tests"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -53,6 +54,7 @@ jobs:
     name: "Coding Standard"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -85,6 +87,7 @@ jobs:
     name: "Dependency Analysis"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -13,6 +13,7 @@ jobs:
   compile:
     name: "Compile PHAR"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,6 +15,7 @@ jobs:
   static-analysis:
     name: "PHPStan"
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -59,7 +60,8 @@ jobs:
   static-analysis-with-result-cache:
     name: "PHPStan with result cache"
 
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -105,6 +107,7 @@ jobs:
     name: "Generate baseline"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
   tests:
     name: "Tests"
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -55,6 +56,7 @@ jobs:
   tests-old-phpunit:
     name: "Tests with old PHPUnit"
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -97,6 +99,7 @@ jobs:
     name: "Tests with code coverage"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
the default of 6h is way to long and produced a overlong queue in case of endless loop bugs