### PR TITLE
False positive with when using in_array with literals (or constants)

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -13,6 +13,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
@@ -100,6 +101,10 @@ class ImpossibleCheckTypeHelper
 
 						$haystackArrayTypes = TypeUtils::getArrays($haystackType);
 						if (count($haystackArrayTypes) === 1 && $haystackArrayTypes[0]->getIterableValueType() instanceof NeverType) {
+							return null;
+						}
+
+						if ($needleType instanceof ConstantType && !$haystackType instanceof ConstantArrayType) {
 							return null;
 						}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -496,6 +496,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4499.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2142.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5584.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5496.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/math.php');
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -497,6 +497,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2142.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5496.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5354.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/math.php');
 

--- a/tests/PHPStan/Analyser/data/bug-5354.php
+++ b/tests/PHPStan/Analyser/data/bug-5354.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bug5354;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param mixed[] $foo
+ */
+function sayHello(array $foo): void
+{
+	$a = [];
+	foreach ($foo as $e) {
+		$a[] = rand(5, 15) > 10 ? 0 : 1;
+	}
+
+	assertType('bool', \in_array(0, $a, true));
+}

--- a/tests/PHPStan/Analyser/data/bug-5496.php
+++ b/tests/PHPStan/Analyser/data/bug-5496.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bug5496;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	/** @var array<string, 'auto'|'copy'> $propagation */
+	$propagation = [];
+
+	assertType('bool', \in_array('auto', $propagation, true));
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/5496
closes https://github.com/phpstan/phpstan/issues/5354