### PR TITLE
faster `TypeCombinator::compareTypesInUnion()`

### DIFF
--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -508,8 +508,8 @@ class IntegerRangeType extends IntegerType implements CompoundType
 			return new NeverType();
 		}
 
-		if ($typeToRemove instanceof IntegerRangeType || $typeToRemove instanceof ConstantIntegerType) {
-			if ($typeToRemove instanceof IntegerRangeType) {
+		if ($typeToRemove instanceof self || $typeToRemove instanceof ConstantIntegerType) {
+			if ($typeToRemove instanceof self) {
 				$removeMin = $typeToRemove->min;
 				$removeMax = $typeToRemove->max;
 			} else {

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -417,6 +417,9 @@ class TypeCombinator
 				return [null, $b];
 			}
 		}
+		if ($a instanceof IntegerRangeType && $b instanceof IntegerRangeType) {
+			return null;
+		}
 
 		if ($a instanceof SubtractableType) {
 			$typeWithoutSubtractedTypeA = $a->getTypeWithoutSubtractedType();


### PR DESCRIPTION
I only played a little with the code, and compared the results via blackfire. Maybe I missed something here, and we can't return `null` directly?

https://blackfire.io/profiles/compare/e4356233-ed30-49c5-8e01-2d7c163a3ef4/graph

![Bildschirmfoto von 2021-10-26 21-13-17](https://user-images.githubusercontent.com/264695/138945754-08c51d05-fef8-46e7-9176-d0fa2446c5c7.png)