### PR TITLE
fix: test callable array when array size is 2 only

### DIFF
--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -209,12 +209,17 @@ class DependencyResolver
 			return false;
 		}
 
-		$itemType = $scope->getType($items[0]->value);
-		if (!$itemType instanceof ConstantStringType) {
-			return false;
+		$stringTypeArray = [];
+
+		foreach ($items as $item) {
+			$itemType = $scope->getType($item);
+			if (! $itemType instanceof ConstantStringType) {
+				return false;
+			}
+			$stringTypeArray[] = $itemType->getValue();
 		}
 
-		return $itemType->isClassString();
+		return method_exists(...$stringTypeArray);
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/phpstan/phpstan/issues/6187

Thank you for your quick fix to the above issue!

I get the error when the array size is 2.

```
class HelloWorld
{
	public function hello(): void
	{
		$arr = ['piyoAlias', 'someString']; /* comment out this line, success */

		new \PiyoAlias;
	}
}
```