### PR TITLE
Correct the return type of `SplFileObject::fstat()`

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11294,7 +11294,7 @@ return [
 'SplFileObject::fread' => ['string|false', 'length'=>'int'],
 'SplFileObject::fscanf' => ['bool', 'format'=>'string', '&...w_vars='=>'string|int|float'],
 'SplFileObject::fseek' => ['int', 'pos'=>'int', 'whence='=>'int'],
-'SplFileObject::fstat' => ['array|false'],
+'SplFileObject::fstat' => ['array'],
 'SplFileObject::ftell' => ['int|false'],
 'SplFileObject::ftruncate' => ['bool', 'size'=>'int'],
 'SplFileObject::fwrite' => ['int', 'str'=>'string', 'length='=>'int'],

--- a/src/Type/Php/StatDynamicReturnTypeExtension.php
+++ b/src/Type/Php/StatDynamicReturnTypeExtension.php
@@ -28,7 +28,7 @@ class StatDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtensi
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		return $this->getReturnType();
+		return TypeCombinator::union($this->getReturnType(), new ConstantBooleanType(false));
 	}
 
 	public function getClass(): string
@@ -74,7 +74,7 @@ class StatDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtensi
 			$builder->setOffsetValueType(new ConstantStringType($key), $valueType);
 		}
 
-		return TypeCombinator::union($builder->getArray(), new ConstantBooleanType(false));
+		return $builder->getArray();
 	}
 
 }

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5563,6 +5563,10 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$fstat',
 			],
 			[
+				'array{0: int, 1: int, 2: int, 3: int, 4: int, 5: int, 6: int, 7: int, 8: int, 9: int, 10: int, 11: int, 12: int, dev: int, ino: int, mode: int, nlink: int, uid: int, gid: int, rdev: int, size: int, atime: int, mtime: int, ctime: int, blksize: int, blocks: int}',
+				'$fileObjectStat',
+			],
+			[
 				'string',
 				'$base64DecodeWithoutStrict',
 			],

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -101,6 +101,8 @@ $resource = doFoo();
 $stat = stat(__FILE__);
 $lstat = lstat(__FILE__);
 $fstat = fstat($resource);
+$fileObject = new \SplFileObject(__FILE__);
+$fileObjectStat = $fileObject->fstat();
 
 $base64DecodeWithoutStrict = base64_decode('');
 $base64DecodeWithStrictDisabled = base64_decode('', false);


### PR DESCRIPTION
Given an invalid file the `*stat()` functions can return boolean false, but the `SplFileObject::fstat()` method cannot because its constructor will throw an exception.

Ref: https://3v4l.org/4IEZL