### PR TITLE
 Reflector::export has been removed in 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"hoa/exception": "^1.0",
 		"hoa/regex": "1.17.01.13",
 		"jean85/pretty-package-versions": "^1.0.3",
-		"jetbrains/phpstorm-stubs": "dev-master#2000119caf61d226e7facad68d7a260d8616a925",
+		"jetbrains/phpstorm-stubs": "dev-master#e8310b02436892908a71387e9f18957c7e787465",
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.0.5",
 		"nette/finder": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5da3ab556c01220b08f037130f2e2062",
+    "content-hash": "02d4a499099c49f3656053c8a29586f6",
     "packages": [
         {
             "name": "clue/block-react",
@@ -1335,17 +1335,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "2000119caf61d226e7facad68d7a260d8616a925"
+                "reference": "e8310b02436892908a71387e9f18957c7e787465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/2000119caf61d226e7facad68d7a260d8616a925",
-                "reference": "2000119caf61d226e7facad68d7a260d8616a925",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/e8310b02436892908a71387e9f18957c7e787465",
+                "reference": "e8310b02436892908a71387e9f18957c7e787465",
                 "shasum": ""
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "@stable",
-                "nikic/php-parser": "dev-master",
+                "nikic/php-parser": "@stable",
                 "php": "^8.0",
                 "phpdocumentor/reflection-docblock": "@stable",
                 "phpunit/phpunit": "@stable"
@@ -1376,7 +1376,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2021-07-21T11:04:10+00:00"
+            "time": "2021-09-07T11:17:50+00:00"
         },
         {
             "name": "nette/bootstrap",

--- a/resources/functionMap_php74delta.php
+++ b/resources/functionMap_php74delta.php
@@ -59,5 +59,6 @@ return [
 	],
 	'old' => [
 		'implode\'2' => ['string', 'pieces'=>'array', 'glue'=>'string'],
+		'Reflector::export' => ['?string'],
 	],
 ];

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -285,6 +285,9 @@ class MethodSignatureRuleTest extends \PHPStan\Testing\RuleTestCase
 
 	public function testBug4084(): void
 	{
+		if (PHP_VERSION_ID < 70200) {
+			$this->markTestSkipped('Test requires PHP 7.2.');
+		}
 		$this->reportMaybes = true;
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-4084.php'], []);


### PR DESCRIPTION
Fix for https://github.com/phpstan/phpstan/issues/5589