### PR TITLE
Fix regression

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -101,6 +101,10 @@ class UnionType implements CompoundType
 			$results[] = $innerType->accepts($type, $strictTypes);
 		}
 
+		if ($type instanceof TemplateUnionType) {
+			$results[] = $type->isAcceptedBy($this, $strictTypes);
+		}
+
 		return TrinaryLogic::createNo()->or(...$results);
 	}
 
@@ -116,6 +120,10 @@ class UnionType implements CompoundType
 		$results = [];
 		foreach ($this->getTypes() as $innerType) {
 			$results[] = $innerType->isSuperTypeOf($otherType);
+		}
+
+		if ($otherType instanceof TemplateUnionType) {
+			$results[] = $otherType->isSubTypeOf($this);
 		}
 
 		return TrinaryLogic::createNo()->or(...$results);

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -345,6 +345,23 @@ class UnionTypeTest extends PHPStanTestCase
 			TrinaryLogic::createNo(),
 		];
 
+		yield 'is super type of template-of-union with same members' => [
+			new UnionType([
+				new IntegerType(),
+				new FloatType(),
+			]),
+			TemplateTypeFactory::create(
+				TemplateTypeScope::createWithClass('Foo'),
+				'T',
+				new UnionType([
+					new IntegerType(),
+					new FloatType(),
+				]),
+				TemplateTypeVariance::createInvariant(),
+			),
+			TrinaryLogic::createYes(),
+		];
+
 		yield 'is super type of template-of-union equal to a union member' => [
 			new UnionType([
 				TemplateTypeFactory::create(
@@ -860,6 +877,22 @@ class UnionTypeTest extends PHPStanTestCase
 					new NullType(),
 				]),
 				new ClosureType([], new MixedType(), false),
+				TrinaryLogic::createYes(),
+			],
+			'accepts template-of-union with same members' => [
+				new UnionType([
+					new IntegerType(),
+					new FloatType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Foo'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
 				TrinaryLogic::createYes(),
 			],
 			'accepts template-of-union equal to a union member' => [


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/phpstan/phpstan-src/pull/992

> For UnionType::accepts(TemplateUnionType) to work, we must treat it as a non-UnionType

Actually we need to treat the TemplateUnionType as both a non-UnionType and a UnionType for these two cases:

1. `(T|null)->accepts(T)`
2. `(int|float)->accepts(T of (int|float))`

In case 1 the TemplateUnionType acts as a member of the UnionType
In case 2 the TemplateUnionType acts as a UnionType