### PR TITLE
Range math bugs

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -487,6 +487,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/sizeof.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/div-by-zero.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/math.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/math.php
+++ b/tests/PHPStan/Analyser/data/math.php
@@ -86,4 +86,13 @@ class Foo
 		assertType('float|int<min, 1610612736>', $volume);
 	}
 
+	public function doDolor(int $i): void
+	{
+		$chunks = min(200, $i);
+		assertType('int<min, 200>', $chunks);
+		$divThirty = $chunks / 30;
+		assertType('float|int<min, 6>', $divThirty);
+		assertType('float|int<min, 9>', $divThirty + 3);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/math.php
+++ b/tests/PHPStan/Analyser/data/math.php
@@ -76,4 +76,14 @@ class Foo
 		assertType('int<-1, 1>', $comparison * $nullsReverse);
 	}
 
+	public function doIpsum(int $newLevel): void
+	{
+		$min = min(30, $newLevel);
+		assertType('int<min, 30>', $min);
+		$minDivFive = $min / 5;
+		assertType('float|int<min, 6>', $minDivFive);
+		$volume = 0x10000000 * $minDivFive;
+		assertType('float|int<min, 1610612736>', $volume);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/math.php
+++ b/tests/PHPStan/Analyser/data/math.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace MathTests;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	const MAX_TOTAL_PRODUCTS = 22;
+
+	public function doFoo(array $excluded, int $i): void
+	{
+		assertType('int<min, 22>', self::MAX_TOTAL_PRODUCTS - count($excluded));
+		assertType('int', self::MAX_TOTAL_PRODUCTS - $i);
+
+		$maxOrPlusOne = self::MAX_TOTAL_PRODUCTS;
+		if (rand(0, 1)) {
+			$maxOrPlusOne++;
+		}
+
+		assertType('22|23', $maxOrPlusOne);
+		assertType('int<min, 23>', $maxOrPlusOne - count($excluded));
+	}
+
+	public function doBar(int $notZero): void
+	{
+		if ($notZero === 0) {
+			return;
+		}
+
+		assertType('int<min, 0>|int<2, max>', $notZero + 1);
+	}
+
+	/**
+	 * @param int<-5, 5> $rangeFiveBoth
+	 * @param int<-5, max> $rangeFiveLeft
+	 * @param int<min, 5> $rangeFiveRight
+	 */
+	public function doBaz(int $rangeFiveBoth, int $rangeFiveLeft, int $rangeFiveRight): void
+	{
+		assertType('int<-4, 6>', $rangeFiveBoth + 1);
+		assertType('int<-4, max>', $rangeFiveLeft + 1);
+		assertType('int<-6, max>', $rangeFiveLeft - 1);
+		assertType('int<min, 6>', $rangeFiveRight + 1);
+		assertType('int<min, 4>', $rangeFiveRight - 1);
+
+		assertType('int', $rangeFiveLeft + $rangeFiveRight);
+		assertType('int', $rangeFiveLeft - $rangeFiveRight);
+
+		assertType('int', $rangeFiveRight + $rangeFiveLeft);
+		assertType('int', $rangeFiveRight - $rangeFiveLeft);
+
+		assertType('int<-10, 10>', $rangeFiveBoth + $rangeFiveBoth);
+		assertType('0', $rangeFiveBoth - $rangeFiveBoth);
+
+		assertType('int<-10, max>', $rangeFiveBoth + $rangeFiveLeft);
+		assertType('int<0, max>', $rangeFiveBoth - $rangeFiveLeft);
+
+		assertType('int<min, 10>', $rangeFiveBoth + $rangeFiveRight);
+		assertType('int<min, 0>', $rangeFiveBoth - $rangeFiveRight);
+
+		assertType('int<-10, max>', $rangeFiveLeft + $rangeFiveBoth);
+		assertType('int<0, max>', $rangeFiveLeft - $rangeFiveBoth);
+
+		assertType('int<min, 10>', $rangeFiveRight + $rangeFiveBoth);
+		assertType('int<min, 0>', $rangeFiveRight - $rangeFiveBoth);
+	}
+
+	public function doLorem($a, $b): void
+	{
+		$nullsReverse = rand(0, 1) ? 1 : -1;
+		$comparison = $a <=> $b;
+		assertType('int<-1, 1>', $comparison);
+		assertType('-1|1', $nullsReverse);
+		assertType('int<-1, 1>', $comparison * $nullsReverse);
+	}
+
+}


### PR DESCRIPTION
/cc @staabm Can you please look into these cases? Thank you.

```
1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php:14" ('type', '/Users/ondrej/Development/php...th.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerRangeType Object (...), 14)
Expected type int<min, 22>, got type int<22, max> in /Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php on line 14.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<min, 22>'
+'int<22, max>'

/Users/ondrej/Development/phpstan/src/Testing/TypeInferenceTestCase.php:126
/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/NodeScopeResolverTest.php:504

2) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php:23" ('type', '/Users/ondrej/Development/php...th.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerRangeType Object (...), 23)
Expected type int<min, 23>, got type int<23, max> in /Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php on line 23.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<min, 23>'
+'int<23, max>'

/Users/ondrej/Development/phpstan/src/Testing/TypeInferenceTestCase.php:126
/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/NodeScopeResolverTest.php:504

3) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php:32" ('type', '/Users/ondrej/Development/php...th.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\NeverType Object (...), 32)
Expected type int<min, 0>|int<2, max>, got type *NEVER* in /Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php on line 32.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<min, 0>|int<2, max>'
+'*NEVER*'

/Users/ondrej/Development/phpstan/src/Testing/TypeInferenceTestCase.php:126
/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/NodeScopeResolverTest.php:504

4) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php:76" ('type', '/Users/ondrej/Development/php...th.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\Constant\ConstantIntegerType Object (...), 76)
Expected type int<-1, 1>, got type 1 in /Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php on line 76.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<-1, 1>'
+'1'
```