### PR TITLE
Fix tests on 32-bit

### DIFF
--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_INT_SIZE;
 use const PHP_VERSION_ID;
 
 /**
@@ -461,6 +462,9 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 
 	public function testBug4848(): void
 	{
+		if (PHP_INT_SIZE !== 8) {
+			$this->markTestSkipped('Test requires 64-bit platform.');
+		}
 		$this->checkAlwaysTrueStrictComparison = true;
 		$this->analyse([__DIR__ . '/data/bug-4848.php'], [
 			[


### PR DESCRIPTION
I know this is kind of esoteric, but this was the only thing that prevented me to cleanly ran `make` with php 8.1 on my 32-bit raspberry pi:
```sh
$ uname -msr
Linux 5.10.90-1-rpi-legacy-ARCH armv7l
```
I had to add 1G of swap to make it run without freezing the system, but this would in general make the build green on 32-bit. No idea if it's really worth pursuing though, but good to know at least, that right now, even without this fix, phpstan runs still just fine on 32-bit :)

The reason is that this test defines a numeric in a string that is bigger than PHP_INT_MAX, casts it to int and then string again. and the int cast behaves different, depending on PHP_INT_SIZE. https://3v4l.org/enuv2

Only doing that because in #693 some 32/64-bit questions came up. The only important thing, I'd say, is to still support _scanning_ code made for 32-bit, phpstan doesn't have to run on 32-bit. But right know it still could, so I'm just trying to find an answer to the question if we still _should_ support running it on 32-bit :) And if yes - how to make sure it stays like that? If not - is it fine to just drop the runtime support then?