### PR TITLE
Fix intersections of constant arrays

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -859,7 +859,8 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return count($otherKeys) === 0;
 	}
 
-	public function merge(self $other): self {
+	public function merge(self $other): self
+	{
 		$keyTypes = $this->keyTypes;
 		$valueTypes = $this->valueTypes;
 		$optionalKeys = $this->optionalKeys;

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -716,6 +716,22 @@ class TypeCombinator
 
 	public static function intersect(Type ...$types): Type
 	{
+		$combinedConstantArray = null;
+		foreach ($types as $index => $type) {
+			if (!$type instanceof ConstantArrayType) {
+				continue;
+			}
+			unset($types[$index]);
+			if ($combinedConstantArray === null) {
+				$combinedConstantArray = clone $type;
+				continue;
+			}
+			$combinedConstantArray = $combinedConstantArray->merge($type);
+		}
+		if ($combinedConstantArray !== null) {
+			$types[] = $combinedConstantArray;
+		}
+
 		$types = array_values($types);
 
 		$sortTypes = static function (Type $a, Type $b): int {

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -3097,6 +3097,100 @@ class TypeCombinatorTest extends \PHPStan\Testing\PHPStanTestCase
 				StrictMixedType::class,
 				'mixed',
 			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()]),
+					new ConstantArrayType([new ConstantStringType('bar')], [new StringType()]),
+				],
+				ConstantArrayType::class,
+				'array{foo: string, bar: string}',
+			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()]),
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()], 0, [0]),
+				],
+				ConstantArrayType::class,
+				'array{foo: string}',
+			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()], 0, [0]),
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()]),
+				],
+				ConstantArrayType::class,
+				'array{foo: string}',
+			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()]),
+					new ConstantArrayType([new ConstantStringType('foo')], [new ConstantStringType('test')]),
+				],
+				ConstantArrayType::class,
+				'array{foo: \'test\'}',
+			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new ConstantStringType('test')]),
+					new ConstantArrayType([new ConstantStringType('foo')], [new ConstantStringType('test')]),
+				],
+				ConstantArrayType::class,
+				'array{foo: \'test\'}',
+			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new IntegerType()]),
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()]),
+				],
+				ConstantArrayType::class,
+				'array{foo: *NEVER*}',
+			],
+			[
+				[
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()], 0, [0]),
+					new ConstantArrayType([new ConstantStringType('foo')], [new StringType()], 0, [0]),
+				],
+				ConstantArrayType::class,
+				'array{foo?: string}',
+			],
+			[
+				[
+					new ConstantArrayType(
+						[new ConstantStringType('name'), new ConstantStringType('age')],
+						[new StringType(), new IntegerType()]
+					),
+					new ConstantArrayType(
+						[new ConstantStringType('age'), new ConstantStringType('codes')],
+						[new IntegerType(), new BooleanType()]
+					),
+					new ConstantArrayType(
+						[new ConstantStringType('name'), new ConstantStringType('drinks')],
+						[new StringType(), new BooleanType()]
+					),
+				],
+				ConstantArrayType::class,
+				'array{name: string, age: int, codes: bool, drinks: bool}',
+			],
+			[
+				[
+					new ConstantArrayType(
+						[new ConstantStringType('foo')],
+						[new ConstantArrayType(
+							[new ConstantStringType('bar')],
+							[new StringType()]
+						)]
+					),
+					new ConstantArrayType(
+						[new ConstantStringType('foo')],
+						[new ConstantArrayType(
+							[new ConstantStringType('baz')],
+							[new IntegerType()]
+						)]
+					),
+				],
+				ConstantArrayType::class,
+				'array{foo: array{bar: string, baz: int}}',
+			],
 		];
 	}
 


### PR DESCRIPTION
Allows intersection of constant arrays (`array{key: type}`)

`array{foo: string} & array{bar: int}` => `array{foo: string, bar: int}`
`array{foo?: string} & array{foo: string}` => `array{foo: string}`
`array{foo: string} & array{foo: int}` => `array{foo: never}`

To do/check:

- [x] What about `array{foo: array{bar: string}} & array{foo: array{baz: int}}`? [TypeScript version](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYg9nKBeKBvKAzBAuNUBGAhgE64DOwxAlgHYDmUAvk1AGR5Zy7pEBeuNAK4BbfBGItGAbgBQMgMZwaFTDWRQAFAA9c8OAEpkAPjQyo5qMQjBBxNQAMAJKi0A6Tq6LFmztx76M9rKMchg0Guic3AQkuADkcQA0MfxQAAyS+rJhEZg4eF7xcZnZ4ZH5PISpGcyMWTI55Vx4tfWNec2CNAAmEBi0EN1MbWV1UkA)