### PR TITLE
`array_fill()`: handle negative cases, support integer ranges and `non-empty-array` 

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -271,7 +271,7 @@ return [
 'array_diff_uassoc\'1' => ['array', 'arr1'=>'array', 'arr2'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest='=>'array|callable'],
 'array_diff_ukey' => ['array', 'arr1'=>'array', 'arr2'=>'array', 'key_comp_func'=>'callable(mixed,mixed):int'],
 'array_diff_ukey\'1' => ['array', 'arr1'=>'array', 'arr2'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest='=>'array|callable(mixed,mixed):int'],
-'array_fill' => ['array', 'start_index'=>'int', 'count'=>'int', 'value'=>'mixed'],
+'array_fill' => ['array', 'start_key'=>'int', 'num'=>'int', 'val'=>'mixed'],
 'array_fill_keys' => ['array', 'keys'=>'array', 'val'=>'mixed'],
 'array_filter' => ['array', 'input'=>'array', 'callback='=>'callable(mixed,mixed):bool|callable(mixed):bool', 'flag='=>'int'],
 'array_flip' => ['array', 'input'=>'array<int|string>'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -271,7 +271,7 @@ return [
 'array_diff_uassoc\'1' => ['array', 'arr1'=>'array', 'arr2'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest='=>'array|callable'],
 'array_diff_ukey' => ['array', 'arr1'=>'array', 'arr2'=>'array', 'key_comp_func'=>'callable(mixed,mixed):int'],
 'array_diff_ukey\'1' => ['array', 'arr1'=>'array', 'arr2'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest='=>'array|callable(mixed,mixed):int'],
-'array_fill' => ['array', 'start_key'=>'int', 'num'=>'int', 'val'=>'mixed'],
+'array_fill' => ['array', 'start_index'=>'int', 'count'=>'int', 'value'=>'mixed'],
 'array_fill_keys' => ['array', 'keys'=>'array', 'val'=>'mixed'],
 'array_filter' => ['array', 'input'=>'array', 'callback='=>'callable(mixed,mixed):bool|callable(mixed):bool', 'flag='=>'int'],
 'array_flip' => ['array', 'input'=>'array<int|string>'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -22,6 +22,7 @@
 return [
 	'new' => [
 		'array_combine' => ['associative-array', 'keys'=>'string[]|int[]', 'values'=>'array'],
+		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'0|positive', 'val'=>'mixed'],
 		'bcdiv' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],
@@ -146,7 +147,6 @@ return [
 	'old' => [
 
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'0|positive', 'val'=>'mixed'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -22,7 +22,7 @@
 return [
 	'new' => [
 		'array_combine' => ['associative-array', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_fill' => ['array', 'start_index'=>'int', 'count'=>'0|positive-int', 'value'=>'mixed'],
+		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'0|positive-int', 'val'=>'mixed'],
 		'bcdiv' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],
@@ -147,7 +147,7 @@ return [
 	'old' => [
 
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_fill' => ['array', 'start_index'=>'int', 'count'=>'int', 'value'=>'mixed'],
+		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'int', 'val'=>'mixed'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -146,6 +146,7 @@ return [
 	'old' => [
 
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
+		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'0|positive', 'val'=>'mixed'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -22,7 +22,7 @@
 return [
 	'new' => [
 		'array_combine' => ['associative-array', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'0|positive', 'val'=>'mixed'],
+		'array_fill' => ['array', 'start_index'=>'int', 'count'=>'0|positive-int', 'value'=>'mixed'],
 		'bcdiv' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],
@@ -147,6 +147,7 @@ return [
 	'old' => [
 
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
+		'array_fill' => ['array', 'start_index'=>'int', 'count'=>'int', 'value'=>'mixed'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],

--- a/src/File/ParentDirectoryRelativePathHelper.php
+++ b/src/File/ParentDirectoryRelativePathHelper.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\File;
 
-use PHPStan\ShouldNotHappenException;
 use function array_slice;
 use function str_replace;
 
@@ -56,7 +55,7 @@ class ParentDirectoryRelativePathHelper implements RelativePathHelper
 
 		$dotsCount = $parentPartsCount - $i;
 		if ($dotsCount < 0) {
-			throw new ShouldNotHappenException();
+			throw new \PHPStan\ShouldNotHappenException();
 		}
 
 		return array_merge(array_fill(0, $dotsCount, '..'), array_slice($filenameParts, $i));

--- a/src/File/ParentDirectoryRelativePathHelper.php
+++ b/src/File/ParentDirectoryRelativePathHelper.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\File;
 
+use PHPStan\ShouldNotHappenException;
 use function array_slice;
 use function str_replace;
 
@@ -54,6 +55,9 @@ class ParentDirectoryRelativePathHelper implements RelativePathHelper
 		}
 
 		$dotsCount = $parentPartsCount - $i;
+		if ($dotsCount < 0) {
+			throw new ShouldNotHappenException();
+		}
 
 		return array_merge(array_fill(0, $dotsCount, '..'), array_slice($filenameParts, $i));
 	}

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -21,6 +21,7 @@ use PHPStan\Type\TypeCombinator;
 
 class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
+
 	private const MAX_SIZE_USE_CONSTANT_ARRAY = 100;
 
 	private PhpVersion $phpVersion;

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -9,7 +9,9 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Type;
@@ -33,6 +35,11 @@ class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunct
 		$startIndexType = $scope->getType($functionCall->args[0]->value);
 		$numberType = $scope->getType($functionCall->args[1]->value);
 		$valueType = $scope->getType($functionCall->args[2]->value);
+
+		// check against negative-int
+		if (IntegerRangeType::fromInterval(null, -1)->isSuperTypeOf($numberType)->yes()) {
+			return new ConstantBooleanType(false);
+		}
 
 		if (
 			$startIndexType instanceof ConstantIntegerType

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
@@ -14,12 +15,20 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-
 	private const MAX_SIZE_USE_CONSTANT_ARRAY = 100;
+
+	private PhpVersion $phpVersion;
+
+	public function __construct(PhpVersion $phpVersion)
+	{
+		$this->phpVersion = $phpVersion;
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -36,8 +45,20 @@ class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunct
 		$numberType = $scope->getType($functionCall->args[1]->value);
 		$valueType = $scope->getType($functionCall->args[2]->value);
 
-		// check against negative-int
+		if ($numberType instanceof IntegerRangeType) {
+			if ($numberType->getMin() < 0) {
+				return TypeCombinator::union(
+					new ArrayType(new IntegerType(), $valueType),
+					new ConstantBooleanType(false)
+				);
+			}
+		}
+
+		// check against negative-int, which is not allowed
 		if (IntegerRangeType::fromInterval(null, -1)->isSuperTypeOf($numberType)->yes()) {
+			if ($this->phpVersion->getVersionId() >= 80000) {
+				return new NeverType();
+			}
 			return new ConstantBooleanType(false);
 		}
 
@@ -63,10 +84,7 @@ class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunct
 			return $arrayBuilder->getArray();
 		}
 
-		if (
-			$numberType instanceof ConstantIntegerType
-			&& $numberType->getValue() > 0
-		) {
+		if (IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($numberType)->yes()) {
 			return new IntersectionType([
 				new ArrayType(new IntegerType(), $valueType),
 				new NonEmptyArrayType(),

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -57,7 +57,7 @@ class ArrayFillFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunct
 
 		// check against negative-int, which is not allowed
 		if (IntegerRangeType::fromInterval(null, -1)->isSuperTypeOf($numberType)->yes()) {
-			if ($this->phpVersion->getVersionId() >= 80000) {
+			if ($this->phpVersion->throwsValueErrorForInternalFunctions()) {
 				return new NeverType();
 			}
 			return new ConstantBooleanType(false);

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5101,8 +5101,16 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$filledIntegers',
 			],
 			[
+				'array()',
+				'$emptyFilled',
+			],
+			[
 				'array(1)',
 				'$filledIntegersWithKeys',
+			],
+			[
+				'array<int, \'foo\'>&nonEmpty',
+				'$filledNonEmptyArray',
 			],
 			[
 				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5105,12 +5105,20 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$filledIntegersWithKeys',
 			],
 			[
-				'false',
+				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
 				'$filledAlwaysFalse',
 			],
 			[
-				'false',
+				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
 				'$filledNegativeConstAlwaysFalse',
+			],
+			[
+				'array<int, 1>|false',
+				'$filledByMaybeNegativeRange',
+			],
+			[
+				'array<int, 1>&nonEmpty',
+				'$filledByPositiveRange',
 			],
 			[
 				'array(1, 2)',

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5105,6 +5105,14 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$filledIntegersWithKeys',
 			],
 			[
+				'false',
+				'$filledAlwaysFalse',
+			],
+			[
+				'false',
+				'$filledNegativeConstAlwaysFalse',
+			],
+			[
 				'array(1, 2)',
 				'array_keys($integerKeys)',
 			],

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -37,9 +37,12 @@ $reducedIntegersToStringWithInt = array_reduce($uniquedIntegers, function (): st
 }, 1);
 
 $filledIntegers = array_fill(0, 5, 1);
+$emptyFilled = array_fill(3, 0, 'banana');
 $filledIntegersWithKeys = array_fill_keys([0], 1);
 /** @var negative-int $negInt */
 $filledAlwaysFalse = array_fill(0, $negInt, 1);
+/** @var positive-int $posInt */
+$filledNonEmptyArray = array_fill(0, $posInt, 'foo');
 $filledNegativeConstAlwaysFalse = array_fill(0, -5, 1);
 /** @var int<-3, 5> $maybeNegRange */
 $filledByMaybeNegativeRange = array_fill(0, $maybeNegRange, 1);

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -38,6 +38,9 @@ $reducedIntegersToStringWithInt = array_reduce($uniquedIntegers, function (): st
 
 $filledIntegers = array_fill(0, 5, 1);
 $filledIntegersWithKeys = array_fill_keys([0], 1);
+/** @var negative-int $negInt */
+$filledAlwaysFalse = array_fill(0, $negInt, 1);
+$filledNegativeConstAlwaysFalse = array_fill(0, -5, 1);
 
 $integerKeys = [
 	1 => 'foo',

--- a/tests/PHPStan/Analyser/data/array-functions.php
+++ b/tests/PHPStan/Analyser/data/array-functions.php
@@ -41,6 +41,9 @@ $filledIntegersWithKeys = array_fill_keys([0], 1);
 /** @var negative-int $negInt */
 $filledAlwaysFalse = array_fill(0, $negInt, 1);
 $filledNegativeConstAlwaysFalse = array_fill(0, -5, 1);
+/** @var int<-3, 5> $maybeNegRange */
+$filledByMaybeNegativeRange = array_fill(0, $maybeNegRange, 1);
+$filledByPositiveRange = array_fill(0, rand(3, 5), 1);
 
 $integerKeys = [
 	1 => 'foo',

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Parallel;
 
+use PHPStan\ShouldNotHappenException;
 use PHPUnit\Framework\TestCase;
 
 class SchedulerTest extends TestCase
@@ -87,6 +88,10 @@ class SchedulerTest extends TestCase
 		array $expectedJobSizes
 	): void
 	{
+		if ($numberOfFiles < 0) {
+			throw new ShouldNotHappenException();
+		}
+
 		$files = array_fill(0, $numberOfFiles, 'file.php');
 		$scheduler = new Scheduler($jobSize, $maximumNumberOfProcesses, $minimumNumberOfJobsPerProcess);
 		$schedule = $scheduler->scheduleWork($cpuCores, $files);

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Parallel;
 
-use PHPStan\ShouldNotHappenException;
 use PHPUnit\Framework\TestCase;
 
 class SchedulerTest extends TestCase
@@ -89,7 +88,7 @@ class SchedulerTest extends TestCase
 	): void
 	{
 		if ($numberOfFiles < 0) {
-			throw new ShouldNotHappenException();
+			throw new \PHPStan\ShouldNotHappenException();
 		}
 
 		$files = array_fill(0, $numberOfFiles, 'file.php');

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -73,7 +73,7 @@ class SchedulerTest extends TestCase
 	 * @param int $maximumNumberOfProcesses
 	 * @param int $minimumNumberOfJobsPerProcess
 	 * @param int $jobSize
-	 * @param int $numberOfFiles
+	 * @param 0|positive-int $numberOfFiles
 	 * @param int $expectedNumberOfProcesses
 	 * @param array<int> $expectedJobSizes
 	 */
@@ -87,10 +87,6 @@ class SchedulerTest extends TestCase
 		array $expectedJobSizes
 	): void
 	{
-		if ($numberOfFiles < 0) {
-			throw new \PHPStan\ShouldNotHappenException();
-		}
-
 		$files = array_fill(0, $numberOfFiles, 'file.php');
 		$scheduler = new Scheduler($jobSize, $maximumNumberOfProcesses, $minimumNumberOfJobsPerProcess);
 		$schedule = $scheduler->scheduleWork($cpuCores, $files);


### PR DESCRIPTION
`array_fill` expected the first arg to be an int.

see https://3v4l.org/Sq4tH

closes https://github.com/phpstan/phpstan/issues/5284