### PR TITLE
Read parameter default values from php8-stubs

### DIFF
--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -64,6 +64,7 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 				TypehintHelper::decideTypeFromReflection($nativeParameters[$i]->getType()),
 				$parameter->passedByReference(),
 				$parameter->isVariadic(),
+				$parameter->getDefaultValue(),
 			);
 		}
 

--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -59,7 +59,7 @@ class NativeFunctionReflectionProvider
 				null,
 				array_map(static function (ParameterSignature $parameterSignature) use ($lowerCasedFunctionName, $phpDoc): NativeParameterReflection {
 					$type = $parameterSignature->getType();
-					$defaultValue = null;
+					$defaultValue = $parameterSignature->getDefaultValue();
 
 					$phpDocType = null;
 					if ($phpDoc !== null) {

--- a/src/Reflection/SignatureMap/ParameterSignature.php
+++ b/src/Reflection/SignatureMap/ParameterSignature.php
@@ -15,6 +15,7 @@ class ParameterSignature
 		private Type $nativeType,
 		private PassedByReference $passedByReference,
 		private bool $variadic,
+		private ?Type $defaultValue,
 	)
 	{
 	}
@@ -47,6 +48,11 @@ class ParameterSignature
 	public function isVariadic(): bool
 	{
 		return $this->variadic;
+	}
+
+	public function getDefaultValue(): ?Type
+	{
+		return $this->defaultValue;
 	}
 
 }

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -199,6 +199,7 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 				$nativeParameterType,
 				$nativeParameter->passedByReference()->yes() ? $functionMapParameter->passedByReference() : $nativeParameter->passedByReference(),
 				$nativeParameter->isVariadic(),
+				$nativeParameter->getDefaultValue(),
 			);
 		}
 
@@ -288,6 +289,12 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 				throw new ShouldNotHappenException();
 			}
 			$parameterType = ParserNodeTypeToPHPStanType::resolve($param->type, null);
+
+			$defaultType = null;
+			if ($param->default !== null) {
+				$defaultType = ParserNodeTypeToPHPStanType::resolveParameterDefaultType($param->default);
+			}
+
 			$parameters[] = new ParameterSignature(
 				$name->name,
 				$param->default !== null || $param->variadic,
@@ -295,6 +302,7 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 				$parameterType,
 				$param->byRef ? PassedByReference::createCreatesNewVariable() : PassedByReference::createNo(),
 				$param->variadic,
+				$defaultType,
 			);
 
 			$variadic = $variadic || $param->variadic;

--- a/src/Reflection/SignatureMap/SignatureMapParser.php
+++ b/src/Reflection/SignatureMap/SignatureMapParser.php
@@ -71,6 +71,7 @@ class SignatureMapParser
 				new MixedType(),
 				$passedByReference,
 				$isVariadic,
+				null, // the functionMap does not provide default values
 			);
 		}
 

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -46,7 +46,7 @@ class ParserNodeTypeToPHPStanType
 			if ($type->name instanceof Identifier) {
 				$constantName = $type->name->name;
 				if (!($type->class instanceof Name)) {
-					throw new \PHPStan\ShouldNotHappenException();
+					throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 				}
 
 				$constantClass = (string) $type->class;
@@ -59,7 +59,7 @@ class ParserNodeTypeToPHPStanType
 				return $constantClassType->getConstant($constantName)->getValueType();
 			}
 
-			throw new \PHPStan\ShouldNotHappenException();
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 		} elseif ($type instanceof String_ || $type instanceof LNumber || $type instanceof DNumber) {
 			return ConstantTypeHelper::getTypeFromValue($type->value);
 		} elseif ($type instanceof Array_) {
@@ -84,7 +84,7 @@ class ParserNodeTypeToPHPStanType
 			$expr = $type->expr;
 
 			if (!($expr instanceof LNumber || $expr instanceof DNumber)) {
-				throw new \PHPStan\ShouldNotHappenException();
+				throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 			}
 
 			$type = self::resolveParameterDefaultType($expr);
@@ -97,7 +97,7 @@ class ParserNodeTypeToPHPStanType
 				}
 			}
 
-			throw new \PHPStan\ShouldNotHappenException();
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 		} elseif ($type instanceof BitwiseOr || $type instanceof BitwiseAnd) {
 
 			if ($type->left instanceof ClassConstFetch && $type->right instanceof ClassConstFetch) {
@@ -112,10 +112,10 @@ class ParserNodeTypeToPHPStanType
 				}
 			}
 
-			throw new \PHPStan\ShouldNotHappenException();
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 		}
 
-		throw new \PHPStan\ShouldNotHappenException();
+		throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 	}
 
 	/**
@@ -165,7 +165,7 @@ class ParserNodeTypeToPHPStanType
 			return TypeCombinator::intersect(...$types);
 
 		} elseif (!$type instanceof Identifier) {
-			throw new ShouldNotHappenException(get_class($type));
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
 		}
 
 		$type = $type->name;

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -116,7 +116,7 @@ class ParserNodeTypeToPHPStanType
 			return new ErrorType();
 		}
 
-		if ($type) {
+		if ($type !== null) {
 			throw new ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 		}
 		throw new ShouldNotHappenException('Type cannot be null');

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -116,7 +116,10 @@ class ParserNodeTypeToPHPStanType
 			return new ErrorType();
 		}
 
-		throw new ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
+		if ($type) {
+			throw new ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
+		}
+		throw new ShouldNotHappenException('Type cannot be null');
 	}
 
 	/**

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -112,8 +112,9 @@ class ParserNodeTypeToPHPStanType
 				return new ConstantIntegerType($left->getValue() & $right->getValue());
 			}
 
+			throw new ShouldNotHappenException('Unable to resolve bitwise operation: '. json_encode($type->jsonSerialize()));
 			// unresolvable constant, e.g. unknown or class not found
-			return new ErrorType();
+//			return new ErrorType();
 		}
 
 		throw new ShouldNotHappenException('Type cannot be null');

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -30,7 +30,7 @@ use function strtolower;
 class ParserNodeTypeToPHPStanType
 {
 
-	public static function resolveParameterDefaultType(?Expr $type): Type
+	public static function resolveParameterDefaultType(Expr $type): Type
 	{
 		if ($type instanceof ConstFetch) {
 			$constName = (string) $type->name;
@@ -116,9 +116,6 @@ class ParserNodeTypeToPHPStanType
 			return new ErrorType();
 		}
 
-		if ($type !== null) {
-			throw new ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
-		}
 		throw new ShouldNotHappenException('Type cannot be null');
 	}
 

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -46,7 +46,7 @@ class ParserNodeTypeToPHPStanType
 			if ($type->name instanceof Identifier) {
 				$constantName = $type->name->name;
 				if (!($type->class instanceof Name)) {
-					throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+					throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 				}
 
 				$constantClass = (string) $type->class;
@@ -59,7 +59,7 @@ class ParserNodeTypeToPHPStanType
 				return $constantClassType->getConstant($constantName)->getValueType();
 			}
 
-			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 		} elseif ($type instanceof String_ || $type instanceof LNumber || $type instanceof DNumber) {
 			return ConstantTypeHelper::getTypeFromValue($type->value);
 		} elseif ($type instanceof Array_) {
@@ -84,7 +84,7 @@ class ParserNodeTypeToPHPStanType
 			$expr = $type->expr;
 
 			if (!($expr instanceof LNumber || $expr instanceof DNumber)) {
-				throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+				throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 			}
 
 			$type = self::resolveParameterDefaultType($expr);
@@ -97,7 +97,7 @@ class ParserNodeTypeToPHPStanType
 				}
 			}
 
-			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 		} elseif ($type instanceof BitwiseOr || $type instanceof BitwiseAnd) {
 
 			if ($type->left instanceof ClassConstFetch && $type->right instanceof ClassConstFetch) {
@@ -112,10 +112,10 @@ class ParserNodeTypeToPHPStanType
 				}
 			}
 
-			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s, left %s, right %s', get_class($type), get_class($type->left), get_class($type->right)));
 		}
 
-		throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+		throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 	}
 
 	/**
@@ -165,7 +165,7 @@ class ParserNodeTypeToPHPStanType
 			return TypeCombinator::intersect(...$types);
 
 		} elseif (!$type instanceof Identifier) {
-			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected typ %s', get_class($type)));
+			throw new \PHPStan\ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));
 		}
 
 		$type = $type->name;

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -112,7 +112,7 @@ class ParserNodeTypeToPHPStanType
 				return new ConstantIntegerType($left->getValue() & $right->getValue());
 			}
 
-			throw new ShouldNotHappenException('Unable to resolve bitwise operation: '. json_encode($type->jsonSerialize()));
+			throw new ShouldNotHappenException('Unable to resolve bitwise operation: '. json_encode($type));
 			// unresolvable constant, e.g. unknown or class not found
 //			return new ErrorType();
 		}

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -112,7 +112,8 @@ class ParserNodeTypeToPHPStanType
 				return new ConstantIntegerType($left->getValue() & $right->getValue());
 			}
 
-			throw new ShouldNotHappenException(sprintf('Unexpected type %s, left %s, right %s', get_class($type), get_class($left), get_class($right)));
+			// unresolvable constant, e.g. unknown or class not found
+			return new ErrorType();
 		}
 
 		throw new ShouldNotHappenException(sprintf('Unexpected type %s', get_class($type)));

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -106,8 +106,15 @@ class ParserNodeTypeToPHPStanType
 			$left = self::resolveParameterDefaultType($type->left);
 			$right = self::resolveParameterDefaultType($type->right);
 
-			if ($left instanceof ConstantIntegerType && $right instanceof ConstantIntegerType ||
-				$left instanceof ConstantStringType && $right instanceof ConstantStringType)
+			if ($left instanceof ConstantStringType && $right instanceof ConstantStringType)
+			{
+				if ($type instanceof BitwiseOr) {
+					return new ConstantIntegerType($left->getValue() | $right->getValue());
+				}
+				return new ConstantIntegerType($left->getValue() & $right->getValue());
+			}
+			
+			if ($left instanceof ConstantIntegerType && $right instanceof ConstantIntegerType)
 			{
 				if ($type instanceof BitwiseOr) {
 					return new ConstantIntegerType($left->getValue() | $right->getValue());

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -48,6 +48,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'fields',
@@ -56,6 +57,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'delimiter',
@@ -64,6 +66,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'enclosure',
@@ -72,6 +75,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'escape_char',
@@ -80,6 +84,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 					],
 					new IntegerType(),
@@ -99,6 +104,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 					],
 					new BooleanType(),
@@ -118,6 +124,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createReadsArgument(),
 							false,
+							null,
 						),
 					],
 					new BooleanType(),
@@ -140,6 +147,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'out',
@@ -148,6 +156,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createCreatesNewVariable(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'notext',
@@ -156,6 +165,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 					],
 					new BooleanType(),
@@ -199,6 +209,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'arr2',
@@ -207,6 +218,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'...',
@@ -215,6 +227,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							true,
+							null,
 						),
 					],
 					new ArrayType(new MixedType(), new MixedType()),
@@ -234,6 +247,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'event',
@@ -242,6 +256,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'...',
@@ -250,6 +265,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							true,
+							null,
 						),
 					],
 					new ResourceType(),
@@ -269,6 +285,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'args',
@@ -277,6 +294,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							true,
+							null,
 						),
 					],
 					new StringType(),
@@ -296,6 +314,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'args',
@@ -304,6 +323,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							true,
+							null,
 						),
 					],
 					new StringType(),
@@ -333,6 +353,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createNo(),
 							false,
+							null,
 						),
 					],
 					new StaticType($reflectionProvider->getClass(DateTime::class)),
@@ -352,6 +373,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createReadsArgument(),
 							false,
+							null,
 						),
 						new ParameterSignature(
 							'strings',
@@ -360,6 +382,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 							new MixedType(),
 							PassedByReference::createReadsArgument(),
 							true,
+							null,
 						),
 					],
 					new BooleanType(),

--- a/tests/PHPStan/Type/ParserNodeTypeToPHPStanTypeTest.php
+++ b/tests/PHPStan/Type/ParserNodeTypeToPHPStanTypeTest.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PDO;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\BinaryOp\BitwiseAnd;
+use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\UnaryMinus;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use function count;
+use function get_defined_functions;
+
+class ParserNodeTypeToPHPStanTypeTest extends PHPStanTestCase
+{
+
+	public function dataParameterDefaults(): array
+	{
+		return [
+			[
+				new ClassConstFetch(new FullyQualified('PDO'), 'PARAM_STR'),
+				new ConstantIntegerType(PDO::PARAM_STR),
+			],
+			[
+				new ConstFetch(new Name('true')),
+				new ConstantBooleanType(true),
+			],
+			[
+				new ConstFetch(new Name('false')),
+				new ConstantBooleanType(false),
+			],
+			[
+				new ConstFetch(new Name('null')),
+				new NullType(),
+			],
+			[
+				new String_('123'),
+				new ConstantStringType('123'),
+			],
+			[
+				new LNumber(123),
+				new ConstantIntegerType(123),
+			],
+			[
+				new DNumber(123.12),
+				new ConstantFloatType(123.12),
+			],
+			[
+				new UnaryMinus(new LNumber(123)),
+				new ConstantIntegerType(-123),
+			],
+			[
+				new UnaryMinus(new DNumber(123.12)),
+				new ConstantFloatType(-123.12),
+			],
+			[
+				new BitwiseOr(
+					new ClassConstFetch(new FullyQualified('PDO'), 'PARAM_STR'),
+					new ClassConstFetch(new FullyQualified('PDO'), 'PARAM_INT'),
+				),
+				new ConstantIntegerType(PDO::PARAM_STR | PDO::PARAM_INT),
+			],
+			[
+				new BitwiseAnd(
+					new ClassConstFetch(new FullyQualified('PDO'), 'PARAM_STR'),
+					new ClassConstFetch(new FullyQualified('PDO'), 'PARAM_INT'),
+				),
+				new ConstantIntegerType(PDO::PARAM_STR & PDO::PARAM_INT),
+			],
+			[
+				new Array_([
+					new ArrayItem(new LNumber(3)),
+					new ArrayItem(new LNumber(7)),
+				]),
+				new ConstantArrayType(
+					[
+						new ConstantIntegerType(0),
+						new ConstantIntegerType(1),
+					],
+					[
+						new ConstantIntegerType(3),
+						new ConstantIntegerType(7),
+					],
+				),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataParameterDefaults
+	 */
+	public function testParameterDefaultType(Expr $expr, Type $expectedType): void
+	{
+		$actualType = ParserNodeTypeToPHPStanType::resolveParameterDefaultType($expr);
+
+		$this->assertSame(
+			$expectedType->describe(VerbosityLevel::precise()),
+			$actualType->describe(VerbosityLevel::precise()),
+		);
+	}
+
+	public function testAllDefinedParameterDefaultsAreParseble(): void
+	{
+		$reflectionProvider = $this->createReflectionProvider();
+
+		$allFunctions = get_defined_functions();
+		foreach (['internal', 'user'] as $functionType) {
+			foreach ($allFunctions[$functionType] as $functionName) {
+				$function = new Name($functionName);
+				if (!$reflectionProvider->hasFunction($function, null)) {
+					continue;
+				}
+
+				$reflectionProvider->getFunction($function, null);
+			}
+		}
+
+		// when we reach this assertion, all defined functions could be reflected without exceptions
+		$this->assertTrue(count($allFunctions) > 0);
+	}
+
+}


### PR DESCRIPTION
Added support for reading parameter default values from JetBrains/phpstorm-stubs files as requested in https://github.com/phpstan/phpstan-src/pull/750/files#r745440887

Just expanded existing singnature tests with expected-default-param-values and also added a few new cases which the existing data did not cover yet.