### PR TITLE
Allow setting error format in configuration

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -164,6 +164,7 @@ parameters:
 		- ZEND_THREAD_SAFE
 	customRulesetUsed: null
 	editorUrl: null
+	errorFormat: null
 	__validate: true
 
 extensions:
@@ -315,6 +316,7 @@ parametersSchema:
 	scanDirectories: listOf(string())
 	fixerTmpDir: string()
 	editorUrl: schema(string(), nullable())
+	errorFormat: schema(string(), nullable())
 
 	# irrelevant Nette parameters
 	debugMode: bool()

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -178,6 +178,10 @@ class AnalyseCommand extends Command
 		}
 
 		if ($errorFormat === null) {
+			$errorFormat = $inceptionResult->getContainer()->getParameter('errorFormat');
+		}
+
+		if ($errorFormat === null) {
 			$errorFormat = 'table';
 			$ciDetector = new CiDetector();
 


### PR DESCRIPTION
In my project I'm using a custom error format that I'd like to have as the default.

I need to run PHPStan with `--error-format=my-format`.

The idea of this PR is to introduce an `errorFormat` configuration option that is picked by default, and can still be overwritten with the CLI option. 

Before I fix the todo, is this something you would consider merging?

## Todo

- [ ] Fix errors
- [ ] Documentation
- [ ] Tests? 


