### PR TITLE
Fix tests

### DIFF
--- a/tests/PHPStan/Analyser/data/bug-1597.php
+++ b/tests/PHPStan/Analyser/data/bug-1597.php
@@ -7,6 +7,9 @@ use function PHPStan\Testing\assertType;
 $date = '';
 
 try {
+	if (rand(0,1) === 0) {
+		throw new \Exception();
+	}
 	$date = new \DateTime($date);
 } catch (\Exception $e) {
 	assertType('\'\'', $date);

--- a/tests/PHPStan/Analyser/data/bug-5817.php
+++ b/tests/PHPStan/Analyser/data/bug-5817.php
@@ -41,12 +41,14 @@ class MyContainer implements
 	}
 
 	/** @return DateTimeInterface|false */
+	#[\ReturnTypeWillChange]
 	public function current()
 	{
 		return current($this->items);
 	}
 
 	/** @return DateTimeInterface|false */
+	#[\ReturnTypeWillChange]
 	public function next()
 	{
 		return next($this->items);
@@ -64,6 +66,7 @@ class MyContainer implements
 	}
 
 	/** @return DateTimeInterface|false */
+	#[\ReturnTypeWillChange]
 	public function rewind()
 	{
 		return reset($this->items);

--- a/tests/PHPStan/Analyser/data/catch-without-variable.php
+++ b/tests/PHPStan/Analyser/data/catch-without-variable.php
@@ -4,13 +4,18 @@ namespace CatchWithoutVariable;
 
 use function PHPStan\Testing\assertType;
 
+interface I
+{
+	function test(): void;
+}
+
 class Foo
 {
 
-	public function doFoo(): void
+	public function doFoo(I $i): void
 	{
 		try {
-
+			$i->test();
 		} catch (\FooException) {
 			assertType('*ERROR*', $e);
 		}


### PR DESCRIPTION
This fixes a few tests that was failing when testing #964:

- In bug-1597.php and catch-without-variable.php, the catch body is not processed when PHPStan knows that no exception can be thrown in the try block. Because of this, the assertType() is ignored in these tests. In #964 they was marked as risky because they didn't make any assertion.
- bug-5817.php triggers notices under PHP 8.1. In #964 the notices became fatal errors.