### PR TITLE
Narrow `list` type to `array<int<0, max>, mixed>`.

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -297,10 +297,10 @@ class TypeNodeResolver
 				return new NeverType(true);
 
 			case 'list':
-				return new ArrayType(new IntegerType(), new MixedType());
+				return new ArrayType(new IntegerRangeType(0, null), new MixedType());
 			case 'non-empty-list':
 				return TypeCombinator::intersect(
-					new ArrayType(new IntegerType(), new MixedType()),
+					new ArrayType(new IntegerRangeType(0, null), new MixedType()),
 					new NonEmptyArrayType(),
 				);
 		}
@@ -468,7 +468,7 @@ class TypeNodeResolver
 			return $arrayType;
 		} elseif ($mainTypeName === 'list' || $mainTypeName === 'non-empty-list') {
 			if (count($genericTypes) === 1) { // list<ValueType>
-				$listType = new ArrayType(new IntegerType(), $genericTypes[0]);
+				$listType = new ArrayType(new IntegerRangeType(0, null), $genericTypes[0]);
 				if ($mainTypeName === 'non-empty-list') {
 					return TypeCombinator::intersect($listType, new NonEmptyArrayType());
 				}

--- a/tests/PHPStan/Analyser/data/array-map.php
+++ b/tests/PHPStan/Analyser/data/array-map.php
@@ -44,7 +44,7 @@ function foo3(array $array): void {
 		$array
 	);
 
-	assertType('array<int, string>', $mapped);
+	assertType('array<int<0, max>, string>', $mapped);
 }
 
 /**
@@ -58,5 +58,5 @@ function foo4(array $array): void {
 		$array
 	);
 
-	assertType('non-empty-array<int, string>', $mapped);
+	assertType('non-empty-array<int<0, max>, string>', $mapped);
 }

--- a/tests/PHPStan/Analyser/data/bug-4499.php
+++ b/tests/PHPStan/Analyser/data/bug-4499.php
@@ -11,7 +11,7 @@ class Foo
 	function thing(array $things) : void{
 		switch(count($things)){
 			case 1:
-				assertType('non-empty-array<int, int>', $things);
+				assertType('non-empty-array<int<0, max>, int>', $things);
 				assertType('int', array_shift($things));
 		}
 	}

--- a/tests/PHPStan/Analyser/data/bug-4587.php
+++ b/tests/PHPStan/Analyser/data/bug-4587.php
@@ -16,7 +16,7 @@ class HelloWorld
 			return $result;
 		}, $results);
 
-		assertType('array<int, array{a: int}>', $type);
+		assertType('array<int<0, max>, array{a: int}>', $type);
 	}
 
 	public function b(): void
@@ -32,6 +32,6 @@ class HelloWorld
 			return $result;
 		}, $results);
 
-		assertType('array<int, array{a: numeric-string}>', $type);
+		assertType('array<int<0, max>, array{a: numeric-string}>', $type);
 	}
 }

--- a/tests/PHPStan/Analyser/data/bug-4606.php
+++ b/tests/PHPStan/Analyser/data/bug-4606.php
@@ -11,7 +11,7 @@ use function PHPStan\Testing\assertType;
  */
 
 assertType(Foo::class, $this);
-assertType('array<int, array{stdClass, int}>', $assigned);
+assertType('array<int<0, max>, array{stdClass, int}>', $assigned);
 
 
 /**

--- a/tests/PHPStan/Analyser/data/list-type.php
+++ b/tests/PHPStan/Analyser/data/list-type.php
@@ -9,25 +9,25 @@ class Foo
 	/** @param list $list */
 	public function directAssertion($list): void
 	{
-		assertType('array<int, mixed>', $list);
+		assertType('array<int<0, max>, mixed>', $list);
 	}
 
 	/** @param list $list */
 	public function directAssertionParamHint(array $list): void
 	{
-		assertType('array<int, mixed>', $list);
+		assertType('array<int<0, max>, mixed>', $list);
 	}
 
 	/** @param list $list */
 	public function directAssertionNullableParamHint(array $list = null): void
 	{
-		assertType('array<int, mixed>|null', $list);
+		assertType('array<int<0, max>, mixed>|null', $list);
 	}
 
 	/** @param list<\DateTime> $list */
 	public function directAssertionObjectParamHint($list): void
 	{
-		assertType('array<int, DateTime>', $list);
+		assertType('array<int<0, max>, DateTime>', $list);
 	}
 
 	public function withoutGenerics(): void
@@ -91,7 +91,7 @@ class Foo
 		/** @var list $list2 */
 		$list2 = [];
 		$list2[2] = '1';//Most likely to create a gap in indexes
-		assertType('non-empty-array<int, mixed>', $list2);
+		assertType('non-empty-array<int<0, max>, mixed>', $list2);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/non-empty-array.php
+++ b/tests/PHPStan/Analyser/data/non-empty-array.php
@@ -26,10 +26,10 @@ class Foo
 	): void
 	{
 		assertType('non-empty-array', $array);
-		assertType('non-empty-array<int, mixed>', $list);
+		assertType('non-empty-array<int<0, max>, mixed>', $list);
 		assertType('non-empty-array<int, string>', $arrayOfStrings);
-		assertType('non-empty-array<int, stdClass>', $listOfStd);
-		assertType('non-empty-array<int, stdClass>', $listOfStd2);
+		assertType('non-empty-array<int<0, max>, stdClass>', $listOfStd);
+		assertType('non-empty-array<int<0, max>, stdClass>', $listOfStd2);
 		assertType('array', $invalidList);
 		assertType('mixed', $invalidList2);
 	}

--- a/tests/PHPStan/Analyser/data/psalm-prefix-unresolvable.php
+++ b/tests/PHPStan/Analyser/data/psalm-prefix-unresolvable.php
@@ -18,7 +18,7 @@ class Foo
 
 	public function doBar(): void
 	{
-		assertType('array<int, string>', $this->doFoo());
+		assertType('array<int<0, max>, string>', $this->doFoo());
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -791,7 +791,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/proc_open.php'], [
 			[
-				'Parameter #1 $command of function proc_open expects array<int, string>|string, array<string, string> given.',
+				'Parameter #1 $command of function proc_open expects array<int<0, max>, string>|string, array{something: \'bogus\', in: \'here\'} given.',
 				6,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -308,7 +308,7 @@ class MethodSignatureRuleTest extends RuleTestCase
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-4707.php'], [
 			[
-				'Return type (array<int, Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be compatible with return type (array<int, Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()',
+				'Return type (array<int<0, max>, Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be compatible with return type (array<int<0, max>, Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()',
 				38,
 			],
 		]);
@@ -320,7 +320,7 @@ class MethodSignatureRuleTest extends RuleTestCase
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-4707-covariant.php'], [
 			[
-				'Return type (array<int, Bug4707Covariant\Row2>) of method Bug4707Covariant\Block2::getChildren() should be covariant with return type (array<int, Bug4707Covariant\ChildNodeInterface<static(Bug4707Covariant\ParentNodeInterface)>>) of method Bug4707Covariant\ParentNodeInterface::getChildren()',
+				'Return type (array<int<0, max>, Bug4707Covariant\Row2>) of method Bug4707Covariant\Block2::getChildren() should be covariant with return type (array<int<0, max>, Bug4707Covariant\ChildNodeInterface<static(Bug4707Covariant\ParentNodeInterface)>>) of method Bug4707Covariant\ParentNodeInterface::getChildren()',
 				38,
 			],
 		]);


### PR DESCRIPTION
Thanks to the recently-introduced `IntegerRangeType`, we can narrow the `list<T>` pseudo-type to `array<int<0, max>, T>`. It's still not perfect, since it allows index gaps (unlike a true list), but this is a good improvement in the meantime.