### PR TITLE
Return literal string from sprintf on literal input

### DIFF
--- a/tests/PHPStan/Type/Php/SprintfFunctionDynamicReturnTypeExtensionTest.php
+++ b/tests/PHPStan/Type/Php/SprintfFunctionDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class SprintfFunctionDynamicReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	/** @return iterable<mixed> */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/sprintf.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+}

--- a/tests/PHPStan/Type/Php/data/sprintf.php
+++ b/tests/PHPStan/Type/Php/data/sprintf.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PHPStan\Type\Php\Test;
+
+use function PHPStan\Testing\assertType;
+
+$foo = 'foo';
+assertType("'foo'", sprintf('%s', $foo));
+
+function foo (string $nonLiteral): void {
+	assertType('non-empty-string', sprintf('%s', $nonLiteral));
+}
+
+/** @var literal-string $literal */
+$literal = '';
+assertType('literal-string&non-empty-string', sprintf('%s', $literal));
+
+function bar (int $int): void {
+	assertType('literal-string&non-empty-string', sprintf('%d', $int));
+}
+
+/** @var int|literal-string|float $union */
+$union = '';
+assertType('literal-string&non-empty-string', sprintf('%s', $union));
+
+/** @var int|string|float $union */
+$union = '';
+assertType('non-empty-string', sprintf('%s', $union));
+


### PR DESCRIPTION
I noticed this when updating `phpstan-doctrine`, which now requires `literal-string` as arguments to `where`. We have a couple of where-clauses with dynamic columns, which we build using `sprintf`. But `sprintf` does not return a `literal-string`, even if all inputs are `literal-string`.