### PR TITLE
added failling NeverReturnStubFileTest

### DIFF
--- a/tests/PHPStan/Analyser/NeverReturnStubFileTest.php
+++ b/tests/PHPStan/Analyser/NeverReturnStubFileTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class NeverReturnStubFileTest extends TypeInferenceTestCase
+{
+
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/never-return-stub-files.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param string $assertType
+	 * @param string $file
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/neverReturnStubFiles.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/never-return-stub-files.php
+++ b/tests/PHPStan/Analyser/data/never-return-stub-files.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace NeverReturnStubFiles;
+
+use function PHPStan\Testing\assertType;
+
+class Redirector {
+	public function gotoUrlAndExit($url)
+	{
+		exit();
+	}
+}
+
+
+class foo {
+	/**
+	 * @return no-return
+	 */
+	public function gotoUrlAndExit($url)
+	{
+		$redirect = new Redirector();
+		assertType('*NEVER*', $redirect->gotoUrlAndExit($url));
+	}
+
+	public function ifXRedirect() {
+		if (rand(0,1)) {
+			assertType('*NEVER*', $this->gotoUrlAndExit());
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/neverReturnStub.stub
+++ b/tests/PHPStan/Analyser/neverReturnStub.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace NeverReturnStubFiles;
+
+class Redirector {
+    /**
+     * @return no-return
+     */
+    public function gotoUrlAndExit($url)
+    {}
+}

--- a/tests/PHPStan/Analyser/neverReturnStubFiles.neon
+++ b/tests/PHPStan/Analyser/neverReturnStubFiles.neon
@@ -1,0 +1,3 @@
+parameters:
+	stubFiles:
+		- neverReturnStub.stub


### PR DESCRIPTION
In my real world project, I have a class-method with a `no-return`-return type:

```
<?php

class ClxProductNet_Redirector
{
    /**
     * Set a URL string for a redirect, perform redirect, and immediately exit.
     *
     * @param string $url
     *
     * @return no-return
     */
    public function gotoUrlAndExit($url)
    {
        $redirect = new Zend_Controller_Action_Helper_Redirector();
        $redirect->gotoUrlAndExit($url);
    }
}
```

this class is calling into zendframework v1 which defines
```
    /**
     * Set a URL string for a redirect, perform redirect, and immediately exit
     *
     * @param  string $url
     * @param  array  $options
     * @return void
     */
    public function gotoUrlAndExit($url, array $options = array())
    {
        $this->setGotoUrl($url, $options);
        $this->redirectAndExit();
    }
```