### PR TITLE
Only show `Using configuration file` when verbose

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -134,7 +134,9 @@ class CommandHelper
 				$discoverableConfigFile = $currentWorkingDirectory . DIRECTORY_SEPARATOR . $discoverableConfigName;
 				if (is_file($discoverableConfigFile)) {
 					$projectConfigFile = $discoverableConfigFile;
-					$errorOutput->writeLineFormatted(sprintf('Note: Using configuration file %s.', $projectConfigFile));
+					if ($errorOutput->isVerbose()) {
+						$errorOutput->writeLineFormatted(sprintf('Note: Using configuration file %s.', $projectConfigFile));
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
You can show it by using `-v`.