### PR TITLE
Fixed InterRangeType multiplication/division of maximas by a negative constant

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5216,6 +5216,7 @@ class MutatingScope implements Scope
 				[$min, $max] = [$max, $min];
 			}
 
+			// invert maximas multiplication < 0
 			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
 				|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
 				&& ($min === null || $max === null)) {
@@ -5244,6 +5245,13 @@ class MutatingScope implements Scope
 				}
 
 				if ($min !== null && $max !== null && $min > $max) {
+					[$min, $max] = [$max, $min];
+				}
+
+				// invert maximas on division < 0
+				if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
+						|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
+					&& ($min === null || $max === null)) {
 					[$min, $max] = [$max, $min];
 				}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5216,7 +5216,7 @@ class MutatingScope implements Scope
 				[$min, $max] = [$max, $min];
 			}
 
-			// invert maximas multiplication < 0
+			// invert maximas on multiplication with negative constants
 			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
 				|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
 				&& ($min === null || $max === null)) {
@@ -5248,7 +5248,7 @@ class MutatingScope implements Scope
 					[$min, $max] = [$max, $min];
 				}
 
-				// invert maximas on division < 0
+				// invert maximas on division with negative constants
 				if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
 						|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
 					&& ($min === null || $max === null)) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1021,12 +1021,7 @@ class MutatingScope implements Scope
 			}
 
 			if ($type instanceof IntegerRangeType) {
-				$negativeRange = $this->resolveType(new Node\Expr\BinaryOp\Mul($node->expr, new LNumber(-1)));
-
-				if ( $negativeRange instanceof IntegerRangeType && ($negativeRange->getMin() === null || $negativeRange->getMax() === null)) {
-					return IntegerRangeType::fromInterval($negativeRange->getMax(), $negativeRange->getMin());
-				}
-				return $negativeRange;
+				return $this->resolveType(new Node\Expr\BinaryOp\Mul($node->expr, new LNumber(-1)));
 			}
 
 			return $type;
@@ -5203,7 +5198,7 @@ class MutatingScope implements Scope
 						$max = null;
 					}
 
-					if ($min !== null && $max !== null && $min > $max) {
+					if ($operand instanceof ConstantIntegerType && $operand->getValue() < 0 && $min !== null && $max !== null && $min > $max) {
 						[$min, $max] = [$max, $min];
 					}
 				}
@@ -5218,6 +5213,10 @@ class MutatingScope implements Scope
 			}
 
 			if ($min !== null && $max !== null && $min > $max) {
+				[$min, $max] = [$max, $min];
+			}
+			
+			if ($min === null || $max === null) {
 				[$min, $max] = [$max, $min];
 			}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5215,7 +5215,7 @@ class MutatingScope implements Scope
 			if ($min !== null && $max !== null && $min > $max) {
 				[$min, $max] = [$max, $min];
 			}
-			
+
 			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
 				|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
 				&& ($min === null || $max === null)) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5198,7 +5198,7 @@ class MutatingScope implements Scope
 						$max = null;
 					}
 
-					if ($operand instanceof ConstantIntegerType && $operand->getValue() < 0 && $min !== null && $max !== null && $min > $max) {
+					if ($min !== null && $max !== null && $min > $max) {
 						[$min, $max] = [$max, $min];
 					}
 				}
@@ -5216,7 +5216,9 @@ class MutatingScope implements Scope
 				[$min, $max] = [$max, $min];
 			}
 			
-			if ($min === null || $max === null) {
+			if ((($range instanceof ConstantIntegerType && $range->getValue() < 0)
+				|| ($operand instanceof ConstantIntegerType && $operand->getValue() < 0))
+				&& ($min === null || $max === null)) {
 				[$min, $max] = [$max, $min];
 			}
 

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -232,7 +232,7 @@ class X {
 		assertType('int<-2, 9>|int<21, 30>', $r1 - $z);
 		assertType('int<-200, -20>|int<1, 30>', $r1 * $z);
 		assertType('float|int<0, 10>', $r1 / $z);
-		assertType('int<min, 15>', $rMin * $z);
+		assertType('int', $rMin * $z);
 		assertType('int<-100, max>', $rMax * $z);
 
 		assertType('int<2, max>', $pi + 1);

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -286,7 +286,7 @@ class X {
 	 *
 	 * @see e.g. https://www.wolframalpha.com/input/?i=%28interval%5B2%2C%E2%88%9E%5D+%2F+-1%29
 	 */
-	public function maxima($rMin, $rMax) {
+	public function maximaInversion($rMin, $rMax) {
 		assertType('int<-5, max>', -1 * $rMin);
 		assertType('int<min, -10>', -2 * $rMax);
 

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -280,6 +280,9 @@ class X {
 		
 		assertType('int<-5, max>', -1 * $rMin);
 		assertType('int<min, -10>', -2 * $rMax);
+		
+		assertType('int<-5, max>', $rMin * -1);
+		assertType('int<min, -10>', $rMax * -2);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -277,12 +277,25 @@ class X {
 		assertType('float|int<5, max>', $rMax / $r1);
 
 		assertType('5|10|15|20|30', $x / $y);
-		
+
+	}
+
+	/**
+	 * @param int<min, 5> $rMin
+	 * @param int<5, max> $rMax
+	 */
+	public function maxima($rMin, $rMax) {
 		assertType('int<-5, max>', -1 * $rMin);
 		assertType('int<min, -10>', -2 * $rMax);
-		
+
 		assertType('int<-5, max>', $rMin * -1);
 		assertType('int<min, -10>', $rMax * -2);
+
+		assertType('int<-5, max>', -1 / $rMin);
+		assertType('int<min, -10>', -2 / $rMax);
+
+		assertType('int<-5, max>', $rMin / -1);
+		assertType('int<min, -10>', $rMax / -2);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -277,6 +277,9 @@ class X {
 		assertType('float|int<5, max>', $rMax / $r1);
 
 		assertType('5|10|15|20|30', $x / $y);
+		
+		assertType('int<-5, max>', -1 * $rMin);
+		assertType('int<min, -10>', -2 * $rMax);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -233,7 +233,7 @@ class X {
 		assertType('int<-200, -20>|int<1, 30>', $r1 * $z);
 		assertType('float|int<0, 10>', $r1 / $z);
 		assertType('int', $rMin * $z);
-		assertType('int<-100, max>', $rMax * $z);
+		assertType('int<min, -100>|int<5, max>', $rMax * $z);
 
 		assertType('int<2, max>', $pi + 1);
 		assertType('int<-1, max>', $pi - 2);

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -284,7 +284,8 @@ class X {
 	 * @param int<min, 5> $rMin
 	 * @param int<5, max> $rMax
 	 *
-	 * @see e.g. https://www.wolframalpha.com/input/?i=%28interval%5B2%2C%E2%88%9E%5D+%2F+-1%29
+	 * @see https://www.wolframalpha.com/input/?i=%28interval%5B2%2C%E2%88%9E%5D+%2F+-1%29
+	 * @see https://3v4l.org/ur9Wf
 	 */
 	public function maximaInversion($rMin, $rMax) {
 		assertType('int<-5, max>', -1 * $rMin);

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -291,11 +291,11 @@ class X {
 		assertType('int<-5, max>', $rMin * -1);
 		assertType('int<min, -10>', $rMax * -2);
 
-		assertType('int<-5, max>', -1 / $rMin);
-		assertType('int<min, -10>', -2 / $rMax);
+		assertType('float|int<0, max>', -1 / $rMin);
+		assertType('float|int<min, 0>', -2 / $rMax);
 
-		assertType('int<-5, max>', $rMin / -1);
-		assertType('int<min, -10>', $rMax / -2);
+		assertType('float|int<-5, max>', $rMin / -1);
+		assertType('float|int<min, -2>', $rMax / -2);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/integer-range-types.php
+++ b/tests/PHPStan/Analyser/data/integer-range-types.php
@@ -283,6 +283,8 @@ class X {
 	/**
 	 * @param int<min, 5> $rMin
 	 * @param int<5, max> $rMax
+	 *
+	 * @see e.g. https://www.wolframalpha.com/input/?i=%28interval%5B2%2C%E2%88%9E%5D+%2F+-1%29
 	 */
 	public function maxima($rMin, $rMax) {
 		assertType('int<-5, max>', -1 * $rMin);


### PR DESCRIPTION
As discussed in https://github.com/phpstan/phpstan-src/pull/669#discussion_r706811109 maxima need to be inverse when multiplying with a negative constant operand

refs https://github.com/phpstan/phpstan/issues/5614

see https://3v4l.org/AUHH7