### PR TITLE
Detect closure parameter types when passing closure in a partially callable union

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -139,6 +139,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VoidType;
 use Throwable;
 use function array_fill_keys;
+use function array_filter;
 use function array_key_exists;
 use function array_map;
 use function array_merge;
@@ -2858,6 +2859,13 @@ class NodeScopeResolver
 		$byRefUses = [];
 
 		if ($passedToType !== null && !$passedToType->isCallable()->no()) {
+			if ($passedToType instanceof UnionType) {
+				$passedToType = TypeCombinator::union(...array_filter(
+					$passedToType->getTypes(),
+					static fn (Type $type) => $type->isCallable()->yes(),
+				));
+			}
+
 			$callableParameters = null;
 			$acceptors = $passedToType->getCallableParametersAcceptors($scope);
 			if (count($acceptors) === 1) {
@@ -2987,6 +2995,13 @@ class NodeScopeResolver
 		}
 
 		if ($passedToType !== null && !$passedToType->isCallable()->no()) {
+			if ($passedToType instanceof UnionType) {
+				$passedToType = TypeCombinator::union(...array_filter(
+					$passedToType->getTypes(),
+					static fn (Type $type) => $type->isCallable()->yes(),
+				));
+			}
+
 			$callableParameters = null;
 			$acceptors = $passedToType->getCallableParametersAcceptors($scope);
 			if (count($acceptors) === 1) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -714,6 +714,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6672.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6687.php');
 
+		if (self::$useStaticReflectionProvider) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/callable-in-union.php');
+		}
+
 		require_once __DIR__ . '/data/countable.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/countable.php');
 	}

--- a/tests/PHPStan/Analyser/data/callable-in-union.php
+++ b/tests/PHPStan/Analyser/data/callable-in-union.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace CallableInUnion;
+
+use function PHPStan\Testing\assertType;
+
+/** @param array<string, mixed>|(callable(array<string, mixed>): array<string, mixed>) $_ */
+function acceptArrayOrCallable($_)
+{
+}
+
+acceptArrayOrCallable(fn ($parameter) => assertType('array<string, mixed>', $parameter));
+
+acceptArrayOrCallable(function ($parameter) {
+	assertType('array<string, mixed>', $parameter);
+	return $parameter;
+});


### PR DESCRIPTION
Closes phpstan/phpstan#6629

Basically, drop all non-callable parts of a union when we pass a closure. If there is a better way to fix this let me know, happy to look into it.