### PR TITLE
call_user_func_array support named arguments

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -25,6 +25,7 @@ return [
 		'bcdiv' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],
+		'call_user_func_array' => ['mixed', 'function'=>'callable', 'parameters'=>'array<int|string,mixed>'],
 		'com_load_typelib' => ['bool', 'typelib_name'=>'string', 'case_insensitive='=>'true'],
 		'count_chars' => ['array<int,int>|string', 'input'=>'string', 'mode='=>'int'],
 		'date_add' => ['DateTime', 'object'=>'DateTime', 'interval'=>'DateInterval'],

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -905,4 +905,19 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5861.php'], []);
 	}
 
+	public function testCallUserFuncArray(): void
+	{
+		if (PHP_VERSION_ID >= 80000) {
+			$errors = [];
+		} else {
+			$errors = [
+				[
+					'Parameter #2 $parameters of function call_user_func_array expects array<int, mixed>, array<string, array<string, int>> given.',
+					3,
+				],
+			];
+		}
+		$this->analyse([__DIR__ . '/data/call-user-func-array.php'], $errors);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/call-user-func-array.php
+++ b/tests/PHPStan/Rules/Functions/data/call-user-func-array.php
@@ -1,0 +1,3 @@
+<?php
+
+call_user_func_array('array_merge', ['foo' => ['bar' => 2]]);


### PR DESCRIPTION
Relates to https://github.com/phpstan/phpstan/issues/5934

note: this only updates the signature map to allow named arguments, but does not have rules to verify the arguments match the parameters of the called function or method. That can go here or as a follow-up. Right now PHPStan returns an error when using named parameters.