### PR TITLE
Skip suggesting `--memory-limit` when it's already used

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -321,9 +321,11 @@ class CommandHelper
 			$memoryLimitFileContents = FileReader::read($memoryLimitFile);
 			$errorOutput->writeLineFormatted('PHPStan crashed in the previous run probably because of excessive memory consumption.');
 			$errorOutput->writeLineFormatted(sprintf('It consumed around %s of memory.', $memoryLimitFileContents));
-			$errorOutput->writeLineFormatted('');
-			$errorOutput->writeLineFormatted('');
-			$errorOutput->writeLineFormatted('To avoid this issue, allow to use more memory with the --memory-limit option.');
+			if ($memoryLimit === null) {
+				$errorOutput->writeLineFormatted('');
+				$errorOutput->writeLineFormatted('');
+				$errorOutput->writeLineFormatted('To avoid this issue, allow to use more memory with the --memory-limit option.');
+			}
 			@unlink($memoryLimitFile);
 		}
 


### PR DESCRIPTION
When PHPStan crashes, it gives a hint to run with `--memory-limit`. But when you already do
the hint is a but useless.