### PR TITLE
PHPStanTestCase: Added a helper method to assert no errors happend

### DIFF
--- a/build/composer-require-checker.json
+++ b/build/composer-require-checker.json
@@ -3,7 +3,7 @@
     "null", "true", "false",
     "static", "self", "parent",
     "array", "string", "int", "float", "bool", "iterable", "callable", "void", "object",
-    "PHPUnit\\Framework\\TestCase", "PHPUnit\\Framework\\AssertionFailedError", "Composer\\Autoload\\ClassLoader",
+    "PHPUnit\\Framework\\TestCase", "PHPUnit\\Framework\\AssertionFailedError", "Composer\\Autoload\\ClassLoader", "PHPUnit\\Framework\\ExpectationFailedException",
     "JSON_THROW_ON_ERROR", "JSON_INVALID_UTF8_IGNORE", "JsonSerializable", "SimpleXMLElement", "PHPStan\\ExtensionInstaller\\GeneratedConfig", "Nette\\DI\\InvalidConfigurationException",
     "FILTER_SANITIZE_EMAIL", "FILTER_SANITIZE_EMAIL", "FILTER_SANITIZE_ENCODED", "FILTER_SANITIZE_MAGIC_QUOTES", "FILTER_SANITIZE_NUMBER_FLOAT",
     "FILTER_SANITIZE_NUMBER_INT", "FILTER_SANITIZE_SPECIAL_CHARS", "FILTER_SANITIZE_STRING", "FILTER_SANITIZE_URL", "FILTER_VALIDATE_BOOLEAN",

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -36,13 +36,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testMissingPropertyAndMethod(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../../notAutoloaded/Foo.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testMissingClassErrorAboutMisconfiguredAutoloader(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../../notAutoloaded/Bar.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testMissingFunctionErrorAboutMisconfiguredAutoloader(): void
@@ -56,7 +56,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testAnonymousClassWithInheritedConstructor(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/anonymous-class-with-inherited-constructor.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testNestedFunctionCallsDoNotCauseExcessiveFunctionNesting(): void
@@ -65,7 +65,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			$this->markTestSkipped('This test takes too long with XDebug enabled.');
 		}
 		$errors = $this->runAnalyse(__DIR__ . '/data/nested-functions.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testExtendingUnknownClass(): void
@@ -85,7 +85,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testExtendingKnownClassWithCheck(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/extending-known-class-with-check.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 
 		$reflectionProvider = $this->createReflectionProvider();
 		$this->assertTrue($reflectionProvider->hasClass(Foo::class));
@@ -94,7 +94,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testInfiniteRecursionWithCallable(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/Foo-callable.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testClassThatExtendsUnknownClassIn3rdPartyPropertyTypeShouldNotCauseAutoloading(): void
@@ -131,7 +131,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		}
 		require_once __DIR__ . '/data/custom-function-in-signature-map.php';
 		$errors = $this->runAnalyse(__DIR__ . '/data/custom-function-in-signature-map.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testAnonymousClassWithWrongFilename(): void
@@ -159,13 +159,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			$this->markTestSkipped();
 		}
 		$errors = $this->runAnalyse(__DIR__ . '/data/extends-pdo-statement.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testArrayDestructuringArrayDimFetch(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/array-destructuring-array-dim-fetch.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testNestedNamespaces(): void
@@ -181,7 +181,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testClassExistsAutoloadingError(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/class-exists.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testCollectWarnings(): void
@@ -213,13 +213,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testPropertyAssignIntersectionStaticTypeBug(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/property-assign-intersection-static-type-bug.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug2823(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-2823.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testTwoSameClassesInSingleFile(): void
@@ -251,31 +251,31 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug3405(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3405.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3415(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Methods/data/bug-3415.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3415Two(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Methods/data/bug-3415-2.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3468(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3468.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3686(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3686.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3379(): void
@@ -291,19 +291,19 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug3798(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3798.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3909(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3909.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug4097(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4097.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug4300(): void
@@ -317,38 +317,38 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug4513(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4513.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug1871(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1871.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3309(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3309.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3769(): void
 	{
 		require_once __DIR__ . '/../Rules/Generics/data/bug-3769.php';
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug3922(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3922-integration.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug1843(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1843.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug4713(): void
@@ -368,7 +368,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug4288(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4288.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 
 		$reflectionProvider = $this->createReflectionProvider();
 		$class = $reflectionProvider->getClass(MyClass::class);
@@ -388,14 +388,14 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug4702(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4702.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testFunctionThatExistsOn72AndLater(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/ldap-exop-passwd.php');
 		if (PHP_VERSION_ID >= 70200) {
-			$this->assertCount(0, $errors);
+			$this->assertNoErrors($errors);
 			return;
 		}
 
@@ -409,7 +409,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			$this->markTestSkipped('Test requires PHP 7.4.');
 		}
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4715.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug4734(): void
@@ -437,25 +437,25 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug5529(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5529.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug5527(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5527.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug5639(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5639.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug5657(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5657.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testBug5951(): void
@@ -464,7 +464,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			$this->markTestSkipped('Test requires PHP 8.0.');
 		}
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5951.php');
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testEnums(): void

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -87,7 +87,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(0, $result);
+		$this->assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorByPathAndCount(): void
@@ -100,7 +100,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-fails.php', false);
-		$this->assertCount(0, $result);
+		$this->assertNoErrors($result);
 	}
 
 	public function dataTrueAndFalse(): array
@@ -204,7 +204,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(0, $result);
+		$this->assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorByPathsMultipleUnmatched(): void
@@ -277,7 +277,7 @@ class AnalyserTest extends PHPStanTestCase
 			__DIR__ . '/data/traits-ignore/Foo.php',
 			__DIR__ . '/data/traits-ignore/FooTrait.php',
 		], true);
-		$this->assertCount(0, $result);
+		$this->assertNoErrors($result);
 	}
 
 	public function testIgnoredErrorMissingMessage(): void
@@ -358,7 +358,7 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser($ignoreErrors, true, [
 			__DIR__ . '/data/two-fails.php',
 		], $onlyFiles);
-		$this->assertCount(0, $result);
+		$this->assertNoErrors($result);
 	}
 
 	/**
@@ -381,7 +381,7 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser($ignoreErrors, true, [
 			__DIR__ . '/data/two-fails.php',
 		], $onlyFiles);
-		$this->assertCount(0, $result);
+		$this->assertNoErrors($result);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -112,7 +112,7 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 	public function testDuplicateMethodDefinition(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/duplicateMethod/Lesson.php']);
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testWrongPropertyType(): void
@@ -147,13 +147,13 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 	public function testTraitInEval(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/TraitInEvalUse.php']);
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testParameterNotFoundCrash(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/parameter-not-found.php']);
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	public function testMissingReturnInAbstractTraitMethod(): void
@@ -162,7 +162,7 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 			__DIR__ . '/traits/TraitWithAbstractMethod.php',
 			__DIR__ . '/traits/ClassImplementingTraitWithAbstractMethod.php',
 		]);
-		$this->assertCount(0, $errors);
+		$this->assertNoErrors($errors);
 	}
 
 	/**


### PR DESCRIPTION
in case the `assertNoErrors` assertion fails, the helper prints out the emitted errors to ease debugging.

before this PR a unit test which does not expect errors failed with:

```
$ vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --bootstrap tests/bootstrap-static-reflection.php
PHPUnit 9.5.11 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available

..............F.....................................              52 / 52 (100%)

Time: 00:02.842, Memory: 94.00 MB

There was 1 failure:

1) PHPStan\Analyser\AnalyserIntegrationTest::testExtendsPdoStatementCrash
Failed asserting that actual size 6 matches expected size 0.
```

DX wise this is not really helpful, as the next step is to add debugging statements, so we can actually see the errors.

with this PR we add a new `assertNoErrors` helper method which prints out the errors, so we can directly see the problem
```
$ vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --bootstrap tests/bootstrap-static-reflection.php
PHPUnit 9.5.11 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available

..............F.....................................              52 / 52 (100%)

Time: 00:02.842, Memory: 94.00 MB

There was 1 failure:

1) PHPStan\Analyser\AnalyserIntegrationTest::testExtendsPdoStatementCrash
Failed asserting that actual size 2 matches expected size 0.

Emitted errors:
- PHPDoc tag @return with type bool is incompatible with native type void
  in C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\data\extends-pdo-statement.php on line 88

- Method ExtendsPdoStatementCrash\CrashSix::setFetchMode() with return type void returns true but should not return anything
  in C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\data\extends-pdo-statement.php on line 90

```