### PR TITLE
Acknowledge that array<string, something> may still have integer keys

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -180,7 +180,7 @@ class ArrayType implements Type
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
 		if (!$keyType->isNumericString()->no()) {
-			return TypeCombinator::union(new IntegerType, $keyType);
+			return TypeCombinator::union(new IntegerType(), $keyType);
 		}
 
 		return $keyType;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -176,7 +176,7 @@ class ArrayType implements Type
 		if ($keyType instanceof MixedType && !$keyType instanceof TemplateMixedType) {
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
-		if ($keyType instanceof StrictMixedType) {
+		if ($keyType instanceof StrictMixedType || $keyType instanceof StringType) {
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
 

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -179,7 +179,7 @@ class ArrayType implements Type
 		if ($keyType instanceof StrictMixedType) {
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
-		if ($keyType instanceof StringType) {
+		if (!$keyType->isNumericString()->no()) {
 			return new UnionType([new IntegerType, $keyType]);
 		}
 

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -176,8 +176,11 @@ class ArrayType implements Type
 		if ($keyType instanceof MixedType && !$keyType instanceof TemplateMixedType) {
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
-		if ($keyType instanceof StrictMixedType || $keyType instanceof StringType) {
-			return new BenevolentUnionType([new IntegerType(), new StringType()]);
+		if ($keyType instanceof StrictMixedType) {
+			return new UnionType([new IntegerType(), new StringType()]);
+		}
+		if ($keyType instanceof StringType) {
+			return new UnionType([new IntegerType, $keyType]);
 		}
 
 		return $keyType;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -177,7 +177,7 @@ class ArrayType implements Type
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
 		if ($keyType instanceof StrictMixedType) {
-			return new UnionType([new IntegerType(), new StringType()]);
+			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
 		if ($keyType instanceof StringType) {
 			return new UnionType([new IntegerType, $keyType]);

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -180,7 +180,7 @@ class ArrayType implements Type
 			return new BenevolentUnionType([new IntegerType(), new StringType()]);
 		}
 		if (!$keyType->isNumericString()->no()) {
-			return new UnionType([new IntegerType, $keyType]);
+			return TypeCombinator::union(new IntegerType, $keyType);
 		}
 
 		return $keyType;


### PR DESCRIPTION
This "feature" is extremely annoying to me, more so because PHPStan will complain if I cast a key that came from iterating over an `array<string, something>`.

Personally, I think this should _not_ be benevolent at all - it's bit me on the ass more times than I can count, and I would much appreciate if PHPStan reported it properly.
But in keeping with the rest of the code, and to just shut it up about useless casts, I opted for the BUT.

Opening this to get CI feedback since it's a pain to run the tests on Windows.