### PR TITLE
Fix inferring template types in ClosureType

### DIFF
--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -218,7 +218,7 @@ class CallableType implements CompoundType, ParametersAcceptor
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 
-		if ($receivedType->isCallable()->no()) {
+		if (! $receivedType->isCallable()->yes()) {
 			return TemplateTypeMap::createEmpty();
 		}
 

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -334,7 +334,7 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 
-		if ($receivedType->isCallable()->no()) {
+		if ($receivedType->isCallable()->no() || ! $receivedType instanceof self) {
 			return TemplateTypeMap::createEmpty();
 		}
 

--- a/tests/PHPStan/Analyser/data/generic-unions.php
+++ b/tests/PHPStan/Analyser/data/generic-unions.php
@@ -61,3 +61,75 @@ class Foo
 	}
 
 }
+
+class InvokableClass
+{
+	public function __invoke(): string
+	{
+		return 'foo';
+	}
+}
+
+/**
+ *
+ * @template TGetDefault
+ * @template TKey
+ *
+ * @param  TKey  $key
+ * @param  TGetDefault|(\Closure(): TGetDefault)  $default
+ * @return TKey|TGetDefault
+ */
+function getWithDefault($key, $default = null)
+{
+	if(rand(0,10) > 5) {
+		return $key;
+	}
+
+	if (is_callable($default)) {
+		return $default();
+	}
+
+	return $default;
+}
+
+/**
+ *
+ * @template TGetDefault
+ * @template TKey
+ *
+ * @param  TKey  $key
+ * @param  TGetDefault|(callable(): TGetDefault)  $default
+ * @return TKey|TGetDefault
+ */
+function getWithDefaultCallable($key, $default = null)
+{
+	if(rand(0,10) > 5) {
+		return $key;
+	}
+
+	if (is_callable($default)) {
+		return $default();
+	}
+
+	return $default;
+}
+
+assertType('int|null', getWithDefault(3));
+assertType('int|null', getWithDefaultCallable(3));
+assertType('int|string', getWithDefault(3, 'foo'));
+assertType('int|string', getWithDefaultCallable(3, 'foo'));
+assertType('int|string', getWithDefault(3, function () {
+	return 'foo';
+}));
+assertType('int|string', getWithDefaultCallable(3, function () {
+	return 'foo';
+}));
+assertType('GenericUnions\Foo|int', getWithDefault(3, function () {
+	return new Foo;
+}));
+assertType('GenericUnions\Foo|int', getWithDefaultCallable(3, function () {
+	return new Foo;
+}));
+assertType('GenericUnions\Foo|int', getWithDefault(3, new Foo));
+assertType('GenericUnions\Foo|int', getWithDefaultCallable(3, new Foo));
+assertType('int|string', getWithDefaultCallable(3, new InvokableClass));


### PR DESCRIPTION
This PR fixes an issue that can be seen [here](https://phpstan.org/r/6b3721e7-b964-4712-8185-1547f2a66cce) and [here](https://phpstan.org/r/a6fa93d7-ed9f-46c0-82c7-f7722ba0af2b).

Since there are separate types as `ClosureType` and `CallableType` I think it makes sense for `ClosureType` to only infer template types from it's own kind. Cause nothing else can really be a closure. When `callable` is used instead of `Closure` in the playground examples, it'll still be inferred as `mixed`.

I hope this fix makes sense. If you prefer any other way that fixes the issues (both in tests and in playground links) I can adjust to that 👍🏽 