### PR TITLE
Detect deprecated methods from the interface as well.

### DIFF
--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -3,6 +3,7 @@
 namespace PHPStan\PhpDoc;
 
 use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\Tag\DeprecatedTag;
 use PHPStan\PhpDoc\Tag\MixinTag;
 use PHPStan\PhpDoc\Tag\ParamTag;
 use PHPStan\PhpDoc\Tag\ReturnTag;
@@ -189,7 +190,7 @@ class ResolvedPhpDocBlock
 		$result->mixinTags = $this->getMixinTags();
 		$result->typeAliasTags = $this->getTypeAliasTags();
 		$result->typeAliasImportTags = $this->getTypeAliasImportTags();
-		$result->deprecatedTag = $this->getDeprecatedTag();
+		$result->deprecatedTag = self::mergeDeprecatedTags($this->getDeprecatedTag(), $parents);
 		$result->isDeprecated = $result->deprecatedTag !== null;
 		$result->isInternal = $this->isInternal();
 		$result->isFinal = $this->isFinal();
@@ -631,6 +632,25 @@ class ResolvedPhpDocBlock
 		}
 
 		return self::resolveTemplateTypeInTag($parentReturnTag->toImplicit(), $phpDocBlock);
+	}
+
+	/**
+	 * @param array<int, self> $parents
+	 */
+	private static function mergeDeprecatedTags(?DeprecatedTag $deprecatedTag, array $parents): ?DeprecatedTag
+	{
+		if ($deprecatedTag !== null) {
+			return $deprecatedTag;
+		}
+		foreach ($parents as $parent) {
+			$result = $parent->getDeprecatedTag();
+			if ($result === null) {
+				continue;
+			}
+			return $result;
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -131,4 +131,11 @@ class DeprecatedAnnotationsTest extends \PHPStan\Testing\PHPStanTestCase
 		$this->assertFalse($reflectionProvider->getFunction(new Name('function_exists'), null)->isDeprecated()->yes());
 	}
 
+	public function testDeprecatedMethodsFromInterface(): void
+	{
+		$reflectionProvider = $this->createReflectionProvider();
+		$class = $reflectionProvider->getClass(\DeprecatedAnnotations\DeprecatedBar::class);
+		$this->assertTrue($class->getNativeMethod('superDeprecated')->isDeprecated()->yes());
+	}
+
 }

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-deprecated.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-deprecated.php
@@ -187,3 +187,31 @@ class DeprecatedWithMultipleTags
 	}
 
 }
+
+/**
+ * @deprecated This is totally deprecated.
+ */
+interface BarInterface
+{
+
+	/**
+	 * @deprecated This is totally deprecated.
+	 */
+	public function superDeprecated();
+
+}
+
+/**
+ * {@inheritdoc}
+ */
+class DeprecatedBar implements BarInterface
+{
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function superDeprecated()
+	{
+	}
+
+}


### PR DESCRIPTION
Based on feedback from phpstan/phpstan-deprecation-rules#49

Initial bug report on that repo: phpstan/phpstan-deprecation-rules#48