### PR TITLE
Entirely possible for `time()` to return zero/-ve integer

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -12298,7 +12298,7 @@ return [
 'tidyNode::isJste' => ['bool'],
 'tidyNode::isPhp' => ['bool'],
 'tidyNode::isText' => ['bool'],
-'time' => ['positive-int'],
+'time' => ['int'],
 'time_nanosleep' => ['array{0:0|positive-int,1:0|positive-int}|bool', 'seconds'=>'int', 'nanoseconds'=>'int'],
 'time_sleep_until' => ['bool', 'timestamp'=>'float'],
 'timezone_abbreviations_list' => ['array'],


### PR DESCRIPTION
`time()` might not be a positive integer, if you're having a bad day…

```
$ faketime '1970-01-01 00:00:00Z' php -r 'echo time(),"\n";'
0
$ faketime -f -100y php -r 'echo time(),"\n";'
-1511501206
```

https://github.com/phpstan/phpstan-src/pull/760