### PR TITLE
Split TemplateType::isSubTypeOf() and TemplateType::isAcceptedBy()

### DIFF
--- a/src/Type/Generic/TemplateTypeArgumentStrategy.php
+++ b/src/Type/Generic/TemplateTypeArgumentStrategy.php
@@ -25,8 +25,14 @@ class TemplateTypeArgumentStrategy implements TemplateTypeStrategy
 			return TrinaryLogic::createNo();
 		}
 
-		return $left->isSuperTypeOf($right)
-			->or(TrinaryLogic::createFromBoolean($right->equals(new MixedType())));
+		if ($right instanceof TemplateType) {
+			$accepts = $right->isAcceptedBy($left, $strictTypes);
+		} else {
+			$accepts = $left->getBound()->accepts($right, $strictTypes)
+				->and(TrinaryLogic::createMaybe());
+		}
+
+		return $accepts->or(TrinaryLogic::createFromBoolean($right->equals(new MixedType())));
 	}
 
 	public function isArgument(): bool

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -92,7 +92,7 @@ class UnionType implements CompoundType
 			return TrinaryLogic::createYes();
 		}
 
-		if ($type instanceof CompoundType && !$type instanceof CallableType && !$type instanceof TemplateUnionType) {
+		if ($type instanceof CompoundType && !$type instanceof CallableType && !$type instanceof TemplateType) {
 			return $type->isAcceptedBy($this, $strictTypes);
 		}
 

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -16,9 +16,11 @@ class ReturnTypeRuleTest extends RuleTestCase
 
 	private bool $checkExplicitMixed = false;
 
+	private bool $checkUnionTypes = true;
+
 	protected function getRule(): Rule
 	{
-		return new ReturnTypeRule(new FunctionReturnTypeCheck(new RuleLevelHelper($this->createReflectionProvider(), true, false, true, $this->checkExplicitMixed)));
+		return new ReturnTypeRule(new FunctionReturnTypeCheck(new RuleLevelHelper($this->createReflectionProvider(), true, false, $this->checkUnionTypes, $this->checkExplicitMixed)));
 	}
 
 	public function testReturnTypeRule(): void
@@ -584,6 +586,21 @@ class ReturnTypeRuleTest extends RuleTestCase
 	{
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/bug-6438.php'], []);
+	}
+
+	public function testBug6589(): void
+	{
+		$this->checkUnionTypes = false;
+		$this->analyse([__DIR__ . '/data/bug-6589.php'], [
+			[
+				'Method Bug6589\HelloWorldTemplated::getField() should return TField of Bug6589\Field2 but returns Bug6589\Field.',
+				17,
+			],
+			[
+				'Method Bug6589\HelloWorldSimple::getField() should return Bug6589\Field2 but returns Bug6589\Field.',
+				31,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-6589.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-6589.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6589;
+
+class Field {}
+
+class Field2 extends Field {}
+
+/**
+ * @template TField of Field2
+ */
+class HelloWorldTemplated
+{
+	/** @return TField */
+	public function getField()
+	{
+		return new Field();
+	}
+
+	/** @return TField */
+	public function getField2()
+	{
+		return new Field2();
+	}
+}
+
+class HelloWorldSimple
+{
+    public function getField(string $name): Field2
+    {
+        return new Field();
+    }
+}

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -412,7 +412,7 @@ class ObjectTypeTest extends PHPStanTestCase
 					new ObjectType(DateTimeInterface::class),
 					TemplateTypeVariance::createInvariant(),
 				),
-				TrinaryLogic::createMaybe(),
+				TrinaryLogic::createNo(),
 			],
 		];
 	}

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use DateTime;
 use DateTimeInterface;
 use Exception;
+use Iterator;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateType;
@@ -14,6 +15,7 @@ use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use stdClass;
 use Throwable;
+use Traversable;
 use function array_map;
 use function assert;
 use function sprintf;
@@ -84,6 +86,12 @@ class TemplateTypeTest extends PHPStanTestCase
 				$templateType('T', new ObjectType('stdClass')),
 				TrinaryLogic::createYes(),
 				TrinaryLogic::createYes(),
+			],
+			'does not accept ObjectType that is a super type of bound' => [
+				$templateType('T', new ObjectType(Iterator::class)),
+				new ObjectType(Traversable::class),
+				TrinaryLogic::createNo(),
+				TrinaryLogic::createNo(),
 			],
 		];
 	}

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -919,7 +919,7 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				TrinaryLogic::createYes(),
 			],
-			'maybe accepts template-of-union sub type of a union member' => [
+			'accepts template-of-union sub type of a union member' => [
 				new UnionType([
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithClass('Foo'),
@@ -930,6 +930,30 @@ class UnionTypeTest extends PHPStanTestCase
 						]),
 						TemplateTypeVariance::createInvariant(),
 					),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Bar'),
+					'T',
+					new UnionType([
+						new IntegerType(),
+						new FloatType(),
+					]),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createYes(),
+			],
+			'maybe accepts template-of-union sub type of a union member (argument)' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new UnionType([
+							new IntegerType(),
+							new FloatType(),
+						]),
+						TemplateTypeVariance::createInvariant(),
+					)->toArgument(),
 					new NullType(),
 				]),
 				TemplateTypeFactory::create(
@@ -961,7 +985,7 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				TrinaryLogic::createYes(),
 			],
-			'maybe accepts template-of-string sub type of a union member' => [
+			'accepts template-of-string sub type of a union member' => [
 				new UnionType([
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithClass('Foo'),
@@ -969,6 +993,24 @@ class UnionTypeTest extends PHPStanTestCase
 						new StringType(),
 						TemplateTypeVariance::createInvariant(),
 					),
+					new NullType(),
+				]),
+				TemplateTypeFactory::create(
+					TemplateTypeScope::createWithClass('Bar'),
+					'T',
+					new StringType(),
+					TemplateTypeVariance::createInvariant(),
+				),
+				TrinaryLogic::createMaybe(),
+			],
+			'maybe accepts template-of-string sub type of a union member (argument)' => [
+				new UnionType([
+					TemplateTypeFactory::create(
+						TemplateTypeScope::createWithClass('Foo'),
+						'T',
+						new StringType(),
+						TemplateTypeVariance::createInvariant(),
+					)->toArgument(),
 					new NullType(),
 				]),
 				TemplateTypeFactory::create(


### PR DESCRIPTION
TemplateType::isAcceptedBy() delegates to TemplateType::isSubTypeOf(). Because of this, bounds are compared with isSubTypeOf(), which gives undesirable results in the context of isAcceptedBy().

For instance, `ArrayAccess->isSuperTypeOf(Traversable)` being `maybe` causes `(T of ArrayAccess)->accepts(Traversable)` to be `maybe` as well.

In this PR I split the implementations of `TemplateType::isSubTypeOf()` and `TemplateType::isAcceptedBy()`, so that `isAcceptedBy()` can compare bounds with `accepts()`.

This fixes https://github.com/phpstan/phpstan/issues/6589