### PR TITLE
Only run the Update PhpStorm Stubs job for the primary repo

### DIFF
--- a/.github/workflows/update-phpstorm-stubs.yml
+++ b/.github/workflows/update-phpstorm-stubs.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   update-phpstorm-stubs:
     name: "Update PhpStorm stubs"
+    if: ${{ github.repository == 'phpstan/phpstan-src' }}
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout"


### PR DESCRIPTION
There's no need for this event to run on forks, and it's currently sending a failure email once a week to anybody with a fork.