### PR TITLE
Faster `IgnoredError::shouldIgnore()`

### DIFF
--- a/src/Analyser/IgnoredError.php
+++ b/src/Analyser/IgnoredError.php
@@ -52,7 +52,7 @@ class IgnoredError
 		$ignoredMessage = ltrim($ignoredErrorPattern, '#^');
 
 		// fast exit in case the first char of the error is different while making sure its not a regex meta char (wildcard or similar)
-		if ($ignoredMessage[0] !== $ignoredMessage[0] && preg_quote($ignoredMessage[0]) === $ignoredMessage[0]) {
+		if ($ignoredMessage[0] !== $errorMessage[0] && preg_quote($ignoredMessage[0]) === $ignoredMessage[0]) {
 			return false;
 		}
 


### PR DESCRIPTION
this fix is not very elegant, but as it improves the analysis by 7-8% I think its at least worth discussing.

running phpstan https://github.com/phpstan/phpstan-src/commit/1505153525ec010466b4cbd9dcbae79682c43e31 leads to the following profile:

![grafik](https://user-images.githubusercontent.com/120441/138728208-ada16c96-00cd-4e12-bc68-ec09afa7c47b.png)

this means we still see a bottleneck caused by regex-matching of ignore rules.



this PR suggests a fast-exit condition based on the error-messages first character.
if the first char does not match - and its not a regex-meta char, the following regex-matching-logic can never match.

this optimization leads to the following comparison profile:

![grafik](https://user-images.githubusercontent.com/120441/138728581-d6ef32f0-dcbb-4382-a8d7-807625d838da.png)

we can see a ~1s improvement while also saving ~20% memory.