### PR TITLE
added tmp/.memory_limit to .gitignore [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.idea
 /tests/tmp
 /tests/.phpunit.result.cache
+tmp/.memory_limit


### PR DESCRIPTION
to make sure noone can accidentally commit the file, which is created while running phpstan on the codebase