### PR TITLE
Add support for wildcards in the middle and beginning of const type annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"ondram/ci-detector": "^3.4.0",
 		"ondrejmirtes/better-reflection": "4.3.67",
 		"phpstan/php-8-stubs": "^0.1.23",
-		"phpstan/phpdoc-parser": "^0.5.6",
+		"phpstan/phpdoc-parser": "^0.5.7",
 		"react/child-process": "^0.6.1",
 		"react/event-loop": "^1.1",
 		"react/http": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09336621e0dad025e2d6fffd6301ba27",
+    "content-hash": "5f96f805a466ae4dbe320e30ca8f2f7e",
     "packages": [
         {
             "name": "clue/block-react",
@@ -2177,16 +2177,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.5.6",
+            "version": "0.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fac86158ffc7392e49636f77e63684c026df43b8"
+                "reference": "816e826ce0b7fb32098d8cb6de62511ce6021cea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fac86158ffc7392e49636f77e63684c026df43b8",
-                "reference": "fac86158ffc7392e49636f77e63684c026df43b8",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/816e826ce0b7fb32098d8cb6de62511ce6021cea",
+                "reference": "816e826ce0b7fb32098d8cb6de62511ce6021cea",
                 "shasum": ""
             },
             "require": {
@@ -2220,9 +2220,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.6"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.7"
             },
-            "time": "2021-08-31T08:08:22+00:00"
+            "time": "2021-09-12T11:52:00+00:00"
         },
         {
             "name": "psr/container",

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -702,11 +702,12 @@ class TypeNodeResolver
 			$classReflection = $this->getReflectionProvider()->getClass($className);
 
 			$constantName = $constExpr->name;
-			if (Strings::endsWith($constantName, '*')) {
-				$constantNameStartsWith = Strings::substring($constantName, 0, Strings::length($constantName) - 1);
+			if (Strings::contains($constantName, '*')) {
+				// convert * into .*? and escape everything else so the constants can be matched against the pattern
+				$pattern = '{^' . str_replace('\\*', '.*?', preg_quote($constantName)) . '$}D';
 				$constantTypes = [];
 				foreach ($classReflection->getNativeReflection()->getConstants() as $classConstantName => $constantValue) {
-					if (!Strings::startsWith($classConstantName, $constantNameStartsWith)) {
+					if (Strings::match($classConstantName, $pattern) === null) {
 						continue;
 					}
 

--- a/tests/PHPStan/Analyser/data/const-expr-phpdoc-type.php
+++ b/tests/PHPStan/Analyser/data/const-expr-phpdoc-type.php
@@ -10,6 +10,9 @@ class Foo
 
 	public const SOME_CONSTANT = 1;
 	public const SOME_OTHER_CONSTANT = 2;
+	public const YET_ONE_CONST = 3;
+	public const YET_ANOTHER_CONST = 4;
+	public const DUMMY_SOME_CONSTANT = 99; // should only match the *
 
 	/**
 	 * @param 'foo'|'bar' $one
@@ -21,6 +24,9 @@ class Foo
 	 * @param 234 $seven
 	 * @param self::SOME_OTHER_* $eight
 	 * @param self::* $nine
+	 * @param self::*_CONST $ten
+	 * @param self::YET_*_CONST $eleven
+	 * @param self::*OTHER* $twelve
 	 */
 	public function doFoo(
 		$one,
@@ -31,7 +37,10 @@ class Foo
 		$six,
 		$seven,
 		$eight,
-		$nine
+		$nine,
+		$ten,
+		$eleven,
+		$twelve
 	)
 	{
 		assertType("'bar'|'foo'", $one);
@@ -42,7 +51,10 @@ class Foo
 		assertType('1.0', $six);
 		assertType('234', $seven);
 		assertType('2', $eight);
-		assertType('1|2', $nine);
+		assertType('1|2|3|4|99', $nine);
+		assertType('3|4', $ten);
+		assertType('3|4', $eleven);
+		assertType('2|4', $twelve);
 	}
 
 }


### PR DESCRIPTION
Fixes phpstan/phpstan#5534
Depends on https://github.com/phpstan/phpdoc-parser/pull/81 (hence the build failures)