### PR TITLE
Add PHP 8.1 function signature changes

### DIFF
--- a/compiler/build/scoper.inc.php
+++ b/compiler/build/scoper.inc.php
@@ -6,6 +6,7 @@ $stubs = [
 	'../../resources/functionMap.php',
 	'../../resources/functionMap_php74delta.php',
 	'../../resources/functionMap_php80delta.php',
+	'../../resources/functionMap_php81delta.php',
 	'../../resources/functionMetadata.php',
 	'../../vendor/hoa/consistency/Prelude.php',
 	'../../vendor/composer/InstalledVersions.php',

--- a/resources/functionMap_php81delta.php
+++ b/resources/functionMap_php81delta.php
@@ -1,0 +1,23 @@
+<?php // phpcs:ignoreFile
+
+/**
+ * This contains the information needed to convert the function signatures for php 8.1 to php 8.0 (and vice versa)
+ *
+ * This has two sections.
+ * The 'new' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php8.0 or have different signatures in php 8.1.
+ *   If they were just updated, the function/method will be present in the 'added' signatures.
+ * The 'old' signatures contains the signatures that are different in php 8.0.
+ *   Functions are expected to be removed only in major releases of php.
+ *
+ * @see FunctionSignatureMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
+ */
+return [
+	'new' => [
+		'ini_set' => ['string|false', 'option'=>'string', 'value'=>'scalar|null'],
+	],
+	'old' => [
+		'ini_set' => ['string|false', 'option'=>'string', 'value'=>'string'],
+	]
+];

--- a/resources/functionMap_php81delta.php
+++ b/resources/functionMap_php81delta.php
@@ -15,6 +15,8 @@
  */
 return [
 	'new' => [
+		'array_is_list' => ['bool', 'array'=>'array'],
+		'fsync' => ['bool', 'stream'=>'resource'],
 		'ini_set' => ['string|false', 'option'=>'string', 'value'=>'scalar|null'],
 	],
 	'old' => [

--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -184,6 +184,15 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 				$signatureMap = $this->computeSignatureMap($signatureMap, $php80MapDelta);
 			}
 
+			if ($this->phpVersion->getVersionId() >= 80100) {
+				$php81MapDelta = require __DIR__ . '/../../../resources/functionMap_php81delta.php';
+				if (!is_array($php81MapDelta)) {
+					throw new ShouldNotHappenException('Signature map could not be loaded.');
+				}
+
+				$signatureMap = $this->computeSignatureMap($signatureMap, $php81MapDelta);
+			}
+
 			$this->signatureMap = $signatureMap;
 		}
 

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -434,6 +434,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 		return [
 			[70400],
 			[80000],
+			[80100],
 		];
 	}
 


### PR DESCRIPTION
PHP's [`ini_set`](https://www.php.net/manual/en/function.ini-set.php) `$value` now accepts any scalar type (including `null`). Previously, only string values were accepted: https://phpstan.org/r/c753488a-e13c-47a2-8c09-cfae578b0ecb

This is my attempt at adding `functionMap_php81delta.php` (inspiration taken from d775058aa5b80046f12f1ef7487947e8fbf1c7ad) but I'm not sure if that's the way. Phan, which is mentioned in other *delta* files, [has the file already](https://github.com/phan/phan/blob/b70b166d7100328e9aa40d0b332e01d8724342e5/src/Phan/Language/Internal/FunctionSignatureMap_php81_delta.php) although with a different structure with `added`, `changed`, `removed` keys instead of `new`, `old` so I haven't copied the whole file over (and that's why the file header comment doesn't mention Phan, I can add the comment back if needed but I wasn't sure what to put there).

I've copied the functions over from Phan in a separate commit.

Please let me know if something else needs to be done when adding PHP 8.1 signature changes, thanks.