### PR TITLE
Fix trait detection recursion for anonymous classes

### DIFF
--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -189,7 +189,7 @@ class FileTypeMapper
 	private function getNameScopeMap(string $fileName): array
 	{
 		if (!isset($this->memoryCache[$fileName])) {
-			$cacheKey = sprintf('%s-phpdocstring-v18-filter-ast', $fileName);
+			$cacheKey = sprintf('%s-phpdocstring-v19-trait-detection-recursion', $fileName);
 			$variableCacheKey = sprintf('%s-%s', implode(',', array_map(static fn (array $file): string => sprintf('%s-%d', $file['filename'], $file['modifiedTime']), $this->getCachedDependentFilesWithTimestamps($fileName))), $this->phpVersion->getVersionString());
 			$map = $this->cache->load($cacheKey, $variableCacheKey);
 
@@ -294,6 +294,9 @@ class FileTypeMapper
 
 							$className = $this->anonymousClassNameHelper->getAnonymousClassName($node, $fileName);
 						} elseif ((bool) $node->getAttribute('anonymousClass', false)) {
+							if ($traitFound) {
+								return self::SKIP_NODE;
+							}
 							$className = $node->name->name;
 						} else {
 							if ($traitFound) {


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6442

This was a missing edge case that lead to endless recursion in case the trait looking for and anonymous class using it were in the same file. By not skipping the node, it would start looking at the anonymous class, find the trait usage, start looking for the trait, find it, come to the anonymous class, find the trait usage, start looking for the trait, ..

Unfortunately I failed creating an AnalyzerIntegrationTest because of namespacing problems in the data file. Any help appreciated :)