### PR TITLE
Resolve `PHP_INT_MAX` as positive integer

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1979,7 +1979,7 @@ class MutatingScope implements Scope
 					return new IntegerType();
 				}
 				if ($resolvedConstantName === 'PHP_INT_MAX') {
-					return new IntegerRangeType(1, null);
+					return IntegerRangeType::fromInterval(1, null);
 				}
 
 				$constantType = $this->reflectionProvider->getConstant($node->name, $this)->getValueType();

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1978,6 +1978,9 @@ class MutatingScope implements Scope
 				if ($resolvedConstantName === '__COMPILER_HALT_OFFSET__') {
 					return new IntegerType();
 				}
+				if ($resolvedConstantName === 'PHP_INT_MAX') {
+					return new IntegerRangeType(1, PHP_INT_MAX);
+				}
 
 				$constantType = $this->reflectionProvider->getConstant($node->name, $this)->getValueType();
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1979,7 +1979,7 @@ class MutatingScope implements Scope
 					return new IntegerType();
 				}
 				if ($resolvedConstantName === 'PHP_INT_MAX') {
-					return new IntegerRangeType(1, PHP_INT_MAX);
+					return new IntegerRangeType(1, null);
 				}
 
 				$constantType = $this->reflectionProvider->getConstant($node->name, $this)->getValueType();

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -447,6 +447,12 @@ class AnalyserIntegrationTest extends \PHPStan\Testing\PHPStanTestCase
 		$this->assertCount(0, $errors);
 	}
 
+	public function testBug5657(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5657.php');
+		$this->assertCount(0, $errors);
+	}
+
 	/**
 	 * @param string $file
 	 * @return \PHPStan\Analyser\Error[]

--- a/tests/PHPStan/Analyser/data/bug-5657.php
+++ b/tests/PHPStan/Analyser/data/bug-5657.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bug5657;
+
+class HelloWorld
+{
+	/**
+	 * @param positive-int $totalParts
+	 */
+	public function sayHello(int $totalParts = PHP_INT_MAX): void
+	{
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/5657

This is my first PR, I definitely don't know enough about phpstan internals and might have missed something.

I was no sure what this should resolve to. It would be enough and best to set it to "positive int" but I think this concept is not existing, is it? I then chose the positive range because
1. Hard-coding it to `PHP_INT_MAX` feels not correct as that would be the value of the platform phpstan is running on
2. Setting it to something like 1 could make even more problems
3. Setting it to the UnionType of what the most common values for 32 and 64 bit might make problems (e.g. the 64 bit code will not work on 32 bit I assume?)

Initially I tried to be smart and dynamically resolve all int constant via `constant` but realised that this a bad idea because of the already mentioned 1. What do you think?