### PR TITLE
Fix wrong assignation to intersection including `ArrayAccess` not being reported

### DIFF
--- a/tests/PHPStan/Rules/Arrays/OffsetAccessValueAssignmentRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/OffsetAccessValueAssignmentRuleTest.php
@@ -62,4 +62,17 @@ class OffsetAccessValueAssignmentRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRuleOnArrayAccessIntersection(): void
+	{
+		$this->analyse([__DIR__ . '/data/offset-access-value-assignment-on-array-access-intersection.php'], [
+			[
+				'ArrayAccess<int, string> does not accept int.',
+				15,
+			],
+			[
+				'ArrayAccess<int, string>&Countable&iterable<int, string> does not accept int.',
+				16,
+			],
+		]);
+	}
 }

--- a/tests/PHPStan/Rules/Arrays/data/offset-access-value-assignment-on-array-access-intersection.php
+++ b/tests/PHPStan/Rules/Arrays/data/offset-access-value-assignment-on-array-access-intersection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OffsetAccessValueAssignmentOnArrayAccessIntersection;
+
+class Foo
+{
+    /** @var \ArrayAccess<int, string> */
+    private $collection1;
+
+    /** @var \ArrayAccess<int, string>&\Countable&iterable<int, string> */
+    private $collection2;
+
+    public function foo(): void
+    {
+        $this->collection1[] = 1;
+        $this->collection2[] = 2;
+    }
+}


### PR DESCRIPTION
Ref.: https://github.com/phpstan/phpstan/issues/6184

In `OffsetAccessValueAssignmentRule.php`
```php
$resultType = $arrayType->setOffsetValueType(new MixedType(), $assignedValueType);
```
The error is reported when `$resultType` is an instance of `ErrorType`.

In the case that works, `$arrayType` is a `GenericObjectType` and calling `setOffsetValueType()` on it returns an `ErrorType`, so the issue is reported correctly.

But in the failing case, `$arrayType` is an `IntersectionType` containing the `GenericObjectType`. When calling `setOffsetValueType()`, it will internally forward the call to the inner types, pass the results (including the `ErrorType`) to `TypeCombinator::intersect()` that returns a new `IntersectionType` (without `ErrorType`), so the issue is not reported.

I don't know the codebase very well and couldn't figure out a proper fix yet. Can someone help me please?