### PR TITLE
Fix `ExistingClassesInTypehintsRuleTest`

### DIFF
--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -85,7 +85,15 @@ class ExistingClassesInTypehintsRuleTest extends \PHPStan\Testing\RuleTestCase
 				67,
 			],
 			[
+				'Class stdClass referenced with incorrect case: STDClass.',
+				76,
+			],
+			[
 				'Class TestMethodTypehints\FooMethodTypehints referenced with incorrect case: TestMethodTypehints\fOOMethodTypehints.',
+				76,
+			],
+			[
+				'Class stdClass referenced with incorrect case: stdclass.',
 				76,
 			],
 			[


### PR DESCRIPTION
Apparently this started failing with 1f4062f where the default value of `false` from argument `$checkInternalClassCaseSensitivity` of `ClassCaseSensitivityCheck` was removed and called with `true` instead.