### PR TITLE
Make `ReflectionAttribute` generic

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -4,6 +4,7 @@ parameters:
 	bootstrap: null
 	bootstrapFiles:
 		- ../stubs/runtime/ReflectionUnionType.php
+		- ../stubs/runtime/ReflectionAttribute.php
 		- ../stubs/runtime/Attribute.php
 	excludes_analyse: []
 	excludePaths: null

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1492,6 +1492,11 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
+	-
+		class: PHPStan\Type\Php\ReflectionClassGetAttributesMethodReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+
 	exceptionTypeResolver:
 		class: PHPStan\Rules\Exceptions\ExceptionTypeResolver
 		factory: @PHPStan\Rules\Exceptions\DefaultExceptionTypeResolver

--- a/conf/config.stubFiles.neon
+++ b/conf/config.stubFiles.neon
@@ -1,5 +1,6 @@
 parameters:
 	stubFiles:
+		- ../stubs/ReflectionAttribute.stub
 		- ../stubs/ReflectionClass.stub
 		- ../stubs/iterable.stub
 		- ../stubs/ArrayObject.stub

--- a/src/Type/Php/ReflectionClassGetAttributesMethodReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionClassGetAttributesMethodReturnTypeExtension.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ReflectionClassGetAttributesMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return \ReflectionClass::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getAttributes';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		if (count($methodCall->args) === 0) {
+			return $this->getDefaultReturnType($scope, $methodCall, $methodReflection);
+		}
+		$argType = $scope->getType($methodCall->args[0]->value);
+
+		if ($argType instanceof ConstantStringType) {
+			$classType = new ObjectType($argType->getValue());
+		} elseif ($argType instanceof GenericClassStringType) {
+			$classType = $argType->getGenericType();
+		} else {
+			return $this->getDefaultReturnType($scope, $methodCall, $methodReflection);
+		}
+
+		return new ArrayType(new MixedType(), new GenericObjectType(\ReflectionAttribute::class, [$classType]));
+	}
+
+	private function getDefaultReturnType(Scope $scope, MethodCall $methodCall, MethodReflection $methodReflection): Type
+	{
+		return ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$methodCall->args,
+			$methodReflection->getVariants()
+		)->getReturnType();
+	}
+
+}

--- a/stubs/ReflectionAttribute.stub
+++ b/stubs/ReflectionAttribute.stub
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @template-covariant T of object
+ */
+class ReflectionAttribute
+{
+    /**
+     * @return class-string<T>
+     */
+    public function getName() : string
+    {
+    }
+
+    /**
+     * @return T
+     */
+    public function newInstance() : object
+    {
+    }
+}

--- a/stubs/ReflectionClass.stub
+++ b/stubs/ReflectionClass.stub
@@ -42,4 +42,10 @@ class ReflectionClass
 	 */
 	public function newInstanceWithoutConstructor();
 
+    /**
+     * @return array<ReflectionAttribute<object>>
+     */
+    public function getAttributes(?string $name = null, int $flags = 0)
+    {
+    }
 }

--- a/stubs/runtime/ReflectionAttribute.php
+++ b/stubs/runtime/ReflectionAttribute.php
@@ -1,0 +1,38 @@
+<?php
+
+if (\PHP_VERSION_ID < 80000) {
+	if (class_exists('ReflectionAttribute', false)) {
+		return;
+	}
+
+	final class ReflectionAttribute
+	{
+		public function getName(): string
+		{
+		}
+
+		public function getTarget(): int
+		{
+		}
+
+		public function isRepeated(): bool
+		{
+		}
+
+		public function getArguments(): array
+		{
+		}
+
+		public function newInstance(): object
+		{
+		}
+
+		private function __clone()
+		{
+		}
+
+		private function __construct()
+		{
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -468,6 +468,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3379.php');
 		}
 
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/reflectionclass-issue-5511-php8.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/modulo-operator.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/literal-string.php');

--- a/tests/PHPStan/Analyser/data/reflectionclass-issue-5511-php8.php
+++ b/tests/PHPStan/Analyser/data/reflectionclass-issue-5511-php8.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Issue5511;
+
+use function PHPStan\Testing\assertType;
+
+#[\Attribute]
+class Abc
+{
+}
+
+#[Abc]
+class X
+{
+}
+
+/**
+ * @param string $str
+ * @param class-string $className
+ * @param class-string<Abc> $genericClassName
+ */
+function testGetAttributes(string $str, string $className, string $genericClassName): void
+{
+	$class = new \ReflectionClass(X::class);
+
+	$attrsAll = $class->getAttributes();
+	$attrsAbc1 = $class->getAttributes(Abc::class);
+	$attrsAbc2 = $class->getAttributes(Abc::class, \ReflectionAttribute::IS_INSTANCEOF);
+	$attrsGCN = $class->getAttributes($genericClassName);
+	$attrsCN = $class->getAttributes($className);
+	$attrsStr = $class->getAttributes($str);
+	$attrsNonsense = $class->getAttributes("some random string");
+
+	assertType('array<ReflectionAttribute<object>>', $attrsAll);
+	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $attrsAbc1);
+	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $attrsAbc2);
+	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $attrsGCN);
+	assertType('array<ReflectionAttribute<object>>', $attrsCN);
+	assertType('array<ReflectionAttribute<object>>', $attrsStr);
+	assertType('array<ReflectionAttribute<some random string>>', $attrsNonsense);
+}
+
+/**
+ * @param \ReflectionAttribute<Abc> $ra
+ */
+function testNewInstance(\ReflectionAttribute $ra): void
+{
+	assertType('ReflectionAttribute<Issue5511\\Abc>', $ra);
+	$abc = $ra->newInstance();
+	assertType(Abc::class, $abc);
+}

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -169,6 +169,7 @@ class CommandHelperTest extends TestCase
 					'bootstrap' => __DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'here.php',
 					'bootstrapFiles' => [
 						realpath(__DIR__ . '/../../../stubs/runtime/ReflectionUnionType.php'),
+						realpath(__DIR__ . '/../../../stubs/runtime/ReflectionAttribute.php'),
 						realpath(__DIR__ . '/../../../stubs/runtime/Attribute.php'),
 						__DIR__ . DIRECTORY_SEPARATOR . 'relative-paths' . DIRECTORY_SEPARATOR . 'here.php',
 					],


### PR DESCRIPTION
Resolves phpstan/phpstan#5511.

I used an extension from `phpstan-doctrine` as an exemple for the implementation of `ReflectionClassGetAttributesMethodReturnTypeExtension` on  but I'm not sure if it's correct as it allows for return types like `array<ReflectionAttribute<some random string>>`.