### PR TITLE
StrlenFunctionReturnTypeExtension: cover more scalar types (required for weak-type mode)

### DIFF
--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -52,7 +52,8 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 			return IntegerRangeType::fromInterval($min, $max);
 		}
 
-		if ($argType instanceof BooleanType) {
+		$bool = new BooleanType();
+		if ($bool->isSuperTypeOf($argType)->yes()) {
 			return IntegerRangeType::fromInterval(0, 1);
 		}
 

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -49,9 +49,6 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 				$max = $len;
 			}
 		}
-		if ($min !== null && $min === $max) {
-			return new ConstantIntegerType($max);
-		}
 		if ($min || $max) {
 			return IntegerRangeType::fromInterval($min, $max);
 		}

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -43,7 +43,7 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 			if ($min === null || $len < $min) {
 				$min = $len;
 			}
-			if ($len > $max) {
+			if ($max === null || $len > $max) {
 				$max = $len;
 			}
 		}

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -2,14 +2,12 @@
 
 namespace PHPStan\Type\Php;
 
-use Bug4003\Boo;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -47,7 +47,8 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 				$max = $len;
 			}
 		}
-		if ($min || $max) {
+
+		if ($min !== null || $max !== null) {
 			return IntegerRangeType::fromInterval($min, $max);
 		}
 

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -6,9 +6,12 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntegerType;
 
 class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -30,8 +33,16 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		}
 
 		$argType = $scope->getType($args[0]->value);
+
+		if ($argType instanceof ConstantStringType) {
+			return new ConstantIntegerType(strlen($argType->getValue()));
+		}
+		if ($argType instanceof BooleanType) {
+			return IntegerRangeType::fromInterval(0, 1);
+		}
+
 		$isNonEmpty = $argType->isNonEmptyString();
-		if ($isNonEmpty->yes()) {
+		if ($isNonEmpty->yes() || $argType instanceof IntegerType) {
 			return IntegerRangeType::fromInterval(1, null);
 		}
 

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -43,9 +43,11 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 			if ($min === null || $len < $min) {
 				$min = $len;
 			}
-			if ($max === null || $len > $max) {
-				$max = $len;
+			if ($max !== null && $len <= $max) {
+				continue;
 			}
+
+			$max = $len;
 		}
 
 		if ($min !== null || $max !== null) {

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -37,7 +37,7 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		$constantStrings = TypeUtils::getConstantStrings($argType);
 		$min = null;
 		$max = null;
-		foreach($constantStrings as $constantString) {
+		foreach ($constantStrings as $constantString) {
 			$len = strlen($constantString->getValue());
 
 			if ($min === null || $len < $min) {

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -40,17 +40,23 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		foreach ($constantStrings as $constantString) {
 			$len = strlen($constantString->getValue());
 
-			if ($min === null || $len < $min) {
+			if ($min === null) {
+				$min = $len;
+				$max = $len;
+			}
+
+			if ($len < $min) {
 				$min = $len;
 			}
-			if ($max !== null && $len <= $max) {
+			if ($len <= $max) {
 				continue;
 			}
 
 			$max = $len;
 		}
 
-		if ($min !== null || $max !== null) {
+		// $max is always != null, when $min is != null
+		if ($min !== null) {
 			return IntegerRangeType::fromInterval($min, $max);
 		}
 

--- a/tests/PHPStan/Analyser/data/bug-5129.php
+++ b/tests/PHPStan/Analyser/data/bug-5129.php
@@ -20,7 +20,7 @@ class HelloWorld
 		assertType('0', strlen($this->foo));
 
 		$this->foo = 'x';
-		assertType('int<1, max>', strlen($this->foo));
+		assertType('1', strlen($this->foo));
 		if (strlen($this->foo) > 0) {
 			return;
 		}

--- a/tests/PHPStan/Analyser/data/non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string.php
@@ -303,7 +303,7 @@ class MoreNonEmptyStringFunctions
 	/**
 	 * @param non-empty-string $nonEmpty
 	 */
-	public function doFoo(string $s, string $nonEmpty, int $i)
+	public function doFoo(string $s, string $nonEmpty, int $i, bool $bool)
 	{
 		assertType('string', addslashes($s));
 		assertType('non-empty-string', addslashes($nonEmpty));
@@ -349,6 +349,9 @@ class MoreNonEmptyStringFunctions
 		assertType('non-empty-string', vsprintf($nonEmpty, []));
 
 		assertType('0', strlen(''));
+		assertType('5', strlen('hallo'));
+		assertType('int<0, 1>', strlen($bool));
+		assertType('int<1, max>', strlen($i));
 		assertType('int<0, max>', strlen($s));
 		assertType('int<1, max>', strlen($nonEmpty));
 

--- a/tests/PHPStan/Analyser/data/non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string.php
@@ -302,7 +302,7 @@ class MoreNonEmptyStringFunctions
 
 	/**
 	 * @param non-empty-string $nonEmpty
-	 * @param 1|2|5|10 $constUnion
+	 * @param '1'|'2'|'5'|'10' $constUnion
 	 */
 	public function doFoo(string $s, string $nonEmpty, int $i, bool $bool, $constUnion)
 	{

--- a/tests/PHPStan/Analyser/data/non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string.php
@@ -302,8 +302,9 @@ class MoreNonEmptyStringFunctions
 
 	/**
 	 * @param non-empty-string $nonEmpty
+	 * @param 1|2|5|10 $constUnion
 	 */
-	public function doFoo(string $s, string $nonEmpty, int $i, bool $bool)
+	public function doFoo(string $s, string $nonEmpty, int $i, bool $bool, $constUnion)
 	{
 		assertType('string', addslashes($s));
 		assertType('non-empty-string', addslashes($nonEmpty));
@@ -354,6 +355,7 @@ class MoreNonEmptyStringFunctions
 		assertType('int<1, max>', strlen($i));
 		assertType('int<0, max>', strlen($s));
 		assertType('int<1, max>', strlen($nonEmpty));
+		assertType('int<1, 2>', strlen($constUnion));
 
 		assertType('non-empty-string', str_pad($nonEmpty, 0));
 		assertType('non-empty-string', str_pad($nonEmpty, 1));


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/5350

even `0` and negative-int return a strlen => 1, see https://3v4l.org/jjGNT