### PR TITLE
ZEND_ dynamic constants

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -160,6 +160,8 @@ parameters:
 		- PHP_SHLIB_SUFFIX
 		- PHP_FD_SETSIZE
 		- OPENSSL_VERSION_NUMBER
+		- ZEND_DEBUG_BUILD
+		- ZEND_THREAD_SAFE
 	editorUrl: null
 
 extensions:


### PR DESCRIPTION
These constants are like PHP_DEBUG and PHP_ZTS (they have different values on different PHP builds).