### PR TITLE
Distinguish circular type aliases from invalid type definitions

### DIFF
--- a/src/Rules/Classes/LocalTypeAliasesRule.php
+++ b/src/Rules/Classes/LocalTypeAliasesRule.php
@@ -11,6 +11,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\CircularTypeAliasErrorType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\ObjectType;
@@ -137,8 +138,14 @@ class LocalTypeAliasesRule implements Rule
 					return $type;
 				}
 
-				if ($type instanceof ErrorType) {
+				if ($type instanceof CircularTypeAliasErrorType) {
 					$errors[] = RuleErrorBuilder::message(sprintf('Circular definition detected in type alias %s.', $aliasName))->build();
+					$foundError = true;
+					return $type;
+				}
+
+				if ($type instanceof ErrorType) {
+					$errors[] = RuleErrorBuilder::message(sprintf('Invalid type definition detected in type alias %s.', $aliasName))->build();
 					$foundError = true;
 					return $type;
 				}

--- a/src/Type/CircularTypeAliasErrorType.php
+++ b/src/Type/CircularTypeAliasErrorType.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+/** @api */
+class CircularTypeAliasErrorType extends ErrorType
+{
+
+}

--- a/src/Type/TypeAlias.php
+++ b/src/Type/TypeAlias.php
@@ -28,7 +28,7 @@ class TypeAlias
 	public static function invalid(): self
 	{
 		$self = new self(new IdentifierTypeNode('*ERROR*'), new NameScope(null, []));
-		$self->resolvedType = new ErrorType();
+		$self->resolvedType = new CircularTypeAliasErrorType();
 		return $self;
 	}
 

--- a/src/Type/TypeAliasResolver.php
+++ b/src/Type/TypeAliasResolver.php
@@ -123,7 +123,7 @@ class TypeAliasResolver
 			$unresolvedAlias = $localTypeAliases[$aliasName];
 			$resolvedAliasType = $unresolvedAlias->resolve($this->typeNodeResolver);
 		} catch (\PHPStan\Type\CircularTypeAliasDefinitionException $e) {
-			$resolvedAliasType = new ErrorType();
+			$resolvedAliasType = new CircularTypeAliasErrorType();
 		}
 
 		$this->resolvedLocalTypeAliases[$aliasNameInClassScope] = $resolvedAliasType;

--- a/tests/PHPStan/Rules/Classes/LocalTypeAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeAliasesRuleTest.php
@@ -84,6 +84,10 @@ class LocalTypeAliasesRuleTest extends RuleTestCase
 				'Circular definition detected in type alias CircularTypeAliasImport1.',
 				47,
 			],
+			[
+				'Invalid type definition detected in type alias InvalidTypeAlias.',
+				62,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Classes/data/local-type-aliases.php
+++ b/tests/PHPStan/Rules/Classes/data/local-type-aliases.php
@@ -55,3 +55,10 @@ class Qux
 class Generic
 {
 }
+
+/**
+ * @phpstan-type InvalidTypeAlias invalid-type-definition
+ */
+class Invalid
+{
+}


### PR DESCRIPTION
fixes phpstan/phpstan#5608