### PR TITLE
The array returned by `array_count_values()` can never contain a zero

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -262,7 +262,7 @@ return [
 'array_chunk' => ['array[]', 'input'=>'array', 'size'=>'int', 'preserve_keys='=>'bool'],
 'array_column' => ['array', 'array'=>'array', 'column_key'=>'mixed', 'index_key='=>'mixed'],
 'array_combine' => ['array|false', 'keys'=>'array', 'values'=>'array'],
-'array_count_values' => ['array<0|positive-int>', 'input'=>'array'],
+'array_count_values' => ['array<positive-int>', 'input'=>'array'],
 'array_diff' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],
 'array_diff_assoc' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],
 'array_diff_key' => ['array', 'arr1'=>'array', 'arr2'=>'array', '...args='=>'array'],


### PR DESCRIPTION
This function counts the values in an array. There can never be a frequency of zero.