### PR TITLE
Improve performance by change count(array) to empty array [] comparison

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -7,7 +7,6 @@ use PHPStan\Rules\Registry;
 use Throwable;
 use function array_fill_keys;
 use function array_merge;
-use function count;
 use function error_reporting;
 use function in_array;
 use function restore_error_handler;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -74,7 +74,7 @@ class Analyser
 				$dependencies[$file] = $fileAnalyserResult->getDependencies();
 
 				$fileExportedNodes = $fileAnalyserResult->getExportedNodes();
-				if (count($fileExportedNodes) > 0) {
+				if ($fileExportedNodes !== []) {
 					$exportedNodes[$file] = $fileExportedNodes;
 				}
 			} catch (Throwable $t) {

--- a/src/Analyser/ConditionalExpressionHolder.php
+++ b/src/Analyser/ConditionalExpressionHolder.php
@@ -20,7 +20,7 @@ class ConditionalExpressionHolder
 		private VariableTypeHolder $typeHolder,
 	)
 	{
-		if (count($conditionExpressionTypes) === 0) {
+		if ($conditionExpressionTypes === []) {
 			throw new ShouldNotHappenException();
 		}
 	}

--- a/src/Analyser/ConditionalExpressionHolder.php
+++ b/src/Analyser/ConditionalExpressionHolder.php
@@ -5,7 +5,6 @@ namespace PHPStan\Analyser;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function implode;
 use function sprintf;
 

--- a/src/Analyser/IgnoredErrorHelper.php
+++ b/src/Analyser/IgnoredErrorHelper.php
@@ -81,7 +81,7 @@ class IgnoredErrorHelper
 					}
 					$validationResult = $this->ignoredRegexValidator->validate($ignoreMessage);
 					$ignoredTypes = $validationResult->getIgnoredTypes();
-					if (count($ignoredTypes) > 0) {
+					if ($ignoredTypes !== []) {
 						$errors[] = $this->createIgnoredTypesError($ignoreMessage, $ignoredTypes);
 					}
 
@@ -101,7 +101,7 @@ class IgnoredErrorHelper
 					Strings::match('', $ignoreMessage);
 					$validationResult = $this->ignoredRegexValidator->validate($ignoreMessage);
 					$ignoredTypes = $validationResult->getIgnoredTypes();
-					if (count($ignoredTypes) > 0) {
+					if ($ignoredTypes !== []) {
 						$errors[] = $this->createIgnoredTypesError($ignoreMessage, $ignoredTypes);
 					}
 

--- a/src/Analyser/IgnoredErrorHelper.php
+++ b/src/Analyser/IgnoredErrorHelper.php
@@ -10,7 +10,6 @@ use PHPStan\Command\IgnoredRegexValidator;
 use PHPStan\File\FileHelper;
 use function array_keys;
 use function array_map;
-use function count;
 use function implode;
 use function is_array;
 use function is_file;

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -937,7 +937,7 @@ class MutatingScope implements Scope
 			$type = $this->getType($node->expr)->toNumber();
 			$scalarValues = TypeUtils::getConstantScalars($type);
 
-			if (count($scalarValues) > 0) {
+			if ($scalarValues !== []) {
 				$newTypes = [];
 				foreach ($scalarValues as $scalarValue) {
 					if ($scalarValue instanceof ConstantIntegerType) {
@@ -1202,7 +1202,7 @@ class MutatingScope implements Scope
 				$leftConstantArrays = TypeUtils::getConstantArrays($leftType);
 				$rightConstantArrays = TypeUtils::getConstantArrays($rightType);
 
-				if (count($leftConstantArrays) > 0 && count($rightConstantArrays) > 0) {
+				if ($leftConstantArrays !== [] && $rightConstantArrays !== []) {
 					$resultTypes = [];
 					foreach ($rightConstantArrays as $rightConstantArray) {
 						foreach ($leftConstantArrays as $leftConstantArray) {
@@ -1310,7 +1310,7 @@ class MutatingScope implements Scope
 					$extensionTypes[] = $extension->specifyType($operatorSigil, $leftType, $rightType);
 				}
 
-				if (count($extensionTypes) > 0) {
+				if ($extensionTypes !== []) {
 					return TypeCombinator::union(...$extensionTypes);
 				}
 			}
@@ -1567,7 +1567,7 @@ class MutatingScope implements Scope
 								break;
 							}
 
-							if (count($node->getStatementResult()->getExitPoints()) === 0) {
+							if ($node->getStatementResult()->getExitPoints() === []) {
 								$closureExecutionEnds[] = $node;
 							}
 						}
@@ -1597,14 +1597,14 @@ class MutatingScope implements Scope
 					$returnTypes[] = $returnScope->getType($returnNode->expr);
 				}
 
-				if (count($returnTypes) === 0) {
-					if (count($closureExecutionEnds) > 0 && !$hasNull) {
+				if ($returnTypes === []) {
+					if ($closureExecutionEnds !== [] && !$hasNull) {
 						$returnType = new NeverType(true);
 					} else {
 						$returnType = new VoidType();
 					}
 				} else {
-					if (count($closureExecutionEnds) > 0) {
+					if ($closureExecutionEnds !== []) {
 						$returnTypes[] = new NeverType(true);
 					}
 					if ($hasNull) {
@@ -1613,7 +1613,7 @@ class MutatingScope implements Scope
 					$returnType = TypeCombinator::union(...$returnTypes);
 				}
 
-				if (count($closureYieldStatements) > 0) {
+				if ($closureYieldStatements !== []) {
 					$keyTypes = [];
 					$valueTypes = [];
 					foreach ($closureYieldStatements as [$yieldNode, $yieldScope]) {
@@ -1808,7 +1808,7 @@ class MutatingScope implements Scope
 			$varType = $this->getType($node->var);
 			$varScalars = TypeUtils::getConstantScalars($varType);
 			$stringType = new StringType();
-			if (count($varScalars) > 0) {
+			if ($varScalars !== []) {
 				$newTypes = [];
 
 				foreach ($varScalars as $scalar) {
@@ -2061,7 +2061,7 @@ class MutatingScope implements Scope
 
 			$referencedClasses = TypeUtils::getDirectClassNames($constantClassType);
 			if (strtolower($constantName) === 'class') {
-				if (count($referencedClasses) === 0) {
+				if ($referencedClasses === []) {
 					return new ErrorType();
 				}
 				$classTypes = [];
@@ -2118,7 +2118,7 @@ class MutatingScope implements Scope
 				$types[] = $constantType;
 			}
 
-			if (count($types) > 0) {
+			if ($types !== []) {
 				return TypeCombinator::union(...$types);
 			}
 
@@ -3166,7 +3166,7 @@ class MutatingScope implements Scope
 			if ($callableParameters !== null) {
 				if (isset($callableParameters[$i])) {
 					$parameterType = TypehintHelper::decideType($parameterType, $callableParameters[$i]->getType());
-				} elseif (count($callableParameters) > 0) {
+				} elseif ($callableParameters !== []) {
 					$lastParameter = $callableParameters[count($callableParameters) - 1];
 					if ($lastParameter->isVariadic()) {
 						$parameterType = TypehintHelper::decideType($parameterType, $lastParameter->getType());
@@ -3294,7 +3294,7 @@ class MutatingScope implements Scope
 			if ($callableParameters !== null) {
 				if (isset($callableParameters[$i])) {
 					$parameterType = TypehintHelper::decideType($parameterType, $callableParameters[$i]->getType());
-				} elseif (count($callableParameters) > 0) {
+				} elseif ($callableParameters !== []) {
 					$lastParameter = $callableParameters[count($callableParameters) - 1];
 					if ($lastParameter->isVariadic()) {
 						$parameterType = TypehintHelper::decideType($parameterType, $lastParameter->getType());
@@ -3341,7 +3341,7 @@ class MutatingScope implements Scope
 				$newHolders[] = $holder;
 			}
 
-			if (count($newHolders) === 0) {
+			if ($newHolders === []) {
 				continue;
 			}
 
@@ -3365,7 +3365,7 @@ class MutatingScope implements Scope
 					$newHolders[] = $holder;
 				}
 
-				if (count($newHolders) === 0) {
+				if ($newHolders === []) {
 					continue;
 				}
 
@@ -3655,7 +3655,7 @@ class MutatingScope implements Scope
 		} elseif ($expr instanceof Expr\ArrayDimFetch && $expr->dim !== null) {
 			$varType = $this->getType($expr->var);
 			$constantArrays = TypeUtils::getConstantArrays($varType);
-			if (count($constantArrays) > 0) {
+			if ($constantArrays !== []) {
 				$unsetArrays = [];
 				$dimType = $this->getType($expr->dim);
 				foreach ($constantArrays as $constantArray) {
@@ -3669,7 +3669,7 @@ class MutatingScope implements Scope
 
 			$arrays = TypeUtils::getArrays($varType);
 			$scope = $this;
-			if (count($arrays) > 0) {
+			if ($arrays !== []) {
 				$scope = $scope->specifyExpressionType($expr->var, TypeCombinator::union(...$arrays));
 			}
 
@@ -3748,7 +3748,7 @@ class MutatingScope implements Scope
 			);
 		} elseif ($expr instanceof Expr\ArrayDimFetch && $expr->dim !== null) {
 			$constantArrays = TypeUtils::getConstantArrays($this->getType($expr->var));
-			if (count($constantArrays) > 0) {
+			if ($constantArrays !== []) {
 				$setArrays = [];
 				$dimType = $this->getType($expr->dim);
 				foreach ($constantArrays as $constantArray) {
@@ -4053,7 +4053,7 @@ class MutatingScope implements Scope
 					$matchingConditions[$conditionExprString] = $conditionalType;
 				}
 
-				if (count($matchingConditions) === 0) {
+				if ($matchingConditions === []) {
 					$newConditionalExpressions[$variableExprString][$conditionalExpression->getKey()] = $conditionalExpression;
 					continue;
 				}
@@ -4336,7 +4336,7 @@ class MutatingScope implements Scope
 			$typeGuards['$' . $name] = $holder->getType();
 		}
 
-		if (count($typeGuards) === 0) {
+		if ($typeGuards === []) {
 			return $conditionalExpressions;
 		}
 
@@ -4352,7 +4352,7 @@ class MutatingScope implements Scope
 			$variableTypeGuards = $typeGuards;
 			unset($variableTypeGuards[$exprString]);
 
-			if (count($variableTypeGuards) === 0) {
+			if ($variableTypeGuards === []) {
 				continue;
 			}
 
@@ -4483,7 +4483,7 @@ class MutatingScope implements Scope
 	{
 		$nativeExpressionTypes = $this->nativeExpressionTypes;
 		$variableTypes = $this->variableTypes;
-		if (count($byRefUses) === 0) {
+		if ($byRefUses === []) {
 			return $this;
 		}
 
@@ -4706,10 +4706,10 @@ class MutatingScope implements Scope
 			$constantBooleans,
 			$constantStrings,
 		] as $constantTypes) {
-			if (count($constantTypes['a']) === 0) {
+			if ($constantTypes['a'] === []) {
 				continue;
 			}
-			if (count($constantTypes['b']) === 0) {
+			if ($constantTypes['b'] === []) {
 				$resultTypes[] = TypeCombinator::union(...$constantTypes['a']);
 				continue;
 			}
@@ -4724,8 +4724,8 @@ class MutatingScope implements Scope
 			$resultTypes[] = TypeUtils::generalizeType($constantTypes['a'][0], GeneralizePrecision::moreSpecific());
 		}
 
-		if (count($constantArrays['a']) > 0) {
-			if (count($constantArrays['b']) === 0) {
+		if ($constantArrays['a'] !== []) {
+			if ($constantArrays['b'] === []) {
 				$resultTypes[] = TypeCombinator::union(...$constantArrays['a']);
 			} else {
 				$constantArraysA = TypeCombinator::union(...$constantArrays['a']);
@@ -4752,8 +4752,8 @@ class MutatingScope implements Scope
 			}
 		}
 
-		if (count($generalArrays['a']) > 0) {
-			if (count($generalArrays['b']) === 0) {
+		if ($generalArrays['a'] !== []) {
+			if ($generalArrays['b'] === []) {
 				$resultTypes[] = TypeCombinator::union(...$generalArrays['a']);
 			} else {
 				$generalArraysA = TypeCombinator::union(...$generalArrays['a']);
@@ -4982,7 +4982,7 @@ class MutatingScope implements Scope
 			$resolvedTypes[] = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall($constructorMethod, $methodCall, $this);
 		}
 
-		if (count($resolvedTypes) > 0) {
+		if ($resolvedTypes !== []) {
 			return TypeCombinator::union(...$resolvedTypes);
 		}
 
@@ -5097,7 +5097,7 @@ class MutatingScope implements Scope
 
 				$newTypes[] = $innerType;
 			}
-			if (count($newTypes) === 0) {
+			if ($newTypes === []) {
 				return null;
 			}
 			$typeWithMethod = TypeCombinator::union(...$newTypes);
@@ -5141,7 +5141,7 @@ class MutatingScope implements Scope
 			}
 		}
 
-		if (count($resolvedTypes) > 0) {
+		if ($resolvedTypes !== []) {
 			return TypeCombinator::union(...$resolvedTypes);
 		}
 
@@ -5164,7 +5164,7 @@ class MutatingScope implements Scope
 
 				$newTypes[] = $innerType;
 			}
-			if (count($newTypes) === 0) {
+			if ($newTypes === []) {
 				return null;
 			}
 			$typeWithProperty = TypeCombinator::union(...$newTypes);

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -313,7 +313,7 @@ class ResultCacheManager
 				return false;
 			}
 
-			if (count($internalErrors) > 0) {
+			if ($internalErrors !== []) {
 				if ($output->isDebug()) {
 					$output->writeLineFormatted('Result cache was not saved because of internal errors.');
 				}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -736,7 +736,7 @@ class TypeSpecifier
 			return $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->var, $context);
 		} elseif (
 			$expr instanceof Expr\Isset_
-			&& count($expr->vars) > 0
+			&& $expr->vars !== []
 			&& $context->true()
 		) {
 			$vars = [];
@@ -763,7 +763,7 @@ class TypeSpecifier
 				$vars = array_merge($vars, array_reverse($tmpVars));
 			}
 
-			if (count($vars) === 0) {
+			if ($vars === []) {
 				throw new ShouldNotHappenException();
 			}
 
@@ -916,7 +916,7 @@ class TypeSpecifier
 			$conditionExpressionTypes[$exprString] = TypeCombinator::intersect($scope->getType($expr), $type);
 		}
 
-		if (count($conditionExpressionTypes) > 0) {
+		if ($conditionExpressionTypes !== []) {
 			$holders = [];
 			foreach ($rightTypes->getSureNotTypes() as $exprString => [$expr, $type]) {
 				if (!$expr instanceof Expr\Variable) {

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -77,7 +77,7 @@ class AnalyseApplication
 		$resultCacheManager = $this->resultCacheManagerFactory->create([]);
 
 		$ignoredErrorHelperResult = $this->ignoredErrorHelper->initialize();
-		if (count($ignoredErrorHelperResult->getErrors()) > 0) {
+		if ($ignoredErrorHelperResult->getErrors() !== []) {
 			$errors = $ignoredErrorHelperResult->getErrors();
 			$internalErrors = [];
 			$savedResultCache = false;
@@ -98,7 +98,7 @@ class AnalyseApplication
 			$resultCacheResult = $resultCacheManager->process($intermediateAnalyserResult, $resultCache, $errorOutput, $onlyFiles, true);
 			$analyserResult = $resultCacheResult->getAnalyserResult();
 			$internalErrors = $analyserResult->getInternalErrors();
-			$errors = $ignoredErrorHelperResult->process($analyserResult->getErrors(), $onlyFiles, $files, count($internalErrors) > 0 || $analyserResult->hasReachedInternalErrorsCountLimit());
+			$errors = $ignoredErrorHelperResult->process($analyserResult->getErrors(), $onlyFiles, $files, $internalErrors !== [] || $analyserResult->hasReachedInternalErrorsCountLimit());
 			$savedResultCache = $resultCacheResult->isSaved();
 			if ($analyserResult->hasReachedInternalErrorsCountLimit()) {
 				$errors[] = sprintf('Reached internal errors count limit of %d, exiting...', $this->internalErrorsCountLimit);

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -330,7 +330,7 @@ class AnalyseCommand extends Command
 
 			if (
 				$unignorableCount === 0
-				&& count($analysisResult->getNotFileSpecificErrors()) === 0
+				&& $analysisResult->getNotFileSpecificErrors() === []
 			) {
 				$inceptionResult->getStdOutput()->getStyle()->success($message);
 			} else {
@@ -358,7 +358,7 @@ class AnalyseCommand extends Command
 				$nonIgnorableErrorsByException[] = $fileSpecificError;
 			}
 
-			if ($hasInternalErrors || count($nonIgnorableErrorsByException) > 0) {
+			if ($hasInternalErrors || $nonIgnorableErrorsByException !== []) {
 				$fixerAnalysisResult = new AnalysisResult(
 					$nonIgnorableErrorsByException,
 					$analysisResult->getInternalErrors(),
@@ -389,7 +389,7 @@ class AnalyseCommand extends Command
 			if (!$analysisResult->isResultCacheSaved() && !$onlyFiles) {
 				// this can happen only if there are some regex-related errors in ignoreErrors configuration
 				$stdOutput = $inceptionResult->getStdOutput();
-				if (count($analysisResult->getFileSpecificErrors()) > 0) {
+				if ($analysisResult->getFileSpecificErrors() !== []) {
 					$stdOutput->getStyle()->error('Unknown error. Please report this as a bug.');
 					return $inceptionResult->handleReturn(1);
 				}

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -89,7 +89,7 @@ class AnalysisResult
 
 	public function hasWarnings(): bool
 	{
-		return count($this->warnings) > 0;
+		return $this->warnings !== [];
 	}
 
 	public function isDefaultLevelUsed(): bool
@@ -104,7 +104,7 @@ class AnalysisResult
 
 	public function hasInternalErrors(): bool
 	{
-		return count($this->internalErrors) > 0;
+		return $this->internalErrors !== [];
 	}
 
 	public function isResultCacheSaved(): bool

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -193,7 +193,7 @@ class CommandHelper
 			if (isset($projectConfig['parameters']['paths'])) {
 				$analysedPathsFromConfig = Helpers::expand($projectConfig['parameters']['paths'], $defaultParameters);
 			}
-			if (count($paths) === 0) {
+			if ($paths === []) {
 				$paths = $analysedPathsFromConfig;
 			}
 		}

--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -6,7 +6,6 @@ use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
-use function count;
 use function htmlspecialchars;
 use function sprintf;
 use const ENT_COMPAT;

--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -50,7 +50,7 @@ class CheckstyleErrorFormatter implements ErrorFormatter
 
 		$notFileSpecificErrors = $analysisResult->getNotFileSpecificErrors();
 
-		if (count($notFileSpecificErrors) > 0) {
+		if ($notFileSpecificErrors !== []) {
 			$output->writeRaw('<file>');
 			$output->writeLineFormatted('');
 

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -87,7 +87,7 @@ class TableErrorFormatter implements ErrorFormatter
 			$style->table(['Line', $relativeFilePath], $rows);
 		}
 
-		if (count($analysisResult->getNotFileSpecificErrors()) > 0) {
+		if ($analysisResult->getNotFileSpecificErrors() !== []) {
 			$style->table(['', 'Error'], array_map(static fn (string $error): array => ['', $error], $analysisResult->getNotFileSpecificErrors()));
 		}
 

--- a/src/Command/ErrorFormatter/TeamcityErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TeamcityErrorFormatter.php
@@ -7,7 +7,6 @@ use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
 use function array_keys;
 use function array_values;
-use function count;
 use function is_string;
 use function preg_replace;
 use const PHP_EOL;

--- a/src/Command/ErrorFormatter/TeamcityErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TeamcityErrorFormatter.php
@@ -29,7 +29,7 @@ class TeamcityErrorFormatter implements ErrorFormatter
 		$notFileSpecificErrors = $analysisResult->getNotFileSpecificErrors();
 		$warnings = $analysisResult->getWarnings();
 
-		if (count($fileSpecificErrors) === 0 && count($notFileSpecificErrors) === 0 && count($warnings) === 0) {
+		if ($fileSpecificErrors === [] && $notFileSpecificErrors === [] && $warnings === []) {
 			return 0;
 		}
 

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -497,7 +497,7 @@ class FixerApplication
 	): PromiseInterface
 	{
 		$ignoredErrorHelperResult = $this->ignoredErrorHelper->initialize();
-		if (count($ignoredErrorHelperResult->getErrors()) > 0) {
+		if ($ignoredErrorHelperResult->getErrors() !== []) {
 			throw new ShouldNotHappenException();
 		}
 
@@ -506,7 +506,7 @@ class FixerApplication
 		$resultCacheManager = $this->resultCacheManagerFactory->create([]);
 		[$inceptionFiles, $isOnlyFiles] = $inceptionResult->getFiles();
 		$resultCache = $resultCacheManager->restore($inceptionFiles, false, false, $projectConfigArray, $inceptionResult->getErrorOutput(), $fixerSuggestionId);
-		if (count($resultCache->getFilesToAnalyse()) === 0) {
+		if ($resultCache->getFilesToAnalyse() === []) {
 			$result = $resultCacheManager->process(
 				new AnalyserResult([], [], [], [], false),
 				$resultCache,
@@ -518,7 +518,7 @@ class FixerApplication
 				$result->getErrors(),
 				$isOnlyFiles,
 				$inceptionFiles,
-				count($result->getInternalErrors()) > 0 || $result->hasReachedInternalErrorsCountLimit(),
+				$result->getInternalErrors() !== [] || $result->hasReachedInternalErrorsCountLimit(),
 			);
 			$finalFileSpecificErrors = [];
 			$finalNotFileSpecificErrors = [];

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -49,7 +49,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use function Clue\React\Block\await;
-use function count;
 use function defined;
 use function escapeshellarg;
 use function fclose;

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use function count;
 use function is_array;
 use function is_bool;
 use function is_string;

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -127,7 +127,7 @@ class FixerWorkerCommand extends Command
 		/** @var IgnoredErrorHelper $ignoredErrorHelper */
 		$ignoredErrorHelper = $container->getByType(IgnoredErrorHelper::class);
 		$ignoredErrorHelperResult = $ignoredErrorHelper->initialize();
-		if (count($ignoredErrorHelperResult->getErrors()) > 0) {
+		if ($ignoredErrorHelperResult->getErrors() !== []) {
 			throw new ShouldNotHappenException();
 		}
 
@@ -168,7 +168,7 @@ class FixerWorkerCommand extends Command
 			$result->getErrors(),
 			$isOnlyFiles,
 			$inceptionFiles,
-			count($result->getInternalErrors()) > 0 || $result->hasReachedInternalErrorsCountLimit(),
+			$result->getInternalErrors() !== [] || $result->hasReachedInternalErrorsCountLimit(),
 		);
 		$finalFileSpecificErrors = [];
 		$finalNotFileSpecificErrors = [];

--- a/src/DependencyInjection/ConditionalTagsExtension.php
+++ b/src/DependencyInjection/ConditionalTagsExtension.php
@@ -10,7 +10,6 @@ use PHPStan\Broker\BrokerFactory;
 use PHPStan\PhpDoc\TypeNodeResolverExtension;
 use PHPStan\Rules\RegistryFactory;
 use PHPStan\ShouldNotHappenException;
-use function count;
 use function sprintf;
 
 class ConditionalTagsExtension extends CompilerExtension

--- a/src/DependencyInjection/ConditionalTagsExtension.php
+++ b/src/DependencyInjection/ConditionalTagsExtension.php
@@ -42,7 +42,7 @@ class ConditionalTagsExtension extends CompilerExtension
 
 		foreach ($config as $type => $tags) {
 			$services = $builder->findByType($type);
-			if (count($services) === 0) {
+			if ($services === []) {
 				throw new ShouldNotHappenException(sprintf('No services of type "%s" found.', $type));
 			}
 			foreach ($services as $service) {

--- a/src/DependencyInjection/ParametersSchemaExtension.php
+++ b/src/DependencyInjection/ParametersSchemaExtension.php
@@ -40,7 +40,7 @@ class ParametersSchemaExtension extends CompilerExtension
 	 */
 	private function processSchema(array $statements): Schema
 	{
-		if (count($statements) === 0) {
+		if ($statements === []) {
 			throw new ShouldNotHappenException();
 		}
 
@@ -77,7 +77,7 @@ class ParametersSchemaExtension extends CompilerExtension
 					$arguments[] = $schemaArgument;
 				}
 
-				if (count($arguments) === 0) {
+				if ($arguments === []) {
 					throw new ShouldNotHappenException('schema() should have at least one argument.');
 				}
 

--- a/src/DependencyInjection/ParametersSchemaExtension.php
+++ b/src/DependencyInjection/ParametersSchemaExtension.php
@@ -11,7 +11,6 @@ use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use PHPStan\ShouldNotHappenException;
 use function array_map;
-use function count;
 use function is_array;
 
 class ParametersSchemaExtension extends CompilerExtension

--- a/src/File/FileMonitorResult.php
+++ b/src/File/FileMonitorResult.php
@@ -2,8 +2,6 @@
 
 namespace PHPStan\File;
 
-use function count;
-
 class FileMonitorResult
 {
 

--- a/src/File/FileMonitorResult.php
+++ b/src/File/FileMonitorResult.php
@@ -23,9 +23,9 @@ class FileMonitorResult
 
 	public function hasAnyChanges(): bool
 	{
-		return count($this->newFiles) > 0
-			|| count($this->changedFiles) > 0
-			|| count($this->deletedFiles) > 0;
+		return $this->newFiles !== []
+			|| $this->changedFiles !== []
+			|| $this->deletedFiles !== [];
 	}
 
 	public function getTotalFilesCount(): int

--- a/src/File/FuzzyRelativePathHelper.php
+++ b/src/File/FuzzyRelativePathHelper.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\File;
 
-use function count;
 use function explode;
 use function implode;
 use function in_array;

--- a/src/File/FuzzyRelativePathHelper.php
+++ b/src/File/FuzzyRelativePathHelper.php
@@ -91,7 +91,7 @@ class FuzzyRelativePathHelper implements RelativePathHelper
 			$pathToTrimArray = $pathTempParts;
 		}
 
-		if ($pathToTrimArray === null || count($pathToTrimArray) === 0) {
+		if ($pathToTrimArray === null || $pathToTrimArray === []) {
 			return;
 		}
 

--- a/src/Internal/ContainerDynamicReturnTypeExtension.php
+++ b/src/Internal/ContainerDynamicReturnTypeExtension.php
@@ -33,7 +33,7 @@ class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		if ($methodCall->getArgs() === []) {
 			return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 		}
 		$argType = $scope->getType($methodCall->getArgs()[0]->value);

--- a/src/NodeVisitor/StatementOrderVisitor.php
+++ b/src/NodeVisitor/StatementOrderVisitor.php
@@ -43,7 +43,7 @@ class StatementOrderVisitor extends NodeVisitorAbstract
 
 		if (
 			($node instanceof Node\Expr || $node instanceof Node\Arg)
-			&& count($this->expressionOrderStack) > 0
+			&& $this->expressionOrderStack !== []
 		) {
 			$expressionOrder = $this->expressionOrderStack[count($this->expressionOrderStack) - 1];
 			$node->setAttribute('expressionOrder', $expressionOrder);

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -81,7 +81,7 @@ class ParallelAnalyser
 				$identifier = $data['identifier'];
 				$process = $this->processPool->getProcess($identifier);
 				$process->bindConnection($decoder, $encoder);
-				if (count($jobs) === 0) {
+				if ($jobs === []) {
 					$this->processPool->tryQuitProcess($identifier);
 					return;
 				}
@@ -110,7 +110,7 @@ class ParallelAnalyser
 		$dependencies = [];
 		$exportedNodes = [];
 		for ($i = 0; $i < $numberOfProcesses; $i++) {
-			if (count($jobs) === 0) {
+			if ($jobs === []) {
 				break;
 			}
 
@@ -159,7 +159,7 @@ class ParallelAnalyser
 				 * @var array<mixed[]> $fileExportedNodes
 				 */
 				foreach ($json['exportedNodes'] as $file => $fileExportedNodes) {
-					if (count($fileExportedNodes) === 0) {
+					if ($fileExportedNodes === []) {
 						continue;
 					}
 					$exportedNodes[$file] = array_map(static function (array $node): ExportedNode {
@@ -179,7 +179,7 @@ class ParallelAnalyser
 					$this->processPool->quitAll();
 				}
 
-				if (count($jobs) === 0) {
+				if ($jobs === []) {
 					$this->processPool->tryQuitProcess($processIdentifier);
 					return;
 				}
@@ -203,7 +203,7 @@ class ParallelAnalyser
 
 		$loop->run();
 
-		if (count($jobs) > 0 && $internalErrorsCount === 0) {
+		if ($jobs !== [] && $internalErrorsCount === 0) {
 			$internalErrors[] = 'Some parallel worker jobs have not finished.';
 			$internalErrorsCount++;
 		}

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -18,7 +18,6 @@ use Throwable;
 use function array_map;
 use function array_pop;
 use function array_reverse;
-use function count;
 use function defined;
 use function escapeshellarg;
 use function is_string;

--- a/src/Parallel/ProcessPool.php
+++ b/src/Parallel/ProcessPool.php
@@ -6,7 +6,6 @@ use PHPStan\ShouldNotHappenException;
 use React\Socket\TcpServer;
 use function array_key_exists;
 use function array_keys;
-use function count;
 use function sprintf;
 
 class ProcessPool

--- a/src/Parallel/ProcessPool.php
+++ b/src/Parallel/ProcessPool.php
@@ -47,7 +47,7 @@ class ProcessPool
 		$process = $this->getProcess($identifier);
 		$process->quit();
 		unset($this->processes[$identifier]);
-		if (count($this->processes) !== 0) {
+		if ($this->processes !== []) {
 			return;
 		}
 

--- a/src/Php/PhpVersionFactoryFactory.php
+++ b/src/Php/PhpVersionFactoryFactory.php
@@ -6,7 +6,6 @@ use Nette\Utils\Json;
 use Nette\Utils\JsonException;
 use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileReader;
-use function count;
 use function end;
 use function is_file;
 use function is_string;

--- a/src/Php/PhpVersionFactoryFactory.php
+++ b/src/Php/PhpVersionFactoryFactory.php
@@ -27,7 +27,7 @@ class PhpVersionFactoryFactory
 	public function create(): PhpVersionFactory
 	{
 		$composerPhpVersion = null;
-		if (count($this->composerAutoloaderProjectPaths) > 0) {
+		if ($this->composerAutoloaderProjectPaths !== []) {
 			$composerJsonPath = end($this->composerAutoloaderProjectPaths) . '/composer.json';
 			if (is_file($composerJsonPath)) {
 				try {

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -69,14 +69,14 @@ class PhpDocNodeResolver
 				}
 			}
 
-			if (count($tagResolved) === 0) {
+			if ($tagResolved === []) {
 				continue;
 			}
 
 			$resolvedByTag[] = $tagResolved;
 		}
 
-		if (count($resolvedByTag) > 0) {
+		if ($resolvedByTag !== []) {
 			return array_reverse($resolvedByTag)[0];
 		}
 
@@ -344,7 +344,7 @@ class PhpDocNodeResolver
 				$types[] = $type;
 			}
 
-			if (count($types) > 0) {
+			if ($types !== []) {
 				return new ThrowsTag(TypeCombinator::union(...$types));
 			}
 		}
@@ -413,21 +413,21 @@ class PhpDocNodeResolver
 	{
 		$deprecatedTags = $phpDocNode->getTagsByName('@deprecated');
 
-		return count($deprecatedTags) > 0;
+		return $deprecatedTags !== [];
 	}
 
 	public function resolveIsInternal(PhpDocNode $phpDocNode): bool
 	{
 		$internalTags = $phpDocNode->getTagsByName('@internal');
 
-		return count($internalTags) > 0;
+		return $internalTags !== [];
 	}
 
 	public function resolveIsFinal(PhpDocNode $phpDocNode): bool
 	{
 		$finalTags = $phpDocNode->getTagsByName('@final');
 
-		return count($finalTags) > 0;
+		return $finalTags !== [];
 	}
 
 	public function resolveIsPure(PhpDocNode $phpDocNode): bool

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -30,7 +30,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_map;
 use function array_reverse;
-use function count;
 use function in_array;
 use function strpos;
 use function substr;

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -202,7 +202,7 @@ class ResolvedPhpDocBlock
 	 */
 	public function changeParameterNamesByMapping(array $parameterNameMapping): self
 	{
-		if (count($this->phpDocNodes) === 0) {
+		if ($this->phpDocNodes === []) {
 			return $this;
 		}
 
@@ -527,7 +527,7 @@ class ResolvedPhpDocBlock
 	private static function mergeVarTags(array $varTags, array $parents, array $parentPhpDocBlocks): array
 	{
 		// Only allow one var tag per comment. Check the parent if child does not have this tag.
-		if (count($varTags) > 0) {
+		if ($varTags !== []) {
 			return $varTags;
 		}
 

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -22,7 +22,6 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use function array_key_exists;
-use function count;
 use function is_bool;
 
 /** @api */

--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -71,7 +71,7 @@ class StubValidator
 	 */
 	public function validate(array $stubFiles, bool $debug): array
 	{
-		if (count($stubFiles) === 0) {
+		if ($stubFiles === []) {
 			return [];
 		}
 

--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -53,7 +53,6 @@ use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\ObjectType;
 use Throwable;
 use function array_fill_keys;
-use function count;
 use function sprintf;
 
 class StubValidator

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -399,7 +399,7 @@ class TypeNodeResolver
 		}
 
 		$otherTypeTypes = $this->resolveMultiple($otherTypeNodes, $nameScope);
-		if (count($iterableTypeNodes) > 0) {
+		if ($iterableTypeNodes !== []) {
 			$arrayTypeTypes = $this->resolveMultiple($iterableTypeNodes, $nameScope);
 			$arrayTypeType = TypeCombinator::union(...$arrayTypeTypes);
 			$addArray = true;
@@ -741,7 +741,7 @@ class TypeNodeResolver
 					$constantTypes[] = ConstantTypeHelper::getTypeFromValue($constantValue);
 				}
 
-				if (count($constantTypes) === 0) {
+				if ($constantTypes === []) {
 					return new ErrorType();
 				}
 

--- a/src/Process/Runnable/RunnableQueue.php
+++ b/src/Process/Runnable/RunnableQueue.php
@@ -66,7 +66,7 @@ class RunnableQueue
 
 	private function drainQueue(): void
 	{
-		if (count($this->queue) === 0) {
+		if ($this->queue === []) {
 			$this->logger->log('Queue empty');
 			return;
 		}

--- a/src/Process/Runnable/RunnableQueue.php
+++ b/src/Process/Runnable/RunnableQueue.php
@@ -8,7 +8,6 @@ use React\Promise\Deferred;
 use SplObjectStorage;
 use Throwable;
 use function array_shift;
-use function count;
 use function sprintf;
 
 class RunnableQueue

--- a/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php
@@ -216,7 +216,7 @@ class AutoloadSourceLocator implements SourceLocator
 			$classNodesCount = count($this->classNodes[$identifierName]);
 			foreach ($this->classNodes[$identifierName] as $classNode) {
 				if ($classNodesCount > 1 && $startLine !== null) {
-					if (count($classNode->getNode()->attrGroups) > 0 && PHP_VERSION_ID < 80000) {
+					if ($classNode->getNode()->attrGroups !== [] && PHP_VERSION_ID < 80000) {
 						$startLine--;
 					}
 					if ($startLine !== $classNode->getNode()->getStartLine()) {

--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -123,7 +123,7 @@ class ComposerJsonAndInstalledJsonSourceLocatorMaker
 			$files[] = $file;
 		}
 
-		if (count($files) > 0) {
+		if ($files !== []) {
 			$locators[] = $this->optimizedDirectorySourceLocatorFactory->createByFiles($files);
 		}
 

--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -15,7 +15,6 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function array_merge_recursive;
-use function count;
 use function dirname;
 use function is_dir;
 use function is_file;

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -218,7 +218,7 @@ class ClassReflection
 		if (
 			$withTemplateTypes === false
 			|| $this->resolvedTemplateTypeMap === null
-			|| count($this->resolvedTemplateTypeMap->getTypes()) === 0
+			|| $this->resolvedTemplateTypeMap->getTypes() === []
 		) {
 			return $name;
 		}
@@ -308,7 +308,7 @@ class ClassReflection
 		$traits = [];
 		$traitsLeftToAnalyze = $class->getTraits();
 
-		while (count($traitsLeftToAnalyze) !== 0) {
+		while ($traitsLeftToAnalyze !== []) {
 			$trait = reset($traitsLeftToAnalyze);
 			$traits[] = $trait;
 
@@ -1026,7 +1026,7 @@ class ClassReflection
 				return $this->isGeneric = false;
 			}
 
-			$this->isGeneric = count($this->getTemplateTags()) > 0;
+			$this->isGeneric = $this->getTemplateTags() !== [];
 		}
 
 		return $this->isGeneric;

--- a/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
@@ -10,7 +10,6 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use function array_intersect;
-use function count;
 
 class MixinMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {

--- a/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
@@ -44,7 +44,7 @@ class MixinMethodsClassReflectionExtension implements MethodsClassReflectionExte
 	{
 		$mixinTypes = $classReflection->getResolvedMixinTypes();
 		foreach ($mixinTypes as $type) {
-			if (count(array_intersect(TypeUtils::getDirectClassNames($type), $this->mixinExcludeClasses)) > 0) {
+			if (array_intersect(TypeUtils::getDirectClassNames($type), $this->mixinExcludeClasses) !== []) {
 				continue;
 			}
 

--- a/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
@@ -44,7 +44,7 @@ class MixinPropertiesClassReflectionExtension implements PropertiesClassReflecti
 	{
 		$mixinTypes = $classReflection->getResolvedMixinTypes();
 		foreach ($mixinTypes as $type) {
-			if (count(array_intersect(TypeUtils::getDirectClassNames($type), $this->mixinExcludeClasses)) > 0) {
+			if (array_intersect(TypeUtils::getDirectClassNames($type), $this->mixinExcludeClasses) !== []) {
 				continue;
 			}
 

--- a/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
@@ -10,7 +10,6 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use function array_intersect;
-use function count;
 
 class MixinPropertiesClassReflectionExtension implements PropertiesClassReflectionExtension
 {

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -63,8 +63,8 @@ class ParametersAcceptorSelector
 		$types = [];
 		$unpack = false;
 		if (
-			count($args) > 0
-			&& count($parametersAcceptors) > 0
+			$args !== []
+			&& $parametersAcceptors !== []
 		) {
 			$functionName = null;
 			$argParent = $args[0]->getAttribute('parent');
@@ -188,7 +188,7 @@ class ParametersAcceptorSelector
 			return GenericParametersAcceptorResolver::resolve($types, $parametersAcceptors[0]);
 		}
 
-		if (count($parametersAcceptors) === 0) {
+		if ($parametersAcceptors === []) {
 			throw new ShouldNotHappenException(
 				'getVariants() must return at least one variant.',
 			);
@@ -227,7 +227,7 @@ class ParametersAcceptorSelector
 			$acceptableAcceptors[] = $parametersAcceptor;
 		}
 
-		if (count($acceptableAcceptors) === 0) {
+		if ($acceptableAcceptors === []) {
 			return GenericParametersAcceptorResolver::resolve($types, self::combineAcceptors($parametersAcceptors));
 		}
 
@@ -276,7 +276,7 @@ class ParametersAcceptorSelector
 			}
 		}
 
-		if (count($winningAcceptors) === 0) {
+		if ($winningAcceptors === []) {
 			return GenericParametersAcceptorResolver::resolve($types, self::combineAcceptors($acceptableAcceptors));
 		}
 
@@ -288,7 +288,7 @@ class ParametersAcceptorSelector
 	 */
 	public static function combineAcceptors(array $acceptors): ParametersAcceptor
 	{
-		if (count($acceptors) === 0) {
+		if ($acceptors === []) {
 			throw new ShouldNotHappenException(
 				'getVariants() must return at least one variant.',
 			);

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -862,7 +862,7 @@ class PhpClassReflectionExtension
 		$traits = [];
 		$traitsLeftToAnalyze = $class->getTraits();
 
-		while (count($traitsLeftToAnalyze) !== 0) {
+		while ($traitsLeftToAnalyze !== []) {
 			$trait = reset($traitsLeftToAnalyze);
 			$traits[] = $trait;
 

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -11,7 +11,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_map;
-use function count;
 use function implode;
 
 class IntersectionTypeMethodReflection implements MethodReflection

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -105,7 +105,7 @@ class IntersectionTypeMethodReflection implements MethodReflection
 			$descriptions[] = $description;
 		}
 
-		if (count($descriptions) === 0) {
+		if ($descriptions === []) {
 			return null;
 		}
 
@@ -135,7 +135,7 @@ class IntersectionTypeMethodReflection implements MethodReflection
 			$types[] = $type;
 		}
 
-		if (count($types) === 0) {
+		if ($types === []) {
 			return null;
 		}
 

--- a/src/Reflection/Type/IntersectionTypePropertyReflection.php
+++ b/src/Reflection/Type/IntersectionTypePropertyReflection.php
@@ -79,7 +79,7 @@ class IntersectionTypePropertyReflection implements PropertyReflection
 			$descriptions[] = $description;
 		}
 
-		if (count($descriptions) === 0) {
+		if ($descriptions === []) {
 			return null;
 		}
 

--- a/src/Reflection/Type/IntersectionTypePropertyReflection.php
+++ b/src/Reflection/Type/IntersectionTypePropertyReflection.php
@@ -8,7 +8,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_map;
-use function count;
 use function implode;
 
 class IntersectionTypePropertyReflection implements PropertyReflection

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -11,7 +11,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_map;
-use function count;
 use function implode;
 
 class UnionTypeMethodReflection implements MethodReflection

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -106,7 +106,7 @@ class UnionTypeMethodReflection implements MethodReflection
 			$descriptions[] = $description;
 		}
 
-		if (count($descriptions) === 0) {
+		if ($descriptions === []) {
 			return null;
 		}
 
@@ -136,7 +136,7 @@ class UnionTypeMethodReflection implements MethodReflection
 			$types[] = $type;
 		}
 
-		if (count($types) === 0) {
+		if ($types === []) {
 			return null;
 		}
 

--- a/src/Reflection/Type/UnionTypePropertyReflection.php
+++ b/src/Reflection/Type/UnionTypePropertyReflection.php
@@ -79,7 +79,7 @@ class UnionTypePropertyReflection implements PropertyReflection
 			$descriptions[] = $description;
 		}
 
-		if (count($descriptions) === 0) {
+		if ($descriptions === []) {
 			return null;
 		}
 

--- a/src/Reflection/Type/UnionTypePropertyReflection.php
+++ b/src/Reflection/Type/UnionTypePropertyReflection.php
@@ -8,7 +8,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_map;
-use function count;
 use function implode;
 
 class UnionTypePropertyReflection implements PropertyReflection

--- a/src/Rules/Api/ApiClassExtendsRule.php
+++ b/src/Rules/Api/ApiClassExtendsRule.php
@@ -65,7 +65,7 @@ class ApiClassExtendsRule implements Rule
 
 		foreach ($docBlock->getPhpDocNodes() as $phpDocNode) {
 			$apiTags = $phpDocNode->getTagsByName('@api');
-			if (count($apiTags) > 0) {
+			if ($apiTags !== []) {
 				return [];
 			}
 		}

--- a/src/Rules/Api/ApiClassExtendsRule.php
+++ b/src/Rules/Api/ApiClassExtendsRule.php
@@ -9,7 +9,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/Api/ApiClassImplementsRule.php
+++ b/src/Rules/Api/ApiClassImplementsRule.php
@@ -11,7 +11,6 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Type;
 use function array_merge;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/Api/ApiClassImplementsRule.php
+++ b/src/Rules/Api/ApiClassImplementsRule.php
@@ -76,7 +76,7 @@ class ApiClassImplementsRule implements Rule
 
 		foreach ($docBlock->getPhpDocNodes() as $phpDocNode) {
 			$apiTags = $phpDocNode->getTagsByName('@api');
-			if (count($apiTags) > 0) {
+			if ($apiTags !== []) {
 				return [];
 			}
 		}

--- a/src/Rules/Api/ApiInterfaceExtendsRule.php
+++ b/src/Rules/Api/ApiInterfaceExtendsRule.php
@@ -76,7 +76,7 @@ class ApiInterfaceExtendsRule implements Rule
 
 		foreach ($docBlock->getPhpDocNodes() as $phpDocNode) {
 			$apiTags = $phpDocNode->getTagsByName('@api');
-			if (count($apiTags) > 0) {
+			if ($apiTags !== []) {
 				return [];
 			}
 		}

--- a/src/Rules/Api/ApiInterfaceExtendsRule.php
+++ b/src/Rules/Api/ApiInterfaceExtendsRule.php
@@ -11,7 +11,6 @@ use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Type;
 use function array_merge;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/Api/ApiMethodCallRule.php
+++ b/src/Rules/Api/ApiMethodCallRule.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function count;
 use function sprintf;
 use function strpos;
 

--- a/src/Rules/Api/ApiMethodCallRule.php
+++ b/src/Rules/Api/ApiMethodCallRule.php
@@ -65,7 +65,7 @@ class ApiMethodCallRule implements Rule
 		if ($classDocBlock !== null) {
 			foreach ($classDocBlock->getPhpDocNodes() as $phpDocNode) {
 				$apiTags = $phpDocNode->getTagsByName('@api');
-				if (count($apiTags) > 0) {
+				if ($apiTags !== []) {
 					return true;
 				}
 			}

--- a/src/Rules/Api/ApiStaticCallRule.php
+++ b/src/Rules/Api/ApiStaticCallRule.php
@@ -80,7 +80,7 @@ class ApiStaticCallRule implements Rule
 		if ($methodReflection->getName() !== '__construct' && $classDocBlock !== null) {
 			foreach ($classDocBlock->getPhpDocNodes() as $phpDocNode) {
 				$apiTags = $phpDocNode->getTagsByName('@api');
-				if (count($apiTags) > 0) {
+				if ($apiTags !== []) {
 					return true;
 				}
 			}

--- a/src/Rules/Api/ApiStaticCallRule.php
+++ b/src/Rules/Api/ApiStaticCallRule.php
@@ -8,7 +8,6 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function count;
 use function sprintf;
 use function strpos;
 

--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -34,7 +34,7 @@ class InvalidKeyInArrayDimFetchRule implements Rule
 		}
 
 		$varType = $scope->getType($node->var);
-		if (count(TypeUtils::getArrays($varType)) === 0) {
+		if (TypeUtils::getArrays($varType) === []) {
 			return [];
 		}
 

--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -9,7 +9,6 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
@@ -14,7 +14,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 class NonexistentOffsetInArrayDimFetchCheck

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
@@ -49,7 +49,7 @@ class NonexistentOffsetInArrayDimFetchCheck
 		$report = $hasOffsetValueType->no();
 		if ($hasOffsetValueType->maybe()) {
 			$constantArrays = TypeUtils::getOldConstantArrays($type);
-			if (count($constantArrays) > 0) {
+			if ($constantArrays !== []) {
 				foreach ($constantArrays as $constantArray) {
 					if ($constantArray->hasOffsetValueType($dimType)->no()) {
 						$report = true;

--- a/src/Rules/AttributesCheck.php
+++ b/src/Rules/AttributesCheck.php
@@ -85,7 +85,7 @@ class AttributesCheck
 				}
 
 				if (!$attributeClass->hasConstructor()) {
-					if (count($attribute->args) > 0) {
+					if ($attribute->args !== []) {
 						$errors[] = RuleErrorBuilder::message(sprintf('Attribute class %s does not have a constructor and must be instantiated without any parameters.', $name))->line($attribute->getLine())->build();
 					}
 					continue;

--- a/src/Rules/AttributesCheck.php
+++ b/src/Rules/AttributesCheck.php
@@ -10,7 +10,6 @@ use PHPStan\Internal\SprintfHelper;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use function array_key_exists;
-use function count;
 use function sprintf;
 use function strtolower;
 

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -21,7 +21,6 @@ use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use function array_map;
 use function array_merge;
-use function count;
 use function sprintf;
 use function strtolower;
 

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -157,7 +157,7 @@ class InstantiationRule implements Rule
 		}
 
 		if (!$classReflection->hasConstructor()) {
-			if (count($node->getArgs()) > 0) {
+			if ($node->getArgs() !== []) {
 				return array_merge($messages, [
 					RuleErrorBuilder::message(sprintf(
 						'Class %s does not have a constructor and must be instantiated without any parameters.',

--- a/src/Rules/Classes/UnusedConstructorParametersRule.php
+++ b/src/Rules/Classes/UnusedConstructorParametersRule.php
@@ -15,7 +15,6 @@ use PHPStan\ShouldNotHappenException;
 use function array_filter;
 use function array_map;
 use function array_values;
-use function count;
 use function is_string;
 use function sprintf;
 use function strtolower;

--- a/src/Rules/Classes/UnusedConstructorParametersRule.php
+++ b/src/Rules/Classes/UnusedConstructorParametersRule.php
@@ -51,7 +51,7 @@ class UnusedConstructorParametersRule implements Rule
 			return [];
 		}
 
-		if (count($originalNode->params) === 0) {
+		if ($originalNode->params === []) {
 			return [];
 		}
 

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -55,7 +55,7 @@ class ImpossibleCheckTypeHelper
 	{
 		if (
 			$node instanceof FuncCall
-			&& count($node->getArgs()) > 0
+			&& $node->getArgs() !== []
 		) {
 			if ($node->name instanceof Node\Name) {
 				$functionName = strtolower((string) $node->name);
@@ -91,7 +91,7 @@ class ImpossibleCheckTypeHelper
 						return null;
 					}
 
-					if (!$haystackType instanceof ConstantArrayType || count($haystackType->getValueTypes()) > 0) {
+					if (!$haystackType instanceof ConstantArrayType || $haystackType->getValueTypes() !== []) {
 						$needleType = $scope->getType($node->getArgs()[0]->value);
 
 						$haystackArrayTypes = TypeUtils::getArrays($haystackType);
@@ -115,8 +115,8 @@ class ImpossibleCheckTypeHelper
 						}
 
 						if ($isNeedleSupertype->yes()) {
-							$hasConstantNeedleTypes = count(TypeUtils::getConstantScalars($needleType)) > 0;
-							$hasConstantHaystackTypes = count(TypeUtils::getConstantScalars($valueType)) > 0;
+							$hasConstantNeedleTypes = TypeUtils::getConstantScalars($needleType) !== [];
+							$hasConstantHaystackTypes = TypeUtils::getConstantScalars($valueType) !== [];
 							if (
 								(
 									!$hasConstantNeedleTypes
@@ -177,7 +177,7 @@ class ImpossibleCheckTypeHelper
 			) && $scope->isSpecified($expr);
 		};
 
-		if (count($sureTypes) === 1 && count($sureNotTypes) === 0) {
+		if (count($sureTypes) === 1 && $sureNotTypes === []) {
 			$sureType = reset($sureTypes);
 			if ($isSpecified($sureType[0])) {
 				return null;
@@ -200,7 +200,7 @@ class ImpossibleCheckTypeHelper
 			}
 
 			return null;
-		} elseif (count($sureNotTypes) === 1 && count($sureTypes) === 0) {
+		} elseif (count($sureNotTypes) === 1 && $sureTypes === []) {
 			$sureNotType = reset($sureNotTypes);
 			if ($isSpecified($sureNotType[0])) {
 				return null;
@@ -225,7 +225,7 @@ class ImpossibleCheckTypeHelper
 			return null;
 		}
 
-		if (count($sureTypes) > 0) {
+		if ($sureTypes !== []) {
 			foreach ($sureTypes as $sureType) {
 				if ($isSpecified($sureType[0])) {
 					return null;
@@ -239,7 +239,7 @@ class ImpossibleCheckTypeHelper
 			}
 		}
 
-		if (count($sureNotTypes) > 0) {
+		if ($sureNotTypes !== []) {
 			foreach ($sureNotTypes as $sureNotType) {
 				if ($isSpecified($sureNotType[0])) {
 					return null;
@@ -264,7 +264,7 @@ class ImpossibleCheckTypeHelper
 		array $args,
 	): string
 	{
-		if (count($args) === 0) {
+		if ($args === []) {
 			return '';
 		}
 

--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -42,7 +42,7 @@ class MatchExpressionRule implements Rule
 				continue;
 			}
 			$armConditions = $arm->getConditions();
-			if (count($armConditions) === 0) {
+			if ($armConditions === []) {
 				$hasDefault = true;
 			}
 			foreach ($armConditions as $armCondition) {

--- a/src/Rules/DateTimeInstantiationRule.php
+++ b/src/Rules/DateTimeInstantiationRule.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Expr\New_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Constant\ConstantStringType;
 use Throwable;
-use function count;
 use function in_array;
 use function sprintf;
 use function strtolower;

--- a/src/Rules/DateTimeInstantiationRule.php
+++ b/src/Rules/DateTimeInstantiationRule.php
@@ -31,7 +31,7 @@ class DateTimeInstantiationRule implements Rule
 	{
 		if (
 			!($node->class instanceof Node\Name)
-			|| count($node->getArgs()) === 0
+			|| $node->getArgs() === []
 			|| !in_array(strtolower((string) $node->class), ['datetime', 'datetimeimmutable'], true)
 		) {
 			return [];

--- a/src/Rules/DeadCode/UnusedPrivateMethodRule.php
+++ b/src/Rules/DeadCode/UnusedPrivateMethodRule.php
@@ -74,7 +74,7 @@ class UnusedPrivateMethodRule implements Rule
 			} else {
 				$methodNameType = $callScope->getType($methodCallNode->name);
 				$strings = TypeUtils::getConstantStrings($methodNameType);
-				if (count($strings) === 0) {
+				if ($strings === []) {
 					return [];
 				}
 
@@ -108,7 +108,7 @@ class UnusedPrivateMethodRule implements Rule
 			}
 		}
 
-		if (count($methods) > 0) {
+		if ($methods !== []) {
 			foreach ($arrayCalls as $arrayCall) {
 				/** @var Node\Expr\Array_ $array */
 				$array = $arrayCall->getNode();

--- a/src/Rules/DeadCode/UnusedPrivateMethodRule.php
+++ b/src/Rules/DeadCode/UnusedPrivateMethodRule.php
@@ -16,7 +16,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeUtils;
 use function array_map;
-use function count;
 use function sprintf;
 use function strtolower;
 

--- a/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
+++ b/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
@@ -16,7 +16,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeUtils;
 use function array_key_exists;
 use function array_map;
-use function count;
 use function sprintf;
 use function strpos;
 

--- a/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
+++ b/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
@@ -123,7 +123,7 @@ class UnusedPrivatePropertyRule implements Rule
 			} else {
 				$propertyNameType = $usage->getScope()->getType($fetch->name);
 				$strings = TypeUtils::getConstantStrings($propertyNameType);
-				if (count($strings) === 0) {
+				if ($strings === []) {
 					return [];
 				}
 

--- a/src/Rules/Debug/DumpTypeRule.php
+++ b/src/Rules/Debug/DumpTypeRule.php
@@ -8,7 +8,6 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 use function strtolower;
 

--- a/src/Rules/Debug/DumpTypeRule.php
+++ b/src/Rules/Debug/DumpTypeRule.php
@@ -42,7 +42,7 @@ class DumpTypeRule implements Rule
 			return [];
 		}
 
-		if (count($node->getArgs()) === 0) {
+		if ($node->getArgs() === []) {
 			return [
 				RuleErrorBuilder::message(sprintf('Missing argument for %s() function call.', $functionName))
 					->nonIgnorable()

--- a/src/Rules/Exceptions/DefaultExceptionTypeResolver.php
+++ b/src/Rules/Exceptions/DefaultExceptionTypeResolver.php
@@ -75,7 +75,7 @@ class DefaultExceptionTypeResolver implements ExceptionTypeResolver
 		}
 
 		if (!$this->reflectionProvider->hasClass($className)) {
-			return count($this->checkedExceptionRegexes) === 0 && count($this->checkedExceptionClasses) === 0;
+			return $this->checkedExceptionRegexes === [] && $this->checkedExceptionClasses === [];
 		}
 
 		$classReflection = $this->reflectionProvider->getClass($className);
@@ -91,7 +91,7 @@ class DefaultExceptionTypeResolver implements ExceptionTypeResolver
 			return true;
 		}
 
-		return count($this->checkedExceptionRegexes) === 0 && count($this->checkedExceptionClasses) === 0;
+		return $this->checkedExceptionRegexes === [] && $this->checkedExceptionClasses === [];
 	}
 
 }

--- a/src/Rules/Exceptions/DefaultExceptionTypeResolver.php
+++ b/src/Rules/Exceptions/DefaultExceptionTypeResolver.php
@@ -5,7 +5,6 @@ namespace PHPStan\Rules\Exceptions;
 use Nette\Utils\Strings;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
-use function count;
 
 class DefaultExceptionTypeResolver implements ExceptionTypeResolver
 {

--- a/src/Rules/Exceptions/OverwrittenExitPointByFinallyRule.php
+++ b/src/Rules/Exceptions/OverwrittenExitPointByFinallyRule.php
@@ -23,7 +23,7 @@ class OverwrittenExitPointByFinallyRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (count($node->getTryCatchExitPoints()) === 0) {
+		if ($node->getTryCatchExitPoints() === []) {
 			return [];
 		}
 

--- a/src/Rules/Exceptions/OverwrittenExitPointByFinallyRule.php
+++ b/src/Rules/Exceptions/OverwrittenExitPointByFinallyRule.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\FinallyExitPointsNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -93,7 +93,7 @@ class FunctionCallParametersCheck
 			}
 			if ($arg->unpack) {
 				$arrays = TypeUtils::getConstantArrays($type);
-				if (count($arrays) > 0) {
+				if ($arrays !== []) {
 					$minKeys = null;
 					foreach ($arrays as $array) {
 						$keysCount = count($array->getKeyTypes());
@@ -285,7 +285,7 @@ class FunctionCallParametersCheck
 		if ($this->checkMissingTypehints && $parametersAcceptor instanceof ResolvedFunctionVariant) {
 			$originalParametersAcceptor = $parametersAcceptor->getOriginalParametersAcceptor();
 			$resolvedTypes = $parametersAcceptor->getResolvedTemplateTypeMap()->getTypes();
-			if (count($resolvedTypes) > 0) {
+			if ($resolvedTypes !== []) {
 				$returnTemplateTypes = [];
 				TypeTraverser::map($originalParametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use (&$returnTemplateTypes): Type {
 					if ($type instanceof TemplateType) {
@@ -376,7 +376,7 @@ class FunctionCallParametersCheck
 		foreach ($arguments as $i => [$argumentValue, $argumentValueType, $unpack, $argumentName, $argumentLine]) {
 			if ($argumentName === null) {
 				if (!isset($parameters[$i])) {
-					if (!$parametersAcceptor->isVariadic() || count($parameters) === 0) {
+					if (!$parametersAcceptor->isVariadic() || $parameters === []) {
 						$newArguments[$i] = [$argumentValue, $argumentValueType, $unpack, $argumentName, $argumentLine, null];
 						break;
 					}

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -323,7 +323,7 @@ class FunctionDefinitionCheck
 
 		$templateTypeMap = $parametersAcceptor->getTemplateTypeMap();
 		$templateTypes = $templateTypeMap->getTypes();
-		if (count($templateTypes) > 0) {
+		if ($templateTypes !== []) {
 			foreach ($parametersAcceptor->getParameters() as $parameter) {
 				TypeTraverser::map($parameter->getType(), static function (Type $type, callable $traverse) use (&$templateTypes): Type {
 					if ($type instanceof TemplateType) {

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -32,7 +32,6 @@ use PHPStan\Type\VoidType;
 use function array_keys;
 use function array_map;
 use function array_merge;
-use function count;
 use function is_string;
 use function sprintf;
 

--- a/src/Rules/Functions/ClosureReturnTypeRule.php
+++ b/src/Rules/Functions/ClosureReturnTypeRule.php
@@ -53,7 +53,7 @@ class ClosureReturnTypeRule implements Rule
 				'Anonymous function with return type void returns %s but should not return anything.',
 				'Anonymous function should return %s but returns %s.',
 				'Anonymous function should never return but return statement found.',
-				count($node->getYieldStatements()) > 0,
+				$node->getYieldStatements() !== [],
 			);
 
 			foreach ($returnMessages as $returnMessage) {

--- a/src/Rules/Functions/ClosureReturnTypeRule.php
+++ b/src/Rules/Functions/ClosureReturnTypeRule.php
@@ -9,7 +9,6 @@ use PHPStan\Rules\FunctionReturnTypeCheck;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use function count;
 
 /**
  * @implements Rule<ClosureReturnStatementsNode>

--- a/src/Rules/Functions/ParamAttributesRule.php
+++ b/src/Rules/Functions/ParamAttributesRule.php
@@ -7,7 +7,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\AttributesCheck;
 use PHPStan\Rules\Rule;
-use function count;
 
 /**
  * @implements Rule<Node\Param>

--- a/src/Rules/Functions/ParamAttributesRule.php
+++ b/src/Rules/Functions/ParamAttributesRule.php
@@ -37,7 +37,7 @@ class ParamAttributesRule implements Rule
 				$targetName,
 			);
 
-			if (count($propertyTargetErrors) === 0) {
+			if ($propertyTargetErrors === []) {
 				return $propertyTargetErrors;
 			}
 		}

--- a/src/Rules/Functions/PrintfParametersRule.php
+++ b/src/Rules/Functions/PrintfParametersRule.php
@@ -121,13 +121,13 @@ class PrintfParametersRule implements Rule
 
 		$matches = Strings::matchAll($format, $pattern, PREG_SET_ORDER);
 
-		if (count($matches) === 0) {
+		if ($matches === []) {
 			return 0;
 		}
 
 		$placeholders = array_filter($matches, static fn (array $match): bool => strlen($match['before']) % 2 === 0);
 
-		if (count($placeholders) === 0) {
+		if ($placeholders === []) {
 			return 0;
 		}
 

--- a/src/Rules/Functions/UnusedClosureUsesRule.php
+++ b/src/Rules/Functions/UnusedClosureUsesRule.php
@@ -8,7 +8,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\UnusedFunctionParametersCheck;
 use PHPStan\ShouldNotHappenException;
 use function array_map;
-use function count;
 use function is_string;
 
 /**

--- a/src/Rules/Functions/UnusedClosureUsesRule.php
+++ b/src/Rules/Functions/UnusedClosureUsesRule.php
@@ -28,7 +28,7 @@ class UnusedClosureUsesRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (count($node->uses) === 0) {
+		if ($node->uses === []) {
 			return [];
 		}
 

--- a/src/Rules/Generics/GenericAncestorsCheck.php
+++ b/src/Rules/Generics/GenericAncestorsCheck.php
@@ -16,7 +16,6 @@ use function array_fill_keys;
 use function array_keys;
 use function array_map;
 use function array_merge;
-use function count;
 use function implode;
 use function in_array;
 use function sprintf;

--- a/src/Rules/Generics/GenericAncestorsCheck.php
+++ b/src/Rules/Generics/GenericAncestorsCheck.php
@@ -70,7 +70,7 @@ class GenericAncestorsCheck
 
 			$ancestorTypeClassName = $ancestorType->getClassName();
 			if (!isset($names[$ancestorTypeClassName])) {
-				if (count($names) === 0) {
+				if ($names === []) {
 					$messages[] = RuleErrorBuilder::message($noNamesMessage)->build();
 				} else {
 					$messages[] = RuleErrorBuilder::message(sprintf($noRelatedNameMessage, $ancestorTypeClassName, implode(', ', array_keys($names))))->build();

--- a/src/Rules/Methods/OverridingMethodRule.php
+++ b/src/Rules/Methods/OverridingMethodRule.php
@@ -470,7 +470,7 @@ class OverridingMethodRule implements Rule
 		Scope $scope,
 	): array
 	{
-		if (count($errors) > 0) {
+		if ($errors !== []) {
 			return $errors;
 		}
 

--- a/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
@@ -108,7 +108,7 @@ class ExistingNamesInGroupUseRule implements Rule
 		$errors = $this->classCaseSensitivityCheck->checkClassNames([
 			new ClassNameNodePair((string) $name, $name),
 		]);
-		if (count($errors) === 0) {
+		if ($errors === []) {
 			return null;
 		} elseif (count($errors) === 1) {
 			return $errors[0];

--- a/src/Rules/PhpDoc/WrongVariableNameInVarTagRule.php
+++ b/src/Rules/PhpDoc/WrongVariableNameInVarTagRule.php
@@ -73,7 +73,7 @@ class WrongVariableNameInVarTagRule implements Rule
 			}
 		}
 
-		if (count($varTags) === 0) {
+		if ($varTags === []) {
 			return [];
 		}
 
@@ -318,7 +318,7 @@ class WrongVariableNameInVarTagRule implements Rule
 		}
 
 		if (count($variableLessVarTags) !== 1 || $defaultExpr === null) {
-			if (count($variableLessVarTags) > 0) {
+			if ($variableLessVarTags !== []) {
 				$errors[] = RuleErrorBuilder::message('PHPDoc tag @var does not specify variable name.')->build();
 			}
 		}

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -21,7 +21,6 @@ use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 use function strpos;
 

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -91,8 +91,8 @@ class RuleLevelHelper
 			$acceptedType->isArray()->yes()
 			&& $acceptingType->isArray()->yes()
 			&& !$acceptingType->isIterableAtLeastOnce()->yes()
-			&& count(TypeUtils::getConstantArrays($acceptedType)) === 0
-			&& count(TypeUtils::getConstantArrays($acceptingType)) === 0
+			&& TypeUtils::getConstantArrays($acceptedType) === []
+			&& TypeUtils::getConstantArrays($acceptingType) === []
 		) {
 			return self::accepts(
 				$acceptingType->getIterableKeyType(),
@@ -162,7 +162,7 @@ class RuleLevelHelper
 			$errors[] = RuleErrorBuilder::message(sprintf($unknownClassErrorPattern, $referencedClass))->line($var->getLine())->discoveringSymbolsTip()->build();
 		}
 
-		if (count($errors) > 0 || $hasClassExistsClass) {
+		if ($errors !== [] || $hasClassExistsClass) {
 			return new FoundTypeResult(new ErrorType(), [], $errors, null);
 		}
 
@@ -180,7 +180,7 @@ class RuleLevelHelper
 					$newTypes[] = $innerType;
 				}
 
-				if (count($newTypes) > 0) {
+				if ($newTypes !== []) {
 					return new FoundTypeResult(TypeCombinator::union(...$newTypes), $directClassNames, [], null);
 				}
 			}

--- a/src/Rules/TooWideTypehints/TooWideClosureReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideClosureReturnTypehintRule.php
@@ -11,7 +11,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/TooWideTypehints/TooWideClosureReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideClosureReturnTypehintRule.php
@@ -43,7 +43,7 @@ class TooWideClosureReturnTypehintRule implements Rule
 		}
 
 		$returnStatements = $node->getReturnStatements();
-		if (count($returnStatements) === 0) {
+		if ($returnStatements === []) {
 			return [];
 		}
 
@@ -57,7 +57,7 @@ class TooWideClosureReturnTypehintRule implements Rule
 			$returnTypes[] = $returnStatement->getScope()->getType($returnNode->expr);
 		}
 
-		if (count($returnTypes) === 0) {
+		if ($returnTypes === []) {
 			return [];
 		}
 

--- a/src/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRule.php
@@ -14,7 +14,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideFunctionReturnTypehintRule.php
@@ -45,7 +45,7 @@ class TooWideFunctionReturnTypehintRule implements Rule
 		}
 
 		$returnStatements = $node->getReturnStatements();
-		if (count($returnStatements) === 0) {
+		if ($returnStatements === []) {
 			return [];
 		}
 
@@ -59,7 +59,7 @@ class TooWideFunctionReturnTypehintRule implements Rule
 			$returnTypes[] = $returnStatement->getScope()->getType($returnNode->expr);
 		}
 
-		if (count($returnTypes) === 0) {
+		if ($returnTypes === []) {
 			return [];
 		}
 

--- a/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php
@@ -15,7 +15,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 /**

--- a/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php
+++ b/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php
@@ -59,7 +59,7 @@ class TooWideMethodReturnTypehintRule implements Rule
 		}
 
 		$returnStatements = $node->getReturnStatements();
-		if (count($returnStatements) === 0) {
+		if ($returnStatements === []) {
 			return [];
 		}
 
@@ -73,7 +73,7 @@ class TooWideMethodReturnTypehintRule implements Rule
 			$returnTypes[] = $returnStatement->getScope()->getType($returnNode->expr);
 		}
 
-		if (count($returnTypes) === 0) {
+		if ($returnTypes === []) {
 			return [];
 		}
 

--- a/src/Rules/Whitespace/FileWhitespaceRule.php
+++ b/src/Rules/Whitespace/FileWhitespaceRule.php
@@ -26,7 +26,7 @@ class FileWhitespaceRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$nodes = $node->getNodes();
-		if (count($nodes) === 0) {
+		if ($nodes === []) {
 			return [];
 		}
 
@@ -54,7 +54,7 @@ class FileWhitespaceRule implements Rule
 					return null;
 				}
 				if ($node instanceof Node\Stmt\Namespace_) {
-					if (count($node->stmts) > 0) {
+					if ($node->stmts !== []) {
 						$this->lastNodes[] = $node->stmts[count($node->stmts) - 1];
 					}
 					return null;

--- a/src/Testing/LevelsTestCase.php
+++ b/src/Testing/LevelsTestCase.php
@@ -143,7 +143,7 @@ abstract class LevelsTestCase extends TestCase
 			$exceptions[] = $exception;
 		}
 
-		if (count($exceptions) > 0) {
+		if ($exceptions !== []) {
 			throw $exceptions[0];
 		}
 	}
@@ -161,7 +161,7 @@ abstract class LevelsTestCase extends TestCase
 	 */
 	private function compareFiles(string $expectedJsonFile, array $expectedMessages): ?AssertionFailedError
 	{
-		if (count($expectedMessages) === 0) {
+		if ($expectedMessages === []) {
 			try {
 				self::assertFileDoesNotExist($expectedJsonFile);
 				return null;

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -18,7 +18,6 @@ use PHPStan\Rules\Registry;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\FileTypeMapper;
 use function array_map;
-use function count;
 use function implode;
 use function sprintf;
 

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -99,7 +99,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			null,
 			true,
 		);
-		if (count($analyserResult->getInternalErrors()) > 0) {
+		if ($analyserResult->getInternalErrors() !== []) {
 			$this->fail(implode("\n", $analyserResult->getInternalErrors()));
 		}
 		$actualErrors = $analyserResult->getUnorderedErrors();

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -62,7 +62,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		$resolver->setAnalysedFiles(array_map(static fn (string $file): string => $fileHelper->normalizePath($file), array_merge([$file], $this->getAdditionalAnalysedFiles())));
 
 		$scopeFactory = $this->createScopeFactory($reflectionProvider, $typeSpecifier);
-		if (count($dynamicConstantNames) > 0) {
+		if ($dynamicConstantNames !== []) {
 			$reflectionProperty = new ReflectionProperty(DirectScopeFactory::class, 'dynamicConstantNames');
 			$reflectionProperty->setAccessible(true);
 			$reflectionProperty->setValue($scopeFactory, $dynamicConstantNames);

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -351,7 +351,7 @@ class ArrayType implements Type
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 
-		if ($receivedType instanceof ConstantArrayType && count($receivedType->getKeyTypes()) === 0) {
+		if ($receivedType instanceof ConstantArrayType && $receivedType->getKeyTypes() === []) {
 			$keyType = $this->getKeyType();
 			$typeMap = TemplateTypeMap::createEmpty();
 			if ($keyType instanceof TemplateType) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -21,7 +21,6 @@ use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use function array_merge;
-use function count;
 use function is_float;
 use function is_int;
 use function key;

--- a/src/Type/BenevolentUnionType.php
+++ b/src/Type/BenevolentUnionType.php
@@ -28,7 +28,7 @@ class BenevolentUnionType extends UnionType
 			$resultTypes[] = $result;
 		}
 
-		if (count($resultTypes) === 0) {
+		if ($resultTypes === []) {
 			return new ErrorType();
 		}
 

--- a/src/Type/BenevolentUnionType.php
+++ b/src/Type/BenevolentUnionType.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use function array_map;
-use function count;
 
 /** @api */
 class BenevolentUnionType extends UnionType

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -76,14 +76,14 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		assert(count($keyTypes) === count($valueTypes));
 
 		parent::__construct(
-			count($keyTypes) > 0 ? TypeCombinator::union(...$keyTypes) : new NeverType(),
-			count($valueTypes) > 0 ? TypeCombinator::union(...$valueTypes) : new NeverType(),
+			$keyTypes !== [] ? TypeCombinator::union(...$keyTypes) : new NeverType(),
+			$valueTypes !== [] ? TypeCombinator::union(...$valueTypes) : new NeverType(),
 		);
 	}
 
 	public function isEmpty(): bool
 	{
-		return count($this->keyTypes) === 0;
+		return $this->keyTypes === [];
 	}
 
 	public function getNextAutoIndex(): int
@@ -206,8 +206,8 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			return $type->isAcceptedBy($this, $strictTypes);
 		}
 
-		if ($type instanceof self && count($this->keyTypes) === 0) {
-			return TrinaryLogic::createFromBoolean(count($type->keyTypes) === 0);
+		if ($type instanceof self && $this->keyTypes === []) {
+			return TrinaryLogic::createFromBoolean($type->keyTypes === []);
 		}
 
 		$result = TrinaryLogic::createYes();
@@ -239,9 +239,9 @@ class ConstantArrayType extends ArrayType implements ConstantType
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
 		if ($type instanceof self) {
-			if (count($this->keyTypes) === 0) {
-				if (count($type->keyTypes) > 0) {
-					if (count($type->optionalKeys) > 0) {
+			if ($this->keyTypes === []) {
+				if ($type->keyTypes !== []) {
+					if ($type->optionalKeys !== []) {
 						return TrinaryLogic::createMaybe();
 					}
 					return TrinaryLogic::createNo();
@@ -269,7 +269,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 		if ($type instanceof ArrayType) {
 			$result = TrinaryLogic::createMaybe();
-			if (count($this->keyTypes) === 0) {
+			if ($this->keyTypes === []) {
 				return $result;
 			}
 
@@ -444,7 +444,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			$matchingValueTypes[] = $this->valueTypes[$i];
 		}
 
-		if (count($matchingValueTypes) > 0) {
+		if ($matchingValueTypes !== []) {
 			$type = TypeCombinator::union(...$matchingValueTypes);
 			if ($type instanceof ErrorType) {
 				return new MixedType();
@@ -519,7 +519,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function removeLast(): self
 	{
-		if (count($this->keyTypes) === 0) {
+		if ($this->keyTypes === []) {
 			return $this;
 		}
 
@@ -565,7 +565,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function slice(int $offset, ?int $limit, bool $preserveKeys = false): self
 	{
-		if (count($this->keyTypes) === 0) {
+		if ($this->keyTypes === []) {
 			return $this;
 		}
 
@@ -621,7 +621,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function generalize(GeneralizePrecision $precision): Type
 	{
-		if (count($this->keyTypes) === 0) {
+		if ($this->keyTypes === []) {
 			return $this;
 		}
 
@@ -827,11 +827,11 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function isKeysSupersetOf(self $otherArray): bool
 	{
-		if (count($this->keyTypes) === 0) {
-			return count($otherArray->keyTypes) === 0;
+		if ($this->keyTypes === []) {
+			return $otherArray->keyTypes === [];
 		}
 
-		if (count($otherArray->keyTypes) === 0) {
+		if ($otherArray->keyTypes === []) {
 			return false;
 		}
 
@@ -847,7 +847,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			}
 		}
 
-		return count($otherKeys) === 0;
+		return $otherKeys === [];
 	}
 
 	public function mergeWith(self $otherArray): self

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -515,18 +515,18 @@ class FileTypeMapper
 			},
 			static function (Node $node, $callbackResult) use ($lookForTrait, &$namespace, &$functionStack, &$classStack, &$typeAliasStack, &$uses, &$typeMapStack): void {
 				if ($node instanceof Node\Stmt\ClassLike && $lookForTrait === null) {
-					if (count($classStack) === 0) {
+					if ($classStack === []) {
 						throw new ShouldNotHappenException();
 					}
 					array_pop($classStack);
 
-					if (count($typeAliasStack) === 0) {
+					if ($typeAliasStack === []) {
 						throw new ShouldNotHappenException();
 					}
 
 					array_pop($typeAliasStack);
 
-					if (count($functionStack) === 0) {
+					if ($functionStack === []) {
 						throw new ShouldNotHappenException();
 					}
 
@@ -535,7 +535,7 @@ class FileTypeMapper
 					$namespace = null;
 					$uses = [];
 				} elseif ($node instanceof Node\Stmt\ClassMethod || $node instanceof Node\Stmt\Function_) {
-					if (count($functionStack) === 0) {
+					if ($functionStack === []) {
 						throw new ShouldNotHappenException();
 					}
 
@@ -545,14 +545,14 @@ class FileTypeMapper
 					return;
 				}
 
-				if (count($typeMapStack) === 0) {
+				if ($typeMapStack === []) {
 					throw new ShouldNotHappenException();
 				}
 				array_pop($typeMapStack);
 			},
 		);
 
-		if (count($typeMapStack) > 0) {
+		if ($typeMapStack !== []) {
 			throw new ShouldNotHappenException();
 		}
 

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -165,7 +165,7 @@ class GenericObjectType extends ObjectType
 			$results[] = $templateType->isValidVariance($this->types[$i], $ancestor->types[$i]);
 		}
 
-		if (count($results) === 0) {
+		if ($results === []) {
 			return $nakedSuperTypeOf;
 		}
 

--- a/src/Type/Generic/TemplateTypeMap.php
+++ b/src/Type/Generic/TemplateTypeMap.php
@@ -104,7 +104,7 @@ class TemplateTypeMap
 		unset($types[$name]);
 		unset($lowerBoundTypes[$name]);
 
-		if (count($types) === 0 && count($lowerBoundTypes) === 0) {
+		if ($types === [] && $lowerBoundTypes === []) {
 			return self::createEmpty();
 		}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1002,7 +1002,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			}
 
 			$cases = array_values($cases);
-			if (count($cases) === 0) {
+			if ($cases === []) {
 				return new NeverType();
 			}
 

--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -31,7 +31,7 @@ class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnT
 		$valueType = $scope->getType($functionCall->getArgs()[1]->value);
 		$keysType = $scope->getType($functionCall->getArgs()[0]->value);
 		$constantArrays = TypeUtils::getConstantArrays($keysType);
-		if (count($constantArrays) === 0) {
+		if ($constantArrays === []) {
 			return new ArrayType($keysType->getIterableValueType(), $valueType);
 		}
 

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -62,13 +62,13 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 			if ($flagArg === null) {
 				$var = null;
 				$expr = null;
-				if ($callbackArg instanceof Closure && count($callbackArg->stmts) === 1 && count($callbackArg->params) > 0) {
+				if ($callbackArg instanceof Closure && count($callbackArg->stmts) === 1 && $callbackArg->params !== []) {
 					$statement = $callbackArg->stmts[0];
 					if ($statement instanceof Return_ && $statement->expr !== null) {
 						$var = $callbackArg->params[0]->var;
 						$expr = $statement->expr;
 					}
-				} elseif ($callbackArg instanceof ArrowFunction && count($callbackArg->params) > 0) {
+				} elseif ($callbackArg instanceof ArrowFunction && $callbackArg->params !== []) {
 					$var = $callbackArg->params[0]->var;
 					$expr = $callbackArg->expr;
 				}

--- a/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use function count;
 
 class ArrayKeyFirstDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
@@ -34,11 +34,11 @@ class ArrayKeyFirstDynamicReturnTypeExtension implements DynamicFunctionReturnTy
 		}
 
 		$constantArrays = TypeUtils::getConstantArrays($argType);
-		if (count($constantArrays) > 0) {
+		if ($constantArrays !== []) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {
 				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($arrayKeyTypes === []) {
 					$keyTypes[] = new NullType();
 					continue;
 				}

--- a/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
@@ -34,11 +34,11 @@ class ArrayKeyLastDynamicReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 
 		$constantArrays = TypeUtils::getConstantArrays($argType);
-		if (count($constantArrays) > 0) {
+		if ($constantArrays !== []) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {
 				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($arrayKeyTypes === []) {
 					$keyTypes[] = new NullType();
 					continue;
 				}

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -64,7 +64,7 @@ class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 				return $arrayType;
 			}
 			$constantArrays = TypeUtils::getConstantArrays($arrayType);
-			if (count($constantArrays) > 0) {
+			if ($constantArrays !== []) {
 				$arrayTypes = [];
 				foreach ($constantArrays as $constantArray) {
 					$returnedArrayBuilder = ConstantArrayTypeBuilder::createEmpty();

--- a/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
@@ -34,7 +34,7 @@ class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunction
 		Scope $scope,
 	): Type
 	{
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
@@ -45,11 +45,11 @@ class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunction
 		}
 
 		$constantArrays = TypeUtils::getConstantArrays($argType);
-		if (count($constantArrays) > 0) {
+		if ($constantArrays !== []) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {
 				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($arrayKeyTypes === []) {
 					$keyTypes[] = new ConstantBooleanType(false);
 					continue;
 				}

--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -34,11 +34,11 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		}
 
 		$constantArrays = TypeUtils::getConstantArrays($argType);
-		if (count($constantArrays) > 0) {
+		if ($constantArrays !== []) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {
 				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($arrayKeyTypes === []) {
 					$valueTypes[] = new NullType();
 					continue;
 				}

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -46,11 +46,11 @@ class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 
 		$arraysType = $scope->getType($functionCall->getArgs()[0]->value);
 		$constantArrays = TypeUtils::getConstantArrays($arraysType);
-		if (count($constantArrays) > 0) {
+		if ($constantArrays !== []) {
 			$onlyEmpty = true;
 			$onlyNonEmpty = true;
 			foreach ($constantArrays as $constantArray) {
-				$isEmpty = count($constantArray->getValueTypes()) === 0;
+				$isEmpty = $constantArray->getValueTypes() === [];
 				$onlyEmpty = $onlyEmpty && $isEmpty;
 				$onlyNonEmpty = $onlyNonEmpty && !$isEmpty;
 			}

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use function count;
 
 class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -63,7 +63,7 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 		}
 
 		$haystackArrays = $this->pickArrays($haystackArgType);
-		if (count($haystackArrays) === 0) {
+		if ($haystackArrays === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
@@ -120,7 +120,7 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 			$matchesByType[] = new ConstantBooleanType(false);
 		}
 
-		if (count($matchesByType) > 0) {
+		if ($matchesByType !== []) {
 			if (
 				$haystack->getIterableValueType()->accepts($needle, true)->yes()
 				&& $needle->isSuperTypeOf(new ObjectWithoutClassType())->no()

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use function count;
 
 class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -34,11 +34,11 @@ class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnType
 		}
 
 		$constantArrays = TypeUtils::getConstantArrays($argType);
-		if (count($constantArrays) > 0) {
+		if ($constantArrays !== []) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {
 				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($arrayKeyTypes === []) {
 					$valueTypes[] = new NullType();
 					continue;
 				}

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -63,9 +63,9 @@ class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnType
 		}
 
 		$constantArrays = TypeUtils::getConstantArrays($valueType);
-		if (count($constantArrays) === 0) {
+		if ($constantArrays === []) {
 			$arrays = TypeUtils::getArrays($valueType);
-			if (count($arrays) !== 0) {
+			if ($arrays !== []) {
 				return TypeCombinator::union(...$arrays);
 			}
 			return new ArrayType(

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -17,7 +17,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function array_map;
-use function count;
 
 class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/CompactFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CompactFunctionReturnTypeExtension.php
@@ -12,7 +12,6 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use function array_merge;
-use function count;
 
 class CompactFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/CompactFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CompactFunctionReturnTypeExtension.php
@@ -33,7 +33,7 @@ class CompactFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExt
 	): Type
 	{
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			return $defaultReturnType;
 		}
 

--- a/src/Type/Php/CountFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CountFunctionReturnTypeExtension.php
@@ -43,7 +43,7 @@ class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
 		$constantArrays = TypeUtils::getConstantArrays($scope->getType($functionCall->getArgs()[0]->value));
-		if (count($constantArrays) === 0) {
+		if ($constantArrays === []) {
 			if ($argType->isIterableAtLeastOnce()->yes()) {
 				return IntegerRangeType::fromInterval(1, null);
 			}

--- a/src/Type/Php/DateFunctionReturnTypeExtension.php
+++ b/src/Type/Php/DateFunctionReturnTypeExtension.php
@@ -32,13 +32,13 @@ class DateFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtens
 		Scope $scope,
 	): Type
 	{
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			return new StringType();
 		}
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
 		$constantStrings = TypeUtils::getConstantStrings($argType);
 
-		if (count($constantStrings) === 0) {
+		if ($constantStrings === []) {
 			return new StringType();
 		}
 

--- a/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
@@ -23,7 +23,7 @@ class DateIntervalConstructorThrowTypeExtension implements DynamicStaticMethodTh
 
 	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		if ($methodCall->getArgs() === []) {
 			return $methodReflection->getThrowType();
 		}
 

--- a/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateIntervalConstructorThrowTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use function count;
 
 class DateIntervalConstructorThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
 {

--- a/src/Type/Php/DateTimeConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateTimeConstructorThrowTypeExtension.php
@@ -25,7 +25,7 @@ class DateTimeConstructorThrowTypeExtension implements DynamicStaticMethodThrowT
 
 	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		if ($methodCall->getArgs() === []) {
 			return null;
 		}
 

--- a/src/Type/Php/DateTimeConstructorThrowTypeExtension.php
+++ b/src/Type/Php/DateTimeConstructorThrowTypeExtension.php
@@ -12,7 +12,6 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
-use function count;
 use function in_array;
 
 class DateTimeConstructorThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension

--- a/src/Type/Php/DsMapDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DsMapDynamicReturnTypeExtension.php
@@ -66,7 +66,7 @@ final class DsMapDynamicReturnTypeExtension implements DynamicMethodReturnTypeEx
 				return $types[0];
 			}
 
-			if (count($types) === 0) {
+			if ($types === []) {
 				return $returnType;
 			}
 

--- a/src/Type/Php/GetClassDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetClassDynamicReturnTypeExtension.php
@@ -32,7 +32,7 @@ class GetClassDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExt
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
 		$args = $functionCall->getArgs();
-		if (count($args) === 0) {
+		if ($args === []) {
 			if ($scope->isInClass()) {
 				return new ConstantStringType($scope->getClassReflection()->getName(), true);
 			}

--- a/src/Type/Php/GetClassDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetClassDynamicReturnTypeExtension.php
@@ -19,7 +19,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
-use function count;
 
 class GetClassDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -17,7 +17,6 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function array_map;
-use function count;
 
 class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -42,7 +42,7 @@ class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicFunctio
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle(
 			$functionReflection->getVariants(),
 		)->getReturnType();
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			if ($scope->isInTrait()) {
 				return $defaultReturnType;
 			}
@@ -61,12 +61,12 @@ class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicFunctio
 		}
 
 		$constantStrings = TypeUtils::getConstantStrings($argType);
-		if (count($constantStrings) > 0) {
+		if ($constantStrings !== []) {
 			return TypeCombinator::union(...array_map(fn (ConstantStringType $stringType): Type => $this->findParentClassNameType($stringType->getValue()), $constantStrings));
 		}
 
 		$classNames = TypeUtils::getDirectClassNames($argType);
-		if (count($classNames) > 0) {
+		if ($classNames !== []) {
 			return TypeCombinator::union(...array_map(fn (string $classNames): Type => $this->findParentClassNameType($classNames), $classNames));
 		}
 

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -45,7 +45,7 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 
 		if (
 			$context->truthy()
-			|| count(TypeUtils::getConstantScalars($arrayValueType)) > 0
+			|| TypeUtils::getConstantScalars($arrayValueType) !== []
 		) {
 			return $this->typeSpecifier->create(
 				$node->getArgs()[0]->value,

--- a/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
@@ -49,7 +49,7 @@ class NonEmptyStringFunctionsReturnTypeExtension implements DynamicFunctionRetur
 	): Type
 	{
 		$args = $functionCall->getArgs();
-		if (count($args) === 0) {
+		if ($args === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use function count;
 use function in_array;
 
 class NonEmptyStringFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension

--- a/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
@@ -28,7 +28,7 @@ class RandomIntFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		if ($functionReflection->getName() === 'rand' && count($functionCall->getArgs()) === 0) {
+		if ($functionReflection->getName() === 'rand' && $functionCall->getArgs() === []) {
 			return IntegerRangeType::fromInterval(0, null);
 		}
 
@@ -70,8 +70,8 @@ class RandomIntFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 			$maxType instanceof UnionType ? $maxType->getTypes() : [$maxType],
 		);
 
-		assert(count($minValues) > 0);
-		assert(count($maxValues) > 0);
+		assert($minValues !== []);
+		assert($maxValues !== []);
 
 		return IntegerRangeType::fromInterval(
 			in_array(null, $minValues, true) ? null : min($minValues),

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -89,7 +89,7 @@ class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 			}
 		}
 
-		if (count($constantReturnTypes) > 0) {
+		if ($constantReturnTypes !== []) {
 			return TypeCombinator::union(...$constantReturnTypes);
 		}
 

--- a/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
@@ -39,7 +39,7 @@ class ReflectionGetAttributesMethodReturnTypeExtension implements DynamicMethodR
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		if ($methodCall->getArgs() === []) {
 			return $this->getDefaultReturnType($scope, $methodCall, $methodReflection);
 		}
 		$argType = $scope->getType($methodCall->getArgs()[0]->value);

--- a/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use ReflectionAttribute;
-use function count;
 
 class ReflectionGetAttributesMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/Type/Php/SimpleXMLElementConstructorThrowTypeExtension.php
+++ b/src/Type/Php/SimpleXMLElementConstructorThrowTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use SimpleXMLElement;
-use function count;
 
 class SimpleXMLElementConstructorThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
 {

--- a/src/Type/Php/SimpleXMLElementConstructorThrowTypeExtension.php
+++ b/src/Type/Php/SimpleXMLElementConstructorThrowTypeExtension.php
@@ -23,7 +23,7 @@ class SimpleXMLElementConstructorThrowTypeExtension implements DynamicStaticMeth
 
 	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
 	{
-		if (count($methodCall->getArgs()) === 0) {
+		if ($methodCall->getArgs() === []) {
 			return $methodReflection->getThrowType();
 		}
 

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -14,7 +14,6 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use Throwable;
 use function array_shift;
-use function count;
 use function is_string;
 use function sprintf;
 

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -33,7 +33,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 	): Type
 	{
 		$args = $functionCall->getArgs();
-		if (count($args) === 0) {
+		if ($args === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -31,7 +31,7 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 	): Type
 	{
 		$args = $functionCall->getArgs();
-		if (count($args) === 0) {
+		if ($args === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -13,7 +13,6 @@ use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
-use function count;
 use function strlen;
 
 class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension

--- a/src/Type/Php/StrtotimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrtotimeFunctionReturnTypeExtension.php
@@ -30,7 +30,7 @@ class StrtotimeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			return $defaultReturnType;
 		}
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/StrvalFamilyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrvalFamilyFunctionReturnTypeExtension.php
@@ -34,7 +34,7 @@ class StrvalFamilyFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		Scope $scope,
 	): Type
 	{
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			return new NullType();
 		}
 

--- a/src/Type/Php/StrvalFamilyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrvalFamilyFunctionReturnTypeExtension.php
@@ -9,7 +9,6 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
-use function count;
 use function in_array;
 
 class StrvalFamilyFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension

--- a/src/Type/Php/SubstrDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SubstrDynamicReturnTypeExtension.php
@@ -30,7 +30,7 @@ class SubstrDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExten
 	): Type
 	{
 		$args = $functionCall->getArgs();
-		if (count($args) === 0) {
+		if ($args === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/Php/ThrowableReturnTypeExtension.php
+++ b/src/Type/Php/ThrowableReturnTypeExtension.php
@@ -66,7 +66,7 @@ final class ThrowableReturnTypeExtension implements DynamicMethodReturnTypeExten
 			$types[] = new IntegerType();
 		}
 
-		if (count($types) === 0) {
+		if ($types === []) {
 			return new ErrorType();
 		}
 

--- a/src/Type/Php/ThrowableReturnTypeExtension.php
+++ b/src/Type/Php/ThrowableReturnTypeExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use Throwable;
-use function count;
 use function in_array;
 use function strtolower;
 

--- a/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
@@ -13,7 +13,6 @@ use PHPStan\Rules\Comparison\ImpossibleCheckTypeHelper;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
-use function count;
 use function in_array;
 
 class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension, TypeSpecifierAwareExtension

--- a/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
@@ -65,7 +65,7 @@ class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFuncti
 		Scope $scope,
 	): Type
 	{
-		if (count($functionCall->getArgs()) === 0) {
+		if ($functionCall->getArgs() === []) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 

--- a/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
@@ -54,7 +54,7 @@ class VersionCompareFunctionDynamicReturnTypeExtension implements DynamicFunctio
 			);
 		}
 
-		if (count(array_filter($counts, static fn (int $count): bool => $count === 0)) > 0) {
+		if (array_filter($counts, static fn (int $count): bool => $count === 0) !== []) {
 			return $returnType; // one of the arguments is not a constant string
 		}
 

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -431,7 +431,7 @@ class StaticType implements TypeWithClassName, SubtractableType
 			}
 
 			$cases = array_values($cases);
-			if (count($cases) === 0) {
+			if ($cases === []) {
 				return new NeverType();
 			}
 

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -282,7 +282,7 @@ class TypeCombinator
 		$arrayAccessoryTypesToProcess = [];
 		if (count($arrayAccessoryTypes) > 1) {
 			$arrayAccessoryTypesToProcess = array_values(array_intersect_key(...$arrayAccessoryTypes));
-		} elseif (count($arrayAccessoryTypes) > 0) {
+		} elseif ($arrayAccessoryTypes !== []) {
 			$arrayAccessoryTypesToProcess = array_values($arrayAccessoryTypes[0]);
 		}
 
@@ -575,7 +575,7 @@ class TypeCombinator
 			if (!$arrayType instanceof ConstantArrayType) {
 				continue;
 			}
-			if (count($arrayType->getKeyTypes()) > 0) {
+			if ($arrayType->getKeyTypes() !== []) {
 				continue;
 			}
 

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -199,7 +199,7 @@ class TypehintHelper
 					$addToUnionTypes[] = $innerType;
 				}
 
-				if (count($addToUnionTypes) > 0) {
+				if ($addToUnionTypes !== []) {
 					$type = TypeCombinator::union($resultType, ...$addToUnionTypes);
 				} else {
 					$type = $resultType;

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -11,7 +11,6 @@ use ReflectionNamedType;
 use ReflectionType;
 use ReflectionUnionType;
 use function array_map;
-use function count;
 use function get_class;
 use function sprintf;
 use function str_ends_with;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -417,7 +417,7 @@ class UnionType implements CompoundType
 			$types[] = $valueType;
 		}
 
-		if (count($types) === 0) {
+		if ($types === []) {
 			return new ErrorType();
 		}
 
@@ -554,7 +554,7 @@ class UnionType implements CompoundType
 				}
 				$remainingReceivedTypes[] = $receivedInnerType;
 			}
-			if (count($remainingReceivedTypes) === 0) {
+			if ($remainingReceivedTypes === []) {
 				return $types;
 			}
 			$receivedType = TypeCombinator::union(...$remainingReceivedTypes);


### PR DESCRIPTION
@ondrejmirtes @TomasVotruba this is for increase PHPStan performance improvement by replace count($array) === 0 or count($array) > 0  to empty array comparison $array === [] or $array !== [], it utilize rector's `Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector::class`.

Rector probably needed to be part of CI workflow to verify it if it is approved, @ondrejmirtes what do you think?