### PR TITLE
WIP: more precise list-type key

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -286,10 +286,10 @@ class TypeNodeResolver
 				return new NeverType(true);
 
 			case 'list':
-				return new ArrayType(new IntegerType(), new MixedType());
+				return new ArrayType(IntegerRangeType::fromInterval(0, null), new MixedType());
 			case 'non-empty-list':
 				return TypeCombinator::intersect(
-					new ArrayType(new IntegerType(), new MixedType()),
+					new ArrayType(IntegerRangeType::fromInterval(0, null), new MixedType()),
 					new NonEmptyArrayType()
 				);
 		}
@@ -457,7 +457,7 @@ class TypeNodeResolver
 			return $arrayType;
 		} elseif ($mainTypeName === 'list' || $mainTypeName === 'non-empty-list') {
 			if (count($genericTypes) === 1) { // list<ValueType>
-				$listType = new ArrayType(new IntegerType(), $genericTypes[0]);
+				$listType = new ArrayType(IntegerRangeType::fromInterval(0, null), $genericTypes[0]);
 				if ($mainTypeName === 'non-empty-list') {
 					return TypeCombinator::intersect($listType, new NonEmptyArrayType());
 				}

--- a/tests/PHPStan/Analyser/data/array-map.php
+++ b/tests/PHPStan/Analyser/data/array-map.php
@@ -44,7 +44,7 @@ function foo3(array $array): void {
 		$array
 	);
 
-	assertType('array<int, string>', $mapped);
+	assertType('array<int<0, max>, string>', $mapped);
 }
 
 /**
@@ -58,5 +58,5 @@ function foo4(array $array): void {
 		$array
 	);
 
-	assertType('array<int, string>&nonEmpty', $mapped);
+	assertType('array<int<0, max>, string>&nonEmpty', $mapped);
 }

--- a/tests/PHPStan/Analyser/data/bug-4499.php
+++ b/tests/PHPStan/Analyser/data/bug-4499.php
@@ -11,7 +11,7 @@ class Foo
 	function thing(array $things) : void{
 		switch(count($things)){
 			case 1:
-				assertType('array<int, int>&nonEmpty', $things);
+				assertType('array<int<0, max>, int>&nonEmpty', $things);
 				assertType('int', array_shift($things));
 		}
 	}

--- a/tests/PHPStan/Analyser/data/bug-4587.php
+++ b/tests/PHPStan/Analyser/data/bug-4587.php
@@ -16,7 +16,7 @@ class HelloWorld
 			return $result;
 		}, $results);
 
-		assertType('array<int, array(\'a\' => int)>', $type);
+		assertType('array<int<0, max>, array(\'a\' => int)>', $type);
 	}
 
 	public function b(): void
@@ -32,6 +32,6 @@ class HelloWorld
 			return $result;
 		}, $results);
 
-		assertType('array<int, array(\'a\' => string&numeric)>', $type);
+		assertType('array<int<0, max>, array(\'a\' => string&numeric)>', $type);
 	}
 }

--- a/tests/PHPStan/Analyser/data/bug-4606.php
+++ b/tests/PHPStan/Analyser/data/bug-4606.php
@@ -11,7 +11,7 @@ use function PHPStan\Testing\assertType;
  */
 
 assertType(Foo::class, $this);
-assertType('array<int, array(stdClass, int)>', $assigned);
+assertType('array<int<0, max>, array(stdClass, int)>', $assigned);
 
 
 /**

--- a/tests/PHPStan/Analyser/data/list-type.php
+++ b/tests/PHPStan/Analyser/data/list-type.php
@@ -86,12 +86,12 @@ class Foo
 		$list[] = '1';
 		$list[] = '2';
 		unset($list[0]);//break list behaviour
-		assertType('array<<0, max>, mixed>', $list);
+		assertType('array<int<0, max>, mixed>', $list);
 
 		/** @var list $list2 */
 		$list2 = [];
 		$list2[2] = '1';//Most likely to create a gap in indexes
-		assertType('array<<0, max>, mixed>&nonEmpty', $list2);
+		assertType('array<int<0, max>, mixed>&nonEmpty', $list2);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/list-type.php
+++ b/tests/PHPStan/Analyser/data/list-type.php
@@ -34,6 +34,7 @@ class Foo
 	{
 		/** @var list $list */
 		$list = [];
+		assertType('array<int<0, max>, mixed>', $list);
 		$list[] = '1';
 		$list[] = true;
 		$list[] = new \stdClass();

--- a/tests/PHPStan/Analyser/data/list-type.php
+++ b/tests/PHPStan/Analyser/data/list-type.php
@@ -9,25 +9,25 @@ class Foo
 	/** @param list $list */
 	public function directAssertion($list): void
 	{
-		assertType('array<int, mixed>', $list);
+		assertType('array<int<0, max>, mixed>', $list);
 	}
 
 	/** @param list $list */
 	public function directAssertionParamHint(array $list): void
 	{
-		assertType('array<int, mixed>', $list);
+		assertType('array<int<0, max>, mixed>', $list);
 	}
 
 	/** @param list $list */
 	public function directAssertionNullableParamHint(array $list = null): void
 	{
-		assertType('array<int, mixed>|null', $list);
+		assertType('array<int<0, max>, mixed>|null', $list);
 	}
 
 	/** @param list<\DateTime> $list */
 	public function directAssertionObjectParamHint($list): void
 	{
-		assertType('array<int, DateTime>', $list);
+		assertType('array<int<0, max>, DateTime>', $list);
 	}
 
 	public function withoutGenerics(): void
@@ -37,7 +37,7 @@ class Foo
 		$list[] = '1';
 		$list[] = true;
 		$list[] = new \stdClass();
-		assertType('array<int, mixed>&nonEmpty', $list);
+		assertType('array<int<0, max>, mixed>&nonEmpty', $list);
 	}
 
 
@@ -48,7 +48,7 @@ class Foo
 		$list[] = '1';
 		$list[] = true;
 		$list[] = new \stdClass();
-		assertType('array<int, mixed>&nonEmpty', $list);
+		assertType('array<int<0, max>, mixed>&nonEmpty', $list);
 	}
 
 	public function withObjectType(): void
@@ -56,7 +56,7 @@ class Foo
 		/** @var list<\DateTime> $list */
 		$list = [];
 		$list[] = new \DateTime();
-		assertType('array<int, DateTime>&nonEmpty', $list);
+		assertType('array<int<0, max>, DateTime>&nonEmpty', $list);
 	}
 
 	/** @return list<scalar> */
@@ -66,7 +66,7 @@ class Foo
 		$list = [];
 		$list[] = '1';
 		$list[] = true;
-		assertType('array<int, bool|float|int|string>&nonEmpty', $list);
+		assertType('array<int<0, max>, bool|float|int|string>&nonEmpty', $list);
 	}
 
 	public function withNumericKey(): void
@@ -75,7 +75,7 @@ class Foo
 		$list = [];
 		$list[] = '1';
 		$list['1'] = true;
-		assertType('array<int, mixed>&nonEmpty', $list);
+		assertType('array<int<0, max>, mixed>&nonEmpty', $list);
 	}
 
 	public function withFullListFunctionality(): void
@@ -86,12 +86,12 @@ class Foo
 		$list[] = '1';
 		$list[] = '2';
 		unset($list[0]);//break list behaviour
-		assertType('array<int, mixed>', $list);
+		assertType('array<<0, max>, mixed>', $list);
 
 		/** @var list $list2 */
 		$list2 = [];
 		$list2[2] = '1';//Most likely to create a gap in indexes
-		assertType('array<int, mixed>&nonEmpty', $list2);
+		assertType('array<<0, max>, mixed>&nonEmpty', $list2);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/non-empty-array.php
+++ b/tests/PHPStan/Analyser/data/non-empty-array.php
@@ -26,10 +26,10 @@ class Foo
 	): void
 	{
 		assertType('array&nonEmpty', $array);
-		assertType('array<int, mixed>&nonEmpty', $list);
+		assertType('array<int<0, max>, mixed>&nonEmpty', $list);
 		assertType('array<int, string>&nonEmpty', $arrayOfStrings);
-		assertType('array<int, stdClass>&nonEmpty', $listOfStd);
-		assertType('array<int, stdClass>&nonEmpty', $listOfStd2);
+		assertType('array<int<0, max>, stdClass>&nonEmpty', $listOfStd);
+		assertType('array<int<0, max>, stdClass>&nonEmpty', $listOfStd2);
 		assertType('array', $invalidList);
 		assertType('mixed', $invalidList2);
 	}

--- a/tests/PHPStan/Analyser/data/psalm-prefix-unresolvable.php
+++ b/tests/PHPStan/Analyser/data/psalm-prefix-unresolvable.php
@@ -18,7 +18,7 @@ class Foo
 
 	public function doBar(): void
 	{
-		assertType('array<int, string>', $this->doFoo());
+		assertType('array<int<0, max>, string>', $this->doFoo());
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -767,7 +767,7 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/proc_open.php'], [
 			[
-				'Parameter #1 $command of function proc_open expects array<int, string>|string, array<string, string> given.',
+				'Parameter #1 $command of function proc_open expects array<int<0, max>, string>|string, array<string, string> given.',
 				6,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -767,7 +767,7 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/proc_open.php'], [
 			[
-				'Parameter #1 $command of function proc_open expects array<int<0, max>, string>|string, array<string, string> given.',
+				'Parameter #1 $command of function proc_open expects array<int<0, max>, string>|string, array(\'something\' => \'bogus\', \'in\' => \'here\') given.',
 				6,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -308,7 +308,7 @@ class MethodSignatureRuleTest extends \PHPStan\Testing\RuleTestCase
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-4707.php'], [
 			[
-				'Return type (array<int, Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be compatible with return type (array<int, Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()',
+				'Return type (array<int<0, max>, Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be compatible with return type (array<int<0, max>, Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()',
 				38,
 			],
 		]);
@@ -320,7 +320,7 @@ class MethodSignatureRuleTest extends \PHPStan\Testing\RuleTestCase
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-4707-covariant.php'], [
 			[
-				'Return type (array<int, Bug4707Covariant\Row2>) of method Bug4707Covariant\Block2::getChildren() should be covariant with return type (array<int, Bug4707Covariant\ChildNodeInterface<static(Bug4707Covariant\ParentNodeInterface)>>) of method Bug4707Covariant\ParentNodeInterface::getChildren()',
+				'Return type (array<int<0, max>, Bug4707Covariant\Row2>) of method Bug4707Covariant\Block2::getChildren() should be covariant with return type (array<int<0, max>, Bug4707Covariant\ChildNodeInterface<static(Bug4707Covariant\ParentNodeInterface)>>) of method Bug4707Covariant\ParentNodeInterface::getChildren()',
 				38,
 			],
 		]);


### PR DESCRIPTION
keys of lists are per definition 0|positive.

this will not implement all properties for a proper list type - I guess - but at least we are getting a more precise key-type for lists with this PR - which I think is usefull.

I guess this changes a lot of user-facing types, but it seems there is no better than implementing this now, as we are approaching the next major release with 1.0