### PR TITLE
No longer verify types, when TypeSpecifyingExtension uses $overwrite=true

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -158,6 +158,12 @@ class ImpossibleCheckTypeHelper
 		}
 
 		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $node, TypeSpecifierContext::createTruthy());
+
+		// don't validate types on overwrite
+		if ($specifiedTypes->shouldOverwrite()) {
+			return null;
+		}
+
 		$sureTypes = $specifiedTypes->getSureTypes();
 		$sureNotTypes = $specifiedTypes->getSureNotTypes();
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ImpossibleCheckTypeMethodCallRule>
+ */
+class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
+{
+
+	private bool $treatPhpDocTypesAsCertain;
+
+	public function getRule(): Rule
+	{
+		return new ImpossibleCheckTypeMethodCallRule(
+			new ImpossibleCheckTypeHelper(
+				$this->createReflectionProvider(),
+				$this->getTypeSpecifier(),
+				[],
+				$this->treatPhpDocTypesAsCertain,
+			),
+			true,
+			$this->treatPhpDocTypesAsCertain,
+		);
+	}
+
+	public function testNoReportedErrorOnOverwrite(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+
+		$this->analyse([__DIR__ . '/data/generic-type-override.php'], [
+		]);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/impossible-check-type-generic-overwrite.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
@@ -31,8 +31,7 @@ class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = false;
 
-		$this->analyse([__DIR__ . '/data/generic-type-override.php'], [
-		]);
+		$this->analyse([__DIR__ . '/data/generic-type-override.php'], []);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
@@ -11,8 +11,6 @@ use PHPStan\Testing\RuleTestCase;
 class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
 {
 
-	private bool $treatPhpDocTypesAsCertain;
-
 	public function getRule(): Rule
 	{
 		return new ImpossibleCheckTypeMethodCallRule(
@@ -20,17 +18,15 @@ class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
 				$this->createReflectionProvider(),
 				$this->getTypeSpecifier(),
 				[],
-				$this->treatPhpDocTypesAsCertain,
+				true,
 			),
 			true,
-			$this->treatPhpDocTypesAsCertain,
+			true,
 		);
 	}
 
 	public function testNoReportedErrorOnOverwrite(): void
 	{
-		$this->treatPhpDocTypesAsCertain = false;
-
 		$this->analyse([__DIR__ . '/data/generic-type-override.php'], []);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/TestTypeOverwriteSpecifyingExtensions.php
+++ b/tests/PHPStan/Rules/Comparison/data/TestTypeOverwriteSpecifyingExtensions.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Generic\GenericObjectType;
+
+class GenericTypeOverride implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	/** @var TypeSpecifier */
+	private $typeSpecifier;
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+	{
+		return \GenericTypeOverride\Foo::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context
+	): bool
+	{
+		return $methodReflection->getName() === 'setFetchMode';
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context
+	): SpecifiedTypes
+	{
+		$newType = new GenericObjectType(\GenericTypeOverride\Foo::class, [\GenericTypeOverride\Bar::class]);
+
+		return $this->typeSpecifier->create(
+			$node->var,
+			$newType,
+			TypeSpecifierContext::createTruthy(),
+			true
+		);
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/TestTypeOverwriteSpecifyingExtensions.php
+++ b/tests/PHPStan/Rules/Comparison/data/TestTypeOverwriteSpecifyingExtensions.php
@@ -10,7 +10,7 @@ use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
-use PHPStan\Type\StringType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
 
 class GenericTypeOverride implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
@@ -45,7 +45,7 @@ class GenericTypeOverride implements MethodTypeSpecifyingExtension, TypeSpecifie
 		TypeSpecifierContext $context
 	): SpecifiedTypes
 	{
-		$newType = new GenericObjectType(\GenericTypeOverride\Foo::class, [\GenericTypeOverride\Bar::class]);
+		$newType = new GenericObjectType(\GenericTypeOverride\Foo::class, [new ObjectType(\GenericTypeOverride\Bar::class)]);
 
 		return $this->typeSpecifier->create(
 			$node->var,

--- a/tests/PHPStan/Rules/Comparison/data/generic-type-override.php
+++ b/tests/PHPStan/Rules/Comparison/data/generic-type-override.php
@@ -11,7 +11,7 @@ class Test {
 
 		// $foo generic will be overridden via MethodTypeSpecifyingExtension
 		$foo->setFetchMode();
-		assertType('Foo<string>', $foo);
+		assertType('Foo<Bar>', $foo);
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Comparison/data/generic-type-override.php
+++ b/tests/PHPStan/Rules/Comparison/data/generic-type-override.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GenericTypeOverride;
+
+use function PHPStan\Testing\assertType;
+
+class Test {
+	public function doFoo() {
+		$foo = $this->createGenericFoo();
+		assertType('Foo<int>', $foo);
+
+		// $foo generic will be overridden via MethodTypeSpecifyingExtension
+		$foo->setFetchMode();
+		assertType('Foo<string>', $foo);
+	}
+
+	/**
+	 * @return Foo<int>
+	 */
+	public function createGenericFoo() {
+
+	}
+}
+
+
+/**
+ * @template T
+ */
+class Foo
+{
+	public function setFetchMode() {
+
+	}
+}
+
+
+class Bar
+{
+}

--- a/tests/PHPStan/Rules/Comparison/impossible-check-type-generic-overwrite.neon
+++ b/tests/PHPStan/Rules/Comparison/impossible-check-type-generic-overwrite.neon
@@ -1,0 +1,5 @@
+services:
+	-
+		class: PHPStan\Rules\Comparison\GenericTypeOverride
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/6620

I am not 100% happy with the test-case.
the test fails without the fix and passes with it - as expected.

but when running the test without the fix I get this error:
```
1) PHPStan\Rules\Comparison\ImpossibleCheckTypeGenericOverwriteRuleTest::testNoReportedErrorOnOverwrite
TypeError: PHPStan\Type\Generic\GenericObjectType::PHPStan\Type\Generic\{closure}(): Argument #1 ($type) must be of type PHPStan\Type\Type, string given

C:\dvl\Workspace\phpstan-src-staabm\src\Type\Generic\GenericObjectType.php:50
C:\dvl\Workspace\phpstan-src-staabm\src\Type\ObjectType.php:433
C:\dvl\Workspace\phpstan-src-staabm\src\Type\ObjectType.php:241
C:\dvl\Workspace\phpstan-src-staabm\src\Type\Generic\GenericObjectType.php:119
C:\dvl\Workspace\phpstan-src-staabm\src\Type\Generic\GenericObjectType.php:110
C:\dvl\Workspace\phpstan-src-staabm\src\Rules\Comparison\ImpossibleCheckTypeHelper.php:201
C:\dvl\Workspace\phpstan-src-staabm\src\Rules\Comparison\ImpossibleCheckTypeMethodCallRule.php:39
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\FileAnalyser.php:92
C:\dvl\Workspace\phpstan-src-staabm\src\Node\ClassStatementsGatherer.php:108
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:503
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:2840
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:1689
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:568
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:259
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:519
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:259
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:624
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:259
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:588
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\NodeScopeResolver.php:219
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\FileAnalyser.php:208
C:\dvl\Workspace\phpstan-src-staabm\src\Analyser\Analyser.php:61
C:\dvl\Workspace\phpstan-src-staabm\src\Testing\RuleTestCase.php:100
C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Rules\Comparison\ImpossibleCheckTypeGenericOverwriteRuleTest.php:37
```

it seems there is something missing which makes the test end properly (without the fix), to render a proper repro-case.

the test errors here
https://github.com/phpstan/phpstan-src/blob/4f72fdc29eecc12771de3d500a3d336b94c3d685/src/Rules/Comparison/ImpossibleCheckTypeHelper.php#L195
because it seems it cannot find some part of the involved objects within `$scope` - I guess.