### PR TITLE
Narrow the type for the `$callback` parameter of `preg_replace_callback()`

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8838,7 +8838,7 @@ return [
 'preg_match_all' => ['int|false|null', 'pattern'=>'string', 'subject'=>'string', '&w_subpatterns='=>'array', 'flags='=>'int', 'offset='=>'int'],
 'preg_quote' => ['string', 'str'=>'string', 'delim_char='=>'string'],
 'preg_replace' => ['string|array|null', 'regex'=>'string|array', 'replace'=>'string|array', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
-'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
+'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable(array<int|string, string>):string', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
 'preg_replace_callback_array' => ['string|array|null', 'pattern'=>'array<string,callable>', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
 'preg_split' => ['array<int, string>|false', 'pattern'=>'string', 'subject'=>'string', 'limit='=>'?int', 'flags='=>'int'],
 'prev' => ['mixed', '&rw_array_arg'=>'array|object'],

--- a/resources/functionMap_php74delta.php
+++ b/resources/functionMap_php74delta.php
@@ -43,7 +43,7 @@ return [
 		'password_algos' => ['array<int, string>'],
 		'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'string|null', 'options='=>'array'],
 		'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'string|null', 'options='=>'array'],
-		'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int', 'flags='=>'int'],
+		'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable(array<int|string, string>):string', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int', 'flags='=>'int'],
 		'preg_replace_callback_array' => ['string|array|null', 'pattern'=>'array<string,callable>', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int', 'flags='=>'int'],
 		'sapi_windows_set_ctrl_handler' => ['bool', 'callable'=>'callable(int):void', 'add='=>'bool'],
 		'ReflectionProperty::getType' => ['?ReflectionType'],

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -628,6 +628,28 @@ class CallToFunctionParametersRuleTest extends \PHPStan\Testing\RuleTestCase
 		]);
 	}
 
+	public function testPregReplaceCallback(): void
+	{
+		$this->analyse([__DIR__ . '/data/preg_replace_callback.php'], [
+			[
+				'Parameter #2 $callback of function preg_replace_callback expects callable(array<int|string, string>): string, Closure(string): string given.',
+				6,
+			],
+			[
+				'Parameter #2 $callback of function preg_replace_callback expects callable(array<int|string, string>): string, Closure(string): string given.',
+				13,
+			],
+			[
+				'Parameter #2 $callback of function preg_replace_callback expects callable(array<int|string, string>): string, Closure(array): void given.',
+				20,
+			],
+			[
+				'Parameter #2 $callback of function preg_replace_callback expects callable(array<int|string, string>): string, Closure(): void given.',
+				25,
+			],
+		]);
+	}
+
 	public function testUasortCallback(): void
 	{
 		$this->analyse([__DIR__ . '/data/uasort.php'], [

--- a/tests/PHPStan/Rules/Functions/data/preg_replace_callback.php
+++ b/tests/PHPStan/Rules/Functions/data/preg_replace_callback.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+// Incorrect
+$string = preg_replace_callback(
+	'#pattern#',
+	function(string $string): string {
+		return $string;
+	},
+	'subject'
+);
+$string = preg_replace_callback(
+	'#pattern#',
+	function(string $string) {
+		return $string;
+	},
+	'subject'
+);
+$string = preg_replace_callback(
+	'#pattern#',
+	function(array $matches) {},
+	'subject'
+);
+$string = preg_replace_callback(
+	'#pattern#',
+	function() {},
+	'subject'
+);
+
+// Correct
+$string = preg_replace_callback(
+	'#pattern#',
+	function(array $matches): string {
+		return $matches[0];
+	},
+	'subject'
+);
+$string = preg_replace_callback(
+	'#pattern#',
+	function(array $matches) {
+		return $matches[0];
+	},
+	'subject'
+);
+$string = preg_replace_callback(
+	'#pattern#',
+	function() {
+		return 'Hello';
+	},
+	'subject'
+);


### PR DESCRIPTION
The `$callback` parameter of `preg_replace_callback()` should be a callable which accepts an array of strings and returns a string. Its signature can be updated to reflect this.

From https://www.php.net/manual/en/function.preg-replace-callback.php:

> A callback that will be called and passed an array of matched elements in the subject string. The callback should return the replacement string. This is the callback signature:
> ```
> handler(array $matches): string
> ```

The `$matches` parameter is of type `array<int|string, string>` because using a named capturing group results in an array element keyed by the capturing group name. Example: https://3v4l.org/bDNbd

Interestingly the callback function can also return an empty value such as `null`, `false`, or `void` and PHP doesn't complain about it, but I would consider it a bug if the callback returns anything other than a string. This might warrant further discussion in case there's a common use case I've not considered.
