### PR TITLE
faster `FileHelper::normalizePath()`

### DIFF
--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -2,8 +2,6 @@
 
 namespace PHPStan\File;
 
-use Nette\Utils\Strings;
-
 class FileHelper
 {
 
@@ -41,7 +39,7 @@ class FileHelper
 	/** @api */
 	public function normalizePath(string $originalPath, string $directorySeparator = DIRECTORY_SEPARATOR): string
 	{
-		$isLocalPath = $originalPath !== '' && $originalPath[0] === '/';;
+		$isLocalPath = $originalPath !== '' && $originalPath[0] === '/';
 
 		$matches = null;
 		if (!$isLocalPath) {


### PR DESCRIPTION
running phpstan on one of our projects consistently leads to a profile like

![grafik](https://user-images.githubusercontent.com/120441/138694459-4315208e-bdd8-4bc7-86c8-44f3d8e89d58.png)
see that `FileHelper::normalizePath()` is a very hot path, mostly dominated by PCRE invocations.

this PR proposes small adjustments so `normalize` no longer needs to invoke PCRE in the common case.
with this changes we get a solid speed improvement:

![grafik](https://user-images.githubusercontent.com/120441/138694759-ec8128d9-1be5-4f2c-9e9c-ebc111959527.png)


![grafik](https://user-images.githubusercontent.com/120441/138694816-c3ae9170-b0d7-4021-a725-ed1efe1dbb09.png)

also note a improvement in memory consumption.


profiles compared are based on the latest commit on master https://github.com/phpstan/phpstan-src/commit/b726e087b729c1732256d9124b4c74e06ae4c803