### PR TITLE
Fix CompileCommand renaming PhpStormStubsMap on Windows

### DIFF
--- a/compiler/src/Console/CompileCommand.php
+++ b/compiler/src/Console/CompileCommand.php
@@ -89,6 +89,9 @@ final class CompileCommand extends Command
 
 		$stubFinder = \Symfony\Component\Finder\Finder::create();
 		$stubsMapPath = realpath($directory . '/PhpStormStubsMap.php');
+		if ($stubsMapPath === false) {
+			throw new \Exception('realpath() failed');
+		}
 		foreach ($stubFinder->files()->name('*.php')->in($directory) as $stubFile) {
 			$path = $stubFile->getPathname();
 			if ($path === $stubsMapPath) {


### PR DESCRIPTION
Windows directory separators use a `\`, not `/`.
Probably nobody ever noticed or cared, but I ran into it today while trying to build PHPStan to appease PhpStorm.