### PR TITLE
faster `IgnoredError->shouldIgnore()`

### DIFF
--- a/src/Analyser/IgnoredError.php
+++ b/src/Analyser/IgnoredError.php
@@ -54,12 +54,11 @@ class IgnoredError
 		$ignoredErrorPattern = str_replace([preg_quote('\r\n'), preg_quote('\r')], preg_quote('\n'), $ignoredErrorPattern);
 
 		if ($path !== null) {
-			$fileExcluder = new FileExcluder($fileHelper, [$path], []);
-
 			if (\Nette\Utils\Strings::match($errorMessage, $ignoredErrorPattern) === null) {
 				return false;
 			}
 
+			$fileExcluder = new FileExcluder($fileHelper, [$path], []);
 			$isExcluded = $fileExcluder->isExcludedFromAnalysing($error->getFilePath());
 			if (!$isExcluded && $error->getTraitFilePath() !== null) {
 				return $fileExcluder->isExcludedFromAnalysing($error->getTraitFilePath());


### PR DESCRIPTION
object creation of `FileExcluder` requires a lot of path normalization.

this PR moves the object creation after the fast-exit IF condition, which prevents the object creation in most cases and leads to major speed improvements.

comparison before/after this change

![grafik](https://user-images.githubusercontent.com/120441/138697975-eed0ead0-a4df-4873-ab4e-6cb4033abcba.png)


![grafik](https://user-images.githubusercontent.com/120441/138697955-0c699261-251c-4827-8a45-e1ab05caef39.png)

also note a improvement in memory consumption.

profiles compared are based on the latest commit on master https://github.com/phpstan/phpstan-src/commit/b726e087b729c1732256d9124b4c74e06ae4c803