### PR TITLE
Fix interaction between template type and union type

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -92,7 +92,7 @@ class UnionType implements CompoundType
 			return TrinaryLogic::createYes();
 		}
 
-		if ($type instanceof CompoundType && !$type instanceof CallableType) {
+		if ($type instanceof CompoundType && !$type instanceof CallableType && !$type instanceof TemplateUnionType) {
 			return $type->isAcceptedBy($this, $strictTypes);
 		}
 
@@ -106,7 +106,10 @@ class UnionType implements CompoundType
 
 	public function isSuperTypeOf(Type $otherType): TrinaryLogic
 	{
-		if ($otherType instanceof self || $otherType instanceof IterableType) {
+		if (
+			($otherType instanceof self && !$otherType instanceof TemplateUnionType)
+			|| $otherType instanceof IterableType
+		) {
 			return $otherType->isSubTypeOf($this);
 		}
 

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2052,6 +2052,14 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5258.php'], []);
 	}
 
+	public function testBug5591(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-5591.php'], []);
+	}
+
 	public function testGenericObjectLowerBound(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -528,11 +528,6 @@ class ReturnTypeRuleTest extends RuleTestCase
 				'Method ReturnTemplateUnion\Foo::doFoo2() should return T of bool|float|int|string but returns (T of bool|float|int|string)|null.',
 				25,
 			],
-			[
-				// should not be reported
-				'Method ReturnTemplateUnion\Foo::doFoo3() should return (T of bool|float|int|string)|null but returns (T of bool|float|int|string)|null.',
-				35,
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/bug-5591.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5591.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug5591;
+
+class EntityA {}
+class EntityB {}
+
+/**
+ * @template TEntity as object
+ */
+class TestClass
+{
+    /** @var class-string<TEntity> The fully-qualified (::class) class name of the entity being managed. */
+    protected $entityClass;
+
+    /** @param TEntity|null $record */
+    public function outerMethod($record = null): void
+    {
+        $record = $this->innerMethod($record);
+    }
+
+    /**
+     * @param TEntity|null $record
+     *
+     * @return TEntity
+     */
+    public function innerMethod($record = null): object
+    {
+		$class = $this->entityClass;
+        return new $class();
+    }
+}
+
+/**
+ * @template TEntity as EntityA|EntityB
+ * @extends TestClass<TEntity>
+ */
+class TestClass2 extends TestClass
+{
+    public function outerMethod($record = null): void
+    {
+        $record = $this->innerMethod($record);
+    }
+}

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -344,6 +344,94 @@ class UnionTypeTest extends PHPStanTestCase
 			new IntersectionType([new StringType(), new CallableType()]),
 			TrinaryLogic::createNo(),
 		];
+
+		yield 'is super type of template-of-union equal to a union member' => [
+			new UnionType([
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
+				new NullType(),
+			]),
+			TemplateTypeFactory::create(
+				TemplateTypeScope::createWithClass('Foo'),
+				'T',
+				new UnionType([
+					new IntegerType(),
+					new FloatType(),
+				]),
+				TemplateTypeVariance::createInvariant(),
+			),
+			TrinaryLogic::createYes(),
+		];
+
+		yield 'maybe super type of template-of-union equal to a union member' => [
+			new UnionType([
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
+				new NullType(),
+			]),
+			TemplateTypeFactory::create(
+				TemplateTypeScope::createWithClass('Bar'),
+				'T',
+				new UnionType([
+					new IntegerType(),
+					new FloatType(),
+				]),
+				TemplateTypeVariance::createInvariant(),
+			),
+			TrinaryLogic::createMaybe(),
+		];
+
+		yield 'is super type of template-of-string equal to a union member' => [
+			new UnionType([
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new StringType(),
+					TemplateTypeVariance::createInvariant(),
+				),
+				new NullType(),
+			]),
+			TemplateTypeFactory::create(
+				TemplateTypeScope::createWithClass('Foo'),
+				'T',
+				new StringType(),
+				TemplateTypeVariance::createInvariant(),
+			),
+			TrinaryLogic::createYes(),
+		];
+
+		yield 'maybe super type of template-of-string sub type of a union member' => [
+			new UnionType([
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new StringType(),
+					TemplateTypeVariance::createInvariant(),
+				),
+				new NullType(),
+			]),
+			TemplateTypeFactory::create(
+				TemplateTypeScope::createWithClass('Bar'),
+				'T',
+				new StringType(),
+				TemplateTypeVariance::createInvariant(),
+			),
+			TrinaryLogic::createMaybe(),
+		];
 	}
 
 	/**
@@ -774,6 +862,134 @@ class UnionTypeTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), false),
 				TrinaryLogic::createYes(),
 			],
+			'accepts template-of-union equal to a union member' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new UnionType([
+							new IntegerType(),
+							new FloatType(),
+						]),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createYes(),
+			],
+			'maybe accepts template-of-union sub type of a union member' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new UnionType([
+							new IntegerType(),
+							new FloatType(),
+						]),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Bar'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createMaybe(),
+			],
+			'accepts template-of-string equal to a union member' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new StringType(),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new StringType(),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createYes(),
+			],
+			'maybe accepts template-of-string sub type of a union member' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new StringType(),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Bar'),
+					'T',
+					new StringType(),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createMaybe(),
+			],
+			'accepts template-of-union containing a union member' => [
+				new UnionType([
+					new IntegerType(),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createMaybe(),
+			],
+			'accepts intersection with template-of-union equal to a union member' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new UnionType([
+							new ObjectType('Iterator'),
+							new ObjectType('IteratorAggregate'),
+						]),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new NullType(),
+				]),
+				new IntersectionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new UnionType([
+							new ObjectType('Iterator'),
+							new ObjectType('IteratorAggregate'),
+						]),
+						TemplateTypeVariance::createInvariant(),
+					),
+					new ObjectType('Countable'),
+				]),
+				TrinaryLogic::createYes(),
+			],
+
 		];
 	}
 


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/5591

Normally, a UnionType A accepts an other UnionType B if every member of B is accepted by A.

This does not hold if B is a TemplateUnionType: If B is a TemplateUnionType and A contains B, then no member of B will be accepted by B itself, and A will not accept B as a result.

For UnionType::accepts(TemplateUnionType) to work, we must treat it as a non-UnionType.