### PR TITLE
stream_bucket_new returns an object

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11700,7 +11700,7 @@ return [
 'strcspn' => ['int', 'str'=>'string', 'mask'=>'string', 'start='=>'int', 'length='=>'int'],
 'stream_bucket_append' => ['void', 'brigade'=>'resource', 'bucket'=>'object'],
 'stream_bucket_make_writeable' => ['object|null', 'brigade'=>'resource'],
-'stream_bucket_new' => ['resource', 'stream'=>'resource', 'buffer'=>'string'],
+'stream_bucket_new' => ['object', 'stream'=>'resource', 'buffer'=>'string'],
 'stream_bucket_prepend' => ['void', 'brigade'=>'resource', 'bucket'=>'object'],
 'stream_context_create' => ['resource', 'options='=>'array', 'params='=>'array'],
 'stream_context_get_default' => ['resource', 'options='=>'array'],


### PR DESCRIPTION
Current official PHP docs for `stream_bucket_new` are at: https://www.php.net/manual/en/function.stream-bucket-new.php

`stream_bucket_new` appears to have returned an object for a long time (since PHP 5): https://github.com/php/php-src/blame/90b7bde61507cee1c6b37f153909d72f5b203b8c/ext/standard/user_filters.c#L479

In PHP 8.0 resource candidates, the function stub originally stated that it returned `object|false`: https://github.com/php/php-src/blame/9ef2c5c3035904cfd453ab5c106f7738c6f20e0a/ext/standard/basic_functions.stub.php#L1458
... but this was later adjusted to state that it returns `object` only: https://github.com/php/php-src/blame/c4334fc616e65962bf2f4253d4a6c14ccaa48981/ext/standard/basic_functions.stub.php#L2021

I originally reported this here: https://github.com/phpstan/phpstan/issues/6027