### PR TITLE
Bugfix DatePeriod::getEndDate declaration

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1590,7 +1590,7 @@ return [
 'DatePeriod::__construct\'2' => ['void', 'iso'=>'string', 'options='=>'int'],
 'DatePeriod::__wakeup' => ['void'],
 'DatePeriod::getDateInterval' => ['DateInterval'],
-'DatePeriod::getEndDate' => ['DateTimeInterface'],
+'DatePeriod::getEndDate' => ['?DateTimeInterface'],
 'DatePeriod::getStartDate' => ['DateTimeInterface'],
 'DateTime::__construct' => ['void', 'time='=>'string', 'timezone='=>'?DateTimeZone'],
 'DateTime::__set_state' => ['static', 'array'=>'array'],


### PR DESCRIPTION
This is a fix to [#6477](https://github.com/phpstan/phpstan/issues/6477) and #762 
I did not try to make the fix clever. It is up to the codebase to check for the method nullability return.