### PR TITLE
fix issue when running tests on PHP < 8.1

### DIFF
--- a/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php
+++ b/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php
@@ -18,6 +18,10 @@ class EnumCaseObjectTypeTest extends PHPStanTestCase
 
 	public function dataIsSuperTypeOf(): iterable
 	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
 		yield [
 			new ObjectType('PHPStan\Fixture\TestEnum'),
 			new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
@@ -120,6 +124,10 @@ class EnumCaseObjectTypeTest extends PHPStanTestCase
 
 	public function dataAccepts(): iterable
 	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
 		yield [
 			new ObjectType('PHPStan\Fixture\TestEnum'),
 			new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),


### PR DESCRIPTION
 (data provider are still executed, while the test skips)

Without this change neither `make tests` nor PHPStorm will pass on a fresh checkout and using the `php:8.0-cli-alpine` image and PHPUnit 9.5.7:

```
1) Error
The data provider specified for PHPStan\Type\Enum\EnumCaseObjectTypeTest::testIsSuperTypeOf is invalid.
ParseError: syntax error, unexpected identifier "TestEnum"
/app/tests/PHPStan/Fixture/TestEnum.php:5
/app/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php:276
/app/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php:167
/app/src/Reflection/BetterReflection/SourceLocator/ClassWhitelistSourceLocator.php:30
/app/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/AggregateSourceLocator.php:36
/app/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/MemoizingSourceLocator.php:42
/app/vendor/ondrejmirtes/better-reflection/src/Reflector/DefaultReflector.php:37
/app/src/Reflection/BetterReflection/Reflector/MemoizingReflector.php:47
/app/src/Reflection/BetterReflection/BetterReflectionProvider.php:99
/app/src/Reflection/ReflectionProvider/ChainReflectionProvider.php:31
/app/src/Reflection/ReflectionProvider/MemoizingReflectionProvider.php:35
/app/src/Type/ObjectType.php:388
/app/src/Type/VerbosityLevel.php:153
/app/src/Type/ObjectType.php:418
/app/src/Type/Enum/EnumCaseObjectType.php:38
/app/src/Type/UnionTypeHelper.php:128
/app/src/Type/UnionTypeHelper.php:129
/app/src/Type/UnionType.php:64
/app/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php:95

2) Error
The data provider specified for PHPStan\Type\Enum\EnumCaseObjectTypeTest::testAccepts is invalid.
ParseError: syntax error, unexpected identifier "TestEnum"
/app/tests/PHPStan/Fixture/TestEnum.php:5
/app/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php:276
/app/src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php:167
/app/src/Reflection/BetterReflection/SourceLocator/ClassWhitelistSourceLocator.php:30
/app/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/AggregateSourceLocator.php:36
/app/vendor/ondrejmirtes/better-reflection/src/SourceLocator/Type/MemoizingSourceLocator.php:42
/app/vendor/ondrejmirtes/better-reflection/src/Reflector/DefaultReflector.php:37
/app/src/Reflection/BetterReflection/Reflector/MemoizingReflector.php:47
/app/src/Reflection/BetterReflection/BetterReflectionProvider.php:99
/app/src/Reflection/ReflectionProvider/ChainReflectionProvider.php:31
/app/src/Reflection/ReflectionProvider/MemoizingReflectionProvider.php:35
/app/src/Type/ObjectType.php:388
/app/src/Type/VerbosityLevel.php:153
/app/src/Type/ObjectType.php:418
/app/src/Type/Enum/EnumCaseObjectType.php:38
/app/src/Type/UnionTypeHelper.php:128
/app/src/Type/UnionTypeHelper.php:129
/app/src/Type/UnionType.php:64
/app/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php:201
```