### PR TITLE
Bugfix DateInterval::createFromDateString return type declaration

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1583,7 +1583,7 @@ return [
 'DateInterval::__construct' => ['void', 'spec'=>'string'],
 'DateInterval::__set_state' => ['DateInterval', 'array'=>'array'],
 'DateInterval::__wakeup' => ['void'],
-'DateInterval::createFromDateString' => ['DateInterval', 'time'=>'string'],
+'DateInterval::createFromDateString' => ['DateInterval|false', 'time'=>'string'],
 'DateInterval::format' => ['string', 'format'=>'string'],
 'DatePeriod::__construct' => ['void', 'start'=>'DateTimeInterface', 'interval'=>'DateInterval', 'recur'=>'int', 'options='=>'int'],
 'DatePeriod::__construct\'1' => ['void', 'start'=>'DateTimeInterface', 'interval'=>'DateInterval', 'end'=>'DateTimeInterface', 'options='=>'int'],


### PR DESCRIPTION
Fixing `DateInterval::createFromDateString` return type to resolve the following snippet.

https://phpstan.org/r/55463eb9-ea4d-41d2-812c-65c60beecd10

and 

https://3v4l.org/IPOmh

PHPStan always expect `DateInterval::createFromDateString` to return a `DateInterval` instance while the named constructor can also return `false`