### PR TITLE
Normalize specified types before intersection

### DIFF
--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -120,6 +120,11 @@ class SpecifiedTypes
 		return new self($sureTypeUnion, $sureNotTypeUnion);
 	}
 
+	public function inverse(): self
+	{
+		return new self($this->sureNotTypes, $this->sureTypes, $this->overwrite, $this->newConditionalExpressionHolders);
+	}
+
 	private function normalize(): self
 	{
 		$sureTypes = $this->sureTypes;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -482,6 +482,8 @@ class TypeSpecifier
 					$argType = $scope->getType($expr->right->getArgs()[0]->value);
 					if ($argType->isArray()->yes()) {
 						$result = $result->unionWith($this->create($expr->right->getArgs()[0]->value, new NonEmptyArrayType(), $context, false, $scope));
+					} else {
+						$result = $result->unionWith($this->create($expr->right->getArgs()[0]->value, new ConstantArrayType([], []), $context->negate(), false, $scope));
 					}
 				}
 			}
@@ -501,6 +503,8 @@ class TypeSpecifier
 					$argType = $scope->getType($expr->right->getArgs()[0]->value);
 					if ($argType instanceof StringType) {
 						$result = $result->unionWith($this->create($expr->right->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $context, false, $scope));
+					} else {
+						$result = $result->unionWith($this->create($expr->right->getArgs()[0]->value, new ConstantStringType(''), $context->negate(), false, $scope));
 					}
 				}
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -692,6 +692,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_VERSION_ID >= 80000) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6308.php');
 		}
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6329.php');
 
 		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-6473.php');

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -965,6 +965,45 @@ class TypeSpecifierTest extends PHPStanTestCase
 				],
 				[],
 			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						$this->createFunctionCall('is_string', 'a'),
+						new NotIdentical(new String_(''), new Variable('a')),
+					),
+					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
+				),
+				['$a' => 'non-empty-string|null'],
+				['$a' => '~null'],
+			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						$this->createFunctionCall('is_string', 'a'),
+						new Expr\BinaryOp\Greater(
+							$this->createFunctionCall('strlen', 'a'),
+							new LNumber(0),
+						),
+					),
+					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
+				),
+				['$a' => 'non-empty-string|null'],
+				['$a' => '~null'],
+			],
+			[
+				new Expr\BinaryOp\BooleanOr(
+					new Expr\BinaryOp\BooleanAnd(
+						$this->createFunctionCall('is_array', 'a'),
+						new Expr\BinaryOp\Greater(
+							$this->createFunctionCall('count', 'a'),
+							new LNumber(0),
+						),
+					),
+					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
+				),
+				['$a' => 'non-empty-array|null'],
+				['$a' => '~null'],
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\BinaryOp\Equal;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\BinaryOp\NotIdentical;
 use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
@@ -988,7 +989,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => '~null'],
+				['$a' => '~non-empty-string|null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1002,7 +1003,24 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-array|null'],
-				['$a' => '~null'],
+				['$a' => '~non-empty-array|null'],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_array', 'foo'),
+					new Identical(
+						new FuncCall(
+							new Name('array_filter'),
+							[new Arg(new Variable('foo')), new Arg(new String_('is_string')), new Arg(new ConstFetch(new Name('ARRAY_FILTER_USE_KEY')))],
+						),
+						new Variable('foo'),
+					),
+				),
+				[
+					'$foo' => 'array<string, mixed>',
+					'array_filter($foo, \'is_string\', ARRAY_FILTER_USE_KEY)' => 'array<string, mixed>',
+				],
+				[],
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/data/bug-6329.php
+++ b/tests/PHPStan/Analyser/data/bug-6329.php
@@ -158,3 +158,28 @@ function inverse($a, $b, $c): void
 		assertType('non-empty-array|null', $c);
 	}
 }
+
+/**
+ * @param mixed $a
+ * @param mixed $b
+ * @param mixed $c
+ * @param mixed $d
+ */
+function combinations($a, $b, $c, $d): void
+{
+	if (is_string($a) && '' !== $a || is_int($a) && $a > 0 || null === $a) {
+		assertType('int<1, max>|non-empty-string|null', $a);
+	}
+	if ((!is_string($b) || '' === $b) && (!is_int($b) || $b <= 0) && null !== $b) {
+	} else {
+		assertType('int<1, max>|non-empty-string|null', $b);
+	}
+
+	if (is_array($c) && $c === array_filter($c, 'is_string', ARRAY_FILTER_USE_KEY) || null === $c) {
+		assertType('array<string, mixed>|null', $c);
+	}
+	if ((!is_array($d) || $d !== array_filter($d, 'is_string', ARRAY_FILTER_USE_KEY)) && null !== $d) {
+	} else {
+		assertType('array<string, mixed>|null', $d);
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-6329.php
+++ b/tests/PHPStan/Analyser/data/bug-6329.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Bug6329;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param mixed $a
+ */
+function nonEmptyString1($a): void
+{
+	if (is_string($a) && '' !== $a || null === $a) {
+		assertType('non-empty-string|null', $a);
+	}
+
+	if ('' !== $a && is_string($a) || null === $a) {
+		assertType('non-empty-string|null', $a);
+	}
+
+	if (null === $a || is_string($a) && '' !== $a) {
+		assertType('non-empty-string|null', $a);
+	}
+
+	if (null === $a || '' !== $a && is_string($a)) {
+		assertType('non-empty-string|null', $a);
+	}
+}
+
+/**
+ * @param mixed $a
+ */
+function nonEmptyString2($a): void
+{
+	if (is_string($a) && strlen($a) > 0 || null === $a) {
+		assertType('non-empty-string|null', $a);
+	}
+
+	if (null === $a || is_string($a) && strlen($a) > 0) {
+		assertType('non-empty-string|null', $a);
+	}
+}
+
+
+/**
+ * @param mixed $a
+ */
+function int1($a): void
+{
+	if (is_int($a) && 0 !== $a || null === $a) {
+		assertType('int<min, -1>|int<1, max>|null', $a);
+	}
+
+	if (0 !== $a && is_int($a) || null === $a) {
+		assertType('int<min, -1>|int<1, max>|null', $a);
+	}
+
+	if (null === $a || is_int($a) && 0 !== $a) {
+		assertType('int<min, -1>|int<1, max>|null', $a);
+	}
+
+	if (null === $a || 0 !== $a && is_int($a)) {
+		assertType('int<min, -1>|int<1, max>|null', $a);
+	}
+}
+
+/**
+ * @param mixed $a
+ */
+function int2($a): void
+{
+	if (is_int($a) && $a > 0 || null === $a) {
+		assertType('int<1, max>|null', $a);
+	}
+
+	if (null === $a || is_int($a) && $a > 0) {
+		assertType('int<1, max>|null', $a);
+	}
+}
+
+
+/**
+ * @param mixed $a
+ */
+function true($a): void
+{
+	if (is_bool($a) && false !== $a || null === $a) {
+		assertType('true|null', $a);
+	}
+
+	if (false !== $a && is_bool($a) || null === $a) {
+		assertType('true|null', $a);
+	}
+
+	if (null === $a || is_bool($a) && false !== $a) {
+		assertType('true|null', $a);
+	}
+
+	if (null === $a || false !== $a && is_bool($a)) {
+		assertType('true|null', $a);
+	}
+}
+
+/**
+ * @param mixed $a
+ */
+function nonEmptyArray1($a): void
+{
+	if (is_array($a) && [] !== $a || null === $a) {
+		assertType('non-empty-array|null', $a);
+	}
+
+	if ([] !== $a && is_array($a) || null === $a) {
+		assertType('non-empty-array|null', $a);
+	}
+
+	if (null === $a || is_array($a) && [] !== $a) {
+		assertType('non-empty-array|null', $a);
+	}
+
+	if (null === $a || [] !== $a && is_array($a)) {
+		assertType('non-empty-array|null', $a);
+	}
+}
+
+/**
+ * @param mixed $a
+ */
+function nonEmptyArray2($a): void
+{
+	if (is_array($a) && count($a) > 0 || null === $a) {
+		assertType('non-empty-array|null', $a);
+	}
+
+	if (null === $a || is_array($a) && count($a) > 0) {
+		assertType('non-empty-array|null', $a);
+	}
+}
+
+/**
+ * @param mixed $a
+ * @param mixed $b
+ * @param mixed $c
+ */
+function inverse($a, $b, $c): void
+{
+	if ((!is_string($a) || '' === $a) && null !== $a) {
+	} else {
+		assertType('non-empty-string|null', $a);
+	}
+
+	if ((!is_int($b) || $b <= 0) && null !== $b) {
+	} else {
+		assertType('int<1, max>|null', $b);
+	}
+
+	if (null !== $c && (!is_array($c) || count($c) <= 0)) {
+	} else {
+		assertType('non-empty-array|null', $c);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6329

This PR is improving type specification with combined BooleanAnd and BooleanIf expressions in 2 ways. Therefore the title does not match anymore :) I think something like "Improve type specification for combined && and || expressions" would fit better.

1. It normalizes the SpecifiedTypes by removing the sureNotTypes from the relevant sureTypes which results in e.g. `AccessoryNonEmptyStringType` or `NonEmptyArrayType`. Without this, sureNotTypes might not be considered when intersecting instances of `SpecifiedType`, which leads to type information loss.

<details>
<summary>Details about the normalization</summary>

In order to narrow down the variable `$a` from `mixed ` to `non-empty-string|null` the following code could (it's maybe a bit odd but this is not relevant) be used in an if (truthy context):
```php
is_string($a) && '' !== $a || null === $a
```
This can be described with the expression
```php
new Expr\BinaryOp\BooleanOr(
	new Expr\BinaryOp\BooleanAnd(
		new FuncCall(new Name('is_string'), [new Arg(new Variable('a'))])
		new NotIdentical(new String_(''), new Variable('a')),
	),
	new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
)
```

The interesting parts are the inner BooleanAnd and the outer BooleanOr. If the TypeSpecifier looks at this it will basically recursively determine the `SpecifiedTypes`. Without going into too much details, that the relevant people know better than me anyway, the following will be the simplified relevant sureTypes and sureNotTypes for `$a` of the relevant SpecifiedTypes instances:

### BooleanAnd
left expression: `StringType` sureType
right expression:  `ConstantStringType` with value `''` sureNotType

#### Result
BooleanAnd uses `SpecifiedTypes->unionWith` for a truthy context like here which results in a new SpecifiedTypes having both of those

### BooleanOr
left expression: the above union => `StringType` sureType,  `ConstantStringType` with value `''` sureNotType
right expression: `NullType` sureType

#### Result
=> BooleanOr uses `SpecifiedTypes->intersectWith`

##### Before
intersectWith only looks at the sureTypes and sureNotTypes of both SpecifiedTypes instances if their expression string occurs also in both. Meaning, it will union (for a truthy context like here) the `StringType` and `NullType` because both SpecifiedTypes instances have sureTypes for `$a`. But, it will not use the sureNotType if there is not a sureNotType in the other SpecifiedTypes for `$a`. Therefore it results in a SpecifiedTypes instance with a `StringType|NullType` sureTypes union only and basically looses the sureNotType information that is relevant for the left expression.

##### After
both SpecifiedTypes instances are normalized which "moves" the sureNotType into the sureType resulting in a `StringType&AccessoryNonEmptyStringType` intersection for the left expression basically. The other SpecifiedTypes instance is not affected here by normalization. The intersectWith logic then unionizes (for a truthy context like here) both instances resulting in a `(StringType&AccessoryNonEmptyStringType)|NullType` union sureType and therfore does not loose the sureNotType information which is coupled to the left expression but does not make any sense for the right one.

Without the BooleanOr the sureNotType is not lost and the MutatingScope can use it to determine that the outcome is `non-empty-string`. With BooleanOr we have to normalize this already here IMO before intersecting in order to not loose the information.

</details>

2. It makes use of the `MutatingScope` in `BooleanAnd` and `BooleanOr` expressions to filter by the specified types of the left espression and uses the resulting mutated scope in the right expression. This ensures that information gathered on the left side can be used on the right side. See https://github.com/phpstan/phpstan-src/pull/1016#issuecomment-1040372045