### PR TITLE
`eval` function can throw exception

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2337,13 +2337,19 @@ class NodeScopeResolver
 			$expr instanceof Expr\BitwiseNot
 			|| $expr instanceof Cast
 			|| $expr instanceof Expr\Clone_
-			|| $expr instanceof Expr\Eval_
 			|| $expr instanceof Expr\Print_
 			|| $expr instanceof Expr\UnaryMinus
 			|| $expr instanceof Expr\UnaryPlus
 		) {
 			$result = $this->processExprNode($expr->expr, $scope, $nodeCallback, $context->enterDeep());
 			$throwPoints = $result->getThrowPoints();
+			$hasYield = $result->hasYield();
+
+			$scope = $result->getScope();
+		} elseif ($expr instanceof Expr\Eval_) {
+			$result = $this->processExprNode($expr->expr, $scope, $nodeCallback, $context->enterDeep());
+			$throwPoints = $result->getThrowPoints();
+			$throwPoints[] = ThrowPoint::createImplicit($scope, $expr);
 			$hasYield = $result->hasYield();
 
 			$scope = $result->getScope();

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -507,6 +507,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/missing-closure-native-return-typehint.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4741.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/more-type-strings.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/eval-implicit-throw.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/eval-implicit-throw.php
+++ b/tests/PHPStan/Analyser/data/eval-implicit-throw.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EvalImplicitThrow;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+
+function evalString(string $evalString) {
+	try {
+		eval($evalString);
+	} catch (\Throwable $exception) {
+		$foo = 1;
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+}

--- a/tests/PHPStan/Rules/Exceptions/data/dead-catch.php
+++ b/tests/PHPStan/Rules/Exceptions/data/dead-catch.php
@@ -29,4 +29,11 @@ class Foo
 		}
 	}
 
+	function evalString(string $evalString) {
+		try {
+			eval($evalString);
+		} catch (\Throwable $exception) {
+			//
+		}
+	}
 }


### PR DESCRIPTION
From the discussion: https://github.com/phpstan/phpstan/discussions/5353#discussioncomment-1032469

This PR adds implicit throw point to `eval` function.

I'm not sure if `tests/PHPStan/Analyser/data/eval-implicit-throw.php` test is neccessary. If not, I can remove it.

(Sorry for the late PR btw. Had holidays and got busy after it)