### PR TITLE
support non-empty-array type in `[] != $arr` conditions

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -24,7 +24,6 @@ use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\HasOffsetType;
 use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -381,7 +381,7 @@ class TypeSpecifier
 				&& $rightType->isArray()->yes()
 				&& $leftType instanceof ConstantArrayType && $leftType->isEmpty()
 			) {
-				return $this->create($expr->right, new NonEmptyArrayType(), $context, false, $scope);
+				return $this->create($expr->right, new NonEmptyArrayType(), $context->negate(), false, $scope);
 			}
 
 			if (
@@ -389,7 +389,7 @@ class TypeSpecifier
 				&& $leftType->isArray()->yes()
 				&& $rightType instanceof ConstantArrayType && $rightType->isEmpty()
 			) {
-				return $this->create($expr->left, new NonEmptyArrayType(), $context, false, $scope);
+				return $this->create($expr->left, new NonEmptyArrayType(), $context->negate(), false, $scope);
 			}
 
 			if (

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -377,7 +377,7 @@ class TypeSpecifier
 			}
 
 			if (
-				$context->truthy()
+				$context->falsey()
 				&& $rightType->isArray()->yes()
 				&& $leftType instanceof ConstantArrayType && $leftType->isEmpty()
 			) {
@@ -385,7 +385,7 @@ class TypeSpecifier
 			}
 
 			if (
-				$context->truthy()
+				$context->falsey()
 				&& $leftType->isArray()->yes()
 				&& $rightType instanceof ConstantArrayType && $rightType->isEmpty()
 			) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -24,7 +24,9 @@ use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\HasOffsetType;
 use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -372,6 +374,22 @@ class TypeSpecifier
 					),
 					$context
 				);
+			}
+
+			if (
+				$context->truthy()
+				&& $rightType->isArray()->yes()
+				&& $leftType instanceof ConstantArrayType && $leftType->isEmpty()
+			) {
+				return $this->create($expr->right, new NonEmptyArrayType(), $context, false, $scope);
+			}
+
+			if (
+				$context->truthy()
+				&& $leftType->isArray()->yes()
+				&& $rightType instanceof ConstantArrayType && $rightType->isEmpty()
+			) {
+				return $this->create($expr->left, new NonEmptyArrayType(), $context, false, $scope);
 			}
 
 			if (

--- a/tests/PHPStan/Analyser/data/sizeof.php
+++ b/tests/PHPStan/Analyser/data/sizeof.php
@@ -44,4 +44,20 @@ class Sizeof
 		}
 		return "";
 	}
+
+	function doFoo5(array $arr): string
+	{
+		if ([] != $arr) {
+			assertType('array&nonEmpty', $arr);
+		}
+		return "";
+	}
+
+	function doFoo6(array $arr): string
+	{
+		if ([] != $arr) {
+			assertType('array&nonEmpty', $arr);
+		}
+		return "";
+	}
 }

--- a/tests/PHPStan/Analyser/data/sizeof.php
+++ b/tests/PHPStan/Analyser/data/sizeof.php
@@ -45,19 +45,19 @@ class Sizeof
 		return "";
 	}
 
-	function doFoo5(array $arr): string
+	function doFoo5(array $arr): void
 	{
 		if ([] != $arr) {
 			assertType('array&nonEmpty', $arr);
 		}
-		return "";
+		assertType('array', $arr);
 	}
 
-	function doFoo6(array $arr): string
+	function doFoo6(array $arr): void
 	{
 		if ($arr != []) {
 			assertType('array&nonEmpty', $arr);
 		}
-		return "";
+		assertType('array', $arr);
 	}
 }

--- a/tests/PHPStan/Analyser/data/sizeof.php
+++ b/tests/PHPStan/Analyser/data/sizeof.php
@@ -55,7 +55,7 @@ class Sizeof
 
 	function doFoo6(array $arr): string
 	{
-		if ([] != $arr) {
+		if ($arr != []) {
 			assertType('array&nonEmpty', $arr);
 		}
 		return "";


### PR DESCRIPTION
with this PR I am trying to fix the last remaining case of https://github.com/phpstan/phpstan/issues/2142

closes https://github.com/phpstan/phpstan/issues/2142