### PR TITLE
Variadic parameters in PHP8 can have int|string key

### DIFF
--- a/src/Analyser/DirectScopeFactory.php
+++ b/src/Analyser/DirectScopeFactory.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\Type\DynamicReturnTypeExtensionRegistryProvider;
 use PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
@@ -39,6 +40,8 @@ class DirectScopeFactory implements ScopeFactory
 	/** @var string[] */
 	private array $dynamicConstantNames;
 
+	private PhpVersion $phpVersion;
+
 	public function __construct(
 		string $scopeClass,
 		ReflectionProvider $reflectionProvider,
@@ -50,7 +53,8 @@ class DirectScopeFactory implements ScopeFactory
 		\PHPStan\Parser\Parser $parser,
 		NodeScopeResolver $nodeScopeResolver,
 		bool $treatPhpDocTypesAsCertain,
-		Container $container
+		Container $container,
+		PhpVersion $phpVersion
 	)
 	{
 		$this->scopeClass = $scopeClass;
@@ -64,6 +68,7 @@ class DirectScopeFactory implements ScopeFactory
 		$this->nodeScopeResolver = $nodeScopeResolver;
 		$this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
 		$this->dynamicConstantNames = $container->getParameter('dynamicConstantNames');
+		$this->phpVersion = $phpVersion;
 	}
 
 	/**
@@ -121,6 +126,7 @@ class DirectScopeFactory implements ScopeFactory
 			$this->parser,
 			$this->nodeScopeResolver,
 			$context,
+			$this->phpVersion,
 			$declareStrictTypes,
 			$constantTypes,
 			$function,

--- a/src/Analyser/LazyScopeFactory.php
+++ b/src/Analyser/LazyScopeFactory.php
@@ -6,6 +6,7 @@ use PhpParser\PrettyPrinter\Standard;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\Type\DynamicReturnTypeExtensionRegistryProvider;
 use PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
@@ -89,6 +90,7 @@ class LazyScopeFactory implements ScopeFactory
 			$this->container->getService('currentPhpVersionSimpleParser'),
 			$this->container->getByType(NodeScopeResolver::class),
 			$context,
+			$this->container->getByType(PhpVersion::class),
 			$declareStrictTypes,
 			$constantTypes,
 			$function,

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -18,6 +18,7 @@ use PHPStan\DependencyInjection\Type\DynamicReturnTypeExtensionRegistryProvider;
 use PHPStan\DependencyInjection\Type\OperatorTypeSpecifyingExtensionRegistryProvider;
 use PHPStan\File\FileHelper;
 use PHPStan\Parser\Parser;
+use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ReflectionProvider;
@@ -131,7 +132,8 @@ abstract class PHPStanTestCase extends \PHPUnit\Framework\TestCase
 			$this->getParser(),
 			self::getContainer()->getByType(NodeScopeResolver::class),
 			$this->shouldTreatPhpDocTypesAsCertain(),
-			$container
+			$container,
+			$container->getByType(PhpVersion::class)
 		);
 	}
 

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -704,6 +704,8 @@ class TypeCombinator
 
 	public static function intersect(Type ...$types): Type
 	{
+		$types = array_values($types);
+
 		$sortTypes = static function (Type $a, Type $b): int {
 			if (!$a instanceof UnionType || !$b instanceof UnionType) {
 				return 0;

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -1284,7 +1284,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$callable',
 			],
 			[
-				'array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>' : 'array<int|string, string>',
 				'$variadicStrings',
 			],
 			[
@@ -4342,7 +4342,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$str',
 			],
 			[
-				'array<int, mixed>',
+				PHP_VERSION_ID < 80000 ? 'array<int, mixed>' : 'array<int|string, mixed>',
 				'$arr',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -93,7 +93,11 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/catch-without-variable.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mixed-typehint.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2600.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2600-php8.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2600.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-typehint-without-null-in-phpdoc.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/override-root-scope-variable.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bitwise-not.php');
@@ -427,7 +431,11 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/arrow-function-types.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4902.php');
+			if (PHP_VERSION_ID >= 80000) {
+				yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4902-php8.php');
+			} else {
+				yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4902.php');
+			}
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-types.php');
@@ -507,6 +515,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/missing-closure-native-return-typehint.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4741.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/more-type-strings.php');
+
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/variadic-parameter-php8.php');
+		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/eval-implicit-throw.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5628.php');

--- a/tests/PHPStan/Analyser/data/bug-2600-php8.php
+++ b/tests/PHPStan/Analyser/data/bug-2600-php8.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bug2600;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	/**
+	 * @param mixed ...$x
+	 */
+	public function doFoo($x = null) {
+		$args = func_get_args();
+		assertType('mixed', $x);
+		assertType('array', $args);
+	}
+
+	/**
+	 * @param mixed ...$x
+	 */
+	public function doBar($x = null) {
+		assertType('mixed', $x);
+	}
+
+	/**
+	 * @param mixed $x
+	 */
+	public function doBaz(...$x) {
+		assertType('array<int|string, mixed>', $x);
+	}
+
+	/**
+	 * @param mixed ...$x
+	 */
+	public function doLorem(...$x) {
+		assertType('array<int|string, mixed>', $x);
+	}
+
+	public function doIpsum($x = null) {
+		$args = func_get_args();
+		assertType('mixed', $x);
+		assertType('array', $args);
+	}
+}
+
+class Bar
+{
+	/**
+	 * @param string ...$x
+	 */
+	public function doFoo($x = null) {
+		$args = func_get_args();
+		assertType('string|null', $x);
+		assertType('array', $args);
+	}
+
+	/**
+	 * @param string ...$x
+	 */
+	public function doBar($x = null) {
+		assertType('string|null', $x);
+	}
+
+	/**
+	 * @param string $x
+	 */
+	public function doBaz(...$x) {
+		assertType('array<int|string, string>', $x);
+	}
+
+	/**
+	 * @param string ...$x
+	 */
+	public function doLorem(...$x) {
+		assertType('array<int|string, string>', $x);
+	}
+}
+
+function foo($x, string ...$y): void
+{
+	assertType('mixed', $x);
+	assertType('array<int|string, string>', $y);
+}
+
+function ($x, string ...$y): void {
+	assertType('mixed', $x);
+	assertType('array<int|string, string>', $y);
+};

--- a/tests/PHPStan/Analyser/data/bug-4902-php8.php
+++ b/tests/PHPStan/Analyser/data/bug-4902-php8.php
@@ -1,0 +1,53 @@
+<?php // lint >= 7.4
+
+namespace Bug4902;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T-wrapper
+ */
+class Wrapper {
+	/** @var T-wrapper */
+	public $value;
+
+	/**
+	 * @param T-wrapper $value
+	 */
+	public function __construct($value) {
+		$this->value = $value;
+	}
+
+	/**
+	 * @template T-unwrap
+	 * @param Wrapper<T-unwrap> $wrapper
+	 * @return T-unwrap
+	 */
+	function unwrap(Wrapper $wrapper) {
+		return $wrapper->value;
+	}
+
+	/**
+	 * @template T-wrap
+	 * @param T-wrap $value
+	 *
+	 * @return Wrapper<T-wrap>
+	 */
+	function wrap($value): Wrapper
+	{
+		return new Wrapper($value);
+	}
+
+
+	/**
+	 * @template T-all
+	 * @param Wrapper<T-all> ...$wrappers
+	 */
+	function unwrapAllAndWrapAgain(Wrapper ...$wrappers): void {
+		assertType('array<int|string, T-all (method Bug4902\Wrapper::unwrapAllAndWrapAgain(), argument)>', array_map(function (Wrapper $item) {
+			return $this->unwrap($item);
+		}, $wrappers));
+		assertType('array<int|string, T-all (method Bug4902\Wrapper::unwrapAllAndWrapAgain(), argument)>', array_map(fn (Wrapper $item) => $this->unwrap($item), $wrappers));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/variadic-parameter-php8.php
+++ b/tests/PHPStan/Analyser/data/variadic-parameter-php8.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace VariadicParameterPHP8;
+
+use function PHPStan\Testing\assertType;
+
+function foo(...$args)
+{
+	assertType('array<int|string, mixed>', $args);
+	assertType('mixed', $args['foo']);
+	assertType('mixed', $args['bar']);
+}
+
+function bar(string ...$args)
+{
+	assertType('array<int|string, string>', $args);
+}
+


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/phpstan/phpstan/issues/4850

When injecting `PhpVersion` into the `MutatingScope` constructor, I had to change a lot of other places. Hope that's ok. 
And I used `$this->phpVersion->supportsNamedArguments()` because it's a side effect of the named arguments feature. But if you like, I can add another method with different name.