### PR TITLE
Support 'literal-string' with Encapsed Strings

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1459,13 +1459,26 @@ class MutatingScope implements Scope
 					continue;
 				}
 
+				$isNonEmpty = false;
+				$isLiteralString = true;
 				foreach ($parts as $partType) {
 					if ($partType->isNonEmptyString()->yes()) {
-						return new IntersectionType([
-							new StringType(),
-							new AccessoryNonEmptyStringType(),
-						]);
+						$isNonEmpty = true;
 					}
+					if (!$partType->isLiteralString()->yes()) {
+						$isLiteralString = false;
+					}
+				}
+
+				$accessoryTypes = [];
+				if ($isNonEmpty === true) {
+					$accessoryTypes[] = new AccessoryNonEmptyStringType();
+				}
+				if ($isLiteralString === true) {
+					$accessoryTypes[] = new AccessoryLiteralStringType();
+				}
+				if (count($accessoryTypes) > 0) {
+					return new IntersectionType([new StringType(), ...$accessoryTypes]);
 				}
 
 				return new StringType();

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1478,7 +1478,8 @@ class MutatingScope implements Scope
 					$accessoryTypes[] = new AccessoryLiteralStringType();
 				}
 				if (count($accessoryTypes) > 0) {
-					return new IntersectionType([new StringType(), ...$accessoryTypes]);
+					$accessoryTypes[] = new StringType();
+					return new IntersectionType($accessoryTypes);
 				}
 
 				return new StringType();

--- a/tests/PHPStan/Analyser/data/literal-string.php
+++ b/tests/PHPStan/Analyser/data/literal-string.php
@@ -15,6 +15,8 @@ class Foo
 		assertType('literal-string', '' . $literalString);
 		assertType('literal-string&non-empty-string', $literalString . 'foo');
 		assertType('literal-string&non-empty-string', 'foo' . $literalString);
+		assertType('literal-string&non-empty-string', "foo ${literalString}");
+		assertType('literal-string&non-empty-string', "${literalString} foo");
 		assertType('string', $string . '');
 		assertType('string', '' . $string);
 		assertType('string', $literalString . $string);


### PR DESCRIPTION
Regarding [Issue #5994](https://github.com/phpstan/phpstan/issues/5994).

This allows a developer to write `"foo {$literal}"`, and it be considered a `literal-string`.

I've added 2 tests, and while they pass (along with all the others from phpunit/paratest), I'm not familiar with the whole process, so I might have missed some steps, or coding styles (feel free to rewrite/discard).