### PR TITLE
Added FunctionTypeSpecifyingExtension for `array_is_list`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1397,6 +1397,11 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
+		class: PHPStan\Type\Php\ArrayIsListFunctionTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
+
+	-
 		class: PHPStan\Type\Php\JsonThrowOnErrorDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -10,12 +10,14 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
@@ -76,6 +78,19 @@ class ImpossibleCheckTypeHelper
 					'interface_exists',
 					'trait_exists',
 				], true)) {
+					return null;
+				}
+				if ($functionName === 'array_is_list' && count($node->getArgs()) === 1) {
+					$arrayValue = $scope->getType($node->getArgs()[0]->value);
+
+					if (!$arrayValue instanceof ArrayType) {
+						return null;
+					}
+
+					if ((new StringType())->isSuperTypeOf($arrayValue->getKeyType())->yes()) {
+						return false;
+					}
+
 					return null;
 				}
 				if (in_array($functionName, ['count', 'sizeof'], true)) {

--- a/src/Type/Php/ArrayIsListFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayIsListFunctionTypeSpecifyingExtension.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\IntegerType;
+
+class ArrayIsListFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private TypeSpecifier $typeSpecifier;
+
+	public function isFunctionSupported(
+		FunctionReflection $functionReflection,
+		FuncCall $node,
+		TypeSpecifierContext $context
+	): bool
+	{
+		return strtolower($functionReflection->getName()) === 'array_is_list'
+			&& !$context->null();
+	}
+
+	public function specifyTypes(
+		FunctionReflection $functionReflection,
+		FuncCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes
+	{
+		if (!isset($node->getArgs()[0])) {
+			return new SpecifiedTypes();
+		}
+
+		$argType = $scope->getType($node->getArgs()[0]->value);
+
+		if (!$argType instanceof ArrayType) {
+			return new SpecifiedTypes();
+		}
+
+		return $this->typeSpecifier->create($node->getArgs()[0]->value, new ArrayType(new IntegerType(), $argType->getItemType()), $context, false, $scope);
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -555,6 +555,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/first-class-callables.php');
 		}
 
+		if (PHP_VERSION_ID >= 80100) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-is-list-type-specifying.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
 	}
 

--- a/tests/PHPStan/Analyser/data/array-is-list-type-specifying.php
+++ b/tests/PHPStan/Analyser/data/array-is-list-type-specifying.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ArrayIsList;
+
+use function PHPStan\Testing\assertType;
+
+function foo(array $foo) {
+	if (array_is_list($foo)) {
+        assertType('array<int, mixed>', $foo);
+    } else {
+		assertType('array', $foo);
+	}
+}
+
+$bar = [1, 2, 3];
+
+if (array_is_list($bar)) {
+    assertType('array{1, 2, 3}', $bar);
+} else {
+	assertType('*NEVER*', $bar);
+}
+
+/** @var array<int|string, mixed> $foo */
+
+if (array_is_list($foo)) {
+    assertType('array<int, mixed>', $foo);
+} else {
+	assertType('array<int|string, mixed>', $foo);
+}
+
+$baz = [];
+
+if (array_is_list($baz)) {
+    assertType('array{}', $baz);
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -238,6 +238,14 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends \PHPStan\Testing\RuleTestC
 					'Call to function property_exists() with CheckTypeFunctionCall\Bug2221 and \'foo\' will always evaluate to true.',
 					786,
 				],
+				[
+					'Call to function array_is_list() with array<string, int> will always evaluate to false.',
+					857,
+				],
+				[
+					"Call to function array_is_list() with array{foo: 'bar', bar: 'baz'} will always evaluate to false.",
+					884,
+				],
 			]
 		);
 	}
@@ -337,6 +345,14 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends \PHPStan\Testing\RuleTestC
 				[
 					'Call to function is_numeric() with \'blabla\' will always evaluate to false.',
 					693,
+				],
+				[
+					'Call to function array_is_list() with array<string, int> will always evaluate to false.',
+					857,
+				],
+				[
+					"Call to function array_is_list() with array{foo: 'bar', bar: 'baz'} will always evaluate to false.",
+					884,
 				],
 			]
 		);

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -845,3 +845,48 @@ class InArray2
 	}
 
 }
+
+class ArrayIsList
+{
+
+	/**
+	 * @param array<string, int> $stringKeyedArray
+	 */
+	public function doFoo(array $stringKeyedArray)
+	{
+		if (array_is_list($stringKeyedArray)) {
+
+		}
+	}
+
+	/**
+	 * @param array<int> $mixedArray
+	 */
+	public function doBar(array $mixedArray)
+	{
+		if (array_is_list($mixedArray)) {
+			// Fine
+		}
+	}
+
+	/**
+	 * @param array<array-key, int> $arrayKeyedInts
+	 */
+	public function doBaz(array $arrayKeyedInts)
+	{
+		if (array_is_list($arrayKeyedInts)) {
+			// Fine
+		}
+	}
+
+	public function doBax()
+	{
+		if (array_is_list(['foo' => 'bar', 'bar' => 'baz'])) {
+
+		}
+
+		if (array_is_list(['foo', 'foo' => 'bar', 'bar' => 'baz'])) {
+			// Fine
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new `FunctionTypeSpecifyingExtension` for PHP 8.1's  `array_is_list` function.

I'm not sure if the tests cover every case that it should cover. If you request I can add more.