### PR TITLE
Add missing SpecifiedTypes for count and strlen identical expressions

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -210,9 +210,9 @@ class TypeSpecifier
 						}
 						$argType = $scope->getType($exprNode->getArgs()[0]->value);
 						if ($argType->isArray()->yes()) {
-							$leftTypes = $this->create($exprNode, $constantType, $context, false, $scope);
-							$rightTypes = $this->create($exprNode->getArgs()[0]->value, new NonEmptyArrayType(), $newContext, false, $scope);
-							return $leftTypes->unionWith($rightTypes);
+							$funcTypes = $this->create($exprNode, $constantType, $context, false, $scope);
+							$valueTypes = $this->create($exprNode->getArgs()[0]->value, new NonEmptyArrayType(), $newContext, false, $scope);
+							return $funcTypes->unionWith($valueTypes);
 						}
 					}
 				}
@@ -232,9 +232,9 @@ class TypeSpecifier
 						}
 						$argType = $scope->getType($exprNode->getArgs()[0]->value);
 						if ($argType instanceof StringType) {
-							$leftTypes = $this->create($exprNode, $constantType, $context, false, $scope);
-							$rightTypes = $this->create($exprNode->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $newContext, false, $scope);
-							return $leftTypes->unionWith($rightTypes);
+							$funcTypes = $this->create($exprNode, $constantType, $context, false, $scope);
+							$valueTypes = $this->create($exprNode->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $newContext, false, $scope);
+							return $funcTypes->unionWith($valueTypes);
 						}
 					}
 				}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -210,7 +210,9 @@ class TypeSpecifier
 						}
 						$argType = $scope->getType($exprNode->getArgs()[0]->value);
 						if ($argType->isArray()->yes()) {
-							return $this->create($exprNode->getArgs()[0]->value, new NonEmptyArrayType(), $newContext, false, $scope);
+							$leftTypes = $this->create($exprNode, $constantType, $context, false, $scope);
+							$rightTypes = $this->create($exprNode->getArgs()[0]->value, new NonEmptyArrayType(), $newContext, false, $scope);
+							return $leftTypes->unionWith($rightTypes);
 						}
 					}
 				}
@@ -230,7 +232,9 @@ class TypeSpecifier
 						}
 						$argType = $scope->getType($exprNode->getArgs()[0]->value);
 						if ($argType instanceof StringType) {
-							return $this->create($exprNode->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $newContext, false, $scope);
+							$leftTypes = $this->create($exprNode, $constantType, $context, false, $scope);
+							$rightTypes = $this->create($exprNode->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $newContext, false, $scope);
+							return $leftTypes->unionWith($rightTypes);
 						}
 					}
 				}

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -1022,6 +1022,59 @@ class TypeSpecifierTest extends PHPStanTestCase
 				],
 				[],
 			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_array', 'foo'),
+					new Expr\BinaryOp\GreaterOrEqual(
+						new FuncCall(
+							new Name('count'),
+							[new Arg(new Variable('foo'))],
+						),
+						new LNumber(2),
+					),
+				),
+				[
+					'$foo' => 'non-empty-array',
+					'count($foo)' => 'mixed~int<min, 1>|false|null',
+				],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_array', 'foo'),
+					new Identical(
+						new FuncCall(
+							new Name('count'),
+							[new Arg(new Variable('foo'))],
+						),
+						new LNumber(2),
+					),
+				),
+				[
+					'$foo' => 'non-empty-array',
+					'count($foo)' => '2',
+				],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_string', 'foo'),
+					new NotIdentical(
+						new FuncCall(
+							new Name('strlen'),
+							[new Arg(new Variable('foo'))],
+						),
+						new LNumber(0),
+					),
+				),
+				[
+					'$foo' => 'non-empty-string',
+					'strlen($foo)' => '~0',
+				],
+				[
+					'$foo' => '~non-empty-string',
+				],
+			],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-2648.php
+++ b/tests/PHPStan/Analyser/data/bug-2648.php
@@ -37,7 +37,7 @@ class Foo
 				assertType('int<0, max>', count($list));
 
 				if (count($list) === 1) {
-					assertType('int<1, max>', count($list));
+					assertType('1', count($list));
 					break;
 				}
 			}

--- a/tests/PHPStan/Analyser/data/bug-2648.php
+++ b/tests/PHPStan/Analyser/data/bug-2648.php
@@ -38,6 +38,8 @@ class Foo
 
 				if (count($list) === 1) {
 					assertType('1', count($list));
+					$list[] = false;
+					assertType('int<1, max>', count($list));
 					break;
 				}
 			}


### PR DESCRIPTION
Stumbled over this while debugging something in the webmozart-assert extension.

This adds missing `SpecifiedTypes` for `count`, `sizeof` and `strlen` expressions used via `Identical`.

E.g. `count($list) === 1` would previously result in the sureType `NonEmptyArrayType` for `$list`. Now additionally it has a `ConstantIntegerType` with value 1 for `count($list)`.
This is a tiny thing, but improved something in `bug-2648.php` and it _should close_ https://github.com/phpstan/phpstan-webmozart-assert/issues/68 if I'm not mistaken.

The first new test case in `TypeSpecifierTestCase` shows that it worked already for `GreaterOrEqual` before.