### PR TITLE
Scheduler: Introduce `minimumNumberOfProcesses` parameter

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -60,6 +60,7 @@ parameters:
 	parallel:
 		jobSize: 20
 		processTimeout: 600.0
+		minimumNumberOfProcesses: 1
 		maximumNumberOfProcesses: 32
 		minimumNumberOfJobsPerProcess: 2
 		buffer: 134217728 # 128 MB
@@ -215,6 +216,7 @@ parametersSchema:
 	parallel: structure([
 		jobSize: int(),
 		processTimeout: float(),
+		minimumNumberOfProcesses: int(),
 		maximumNumberOfProcesses: int(),
 		minimumNumberOfJobsPerProcess: int(),
 		buffer: int()
@@ -454,6 +456,7 @@ services:
 			analysedPaths: %analysedPaths%
 			currentWorkingDirectory: %currentWorkingDirectory%
 			fixerTmpDir: %fixerTmpDir%
+			minimumNumberOfProcesses: %parallel.minimumNumberOfProcesses%
 			maximumNumberOfProcesses: %parallel.maximumNumberOfProcesses%
 
 	-
@@ -571,6 +574,7 @@ services:
 		class: PHPStan\Parallel\Scheduler
 		arguments:
 			jobSize: %parallel.jobSize%
+			minimumNumberOfProcesses: %parallel.minimumNumberOfProcesses%
 			maximumNumberOfProcesses: %parallel.maximumNumberOfProcesses%
 			minimumNumberOfJobsPerProcess: %parallel.minimumNumberOfJobsPerProcess%
 

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -73,6 +73,8 @@ class FixerApplication
 	/** @var string */
 	private $fixerTmpDir;
 
+	private int $minimumNumberOfProcesses;
+
 	private int $maximumNumberOfProcesses;
 
 	/** @var string|null */
@@ -93,6 +95,7 @@ class FixerApplication
 		array $analysedPaths,
 		string $currentWorkingDirectory,
 		string $fixerTmpDir,
+		int $minimumNumberOfProcesses,
 		int $maximumNumberOfProcesses
 	)
 	{
@@ -105,6 +108,7 @@ class FixerApplication
 		$this->analysedPaths = $analysedPaths;
 		$this->currentWorkingDirectory = $currentWorkingDirectory;
 		$this->fixerTmpDir = $fixerTmpDir;
+		$this->minimumNumberOfProcesses = $minimumNumberOfProcesses;
 		$this->maximumNumberOfProcesses = $maximumNumberOfProcesses;
 	}
 
@@ -141,7 +145,10 @@ class FixerApplication
 				}
 
 			},
-			min($this->cpuCoreCounter->getNumberOfCpuCores(), $this->maximumNumberOfProcesses)
+			max(
+				$this->minimumNumberOfProcesses,
+				min($this->cpuCoreCounter->getNumberOfCpuCores(), $this->maximumNumberOfProcesses)
+			)
 		);
 
 		$server->on('connection', function (ConnectionInterface $connection) use ($loop, $projectConfigFile, $input, $output, $fileSpecificErrors, $notFileSpecificErrors, $mainScript, $filesCount, $reanalyseProcessQueue, $inceptionResult): void {

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -10,59 +10,105 @@ class SchedulerTest extends TestCase
 	public function dataSchedule(): array
 	{
 		return [
-			[
-				1,
-				16,
-				1,
-				50,
-				115,
-				1,
-				[50, 50, 15],
+			'should chunk files into job size requested' => [
+				'cpuCores' => 3,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 50,
+				'numberOfFiles' => 115,
+				'expectedNumberOfProcesses' => 3,
+				'expectedJobSizes' => [50, 50, 15],
 			],
-			[
-				16,
-				16,
-				1,
-				30,
-				124,
-				5,
-				[30, 30, 30, 30, 4],
+			'should not create more jobs than CPU cores for the same workload' => [
+				'cpuCores' => 2,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 50,
+				'numberOfFiles' => 115,
+				'expectedNumberOfProcesses' => 2,
+				'expectedJobSizes' => [50, 50, 15],
 			],
-			[
-				16,
-				3,
-				1,
-				30,
-				124,
-				3,
-				[30, 30, 30, 30, 4],
+			'should not create more processes than there are jobs' => [
+				'cpuCores' => 16,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 30,
+				'numberOfFiles' => 124,
+				'expectedNumberOfProcesses' => 5,
+				'expectedJobSizes' => [30, 30, 30, 30, 4],
 			],
-			[
-				16,
-				16,
-				1,
-				10,
-				298,
-				16,
-				[10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 8],
+			'should not create more than the maximum number of processes' => [
+				'cpuCores' => 16,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 3,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 30,
+				'numberOfFiles' => 124,
+				'expectedNumberOfProcesses' => 3,
+				'expectedJobSizes' => [30, 30, 30, 30, 4],
 			],
-			[
-				16,
-				16,
-				2,
-				30,
-				124,
-				2,
-				[30, 30, 30, 30, 4],
+			'should use all available cpu cores to run processes if number of jobs is high' => [
+				'cpuCores' => 16,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 10,
+				'numberOfFiles' => 298,
+				'expectedNumberOfProcesses' => 16,
+				'expectedJobSizes' => [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 8],
 			],
-			[
-				16,
-				16,
-				2,
-				20,
-				1,
-				1,
-				[1],
+			'should not create more processes than required to run min jobs per process' => [
+				'cpuCores' => 16,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 2,
+				'jobSize' => 30,
+				'numberOfFiles' => 124,
+				'expectedNumberOfProcesses' => 2,
+				'expectedJobSizes' => [30, 30, 30, 30, 4],
+			],
+			'should create at least one process even when number of files is small' => [
+				'cpuCores' => 16,
+				'minimumNumberOfProcesses' => 1,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 2,
+				'jobSize' => 20,
+				'numberOfFiles' => 1,
+				'expectedNumberOfProcesses' => 1,
+				'expectedJobSizes' => [1],
+			],
+			'should be able to insist on using more processes than cpu cores' => [
+				'cpuCores' => 1,
+				'minimumNumberOfProcesses' => 2,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 50,
+				'numberOfFiles' => 115,
+				'expectedNumberOfProcesses' => 2,
+				'expectedJobSizes' => [50, 50, 15],
+			],
+			'should not create more processes than jobs even if min number of processes specified' => [
+				'cpuCores' => 1,
+				'minimumNumberOfProcesses' => 8,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 1,
+				'jobSize' => 10,
+				'numberOfFiles' => 50,
+				'expectedNumberOfProcesses' => 5,
+				'expectedJobSizes' => [10, 10, 10, 10, 10],
+			],
+			'should not create more processes than required to run min jobs per process even if min number of processes specified' => [
+				'cpuCores' => 1,
+				'minimumNumberOfProcesses' => 8,
+				'maximumNumberOfProcesses' => 16,
+				'minimumNumberOfJobsPerProcess' => 2,
+				'jobSize' => 10,
+				'numberOfFiles' => 50,
+				'expectedNumberOfProcesses' => 2,
+				'expectedJobSizes' => [10, 10, 10, 10, 10],
 			],
 		];
 	}
@@ -70,6 +116,7 @@ class SchedulerTest extends TestCase
 	/**
 	 * @dataProvider dataSchedule
 	 * @param int $cpuCores
+	 * @param int $minimumNumberOfProcesses
 	 * @param int $maximumNumberOfProcesses
 	 * @param int $minimumNumberOfJobsPerProcess
 	 * @param int $jobSize
@@ -79,6 +126,7 @@ class SchedulerTest extends TestCase
 	 */
 	public function testSchedule(
 		int $cpuCores,
+		int $minimumNumberOfProcesses,
 		int $maximumNumberOfProcesses,
 		int $minimumNumberOfJobsPerProcess,
 		int $jobSize,
@@ -88,7 +136,7 @@ class SchedulerTest extends TestCase
 	): void
 	{
 		$files = array_fill(0, $numberOfFiles, 'file.php');
-		$scheduler = new Scheduler($jobSize, $maximumNumberOfProcesses, $minimumNumberOfJobsPerProcess);
+		$scheduler = new Scheduler($jobSize, $minimumNumberOfProcesses, $maximumNumberOfProcesses, $minimumNumberOfJobsPerProcess);
 		$schedule = $scheduler->scheduleWork($cpuCores, $files);
 
 		$this->assertSame($expectedNumberOfProcesses, $schedule->getNumberOfProcesses());


### PR DESCRIPTION
Hi,

I introduce a parameter to the Scheduler configuration to create a minimum number of processes. Two rationales:

* In some cases multiple processes may be able to check more files than a sequential scan could on a single CPU (OS scheduler would switch process during blocked operations)

* A fatal error scanning a file causes the scanning process to crash. If N = 1, the parent process responsible for producing meaningful output crashes, whereas with N > 1 the parent process collects the error output of the processing process and displays it meaningfully, so that the output can be parsed and displayed by a CI tool. Therefore, someone may wish to always run with N > 1 even if CPU count = 1.

Cheers!