### PR TITLE
Support ArrayAccess in AppendedArrayItemTypeRule

### DIFF
--- a/src/Rules/Arrays/AppendedArrayItemTypeRule.php
+++ b/src/Rules/Arrays/AppendedArrayItemTypeRule.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Arrays;
 
+use ArrayAccess;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
@@ -13,6 +14,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
@@ -67,7 +69,7 @@ class AppendedArrayItemTypeRule implements Rule
 		}
 
 		$assignedToType = $propertyReflection->getWritableType();
-		if (!($assignedToType instanceof ArrayType)) {
+		if (!($assignedToType instanceof ArrayType) && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($assignedToType)->yes()) {
 			return [];
 		}
 
@@ -77,7 +79,7 @@ class AppendedArrayItemTypeRule implements Rule
 			$assignedValueType = $scope->getType($node);
 		}
 
-		$itemType = $assignedToType->getItemType();
+		$itemType = $assignedToType->getIterableValueType();
 		if (!$this->ruleLevelHelper->accepts($itemType, $assignedValueType, $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($itemType, $assignedValueType);
 			return [

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -746,6 +746,15 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return new MixedType();
 		}
 
+		if ($this->isInstanceOf(ArrayAccess::class)->yes()) {
+			$tValue = GenericTypeVariableResolver::getType($this, ArrayAccess::class, 'TValue');
+			if ($tValue !== null) {
+				return $tValue;
+			}
+
+			return new MixedType();
+		}
+
 		return new ErrorType();
 	}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -713,6 +713,15 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return new MixedType();
 		}
 
+		if ($this->isInstanceOf(ArrayAccess::class)->yes()) {
+			$tKey = GenericTypeVariableResolver::getType($this, ArrayAccess::class, 'TKey');
+			if ($tKey !== null) {
+				return $tKey;
+			}
+
+			return new MixedType();
+		}
+
 		return new ErrorType();
 	}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -680,6 +680,15 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function getIterableKeyType(): Type
 	{
+		if ($this->isInstanceOf(ArrayAccess::class)->yes()) {
+			$tKey = GenericTypeVariableResolver::getType($this, ArrayAccess::class, 'TKey');
+			if ($tKey !== null) {
+				return $tKey;
+			}
+
+			return new MixedType();
+		}
+
 		$classReflection = $this->getClassReflection();
 		if ($classReflection === null) {
 			return new ErrorType();
@@ -713,20 +722,20 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return new MixedType();
 		}
 
-		if ($this->isInstanceOf(ArrayAccess::class)->yes()) {
-			$tKey = GenericTypeVariableResolver::getType($this, ArrayAccess::class, 'TKey');
-			if ($tKey !== null) {
-				return $tKey;
-			}
-
-			return new MixedType();
-		}
-
 		return new ErrorType();
 	}
 
 	public function getIterableValueType(): Type
 	{
+		if ($this->isInstanceOf(ArrayAccess::class)->yes()) {
+			$tValue = GenericTypeVariableResolver::getType($this, ArrayAccess::class, 'TValue');
+			if ($tValue !== null) {
+				return $tValue;
+			}
+
+			return new MixedType();
+		}
+
 		if ($this->isInstanceOf(Iterator::class)->yes()) {
 			return RecursionGuard::run($this, function (): Type {
 				return ParametersAcceptorSelector::selectSingle(
@@ -748,15 +757,6 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		if ($this->isInstanceOf(Traversable::class)->yes()) {
 			$tValue = GenericTypeVariableResolver::getType($this, Traversable::class, 'TValue');
-			if ($tValue !== null) {
-				return $tValue;
-			}
-
-			return new MixedType();
-		}
-
-		if ($this->isInstanceOf(ArrayAccess::class)->yes()) {
-			$tValue = GenericTypeVariableResolver::getType($this, ArrayAccess::class, 'TValue');
 			if ($tValue !== null) {
 				return $tValue;
 			}

--- a/tests/PHPStan/Analyser/data/bug-2676.php
+++ b/tests/PHPStan/Analyser/data/bug-2676.php
@@ -39,7 +39,7 @@ function (Wallet $wallet): void
 	assertType('DoctrineIntersectionTypeIsSupertypeOf\Collection&iterable<Bug2676\BankAccount>', $bankAccounts);
 
 	foreach ($bankAccounts as $key => $bankAccount) {
-		assertType('(int|string)', $key);
+		assertType('int|string|null', $key);
 		assertType('Bug2676\BankAccount', $bankAccount);
 	}
 };

--- a/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
@@ -60,15 +60,19 @@ class AppendedArrayItemTypeRuleTest extends RuleTestCase
 				],
 				[
 					'Array (ArrayAccess<int, string>) does not accept int.',
-					95,
+					99,
 				],
 				[
 					'Array (ArrayAccess<int, string>&Countable) does not accept int.',
-					96,
+					102,
 				],
 				[
 					'Array (ArrayAccess<int, string>&Countable&iterable<int, string>) does not accept int.',
-					97,
+					105,
+				],
+				[
+					'Array (SplObjectStorage<int, string>) does not accept int.',
+					108,
 				],
 			]
 		);

--- a/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
@@ -58,6 +58,18 @@ class AppendedArrayItemTypeRuleTest extends RuleTestCase
 					'Array (array<AppendedArrayItem\Lorem>) does not accept AppendedArrayItem\Baz.',
 					79,
 				],
+				[
+					'Array (ArrayAccess<int, string>) does not accept int.',
+					95,
+				],
+				[
+					'Array (ArrayAccess<int, string>&Countable) does not accept int.',
+					96,
+				],
+				[
+					'Array (ArrayAccess<int, string>&Countable&iterable<int, string>) does not accept int.',
+					97,
+				],
 			]
 		);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
+++ b/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
@@ -78,3 +78,22 @@ function (Lorem $lorem)
 {
 	$lorem->staticProperty[] = new Baz();
 };
+
+class ArrayAccess
+{
+	/** @var \ArrayAccess<int, string> */
+	private $collection1;
+
+	/** @var \ArrayAccess<int, string>&\Countable */
+	private $collection2;
+
+	/** @var \ArrayAccess<int, string>&\Countable&iterable<int, string> */
+	private $collection3;
+
+	public function doFoo()
+	{
+		$this->collection1[] = 1;
+		$this->collection2[] = 2;
+		$this->collection3[] = 3;
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
+++ b/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
@@ -90,10 +90,21 @@ class ArrayAccess
 	/** @var \ArrayAccess<int, string>&\Countable&iterable<int, string> */
 	private $collection3;
 
+	/** @var \SplObjectStorage<int, string> */
+	private $collection4;
+
 	public function doFoo()
 	{
+		$this->collection1[] = 'foo';
 		$this->collection1[] = 1;
+
+		$this->collection2[] = 'foo';
 		$this->collection2[] = 2;
+
+		$this->collection3[] = 'foo';
 		$this->collection3[] = 3;
+
+		$this->collection4[] = 'foo';
+		$this->collection4[] = 4;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6184

But I noticed too late that this is also covered by `OffsetAccessValueAssignmentRule`, so maybe https://github.com/phpstan/phpstan-src/pull/843 should be preferred when ready as it handles all offset assignments. I took a quick look but did not get far because it works quite differently and the problems are others