### PR TITLE
Literal string concat with scalars

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1040,6 +1040,7 @@ class MutatingScope implements Scope
 
 			$leftStringType = $this->getType($left)->toString();
 			$rightStringType = $this->getType($right)->toString();
+
 			if (TypeCombinator::union(
 				$leftStringType,
 				$rightStringType
@@ -1059,12 +1060,27 @@ class MutatingScope implements Scope
 				return $leftStringType->append($rightStringType);
 			}
 
-			$accessoryTypes = [];
+			$isLiteralString = false;
+			$isNonEmpty = false;
 			if ($leftStringType->isNonEmptyString()->or($rightStringType->isNonEmptyString())->yes()) {
-				$accessoryTypes[] = new AccessoryNonEmptyStringType();
+				$isNonEmpty = true;
+			}
+			if ($leftStringType->isLiteralString()->and($rightStringType->isLiteralString())->yes()) {
+				$isLiteralString = true;
 			}
 
-			if ($leftStringType->isLiteralString()->and($rightStringType->isLiteralString())->yes()) {
+			if ($leftStringType->isLiteralString()->yes() && $rightStringType->isNumericString()->yes()) {
+				$isLiteralString = true;
+			}
+			if ($rightStringType->isLiteralString()->yes() && $leftStringType->isNumericString()->yes()) {
+				$isLiteralString = true;
+			}
+
+			$accessoryTypes = [];
+			if ($isNonEmpty) {
+				$accessoryTypes[] = new AccessoryNonEmptyStringType();
+			}
+			if ($isLiteralString) {
 				$accessoryTypes[] = new AccessoryLiteralStringType();
 			}
 

--- a/tests/PHPStan/Analyser/data/literal-string.php
+++ b/tests/PHPStan/Analyser/data/literal-string.php
@@ -51,4 +51,24 @@ class Foo
 		assertType('string', $string);
 	}
 
+	/**
+	 * @param string $s
+	 * @param literal-string $ls
+	 * @param numeric-string $ns
+	 * @param int $i
+	 * @param float $f
+	 * @param bool $b
+	 */
+	public function scalarConcat($s, $ls, $ns, $i, $f, $b): void
+	{
+		$literal = "hello";
+
+		assertType("non-empty-string", $literal . $s);
+		assertType("literal-string&non-empty-string", $literal . $ls);
+		assertType("literal-string&non-empty-string", $literal . $ns);
+
+		assertType("literal-string&non-empty-string", $literal . $i);
+		assertType("literal-string&non-empty-string", $literal . $f);
+		assertType("literal-string&non-empty-string", $literal . $b);
+	}
 }

--- a/tests/PHPStan/Analyser/data/literal-string.php
+++ b/tests/PHPStan/Analyser/data/literal-string.php
@@ -66,9 +66,15 @@ class Foo
 		assertType("non-empty-string", $literal . $s);
 		assertType("literal-string&non-empty-string", $literal . $ls);
 		assertType("literal-string&non-empty-string", $literal . $ns);
+		assertType("non-empty-string", $s . $literal);
+		assertType("literal-string&non-empty-string", $ls . $literal);
+		assertType("literal-string&non-empty-string", $ns . $literal);
 
 		assertType("literal-string&non-empty-string", $literal . $i);
 		assertType("literal-string&non-empty-string", $literal . $f);
 		assertType("literal-string&non-empty-string", $literal . $b);
+		assertType("literal-string&non-empty-string", $i . $literal);
+		assertType("literal-string&non-empty-string", $f . $literal);
+		assertType("literal-string&non-empty-string", $b . $literal);
 	}
 }


### PR DESCRIPTION
simliar to https://github.com/phpstan/phpstan-src/pull/768 this PR improves the `literal-string`-type for string-concat cases with other scalar types

closes https://github.com/phpstan/phpstan/issues/6033