### PR TITLE
Reproduce generics union bound issue

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2328,4 +2328,12 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug5591(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-5591.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-5591.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5591.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bug5591;
+
+class EntityA {}
+class EntityB {}
+
+/**
+ * @template TEntity as object
+ */
+class TestClass
+{
+	/** @var class-string<TEntity> The fully-qualified (::class) class name of the entity being managed. */
+	protected string $entityClass;
+
+	/** @param TEntity|null $record */
+	public function outerMethod(?object $record = null): void
+	{
+		$record = $this->innerMethod($record);
+	}
+
+	/**
+	 * @param TEntity|null $record
+	 *
+	 * @return TEntity
+	 */
+	public function innerMethod(?object $record = null): object
+	{
+		return $record ?? new ($this->entityClass)();
+	}
+}
+
+/**
+ * @template TEntity as EntityA|EntityB
+ * @extends TestClass<TEntity>
+ */
+class TestClass2 extends TestClass
+{
+	public function outerMethod(?object $record = null): void
+	{
+		$this->innerMethod($record);
+	}
+}


### PR DESCRIPTION
See https://github.com/phpstan/phpstan/issues/5591

/cc @arnaud-lb Looks like you're digging through some older issues, I've got one that you're more equipped to fix rather than me :) The problem here is that the type is rejected although it's exactly the same one: https://phpstan.org/r/cc421f16-0749-407d-80ac-e05e7624d3f7

> Parameter #1 $record of method App\TestClass<TEntity of App\EntityA|App\EntityB>::innerMethod() expects (TEntity of App\EntityA|App\EntityB)|null, (TEntity of App\EntityA|App\EntityB)|null given.

The problem is that we're representing `TEntity|null` as a `UnionType(new TemplateUnionType(EntityA, EntityB), null)`. Union inside union might not be ideal but I don't know how differently it could work.

The problem is that `UnionType::accepts()` does not accept the same type it's itself. Can you please look into it and figure out what's the root cause and how it could be fixed?

Thank you :)