### PR TITLE
Add return type extension for array_column()

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -893,6 +893,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\ArrayColumnFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ArrayCombineFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -92,6 +92,9 @@ class TrinaryLogic
 
 	public static function extremeIdentity(self ...$operands): self
 	{
+		if ($operands === []) {
+			throw new ShouldNotHappenException();
+		}
 		$operandValues = array_column($operands, 'value');
 		$min = min($operandValues);
 		$max = max($operandValues);
@@ -100,6 +103,9 @@ class TrinaryLogic
 
 	public static function maxMin(self ...$operands): self
 	{
+		if ($operands === []) {
+			throw new ShouldNotHappenException();
+		}
 		$operandValues = array_column($operands, 'value');
 		return self::create(max($operandValues) > 0 ? max($operandValues) : min($operandValues));
 	}

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
+use function count;
+
+class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'array_column';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$numArgs = count($functionCall->getArgs());
+		if ($numArgs < 2) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$columnType = $scope->getType($functionCall->getArgs()[1]->value);
+		$indexType = $numArgs >= 3 ? $scope->getType($functionCall->getArgs()[2]->value) : null;
+
+		$constantArrayTypes = TypeUtils::getConstantArrays($arrayType);
+		if (count($constantArrayTypes) === 1) {
+			$type = $this->handleConstantArray($constantArrayTypes[0], $columnType, $indexType, $scope);
+			if ($type !== null) {
+				return $type;
+			}
+		}
+
+		return $this->handleAnyArray($arrayType, $columnType, $indexType, $scope);
+	}
+
+	private function handleAnyArray(Type $arrayType, Type $columnType, ?Type $indexType, Scope $scope): Type
+	{
+		$iterableAtLeastOnce = $arrayType->isIterableAtLeastOnce();
+		if ($iterableAtLeastOnce->no()) {
+			return new ConstantArrayType([], []);
+		}
+
+		$iterableValueType = $arrayType->getIterableValueType();
+		$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
+
+		if ($returnValueType === null) {
+			$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, true);
+			$iterableAtLeastOnce = TrinaryLogic::createMaybe();
+			if ($returnValueType === null) {
+				throw new ShouldNotHappenException();
+			}
+		}
+
+		if ($returnValueType instanceof NeverType) {
+			return new ConstantArrayType([], []);
+		}
+
+		if ($indexType !== null) {
+			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
+			if ($type !== null) {
+				$returnKeyType = $type;
+			} else {
+				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
+				if ($type !== null) {
+					$returnKeyType = TypeCombinator::union($type, new IntegerType());
+				} else {
+					$returnKeyType = new IntegerType();
+				}
+			}
+		} else {
+			$returnKeyType = new IntegerType();
+		}
+
+		$returnType = new ArrayType($returnKeyType, $returnValueType);
+
+		if ($iterableAtLeastOnce->yes()) {
+			$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
+		}
+
+		return $returnType;
+	}
+
+	private function handleConstantArray(ConstantArrayType $arrayType, Type $columnType, ?Type $indexType, Scope $scope): ?Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		foreach ($arrayType->getValueTypes() as $iterableValueType) {
+			$valueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
+			if ($valueType === null) {
+				return null;
+			}
+
+			if ($indexType !== null) {
+				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
+				if ($type !== null) {
+					$keyType = $type;
+				} else {
+					$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
+					if ($type !== null) {
+						$keyType = TypeCombinator::union($type, new IntegerType());
+					} else {
+						$keyType = null;
+					}
+				}
+			} else {
+				$keyType = null;
+			}
+
+			$builder->setOffsetValueType($keyType, $valueType);
+		}
+
+		return $builder->getArray();
+	}
+
+	private function getOffsetOrProperty(Type $type, Type $offsetOrProperty, Scope $scope, bool $allowMaybe): ?Type
+	{
+		$returnTypes = [];
+
+		if (!$type->canAccessProperties()->no()) {
+			$propertyTypes = TypeUtils::getConstantStrings($offsetOrProperty);
+			if ($propertyTypes === []) {
+				return new MixedType();
+			}
+			foreach ($propertyTypes as $propertyType) {
+				$propertyName = $propertyType->getValue();
+				$hasProperty = $type->hasProperty($propertyName);
+				if ($hasProperty->maybe()) {
+					return $allowMaybe ? new MixedType() : null;
+				}
+				if (!$hasProperty->yes()) {
+					continue;
+				}
+
+				$returnTypes[] = $type->getProperty($propertyName, $scope)->getReadableType();
+			}
+		}
+
+		if ($type->isOffsetAccessible()->yes()) {
+			$hasOffset = $type->hasOffsetValueType($offsetOrProperty);
+			if (!$allowMaybe && $hasOffset->maybe()) {
+				return null;
+			}
+			if (!$hasOffset->no()) {
+				$returnTypes[] = $type->getOffsetValueType($offsetOrProperty);
+			}
+		}
+
+		if ($returnTypes === []) {
+			return new NeverType();
+		}
+
+		return TypeCombinator::union(...$returnTypes);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -627,6 +627,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6399.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4357.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5817.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-column.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/array-column.php
+++ b/tests/PHPStan/Analyser/data/array-column.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace ArrayColumn;
+
+use DOMElement;
+use function PHPStan\Testing\assertType;
+
+function testArrays(array $array): void
+{
+	/** @var array<int, array<string, string>> $array */
+	assertType('array<int, string>', array_column($array, 'column'));
+	assertType('array<int|string, string>', array_column($array, 'column', 'key'));
+
+	/** @var non-empty-array<int, array<string, string>> $array */
+	// Note: Array may still be empty!
+	assertType('array<int, string>', array_column($array, 'column'));
+
+	/** @var array{} $array */
+	assertType('array{}', array_column($array, 'column'));
+	assertType('array{}', array_column($array, 'column', 'key'));
+}
+
+function testConstantArrays(array $array): void
+{
+	/** @var array<int, array{column: string, key: string}> $array */
+	assertType('array<int, string>', array_column($array, 'column'));
+	assertType('array<string, string>', array_column($array, 'column', 'key'));
+
+	/** @var array<int, array{column: string, key: string}> $array */
+	assertType('array{}', array_column($array, 'foo'));
+	assertType('array{}', array_column($array, 'foo', 'key'));
+
+	/** @var array{array{column: string, key: 'bar'}} $array */
+	assertType("array{string}", array_column($array, 'column'));
+	assertType("array{bar: string}", array_column($array, 'column', 'key'));
+
+	/** @var array{array{column: string, key: string}} $array */
+	assertType("non-empty-array<string, string>", array_column($array, 'column', 'key'));
+
+	/** @var array<int, array{column?: 'foo', key?: 'bar'}> $array */
+	assertType("array<int, 'foo'>", array_column($array, 'column'));
+	assertType("array<'bar'|int, 'foo'>", array_column($array, 'column', 'key'));
+
+	/** @var array<int, array{column1: string, column2: bool}> $array */
+	assertType('array<int, bool|string>', array_column($array, mt_rand(0, 1) === 0 ? 'column1' : 'column2'));
+
+	/** @var non-empty-array<int, array{column: string, key: string}> $array */
+	assertType('non-empty-array<int, string>', array_column($array, 'column'));
+	assertType('non-empty-array<string, string>', array_column($array, 'column', 'key'));
+}
+
+function testImprecise(array $array): void {
+	// These cases aren't handled precisely and will return non-constant arrays.
+
+	/** @var array{array{column?: 'foo', key: 'bar'}} $array */
+	assertType("array<int, 'foo'>", array_column($array, 'column'));
+	assertType("array<'bar', 'foo'>", array_column($array, 'column', 'key'));
+
+	/** @var array{array{column: 'foo', key?: 'bar'}} $array */
+	assertType("non-empty-array<'bar'|int, 'foo'>", array_column($array, 'column', 'key'));
+
+	/** @var array{array{column: 'foo', key: 'bar'}}|array<int, array<string, string>> $array */
+	assertType('array<int, string>', array_column($array, 'column'));
+	assertType('array<int|string, string>', array_column($array, 'column', 'key'));
+
+	/** @var array{0?: array{column: 'foo', key: 'bar'}} $array */
+	assertType("array<int, 'foo'>", array_column($array, 'column'));
+	assertType("array<'bar', 'foo'>", array_column($array, 'column', 'key'));
+}
+
+function testObjects(array $array): void {
+	/** @var array<int, DOMElement> $array */
+	assertType('array<int, string>', array_column($array, 'nodeName'));
+	assertType('array<string, string>', array_column($array, 'nodeName', 'tagName'));
+	assertType('array<int, mixed>', array_column($array, 'foo'));
+	assertType('array<string, mixed>', array_column($array, 'foo', 'tagName'));
+	assertType('array<string>', array_column($array, 'nodeName', 'foo'));
+
+	/** @var non-empty-array<int, DOMElement> $array */
+	assertType('non-empty-array<int, string>', array_column($array, 'nodeName'));
+	assertType('non-empty-array<string, string>', array_column($array, 'nodeName', 'tagName'));
+	assertType('array<int, mixed>', array_column($array, 'foo'));
+	assertType('array<string, mixed>', array_column($array, 'foo', 'tagName'));
+	assertType('non-empty-array<string>', array_column($array, 'nodeName', 'foo'));
+
+	/** @var array{DOMElement} $array */
+	assertType('array{string}', array_column($array, 'nodeName'));
+	assertType('non-empty-array<string, string>', array_column($array, 'nodeName', 'tagName'));
+	assertType('array<int, mixed>', array_column($array, 'foo'));
+	assertType('array<string, mixed>', array_column($array, 'foo', 'tagName'));
+	assertType('non-empty-array<int|string, string>', array_column($array, 'nodeName', 'foo'));
+}


### PR DESCRIPTION
Note that when the iterable value type of the given array is a `ConstantArrayType` with optional keys, then it will not attempt to produce a precise result. I think it's not worth supporting this and would either produce useless types, or unnecessarily complex types.