### PR TITLE
Array unpacking support for string-keyed arrays

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1777,12 +1777,29 @@ class MutatingScope implements Scope
 				$valueType = $this->getType($arrayItem->value);
 				if ($arrayItem->unpack) {
 					if ($valueType instanceof ConstantArrayType) {
-						foreach ($valueType->getValueTypes() as $innerValueType) {
-							$arrayBuilder->setOffsetValueType(null, $innerValueType);
+						$hasStringKey = false;
+						foreach ($valueType->getKeyTypes() as $keyType) {
+							if ($keyType instanceof ConstantStringType) {
+								$hasStringKey = true;
+								break;
+							}
+						}
+
+						foreach ($valueType->getValueTypes() as $i => $innerValueType) {
+							if ($hasStringKey && $this->phpVersion->supportsArrayUnpackingWithStringKeys()) {
+								$arrayBuilder->setOffsetValueType($valueType->getKeyTypes()[$i], $innerValueType);
+							} else {
+								$arrayBuilder->setOffsetValueType(null, $innerValueType);
+							}
 						}
 					} else {
 						$arrayBuilder->degradeToGeneralArray();
-						$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType(), !$valueType->isIterableAtLeastOnce()->yes() && !$valueType->getIterableValueType()->isIterableAtLeastOnce()->yes());
+
+						if (! (new StringType())->isSuperTypeOf($valueType->getIterableKeyType())->no() && $this->phpVersion->supportsArrayUnpackingWithStringKeys()) {
+							$arrayBuilder->setOffsetValueType($valueType->getIterableKeyType(), $valueType->getIterableValueType());
+						} else {
+							$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType(), !$valueType->isIterableAtLeastOnce()->yes() && !$valueType->getIterableValueType()->isIterableAtLeastOnce()->yes());
+						}
 					}
 				} else {
 					$arrayBuilder->setOffsetValueType(

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -169,4 +169,9 @@ class PhpVersion
 		return $this->versionId >= 80100;
 	}
 
+	public function supportsArrayUnpackingWithStringKeys(): bool
+	{
+		return $this->versionId >= 80100;
+	}
+
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -537,7 +537,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5017.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5992.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6001.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5287.php');
+
+		if (PHP_VERSION_ID >= 80100) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5287-php81.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5287.php');
+		}
 
 		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5458.php');
@@ -568,6 +573,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		if (PHP_VERSION_ID >= 80100) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-is-list-type-specifying.php');
+		}
+
+		if (PHP_VERSION_ID >= 80100) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-unpacking-string-keys.php');
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');

--- a/tests/PHPStan/Analyser/data/array-spread.php
+++ b/tests/PHPStan/Analyser/data/array-spread.php
@@ -6,8 +6,8 @@ class Foo
 {
 
 	/**
-	 * @param int[] $integersArray
-	 * @param int[] $integersIterable
+	 * @param array<int, int> $integersArray
+	 * @param array<int, int> $integersIterable
 	 */
 	public function doFoo(
 		array $integersArray,

--- a/tests/PHPStan/Analyser/data/array-unpacking-string-keys.php
+++ b/tests/PHPStan/Analyser/data/array-unpacking-string-keys.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ArrayUnpackingWithStringKeys;
+
+use function PHPStan\Testing\assertType;
+
+$foo = ['a' => 0, ...['a' => 1], ...['b' => 2]];
+
+assertType('array{a: 1, b: 2}', $foo);
+
+$bar = [1, ...['a' => 1], ...['b' => 2]];
+
+assertType('array{0: 1, a: 1, b: 2}', $bar);
+
+/**
+ * @param array<string, int> $a
+ * @param array<int, int> $b
+ */
+function foo(array $a, array $b)
+{
+	$c = [...$a, ...$b];
+
+	assertType('non-empty-array<int|string, int>', $c);
+}
+
+/**
+ * @param array<array-key, int> $a
+ * @param array<int, int> $b
+ */
+function bar(array $a, array $b)
+{
+	$c = [...$a, ...$b];
+
+	assertType('non-empty-array<int>', $c);
+}
+
+/**
+ * @param array<string, int> $a
+ * @param array<string, int> $b
+ */
+function baz(array $a, array $b)
+{
+	$c = [...$a, ...$b];
+
+	assertType('non-empty-array<string, int>', $c);
+}

--- a/tests/PHPStan/Analyser/data/bug-5287-php81.php
+++ b/tests/PHPStan/Analyser/data/bug-5287-php81.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Bug5287;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param list<mixed> $arr
+ */
+function foo(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('array<int, mixed>', $arrSpread);
+}
+
+/**
+ * @param list<non-empty-array> $arr
+ */
+function foo2(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('non-empty-array<int, non-empty-array>', $arrSpread);
+}
+
+/**
+ * @param non-empty-list<string> $arr
+ */
+function foo3(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('non-empty-array<int, string>', $arrSpread);
+}
+
+/**
+ * @param non-empty-array<string, int> $arr
+ */
+function foo3(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('non-empty-array<string, int>', $arrSpread);
+}
+
+/**
+ * @param non-empty-array<mixed, bool|int> $arr
+ */
+function foo4(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('non-empty-array<int|string, bool|int>', $arrSpread);
+}
+
+/**
+ * @param array{foo: 17, bar: 19} $arr
+ */
+function bar(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('array{foo: 17, bar: 19}', $arrSpread);
+}


### PR DESCRIPTION
PHPStan didn't seem to have support for unpacking string keyed arrays: https://phpstan.org/r/e187af75-320b-4fa6-ba5a-54ceec396f42

This PR adds it only for PHP 8.1 and above.

I think my implementation may not be the best (especially the `$hasStringKey` hackery), feel free to override it or I'd be happy to change it according to suggestions 👍🏽 