### PR TITLE
RenameTestCase to BaseTestCase to prevent import conflicts with PHPUnit's TestCase.

### DIFF
--- a/compiler/build/scoper.inc.php
+++ b/compiler/build/scoper.inc.php
@@ -80,7 +80,7 @@ return [
 			return $content;
 		},
 		function (string $filePath, string $prefix, string $content): string {
-			if ($filePath !== 'src/Testing/BaseTestCase.php') {
+			if ($filePath !== 'src/Testing/PHPStanTestCase.php') {
 				return $content;
 			}
 			return str_replace(sprintf('\\%s\\PHPUnit\\Framework\\TestCase', $prefix), '\\PHPUnit\\Framework\\TestCase', $content);
@@ -160,7 +160,7 @@ return [
 		function (string $filePath, string $prefix, string $content): string {
 			if (!in_array($filePath, [
 				'src/Testing/TestCaseSourceLocatorFactory.php',
-				'src/Testing/BaseTestCase.php',
+				'src/Testing/PHPStanTestCase.php',
 			], true)) {
 				return $content;
 			}

--- a/compiler/build/scoper.inc.php
+++ b/compiler/build/scoper.inc.php
@@ -80,7 +80,7 @@ return [
 			return $content;
 		},
 		function (string $filePath, string $prefix, string $content): string {
-			if ($filePath !== 'src/Testing/TestCase.php') {
+			if ($filePath !== 'src/Testing/BaseTestCase.php') {
 				return $content;
 			}
 			return str_replace(sprintf('\\%s\\PHPUnit\\Framework\\TestCase', $prefix), '\\PHPUnit\\Framework\\TestCase', $content);
@@ -160,7 +160,7 @@ return [
 		function (string $filePath, string $prefix, string $content): string {
 			if (!in_array($filePath, [
 				'src/Testing/TestCaseSourceLocatorFactory.php',
-				'src/Testing/TestCase.php',
+				'src/Testing/BaseTestCase.php',
 			], true)) {
 				return $content;
 			}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -52,7 +52,7 @@
 	</rule>
 	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure.UnusedInheritedVariable">
 		<exclude-pattern>src/Command/CommandHelper.php</exclude-pattern>
-		<exclude-pattern>src/Testing/BaseTestCase.php</exclude-pattern>
+		<exclude-pattern>src/Testing/PHPStanTestCase.php</exclude-pattern>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException">
 		<exclude-pattern>tests</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -52,7 +52,7 @@
 	</rule>
 	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure.UnusedInheritedVariable">
 		<exclude-pattern>src/Command/CommandHelper.php</exclude-pattern>
-		<exclude-pattern>src/Testing/TestCase.php</exclude-pattern>
+		<exclude-pattern>src/Testing/BaseTestCase.php</exclude-pattern>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException">
 		<exclude-pattern>tests</exclude-pattern>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -243,7 +243,7 @@ parameters:
 		-
 			message: "#^Anonymous function has an unused use \\$container\\.$#"
 			count: 1
-			path: src/Testing/TestCase.php
+			path: src/Testing/BaseTestCase.php
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -243,7 +243,7 @@ parameters:
 		-
 			message: "#^Anonymous function has an unused use \\$container\\.$#"
 			count: 1
-			path: src/Testing/BaseTestCase.php
+			path: src/Testing/PHPStanTestCase.php
 
 		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"

--- a/src/Testing/BaseTestCase.php
+++ b/src/Testing/BaseTestCase.php
@@ -76,7 +76,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeAliasResolver;
 
 /** @api */
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
 {
 
 	/** @var bool */

--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -11,7 +11,7 @@ use PHPStan\Command\Symfony\SymfonyStyle;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
-abstract class ErrorFormatterTestCase extends \PHPStan\Testing\TestCase
+abstract class ErrorFormatterTestCase extends \PHPStan\Testing\BaseTestCase
 {
 
 	protected const DIRECTORY_PATH = '/data/folder/with space/and unicode 😃/project';

--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -11,7 +11,7 @@ use PHPStan\Command\Symfony\SymfonyStyle;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\StreamOutput;
 
-abstract class ErrorFormatterTestCase extends \PHPStan\Testing\BaseTestCase
+abstract class ErrorFormatterTestCase extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	protected const DIRECTORY_PATH = '/data/folder/with space/and unicode 😃/project';

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -76,7 +76,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeAliasResolver;
 
 /** @api */
-abstract class BaseTestCase extends \PHPUnit\Framework\TestCase
+abstract class PHPStanTestCase extends \PHPUnit\Framework\TestCase
 {
 
 	/** @var bool */

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -28,7 +28,7 @@ use PHPStan\Type\FileTypeMapper;
  * @api
  * @template TRule of \PHPStan\Rules\Rule
  */
-abstract class RuleTestCase extends \PHPStan\Testing\BaseTestCase
+abstract class RuleTestCase extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	private ?\PHPStan\Analyser\Analyser $analyser = null;

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -28,7 +28,7 @@ use PHPStan\Type\FileTypeMapper;
  * @api
  * @template TRule of \PHPStan\Rules\Rule
  */
-abstract class RuleTestCase extends \PHPStan\Testing\TestCase
+abstract class RuleTestCase extends \PHPStan\Testing\BaseTestCase
 {
 
 	private ?\PHPStan\Analyser\Analyser $analyser = null;

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -28,7 +28,7 @@ use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\VerbosityLevel;
 
 /** @api */
-abstract class TypeInferenceTestCase extends \PHPStan\Testing\BaseTestCase
+abstract class TypeInferenceTestCase extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/**

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -28,7 +28,7 @@ use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\VerbosityLevel;
 
 /** @api */
-abstract class TypeInferenceTestCase extends \PHPStan\Testing\TestCase
+abstract class TypeInferenceTestCase extends \PHPStan\Testing\BaseTestCase
 {
 
 	/**

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -13,7 +13,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use const PHP_VERSION_ID;
 use function array_reverse;
 
-class AnalyserIntegrationTest extends \PHPStan\Testing\BaseTestCase
+class AnalyserIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testUndefinedVariableFromAssignErrorHasLine(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -13,7 +13,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use const PHP_VERSION_ID;
 use function array_reverse;
 
-class AnalyserIntegrationTest extends \PHPStan\Testing\TestCase
+class AnalyserIntegrationTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testUndefinedVariableFromAssignErrorHasLine(): void

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -23,7 +23,7 @@ use PHPStan\Rules\AlwaysFailRule;
 use PHPStan\Rules\Registry;
 use PHPStan\Type\FileTypeMapper;
 
-class AnalyserTest extends \PHPStan\Testing\BaseTestCase
+class AnalyserTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testReturnErrorIfIgnoredMessagesDoesNotOccur(): void

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -23,7 +23,7 @@ use PHPStan\Rules\AlwaysFailRule;
 use PHPStan\Rules\Registry;
 use PHPStan\Type\FileTypeMapper;
 
-class AnalyserTest extends \PHPStan\Testing\TestCase
+class AnalyserTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testReturnErrorIfIgnoredMessagesDoesNotOccur(): void

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Analyser;
 
 use PHPStan\File\FileHelper;
 
-class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\BaseTestCase
+class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/** @var \PHPStan\File\FileHelper */

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Analyser;
 
 use PHPStan\File\FileHelper;
 
-class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\TestCase
+class AnalyserTraitsIntegrationTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	/** @var \PHPStan\File\FileHelper */

--- a/tests/PHPStan/Analyser/ErrorTest.php
+++ b/tests/PHPStan/Analyser/ErrorTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Analyser;
 
-class ErrorTest extends \PHPStan\Testing\TestCase
+class ErrorTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testError(): void

--- a/tests/PHPStan/Analyser/ErrorTest.php
+++ b/tests/PHPStan/Analyser/ErrorTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Analyser;
 
-class ErrorTest extends \PHPStan\Testing\BaseTestCase
+class ErrorTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testError(): void

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Analyser;
 
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name\FullyQualified;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class ScopeTest extends BaseTestCase
+class ScopeTest extends PHPStanTestCase
 {
 
 	public function dataGeneralize(): array

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Analyser;
 
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Name\FullyQualified;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class ScopeTest extends TestCase
+class ScopeTest extends BaseTestCase
 {
 
 	public function dataGeneralize(): array

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -9,7 +9,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 
-class StatementResultTest extends \PHPStan\Testing\TestCase
+class StatementResultTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsAlwaysTerminating(): array

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -9,7 +9,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 
-class StatementResultTest extends \PHPStan\Testing\BaseTestCase
+class StatementResultTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsAlwaysTerminating(): array

--- a/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Analyser;
 
-class TypeSpecifierContextTest extends \PHPStan\Testing\TestCase
+class TypeSpecifierContextTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataContext(): array

--- a/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Analyser;
 
-class TypeSpecifierContextTest extends \PHPStan\Testing\BaseTestCase
+class TypeSpecifierContextTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataContext(): array

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -27,7 +27,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class TypeSpecifierTest extends \PHPStan\Testing\BaseTestCase
+class TypeSpecifierTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	private const FALSEY_TYPE_DESCRIPTION = '0|0.0|\'\'|\'0\'|array()|false|null';

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -27,7 +27,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class TypeSpecifierTest extends \PHPStan\Testing\TestCase
+class TypeSpecifierTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	private const FALSEY_TYPE_DESCRIPTION = '0|0.0|\'\'|\'0\'|array()|false|null';

--- a/tests/PHPStan/Analyser/traitsCachingIssue/TraitsCachingIssueIntegrationTest.php
+++ b/tests/PHPStan/Analyser/traitsCachingIssue/TraitsCachingIssueIntegrationTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Analyser;
 
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use function file_exists;
@@ -12,7 +12,7 @@ use function file_exists;
 /**
  * @group exec
  */
-class TraitsCachingIssueIntegrationTest extends BaseTestCase
+class TraitsCachingIssueIntegrationTest extends PHPStanTestCase
 {
 
 	/** @var string|null */

--- a/tests/PHPStan/Analyser/traitsCachingIssue/TraitsCachingIssueIntegrationTest.php
+++ b/tests/PHPStan/Analyser/traitsCachingIssue/TraitsCachingIssueIntegrationTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Analyser;
 
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use function file_exists;
@@ -12,7 +12,7 @@ use function file_exists;
 /**
  * @group exec
  */
-class TraitsCachingIssueIntegrationTest extends TestCase
+class TraitsCachingIssueIntegrationTest extends BaseTestCase
 {
 
 	/** @var string|null */

--- a/tests/PHPStan/Broker/BrokerTest.php
+++ b/tests/PHPStan/Broker/BrokerTest.php
@@ -22,7 +22,7 @@ use PHPStan\Reflection\Runtime\RuntimeReflectionProvider;
 use PHPStan\Reflection\SignatureMap\NativeFunctionReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
 
-class BrokerTest extends \PHPStan\Testing\TestCase
+class BrokerTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	/** @var \PHPStan\Broker\Broker */

--- a/tests/PHPStan/Broker/BrokerTest.php
+++ b/tests/PHPStan/Broker/BrokerTest.php
@@ -22,7 +22,7 @@ use PHPStan\Reflection\Runtime\RuntimeReflectionProvider;
 use PHPStan\Reflection\SignatureMap\NativeFunctionReflectionProvider;
 use PHPStan\Type\FileTypeMapper;
 
-class BrokerTest extends \PHPStan\Testing\BaseTestCase
+class BrokerTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/** @var \PHPStan\Broker\Broker */

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class AnalyseApplicationIntegrationTest extends \PHPStan\Testing\BaseTestCase
+class AnalyseApplicationIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testExecuteOnAFile(): void

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class AnalyseApplicationIntegrationTest extends \PHPStan\Testing\TestCase
+class AnalyseApplicationIntegrationTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testExecuteOnAFile(): void

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -8,7 +8,7 @@ use const DIRECTORY_SEPARATOR;
 /**
  * @group exec
  */
-class AnalyseCommandTest extends \PHPStan\Testing\TestCase
+class AnalyseCommandTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	/**

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -8,7 +8,7 @@ use const DIRECTORY_SEPARATOR;
 /**
  * @group exec
  */
-class AnalyseCommandTest extends \PHPStan\Testing\BaseTestCase
+class AnalyseCommandTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/**

--- a/tests/PHPStan/Command/AnalysisResultTest.php
+++ b/tests/PHPStan/Command/AnalysisResultTest.php
@@ -3,9 +3,9 @@
 namespace PHPStan\Command;
 
 use PHPStan\Analyser\Error;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 
-final class AnalysisResultTest extends TestCase
+final class AnalysisResultTest extends BaseTestCase
 {
 
 	public function testErrorsAreSortedByFileNameAndLine(): void

--- a/tests/PHPStan/Command/AnalysisResultTest.php
+++ b/tests/PHPStan/Command/AnalysisResultTest.php
@@ -3,9 +3,9 @@
 namespace PHPStan\Command;
 
 use PHPStan\Analyser\Error;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 
-final class AnalysisResultTest extends BaseTestCase
+final class AnalysisResultTest extends PHPStanTestCase
 {
 
 	public function testErrorsAreSortedByFileNameAndLine(): void

--- a/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
+++ b/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
@@ -3,9 +3,9 @@
 namespace PHPStan\Command;
 
 use PHPStan\PhpDoc\TypeStringResolver;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 
-class IgnoredRegexValidatorTest extends TestCase
+class IgnoredRegexValidatorTest extends BaseTestCase
 {
 
 	public function dataValidate(): array

--- a/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
+++ b/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
@@ -3,9 +3,9 @@
 namespace PHPStan\Command;
 
 use PHPStan\PhpDoc\TypeStringResolver;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 
-class IgnoredRegexValidatorTest extends BaseTestCase
+class IgnoredRegexValidatorTest extends PHPStanTestCase
 {
 
 	public function dataValidate(): array

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\File;
 
-class FileExcluderTest extends \PHPStan\Testing\BaseTestCase
+class FileExcluderTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/**

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\File;
 
-class FileExcluderTest extends \PHPStan\Testing\TestCase
+class FileExcluderTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	/**

--- a/tests/PHPStan/File/FileHelperTest.php
+++ b/tests/PHPStan/File/FileHelperTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\File;
 
-class FileHelperTest extends \PHPStan\Testing\BaseTestCase
+class FileHelperTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/**

--- a/tests/PHPStan/File/FileHelperTest.php
+++ b/tests/PHPStan/File/FileHelperTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\File;
 
-class FileHelperTest extends \PHPStan\Testing\TestCase
+class FileHelperTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	/**

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class TemplateTypeFactoryTest extends \PHPStan\Testing\BaseTestCase
+class TemplateTypeFactoryTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/** @return array<array{?Type, Type}> */

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class TemplateTypeFactoryTest extends \PHPStan\Testing\TestCase
+class TemplateTypeFactoryTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	/** @return array<array{?Type, Type}> */

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -4,9 +4,9 @@ namespace PHPStan\Parser;
 
 use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\File\FileReader;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 
-class CachedParserTest extends BaseTestCase
+class CachedParserTest extends PHPStanTestCase
 {
 
 	/**

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -4,9 +4,9 @@ namespace PHPStan\Parser;
 
 use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\File\FileReader;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 
-class CachedParserTest extends TestCase
+class CachedParserTest extends BaseTestCase
 {
 
 	/**

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -9,7 +9,7 @@ use PHPStan\Reflection\PassedByReference;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\VerbosityLevel;
 
-class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\BaseTestCase
+class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataMethods(): array

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -9,7 +9,7 @@ use PHPStan\Reflection\PassedByReference;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Type\VerbosityLevel;
 
-class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
+class AnnotationsMethodsClassReflectionExtensionTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataMethods(): array

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -6,7 +6,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Type\VerbosityLevel;
 
-class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
+class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataProperties(): array

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -6,7 +6,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Type\VerbosityLevel;
 
-class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\Testing\BaseTestCase
+class AnnotationsPropertiesClassReflectionExtensionTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataProperties(): array

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 
-class DeprecatedAnnotationsTest extends \PHPStan\Testing\BaseTestCase
+class DeprecatedAnnotationsTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataDeprecatedAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 
-class DeprecatedAnnotationsTest extends \PHPStan\Testing\TestCase
+class DeprecatedAnnotationsTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataDeprecatedAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 
-class FinalAnnotationsTest extends \PHPStan\Testing\TestCase
+class FinalAnnotationsTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataFinalAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 
-class FinalAnnotationsTest extends \PHPStan\Testing\BaseTestCase
+class FinalAnnotationsTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataFinalAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 
-class InternalAnnotationsTest extends \PHPStan\Testing\TestCase
+class InternalAnnotationsTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataInternalAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 
-class InternalAnnotationsTest extends \PHPStan\Testing\BaseTestCase
+class InternalAnnotationsTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataInternalAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
@@ -7,7 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Type\VerbosityLevel;
 
-class ThrowsAnnotationsTest extends \PHPStan\Testing\BaseTestCase
+class ThrowsAnnotationsTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataThrowsAnnotations(): array

--- a/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
@@ -7,7 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Broker\Broker;
 use PHPStan\Type\VerbosityLevel;
 
-class ThrowsAnnotationsTest extends \PHPStan\Testing\TestCase
+class ThrowsAnnotationsTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataThrowsAnnotations(): array

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
@@ -6,7 +6,7 @@ use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\ConstantReflector;
 use PHPStan\BetterReflection\Reflector\FunctionReflector;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use TestSingleFileSourceLocator\AFoo;
 use TestSingleFileSourceLocator\InCondition;
 
@@ -15,7 +15,7 @@ function testFunctionForLocator(): void // phpcs:disable
 
 }
 
-class AutoloadSourceLocatorTest extends BaseTestCase
+class AutoloadSourceLocatorTest extends PHPStanTestCase
 {
 
 	public function testAutoloadEverythingInFile(): void

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
@@ -6,7 +6,7 @@ use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\ConstantReflector;
 use PHPStan\BetterReflection\Reflector\FunctionReflector;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use TestSingleFileSourceLocator\AFoo;
 use TestSingleFileSourceLocator\InCondition;
 
@@ -15,7 +15,7 @@ function testFunctionForLocator(): void // phpcs:disable
 
 }
 
-class AutoloadSourceLocatorTest extends TestCase
+class AutoloadSourceLocatorTest extends BaseTestCase
 {
 
 	public function testAutoloadEverythingInFile(): void

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
@@ -5,10 +5,10 @@ namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\FunctionReflector;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use TestDirectorySourceLocator\AFoo;
 
-class OptimizedDirectorySourceLocatorTest extends BaseTestCase
+class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 {
 
 	public function dataClass(): array

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
@@ -5,10 +5,10 @@ namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\FunctionReflector;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use TestDirectorySourceLocator\AFoo;
 
-class OptimizedDirectorySourceLocatorTest extends TestCase
+class OptimizedDirectorySourceLocatorTest extends BaseTestCase
 {
 
 	public function dataClass(): array

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
@@ -6,10 +6,10 @@ use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\ConstantReflector;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\FunctionReflector;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use TestSingleFileSourceLocator\AFoo;
 
-class OptimizedSingleFileSourceLocatorTest extends TestCase
+class OptimizedSingleFileSourceLocatorTest extends BaseTestCase
 {
 
 	public function dataClass(): array

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
@@ -6,10 +6,10 @@ use PHPStan\BetterReflection\Reflector\ClassReflector;
 use PHPStan\BetterReflection\Reflector\ConstantReflector;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\BetterReflection\Reflector\FunctionReflector;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use TestSingleFileSourceLocator\AFoo;
 
-class OptimizedSingleFileSourceLocatorTest extends BaseTestCase
+class OptimizedSingleFileSourceLocatorTest extends PHPStanTestCase
 {
 
 	public function dataClass(): array

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -13,7 +13,7 @@ use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Type\FileTypeMapper;
 use WrongClassConstantFile\SecuredRouter;
 
-class ClassReflectionTest extends \PHPStan\Testing\TestCase
+class ClassReflectionTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataHasTraitUse(): array

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -13,7 +13,7 @@ use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Type\FileTypeMapper;
 use WrongClassConstantFile\SecuredRouter;
 
-class ClassReflectionTest extends \PHPStan\Testing\BaseTestCase
+class ClassReflectionTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataHasTraitUse(): array

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -18,7 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\TestCase
+class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\BaseTestCase
 {
 
 	/**

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -18,7 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\BaseTestCase
+class GenericParametersAcceptorResolverTest  extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	/**

--- a/tests/PHPStan/Reflection/MixedTypeTest.php
+++ b/tests/PHPStan/Reflection/MixedTypeTest.php
@@ -4,10 +4,10 @@ namespace PHPStan\Reflection;
 
 use NativeMixedType\Foo;
 use PhpParser\Node\Name;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\Type\MixedType;
 
-class MixedTypeTest extends TestCase
+class MixedTypeTest extends BaseTestCase
 {
 
 	public function testMixedType(): void

--- a/tests/PHPStan/Reflection/MixedTypeTest.php
+++ b/tests/PHPStan/Reflection/MixedTypeTest.php
@@ -4,10 +4,10 @@ namespace PHPStan\Reflection;
 
 use NativeMixedType\Foo;
 use PhpParser\Node\Name;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\MixedType;
 
-class MixedTypeTest extends BaseTestCase
+class MixedTypeTest extends PHPStanTestCase
 {
 
 	public function testMixedType(): void

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -22,7 +22,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class ParametersAcceptorSelectorTest extends \PHPStan\Testing\BaseTestCase
+class ParametersAcceptorSelectorTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataSelectFromTypes(): \Generator

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -22,7 +22,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class ParametersAcceptorSelectorTest extends \PHPStan\Testing\TestCase
+class ParametersAcceptorSelectorTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataSelectFromTypes(): \Generator

--- a/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
@@ -6,7 +6,7 @@ use PHPStan\Broker\Broker;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 
-class UniversalObjectCratesClassReflectionExtensionTest extends \PHPStan\Testing\TestCase
+class UniversalObjectCratesClassReflectionExtensionTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testNonexistentClass(): void

--- a/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
@@ -6,7 +6,7 @@ use PHPStan\Broker\Broker;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 
-class UniversalObjectCratesClassReflectionExtensionTest extends \PHPStan\Testing\BaseTestCase
+class UniversalObjectCratesClassReflectionExtensionTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testNonexistentClass(): void

--- a/tests/PHPStan/Reflection/ReflectionProviderTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderTest.php
@@ -3,12 +3,12 @@
 namespace PHPStan\Reflection;
 
 use PhpParser\Node\Name;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
-class ReflectionProviderTest extends TestCase
+class ReflectionProviderTest extends BaseTestCase
 {
 
 	public function dataFunctionThrowType(): iterable

--- a/tests/PHPStan/Reflection/ReflectionProviderTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderTest.php
@@ -3,12 +3,12 @@
 namespace PHPStan\Reflection;
 
 use PhpParser\Node\Name;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
-class ReflectionProviderTest extends BaseTestCase
+class ReflectionProviderTest extends PHPStanTestCase
 {
 
 	public function dataFunctionThrowType(): iterable

--- a/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
@@ -4,9 +4,9 @@ namespace PHPStan\Reflection\SignatureMap;
 
 use Nette\Schema\Expect;
 use Nette\Schema\Processor;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 
-class FunctionMetadataTest extends TestCase
+class FunctionMetadataTest extends BaseTestCase
 {
 
 	public function testSchema(): void

--- a/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
@@ -4,9 +4,9 @@ namespace PHPStan\Reflection\SignatureMap;
 
 use Nette\Schema\Expect;
 use Nette\Schema\Processor;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 
-class FunctionMetadataTest extends BaseTestCase
+class FunctionMetadataTest extends PHPStanTestCase
 {
 
 	public function testSchema(): void

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -7,7 +7,7 @@ use PHPStan\Php8StubsMap;
 use PHPStan\Reflection\BetterReflection\SourceLocator\FileNodesFetcher;
 use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\PassedByReference;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
@@ -26,7 +26,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 
-class Php8SignatureMapProviderTest extends TestCase
+class Php8SignatureMapProviderTest extends BaseTestCase
 {
 
 	public function dataFunctions(): array

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -7,7 +7,7 @@ use PHPStan\Php8StubsMap;
 use PHPStan\Reflection\BetterReflection\SourceLocator\FileNodesFetcher;
 use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\PassedByReference;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
@@ -26,7 +26,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 
-class Php8SignatureMapProviderTest extends BaseTestCase
+class Php8SignatureMapProviderTest extends PHPStanTestCase
 {
 
 	public function dataFunctions(): array

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -18,7 +18,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class SignatureMapParserTest extends \PHPStan\Testing\TestCase
+class SignatureMapParserTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataGetFunctions(): array

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -18,7 +18,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class SignatureMapParserTest extends \PHPStan\Testing\BaseTestCase
+class SignatureMapParserTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataGetFunctions(): array

--- a/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Reflection\Type;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
 
-class IntersectionTypeMethodReflectionTest extends \PHPStan\Testing\TestCase
+class IntersectionTypeMethodReflectionTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testCollectsDeprecatedMessages(): void

--- a/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Reflection\Type;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
 
-class IntersectionTypeMethodReflectionTest extends \PHPStan\Testing\BaseTestCase
+class IntersectionTypeMethodReflectionTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testCollectsDeprecatedMessages(): void

--- a/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Reflection\Type;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
 
-class UnionTypeMethodReflectionTest extends \PHPStan\Testing\TestCase
+class UnionTypeMethodReflectionTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testCollectsDeprecatedMessages(): void

--- a/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Reflection\Type;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\TrinaryLogic;
 
-class UnionTypeMethodReflectionTest extends \PHPStan\Testing\BaseTestCase
+class UnionTypeMethodReflectionTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testCollectsDeprecatedMessages(): void

--- a/tests/PHPStan/Reflection/UnionTypesTest.php
+++ b/tests/PHPStan/Reflection/UnionTypesTest.php
@@ -4,11 +4,11 @@ namespace PHPStan\Reflection;
 
 use NativeUnionTypes\Foo;
 use PhpParser\Node\Name;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class UnionTypesTest extends BaseTestCase
+class UnionTypesTest extends PHPStanTestCase
 {
 
 	public function testUnionTypes(): void

--- a/tests/PHPStan/Reflection/UnionTypesTest.php
+++ b/tests/PHPStan/Reflection/UnionTypesTest.php
@@ -4,11 +4,11 @@ namespace PHPStan\Reflection;
 
 use NativeUnionTypes\Foo;
 use PhpParser\Node\Name;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class UnionTypesTest extends TestCase
+class UnionTypesTest extends BaseTestCase
 {
 
 	public function testUnionTypes(): void

--- a/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
+++ b/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
@@ -4,9 +4,9 @@ namespace PHPStan\Rules\Exceptions;
 
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory;
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 
-class DefaultExceptionTypeResolverTest extends TestCase
+class DefaultExceptionTypeResolverTest extends BaseTestCase
 {
 
 	public function dataIsCheckedException(): array

--- a/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
+++ b/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
@@ -4,9 +4,9 @@ namespace PHPStan\Rules\Exceptions;
 
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory;
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 
-class DefaultExceptionTypeResolverTest extends BaseTestCase
+class DefaultExceptionTypeResolverTest extends PHPStanTestCase
 {
 
 	public function dataIsCheckedException(): array

--- a/tests/PHPStan/Rules/RegistryTest.php
+++ b/tests/PHPStan/Rules/RegistryTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Rules;
 
 use PHPStan\Analyser\Scope;
 
-class RegistryTest extends \PHPStan\Testing\BaseTestCase
+class RegistryTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testGetRules(): void

--- a/tests/PHPStan/Rules/RegistryTest.php
+++ b/tests/PHPStan/Rules/RegistryTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Rules;
 
 use PHPStan\Analyser\Scope;
 
-class RegistryTest extends \PHPStan\Testing\TestCase
+class RegistryTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testGetRules(): void

--- a/tests/PHPStan/TrinaryLogicTest.php
+++ b/tests/PHPStan/TrinaryLogicTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan;
 
-class TrinaryLogicTest extends \PHPStan\Testing\BaseTestCase
+class TrinaryLogicTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAnd(): array

--- a/tests/PHPStan/TrinaryLogicTest.php
+++ b/tests/PHPStan/TrinaryLogicTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan;
 
-class TrinaryLogicTest extends \PHPStan\Testing\TestCase
+class TrinaryLogicTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAnd(): array

--- a/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class HasMethodTypeTest extends \PHPStan\Testing\BaseTestCase
+class HasMethodTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class HasMethodTypeTest extends \PHPStan\Testing\TestCase
+class HasMethodTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class HasPropertyTypeTest extends \PHPStan\Testing\TestCase
+class HasPropertyTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class HasPropertyTypeTest extends \PHPStan\Testing\BaseTestCase
+class HasPropertyTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class ArrayTypeTest extends \PHPStan\Testing\TestCase
+class ArrayTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class ArrayTypeTest extends \PHPStan\Testing\BaseTestCase
+class ArrayTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/BooleanTypeTest.php
+++ b/tests/PHPStan/Type/BooleanTypeTest.php
@@ -6,7 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 
-class BooleanTypeTest extends \PHPStan\Testing\TestCase
+class BooleanTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/BooleanTypeTest.php
+++ b/tests/PHPStan/Type/BooleanTypeTest.php
@@ -6,7 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 
-class BooleanTypeTest extends \PHPStan\Testing\BaseTestCase
+class BooleanTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class CallableTypeTest extends \PHPStan\Testing\TestCase
+class CallableTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -14,7 +14,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class CallableTypeTest extends \PHPStan\Testing\BaseTestCase
+class CallableTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ClassStringTypeTest.php
+++ b/tests/PHPStan/Type/ClassStringTypeTest.php
@@ -2,12 +2,12 @@
 
 namespace PHPStan\Type;
 
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 
-class ClassStringTypeTest extends TestCase
+class ClassStringTypeTest extends BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ClassStringTypeTest.php
+++ b/tests/PHPStan/Type/ClassStringTypeTest.php
@@ -2,12 +2,12 @@
 
 namespace PHPStan\Type;
 
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 
-class ClassStringTypeTest extends BaseTestCase
+class ClassStringTypeTest extends PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ClosureTypeTest.php
+++ b/tests/PHPStan/Type/ClosureTypeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 
-class ClosureTypeTest extends \PHPStan\Testing\TestCase
+class ClosureTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ClosureTypeTest.php
+++ b/tests/PHPStan/Type/ClosureTypeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 
-class ClosureTypeTest extends \PHPStan\Testing\BaseTestCase
+class ClosureTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -18,7 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantArrayTypeTest extends \PHPStan\Testing\BaseTestCase
+class ConstantArrayTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): iterable

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -18,7 +18,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantArrayTypeTest extends \PHPStan\Testing\TestCase
+class ConstantArrayTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): iterable

--- a/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Type\Constant;
 
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantFloatTypeTest extends \PHPStan\Testing\TestCase
+class ConstantFloatTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataDescribe(): array

--- a/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Type\Constant;
 
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantFloatTypeTest extends \PHPStan\Testing\BaseTestCase
+class ConstantFloatTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataDescribe(): array

--- a/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
@@ -7,7 +7,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantIntegerTypeTest extends \PHPStan\Testing\TestCase
+class ConstantIntegerTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): iterable

--- a/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
@@ -7,7 +7,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantIntegerTypeTest extends \PHPStan\Testing\BaseTestCase
+class ConstantIntegerTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): iterable

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Type\Constant;
 
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\GenericClassStringType;
@@ -14,7 +14,7 @@ use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantStringTypeTest extends BaseTestCase
+class ConstantStringTypeTest extends PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Type\Constant;
 
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\GenericClassStringType;
@@ -14,7 +14,7 @@ use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
-class ConstantStringTypeTest extends TestCase
+class ConstantStringTypeTest extends BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Type;
 
-class FileTypeMapperTest extends \PHPStan\Testing\BaseTestCase
+class FileTypeMapperTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testGetResolvedPhpDoc(): void

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Type;
 
-class FileTypeMapperTest extends \PHPStan\Testing\TestCase
+class FileTypeMapperTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testGetResolvedPhpDoc(): void

--- a/tests/PHPStan/Type/FloatTypeTest.php
+++ b/tests/PHPStan/Type/FloatTypeTest.php
@@ -7,7 +7,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 
-class FloatTypeTest extends \PHPStan\Testing\TestCase
+class FloatTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/FloatTypeTest.php
+++ b/tests/PHPStan/Type/FloatTypeTest.php
@@ -7,7 +7,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 
-class FloatTypeTest extends \PHPStan\Testing\BaseTestCase
+class FloatTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
@@ -15,7 +15,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class GenericClassStringTypeTest extends \PHPStan\Testing\BaseTestCase
+class GenericClassStringTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
@@ -15,7 +15,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class GenericClassStringTypeTest extends \PHPStan\Testing\TestCase
+class GenericClassStringTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -16,7 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class GenericObjectTypeTest extends \PHPStan\Testing\BaseTestCase
+class GenericObjectTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -16,7 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class GenericObjectTypeTest extends \PHPStan\Testing\TestCase
+class GenericObjectTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
@@ -6,7 +6,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 
-class TemplateTypeHelperTest extends \PHPStan\Testing\TestCase
+class TemplateTypeHelperTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function testIssue2512(): void

--- a/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
@@ -6,7 +6,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 
-class TemplateTypeHelperTest extends \PHPStan\Testing\BaseTestCase
+class TemplateTypeHelperTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function testIssue2512(): void

--- a/tests/PHPStan/Type/IntegerTypeTest.php
+++ b/tests/PHPStan/Type/IntegerTypeTest.php
@@ -7,7 +7,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 
-class IntegerTypeTest extends \PHPStan\Testing\BaseTestCase
+class IntegerTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/IntegerTypeTest.php
+++ b/tests/PHPStan/Type/IntegerTypeTest.php
@@ -7,7 +7,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 
-class IntegerTypeTest extends \PHPStan\Testing\TestCase
+class IntegerTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/IntersectionTypeTest.php
+++ b/tests/PHPStan/Type/IntersectionTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use Test\ClassWithToString;
 
-class IntersectionTypeTest extends \PHPStan\Testing\TestCase
+class IntersectionTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): \Iterator

--- a/tests/PHPStan/Type/IntersectionTypeTest.php
+++ b/tests/PHPStan/Type/IntersectionTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use Test\ClassWithToString;
 
-class IntersectionTypeTest extends \PHPStan\Testing\BaseTestCase
+class IntersectionTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): \Iterator

--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class IterableTypeTest extends \PHPStan\Testing\BaseTestCase
+class IterableTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class IterableTypeTest extends \PHPStan\Testing\TestCase
+class IterableTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantIntegerType;
 
-class MixedTypeTest extends \PHPStan\Testing\TestCase
+class MixedTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantIntegerType;
 
-class MixedTypeTest extends \PHPStan\Testing\BaseTestCase
+class MixedTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class ObjectTypeTest extends \PHPStan\Testing\BaseTestCase
+class ObjectTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsIterable(): array

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class ObjectTypeTest extends \PHPStan\Testing\TestCase
+class ObjectTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsIterable(): array

--- a/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
+++ b/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 
-class ObjectWithoutClassTypeTest extends \PHPStan\Testing\TestCase
+class ObjectWithoutClassTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
+++ b/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
@@ -4,7 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 
-class ObjectWithoutClassTypeTest extends \PHPStan\Testing\BaseTestCase
+class ObjectWithoutClassTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/StaticTypeTest.php
+++ b/tests/PHPStan/Type/StaticTypeTest.php
@@ -8,7 +8,7 @@ use StaticTypeTest\Base;
 use StaticTypeTest\Child;
 use StaticTypeTest\FinalChild;
 
-class StaticTypeTest extends \PHPStan\Testing\TestCase
+class StaticTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsIterable(): array

--- a/tests/PHPStan/Type/StaticTypeTest.php
+++ b/tests/PHPStan/Type/StaticTypeTest.php
@@ -8,7 +8,7 @@ use StaticTypeTest\Base;
 use StaticTypeTest\Child;
 use StaticTypeTest\FinalChild;
 
-class StaticTypeTest extends \PHPStan\Testing\BaseTestCase
+class StaticTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsIterable(): array

--- a/tests/PHPStan/Type/StringTypeTest.php
+++ b/tests/PHPStan/Type/StringTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Type;
 
-use PHPStan\Testing\BaseTestCase;
+use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -12,7 +12,7 @@ use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use Test\ClassWithToString;
 
-class StringTypeTest extends BaseTestCase
+class StringTypeTest extends PHPStanTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/StringTypeTest.php
+++ b/tests/PHPStan/Type/StringTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Type;
 
-use PHPStan\Testing\TestCase;
+use PHPStan\Testing\BaseTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -12,7 +12,7 @@ use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use Test\ClassWithToString;
 
-class StringTypeTest extends TestCase
+class StringTypeTest extends BaseTestCase
 {
 
 	public function dataIsSuperTypeOf(): array

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -9,7 +9,7 @@ use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class TemplateTypeTest extends \PHPStan\Testing\TestCase
+class TemplateTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -9,7 +9,7 @@ use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class TemplateTypeTest extends \PHPStan\Testing\BaseTestCase
+class TemplateTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAccepts(): array

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -24,7 +24,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class TypeCombinatorTest extends \PHPStan\Testing\BaseTestCase
+class TypeCombinatorTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataAddNull(): array

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -24,7 +24,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class TypeCombinatorTest extends \PHPStan\Testing\TestCase
+class TypeCombinatorTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataAddNull(): array

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -21,7 +21,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class UnionTypeTest extends \PHPStan\Testing\BaseTestCase
+class UnionTypeTest extends \PHPStan\Testing\PHPStanTestCase
 {
 
 	public function dataIsCallable(): array

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -21,7 +21,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 
-class UnionTypeTest extends \PHPStan\Testing\TestCase
+class UnionTypeTest extends \PHPStan\Testing\BaseTestCase
 {
 
 	public function dataIsCallable(): array

--- a/tests/bootstrap-runtime-reflection.php
+++ b/tests/bootstrap-runtime-reflection.php
@@ -2,4 +2,4 @@
 
 require_once __DIR__ . '/bootstrap.php';
 
-\PHPStan\Testing\TestCase::getContainer();
+\PHPStan\Testing\BaseTestCase::getContainer();

--- a/tests/bootstrap-runtime-reflection.php
+++ b/tests/bootstrap-runtime-reflection.php
@@ -2,4 +2,4 @@
 
 require_once __DIR__ . '/bootstrap.php';
 
-\PHPStan\Testing\BaseTestCase::getContainer();
+\PHPStan\Testing\PHPStanTestCase::getContainer();

--- a/tests/bootstrap-static-reflection.php
+++ b/tests/bootstrap-static-reflection.php
@@ -2,6 +2,6 @@
 
 require_once __DIR__ . '/bootstrap.php';
 
-\PHPStan\Testing\BaseTestCase::$useStaticReflectionProvider = true;
+\PHPStan\Testing\PHPStanTestCase::$useStaticReflectionProvider = true;
 
-\PHPStan\Testing\BaseTestCase::getContainer();
+\PHPStan\Testing\PHPStanTestCase::getContainer();

--- a/tests/bootstrap-static-reflection.php
+++ b/tests/bootstrap-static-reflection.php
@@ -2,6 +2,6 @@
 
 require_once __DIR__ . '/bootstrap.php';
 
-\PHPStan\Testing\TestCase::$useStaticReflectionProvider = true;
+\PHPStan\Testing\BaseTestCase::$useStaticReflectionProvider = true;
 
-\PHPStan\Testing\TestCase::getContainer();
+\PHPStan\Testing\BaseTestCase::getContainer();


### PR DESCRIPTION
I use auto-complete quite a lot, and although PHPStorm tries to be clever around what class name it will actually import, many time I'm importing PHPStan's test case class instead of PHPUnit's version I intended to import. This causes me to manually remove the import and re-import the intended class.

I hope you'll consider merging this PR 🙏