### PR TITLE
Remove array_filter mixed handling which breaks type specification

### DIFF
--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -18,13 +18,11 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -55,13 +53,6 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 		$arrayArgType = $scope->getType($arrayArg);
 		$keyType = $arrayArgType->getIterableKeyType();
 		$itemType = $arrayArgType->getIterableValueType();
-
-		if ($arrayArgType instanceof MixedType) {
-			return new BenevolentUnionType([
-				new ArrayType(new MixedType(), new MixedType()),
-				new NullType(),
-			]);
-		}
 
 		if ($callbackArg === null || ($callbackArg instanceof ConstFetch && strtolower($callbackArg->name->parts[0]) === 'null')) {
 			return TypeCombinator::union(

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4889,7 +4889,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_filter($withPossiblyFalsey)',
 			],
 			[
-				'(array|null)',
+				'*NEVER*',
 				'array_filter($mixed)',
 			],
 			[

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\BinaryOp\Equal;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -962,6 +963,23 @@ class TypeSpecifierTest extends PHPStanTestCase
 				]),
 				[
 					'$string' => 'object',
+				],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_array', 'foo'),
+					new Identical(
+						new FuncCall(
+							new Name('array_filter'),
+							[new Arg(new Variable('foo')), new Arg(new String_('is_string')), new Arg(new ConstFetch(new Name('ARRAY_FILTER_USE_KEY')))],
+						),
+						new Variable('foo'),
+					),
+				),
+				[
+					'$foo' => 'array<string, mixed>',
+					'array_filter($foo, \'is_string\', ARRAY_FILTER_USE_KEY)' => 'array<string, mixed>',
 				],
 				[],
 			],

--- a/tests/PHPStan/Analyser/data/array-filter.php
+++ b/tests/PHPStan/Analyser/data/array-filter.php
@@ -16,7 +16,7 @@ function withoutAnyArgs(): void
 function withMixedInsteadOfArray($var1): void
 {
 	$filtered1 = array_filter($var1);
-	assertType('(array|null)', $filtered1);
+	assertType('*NEVER*', $filtered1);
 }
 
 /**


### PR DESCRIPTION
This adapts `ArrayFilterFunctionReturnTypeReturnTypeExtension` to not handle a mixed argument anymore with a `BenevolentUnionType`.

This fixes truthy type specification with `is_array && array_filter` if the input is mixed, but I guess this is just a side-effect and there might be a better fix..
Context / use case: https://github.com/phpstan/phpstan-webmozart-assert/pull/101

Without the modifications here I'd get
```diff
1) PHPStan\Analyser\TypeSpecifierTest::testCondition with data set #90 (PhpParser\Node\Expr\BinaryOp\BooleanAnd Object (...), array('array<string, mixed>', 'array<string, mixed>'), array())
if (is_array($foo) && array_filter($foo, 'is_string', ARRAY_FILTER_USE_KEY) === $foo)
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 (
-    '$foo' => 'array<string, mixed>'
-    'array_filter($foo, 'is_string', ARRAY_FILTER_USE_KEY)' => 'array<string, mixed>'
+    '$foo' => 'array'
+    'array_filter($foo, 'is_string', ARRAY_FILTER_USE_KEY)' => '(array|null)'
 )
```

BUT I'm also aware that the changes here might be negatively affecting `array_filter` behaviour pre PHP 8, see https://3v4l.org/sOWbb. Is there a better / more pragmatical way to improve this? On the other hand, is PHPStan actively supporting PHP quirks with warnings and such?

The main problem / limitation that I have is apparently how `TypeSpecifier` handles the BooleanAnd expression.
- In https://github.com/phpstan/phpstan-src/blob/1.4.6/src/Analyser/TypeSpecifier.php#L668 it looks at the left and right expressions and then "merges" them
- The left one (is_array) is handled via `IsArrayFunctionTypeSpecifyingExtension` in https://github.com/phpstan/phpstan-src/blob/1.4.6/src/Analyser/TypeSpecifier.php#L608 and makes PHPStan aware that my input var is of type ArrayType, which is good
- The right one (array_filter) though seems to be not using that information and starts from scratch again (mixed) which leads to the BenevolentUnionType which messes up my result

Any other ideas how to improve that? It looks like NodeScopeResolver is handling this a bit different and not loosing the information so to say. Or I'm misunderstanding it somehow :)