### PR TITLE
Do not error when baseline is generated when all errors are fixed

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -239,11 +239,6 @@ class AnalyseCommand extends \Symfony\Component\Console\Command\Command
 		}
 
 		if ($generateBaselineFile !== null) {
-			if (!$analysisResult->hasErrors()) {
-				$inceptionResult->getStdOutput()->getStyle()->error('No errors were found during the analysis. Baseline could not be generated.');
-
-				return $inceptionResult->handleReturn(1);
-			}
 			if ($analysisResult->hasInternalErrors()) {
 				$inceptionResult->getStdOutput()->getStyle()->error('An internal error occurred. Baseline could not be generated. Re-run PHPStan without --generate-baseline to see what\'s going on.');
 


### PR DESCRIPTION
I'm not sure if there is more needed. When I updated https://github.com/Jan0707/phpstan-prophecy/pull/266 to phpstan 1.0 I found out after I fixed all errors phpstan will error that it can not update the baseline when there are 0 errors. I think it would great if it update the baseline with an empty array and so not exit 1 when there are no errors found.