### PR TITLE
more precise `preg_match_all` return type on php8

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -85,6 +85,7 @@ return [
 		'PhpToken::is' => ['bool', 'kind'=>'string|int|string[]|int[]'],
 		'PhpToken::isIgnorable' => ['bool'],
 		'PhpToken::getTokenName' => ['string'],
+		'preg_match_all' => ['0|positive-int|false', 'pattern'=>'string', 'subject'=>'string', '&w_subpatterns='=>'array', 'flags='=>'int', 'offset='=>'int'],
 		'proc_get_status' => ['array{command: string, pid: int, running: bool, signaled: bool, stopped: bool, exitcode: int, termsig: int, stopsig: int}', 'process'=>'resource'],
 		'set_error_handler' => ['?callable', 'callback'=>'null|callable(int,string,string,int):bool', 'error_types='=>'int'],
 		'socket_addrinfo_lookup' => ['AddressInfo[]', 'node'=>'string', 'service='=>'mixed', 'hints='=>'array'],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -722,6 +722,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/callable-in-union.php');
 		}
 
+		if (PHP_VERSION_ID < 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/preg_match_php7.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/preg_match_php8.php');
+		}
+
 		require_once __DIR__ . '/data/countable.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/countable.php');
 

--- a/tests/PHPStan/Analyser/data/preg_match_php7.php
+++ b/tests/PHPStan/Analyser/data/preg_match_php7.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PregMatch;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+	public function doFoo() {
+		assertType('0|1|false', preg_match('{}', ''));
+		assertType('int<0, max>|false|null', preg_match_all('{}', ''));
+	}
+}

--- a/tests/PHPStan/Analyser/data/preg_match_php8.php
+++ b/tests/PHPStan/Analyser/data/preg_match_php8.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PregMatch;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+	public function doFoo() {
+		assertType('0|1|false', preg_match('{}', ''));
+		assertType('int<0, max>|false', preg_match_all('{}', ''));
+
+	}
+}


### PR DESCRIPTION
fixes issue reported in https://github.com/phpstan/phpstan-src/pull/918#issuecomment-1042983239