### PR TITLE
Fix openssl_seal()'s $iv parameter

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8117,7 +8117,7 @@ return [
 'openssl_public_decrypt' => ['bool', 'data'=>'string', '&w_decrypted'=>'string', 'key'=>'string|resource', 'padding='=>'int'],
 'openssl_public_encrypt' => ['bool', 'data'=>'string', '&w_crypted'=>'string', 'key'=>'string|resource', 'padding='=>'int'],
 'openssl_random_pseudo_bytes' => ['string|false', 'length'=>'int', '&w_crypto_strong='=>'bool'],
-'openssl_seal' => ['int|false', 'data'=>'string', '&w_sealed_data'=>'string', '&w_env_keys'=>'array', 'pub_key_ids'=>'array', 'method='=>'string', '&rw_iv='=>'string'],
+'openssl_seal' => ['int|false', 'data'=>'string', '&w_sealed_data'=>'string', '&w_env_keys'=>'array', 'pub_key_ids'=>'array', 'method='=>'string', '&w_iv='=>'string'],
 'openssl_sign' => ['bool', 'data'=>'string', '&w_signature'=>'string', 'priv_key_id'=>'resource|string', 'signature_alg='=>'int|string'],
 'openssl_spki_export' => ['string|null|false', 'spkac'=>'string'],
 'openssl_spki_export_challenge' => ['string|null|false', 'spkac'=>'string'],


### PR DESCRIPTION
This was incorrectly added in #327.

[The implementation of openssl_seal()](https://github.com/php/php-src/blob/master/ext/openssl/openssl.c#L6833) shows that while the `$iv` parameter is briefly checked, its value is never used. The check is only to verify its presence, since it does not make sense to encrypt and then throw away the IV.

This resulted in [this perfectly fine code](https://phpstan.org/r/bdfa0d43-7a70-4738-8521-056f6062b6db) being flagged.