### PR TITLE
FileExcluder: Improve performance of isExcludedFromAnalysing

### DIFF
--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -12,6 +12,10 @@ class FileExcluder
 	 */
 	private array $literalAnalyseExcludes = [];
 
+	/**
+	 * fnmatch() patterns to use for excluding files and directories from analysing
+	 * @var string[]
+	 */
 	private array $fnmatchAnalyseExcludes = [];
 
 	private int $fnmatchFlags;


### PR DESCRIPTION
I discovered this while debugging phpstan/phpstan#5825.

When analysing pmmp/PocketMine-MP@701a71a4ee7d54de8ad9fbed9796059d87b7256f with a result cache + no unchanged files, I noticed that isExcludedFromAnalysing() took over 9% of the total time spent. I'm not sure why this is needed when result cache is used, but it became immediately obvious to me that there were performance gains to be had here.

Before analysis, an xdebug profiler snapshot showed that this method took 9% of the total CPU time and called isFnmatchPattern() over 124,000 times. This is pretty bad considering that PM doesn't use fnmatch patterns at all.
isFnmatchPattern() took about 2.7% time.

After the patch, this drops to about 1.9% for isExcludedFromAnalysis() and 0.1% for isFnmatchPattern(), with isFnmatchPattern() now being called only ~2,200 times.

In real numbers, this shaves off a fraction of a second of pre-analysis time when a result cache is used (at least on Windows).