### PR TITLE
Fix preg_filter function signature

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8825,7 +8825,7 @@ return [
 'Postal\Expand::expand_address' => ['string[]', 'address'=>'string', 'options='=>'array<string, mixed>'],
 'Postal\Parser::parse_address' => ['array<string,string>', 'address'=>'string', 'options='=>'array<string, string>'],
 'pow' => ['float|int', 'base'=>'int|float', 'exponent'=>'int|float'],
-'preg_filter' => ['mixed', 'regex'=>'mixed', 'replace'=>'mixed', 'subject'=>'mixed', 'limit='=>'int', '&w_count='=>'int'],
+'preg_filter' => ['string|array|null', 'regex'=>'string|array', 'replace'=>'string|array', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],	
 'preg_grep' => ['array|false', 'regex'=>'string', 'input'=>'array', 'flags='=>'int'],
 'preg_last_error' => ['int'],
 'preg_match' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_subpatterns='=>'string[]', 'flags='=>'int', 'offset='=>'int'],


### PR DESCRIPTION
`preg_filter` has had the same function signature as `preg_replace` since it was first introduced in PHP 5.3, but this has not been updated in functionMap.php.

This causes a failure on PHP <8.0 as per: https://phpstan.org/r/20453e88-edfc-4e1b-8e1f-728a9a1c7c60

#### Function signatures
preg_filter: https://github.com/php/php-src/blob/7311087cf06bf9f3d6b5863d9b54272f3d163ba9/ext/pcre/php_pcre.c#L1418-L1419
preg_replace: https://github.com/php/php-src/blob/7311087cf06bf9f3d6b5863d9b54272f3d163ba9/ext/pcre/php_pcre.c#L1402-L1403