### PR TITLE
filter_var() should return non empty string only when it will not be sanitized

### DIFF
--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -231,7 +231,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 
 	private function canStringBeSanitized(Type $filterType, int $filterValue, ?Node\Arg $flagsArg, Scope $scope): bool
 	{
-		if (!$filterType instanceof StringType) {
+		if ($filterType->isSuperTypeOf(new StringType())->no()) {
 			return true;
 		}
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -224,7 +224,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return $exprType->getOffsetValueType($this->flagsString);
 	}
 
-	private function canStringBeSanitized(Type $filterType, int $filterValue, ?Node\Arg $flagsArg, $scope): bool
+	private function canStringBeSanitized(Type $filterType, int $filterValue, ?Node\Arg $flagsArg, Scope $scope): bool
 	{
 		if (!$filterType instanceof StringType) {
 			return true;

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -137,7 +137,8 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			$otherType = $this->getOtherType($flagsArg, $scope);
 
 			if ($inputType->isNonEmptyString()->yes()
-				&& !$this->canStringBeSanitized($type, $filterValue, $flagsArg, $scope)) {
+				&& $type instanceof StringType
+				&& !$this->canStringBeSanitized($filterValue, $flagsArg, $scope)) {
 				$type = new IntersectionType([$type, new AccessoryNonEmptyStringType()]);
 			}
 
@@ -229,12 +230,8 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return $exprType->getOffsetValueType($this->flagsString);
 	}
 
-	private function canStringBeSanitized(Type $filterType, int $filterValue, ?Node\Arg $flagsArg, Scope $scope): bool
+	private function canStringBeSanitized(int $filterValue, ?Node\Arg $flagsArg, Scope $scope): bool
 	{
-		if ($filterType->isSuperTypeOf(new StringType())->no()) {
-			return true;
-		}
-
 		// If it is a validation filter, the string will not be changed
 		if (($filterValue & self::VALIDATION_FILTER_BITMASK) !== 0) {
 			return false;

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -232,7 +232,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 
 		// All validation filters match 0x100
 		// If it is a validation filter, the string will not be changed
-		if ($filterValue & 0x100) {
+		if (($filterValue & 0x100) !== 0) {
 			return false;
 		}
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -27,6 +27,12 @@ use PHPStan\Type\UnionType;
 
 class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+	/**
+	 * All validation filters match 0x100.
+	 *
+	 * @var int
+	 */
+	private const VALIDATION_FILTER_BITMASK = 0x100;
 
 	private ReflectionProvider $reflectionProvider;
 
@@ -230,9 +236,8 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			return true;
 		}
 
-		// All validation filters match 0x100
 		// If it is a validation filter, the string will not be changed
-		if (($filterValue & 0x100) !== 0) {
+		if (($filterValue & self::VALIDATION_FILTER_BITMASK) !== 0) {
 			return false;
 		}
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -27,10 +27,9 @@ use PHPStan\Type\UnionType;
 
 class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
 	/**
 	 * All validation filters match 0x100.
-	 *
-	 * @var int
 	 */
 	private const VALIDATION_FILTER_BITMASK = 0x100;
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -66,6 +66,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			$this->getConstant('FILTER_SANITIZE_STRING') => $stringType,
 			$this->getConstant('FILTER_SANITIZE_URL') => $stringType,
 			$this->getConstant('FILTER_VALIDATE_BOOLEAN') => $booleanType,
+			$this->getConstant('FILTER_VALIDATE_DOMAIN') => $stringType,
 			$this->getConstant('FILTER_VALIDATE_EMAIL') => $stringType,
 			$this->getConstant('FILTER_VALIDATE_FLOAT') => $floatType,
 			$this->getConstant('FILTER_VALIDATE_INT') => $intType,

--- a/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
@@ -56,5 +56,9 @@ class Foo
 
 		$return = filter_var($str2, FILTER_VALIDATE_URL);
 		assertType('string|false', $return);
+
+		$str2 = 'foo';
+		$return = filter_var($str2, FILTER_VALIDATE_INT);
+		assertType('int|false', $return);
 	}
 }

--- a/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
@@ -14,11 +14,47 @@ class Foo
 		$return = filter_var($str, FILTER_DEFAULT);
 		assertType('non-empty-string|false', $return);
 
-		$return = filter_var($str, FILTER_SANITIZE_STRING);
+		$return = filter_var($str, FILTER_DEFAULT, FILTER_FLAG_STRIP_LOW);
+		assertType('string|false', $return);
+
+		$return = filter_var($str, FILTER_DEFAULT, FILTER_FLAG_STRIP_HIGH);
+		assertType('string|false', $return);
+
+		$return = filter_var($str, FILTER_DEFAULT, FILTER_FLAG_STRIP_BACKTICK);
+		assertType('string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_EMAIL);
 		assertType('non-empty-string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_REGEXP);
+		assertType('non-empty-string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_URL);
+		assertType('non-empty-string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE);
+		assertType('non-empty-string|null', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_IP);
+		assertType('non-empty-string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_MAC);
+		assertType('non-empty-string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_DOMAIN);
+		assertType('non-empty-string|false', $return);
+
+		$return = filter_var($str, FILTER_SANITIZE_STRING);
+		assertType('string|false', $return);
+
+		$return = filter_var($str, FILTER_VALIDATE_INT);
+		assertType('int|false', $return);
 
 		$str2 = '';
 		$return = filter_var($str2, FILTER_DEFAULT);
+		assertType('string|false', $return);
+
+		$return = filter_var($str2, FILTER_VALIDATE_URL);
 		assertType('string|false', $return);
 	}
 }


### PR DESCRIPTION
This expands on PR #642. @BackEndTea pointed out that `FILTER_SANITIZE_STRING` could strip out all characters in a non-empty-string and so make it empty. So I added more edge cases and it should now only return non-empty-string when there is no chance of it being sanitized.

I also added support for `FILTER_VALIDATE_DOMAIN`, which was not included in the filter map and so always returned `mixed`.