### PR TITLE
Spreading of general arrays should not lead to a non-empty-array

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1774,7 +1774,7 @@ class MutatingScope implements Scope
 						}
 					} else {
 						$arrayBuilder->degradeToGeneralArray();
-						$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType());
+						$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType(), true);
 					}
 				} else {
 					$arrayBuilder->setOffsetValueType(

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -105,6 +105,9 @@ class ConstantArrayTypeBuilder
 
 		$this->keyTypes[] = TypeUtils::generalizeType($offsetType, GeneralizePrecision::moreSpecific());
 		$this->valueTypes[] = $valueType;
+		if ($optional) {
+			$this->optionalKeys[] = count($this->keyTypes) - 1;
+		}
 		$this->degradeToGeneralArray = true;
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -533,6 +533,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5017.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5992.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6001.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5287.php');
 
 		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5458.php');

--- a/tests/PHPStan/Analyser/data/bug-5287.php
+++ b/tests/PHPStan/Analyser/data/bug-5287.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Bug5287;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param list<mixed> $arr
+ */
+function foo(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('array<int, mixed>', $arrSpread);
+}
+
+/**
+ * @param array{foo: 17, bar: 19} $arr
+ */
+function bar(array $arr): void
+{
+	$arrSpread = [...$arr];
+	assertType('array{17, 19}', $arrSpread);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/5287 and https://github.com/phpstan/phpstan/issues/6109

It looked like optional keys were not handled correctly in the array builder in case `degradeToGeneralArray` is set, but I'm not a 100% sure if I understood it correctly and hence this is the right fix.