### PR TITLE
make PDOStatement generic

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -22,7 +22,9 @@ parameters:
 	featureToggles:
 		bleedingEdge: false
 		disableRuntimeReflectionProvider: false
-		skipCheckGenericClasses: []
+		skipCheckGenericClasses: [
+			'PDOStatement'
+		]
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false

--- a/stubs/PDOStatement.stub
+++ b/stubs/PDOStatement.stub
@@ -1,8 +1,9 @@
 <?php
 
 /**
- * @implements Traversable<array<int|string, mixed>>
- * @implements IteratorAggregate<array<int|string, mixed>>
+ * @template RowType of array
+ * @implements Traversable<int, RowType>
+ * @implements IteratorAggregate<int, RowType>
  * @link https://php.net/manual/en/class.pdostatement.php
  */
 class PDOStatement implements Traversable, IteratorAggregate

--- a/stubs/PDOStatement.stub
+++ b/stubs/PDOStatement.stub
@@ -9,7 +9,7 @@
 class PDOStatement implements Traversable, IteratorAggregate
 {
     /**
-     * @template T
+     * @template T of object
      * @param class-string<T> $class
      * @param array<mixed> $ctorArgs
      * @return false|T

--- a/stubs/PDOStatement.stub
+++ b/stubs/PDOStatement.stub
@@ -1,12 +1,18 @@
 <?php
 
 /**
- * @template RowType of array
- * @implements Traversable<int, RowType>
- * @implements IteratorAggregate<int, RowType>
+ * @template TValue
+ * @implements Traversable<int, TValue>
+ * @implements IteratorAggregate<int, TValue>
  * @link https://php.net/manual/en/class.pdostatement.php
  */
 class PDOStatement implements Traversable, IteratorAggregate
 {
-
+    /**
+     * @template T
+     * @param class-string<T> $class
+     * @param array $ctorArgs
+     * @return false|T
+     */
+    public function fetchObject($class = \stdclass::class, array $ctorArgs = array()) {}
 }

--- a/stubs/PDOStatement.stub
+++ b/stubs/PDOStatement.stub
@@ -11,7 +11,7 @@ class PDOStatement implements Traversable, IteratorAggregate
     /**
      * @template T
      * @param class-string<T> $class
-     * @param array $ctorArgs
+     * @param array<mixed> $ctorArgs
      * @return false|T
      */
     public function fetchObject($class = \stdclass::class, array $ctorArgs = array()) {}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -595,6 +595,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-destructuring-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pdo-prepare.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/pdo-statement-generic.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/extends-pdo-statement.php
+++ b/tests/PHPStan/Analyser/data/extends-pdo-statement.php
@@ -2,9 +2,6 @@
 
 namespace ExtendsPdoStatementCrash;
 
-/**
- * @extends \PDOStatement<array<array-key, mixed>>
- */
 class CrashOne extends \PDOStatement
 {
 	/**
@@ -18,9 +15,6 @@ class CrashOne extends \PDOStatement
 	}
 }
 
-/**
- * @extends \PDOStatement<array<array-key, mixed>>
- */
 class CrashTwo extends \PDOStatement
 {
 
@@ -36,9 +30,6 @@ class CrashTwo extends \PDOStatement
 
 }
 
-/**
- * @extends \PDOStatement<array<array-key, mixed>>
- */
 class CrashThree extends \PDOStatement
 {
 
@@ -54,9 +45,6 @@ class CrashThree extends \PDOStatement
 
 }
 
-/**
- * @extends \PDOStatement<array<array-key, mixed>>
- */
 class CrashFour extends \PDOStatement
 {
 
@@ -73,9 +61,6 @@ class CrashFour extends \PDOStatement
 
 }
 
-/**
- * @extends \PDOStatement<array<array-key, mixed>>
- */
 class CrashFive extends \PDOStatement
 {
 
@@ -92,9 +77,6 @@ class CrashFive extends \PDOStatement
 
 }
 
-/**
- * @extends \PDOStatement<array<array-key, mixed>>
- */
 class CrashSix extends \PDOStatement
 {
 

--- a/tests/PHPStan/Analyser/data/extends-pdo-statement.php
+++ b/tests/PHPStan/Analyser/data/extends-pdo-statement.php
@@ -2,6 +2,9 @@
 
 namespace ExtendsPdoStatementCrash;
 
+/**
+ * @extends \PDOStatement<array<array-key, mixed>>
+ */
 class CrashOne extends \PDOStatement
 {
 	/**
@@ -15,6 +18,9 @@ class CrashOne extends \PDOStatement
 	}
 }
 
+/**
+ * @extends \PDOStatement<array<array-key, mixed>>
+ */
 class CrashTwo extends \PDOStatement
 {
 
@@ -30,6 +36,9 @@ class CrashTwo extends \PDOStatement
 
 }
 
+/**
+ * @extends \PDOStatement<array<array-key, mixed>>
+ */
 class CrashThree extends \PDOStatement
 {
 
@@ -45,6 +54,9 @@ class CrashThree extends \PDOStatement
 
 }
 
+/**
+ * @extends \PDOStatement<array<array-key, mixed>>
+ */
 class CrashFour extends \PDOStatement
 {
 
@@ -61,6 +73,9 @@ class CrashFour extends \PDOStatement
 
 }
 
+/**
+ * @extends \PDOStatement<array<array-key, mixed>>
+ */
 class CrashFive extends \PDOStatement
 {
 
@@ -77,6 +92,9 @@ class CrashFive extends \PDOStatement
 
 }
 
+/**
+ * @extends \PDOStatement<array<array-key, mixed>>
+ */
 class CrashSix extends \PDOStatement
 {
 

--- a/tests/PHPStan/Analyser/data/pdo-statement-generic.php
+++ b/tests/PHPStan/Analyser/data/pdo-statement-generic.php
@@ -22,6 +22,8 @@ class Foo {
 
 	public function foobar(PDOStatement $statement) {
 		assertType('PdoStatementGeneric\Foo|false', $statement->fetchObject(Foo::class));
+		assertType('PdoStatementGeneric\Foo|false', $statement->fetchObject('PdoStatementGeneric\Foo'));
+		assertType('PdoStatementGeneric\Foo|false', $statement->fetchObject(__CLASS__));
 	}
 }
 

--- a/tests/PHPStan/Analyser/data/pdo-statement-generic.php
+++ b/tests/PHPStan/Analyser/data/pdo-statement-generic.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PdoStatementGeneric;
+
+use PDOStatement;
+use PDO;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+    public function bar(PDO $pdo) {
+        $query = 'select question_id, title from question_view';
+
+        /** @var PDOStatement<array{question_id: int, title: string}> */
+        $questions = $pdo->query($query, PDO::FETCH_ASSOC);
+
+        foreach($questions as $question) {
+            assertType('int', $question['question_id']);
+            assertType('string', $question['title']);
+        }
+    }
+}
+

--- a/tests/PHPStan/Analyser/data/pdo-statement-generic.php
+++ b/tests/PHPStan/Analyser/data/pdo-statement-generic.php
@@ -19,5 +19,10 @@ class Foo {
             assertType('string', $question['title']);
         }
     }
+
+	public function foobar(PDOStatement $statement) {
+		assertType('PdoStatementGeneric\Foo|false', $statement->fetchObject(Foo::class));
+	}
 }
+
 

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -81,7 +81,13 @@ class MissingMethodReturnTypehintRuleTest extends RuleTestCase
 
 	public function testBug5436(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-5436.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-5436.php'], [
+			[
+				'Method Bug5436\PDO::query() return type with generic class PDOStatement does not specify its types: TValue',
+				8,
+				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -81,10 +81,17 @@ class MissingMethodReturnTypehintRuleTest extends RuleTestCase
 
 	public function testBug5436(): void
 	{
+		$errorLine = 7;
+
+		// compensate the ReturnTypeWillChange attribute
+		if (PHP_VERSION_ID >= 80100) {
+			$errorLine = 8;
+		}
+
 		$this->analyse([__DIR__ . '/data/bug-5436.php'], [
 			[
 				'Method Bug5436\PDO::query() return type with generic class PDOStatement does not specify its types: TValue',
-				8,
+				$errorLine,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -81,17 +81,10 @@ class MissingMethodReturnTypehintRuleTest extends RuleTestCase
 
 	public function testBug5436(): void
 	{
-		$errorLine = 7;
-
-		// compensate the ReturnTypeWillChange attribute
-		if (PHP_VERSION_ID >= 80100) {
-			$errorLine = 8;
-		}
-
 		$this->analyse([__DIR__ . '/data/bug-5436.php'], [
 			[
 				'Method Bug5436\PDO::query() return type with generic class PDOStatement does not specify its types: TValue',
-				$errorLine,
+				7,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/data/bug-5436.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5436.php
@@ -4,7 +4,6 @@ namespace Bug5436;
 
 final class PDO extends \PDO
 {
-	#[\ReturnTypeWillChange]
 	public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
 	{
 		return parent::query($query, $fetchMode, ...$fetchModeArgs);

--- a/tests/PHPStan/Rules/Methods/data/bug-5436.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5436.php
@@ -4,9 +4,6 @@ namespace Bug5436;
 
 final class PDO extends \PDO
 {
-    /**
-     * @return \PDOStatement<array<array-key, mixed>>|false
-     */
 	#[\ReturnTypeWillChange]
 	public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
 	{

--- a/tests/PHPStan/Rules/Methods/data/bug-5436.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5436.php
@@ -4,6 +4,9 @@ namespace Bug5436;
 
 final class PDO extends \PDO
 {
+    /**
+     * @return \PDOStatement<array<array-key, mixed>>|false
+     */
 	#[\ReturnTypeWillChange]
 	public function query(string $query, ?int $fetchMode = null, ...$fetchModeArgs)
 	{


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan/discussions/6242 I want to build a dynamic return type extension for PDOStatement and therefore need a generic signature.

since I want to add a array-shape RowType, I need a single template for the whole type.
~~using the [same generic template as psalm uses](https://github.com/vimeo/psalm/blob/93e9054f98b040bf246c2023201503db3dbf162c/stubs/pdo.phpstub), would not allow me to define the exact type.~~

I am wondering that psalm defines the `Traversable` key as `int` but phpstan as `int|string`. 

~~[I opened another a Issue on psalm to discuss](https://github.com/vimeo/psalm/issues/7231) why the stub in psalm looks like that~~