### PR TITLE
FileReadTrapStreamWrapper: Detect non existent files

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
@@ -88,7 +88,7 @@ final class FileReadTrapStreamWrapper
 	 */
 	public function stream_open($path, $mode, $options, &$openedPath): bool
 	{
-		self::$autoloadLocatedFile = $path;
+		self::$autoloadLocatedFile = $openedPath;
 		$this->readFromFile = false;
 		$this->seekPosition = 0;
 


### PR DESCRIPTION
I propose this change to: Restrict the detection to actually opened files while detection loaded classes from autoloader.
This will mitigate errors with old "shot in the dark" auto-loaders that are not using any kind of include restriction like:
```
Could not read file: boolean.php
```

As mentioned in: https://github.com/phpstan/phpstan/discussions/5074?sort=new#discussioncomment-1507494

THIS PROPOSAL IS ONLY FOR YOUR CONVENIENCE ! Feel free to discard without comment.