### PR TITLE
 Remove specific configuration for array_fill() with PHP 8

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -22,7 +22,6 @@
 return [
 	'new' => [
 		'array_combine' => ['associative-array', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'0|positive-int', 'val'=>'mixed'],
 		'bcdiv' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],
@@ -147,7 +146,6 @@ return [
 	'old' => [
 
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_fill' => ['array', 'start_key'=>'int', 'num'=>'int', 'val'=>'mixed'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],


### PR DESCRIPTION
PHP 8 allow `array_fill()` `$start_key` parameter to be less than `0`, as PHP 7.x does:
http://sandbox.onlinephpfunctions.com/code/f41f7ca4e9acd877de048ff3d7905f8d354d99c2

A little difference is: with PHP 7.x if you have a negative number for `$start_index`, first index will be your number but next one will be `0`:
http://sandbox.onlinephpfunctions.com/code/f41f7ca4e9acd877de048ff3d7905f8d354d99c2

With PHP 8 it will not be `0` but the next number:
http://sandbox.onlinephpfunctions.com/code/f41f7ca4e9acd877de048ff3d7905f8d354d99c2