### PR TITLE
Fix interaction between template type and intersection type

### DIFF
--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -121,7 +121,7 @@ trait TemplateTypeTrait
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
-		if ($type instanceof self) {
+		if ($type instanceof self || $type instanceof IntersectionType) {
 			return $type->isSubTypeOf($this);
 		}
 

--- a/tests/PHPStan/Generics/GenericsIntegrationTest.php
+++ b/tests/PHPStan/Generics/GenericsIntegrationTest.php
@@ -24,6 +24,7 @@ class GenericsIntegrationTest extends LevelsTestCase
 			['bug2620'],
 			['bug2622'],
 			['bug2627'],
+			['bug6210'],
 		];
 	}
 

--- a/tests/PHPStan/Generics/data/bug6210.php
+++ b/tests/PHPStan/Generics/data/bug6210.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Generics\Bug6210;
+
+/**
+ * @template TEntityClass of object
+ */
+class HelloWorld
+{
+	/**
+	 * @phpstan-param TEntityClass $entity
+	 */
+	public function provide($entity, ?string $value): void
+	{
+		if (null !== $value) {
+			if (!method_exists($entity, 'getId')) {
+				throw new \InvalidArgumentException();
+			}
+		}
+		$this->show($entity);
+	}
+
+	/**
+	 * @phpstan-param TEntityClass $entity
+	 */
+	private function show($entity): void
+	{
+	}
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -28,6 +28,7 @@ use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateBenevolentUnionType;
+use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\Generic\TemplateObjectWithoutClassType;
 use PHPStan\Type\Generic\TemplateType;
@@ -1203,6 +1204,112 @@ class TypeCombinatorTest extends PHPStanTestCase
 				],
 				UnionType::class,
 				'T of DateTime (function a(), parameter)|U of DateTime (function a(), parameter)',
+			],
+			'bug6210-1' => [
+				[
+					new ObjectWithoutClassType(),
+					new IntersectionType([
+						new ObjectWithoutClassType(),
+						new HasMethodType('getId'),
+					]),
+				],
+				ObjectWithoutClassType::class,
+				'object',
+			],
+			'bug6210-2' => [
+				[
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithFunction('a'),
+						'T',
+						null,
+						TemplateTypeVariance::createInvariant(),
+					),
+					new IntersectionType([
+						TemplateTypeFactory::create(
+							TemplateTypeScope::createWithFunction('a'),
+							'T',
+							null,
+							TemplateTypeVariance::createInvariant(),
+						),
+						new HasMethodType('getId'),
+					]),
+				],
+				TemplateMixedType::class,
+				'T (function a(), parameter)=explicit',
+			],
+			'bug6210-3' => [
+				[
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithFunction('a'),
+						'T',
+						new ObjectWithoutClassType(),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new IntersectionType([
+						TemplateTypeFactory::create(
+							TemplateTypeScope::createWithFunction('a'),
+							'T',
+							new ObjectWithoutClassType(),
+							TemplateTypeVariance::createInvariant(),
+						),
+						new HasMethodType('getId'),
+					]),
+				],
+				TemplateObjectWithoutClassType::class,
+				'T of object (function a(), parameter)',
+			],
+			'bug6210-4' => [
+				[
+					new ObjectWithoutClassType(),
+					new IntersectionType([
+						new ObjectWithoutClassType(),
+						new HasPropertyType('getId'),
+					]),
+				],
+				ObjectWithoutClassType::class,
+				'object',
+			],
+			'bug6210-5' => [
+				[
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithFunction('a'),
+						'T',
+						null,
+						TemplateTypeVariance::createInvariant(),
+					),
+					new IntersectionType([
+						TemplateTypeFactory::create(
+							TemplateTypeScope::createWithFunction('a'),
+							'T',
+							null,
+							TemplateTypeVariance::createInvariant(),
+						),
+						new HasPropertyType('getId'),
+					]),
+				],
+				TemplateMixedType::class,
+				'T (function a(), parameter)=explicit',
+			],
+			'bug6210-6' => [
+				[
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithFunction('a'),
+						'T',
+						new ObjectWithoutClassType(),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new IntersectionType([
+						TemplateTypeFactory::create(
+							TemplateTypeScope::createWithFunction('a'),
+							'T',
+							new ObjectWithoutClassType(),
+							TemplateTypeVariance::createInvariant(),
+						),
+						new HasPropertyType('getId'),
+					]),
+				],
+				TemplateObjectWithoutClassType::class,
+				'T of object (function a(), parameter)',
 			],
 			[
 				[


### PR DESCRIPTION
This fixes https://github.com/phpstan/phpstan/issues/6210 by ensuring that `TemplateType | (TemplateType & something)` is collapsed to `TemplateType`. This was not happening because TemplateType was not considered to be a super type of an intersection containing itself.