### PR TITLE
Failing test

### DIFF
--- a/tests/PHPStan/Analyser/data/math.php
+++ b/tests/PHPStan/Analyser/data/math.php
@@ -95,4 +95,18 @@ class Foo
 		assertType('float|int<min, 9>', $divThirty + 3);
 	}
 
+	public function doSit(int $i, int $j): void
+	{
+		if ($i < 0) {
+			return;
+		}
+		if ($j < 1) {
+			return;
+		}
+
+		assertType('int<0, max>', $i);
+		assertType('int<1, max>', $j);
+		assertType('int', $i - $j);
+	}
+
 }


### PR DESCRIPTION
/cc @staabm One more failing test, can you please look into it? :) Thanks!

```
1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php:109" ('type', '/Users/ondrej/Development/php...th.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerRangeType Object (...), 109)
Expected type int, got type int<-1, max> in /Users/ondrej/Development/phpstan/tests/PHPStan/Analyser/data/math.php on line 109.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int'
+'int<-1, max>'
```