### PR TITLE
take return-type into account while `TemplateType` validation

### DIFF
--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -77,7 +77,7 @@ class FunctionDefinitionCheck
 		string $parameterMessage,
 		string $returnMessage,
 		string $unionTypesMessage,
-		string $templateTypeMissingInParameterMessage,
+		string $unusedTemplateTypeMessage,
 		string $unresolvableParameterTypeMessage,
 		string $unresolvableReturnTypeMessage,
 	): array
@@ -90,7 +90,7 @@ class FunctionDefinitionCheck
 			$parameterMessage,
 			$returnMessage,
 			$unionTypesMessage,
-			$templateTypeMissingInParameterMessage,
+			$unusedTemplateTypeMessage,
 			$unresolvableParameterTypeMessage,
 			$unresolvableReturnTypeMessage,
 		);
@@ -204,7 +204,7 @@ class FunctionDefinitionCheck
 		string $parameterMessage,
 		string $returnMessage,
 		string $unionTypesMessage,
-		string $templateTypeMissingInParameterMessage,
+		string $unusedTemplateTypeMessage,
 		string $unresolvableParameterTypeMessage,
 		string $unresolvableReturnTypeMessage,
 	): array
@@ -218,7 +218,7 @@ class FunctionDefinitionCheck
 			$parameterMessage,
 			$returnMessage,
 			$unionTypesMessage,
-			$templateTypeMissingInParameterMessage,
+			$unusedTemplateTypeMessage,
 			$unresolvableParameterTypeMessage,
 			$unresolvableReturnTypeMessage,
 		);
@@ -233,7 +233,7 @@ class FunctionDefinitionCheck
 		string $parameterMessage,
 		string $returnMessage,
 		string $unionTypesMessage,
-		string $templateTypeMissingInParameterMessage,
+		string $unusedTemplateTypeMessage,
 		string $unresolvableParameterTypeMessage,
 		string $unresolvableReturnTypeMessage,
 	): array
@@ -363,7 +363,7 @@ class FunctionDefinitionCheck
 			});
 
 			foreach (array_keys($templateTypes) as $templateTypeName) {
-				$errors[] = RuleErrorBuilder::message(sprintf($templateTypeMissingInParameterMessage, $templateTypeName))->build();
+				$errors[] = RuleErrorBuilder::message(sprintf($unusedTemplateTypeMessage, $templateTypeName))->build();
 			}
 		}
 

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -353,6 +353,15 @@ class FunctionDefinitionCheck
 				});
 			}
 
+			TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use (&$templateTypes): Type {
+				if ($type instanceof TemplateType) {
+					unset($templateTypes[$type->getName()]);
+					return $traverse($type);
+				}
+
+				return $traverse($type);
+			});
+
 			foreach (array_keys($templateTypes) as $templateTypeName) {
 				$errors[] = RuleErrorBuilder::message(sprintf($templateTypeMissingInParameterMessage, $templateTypeName))->build();
 			}

--- a/src/Rules/Functions/ExistingClassesInTypehintsRule.php
+++ b/src/Rules/Functions/ExistingClassesInTypehintsRule.php
@@ -49,7 +49,7 @@ class ExistingClassesInTypehintsRule implements Rule
 				$functionName,
 			),
 			sprintf('Function %s() uses native union types but they\'re supported only on PHP 8.0 and later.', $functionName),
-			sprintf('Template type %%s of function %s() is not referenced in a parameter.', $functionName),
+			sprintf('Template type %%s of function %s() is neither referenced in a parameter nor in the return type.', $functionName),
 			sprintf(
 				'Parameter $%%s of function %s() has unresolvable native type.',
 				$functionName,

--- a/src/Rules/Methods/ExistingClassesInTypehintsRule.php
+++ b/src/Rules/Methods/ExistingClassesInTypehintsRule.php
@@ -57,7 +57,7 @@ class ExistingClassesInTypehintsRule implements Rule
 				$methodName,
 			),
 			sprintf('Method %s::%s() uses native union types but they\'re supported only on PHP 8.0 and later.', $className, $methodName),
-			sprintf('Template type %%s of method %s::%s() is not referenced in a parameter.', $className, $methodName),
+			sprintf('Template type %%s of method %s::%s() is neither referenced in a parameter nor in the return type.', $className, $methodName),
 			sprintf(
 				'Parameter $%%s of method %s::%s() has unresolvable native type.',
 				$className,

--- a/tests/PHPStan/Generics/data/variance-0.json
+++ b/tests/PHPStan/Generics/data/variance-0.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Template type T of function PHPStan\\Generics\\Variance\\returnOut() is not referenced in a parameter.",
+        "message": "Template type T of function PHPStan\\Generics\\Variance\\returnOut() is neither referenced in a parameter nor in the return type.",
         "line": 109,
         "ignorable": true
     },
     {
-        "message": "Template type T of function PHPStan\\Generics\\Variance\\returnInvariant() is not referenced in a parameter.",
+        "message": "Template type T of function PHPStan\\Generics\\Variance\\returnInvariant() is neither referenced in a parameter nor in the return type.",
         "line": 117,
         "ignorable": true
     }

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -89,7 +89,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 				87,
 			],
 			[
-				'Template type T of function TestFunctionTypehints\templateTypeMissingInParameter() is not referenced in a parameter.',
+				'Template type T of function TestFunctionTypehints\templateTypeMissingInParameter() is neither referenced in a parameter nor in the return type.',
 				96,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/data/typehints.php
+++ b/tests/PHPStan/Rules/Functions/data/typehints.php
@@ -97,3 +97,12 @@ function templateTypeMissingInParameter(string $a)
 {
 
 }
+
+/**
+ * @template T
+ * @return class-string<T>
+ */
+function genericTemplateReturnClassString(string $string)
+{
+
+}

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -131,7 +131,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 				113,
 			],
 			[
-				'Template type U of method TestMethodTypehints\TemplateTypeMissingInParameter::doFoo() is not referenced in a parameter.',
+				'Template type U of method TestMethodTypehints\TemplateTypeMissingInParameter::doFoo() is neither referenced in a parameter nor in the return type.',
 				130,
 			],
 		]);
@@ -242,7 +242,7 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-4641.php'], [
 			[
-				'Template type U of method Bug4641\I::getRepository() is not referenced in a parameter.',
+				'Template type U of method Bug4641\I::getRepository() is neither referenced in a parameter nor in the return type.',
 				26,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/data/typehints.php
+++ b/tests/PHPStan/Rules/Methods/data/typehints.php
@@ -141,4 +141,13 @@ class TemplateTypeMissingInParameter
 
 	}
 
+    /**
+     * @template U of object
+     * @return class-string<U>
+     */
+    public function doBarReturn(string $class): string
+    {
+        return get_class($class);
+    }
+
 }


### PR DESCRIPTION
while implementing https://github.com/phpstan/phpstan-src/pull/890 I realized that [the newly added TemplateType validation](https://github.com/phpstan/phpstan-src/commit/021e25ed2b6da96401ef754455ac5589db8eeda1#diff-439bf309b8c0d00d03503e1ca207ef58de1ccc9da19dc72eb08c296d18a2cd26) does not take the return type into account:

![grafik](https://user-images.githubusercontent.com/120441/147550381-26c51f11-e627-4fe0-ac06-c852ee74fae8.png)


this PR added return-type checking and fixes the reported phpstan error message accordingly.