### PR TITLE
Revert "Skip ErrorFormatterTestCase on Windows & PHP 8"

### DIFF
--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -22,9 +22,6 @@ abstract class ErrorFormatterTestCase extends \PHPStan\Testing\TestCase
 
 	private function getOutputStream(): StreamOutput
 	{
-		if (PHP_VERSION_ID >= 80000 && DIRECTORY_SEPARATOR === '\\') {
-			$this->markTestSkipped('Skipped because of https://github.com/symfony/symfony/issues/37508');
-		}
 		if ($this->outputStream === null) {
 			$resource = fopen('php://memory', 'w', false);
 			if ($resource === false) {


### PR DESCRIPTION
This reverts commit c42d29e2f0c1c2f6a28f16d4885f5a06efb35562.

The upstream bug is fixed:
- https://github.com/symfony/symfony/issues/37508
- https://github.com/php/php-src/pull/5863