### PR TITLE
Make type inference test data providers lazy

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -107,6 +107,13 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		}
 	}
 
+	public function assertFileAssertsLazy(string $file): void
+	{
+		foreach ($this->gatherAssertTypes($file) as $assertion) {
+			$this->assertFileAsserts(...$assertion);
+		}
+	}
+
 	/**
 	 * @api
 	 * @return array<string, mixed[]>
@@ -179,6 +186,14 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		});
 
 		return $asserts;
+	}
+
+	/**
+	 * @return array<string, array{string}>
+	 */
+	public function gatherAssertTypesLazy(string $file): array
+	{
+		return [$file => [$file]];
 	}
 
 	/** @return string[] */

--- a/tests/PHPStan/Analyser/ClassConstantStubFileTest.php
+++ b/tests/PHPStan/Analyser/ClassConstantStubFileTest.php
@@ -9,20 +9,15 @@ class ClassConstantStubFileTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/class-constant-stub-files.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/class-constant-stub-files.php');
 	}
 
 	/**
 	 * @dataProvider dataFileAsserts
-	 * @param mixed ...$args
 	 */
-	public function testFileAsserts(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testFileAsserts(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionTest.php
+++ b/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionTest.php
@@ -9,20 +9,15 @@ class DynamicMethodThrowTypeExtensionTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-throw-type-extension.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/dynamic-method-throw-type-extension.php');
 	}
 
 	/**
 	 * @dataProvider dataFileAsserts
-	 * @param mixed ...$args
 	 */
-	public function testFileAsserts(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testFileAsserts(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/DynamicReturnTypeExtensionTypeInferenceTest.php
+++ b/tests/PHPStan/Analyser/DynamicReturnTypeExtensionTypeInferenceTest.php
@@ -9,21 +9,16 @@ class DynamicReturnTypeExtensionTypeInferenceTest extends TypeInferenceTestCase
 
 	public function dataAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-types.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-compound-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/dynamic-method-return-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/dynamic-method-return-compound-types.php');
 	}
 
 	/**
 	 * @dataProvider dataAsserts
-	 * @param mixed ...$args
 	 */
-	public function testAsserts(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testAsserts(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -16,668 +16,663 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		require_once __DIR__ . '/data/bug2574.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug2574.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug2574.php');
 
 		require_once __DIR__ . '/data/bug2577.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug2577.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug2577.php');
 
 		require_once __DIR__ . '/data/generics.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generics.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generics.php');
 
 		require_once __DIR__ . '/data/generic-class-string.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-class-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generic-class-string.php');
 
 		require_once __DIR__ . '/data/instanceof.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/date.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/instanceof.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/integer-range-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/date.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/instanceof.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/integer-range-types.php');
 		if (PHP_INT_SIZE === 8) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/random-int.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/random-int.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-return-type-extensions.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-key.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/intersection-static.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/static-properties.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/static-methods.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2612.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2677.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2676.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/psalm-prefix-unresolvable.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/complex-generics-example.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2648.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2740.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2822.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inheritdoc-parameter-remapping.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inheritdoc-constructors.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-type.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2835.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2443.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2750.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2850.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2863.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/native-types.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-change-after-array-access-assignment.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/iterator_to_array.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/key-of.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/value-of.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/closure-return-type-extensions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-key.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/intersection-static.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/static-properties.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/static-methods.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2612.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2677.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2676.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/psalm-prefix-unresolvable.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/complex-generics-example.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2648.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2740.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2822.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inheritdoc-parameter-remapping.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inheritdoc-constructors.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/list-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2835.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2443.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2750.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2850.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2863.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/native-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-change-after-array-access-assignment.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/iterator_to_array.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/key-of.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/value-of.php');
 
 		if (self::$useStaticReflectionProvider || extension_loaded('ds')) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/ext-ds.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/ext-ds.php');
 		}
 		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 70401) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/arrow-function-return-type.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/arrow-function-return-type.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/is-numeric.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/is-a.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3142.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-shapes-keys-strings.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1216.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/const-expr-phpdoc-type.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3226.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2001.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2232.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3009.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/is-numeric.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/is-a.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3142.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-shapes-keys-strings.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1216.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/const-expr-phpdoc-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3226.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2001.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2232.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3009.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inherit-phpdoc-merging-var.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inherit-phpdoc-merging-param.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inherit-phpdoc-merging-return.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inherit-phpdoc-merging-template.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3266.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3269.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/assign-nested-arrays.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inherit-phpdoc-merging-var.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inherit-phpdoc-merging-param.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inherit-phpdoc-merging-return.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inherit-phpdoc-merging-template.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3266.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3269.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/assign-nested-arrays.php');
 		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3276.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3276.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/shadowed-trait-methods.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/const-in-functions.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/const-in-functions-namespaced.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/root-scope-maybe-defined.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/shadowed-trait-methods.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/const-in-functions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/const-in-functions-namespaced.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/root-scope-maybe-defined.php');
 		if (PHP_VERSION_ID < 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3336.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3336.php');
 		}
 		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/catch-without-variable.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/catch-without-variable.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/mixed-typehint.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/mixed-typehint.php');
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2600-php8.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2600-php8.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2600.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2600.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-typehint-without-null-in-phpdoc.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/override-root-scope-variable.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bitwise-not.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-typehint-without-null-in-phpdoc.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/override-root-scope-variable.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bitwise-not.php');
 		if (extension_loaded('gd')) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/graphics-draw-return-types.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/graphics-draw-return-types.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
 			require_once __DIR__ . '/../../../stubs/runtime/ReflectionUnionType.php';
 
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/unionTypes.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Reflection/data/unionTypes.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/mixedType.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Reflection/data/mixedType.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/staticReturnType.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Reflection/data/staticReturnType.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/minmax-arrays.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/classPhpDocs.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-array-key-type.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3133.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-2550.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2899.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/preg_split.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bcmath-dynamic-return.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3875.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2611.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3548.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3866.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1014.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-pr-339.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/pow.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/minmax-arrays.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/classPhpDocs.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/non-empty-array-key-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3133.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Comparison/data/bug-2550.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2899.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/preg_split.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bcmath-dynamic-return.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3875.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2611.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3548.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3866.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1014.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-pr-339.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/pow.php');
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-expr.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-expr.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-array.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/non-empty-array.php');
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/class-constant-on-expr.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/class-constant-on-expr.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3961-php8.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3961-php8.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3961.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3961.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1924.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1924.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/extra-int-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/extra-int-types.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/count-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/count-type.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2816.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2816.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2816-2.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2816-2.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3985.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3985.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-slice.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-slice.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3990.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3990.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3991.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3991.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3993.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3993.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3997.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3997.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4016.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4016.php');
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/promoted-properties-types.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/promoted-properties-types.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/early-termination-phpdoc.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/early-termination-phpdoc.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3915.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3915.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2378.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2378.php');
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/match-expr.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/match-expr.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/nullsafe.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/nullsafe.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/specified-types-closure-use.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/specified-types-closure-use.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/cast-to-numeric-string.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2539.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2733.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3132.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1233.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/comparison-operators.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3880.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/inc-dec-in-conditions.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4099.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3760.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2997.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1657.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2945.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4207.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4206.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-empty-array.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4205.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/dependent-variable-certainty.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1865.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/conditional-non-empty-array.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/foreach-dependent-key-value.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/dependent-variables-type-guard-same-as-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/cast-to-numeric-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2539.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2733.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3132.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1233.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/comparison-operators.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3880.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/inc-dec-in-conditions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4099.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3760.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2997.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1657.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2945.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4207.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4206.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-empty-array.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4205.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/dependent-variable-certainty.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1865.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/conditional-non-empty-array.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/foreach-dependent-key-value.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/dependent-variables-type-guard-same-as-type.php');
 
 		if (PHP_VERSION_ID >= 70400 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/dependent-variables-arrow-function.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/dependent-variables-arrow-function.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-801.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1209.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2980.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3986.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-801.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1209.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2980.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3986.php');
 
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4188.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4188.php');
 		}
 
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4339.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4339.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4343.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/impure-method.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4351.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/var-above-use.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/var-above-declare.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-return-type.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4398.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4415.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/compact.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4500.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4504.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4436.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Properties/data/bug-3777.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2549.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1945.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2003.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-651.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1283.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4538.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/proc_get_status.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-4552.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1897.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1801.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2927.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4558.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4557.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4209.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4209-2.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2869.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3024.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3134.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/infer-array-key.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/offset-value-after-assign.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2112.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4343.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/impure-method.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4351.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/var-above-use.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/var-above-declare.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/closure-return-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4398.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4415.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/compact.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4500.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4504.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4436.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Properties/data/bug-3777.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2549.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1945.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2003.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-651.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1283.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4538.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/proc_get_status.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/bug-4552.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1897.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1801.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2927.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4558.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4557.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4209.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4209-2.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2869.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3024.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3134.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/infer-array-key.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/offset-value-after-assign.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2112.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-filter.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-filter-callables.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-filter.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-filter-callables.php');
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-filter-arrow-functions.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-filter-arrow-functions.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-flip.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-map.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-map-closure.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-sum.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-plus.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4573.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4577.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4579.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3321.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-flip.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-map.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-map-closure.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-sum.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-plus.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4573.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4577.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4579.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3321.php');
 
 		require_once __DIR__ . '/../Rules/Generics/data/bug-3769.php';
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/instanceof-class-string.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4498.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4587.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4606.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/nested-generic-types.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3922.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/nested-generic-types-unwrapping.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/nested-generic-types-unwrapping-covariant.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/nested-generic-incomplete-constructor.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/iterator-iterator.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4642.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-4643.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/instanceof-class-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4498.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4587.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4606.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/nested-generic-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3922.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/nested-generic-types-unwrapping.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/nested-generic-types-unwrapping-covariant.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/nested-generic-incomplete-constructor.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/iterator-iterator.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4642.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/PhpDoc/data/bug-4643.php');
 		require_once __DIR__ . '/data/throw-points/helpers.php';
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/php8/null-safe-method-call.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/php8/null-safe-method-call.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/and.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/array.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/array-dim-fetch.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/assign.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/assign-op.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/do-while.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/for.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/foreach.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/func-call.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/if.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/method-call.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/or.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/property-fetch.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/static-call.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/switch.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/throw.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/try-catch-finally.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/variable.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/while.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-points/try-catch.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-pseudotype-override.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/and.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/array.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/array-dim-fetch.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/assign.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/assign-op.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/do-while.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/for.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/foreach.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/func-call.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/if.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/method-call.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/or.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/property-fetch.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/static-call.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/switch.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/throw.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/try-catch-finally.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/variable.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/while.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/throw-points/try-catch.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/phpdoc-pseudotype-override.php');
 		require_once __DIR__ . '/data/phpdoc-pseudotype-namespace.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-pseudotype-namespace.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-pseudotype-global.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-traits.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4423.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-unions.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-parent.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4247.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4267.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2231.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3558.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3351.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4213.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4657.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4707.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4545.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4714.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4725.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4733.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4326.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-987.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3677.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4215.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4695.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2977.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3190.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/ternary-specified-types.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-560.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/do-not-remember-impure-functions.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4190.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/clear-stat-cache.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/invalidate-object-argument.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/invalidate-object-argument-static.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/phpdoc-pseudotype-namespace.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/phpdoc-pseudotype-global.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generic-traits.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4423.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generic-unions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generic-parent.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4247.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4267.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2231.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3558.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3351.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4213.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4657.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4707.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4545.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4714.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4725.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4733.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4326.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-987.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3677.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4215.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4695.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2977.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3190.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/ternary-specified-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-560.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/do-not-remember-impure-functions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4190.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/clear-stat-cache.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/invalidate-object-argument.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/invalidate-object-argument-static.php');
 
 		require_once __DIR__ . '/data/invalidate-object-argument-function.php';
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/invalidate-object-argument-function.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/invalidate-object-argument-function.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4588.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4091.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3382.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4177.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2288.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1157.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1597.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3617.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-778.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2969.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3004.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3710.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3822.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-505.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1670.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1219.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3302.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1511.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4434.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4231.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4287.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4700.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/phpdoc-in-closure-bind.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/multi-assign.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generics-reduce-types-first.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4803.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4588.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4091.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3382.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4177.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2288.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1157.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1597.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3617.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-778.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2969.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3004.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3710.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3822.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-505.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1670.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1219.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3302.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1511.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4434.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4231.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4287.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4700.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/phpdoc-in-closure-bind.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/multi-assign.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generics-reduce-types-first.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4803.php');
 
 		require_once __DIR__ . '/data/type-aliases.php';
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-aliases.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4650.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2906.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-aliases.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4650.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2906.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeDynamicReturnTypes.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4821.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4838.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4879.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4820.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4822.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4816.php');
-
-		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4757.php');
-		}
-
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4814.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4982.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4761.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3331.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3106.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2640.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2413.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3446.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/getopt.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generics-default.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4985.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5000.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/number_format.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5140.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/DateTimeDynamicReturnTypes.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4821.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4838.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4879.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4820.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4822.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4816.php');
 
 		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-4857.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4757.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/empty-array-shape.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5089.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3158.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/unable-to-resolve-callback-parameter-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4814.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4982.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4761.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3331.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3106.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2640.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2413.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3446.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/getopt.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generics-default.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4985.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5000.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/number_format.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5140.php');
+
+		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Comparison/data/bug-4857.php');
+		}
+
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/empty-array-shape.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/bug-5089.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3158.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/unable-to-resolve-callback-parameter-type.php');
 
 		require_once __DIR__ . '/../Rules/Functions/data/varying-acceptor.php';
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/varying-acceptor.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Functions/data/varying-acceptor.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/uksort-bug.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/uksort-bug.php');
 
 		if (self::$useStaticReflectionProvider || PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/arrow-function-types.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/arrow-function-types.php');
 			if (PHP_VERSION_ID >= 80000) {
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4902-php8.php');
+				yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4902-php8.php');
 			} else {
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4902.php');
+				yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4902.php');
 			}
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-types.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5219.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/strval.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-next.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-replace-functions.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3981.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4711.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/sscanf.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-offset-get.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-object-lower-bound.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/class-reflection-interfaces.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-4415.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5259.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5293.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5129.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4970.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5322.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/splfixedarray-iterator-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/closure-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5219.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/strval.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-next.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/non-empty-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/non-empty-string-replace-functions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3981.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4711.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/sscanf.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generic-offset-get.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/generic-object-lower-bound.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/class-reflection-interfaces.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/bug-4415.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5259.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5293.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5129.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4970.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5322.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/splfixedarray-iterator-types.php');
 
 		if (PHP_VERSION_ID >= 70400 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5372.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/bug-5372.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-5372_2.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Arrays/data/bug-5372_2.php');
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/mb_substitute_character-php8.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/mb_substitute_character-php8.php');
 		} elseif (PHP_VERSION_ID < 70200) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/mb_substitute_character-php71.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/mb_substitute_character-php71.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/mb_substitute_character.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/mb_substitute_character.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/class-constant-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/class-constant-types.php');
 
 		if (self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3379.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3379.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/reflectionclass-issue-5511-php8.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/reflectionclass-issue-5511-php8.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/modulo-operator.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/modulo-operator.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/literal-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/literal-string.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var-returns-non-empty-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/filter-var-returns-non-empty-string.php');
 
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/model-mixin.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/model-mixin.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5529.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5529.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/sizeof.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/sizeof.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/div-by-zero.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/div-by-zero.php');
 
 		if (PHP_INT_SIZE === 8) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5072.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5072.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5530.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1861.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4843.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4602.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4499.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2142.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5584.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5530.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1861.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4843.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4602.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4499.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2142.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5584.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/math.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/math.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1870.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5562.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5615.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_map_multiple.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/range-numeric-string.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/missing-closure-native-return-typehint.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4741.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/more-type-strings.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-1870.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/../Rules/Methods/data/bug-5562.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5615.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array_map_multiple.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/range-numeric-string.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/missing-closure-native-return-typehint.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4741.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/more-type-strings.php');
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/variadic-parameter-php8.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4896.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5843.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/variadic-parameter-php8.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4896.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5843.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/eval-implicit-throw.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5628.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5501.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4743.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5017.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5992.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6001.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/eval-implicit-throw.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5628.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5501.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4743.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5017.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5992.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-6001.php');
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5287-php81.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5287-php81.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5287.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5287.php');
 		}
 
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5458.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5458.php');
 		}
 
 		if (PHP_VERSION_ID >= 80100 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/never.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/never.php');
 		}
 
 		if (PHP_VERSION_ID >= 80100 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/native-intersection.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/native-intersection.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2760.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2760.php');
 
 		if (PHP_VERSION_ID >= 80100 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/new-in-initializers.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/new-in-initializers.php');
 
 			if (PHP_VERSION_ID >= 80100) {
 				define('TEST_OBJECT_CONSTANT', new stdClass());
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/new-in-initializers-runtime.php');
+				yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/new-in-initializers-runtime.php');
 			}
 		}
 
 		if (PHP_VERSION_ID >= 80100 || self::$useStaticReflectionProvider) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/first-class-callables.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/first-class-callables.php');
 		}
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-is-list-type-specifying.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-is-list-type-specifying.php');
 		}
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-unpacking-string-keys.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-unpacking-string-keys.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/filesystem-functions.php');
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums-import-alias.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/enums.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/enums-import-alias.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6293.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-6293.php');
 		}
 
 		if (PHP_VERSION_ID >= 70200) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants-php72.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/predefined-constants-php72.php');
 		}
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants-php74.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/predefined-constants-php74.php');
 		}
 		if (PHP_INT_SIZE === 8) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants-64bit.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/predefined-constants-64bit.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants-32bit.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/predefined-constants-32bit.php');
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/predefined-constants.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/classPhpDocs-phpstanPropertyPrefix.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/classPhpDocs-phpstanPropertyPrefix.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-destructuring-types.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/pdo-prepare.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/constant-array-type-set.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/for-loop-i-type.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5316.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3858.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-2806.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5328.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3044.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-destructuring-types.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/pdo-prepare.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/constant-array-type-set.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/for-loop-i-type.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5316.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3858.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-2806.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5328.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-3044.php');
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/invalidate-readonly-properties.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/invalidate-readonly-properties.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/weird-array_key_exists-issue.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/equal.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/weird-array_key_exists-issue.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/equal.php');
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5698-php8.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5698-php8.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5698-php7.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5698-php7.php');
 		}
 
 		if (PHP_VERSION_ID >= 70304) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/date-period-return-types.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/date-period-return-types.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6404.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6399.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4357.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5817.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-column.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-6404.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-6399.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4357.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-5817.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/array-column.php');
 
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/isset-coalesce-empty-type.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/isset-coalesce-empty-type-root.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/isset-coalesce-empty-type.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/isset-coalesce-empty-type-root.php');
 		}
 
 		if (PHP_VERSION_ID < 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/isset-coalesce-empty-type-pre-81.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/isset-coalesce-empty-type-pre-81.php');
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/isset-coalesce-empty-type-post-81.php');
+			yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/isset-coalesce-empty-type-post-81.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/template-null-bound.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4592.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4903.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/template-null-bound.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4592.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/bug-4903.php');
 	}
 
 	/**
 	 * @dataProvider dataFileAsserts
-	 * @param mixed ...$args
 	 */
-	public function testFileAsserts(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testFileAsserts(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/TypeSpecifyingExtensionTypeInferenceFalseTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifyingExtensionTypeInferenceFalseTest.php
@@ -9,22 +9,17 @@ class TypeSpecifyingExtensionTypeInferenceFalseTest extends TypeInferenceTestCas
 
 	public function dataTypeSpecifyingExtensionsFalse(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-1-false.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-2-false.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-3-false.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-1-false.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-2-false.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-3-false.php');
 	}
 
 	/**
 	 * @dataProvider dataTypeSpecifyingExtensionsFalse
-	 * @param mixed ...$args
 	 */
-	public function testTypeSpecifyingExtensionsFalse(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testTypeSpecifyingExtensionsFalse(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/TypeSpecifyingExtensionTypeInferenceNullTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifyingExtensionTypeInferenceNullTest.php
@@ -9,22 +9,17 @@ class TypeSpecifyingExtensionTypeInferenceNullTest extends TypeInferenceTestCase
 
 	public function dataTypeSpecifyingExtensionsNull(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-1-null.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-2-null.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-3-null.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-1-null.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-2-null.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-3-null.php');
 	}
 
 	/**
 	 * @dataProvider dataTypeSpecifyingExtensionsNull
-	 * @param mixed ...$args
 	 */
-	public function testTypeSpecifyingExtensionsNull(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testTypeSpecifyingExtensionsNull(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/TypeSpecifyingExtensionTypeInferenceTrueTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifyingExtensionTypeInferenceTrueTest.php
@@ -9,22 +9,17 @@ class TypeSpecifyingExtensionTypeInferenceTrueTest extends TypeInferenceTestCase
 
 	public function dataTypeSpecifyingExtensionsTrue(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-1-true.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-2-true.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifying-extensions-3-true.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-1-true.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-2-true.php');
+		yield from $this->gatherAssertTypesLazy(__DIR__ . '/data/type-specifying-extensions-3-true.php');
 	}
 
 	/**
 	 * @dataProvider dataTypeSpecifyingExtensionsTrue
-	 * @param mixed ...$args
 	 */
-	public function testTypeSpecifyingExtensionsTrue(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testTypeSpecifyingExtensionsTrue(string $file): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		$this->assertFileAssertsLazy($file);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Analyser/data/bug-1597.php
+++ b/tests/PHPStan/Analyser/data/bug-1597.php
@@ -7,6 +7,9 @@ use function PHPStan\Testing\assertType;
 $date = '';
 
 try {
+	if (rand(0,1) === 0) {
+		throw new \Exception();
+	}
 	$date = new \DateTime($date);
 } catch (\Exception $e) {
 	assertType('\'\'', $date);

--- a/tests/PHPStan/Analyser/data/bug-5817.php
+++ b/tests/PHPStan/Analyser/data/bug-5817.php
@@ -41,12 +41,14 @@ class MyContainer implements
 	}
 
 	/** @return DateTimeInterface|false */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		return current($this->items);
 	}
 
 	/** @return DateTimeInterface|false */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		return next($this->items);
@@ -64,6 +66,7 @@ class MyContainer implements
 	}
 
 	/** @return DateTimeInterface|false */
+	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
 		return reset($this->items);

--- a/tests/PHPStan/Analyser/data/catch-without-variable.php
+++ b/tests/PHPStan/Analyser/data/catch-without-variable.php
@@ -4,13 +4,18 @@ namespace CatchWithoutVariable;
 
 use function PHPStan\Testing\assertType;
 
+interface I
+{
+	function test(): void;
+}
+
 class Foo
 {
 
-	public function doFoo(): void
+	public function doFoo(I $i): void
 	{
 		try {
-
+			$i->test();
 		} catch (\FooException) {
 			assertType('*ERROR*', $e);
 		}


### PR DESCRIPTION
This delays the work done by the TypeInferenceTestCase data provider until the test execution.

This has the following benefits:
- It makes it possible to execute only one data set (this is convenient when step debugging for example)
- It makes it faster to execute only one data set: `phpunit  tests/PHPStan/Analyser/NodeScopeResolverTest.php --filter=bug2574.php` is almost instantaneous

I'm open to suggestions on better naming/API