### PR TITLE
6431 add top consumers to debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ phpstan-result-cache:
 phpstan-generate-baseline:
 	php -d memory_limit=768M bin/phpstan --generate-baseline
 
+phpstan-debug:
+	php -d memory_limit=1G bin/phpstan --debug -vvv
+
 phpstan-validate-stub-files:
 	php bin/phpstan analyse -c conf/config.stubFiles.neon -l 8 tests/notAutoloaded/empty.php
 

--- a/src/Internal/ConsumptionCollector.php
+++ b/src/Internal/ConsumptionCollector.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use PHPStan\ShouldNotHappenException;
+use RuntimeException;
+use function array_map;
+use function array_slice;
+use function arsort;
+use function memory_get_peak_usage;
+use function microtime;
+use const SORT_NUMERIC;
+
+class ConsumptionCollector
+{
+
+	private int $consumersAdded = 0;
+
+	private string $file = '';
+
+	private int $totalMemoryConsumed = 0;
+
+	private float $processingStartedAt = 0;
+
+	private int $memoryConsumedAtStart = 0;
+
+	/** @var array<string, int>  */
+	private array $topMemoryConsumer = [];
+
+	/** @var array<string, float>  */
+	private array $topTimeConsumer = [];
+
+
+	public function __construct(private int $topX = 15)
+	{
+	}
+
+	public function registerFile(string $fileProcessed): void
+	{
+		if ($this->consumersAdded > 2000) {
+			$this->purgeOverflow();
+		}
+
+		$this->processingStartedAt = microtime(true);
+		$this->memoryConsumedAtStart = memory_get_peak_usage(true);
+
+		$this->file = $fileProcessed;
+		$this->consumersAdded++;
+	}
+
+	public function trackConsumption(): void
+	{
+		$this->totalMemoryConsumed = memory_get_peak_usage(true);
+
+		$this->topMemoryConsumer[$this->file] = $this->totalMemoryConsumed - $this->memoryConsumedAtStart;
+		$this->topTimeConsumer[$this->file] = microtime(true) - $this->processingStartedAt;
+	}
+
+	public function getTotalMemoryConsumed(): int
+	{
+		return $this->totalMemoryConsumed;
+	}
+
+	public function getMemoryConsumed(): int
+	{
+		if ($this->consumersAdded === 0) {
+			throw new RuntimeException('no files were registered');
+		} elseif (!isset($this->topMemoryConsumer[$this->file])) {
+			throw new ShouldNotHappenException('no memory consumption found for ' . $this->file . ' (consumers added: ' . $this->consumersAdded . ')');
+		}
+
+		return $this->topMemoryConsumer[$this->file];
+	}
+
+	public function getTimeConsumed(): float
+	{
+		if ($this->consumersAdded === 0) {
+			throw new RuntimeException('no files were registered');
+		} elseif (!isset($this->topTimeConsumer[$this->file])) {
+			throw new ShouldNotHappenException('no time consumption found for ' . $this->file . ' (consumers added: ' . $this->consumersAdded . ')');
+		}
+
+		return $this->topTimeConsumer[$this->file];
+	}
+
+	/**
+	 * @return array<string, int>
+	 */
+	public function getTopMemoryConsumers(): array
+	{
+		$this->purgeOverflow();
+		return $this->topMemoryConsumer;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getHumanisedTopMemoryConsumers(): array
+	{
+		return array_map(
+			static fn (int $usedMemory): string => BytesHelper::bytes($usedMemory),
+			$this->getTopMemoryConsumers(),
+		);
+	}
+
+	/**
+	 * @return array<string, float>
+	 */
+	public function getTopTimeConsumers(): array
+	{
+		$this->purgeOverflow();
+		return $this->topTimeConsumer;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getHumanisedTopTimeConsumers(): array
+	{
+		return array_map(
+			static fn (float $time): string => TimeHelper::humaniseFractionalSeconds($time),
+			$this->getTopTimeConsumers(),
+		);
+	}
+
+	/**
+	 * Keep memory footprint low - purge data not needed
+	 */
+	private function purgeOverflow(): void
+	{
+		arsort($this->topMemoryConsumer, SORT_NUMERIC);
+		$this->topMemoryConsumer = array_slice($this->topMemoryConsumer, 0, $this->topX, true);
+
+		arsort($this->topTimeConsumer, SORT_NUMERIC);
+		$this->topTimeConsumer = array_slice($this->topTimeConsumer, 0, $this->topX, true);
+
+		$this->consumersAdded = $this->topX;
+	}
+
+}

--- a/src/Internal/TimeHelper.php
+++ b/src/Internal/TimeHelper.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use function floor;
+use function round;
+
+class TimeHelper
+{
+
+	public static function humaniseFractionalSeconds(float $fractionalSeconds): string
+	{
+		$hoursAsString = $minutesAsString = $secondsAsString = '';
+		if ($fractionalSeconds < 5) {
+			// milliseconds as seconds
+			$secondsAsString = round($fractionalSeconds, 3) . 's';
+		} else {
+			$hours = floor($fractionalSeconds / 3600);
+			$minutes = floor(($fractionalSeconds / 60) % 60);
+			$seconds = $fractionalSeconds % 60;
+
+			if ($hours > 0) {
+				$hoursAsString = $hours . 'h';
+			}
+			if ($minutes > 0) {
+				$minutesAsString = $minutes . 'm';
+			}
+			if ($seconds > 0) {
+				$secondsAsString = $seconds . 's';
+			}
+		}
+
+		return $hoursAsString . $minutesAsString . $secondsAsString;
+	}
+
+}

--- a/tests/PHPStan/Internal/TimeHelperTest.php
+++ b/tests/PHPStan/Internal/TimeHelperTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+class TimeHelperTest extends TestCase
+{
+
+	/**
+	 * @dataProvider dataHumaniseFractionalSeconds
+	 */
+	public function testHumaniseFractionalSeconds(float $fractionalSeconds, string $humanisedOutputExpected): void
+	{
+		$this->assertEquals($humanisedOutputExpected, TimeHelper::humaniseFractionalSeconds($fractionalSeconds));
+	}
+
+	public function dataHumaniseFractionalSeconds(): Generator
+	{
+		yield 'fractional seconds below one second' => [
+			'fractionalSeconds' => 0.12345,
+			'humanisedOutputExpected' => '0.123s',
+		];
+
+		yield 'fractional seconds below threshold' => [
+			'fractionalSeconds' => 1.2345,
+			'humanisedOutputExpected' => '1.235s',
+		];
+
+		yield 'seconds' => [
+			'fractionalSeconds' => 12.345,
+			'humanisedOutputExpected' => '12s',
+		];
+
+		yield 'full minute' => [
+			'fractionalSeconds' => 60,
+			'humanisedOutputExpected' => '1m',
+		];
+
+		yield 'minute with seconds' => [
+			'fractionalSeconds' => 70,
+			'humanisedOutputExpected' => '1m10s',
+		];
+
+		yield 'full hour' => [
+			'fractionalSeconds' => 3600,
+			'humanisedOutputExpected' => '1h',
+		];
+
+		yield 'hour full minute' => [
+			'fractionalSeconds' => 3660,
+			'humanisedOutputExpected' => '1h1m',
+		];
+
+		yield 'hour minute seconds' => [
+			'fractionalSeconds' => 3665,
+			'humanisedOutputExpected' => '1h1m5s',
+		];
+	}
+
+}


### PR DESCRIPTION
resolves phpstan/phpstan#6431

@ondrejmirtes What do you think? It's solving the first part of the "I would accept PR which..." (with a little bonus added) and it does it's thing when running in debug mode (as "requested" in the issue):

1. output processing time per file
2. collect top consumers (both memory and time) and display topX as a summary

It has some room for improvements I'm aware of:

1. requires both `preFileCallback` and `postFileCallback` to be able to catch the file processed (= unable to be handled by workers atm)
2. I'm unsure if the tables are rendered in a good place or if the result should be returned via `AnalyserResult` (because it's a summary)
3. lacks tests for the Collector but I got no clear vision what's tested in PHPStan and what is not. (And I'm not sure how to mock the `memory_get_peak_usage` and `microtime` function calls  - PHP-Mock or libraries like this are no dependency atm)

Imho it's a base for further iteration.
