### PR TITLE
Pass verbosity to workers and show stack trace on error

### DIFF
--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -188,14 +188,11 @@ class WorkerCommand extends Command
 			$out->end();
 		};
 		$out->on('error', $handleError);
-
 		/** @var FileAnalyser $fileAnalyser */
 		$fileAnalyser = $container->getByType(FileAnalyser::class);
-
 		/** @var Registry $registry */
 		$registry = $container->getByType(Registry::class);
-
-		$in->on('data', function (array $json) use ($fileAnalyser, $registry, $out, $analysedFiles, $tmpFile, $insteadOfFile): void {
+		$in->on('data', function (array $json) use ($fileAnalyser, $registry, $out, $analysedFiles, $tmpFile, $insteadOfFile, $output): void {
 			$action = $json['action'];
 			if ($action !== 'analyse') {
 				return;
@@ -222,12 +219,12 @@ class WorkerCommand extends Command
 					$this->errorCount++;
 					$internalErrorsCount++;
 					$internalErrorMessage = sprintf('Internal error: %s in file %s', $t->getMessage(), $file);
-					$internalErrorMessage .= sprintf(
-						'%sRun PHPStan with --debug option and post the stack trace to:%s%s',
-						"\n",
-						"\n",
-						'https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md',
-					);
+					$internalErrorMessage .= sprintf('%sRun PHPStan with --debug option and post the stack trace to:%s%s', "\n", "\n", 'https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md');
+
+					if (OutputInterface::VERBOSITY_VERBOSE >= $output->getVerbosity()) {
+						$internalErrorMessage .= sprintf('%sStack trace: %s%s', "\n\n", "\n", $t->getTraceAsString());
+					}
+
 					$errors[] = $internalErrorMessage;
 				}
 			}

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -219,10 +219,12 @@ class WorkerCommand extends Command
 					$this->errorCount++;
 					$internalErrorsCount++;
 					$internalErrorMessage = sprintf('Internal error: %s in file %s', $t->getMessage(), $file);
-					$internalErrorMessage .= sprintf('%sRun PHPStan with -v option and post the stack trace to:%s%s', "\n", "\n", 'https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md');
 
-					if (OutputInterface::VERBOSITY_VERBOSE >= $output->getVerbosity()) {
-						$internalErrorMessage .= sprintf('%sStack trace: %s%s', "\n\n", "\n", $t->getTraceAsString());
+					$bugReportUrl = 'https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md';
+					if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) {
+						$internalErrorMessage .= sprintf('%sPost the following stack trace to %s: %s%s', "\n\n", $bugReportUrl, "\n", $t->getTraceAsString());
+					} else {
+						$internalErrorMessage .= sprintf('%sRun PHPStan with -v option and post the stack trace to:%s%s', "\n", "\n", $bugReportUrl);
 					}
 
 					$errors[] = $internalErrorMessage;

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -219,7 +219,7 @@ class WorkerCommand extends Command
 					$this->errorCount++;
 					$internalErrorsCount++;
 					$internalErrorMessage = sprintf('Internal error: %s in file %s', $t->getMessage(), $file);
-					$internalErrorMessage .= sprintf('%sRun PHPStan with --debug option and post the stack trace to:%s%s', "\n", "\n", 'https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md');
+					$internalErrorMessage .= sprintf('%sRun PHPStan with -v option and post the stack trace to:%s%s', "\n", "\n", 'https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md');
 
 					if (OutputInterface::VERBOSITY_VERBOSE >= $output->getVerbosity()) {
 						$internalErrorMessage .= sprintf('%sStack trace: %s%s', "\n\n", "\n", $t->getTraceAsString());

--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -53,6 +53,7 @@ class ProcessHelper
 			'autoload-file',
 			'memory-limit',
 			'xdebug',
+			'verbose'
 		];
 		foreach ($options as $optionName) {
 			/** @var bool|string|null $optionValue */

--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -53,7 +53,7 @@ class ProcessHelper
 			'autoload-file',
 			'memory-limit',
 			'xdebug',
-			'verbose'
+			'verbose',
 		];
 		foreach ($options as $optionName) {
 			/** @var bool|string|null $optionValue */


### PR DESCRIPTION
This PR allows displaying the stack trace when an error is thrown in a worker. The stack trace is only displayed when either `-v`, `-vv` or `-vvv` is passed to the `analyse` command.

I believed the message could also be improved. For example, the error says "[...] in file src/...". However, it is the analysed file, not the file in which the error occurred. 

This is the result:
![image](https://user-images.githubusercontent.com/212269/150615619-552a4336-947f-433e-8efa-0ac7f69c6bd4.png)
