### PR TITLE
Third parameter of sodium_base642bin is optional.

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -10416,7 +10416,7 @@ return [
 'Sodium\randombytes_uniform' => ['int', 'upperBoundNonInclusive'=>'int'],
 'Sodium\version_string' => ['string'],
 'sodium_add' => ['string', 'string_1'=>'string', 'string_2'=>'string'],
-'sodium_base642bin' => ['string', 'base64'=>'string', 'variant'=>'int', 'ignore'=>'string'],
+'sodium_base642bin' => ['string', 'base64'=>'string', 'variant'=>'int', 'ignore='=>'string'],
 'sodium_bin2base64' => ['string', 'binary'=>'string', 'variant'=>'int'],
 'sodium_bin2hex' => ['string', 'binary'=>'string'],
 'sodium_compare' => ['int', 'string_1'=>'string', 'string_2'=>'string'],


### PR DESCRIPTION
Fixes issue where:

```php
$text = sodium_base642bin($encodedText, SODIUM_BASE64_VARIANT_ORIGINAL_NO_PADDING);
```

is flagged with error: "Function sodium_base642bin invoked with 2 parameters, 3 required."

Correct signature is: `sodium_base642bin(string $string, int $id, string $ignore = ""): string`