### PR TITLE
Improve falsey type specification with constant string comparison

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -53,6 +53,7 @@ use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\StringType;
+use PHPStan\Type\SubtractableType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeTraverser;
@@ -232,6 +233,13 @@ class TypeSpecifier
 						if ($argType instanceof StringType) {
 							return $this->create($exprNode->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $newContext, false, $scope);
 						}
+					}
+				}
+
+				if ($context->falsey() && $constantType instanceof ConstantStringType) {
+					$exprType = $scope->getType($exprNode);
+					if ($exprType instanceof SubtractableType) {
+						return $this->create($exprNode, $exprType->subtract($constantType), $context->negate(), false, $scope);
 					}
 				}
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -692,6 +692,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_VERSION_ID >= 80000) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6308.php');
 		}
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6329.php');
 
 		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-6473.php');

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -965,6 +965,17 @@ class TypeSpecifierTest extends PHPStanTestCase
 				],
 				[],
 			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						$this->createFunctionCall('is_string', 'a'),
+						new NotIdentical(new String_(''), new Variable('a')),
+					),
+					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
+				),
+				['$a' => 'non-empty-string|null'],
+				['$a' => '~null'],
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-6329.php
+++ b/tests/PHPStan/Analyser/data/bug-6329.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bug6329;
+
+use function PHPStan\Testing\assertType;
+
+function foo($a): void
+{
+	if (is_string($a) && '' !== $a) {
+		assertType('non-empty-string', $a);
+	}
+
+	if (is_string($a) && '' !== $a || null === $a) {
+		assertType('non-empty-string|null', $a);
+	}
+
+	if (is_string($a) || null === $a) {
+		assertType('string|null', $a);
+		if ('' !== $a) {
+			assertType('non-empty-string|null', $a);
+		}
+	}
+
+	if ((is_string($a) || null === $a) && '' !== $a) {
+		assertType('non-empty-string|null', $a);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6329

This makes use of type subtraction to add information about constant strings that **cannot** be part of the type.

E.g. `is_string($a) && '' !== $a || null === $a` with `$a` being `mixed` would lead to a `MixedType` **sureType** with the empty constant string `''` substracted for the inner BooleanAnd expression. And that leads to a intersection of `StringType` and `AccessoryNonEmptyStringType`.

Previously, it would determine that the empty constant string `''` is a **sureNotType** but loose that information on merging left and right types for the outer BooleanOr.

But I'm not sure if this is the best fix :) Initially I tried adapting the left/right type merging, particularly the intersection for BooleanOr, but that made things even worse by breaking other things.