### PR TITLE
[ReturnTypeExtension] add test case for narrow typed json_decode

### DIFF
--- a/build/composer-require-checker.json
+++ b/build/composer-require-checker.json
@@ -12,6 +12,7 @@
 	  "Clue\\React\\Block\\await", "Hoa\\File\\Read"
   ],
   "php-core-extensions" : [
+    "json",
     "Core",
     "date",
     "pcre",

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -2,41 +2,21 @@
 
 namespace PHPStan\Type\Php;
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-use PhpParser\Node\Arg;
-=======
-=======
 use PhpParser\ConstExprEvaluationException;
->>>>>>> decopule type resolution to static
 use PhpParser\ConstExprEvaluator;
->>>>>>> check for JSON_OBJECT_AS_ARRAY, in case of null and array
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
 use PhpParser\Node\Expr\ConstFetch;
->>>>>>> Extend JsonThrowOnErrorDynamicReturnTypeExtension to detect knonw type from contssant string value
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
-<<<<<<< HEAD
-<<<<<<< HEAD
 use PHPStan\Type\BitwiseFlagHelper;
-use PHPStan\Type\Constant\ConstantBooleanType;
-=======
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\BooleanType;
-=======
->>>>>>> return mixed type
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantTypeHelper;
->>>>>>> Extend JsonThrowOnErrorDynamicReturnTypeExtension to detect knonw type from contssant string value
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -53,22 +33,18 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 
 	private const UNABLE_TO_RESOLVE = '__UNABLE_TO_RESOLVE__';
 
+	private ConstExprEvaluator $constExprEvaluator;
+
 	/** @var array<string, int> */
 	private array $argumentPositions = [
 		'json_encode' => 1,
 		'json_decode' => 3,
 	];
 
-<<<<<<< HEAD
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
 		private BitwiseFlagHelper $bitwiseFlagAnalyser,
 	)
-=======
-	private ConstExprEvaluator $constExprEvaluator;
-
-	public function __construct(private ReflectionProvider $reflectionProvider)
->>>>>>> decopule type resolution to static
 	{
 		$this->constExprEvaluator = new ConstExprEvaluator(static function (Expr $expr) {
 			if ($expr instanceof ConstFetch) {

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -26,7 +26,6 @@ use stdClass;
 use function constant;
 use function is_bool;
 use function json_decode;
-use const JSON_OBJECT_AS_ARRAY;
 
 class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -138,8 +137,7 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 
 				// @see https://www.php.net/manual/en/json.constants.php#constant.json-object-as-array
 				$thirdArgValue = $args[3]->value;
-				$resolvedThirdArgValue = $this->resolveMaskValue($thirdArgValue, $scope);
-				if (($resolvedThirdArgValue & JSON_OBJECT_AS_ARRAY) !== 0) {
+				if ($this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($thirdArgValue, $scope, 'JSON_OBJECT_AS_ARRAY')->yes()) {
 					return true;
 				}
 			}

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -78,9 +78,7 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 		$args = $funcCall->getArgs();
 		$isArrayWithoutStdClass = $this->isForceArrayWithoutStdClass($funcCall, $scope);
 
-		$firstArgValue = $args[0]->value;
-		$firstValueType = $scope->getType($firstArgValue);
-
+		$firstValueType = $scope->getType($args[0]->value);
 		if ($firstValueType instanceof ConstantStringType) {
 			return $this->resolveConstantStringType($firstValueType, $isArrayWithoutStdClass);
 		}

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -75,7 +75,6 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 		$argumentPosition = $this->argumentPositions[$functionReflection->getName()];
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 
-		// narrow type for json_decode()
 		if ($functionReflection->getName() === 'json_decode') {
 			$defaultReturnType = $this->narrowTypeForJsonDecode($functionCall, $scope);
 		}

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -71,7 +71,6 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 		Scope $scope,
 	): Type
 	{
-		// update type based on JSON_THROW_ON_ERROR
 		$argumentPosition = $this->argumentPositions[$functionReflection->getName()];
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8711,10 +8711,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'float|int|stdClass|string|true',
-				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
-			],
-			[
 				'mixed~false',
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8704,14 +8704,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			],
 			[
 				'mixed',
-				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
-			],
-			[
-				'float|int|stdClass|string|true',
-				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
-			],
-			[
-				'mixed~false',
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8699,10 +8699,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'json_encode($mixed,  $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'bool|float|int|stdClass|string',
+				'mixed',
 				'json_decode($mixed)',
 			],
 			[
+<<<<<<< HEAD
 <<<<<<< HEAD
 				'mixed',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
@@ -8716,6 +8717,13 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			[
 				'float|int|stdClass|string|true',
 >>>>>>> update type in LegacyNodeScopeResolverTest
+=======
+				'mixed~false',
+				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
+			],
+			[
+				'mixed~false',
+>>>>>>> return mixed type
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8703,27 +8703,19 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'json_decode($mixed)',
 			],
 			[
-<<<<<<< HEAD
-<<<<<<< HEAD
 				'mixed',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'mixed',
-=======
 				'float|int|stdClass|string|true',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
 				'float|int|stdClass|string|true',
->>>>>>> update type in LegacyNodeScopeResolverTest
-=======
-				'mixed~false',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
 				'mixed~false',
->>>>>>> return mixed type
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8699,15 +8699,23 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'json_encode($mixed,  $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'mixed',
+				'bool|float|int|stdClass|string',
 				'json_decode($mixed)',
 			],
 			[
+<<<<<<< HEAD
 				'mixed',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
 				'mixed',
+=======
+				'float|int|stdClass|string|true',
+				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
+			],
+			[
+				'float|int|stdClass|string|true',
+>>>>>>> update type in LegacyNodeScopeResolverTest
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8704,6 +8704,10 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			],
 			[
 				'mixed',
+				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
+			],
+			[
+				'mixed',
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -14,8 +14,13 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
+<<<<<<< HEAD
 		require_once __DIR__ . '/data/implode.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/implode.php');
+=======
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/narrow_type.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/narrow_type_with_force_array.php');
+>>>>>>> add test case for narrow typed json_decode
 
 		require_once __DIR__ . '/data/bug2574.php';
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -14,13 +14,13 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
-<<<<<<< HEAD
 		require_once __DIR__ . '/data/implode.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/implode.php');
-=======
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/narrow_type.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/narrow_type_with_force_array.php');
->>>>>>> add test case for narrow typed json_decode
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/invalid_type.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/json_object_as_array.php');
 
 		require_once __DIR__ . '/data/bug2574.php';
 

--- a/tests/PHPStan/Analyser/data/json-decode/invalid_type.php
+++ b/tests/PHPStan/Analyser/data/json-decode/invalid_type.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Analyser\JsonDecode;
+
+use function PHPStan\Testing\assertType;
+
+$value = json_decode('{"key"}');
+assertType('null', $value);
+
+$value = json_decode('{"key"}', true);
+assertType('null', $value);
+
+$value = json_decode('{"key"}', null);
+assertType('null', $value);
+
+$value = json_decode('{"key"}', false);
+assertType('null', $value);

--- a/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Analyser\JsonDecode;
+
+use function PHPStan\Testing\assertType;
+
+// @see https://3v4l.org/YFlHF
+function ($mixed) {
+	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY);
+	assertType('mixed~stdClass', $value);
+};
+
+function ($mixed) {
+	$value = json_decode($mixed, null);
+	assertType('mixed', $value);
+};

--- a/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
@@ -11,6 +11,13 @@ function ($mixed) {
 };
 
 function ($mixed) {
+	$flagsAsVariable = JSON_OBJECT_AS_ARRAY;
+
+	$value = json_decode($mixed, null, 512, $flagsAsVariable);
+	assertType('mixed~stdClass', $value);
+};
+
+function ($mixed) {
 	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY | JSON_BIGINT_AS_STRING);
 	assertType('mixed~stdClass', $value);
 };

--- a/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
@@ -11,6 +11,16 @@ function ($mixed) {
 };
 
 function ($mixed) {
+	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY | JSON_BIGINT_AS_STRING);
+	assertType('mixed~stdClass', $value);
+};
+
+function ($mixed) {
 	$value = json_decode($mixed, null);
+	assertType('mixed', $value);
+};
+
+function ($mixed, $unknownFlags) {
+	$value = json_decode($mixed, null, 512, $unknownFlags);
 	assertType('mixed', $value);
 };

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
@@ -27,3 +27,8 @@ function ($mixed) {
 	$value = json_decode($mixed);
 	assertType('mixed', $value);
 };
+
+function ($mixed) {
+	$value = json_decode($mixed, false);
+	assertType('mixed', $value);
+};

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
@@ -21,3 +21,9 @@ assertType('stdClass', $value);
 
 $value = json_decode('[1, 2, 3]');
 assertType('array{1, 2, 3}', $value);
+
+
+function ($mixed) {
+	$value = json_decode($mixed);
+	assertType('mixed', $value);
+};

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Analyser\JsonDecode;
+
+use function PHPStan\Testing\assertType;
+
+$value = json_decode('true');
+assertType('true', $value);
+
+$value = json_decode('1');
+assertType('1', $value);
+
+$value = json_decode('1.5');
+assertType('1.5', $value);
+
+$value = json_decode('false');
+assertType('false', $value);
+
+$value = json_decode('{}');
+assertType('stdClass', $value);
+
+$value = json_decode('[1, 2, 3]');
+assertType('array{1, 2, 3}', $value);

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
@@ -26,9 +26,3 @@ function ($mixed) {
 	$value = json_decode($mixed, true);
 	assertType('mixed~stdClass', $value);
 };
-
-// @see https://3v4l.org/YFlHF
-function ($mixed) {
-	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY);
-	assertType('mixed~stdClass', $value);
-};

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Analyser\JsonDecode;
+
+use function PHPStan\Testing\assertType;
+
+$value = json_decode('true', true);
+assertType('true', $value);
+
+$value = json_decode('1', true);
+assertType('1', $value);
+
+$value = json_decode('1.5', true);
+assertType('1.5', $value);
+
+$value = json_decode('false', true);
+assertType('false', $value);
+
+$value = json_decode('{}', true);
+assertType('array{}', $value);
+
+$value = json_decode('[1, 2, 3]', true);
+assertType('array{1, 2, 3}', $value);

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
@@ -26,3 +26,9 @@ function ($mixed) {
 	$value = json_decode($mixed, true);
 	assertType('mixed~stdClass', $value);
 };
+
+// @see https://3v4l.org/YFlHF
+function ($mixed) {
+	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY);
+	assertType('mixed~stdClass', $value);
+};

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
@@ -21,3 +21,8 @@ assertType('array{}', $value);
 
 $value = json_decode('[1, 2, 3]', true);
 assertType('array{1, 2, 3}', $value);
+
+function ($mixed) {
+	$value = json_decode($mixed, true);
+	assertType('mixed~stdClass', $value);
+};


### PR DESCRIPTION
Port of https://github.com/phpstan/phpstan-nette/pull/89/files for `json_decode()`

Any feedback appreciated :+1: 

### How to test?

```bash
vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php --filter "json"
```