### PR TITLE
Remove hardcoded `TableErrorFormatter` dependency in `GithubErrorFormatter`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1789,6 +1789,7 @@ services:
 		class: PHPStan\Command\ErrorFormatter\GithubErrorFormatter
 		arguments:
 			relativePathHelper: @simpleRelativePathHelper
+			errorFormatter: @errorFormatter.table
 
 	errorFormatter.teamcity:
 		class: PHPStan\Command\ErrorFormatter\TeamcityErrorFormatter

--- a/src/Command/ErrorFormatter/GithubErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GithubErrorFormatter.php
@@ -19,20 +19,20 @@ class GithubErrorFormatter implements ErrorFormatter
 
 	private RelativePathHelper $relativePathHelper;
 
-	private TableErrorFormatter $tableErrorformatter;
+	private ErrorFormatter $errorFormatter;
 
 	public function __construct(
 		RelativePathHelper $relativePathHelper,
-		TableErrorFormatter $tableErrorformatter
+		ErrorFormatter $errorFormatter
 	)
 	{
 		$this->relativePathHelper = $relativePathHelper;
-		$this->tableErrorformatter = $tableErrorformatter;
+		$this->errorFormatter = $errorFormatter;
 	}
 
 	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
 	{
-		$this->tableErrorformatter->formatErrors($analysisResult, $output);
+		$this->errorFormatter->formatErrors($analysisResult, $output);
 
 		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
 			$metas = [


### PR DESCRIPTION
This makes it possible to use the `GithubErrorFormatter` with any `ErrorFormatter`.

In my project, I have a custom ErrorFormatter but I also want to use the `GitHubErrorFormatter` on CI.