### PR TITLE
Add "DynamicFunctionReturnTypeExtension" for "array_replace" + fix for "array_merge"

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -915,6 +915,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\ArrayReplaceFunctionDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ArrayKeysFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -16,7 +17,10 @@ use PHPStan\Type\UnionType;
 
 class ArrayMergeFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-	private const MAX_SIZE_USE_CONSTANT_ARRAY = 100;
+
+	private const MAX_ARGUMENT_TYPES = 5;
+	private const MAX_CONSTANT_ARRAY_TYPES = 10;
+	private const MAX_CONSTANT_ARRAY_TYPE_KEYS = 10;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -47,22 +51,40 @@ class ArrayMergeFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dyna
 			$argumentTypes[] = $argType;
 		}
 
+		$constantData = $this->getConstantData($argumentTypes);
+		$constantArrays = $constantData['constantArrays'];
+		$isIterableAtLeastOnceArrays = $constantData['isIterableAtLeastOnceArrays'];
+		$useConstantArrays = $constantData['useConstantArrays'];
+		$useReturnedArrayBuilder = $constantData['useReturnedArrayBuilder'];
+
 		$keyTypes = [];
 		$valueTypes = [];
+		$returnedArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+		$returnedArrayBuilderFilled = false;
 		$nonEmpty = false;
-		foreach ($argumentTypes as $argType) {
+		foreach ($argumentTypes as $argKey => $argType) {
+			if ($useConstantArrays === true) {
+				if ($useReturnedArrayBuilder === true) {
+					foreach ($constantArrays[$argKey] as $constantArray) {
+						foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+							$returnedArrayBuilderFilled = true;
 
-			$arrays = TypeUtils::getConstantArrays($argType);
-			$arraysCount = count($arrays);
-			if ($arraysCount > 0 && $arraysCount <= self::MAX_SIZE_USE_CONSTANT_ARRAY) {
-				foreach ($arrays as $constantArray) {
-					foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-						if (is_numeric($keyType->getValue())) {
-							$keyTypes[] = $keyType;
-							$valueTypes[] = $constantArray->getValueTypes()[$i];
-						} else {
-							$keyTypes[$keyType->getValue()] = $keyType;
-							$valueTypes[$keyType->getValue()] = $constantArray->getValueTypes()[$i];
+							$returnedArrayBuilder->setOffsetValueType(
+								is_numeric($keyType->getValue()) ? null : $keyType,
+								$constantArray->getValueTypes()[$i]
+							);
+						}
+					}
+				} else {
+					foreach ($constantArrays[$argKey] as $constantArray) {
+						foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+							if (is_numeric($keyType->getValue())) {
+								$keyTypes[] = $keyType;
+								$valueTypes[] = $constantArray->getValueTypes()[$i];
+							} else {
+								$keyTypes[$keyType->getValue()] = $keyType;
+								$valueTypes[$keyType->getValue()] = $constantArray->getValueTypes()[$i];
+							}
 						}
 					}
 				}
@@ -71,23 +93,99 @@ class ArrayMergeFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dyna
 				$valueTypes[] = $argType->getIterableValueType();
 			}
 
-			if (!$argType->isIterableAtLeastOnce()->yes()) {
+			if (
+				(isset($isIterableAtLeastOnceArrays[$argKey]) && !$isIterableAtLeastOnceArrays[$argKey])
+				||
+				!$argType->isIterableAtLeastOnce()->yes()
+			) {
 				continue;
 			}
 
 			$nonEmpty = true;
 		}
 
-		$arrayType = new ArrayType(
-			TypeCombinator::union(...array_values($keyTypes)),
-			TypeCombinator::union(...array_values($valueTypes))
-		);
+		if (count($keyTypes) > 0) {
+			$arrayType = new ArrayType(
+				TypeCombinator::union(...array_values($keyTypes)),
+				TypeCombinator::union(...array_values($valueTypes))
+			);
+
+			if ($returnedArrayBuilderFilled) {
+				$arrayType = TypeCombinator::union($returnedArrayBuilder->getArray(), $arrayType);
+			}
+		} elseif ($returnedArrayBuilderFilled) {
+			$arrayType = $returnedArrayBuilder->getArray();
+		} else {
+			$arrayType = new ArrayType(
+				TypeCombinator::union(...array_values($keyTypes)),
+				TypeCombinator::union(...array_values($valueTypes))
+			);
+		}
 
 		if ($nonEmpty) {
 			$arrayType = TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
 		}
 
 		return $arrayType;
+	}
+
+	/**
+	 * @param Type[] $argumentTypes
+	 * @return array{
+	 *     constantArrays: array<int, \PHPStan\Type\Constant\ConstantArrayType[]>,
+	 *     isIterableAtLeastOnceArrays: bool[],
+	 *     useReturnedArrayBuilder: ?bool,
+	 *     useConstantArrays: ?bool
+	 * }
+	 */
+	private function getConstantData(array $argumentTypes): array
+	{
+		$isIterableAtLeastOnceArrays = [];
+		$constantArrays = [];
+		$useReturnedArrayBuilder = null;
+		$useConstantArrays = null;
+
+		// because of performance issues with "ConstantArrays" we do not collect / merge all arrays
+
+		if (count($argumentTypes) <= self::MAX_ARGUMENT_TYPES) {
+			foreach ($argumentTypes as $argKey => $argType) {
+				$isIterableAtLeastOnceArrays[$argKey] = $argType->isIterableAtLeastOnce()->yes();
+				$constantArrays[$argKey] = TypeUtils::getConstantArrays($argType);
+
+				$constantArraysCount = count($constantArrays[$argKey]);
+				if ($useConstantArrays !== false && $constantArraysCount > 0) {
+					$useConstantArrays = true;
+				} else {
+					$useConstantArrays = false;
+				}
+				if ($constantArraysCount > self::MAX_CONSTANT_ARRAY_TYPES) {
+					$useConstantArrays = false;
+
+					break;
+				}
+			}
+
+			foreach ($argumentTypes as $argKey => $argType) { // phpcs:ignore
+				foreach ($constantArrays[$argKey] ?? [] as $constantArray) {
+					$constantArraysKeyCount = count($constantArray->getKeyTypes());
+					if ($constantArraysKeyCount > 0) {
+						$useReturnedArrayBuilder = true;
+					}
+					if ($constantArraysKeyCount > self::MAX_CONSTANT_ARRAY_TYPE_KEYS) {
+						$useReturnedArrayBuilder = false;
+
+						break 2;
+					}
+				}
+			}
+		}
+
+		return [
+			'constantArrays' => $constantArrays,
+			'isIterableAtLeastOnceArrays' => $isIterableAtLeastOnceArrays,
+			'useReturnedArrayBuilder' => $useReturnedArrayBuilder,
+			'useConstantArrays' => $useConstantArrays,
+		];
 	}
 
 }

--- a/src/Type/Php/ArrayReplaceFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionDynamicReturnTypeExtension.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\GeneralizePrecision;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
+use PHPStan\Type\UnionType;
+
+class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'array_replace';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		if (!isset($functionCall->getArgs()[0])) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$keyTypes = [];
+		$valueTypes = [];
+		$nonEmpty = false;
+		foreach ($functionCall->getArgs() as $arg) {
+			$argType = $scope->getType($arg->value);
+			if ($arg->unpack) {
+				$argType = $argType->getIterableValueType();
+				if ($argType instanceof UnionType) {
+					foreach ($argType->getTypes() as $innerType) {
+						$argType = $innerType;
+					}
+				}
+			}
+
+			$keyTypes[] = TypeUtils::generalizeType($argType->getIterableKeyType(), GeneralizePrecision::moreSpecific());
+			$valueTypes[] = $argType->getIterableValueType();
+
+			if (!$argType->isIterableAtLeastOnce()->yes()) {
+				continue;
+			}
+
+			$nonEmpty = true;
+		}
+
+		$arrayType = new ArrayType(
+			TypeCombinator::union(...$keyTypes),
+			TypeCombinator::union(...$valueTypes)
+		);
+
+		if ($nonEmpty) {
+			$arrayType = TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
+		}
+
+		return $arrayType;
+	}
+
+}

--- a/src/Type/Php/ArrayReplaceFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -16,7 +17,10 @@ use PHPStan\Type\UnionType;
 
 class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-	private const MAX_SIZE_USE_CONSTANT_ARRAY = 100;
+
+	private const MAX_ARGUMENT_TYPES = 5;
+	private const MAX_CONSTANT_ARRAY_TYPES = 10;
+	private const MAX_CONSTANT_ARRAY_TYPE_KEYS = 10;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -47,18 +51,36 @@ class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dy
 			$argumentTypes[] = $argType;
 		}
 
+		$constantData = $this->getConstantData($argumentTypes);
+		$constantArrays = $constantData['constantArrays'];
+		$isIterableAtLeastOnceArrays = $constantData['isIterableAtLeastOnceArrays'];
+		$useConstantArrays = $constantData['useConstantArrays'];
+		$useReturnedArrayBuilder = $constantData['useReturnedArrayBuilder'];
+
 		$keyTypes = [];
 		$valueTypes = [];
+		$returnedArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+		$returnedArrayBuilderFilled = false;
 		$nonEmpty = false;
-		foreach ($argumentTypes as $argType) {
+		foreach ($argumentTypes as $argKey => $argType) {
+			if ($useConstantArrays === true) {
+				if ($useReturnedArrayBuilder === true) {
+					foreach ($constantArrays[$argKey] as $constantArray) {
+						foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+							$returnedArrayBuilderFilled = true;
 
-			$arrays = TypeUtils::getConstantArrays($argType);
-			$arraysCount = count($arrays);
-			if ($arraysCount > 0 && $arraysCount <= self::MAX_SIZE_USE_CONSTANT_ARRAY) {
-				foreach ($arrays as $constantArray) {
-					foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-						$keyTypes[$keyType->getValue()] = $keyType;
-						$valueTypes[$keyType->getValue()] = $constantArray->getValueTypes()[$i];
+							$returnedArrayBuilder->setOffsetValueType(
+								$keyType,
+								$constantArray->getValueTypes()[$i]
+							);
+						}
+					}
+				} else {
+					foreach ($constantArrays[$argKey] as $constantArray) {
+						foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+							$keyTypes[$keyType->getValue()] = $keyType;
+							$valueTypes[$keyType->getValue()] = $constantArray->getValueTypes()[$i];
+						}
 					}
 				}
 			} else {
@@ -66,23 +88,99 @@ class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dy
 				$valueTypes[] = $argType->getIterableValueType();
 			}
 
-			if (!$argType->isIterableAtLeastOnce()->yes()) {
+			if (
+				(isset($isIterableAtLeastOnceArrays[$argKey]) && !$isIterableAtLeastOnceArrays[$argKey])
+				||
+				!$argType->isIterableAtLeastOnce()->yes()
+			) {
 				continue;
 			}
 
 			$nonEmpty = true;
 		}
 
-		$arrayType = new ArrayType(
-			TypeCombinator::union(...array_values($keyTypes)),
-			TypeCombinator::union(...array_values($valueTypes))
-		);
+		if (count($keyTypes) > 0) {
+			$arrayType = new ArrayType(
+				TypeCombinator::union(...array_values($keyTypes)),
+				TypeCombinator::union(...array_values($valueTypes))
+			);
+
+			if ($returnedArrayBuilderFilled) {
+				$arrayType = TypeCombinator::union($returnedArrayBuilder->getArray(), $arrayType);
+			}
+		} elseif ($returnedArrayBuilderFilled) {
+			$arrayType = $returnedArrayBuilder->getArray();
+		} else {
+			$arrayType = new ArrayType(
+				TypeCombinator::union(...array_values($keyTypes)),
+				TypeCombinator::union(...array_values($valueTypes))
+			);
+		}
 
 		if ($nonEmpty) {
 			$arrayType = TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
 		}
 
 		return $arrayType;
+	}
+
+	/**
+	 * @param Type[] $argumentTypes
+	 * @return array{
+	 *     constantArrays: array<int, \PHPStan\Type\Constant\ConstantArrayType[]>,
+	 *     isIterableAtLeastOnceArrays: bool[],
+	 *     useReturnedArrayBuilder: ?bool,
+	 *     useConstantArrays: ?bool
+	 * }
+	 */
+	private function getConstantData(array $argumentTypes): array
+	{
+		$isIterableAtLeastOnceArrays = [];
+		$constantArrays = [];
+		$useReturnedArrayBuilder = null;
+		$useConstantArrays = null;
+
+		// because of performance issues with "ConstantArrays" we do not collect / merge all arrays
+
+		if (count($argumentTypes) <= self::MAX_ARGUMENT_TYPES) {
+			foreach ($argumentTypes as $argKey => $argType) {
+				$isIterableAtLeastOnceArrays[$argKey] = $argType->isIterableAtLeastOnce()->yes();
+				$constantArrays[$argKey] = TypeUtils::getConstantArrays($argType);
+
+				$constantArraysCount = count($constantArrays[$argKey]);
+				if ($useConstantArrays !== false && $constantArraysCount > 0) {
+					$useConstantArrays = true;
+				} else {
+					$useConstantArrays = false;
+				}
+				if ($constantArraysCount > self::MAX_CONSTANT_ARRAY_TYPES) {
+					$useConstantArrays = false;
+
+					break;
+				}
+			}
+
+			foreach ($argumentTypes as $argKey => $argType) { // phpcs:ignore
+				foreach ($constantArrays[$argKey] ?? [] as $constantArray) {
+					$constantArraysKeyCount = count($constantArray->getKeyTypes());
+					if ($constantArraysKeyCount > 0) {
+						$useReturnedArrayBuilder = true;
+					}
+					if ($constantArraysKeyCount > self::MAX_CONSTANT_ARRAY_TYPE_KEYS) {
+						$useReturnedArrayBuilder = false;
+
+						break 2;
+					}
+				}
+			}
+		}
+
+		return [
+			'constantArrays' => $constantArrays,
+			'isIterableAtLeastOnceArrays' => $isIterableAtLeastOnceArrays,
+			'useReturnedArrayBuilder' => $useReturnedArrayBuilder,
+			'useConstantArrays' => $useConstantArrays,
+		];
 	}
 
 }

--- a/src/Type/Php/ArrayReplaceFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionDynamicReturnTypeExtension.php
@@ -16,6 +16,7 @@ use PHPStan\Type\UnionType;
 
 class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
+	private const MAX_SIZE_USE_CONSTANT_ARRAY = 100;
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -28,22 +29,42 @@ class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dy
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
-		$keyTypes = [];
-		$valueTypes = [];
-		$nonEmpty = false;
+		$argumentTypes = [];
 		foreach ($functionCall->getArgs() as $arg) {
 			$argType = $scope->getType($arg->value);
 			if ($arg->unpack) {
-				$argType = $argType->getIterableValueType();
-				if ($argType instanceof UnionType) {
-					foreach ($argType->getTypes() as $innerType) {
-						$argType = $innerType;
+				$iterableValueType = $argType->getIterableValueType();
+				if ($iterableValueType instanceof UnionType) {
+					foreach ($iterableValueType->getTypes() as $innerType) {
+						$argumentTypes[] = $innerType;
 					}
+				} else {
+					$argumentTypes[] = $iterableValueType;
 				}
+				continue;
 			}
 
-			$keyTypes[] = TypeUtils::generalizeType($argType->getIterableKeyType(), GeneralizePrecision::moreSpecific());
-			$valueTypes[] = $argType->getIterableValueType();
+			$argumentTypes[] = $argType;
+		}
+
+		$keyTypes = [];
+		$valueTypes = [];
+		$nonEmpty = false;
+		foreach ($argumentTypes as $argType) {
+
+			$arrays = TypeUtils::getConstantArrays($argType);
+			$arraysCount = count($arrays);
+			if ($arraysCount > 0 && $arraysCount <= self::MAX_SIZE_USE_CONSTANT_ARRAY) {
+				foreach ($arrays as $constantArray) {
+					foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+						$keyTypes[$keyType->getValue()] = $keyType;
+						$valueTypes[$keyType->getValue()] = $constantArray->getValueTypes()[$i];
+					}
+				}
+			} else {
+				$keyTypes[] = TypeUtils::generalizeType($argType->getIterableKeyType(), GeneralizePrecision::moreSpecific());
+				$valueTypes[] = $argType->getIterableValueType();
+			}
 
 			if (!$argType->isIterableAtLeastOnce()->yes()) {
 				continue;
@@ -53,8 +74,8 @@ class ArrayReplaceFunctionDynamicReturnTypeExtension implements \PHPStan\Type\Dy
 		}
 
 		$arrayType = new ArrayType(
-			TypeCombinator::union(...$keyTypes),
-			TypeCombinator::union(...$valueTypes)
+			TypeCombinator::union(...array_values($keyTypes)),
+			TypeCombinator::union(...array_values($valueTypes))
 		);
 
 		if ($nonEmpty) {

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4823,7 +4823,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_values($generalStringKeys)',
 			],
 			[
-				"non-empty-array<1|'foo', stdClass>",
+				'array{foo: stdClass, 0: stdClass}',
 				'array_merge($stringOrIntegerKeys)',
 			],
 			[
@@ -4831,23 +4831,23 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_merge($generalStringKeys, $generalDateTimeValues)',
 			],
 			[
-				'non-empty-array<1|string, int|stdClass>',
+				'non-empty-array<int|string, int|stdClass>',
 				'array_merge($generalStringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				'non-empty-array<1|string, int|stdClass>',
+				'non-empty-array<int|string, int|stdClass>',
 				'array_merge($stringOrIntegerKeys, $generalStringKeys)',
 			],
 			[
-				"non-empty-array<1|'bar'|'foo', stdClass>",
+				'array{foo: stdClass, bar: stdClass, 0: stdClass}',
 				'array_merge($stringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				"non-empty-array<1|'bar'|'foo', 'foo'|stdClass>",
+				"array{foo: 'foo', 0: stdClass, bar: stdClass}",
 				'array_merge($stringOrIntegerKeys, $stringKeys)',
 			],
 			[
-				"non-empty-array<0|1|2|'color'|'shape', 2|4|'a'|'b'|'green'|'trapezoid'>",
+				"array{color: 'green', 0: 2, 1: 4, 2: 'a', 3: 'b', shape: 'trapezoid', 4: 4}",
 				'array_merge(array("color" => "red", 2, 4), array("a", "b", "color" => "green", "shape" => "trapezoid", 4))',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4823,7 +4823,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_values($generalStringKeys)',
 			],
 			[
-				'non-empty-array<int|(literal-string&non-empty-string), stdClass>',
+				"non-empty-array<1|'foo', stdClass>",
 				'array_merge($stringOrIntegerKeys)',
 			],
 			[
@@ -4831,23 +4831,23 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_merge($generalStringKeys, $generalDateTimeValues)',
 			],
 			[
-				'non-empty-array<int|string, int|stdClass>',
+				'non-empty-array<1|string, int|stdClass>',
 				'array_merge($generalStringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				'non-empty-array<int|string, int|stdClass>',
+				'non-empty-array<1|string, int|stdClass>',
 				'array_merge($stringOrIntegerKeys, $generalStringKeys)',
 			],
 			[
-				'non-empty-array<int|(literal-string&non-empty-string), \'foo\'|stdClass>',
+				"non-empty-array<1|'bar'|'foo', stdClass>",
 				'array_merge($stringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				'non-empty-array<int|(literal-string&non-empty-string), \'foo\'|stdClass>',
+				"non-empty-array<1|'bar'|'foo', 'foo'|stdClass>",
 				'array_merge($stringOrIntegerKeys, $stringKeys)',
 			],
 			[
-				'non-empty-array<int|(literal-string&non-empty-string), 2|4|\'a\'|\'b\'|\'green\'|\'red\'|\'trapezoid\'>',
+				"non-empty-array<0|1|2|'color'|'shape', 2|4|'a'|'b'|'green'|'trapezoid'>",
 				'array_merge(array("color" => "red", 2, 4), array("a", "b", "color" => "green", "shape" => "trapezoid", 4))',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -139,6 +139,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-expr.php');
 		}
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-merge.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-replace.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-array.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -139,6 +139,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-expr.php');
 		}
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-replace.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-array.php');
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {

--- a/tests/PHPStan/Analyser/data/array-merge.php
+++ b/tests/PHPStan/Analyser/data/array-merge.php
@@ -42,14 +42,69 @@ class Foo
 	}
 
 	/**
+	 * @param array{a?: int, b?: string} $overrides
+	 */
+	public function arrayMergeArrayShapes(array $overrides = []): void
+	{
+		$defaults = ['a' => 1, 'b' => 'bee'];
+		$data = array_merge($defaults, $overrides);
+
+		assertType("array{a: int, b: string}", $data);
+	}
+
+	/**
 	 * @param array{foo: '1'} $array1
 	 * @param array{foo: '2'} $array2
 	 */
 	public function arrayMergeUnionTypeArrayShapesSimple($array1, $array2): void
 	{
-		assertType("non-empty-array<'foo', '1'>", array_merge($array1, $array1));
-		assertType("non-empty-array<'foo', '2'>", array_merge($array1, $array2));
-		assertType("non-empty-array<'foo', '1'>", array_merge($array2, $array1));
+		assertType("array{foo: '1'}", array_merge($array1, $array1));
+		assertType("array{foo: '2'}", array_merge($array1, $array2));
+		assertType("array{foo: '1'}", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array{foo: string, bar: int} $bar
+	 */
+	public function arrayMergeMoreSimpleTests(array $bar): void {
+		assertType('array{foo: string, bar: int}', array_merge($bar));
+		assertType('array{foo: string, bar: int}', array_merge($bar, []));
+		assertType('array{foo: string, bar: int, zzz: 1}', array_merge($bar, ['zzz' => 1]));
+	}
+
+	/**
+	 * @param array{a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10', k: '11'} $array1
+	 * @param array{foo: '2'} $array2
+	 */
+	public function arrayMergeUnionTypeArrayShapesBig($array1, $array2): void
+	{
+		assertType("non-empty-array<'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'|'i'|'j'|'k', '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_merge($array1, $array1));
+		assertType("non-empty-array<'a'|'b'|'c'|'d'|'e'|'f'|'foo'|'g'|'h'|'i'|'j'|'k', '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_merge($array1, $array2));
+		assertType("non-empty-array<'a'|'b'|'c'|'d'|'e'|'f'|'foo'|'g'|'h'|'i'|'j'|'k', '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array{a: '1'} $array1
+	 * @param array{b: '2'} $array2
+	 * @param array{c: '3'} $array3
+	 * @param array{d: '4'} $array4
+	 * @param array{e: '5'} $array5
+	 * @param array{f: '6'} $array6
+	 */
+	public function arrayMergeUnionTypeArrayShapesArgumentsMany($array1, $array2, $array3, $array4, $array5, $array6): void
+	{
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'2'|'3'|'4'|'5'|'6'>", array_merge($array1, $array2, $array3, $array4, $array5, $array6));
+	}
+
+	/**
+	 * @param array{a: '1'}|array{b: '2'}|array{c: '3'}|array{d: '4'}|array{e: '5'}|array{f: '6'}|array{g: '7'}|array{h: '8'}|array{i: '9'}|array{j: '10'}|array{k: '11'} $array1
+	 * @param array{foo: '2'} $array2
+	 */
+	public function arrayMergeUnionTypeArrayShapesMany($array1, $array2): void
+	{
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_merge($array1, $array1));
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_merge($array1, $array2));
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_merge($array2, $array1));
 	}
 
 	public function arrayMergeLogic(): void
@@ -58,6 +113,6 @@ class Foo
 		$replacements = [0 => "pineapple", 4 => "cherry", 'foo' => "lall"];
 		$replacements2 = [0 => "grape"];
 
-		assertType("non-empty-array<0|1|2|4|'foo', 'apple'|'banana'|'cherry'|'grape'|'lall'|'orange'|'pineapple'>", array_merge($base, $replacements, $replacements2));
+		assertType("array{0: 'orange', 1: 'banana', 2: 'apple', foo: 'lall', 3: 'pineapple', 4: 'cherry', 5: 'grape'}", array_merge($base, $replacements, $replacements2));
 	}
 }

--- a/tests/PHPStan/Analyser/data/array-merge.php
+++ b/tests/PHPStan/Analyser/data/array-merge.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NonEmptyArray;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param int[] $array1
+	 * @param string[] $array2
+	 */
+	public function arrayMergeSimple($array1, $array2): void
+	{
+		assertType("array<int>", array_merge($array1, $array1));
+		assertType("array<int|string>", array_merge($array1, $array2));
+		assertType("array<int|string>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array<int, int|string> $array1
+	 * @param array<int, bool|float> $array2
+	 */
+	public function arrayMergeUnionType($array1, $array2): void
+	{
+		assertType("array<int, int|string>", array_merge($array1, $array1));
+		assertType("array<int, int|string>", array_merge($array1, $array1, $array1, $array1));
+		assertType("array<int, bool|float|int|string>", array_merge($array1, $array2));
+		assertType("array<int, bool|float|int|string>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array<int, array{bar: '2'}|array{foo: '1'}> $array1
+	 * @param array<int, array{bar: '3'}|array{foo: '2'}> $array2
+	 */
+	public function arrayMergeUnionTypeArrayShapes($array1, $array2): void
+	{
+		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_merge($array1, $array1));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array1, $array2));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array{foo: '1'} $array1
+	 * @param array{foo: '2'} $array2
+	 */
+	public function arrayMergeUnionTypeArrayShapesSimple($array1, $array2): void
+	{
+		assertType("non-empty-array<'foo', '1'>", array_merge($array1, $array1));
+		assertType("non-empty-array<'foo', '2'>", array_merge($array1, $array2));
+		assertType("non-empty-array<'foo', '1'>", array_merge($array2, $array1));
+	}
+
+	public function arrayMergeLogic(): void
+	{
+		$base = ["orange", "banana", "apple", 'foo' => "raspberry"];
+		$replacements = [0 => "pineapple", 4 => "cherry", 'foo' => "lall"];
+		$replacements2 = [0 => "grape"];
+
+		assertType("non-empty-array<0|1|2|4|'foo', 'apple'|'banana'|'cherry'|'grape'|'lall'|'orange'|'pineapple'>", array_merge($base, $replacements, $replacements2));
+	}
+}

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace NonEmptyArray;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param int[] $array1
+	 * @param string[] $array2
+	 */
+	public function arrayReplaceSimple($array1, $array2): void
+	{
+		assertType("array<int>", array_replace($array1, $array1));
+		assertType("array<int|string>", array_replace($array1, $array2));
+		assertType("array<int|string>", array_replace($array2, $array1));
+	}
+
+	/**
+	 * @param array<int, int|string> $array1
+	 * @param array<int, bool|float> $array2
+	 */
+	public function arrayReplaceUnionType($array1, $array2): void
+	{
+		assertType("array<int, int|string>", array_replace($array1, $array1));
+		assertType("array<int, bool|float|int|string>", array_replace($array1, $array2));
+		assertType("array<int, bool|float|int|string>", array_replace($array2, $array1));
+	}
+
+	/**
+	 * @param array<int, array{bar: '2'}|array{foo: '1'}> $array1
+	 * @param array<int, array{bar: '3'}|array{foo: '2'}> $array2
+	 */
+	public function arrayReplaceUnionTypeArrayShapes($array1, $array2): void
+	{
+		assertType("array<int, array('bar' => '2')|array('foo' => '1')>", array_replace($array1, $array1));
+		assertType("array<int, array('bar' => '2'|'3')|array('foo' => '1'|'2')>", array_replace($array1, $array2));
+		assertType("array<int, array('bar' => '2'|'3')|array('foo' => '1'|'2')>", array_replace($array2, $array1));
+	}
+}

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -36,9 +36,20 @@ class Foo
 	 */
 	public function arrayReplaceUnionTypeArrayShapes($array1, $array2): void
 	{
-		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_merge($array1, $array1));
-		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array1, $array2));
-		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array2, $array1));
+		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_replace($array1, $array1));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_replace($array1, $array2));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_replace($array2, $array1));
+	}
+
+	/**
+	 * @param array{a?: int, b?: string} $overrides
+	 */
+	public function arrayReplaceArrayShapes(array $overrides = []): void
+	{
+		$defaults = ['a' => 1, 'b' => 'bee'];
+		$data = array_replace($defaults, $overrides);
+
+		assertType("array{a: int, b: string}", $data);
 	}
 
 	/**
@@ -47,9 +58,44 @@ class Foo
 	 */
 	public function arrayReplaceUnionTypeArrayShapesSimple($array1, $array2): void
 	{
-		assertType("non-empty-array<'foo', '1'>", array_replace($array1, $array1));
-		assertType("non-empty-array<'foo', '2'>", array_replace($array1, $array2));
-		assertType("non-empty-array<'foo', '1'>", array_replace($array2, $array1));
+		assertType("array{foo: '1'}", array_replace($array1, $array1));
+		assertType("array{foo: '2'}", array_replace($array1, $array2));
+		assertType("array{foo: '1'}", array_replace($array2, $array1));
+	}
+
+	/**
+	 * @param array{a: '1', b: '2', c: '3', d: '4', e: '5', f: '6', g: '7', h: '8', i: '9', j: '10', k: '11'} $array1
+	 * @param array{foo: '2'} $array2
+	 */
+	public function arrayReplaceUnionTypeArrayShapesBig($array1, $array2): void
+	{
+		assertType("non-empty-array<'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'|'i'|'j'|'k', '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_replace($array1, $array1));
+		assertType("non-empty-array<'a'|'b'|'c'|'d'|'e'|'f'|'foo'|'g'|'h'|'i'|'j'|'k', '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_replace($array1, $array2));
+		assertType("non-empty-array<'a'|'b'|'c'|'d'|'e'|'f'|'foo'|'g'|'h'|'i'|'j'|'k', '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_replace($array2, $array1));
+	}
+
+	/**
+	 * @param array{a: '1'} $array1
+	 * @param array{b: '2'} $array2
+	 * @param array{c: '3'} $array3
+	 * @param array{d: '4'} $array4
+	 * @param array{e: '5'} $array5
+	 * @param array{f: '6'} $array6
+	 */
+	public function arrayReplaceUnionTypeArrayShapesArgumentsMany($array1, $array2, $array3, $array4, $array5, $array6): void
+	{
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'2'|'3'|'4'|'5'|'6'>", array_replace($array1, $array2, $array3, $array4, $array5, $array6));
+	}
+
+	/**
+	 * @param array{a: '1'}|array{b: '2'}|array{c: '3'}|array{d: '4'}|array{e: '5'}|array{f: '6'}|array{g: '7'}|array{h: '8'}|array{i: '9'}|array{j: '10'}|array{k: '11'} $array1
+	 * @param array{foo: '2'} $array2
+	 */
+	public function arrayReplaceUnionTypeArrayShapesMany($array1, $array2): void
+	{
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_replace($array1, $array1));
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_replace($array1, $array2));
+		assertType("non-empty-array<literal-string&non-empty-string, '1'|'10'|'11'|'2'|'3'|'4'|'5'|'6'|'7'|'8'|'9'>", array_replace($array2, $array1));
 	}
 
 	public function arrayReplaceLogic(): void
@@ -58,6 +104,6 @@ class Foo
 		$replacements = [0 => "pineapple", 4 => "cherry", 'foo' => "lall"];
 		$replacements2 = [0 => "grape"];
 
-		assertType("non-empty-array<0|1|2|4|'foo', 'apple'|'banana'|'cherry'|'grape'|'lall'>", array_replace($base, $replacements, $replacements2));
+		assertType("array{0: 'grape', 1: 'banana', 2: 'apple', foo: 'lall', 4: 'cherry'}", array_replace($base, $replacements, $replacements2));
 	}
 }

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -25,6 +25,7 @@ class Foo
 	public function arrayReplaceUnionType($array1, $array2): void
 	{
 		assertType("array<int, int|string>", array_replace($array1, $array1));
+		assertType("array<int, int|string>", array_replace($array1, $array1, $array1, $array1));
 		assertType("array<int, bool|float|int|string>", array_replace($array1, $array2));
 		assertType("array<int, bool|float|int|string>", array_replace($array2, $array1));
 	}
@@ -35,8 +36,28 @@ class Foo
 	 */
 	public function arrayReplaceUnionTypeArrayShapes($array1, $array2): void
 	{
-		assertType("array<int, array('bar' => '2')|array('foo' => '1')>", array_replace($array1, $array1));
-		assertType("array<int, array('bar' => '2'|'3')|array('foo' => '1'|'2')>", array_replace($array1, $array2));
-		assertType("array<int, array('bar' => '2'|'3')|array('foo' => '1'|'2')>", array_replace($array2, $array1));
+		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_merge($array1, $array1));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array1, $array2));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array{foo: '1'} $array1
+	 * @param array{foo: '2'} $array2
+	 */
+	public function arrayReplaceUnionTypeArrayShapesSimple($array1, $array2): void
+	{
+		assertType("non-empty-array<'foo', '1'>", array_replace($array1, $array1));
+		assertType("non-empty-array<'foo', '2'>", array_replace($array1, $array2));
+		assertType("non-empty-array<'foo', '1'>", array_replace($array2, $array1));
+	}
+
+	public function arrayReplaceLogic(): void
+	{
+		$base = ["orange", "banana", "apple", 'foo' => "raspberry"];
+		$replacements = [0 => "pineapple", 4 => "cherry", 'foo' => "lall"];
+		$replacements2 = [0 => "grape"];
+
+		assertType("non-empty-array<0|1|2|4|'foo', 'apple'|'banana'|'cherry'|'grape'|'lall'>", array_replace($base, $replacements, $replacements2));
 	}
 }

--- a/tests/PHPStan/Analyser/data/non-empty-array.php
+++ b/tests/PHPStan/Analyser/data/non-empty-array.php
@@ -49,6 +49,11 @@ class Foo
 		assertType('non-empty-array', array_merge($array, []));
 		assertType('non-empty-array', array_merge($array, $array));
 
+		assertType('non-empty-array', array_replace($array));
+		assertType('non-empty-array', array_replace([], $array));
+		assertType('non-empty-array', array_replace($array, []));
+		assertType('non-empty-array', array_replace($array, $array));
+
 		assertType('non-empty-array<int|string, (int|string)>', array_flip($array));
 		assertType('non-empty-array<string, (int|string)>', array_flip($stringArray));
 	}


### PR DESCRIPTION
This Extension is a copy of "ArrayMergeFunctionDynamicReturnTypeExtension"

⇾ requested here: https://github.com/phpstan/phpstan-src/pull/622

INFO: Currently we are getting wrong types from "ArrayMergeFunctionDynamicReturnTypeExtension" because PHP handles array-keys different here: https://3v4l.org/YfKYq
- if the key is numeric, then the value will be added
- if the key is non-numeric, then the value will be replaced 

