### PR TITLE
implemented constant-type inference in ImplodeFunctionReturnTypeExtension

### DIFF
--- a/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
@@ -15,6 +15,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
+use function implode;
 use function in_array;
 
 class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -80,12 +81,12 @@ class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExt
 		return new StringType();
 	}
 
-	private function inferConstantType(ConstantArrayType $arrayType, ConstantStringType $separatorType):?Type
+	private function inferConstantType(ConstantArrayType $arrayType, ConstantStringType $separatorType): ?Type
 	{
 		$valueTypes = $arrayType->getValueTypes();
 
 		$arrayValues = [];
-		foreach($valueTypes as $valueType) {
+		foreach ($valueTypes as $valueType) {
 			if (!$valueType instanceof ConstantScalarType) {
 				return null;
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -14,6 +14,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
+		require_once __DIR__ . '/data/implode.php';
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/implode.php');
+
 		require_once __DIR__ . '/data/bug2574.php';
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug2574.php');

--- a/tests/PHPStan/Analyser/data/bug-5219.php
+++ b/tests/PHPStan/Analyser/data/bug-5219.php
@@ -7,9 +7,9 @@ use function PHPStan\Testing\assertType;
 class HelloWorld
 {
 
-	protected function foo(string $message): void
+	protected function foo(string $message, string $x): void
 	{
-		$header = sprintf('%s-%s', '', implode('-', ['x']));
+		$header = sprintf('%s-%s', '', implode('-', [$x]));
 
 		assertType('non-empty-string', $header);
 		assertType('non-empty-array<non-empty-string, string>', [$header => $message]);

--- a/tests/PHPStan/Analyser/data/implode.php
+++ b/tests/PHPStan/Analyser/data/implode.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace ImplodeFunctionReturn;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	const X = 'x';
+	const ONE = 1;
+
+	public function constants() {
+		assertType("'12345'", implode(['12', '345']));
+
+		assertType("'12345'", implode('', ['12', '345']));
+		assertType("'12345'", join('', ['12', '345']));
+
+		assertType("'12,345'", implode(',', ['12', '345']));
+		assertType("'12,345'", join(',', ['12', '345']));
+
+		assertType("'x,345'", join(',', [self::X, '345']));
+		assertType("'1,345'", join(',', [self::ONE, '345']));
+	}
+}

--- a/tests/PHPStan/Analyser/data/non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string.php
@@ -206,10 +206,10 @@ class ImplodingStrings
 		assertType('non-empty-string', implode($nonEmptyArrayWithNonEmptyStrings));
 	}
 
-	public function sayHello(): void
+	public function sayHello(int $i): void
 	{
 		// coming from issue #5291
-		$s = array(1, 2);
+		$s = array(1, $i);
 
 		assertType('non-empty-string', implode("a", $s));
 	}
@@ -227,10 +227,10 @@ class ImplodingStrings
 		assertType('non-empty-string', implode($glue, $a));
 	}
 
-	public function sayHello2(): void
+	public function sayHello2(int $i): void
 	{
 		// coming from issue #5291
-		$s = array(1, 2);
+		$s = array(1, $i);
 
 		assertType('non-empty-string', join("a", $s));
 	}


### PR DESCRIPTION
to allow phpstan-dba to check syntax errors in queries which use `implode` like

`$query = 'SELECT * FROM abc WHERE id IN ('. implode(',', [A::ONE, B::TWO, 3]) .')';`

I am aware that such queries are not optimal use and should better be expressed with a prepared statement and separated values, but I think there is a lot of code out their constructed like this .. would be great phpstan-dba could cover such existing but non-optimal query-code