### PR TITLE
ADD: Support for @phpstan-property @phpstan-property-read and @phpstan-property-write

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -97,37 +97,43 @@ class PhpDocNodeResolver
 	{
 		$resolved = [];
 
-		foreach ($phpDocNode->getPropertyTagValues() as $tagValue) {
-			$propertyName = substr($tagValue->propertyName, 1);
-			$propertyType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
+		foreach (['@property', '@phpstan-property'] as $tagName) {
+			foreach ($phpDocNode->getPropertyTagValues($tagName) as $tagValue) {
+				$propertyName = substr($tagValue->propertyName, 1);
+				$propertyType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
 
-			$resolved[$propertyName] = new PropertyTag(
-				$propertyType,
-				true,
-				true
-			);
+				$resolved[$propertyName] = new PropertyTag(
+					$propertyType,
+					true,
+					true
+				);
+			}
 		}
 
-		foreach ($phpDocNode->getPropertyReadTagValues() as $tagValue) {
-			$propertyName = substr($tagValue->propertyName, 1);
-			$propertyType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
+		foreach (['@property-read', '@phpstan-property-read'] as $tagName) {
+			foreach ($phpDocNode->getPropertyReadTagValues($tagName) as $tagValue) {
+				$propertyName = substr($tagValue->propertyName, 1);
+				$propertyType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
 
-			$resolved[$propertyName] = new PropertyTag(
-				$propertyType,
-				true,
-				false
-			);
+				$resolved[$propertyName] = new PropertyTag(
+					$propertyType,
+					true,
+					false
+				);
+			}
 		}
 
-		foreach ($phpDocNode->getPropertyWriteTagValues() as $tagValue) {
-			$propertyName = substr($tagValue->propertyName, 1);
-			$propertyType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
+		foreach (['@property-write', '@phpstan-property-write'] as $tagName) {
+			foreach ($phpDocNode->getPropertyWriteTagValues($tagName) as $tagValue) {
+				$propertyName = substr($tagValue->propertyName, 1);
+				$propertyType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
 
-			$resolved[$propertyName] = new PropertyTag(
-				$propertyType,
-				false,
-				true
-			);
+				$resolved[$propertyName] = new PropertyTag(
+					$propertyType,
+					false,
+					true
+				);
+			}
 		}
 
 		return $resolved;

--- a/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
+++ b/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
@@ -33,6 +33,9 @@ class InvalidPHPStanDocTagRule implements \PHPStan\Rules\Rule
 		'@phpstan-impure',
 		'@phpstan-type',
 		'@phpstan-import-type',
+		'@phpstan-property',
+		'@phpstan-property-read',
+		'@phpstan-property-write',
 	];
 
 	private Lexer $phpDocLexer;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -560,6 +560,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/classPhpDocs-phpstanPropertyPrefix.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/classPhpDocs-phpstanPropertyPrefix.php
+++ b/tests/PHPStan/Analyser/data/classPhpDocs-phpstanPropertyPrefix.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ClassPhpDocsNamespace;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @property string $base
+ *
+ * @property string $foo
+ * @phpstan-property int $foo
+ *
+ * @property-read string $bar
+ * @phpstan-property-read int $bar
+ *
+ * @property-write string $baz
+ * @phpstan-property-write int $baz
+ */
+class PhpstanProperties
+{
+	public function doFoo()
+	{
+		assertType('string', $this->base);
+		assertType('int', $this->foo);
+		assertType('int', $this->bar);
+		assertType('int', $this->baz);
+	}
+}


### PR DESCRIPTION
Implements [issue 6040](https://github.com/phpstan/phpstan/issues/6040) in the PHPStan repository.

Adds support for `@phpstan-property` `@phpstan-property-read` and `@phpstan-property-write` in class declarations.