### PR TITLE
6431 add consumption tracking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ phpstan-result-cache:
 phpstan-generate-baseline:
 	php -d memory_limit=768M bin/phpstan --generate-baseline
 
+phpstan-debug:
+	php -d memory_limit=1G bin/phpstan --debug -vvv
+
 phpstan-validate-stub-files:
 	php bin/phpstan analyse -c conf/config.stubFiles.neon -l 8 tests/notAutoloaded/empty.php
 

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command;
 use Closure;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\AnalyserResult;
+use PHPStan\Internal\ConsumptionTrackingCollector;
 use PHPStan\Parallel\ParallelAnalyser;
 use PHPStan\Parallel\Scheduler;
 use PHPStan\Process\CpuCoreCounter;
@@ -43,6 +44,7 @@ class AnalyserRunner
 		?string $tmpFile,
 		?string $insteadOfFile,
 		InputInterface $input,
+		?ConsumptionTrackingCollector $consumptionTrackingCollector = null,
 	): AnalyserResult
 	{
 		$filesCount = count($files);
@@ -62,7 +64,16 @@ class AnalyserRunner
 			&& $mainScript !== null
 			&& $schedule->getNumberOfProcesses() > 1
 		) {
-			return $this->parallelAnalyser->analyse($schedule, $mainScript, $postFileCallback, $projectConfigFile, $tmpFile, $insteadOfFile, $input);
+			return $this->parallelAnalyser->analyse(
+				$schedule,
+				$mainScript,
+				$postFileCallback,
+				$projectConfigFile,
+				$tmpFile,
+				$insteadOfFile,
+				$input,
+				$consumptionTrackingCollector,
+			);
 		}
 
 		return $this->analyser->analyse(
@@ -71,6 +82,7 @@ class AnalyserRunner
 			$postFileCallback,
 			$debug,
 			$this->switchTmpFile($allAnalysedFiles, $insteadOfFile, $tmpFile),
+			$consumptionTrackingCollector,
 		);
 	}
 

--- a/src/Internal/ConsumptionTrackingCollector.php
+++ b/src/Internal/ConsumptionTrackingCollector.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use PHPStan\ShouldNotHappenException;
+use RuntimeException;
+use function array_map;
+use function array_slice;
+use function arsort;
+use const SORT_NUMERIC;
+
+class ConsumptionTrackingCollector
+{
+
+	private int $consumersAdded = 0;
+
+	private int $totalMemoryConsumed = 0;
+
+	/** @var array<string, int>  */
+	private array $topMemoryConsumer = [];
+
+	/** @var array<string, float>  */
+	private array $topTimeConsumer = [];
+
+	private string $file = '';
+
+	public function __construct(private int $topX = 15, private int $purgeEveryX = 2000)
+	{
+	}
+
+	public function addConsumption(FileConsumptionTracker $consumption): void
+	{
+		$this->consumersAdded++;
+		if ($this->consumersAdded > $this->purgeEveryX) {
+			// save some memory on very large code bases
+			$this->purgeOverflow();
+		}
+
+		$this->totalMemoryConsumed = $consumption->getTotalMemoryConsumed();
+
+		$this->topMemoryConsumer[$consumption->getFile()] = $consumption->getMemoryConsumed();
+		$this->topTimeConsumer[$consumption->getFile()] = $consumption->getTimeConsumed();
+
+		$this->file = $consumption->getFile();
+	}
+
+	public function getTotalMemoryConsumed(): int
+	{
+		return $this->totalMemoryConsumed;
+	}
+
+	public function getMemoryConsumedForLatestFile(): int
+	{
+		if ($this->consumersAdded === 0) {
+			throw new RuntimeException('no files were tracked');
+		} elseif (!isset($this->topMemoryConsumer[$this->file])) {
+			throw new ShouldNotHappenException('no memory consumption found for ' . $this->file . ' (consumers added: ' . $this->consumersAdded . ')');
+		}
+
+		return $this->topMemoryConsumer[$this->file];
+	}
+
+	public function getTimeConsumedForLatestFile(): float
+	{
+		if ($this->consumersAdded === 0) {
+			throw new RuntimeException('no files were tracked');
+		} elseif (!isset($this->topTimeConsumer[$this->file])) {
+			throw new ShouldNotHappenException('no time consumption found for ' . $this->file . ' (consumers added: ' . $this->consumersAdded . ')');
+		}
+
+		return $this->topTimeConsumer[$this->file];
+	}
+
+	/**
+	 * @return array<string, int>
+	 */
+	public function getTopMemoryConsumers(): array
+	{
+		$this->purgeOverflow();
+		return $this->topMemoryConsumer;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getHumanisedTopMemoryConsumers(): array
+	{
+		return array_map(
+			static fn (int $usedMemory): string => BytesHelper::bytes($usedMemory),
+			$this->getTopMemoryConsumers(),
+		);
+	}
+
+	/**
+	 * @return array<string, float>
+	 */
+	public function getTopTimeConsumers(): array
+	{
+		$this->purgeOverflow();
+		return $this->topTimeConsumer;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getHumanisedTopTimeConsumers(): array
+	{
+		return array_map(
+			static fn (float $time): string => TimeHelper::humaniseFractionalSeconds($time),
+			$this->getTopTimeConsumers(),
+		);
+	}
+
+	/**
+	 * Keep memory footprint low - purge data not needed
+	 */
+	private function purgeOverflow(): void
+	{
+		arsort($this->topMemoryConsumer, SORT_NUMERIC);
+		$this->topMemoryConsumer = array_slice($this->topMemoryConsumer, 0, $this->topX, true);
+
+		arsort($this->topTimeConsumer, SORT_NUMERIC);
+		$this->topTimeConsumer = array_slice($this->topTimeConsumer, 0, $this->topX, true);
+
+		$this->consumersAdded = $this->topX;
+	}
+
+}

--- a/src/Internal/FileConsumptionTracker.php
+++ b/src/Internal/FileConsumptionTracker.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use InvalidArgumentException;
+use RuntimeException;
+use function is_float;
+use function is_int;
+use function is_string;
+use function memory_get_peak_usage;
+use function microtime;
+
+class FileConsumptionTracker
+{
+
+	private int $memoryConsumedAtStart = 0;
+
+	private float $processingStartedAt = 0;
+
+	private float $timeConsumed = 0;
+
+	private int $memoryConsumed = 0;
+
+	private int $totalMemoryConsumed = 0;
+
+	private bool $trackingIsRunning = false;
+
+	private bool $trackingWasStarted = false;
+
+	public function __construct(private string $file)
+	{
+	}
+
+	public function start(): void
+	{
+		$this->processingStartedAt = microtime(true);
+		$this->memoryConsumedAtStart = memory_get_peak_usage(true);
+		$this->trackingIsRunning = true;
+		$this->trackingWasStarted = true;
+	}
+
+	public function stop(): void
+	{
+		if (!$this->trackingWasStarted) {
+			throw new RuntimeException('can not return data when data collection was not started');
+		} elseif (!$this->trackingIsRunning) {
+			throw new RuntimeException('tracking is not running');
+		}
+
+		$this->totalMemoryConsumed = memory_get_peak_usage(true);
+		$this->memoryConsumed = $this->totalMemoryConsumed - $this->memoryConsumedAtStart;
+		$this->timeConsumed = microtime(true) - $this->processingStartedAt;
+
+		$this->trackingIsRunning = false;
+	}
+
+	public function getFile(): string
+	{
+		return $this->file;
+	}
+
+	public function getTimeConsumed(): float
+	{
+		if (!$this->trackingWasStarted) {
+			throw new RuntimeException('can not return data when data collection was not started');
+		} elseif ($this->trackingIsRunning) {
+			throw new RuntimeException('can not return data when data collection is running');
+		}
+
+		return $this->timeConsumed;
+	}
+
+	public function getMemoryConsumed(): int
+	{
+		if (!$this->trackingWasStarted) {
+			throw new RuntimeException('can not return data when data collection was not started');
+		} elseif ($this->trackingIsRunning) {
+			throw new RuntimeException('can not return data when data collection is running');
+		}
+
+		return $this->memoryConsumed;
+	}
+
+	public function getTotalMemoryConsumed(): int
+	{
+		if (!$this->trackingWasStarted) {
+			throw new RuntimeException('can not return data when data collection was not started');
+		} elseif ($this->trackingIsRunning) {
+			throw new RuntimeException('can not return data when data collection is running');
+		}
+
+		return $this->totalMemoryConsumed;
+	}
+
+	/**
+	 * Set data from params without actually running
+	 */
+	private function setConsumptionData(float $timeConsumed, int $memoryConsumed, int $totalMemoryConsumed): void
+	{
+		$this->timeConsumed = $timeConsumed;
+		$this->memoryConsumed = $memoryConsumed;
+		$this->totalMemoryConsumed = $totalMemoryConsumed;
+
+		$this->trackingWasStarted = true;
+	}
+
+	/**
+	 * @return array{"file": string, "timeConsumed": float, "memoryConsumed": int, "totalMemoryConsumed": int}
+	 */
+	public function toArray(): array
+	{
+		return [
+			'file' => $this->file,
+			'timeConsumed' => $this->getTimeConsumed(),
+			'memoryConsumed' => $this->getMemoryConsumed(),
+			'totalMemoryConsumed' => $this->getTotalMemoryConsumed(),
+		];
+	}
+
+	/**
+	 * @param array<mixed> $consumptionData
+	 */
+	public static function createFromArray(array $consumptionData): self
+	{
+		if (
+			!isset($consumptionData['file'])
+			|| !is_string($consumptionData['file'])
+			|| !isset($consumptionData['totalMemoryConsumed'])
+			|| !is_int($consumptionData['totalMemoryConsumed'])
+			|| !isset($consumptionData['memoryConsumed'])
+			|| !is_int($consumptionData['memoryConsumed'])
+			|| !isset($consumptionData['timeConsumed'])
+			|| !is_float($consumptionData['timeConsumed'])
+		) {
+			throw new InvalidArgumentException('invalid consumption data');
+		}
+
+		$obj = new self($consumptionData['file']);
+		$obj->setConsumptionData(
+			$consumptionData['timeConsumed'],
+			$consumptionData['memoryConsumed'],
+			$consumptionData['totalMemoryConsumed'],
+		);
+
+		return $obj;
+	}
+
+}

--- a/src/Internal/TimeHelper.php
+++ b/src/Internal/TimeHelper.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use function floor;
+use function round;
+
+class TimeHelper
+{
+
+	public static function humaniseFractionalSeconds(float $fractionalSeconds): string
+	{
+		$hoursAsString = $minutesAsString = $secondsAsString = '';
+		if ($fractionalSeconds < 5) {
+			// milliseconds as seconds
+			$secondsAsString = round($fractionalSeconds, 3) . 's';
+		} else {
+			$hours = floor($fractionalSeconds / 3600);
+			$minutes = floor((int) ($fractionalSeconds / 60) % 60);
+			$seconds = (int) $fractionalSeconds % 60;
+
+			if ($hours > 0) {
+				$hoursAsString = $hours . 'h';
+			}
+			if ($minutes > 0) {
+				$minutesAsString = $minutes . 'm';
+			}
+			if ($seconds > 0) {
+				$secondsAsString = $seconds . 's';
+			}
+		}
+
+		return $hoursAsString . $minutesAsString . $secondsAsString;
+	}
+
+}

--- a/tests/PHPStan/Internal/ConsumptionTrackingCollectorTest.php
+++ b/tests/PHPStan/Internal/ConsumptionTrackingCollectorTest.php
@@ -1,0 +1,203 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ConsumptionTrackingCollectorTest extends TestCase
+{
+
+	public function testConsumptionTrackersAreAdded(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$data = ['file' => 'phpunit', 'timeConsumed' => 123.45, 'memoryConsumed' => 123, 'totalMemoryConsumed' => 200];
+
+		$collector->addConsumption(FileConsumptionTracker::createFromArray($data));
+
+		$expectedTimeResult = [$data['file'] => $data['timeConsumed']];
+		$expectedMemoryResult = [$data['file'] => $data['memoryConsumed']];
+
+		$this->assertEquals($expectedTimeResult, $collector->getTopTimeConsumers());
+		$this->assertEquals($expectedMemoryResult, $collector->getTopMemoryConsumers());
+		$this->assertEquals($data['totalMemoryConsumed'], $collector->getTotalMemoryConsumed());
+	}
+
+	public function testTopTimeConsumersAreReturnedSorted(): void
+	{
+		$collector = new ConsumptionTrackingCollector(3);
+
+		$dataSets = [];
+		$dataSets['skipped 1'] = ['file' => 'skipped 1', 'timeConsumed' => 0.123, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+		$dataSets['1st'] = ['file' => '1st', 'timeConsumed' => 6.78, 'memoryConsumed' => 2, 'totalMemoryConsumed' => 200];
+		$dataSets['skipped 2'] = ['file' => 'skipped 2', 'timeConsumed' => 0.234, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+		$dataSets['2nd'] = ['file' => '2nd', 'timeConsumed' => 4.56, 'memoryConsumed' => 4, 'totalMemoryConsumed' => 200];
+		$dataSets['3rd'] = ['file' => '3rd', 'timeConsumed' => 3.45, 'memoryConsumed' => 3, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$expectedResult = [
+			$dataSets['1st']['file'] => $dataSets['1st']['timeConsumed'],
+			$dataSets['2nd']['file'] => $dataSets['2nd']['timeConsumed'],
+			$dataSets['3rd']['file'] => $dataSets['3rd']['timeConsumed'],
+		];
+
+		$this->assertEquals($expectedResult, $collector->getTopTimeConsumers(), 'top time consumer not as expected');
+	}
+
+	public function testTopTimeConsumersWillHandleNoFilesAdded(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$this->assertEquals([], $collector->getTopTimeConsumers(), 'top memory consumers not as expected');
+	}
+
+	public function testTopTimeConsumersCanBeReturnedHumanised(): void
+	{
+		$collector = new ConsumptionTrackingCollector(3);
+
+		$dataSets = [];
+		$dataSets['2nd'] = ['file' => '2nd', 'timeConsumed' => 4.56, 'memoryConsumed' => 4, 'totalMemoryConsumed' => 200];
+		$dataSets['1st'] = ['file' => '1st', 'timeConsumed' => 6.78, 'memoryConsumed' => 2, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$expectedResult = [
+			$dataSets['1st']['file'] => TimeHelper::humaniseFractionalSeconds($dataSets['1st']['timeConsumed']),
+			$dataSets['2nd']['file'] => TimeHelper::humaniseFractionalSeconds($dataSets['2nd']['timeConsumed']),
+		];
+
+		$this->assertEquals($expectedResult, $collector->getHumanisedTopTimeConsumers(), 'top time consumer not as expected');
+	}
+
+	public function testTopMemoryConsumersAreReturnedSorted(): void
+	{
+		$collector = new ConsumptionTrackingCollector(3);
+
+		$dataSets = [];
+		$dataSets['skipped 1'] = ['file' => 'skipped 1', 'timeConsumed' => 0.123, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+		$dataSets['3rd'] = ['file' => '3rd', 'timeConsumed' => 6.78, 'memoryConsumed' => 2, 'totalMemoryConsumed' => 200];
+		$dataSets['skipped 2'] = ['file' => 'skipped 2', 'timeConsumed' => 0.234, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+		$dataSets['1st'] = ['file' => '1st', 'timeConsumed' => 4.56, 'memoryConsumed' => 4, 'totalMemoryConsumed' => 200];
+		$dataSets['2nd'] = ['file' => '2nd', 'timeConsumed' => 3.45, 'memoryConsumed' => 3, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$expectedResult = [
+			$dataSets['1st']['file'] => $dataSets['1st']['memoryConsumed'],
+			$dataSets['2nd']['file'] => $dataSets['2nd']['memoryConsumed'],
+			$dataSets['3rd']['file'] => $dataSets['3rd']['memoryConsumed'],
+		];
+
+		$this->assertEquals($expectedResult, $collector->getTopMemoryConsumers(), 'top memory consumers not as expected');
+	}
+
+	public function testTopMemoryConsumersWillHandleNoFilesAdded(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$this->assertEquals([], $collector->getTopMemoryConsumers(), 'top memory consumers not as expected');
+	}
+
+	public function testTopMemoryConsumersCanBeReturnedHumanised(): void
+	{
+		$collector = new ConsumptionTrackingCollector(3);
+
+		$dataSets = [];
+		$dataSets['2nd'] = ['file' => '2nd', 'timeConsumed' => 6.78, 'memoryConsumed' => 2, 'totalMemoryConsumed' => 200];
+		$dataSets['1st'] = ['file' => '1st', 'timeConsumed' => 4.56, 'memoryConsumed' => 4, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$expectedResult = [
+			$dataSets['1st']['file'] => BytesHelper::bytes($dataSets['1st']['memoryConsumed']),
+			$dataSets['2nd']['file'] => BytesHelper::bytes($dataSets['2nd']['memoryConsumed']),
+		];
+
+		$this->assertEquals($expectedResult, $collector->getHumanisedTopMemoryConsumers(), 'top memory consumer not as expected');
+	}
+
+	public function testOverflowIsPurged(): void
+	{
+		$collector = new ConsumptionTrackingCollector(1, 1);
+
+		$dataSets = [];
+		// will be purged from time and purged from memory - poor boy
+		$dataSets['1st file - purged from both'] = ['file' => '1st file', 'timeConsumed' => 0.123, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+		// will be returned for time / purged from memory
+		$dataSets['2nd file - top time'] = ['file' => '2nd file', 'timeConsumed' => 1.234, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+		// will be purged from time / returned for memory
+		$dataSets['3rd file - top memory'] = ['file' => '1st file', 'timeConsumed' => 0.234, 'memoryConsumed' => 1, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$expectedTimeResult = [$dataSets['2nd file - top time']['file'] => $dataSets['2nd file - top time']['timeConsumed']];
+		$expectedMemoryResult = [$dataSets['3rd file - top memory']['file'] => $dataSets['3rd file - top memory']['memoryConsumed']];
+
+		$this->assertEquals($expectedTimeResult, $collector->getTopTimeConsumers(), 'top time consumers not as expected');
+		$this->assertEquals($expectedMemoryResult, $collector->getTopMemoryConsumers(), 'top memory consumers not as expected');
+	}
+
+	public function testExpectedTimeConsumedIsReturnedForLatestFile(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$dataSets = [];
+		$dataSets['1st'] = ['file' => '1st file', 'timeConsumed' => 1.234, 'memoryConsumed' => 1, 'totalMemoryConsumed' => 200];
+		$dataSets['2nd'] = ['file' => '2nd file', 'timeConsumed' => 0.123, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$this->assertEquals($dataSets['2nd']['timeConsumed'], $collector->getTimeConsumedForLatestFile());
+	}
+
+
+	public function testExpectedMemoryConsumedIsReturnedForLatestFile(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$dataSets = [];
+		$dataSets['1st'] = ['file' => '1st file', 'timeConsumed' => 1.234, 'memoryConsumed' => 1, 'totalMemoryConsumed' => 200];
+		$dataSets['2nd'] = ['file' => '2nd file', 'timeConsumed' => 0.123, 'memoryConsumed' => 0, 'totalMemoryConsumed' => 200];
+
+		foreach ($dataSets as $dataSet) {
+			$collector->addConsumption(FileConsumptionTracker::createFromArray($dataSet));
+		}
+
+		$this->assertEquals($dataSets['2nd']['memoryConsumed'], $collector->getMemoryConsumedForLatestFile());
+	}
+
+	public function testTimeConsumedForLatestFileWillThrowOnNoFilesAdded(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('no files were tracked');
+
+		$collector->getTimeConsumedForLatestFile();
+	}
+
+	public function testMemoryConsumedForLatestFileWillThrowOnNoFilesAdded(): void
+	{
+		$collector = new ConsumptionTrackingCollector();
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('no files were tracked');
+
+		$collector->getMemoryConsumedForLatestFile();
+	}
+
+}

--- a/tests/PHPStan/Internal/FileConsumptionTrackerTest.php
+++ b/tests/PHPStan/Internal/FileConsumptionTrackerTest.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use Generator;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class FileConsumptionTrackerTest extends TestCase
+{
+
+	/**
+	 * @param mixed[] $data
+	 * @dataProvider dataCreateFromArrayWillThrowOnInvalidData
+	 */
+	public function testCreateFromArrayWillThrowOnInvalidData(array $data): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+
+		FileConsumptionTracker::createFromArray($data);
+	}
+
+	public function dataCreateFromArrayWillThrowOnInvalidData(): Generator
+	{
+		yield 'missing file' => [[
+			'timeConsumed' => 1.23,
+			'memoryConsumed' => 2,
+			'totalMemoryConsumed' => 3,
+		]];
+
+		yield 'file is no string' => [[
+			'file' => 0,
+			'timeConsumed' => 1,
+			'memoryConsumed' => 2,
+			'totalMemoryConsumed' => 3,
+		]];
+
+		yield 'missing time consumed' => [[
+			'file' => 'phpunit',
+			'memoryConsumed' => 2,
+			'totalMemoryConsumed' => 3,
+		]];
+
+		yield 'time consumed is no float' => [[
+			'file' => 'phpunit',
+			'timeConsumed' => '1.23',
+			'memoryConsumed' => 2,
+			'totalMemoryConsumed' => 3,
+		]];
+
+		yield 'missing memory consumed' => [[
+			'file' => 'phpunit',
+			'timeConsumed' => 1,
+			'totalMemoryConsumed' => 3,
+		]];
+
+		yield 'memory consumed is no int' => [[
+			'file' => 0,
+			'timeConsumed' => 1,
+			'memoryConsumed' => '2',
+			'totalMemoryConsumed' => 3,
+		]];
+
+		yield 'missing total memory consumed' => [[
+			'file' => 'phpunit',
+			'timeConsumed' => 1,
+			'memoryConsumed' => 2,
+		]];
+
+		yield 'total memory is no int' => [[
+			'file' => 0,
+			'timeConsumed' => 1,
+			'memoryConsumed' => 2,
+			'totalMemoryConsumed' => '3',
+		]];
+	}
+
+}

--- a/tests/PHPStan/Internal/TimeHelperTest.php
+++ b/tests/PHPStan/Internal/TimeHelperTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use Generator;
+use PHPUnit\Framework\TestCase;
+
+class TimeHelperTest extends TestCase
+{
+
+	/**
+	 * @dataProvider dataHumaniseFractionalSeconds
+	 */
+	public function testHumaniseFractionalSeconds(float $fractionalSeconds, string $humanisedOutputExpected): void
+	{
+		$this->assertEquals($humanisedOutputExpected, TimeHelper::humaniseFractionalSeconds($fractionalSeconds));
+	}
+
+	public function dataHumaniseFractionalSeconds(): Generator
+	{
+		yield 'fractional seconds below one second' => [
+			'fractionalSeconds' => 0.12345,
+			'humanisedOutputExpected' => '0.123s',
+		];
+
+		yield 'fractional seconds below threshold' => [
+			'fractionalSeconds' => 1.2345,
+			'humanisedOutputExpected' => '1.235s',
+		];
+
+		yield 'seconds' => [
+			'fractionalSeconds' => 12.345,
+			'humanisedOutputExpected' => '12s',
+		];
+
+		yield 'full minute' => [
+			'fractionalSeconds' => 60,
+			'humanisedOutputExpected' => '1m',
+		];
+
+		yield 'minute with seconds' => [
+			'fractionalSeconds' => 70,
+			'humanisedOutputExpected' => '1m10s',
+		];
+
+		yield 'full hour' => [
+			'fractionalSeconds' => 3600,
+			'humanisedOutputExpected' => '1h',
+		];
+
+		yield 'hour full minute' => [
+			'fractionalSeconds' => 3660,
+			'humanisedOutputExpected' => '1h1m',
+		];
+
+		yield 'hour minute seconds' => [
+			'fractionalSeconds' => 3665,
+			'humanisedOutputExpected' => '1h1m5s',
+		];
+
+		yield 'hour minute seconds with fractional seconds' => [
+			'fractionalSeconds' => 3665.12345,
+			'humanisedOutputExpected' => '1h1m5s',
+		];
+	}
+
+}


### PR DESCRIPTION
resolves phpstan/phpstan#6431

[As requested](https://github.com/phpstan/phpstan/issues/6431#issuecomment-1023579070) this PR adds consumption tracking and output for both debug runs and standard analyser/parallel analyser (when started with `-vvv`).

(This is a follow up to https://github.com/phpstan/phpstan-src/pull/966 which was closed refactoring / adding worker support.)

### What is added:

* added `make` target for debug mode (increased memory limit already required for runs on `master` branch)
* added helper for converting (fractional) seconds into human readable format
* added per file (memory/time) consumption tracking for both standard and parallel analyser when started with `-vvv`

### How does it look like

![image](https://user-images.githubusercontent.com/27000029/152424642-6dcb1d25-92dc-4c38-a940-2cd3c14b2f47.png)

💡 Top memory consumers are shown only when run in debug mode, because workers/reactphp mess this up in parallel mode.

### Negative impact

In my opinion: not really. Did lots of runs on my local machine (ryzen 3700x on wsl2) for both `master` and this development branch and the  time impact was minimal (+~2seconds on PHPStan compared to `master`), memory impact not even worth mentioning.

I put a lot of effort into this, feedback is appreciated. 🙏 