### PR TITLE
support integer-range type in min/max 

### DIFF
--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\ErrorType;
@@ -140,35 +141,35 @@ class MinMaxFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunction
 		string $functionName
 	): ?Type
 	{
-		$rangeType = $scalarType = null;
+		$rangeType = $intType = null;
 
 		if (
 			$firstType instanceof IntegerRangeType
-			&& $secondType instanceof ConstantScalarType
+			&& $secondType instanceof ConstantIntegerType
 		) {
 			$rangeType = $firstType;
-			$scalarType = $secondType;
+			$intType = $secondType;
 		}
 
 		if (
-			$firstType instanceof ConstantScalarType
+			$firstType instanceof ConstantIntegerType
 			&& $secondType instanceof IntegerRangeType
 		) {
 			$rangeType = $secondType;
-			$scalarType = $firstType;
+			$intType = $firstType;
 		}
 
-		if ($rangeType !== null && $scalarType !== null) {
+		if ($rangeType !== null && $intType !== null) {
 			$min = $rangeType->getMin();
 			$max = $rangeType->getMax();
 
 			if ($functionName === 'min') {
 				if ($rangeType->getMax() === null) {
-					$max = $scalarType->getValue();
+					$max = $intType->getValue();
 				}
 			} elseif ($functionName === 'max') {
 				if ($rangeType->getMin() === null) {
-					$min = $scalarType->getValue();
+					$min = $intType->getValue();
 				}
 			}
 

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -111,7 +111,7 @@ class MinMaxFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunction
 			}
 
 			$mergedType = $this->mergeRangeTypes($resultType, $type, $functionName);
-			if ($mergedType) {
+			if ($mergedType !== null) {
 				$resultType = $mergedType;
 			}
 
@@ -158,7 +158,7 @@ class MinMaxFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunction
 			$scalarType = $firstType;
 		}
 
-		if ($rangeType && $scalarType) {
+		if ($rangeType !== null && $scalarType !== null) {
 			$min = $rangeType->getMin();
 			$max = $rangeType->getMax();
 

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -164,11 +164,11 @@ class MinMaxFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunction
 			$max = $rangeType->getMax();
 
 			if ($functionName === 'min') {
-				if ($rangeType->getMax() === null) {
+				if ($rangeType->getMax() === null || $rangeType->getMax() > $intType->getValue()) {
 					$max = $intType->getValue();
 				}
 			} elseif ($functionName === 'max') {
-				if ($rangeType->getMin() === null) {
+				if ($rangeType->getMin() === null || $rangeType->getMin() < $intType->getValue()) {
 					$min = $intType->getValue();
 				}
 			}

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -118,3 +118,22 @@ function dummy5(int $i, int $j): void
 function dummy6(string $s, string $t): void {
 	assertType('array(?0 => non-empty-string, ?1 => non-empty-string)', array_filter([$s, $t]));
 }
+
+class HelloWorld
+{
+	public function setRange(int $range): void
+	{
+		if ($range < 0) {
+			return;
+		}
+		assertType('int<0, 100>', min($range, 100));
+	}
+
+	public function setRange2(int $range): void
+	{
+		if ($range > 100) {
+			return;
+		}
+		assertType('int<0, 100>', max($range, 0));
+	}
+}

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -138,4 +138,13 @@ class HelloWorld
 		assertType('int<0, 100>', max($range, 0));
 		assertType('int<0, 100>', max(0, $range));
 	}
+	
+	/**
+	 * @var int<3, 5> $range
+	 */
+	public function boundRange($range): void
+	{
+		assertType('int<4, 5>', min($range, 4));
+		assertType('int<3, 4>', max(4, $range));
+	}
 }

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -138,12 +138,14 @@ class HelloWorld
 		assertType('int<0, 100>', max($range, 0));
 		assertType('int<0, 100>', max(0, $range));
 	}
-	
-	/**
-	 * @var int<1, 6> $range
-	 */
-	public function boundRange($range): void
+
+	public function boundRange(): void
 	{
+		/**
+		 * @var int<1, 6> $range
+		 */
+		$range = getFoo();
+
 		assertType('int<1, 4>', min($range, 4));
 		assertType('int<4, 6>', max(4, $range));
 	}

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -127,6 +127,7 @@ class HelloWorld
 			return;
 		}
 		assertType('int<0, 100>', min($range, 100));
+		assertType('int<0, 100>', min(100, $range));
 	}
 
 	public function setRange2(int $range): void
@@ -135,5 +136,6 @@ class HelloWorld
 			return;
 		}
 		assertType('int<0, 100>', max($range, 0));
+		assertType('int<0, 100>', max(0, $range));
 	}
 }

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -140,11 +140,11 @@ class HelloWorld
 	}
 	
 	/**
-	 * @var int<3, 5> $range
+	 * @var int<1, 6> $range
 	 */
 	public function boundRange($range): void
 	{
-		assertType('int<4, 5>', min($range, 4));
-		assertType('int<3, 4>', max(4, $range));
+		assertType('int<1, 4>', min($range, 4));
+		assertType('int<4, 6>', max(4, $range));
 	}
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/5398


this fixes the reported issue, but I can think of more complex scenarios which are not yet covered, e.g.

```php
	/**
	 * @param int<0, 10> $range1
	 * @param int<3, 9> $range2
	 * @param int<4, 5> $range3
	 * @param int $int
	 */
	public function complexRanges($range1, $range2, $range3, $int) {
		assertType('int', min($range1, $range2, $int));
		assertType('int', max($range1, $range2, $int));

		assertType('int<0, 5>', min($range1, $range2, $range3));
		assertType('int<4, 10>', max($range1, $range2, $range3));
	}
```

but I think these should be covered in a separate PR, as they are rare and this PR - as is - already covers a lot of real world code