### PR TITLE
TypeSpecifierContext - Do not create multiple equivalent objects

### DIFF
--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -12,6 +12,7 @@ class TypeSpecifierContext
 	public const CONTEXT_FALSE = 0b0100;
 	public const CONTEXT_FALSEY_BUT_NOT_FALSE = 0b1000;
 	public const CONTEXT_FALSEY = self::CONTEXT_FALSE | self::CONTEXT_FALSEY_BUT_NOT_FALSE;
+	public const CONTEXT_BITMASK = 0b1111;
 
 	private ?int $value;
 
@@ -59,7 +60,7 @@ class TypeSpecifierContext
 		if ($this->value === null) {
 			throw new \PHPStan\ShouldNotHappenException();
 		}
-		return self::create(~$this->value);
+		return self::create(~$this->value & self::CONTEXT_BITMASK);
 	}
 
 	public function true(): bool


### PR DESCRIPTION
Previously, ->negate() would create objects with negative values, which are
harder to understand in the debugger, but behave the same way as their positive
counterpart (e.g. -4 and 12 are equivalent in the lower 4 bits).