### PR TITLE
Add `identifier` and `metadata` for AppendedArrayItemTypeRule

### DIFF
--- a/src/Rules/Arrays/AppendedArrayItemTypeRule.php
+++ b/src/Rules/Arrays/AppendedArrayItemTypeRule.php
@@ -85,7 +85,13 @@ class AppendedArrayItemTypeRule implements Rule
 					'Array (%s) does not accept %s.',
 					$assignedToType->describe($verbosityLevel),
 					$assignedValueType->describe($verbosityLevel),
-				))->build(),
+				))
+					->identifier('arrays.doesNotAcceptType')
+					->metadata([
+						'assignedToType' => $assignedToType,
+						'assignedValueType' => $assignedValueType,
+					])
+					->build(),
 			];
 		}
 


### PR DESCRIPTION
For my custom error formatter I want to display `Array (%s) does not accept %s.` errors in a different way.

At first, I did this by using a regex that takes out both variable parts.

But soon I realized that large `ConstantArrayType` can be truncated making it impossible to re-use the printed type.
https://github.com/phpstan/phpstan-src/blob/7b798840b3b7353ae099fc7b2c970ea4a79e611e/src/Type/Constant/ConstantArrayType.php#L761-L765

Therefore I would like to add both types to the metadata. This way, I can detect this error based on identifier and take both types from the metadata. 