### PR TITLE
Attempt to ensure consistent baseline file sort

### DIFF
--- a/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
@@ -40,7 +40,9 @@ class BaselineNeonErrorFormatter implements ErrorFormatter
 			if (!$fileSpecificError->canBeIgnored()) {
 				continue;
 			}
-			$fileErrors[$fileSpecificError->getFilePath()][] = $fileSpecificError->getMessage();
+			$filePath = $fileSpecificError->getFilePath();
+			$relativeFilePath = $this->relativePathHelper->getRelativePath($filePath);
+			$fileErrors[$relativeFilePath][] = $fileSpecificError->getMessage();
 		}
 		ksort($fileErrors, SORT_STRING);
 
@@ -61,7 +63,7 @@ class BaselineNeonErrorFormatter implements ErrorFormatter
 				$errorsToOutput[] = [
 					'message' => Helpers::escape('#^' . preg_quote($message, '#') . '$#'),
 					'count' => $count,
-					'path' => Helpers::escape($this->relativePathHelper->getRelativePath($file)),
+					'path' => Helpers::escape($file),
 				];
 			}
 		}


### PR DESCRIPTION
This is an **untested** proposition to solve [#5085](https://github.com/phpstan/phpstan/issues/5085).

In ASCII table, the "/" char, delimiter in Linux systems is at position 47 (before [A-Z]) while the "\" char, delimiter for Windows systems is at potision 92 (after [A-Z]). 
This is why the sorting is inconsistent: file path used at previous line 43 is OS dependent and keys of the `$fileErrors` array are differents when you're running the code on Linux or on Windows.  
Different keys means different orders when sorting by keys, after the hydratation of the array.

Therefore, using the same calculated relative file path as the one displayed in the baseline output will force the same character to be used as a directory separator in this exclusive context of "sorting files by name". No matter the OS or the directory separator character used, the keys of `$fileErrors` will always be the same.

I unfortunately can't test it myself (lacking of mulitple OS), sorry about that.

Regards,