### PR TITLE
Function chr() always return not empty string

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -944,7 +944,7 @@ return [
 'chmod' => ['bool', 'filename'=>'string', 'mode'=>'int'],
 'chop' => ['string', 'str'=>'string', 'character_mask='=>'string'],
 'chown' => ['bool', 'filename'=>'string', 'user'=>'string|int'],
-'chr' => ['string', 'ascii'=>'int'],
+'chr' => ['non-empty-string', 'ascii'=>'int'],
 'chroot' => ['bool', 'directory'=>'string'],
 'chunk_split' => ['string', 'str'=>'string', 'chunklen='=>'int', 'ending='=>'string'],
 'class_alias' => ['bool', 'user_class_name'=>'string', 'alias_name'=>'string', 'autoload='=>'bool'],


### PR DESCRIPTION
The chr () function always returns a non-empty string. Now the result of the function returns the type String, I changed to return a non-empty string.

Example: https://phpstan.org/r/65a9381f-0a7d-4920-896c-0ce67346d972