### PR TITLE
Add support for the `key-of<...>` type

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -38,7 +38,6 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\ClosureType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -507,8 +506,14 @@ class TypeNodeResolver
 				return IntegerRangeType::fromInterval($min, $max);
 			}
 		} elseif ($mainTypeName === 'key-of') {
-			if (count($genericTypes) === 1 && $genericTypes[0] instanceof ConstantArrayType) { // key-of<ValueType>
+			if (count($genericTypes) === 1) { // key-of<ValueType>
 				return $genericTypes[0]->getIterableKeyType();
+			}
+
+			return new ErrorType();
+		} elseif ($mainTypeName === 'value-of') {
+			if (count($genericTypes) === 1) { // value-of<ValueType>
+				return $genericTypes[0]->getIterableValueType();
 			}
 
 			return new ErrorType();

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -38,6 +38,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\ClosureType;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -505,6 +506,12 @@ class TypeNodeResolver
 
 				return IntegerRangeType::fromInterval($min, $max);
 			}
+		} elseif ($mainTypeName === 'key-of') {
+			if (count($genericTypes) === 1 && $genericTypes[0] instanceof ConstantArrayType) { // key-of<ValueType>
+				return $genericTypes[0]->getIterableKeyType();
+			}
+
+			return new ErrorType();
 		}
 
 		$mainType = $this->resolveIdentifierTypeNode($typeNode->type, $nameScope);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -55,6 +55,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/native-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-change-after-array-access-assignment.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/iterator_to_array.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/key-of.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/value-of.php');
 
 		if (self::$useStaticReflectionProvider || extension_loaded('ds')) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/ext-ds.php');

--- a/tests/PHPStan/Analyser/data/key-of.php
+++ b/tests/PHPStan/Analyser/data/key-of.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace KeyOfType;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public const JFK = 'jfk';
+	public const LGA = 'lga';
+
+	private const ALL = [
+		self::JFK => 'John F. Kennedy Airport',
+		self::LGA => 'La Guardia Airport',
+	];
+
+	/**
+	 * @param key-of<self::ALL> $code
+	 */
+	public static function foo(string $code): void
+	{
+		assertType('\'jfk\'|\'lga\'', $code);
+	}
+
+	/**
+	 * @param key-of<'jfk'> $code
+	 */
+	public static function bar(string $code): void
+	{
+		assertType('string', $code);
+	}
+
+	/**
+	 * @param key-of<'jfk'|'lga'> $code
+	 */
+	public static function baz(string $code): void
+	{
+		assertType('string', $code);
+	}
+}

--- a/tests/PHPStan/Analyser/data/value-of.php
+++ b/tests/PHPStan/Analyser/data/value-of.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ValueOfType;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	private const ALL = [
+		'jfk',
+		'lga',
+	];
+
+	/**
+	 * @param value-of<self::ALL> $code
+	 */
+	public static function foo(string $code): void
+	{
+		assertType('\'jfk\'|\'lga\'', $code);
+	}
+
+	/**
+	 * @param value-of<'jfk'> $code
+	 */
+	public static function bar(string $code): void
+	{
+		assertType('string', $code);
+	}
+
+	/**
+	 * @param value-of<'jfk'|'lga'> $code
+	 */
+	public static function baz(string $code): void
+	{
+		assertType('string', $code);
+	}
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -500,6 +500,14 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 				1751,
 				'See: https://phpstan.org/blog/solving-phpstan-error-unable-to-resolve-template-type',
 			],
+			[
+				'Parameter #1 $code of method Test\\KeyOfParam::foo() expects \'jfk\'|\'lga\', \'sfo\' given.',
+				1777,
+			],
+			[
+				'Parameter #1 $code of method Test\\ValueOfParam::foo() expects \'John F. Kennedy…\'|\'La Guardia Airport\', \'Newark Liberty…\' given.',
+				1802,
+			],
 		]);
 	}
 
@@ -786,6 +794,14 @@ class CallMethodsRuleTest extends \PHPStan\Testing\RuleTestCase
 				'Unable to resolve the template type T in call to method Test\InvalidReturnTypeUsingArrayTemplateTypeBound::bar()',
 				1751,
 				'See: https://phpstan.org/blog/solving-phpstan-error-unable-to-resolve-template-type',
+			],
+			[
+				'Parameter #1 $code of method Test\\KeyOfParam::foo() expects \'jfk\'|\'lga\', \'sfo\' given.',
+				1777,
+			],
+			[
+				'Parameter #1 $code of method Test\\ValueOfParam::foo() expects \'John F. Kennedy…\'|\'La Guardia Airport\', \'Newark Liberty…\' given.',
+				1802,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/data/call-methods.php
+++ b/tests/PHPStan/Rules/Methods/data/call-methods.php
@@ -1752,3 +1752,53 @@ class InvalidReturnTypeUsingArrayTemplateTypeBound
 	}
 
 }
+
+class KeyOfParam
+{
+	public const JFK = 'jfk';
+	public const LGA = 'lga';
+
+	private const ALL = [
+		self::JFK => 'John F. Kennedy Airport',
+		self::LGA => 'La Guardia Airport',
+	];
+
+	/**
+	 * @param key-of<self::ALL> $code
+	 */
+	public function foo(string $code): void
+	{
+	}
+
+	public function test(): void
+	{
+		$this->foo(KeyOfParam::JFK);
+		$this->foo('jfk');
+		$this->foo('sfo');
+	}
+}
+
+class ValueOfParam
+{
+	public const JFK = 'jfk';
+	public const LGA = 'lga';
+
+	public const ALL = [
+		self::JFK => 'John F. Kennedy Airport',
+		self::LGA => 'La Guardia Airport',
+	];
+
+	/**
+	 * @param value-of<self::ALL> $code
+	 */
+	public function foo(string $code): void
+	{
+	}
+
+	public function test(): void
+	{
+		$this->foo(ValueOfParam::ALL[ValueOfParam::JFK]);
+		$this->foo('John F. Kennedy Airport');
+		$this->foo('Newark Liberty International');
+	}
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#6084. This is my attempt at implementing the `key-of<...>` type borrowed from Psalm. However, I'm not sure where I should place the tests as I see a lot of files, but none that looks the right one. Also, Psalm tells the user precise errors when an invalid value is used as generic argument of the `key-of` type, however the `resolveGenericTypeNode()` method cannot return a `RuleError` and so I wonder how I could return a custom error message for certain cases. Any advice on these two qustions would be highly appreciated