### PR TITLE
use forward slashes in `TableFormatter` to make paths clickable

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -6,6 +6,7 @@ use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalyseCommand;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
+use PHPStan\File\FileHelper;
 use PHPStan\File\RelativePathHelper;
 use function array_map;
 use function count;
@@ -20,6 +21,7 @@ class TableErrorFormatter implements ErrorFormatter
 		private RelativePathHelper $relativePathHelper,
 		private bool $showTipsOfTheDay,
 		private ?string $editorUrl,
+		private FileHelper $fileHelper,
 	)
 	{
 	}
@@ -74,7 +76,11 @@ class TableErrorFormatter implements ErrorFormatter
 					$message .= "\n💡 " . $tip;
 				}
 				if (is_string($this->editorUrl)) {
-					$url = str_replace(['%file%', '%line%'], [$error->getTraitFilePath() ?? $error->getFilePath(), (string) $error->getLine()], $this->editorUrl);
+					// always use forward-slashes, even on windows to make file-paths clickable
+					$file = $error->getTraitFilePath() ?? $error->getFilePath();
+					$file = $this->fileHelper->forwardSlashes($file);
+
+					$url = str_replace(['%file%', '%line%'], [$file, (string) $error->getLine()], $this->editorUrl);
 					$message .= "\n✏️  <href=" . $url . '>' . $url . '</>';
 				}
 				$rows[] = [
@@ -83,7 +89,9 @@ class TableErrorFormatter implements ErrorFormatter
 				];
 			}
 
+			// always use forward-slashes, even on windows to make file-paths clickable
 			$relativeFilePath = $this->relativePathHelper->getRelativePath($file);
+			$relativeFilePath = $this->fileHelper->forwardSlashes($relativeFilePath);
 
 			$style->table(['Line', $relativeFilePath], $rows);
 		}

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -50,6 +50,12 @@ class FileHelper
 	}
 
 	/** @api */
+	public function forwardSlashes(string $originalPath): string
+	{
+		return str_replace('\\', '/', $originalPath);
+	}
+
+	/** @api */
 	public function normalizePath(string $originalPath, string $directorySeparator = DIRECTORY_SEPARATOR): string
 	{
 		$isLocalPath = $originalPath !== '' && $originalPath[0] === '/';

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command;
 use PHPStan\Analyser\ResultCache\ResultCacheClearer;
 use PHPStan\Command\ErrorFormatter\TableErrorFormatter;
 use PHPStan\Command\Symfony\SymfonyOutput;
+use PHPStan\File\FileHelper;
 use PHPStan\File\FuzzyRelativePathHelper;
 use PHPStan\File\NullRelativePathHelper;
 use PHPStan\ShouldNotHappenException;
@@ -64,7 +65,8 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 		$memoryLimitFile = self::getContainer()->getParameter('memoryLimitFile');
 
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), __DIR__, [], DIRECTORY_SEPARATOR);
-		$errorFormatter = new TableErrorFormatter($relativePathHelper, false, null);
+		$fileHelper = new FileHelper(__DIR__);
+		$errorFormatter = new TableErrorFormatter($relativePathHelper, false, null, $fileHelper);
 		$analysisResult = $analyserApplication->analyse(
 			[$path],
 			true,

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Command\ErrorFormatter;
 
+use PHPStan\File\FileHelper;
 use PHPStan\File\FuzzyRelativePathHelper;
 use PHPStan\File\NullRelativePathHelper;
 use PHPStan\Testing\ErrorFormatterTestCase;
@@ -165,10 +166,11 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 		if (PHP_VERSION_ID >= 80100) {
 			self::markTestSkipped('Skipped on PHP 8.1 because of different result');
 		}
+		$fileHelper = new FileHelper(__DIR__);
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
 		$formatter = new GithubErrorFormatter(
 			$relativePathHelper,
-			new TableErrorFormatter($relativePathHelper, false, null),
+			new TableErrorFormatter($relativePathHelper, false, null, $fileHelper),
 		);
 
 		$this->assertSame($exitCode, $formatter->formatErrors(

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Command\ErrorFormatter;
 
 use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalysisResult;
+use PHPStan\File\FileHelper;
 use PHPStan\File\FuzzyRelativePathHelper;
 use PHPStan\File\NullRelativePathHelper;
 use PHPStan\Testing\ErrorFormatterTestCase;
@@ -153,7 +154,9 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		if (PHP_VERSION_ID >= 80100) {
 			self::markTestSkipped('Skipped on PHP 8.1 because of different result');
 		}
-		$formatter = new TableErrorFormatter(new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/'), false, null);
+		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
+		$fileHelper = new FileHelper(__DIR__);
+		$formatter = new TableErrorFormatter($relativePathHelper, false, null, $fileHelper);
 
 		$this->assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
@@ -165,7 +168,9 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 	public function testEditorUrlWithTrait(): void
 	{
-		$formatter = new TableErrorFormatter(new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/'), false, 'editor://%file%/%line%');
+		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
+		$fileHelper = new FileHelper(__DIR__);
+		$formatter = new TableErrorFormatter($relativePathHelper, false, 'editor://%file%/%line%', $fileHelper);
 		$error = new Error('Test', 'Foo.php (in context of trait)', 12, true, 'Foo.php', 'Bar.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], false, null, true), $this->getOutput());
 

--- a/tests/PHPStan/File/FileHelperTest.php
+++ b/tests/PHPStan/File/FileHelperTest.php
@@ -112,4 +112,23 @@ class FileHelperTest extends PHPStanTestCase
 		$this->assertSame($normalizedPath, self::getContainer()->getByType(FileHelper::class)->normalizePath($path));
 	}
 
+	/**
+	 * @return string[][]
+	 */
+	public function dataNormalizePathToForwardSlashes(): array
+	{
+		return [
+			['C:\Program Files\PHP', 'C:/Program Files/PHP'],
+			['/home/users/phpstan', '/home/users/phpstan'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataNormalizePathToForwardSlashes
+	 */
+	public function testNormalizePathToForwardSlashes(string $path, string $normalizedPath): void
+	{
+		$this->assertSame($normalizedPath, self::getContainer()->getByType(FileHelper::class)->forwardSlashes($path));
+	}
+
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/6483

using forward slashes in e.g. Git Bash for windows to make the links clickable.
I tested it on gitbash for windows. with this patch I can hold CTRL key and click file-paths - even without configuring `editorUrl`.

![grafik](https://user-images.githubusercontent.com/120441/153870869-f72cab7a-b010-4a88-8c02-e2c08d1f075e.png)
