### PR TITLE
AnalyseApplication: Do not re-analyse stubs on every run

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -216,6 +216,15 @@ class ResultCacheManager
 		$filteredErrors = [];
 		$filteredExportedNodes = [];
 		$newFileAppeared = false;
+
+		foreach ($this->stubFiles as $stubFile) {
+			if (!array_key_exists($stubFile, $errors)) {
+				continue;
+			}
+
+			$filteredErrors[$stubFile] = $errors[$stubFile];
+		}
+
 		foreach ($allAnalysedFiles as $analysedFile) {
 			if (array_key_exists($analysedFile, $errors)) {
 				$filteredErrors[$analysedFile] = $errors[$analysedFile];


### PR DESCRIPTION
Instead, only analyse them on full runs. Since a change in any stub already invalidates the whole result cache, this means we only need to analyse them on full runs and then remember their errors for later.

On pmmp/PocketMine-MP, this reduces the time to re-analyse with a result cache from ~1300ms to ~1000ms on an XPS 17 9710.

This is a rough shot at implementing phpstan/phpstan#5826.