### PR TITLE
Fix ArrayColumnFunctionReturnTypeExtension producing array key types

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -342,7 +342,11 @@ class ArrayType implements Type
 				return $offsetType;
 			}
 
-			if ($offsetType instanceof FloatType || $offsetType instanceof BooleanType || $offsetType->isNumericString()->yes()) {
+			if ($offsetType instanceof BooleanType) {
+				return new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(1)]);
+			}
+
+			if ($offsetType instanceof FloatType || $offsetType->isNumericString()->yes()) {
 				return new IntegerType();
 			}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -750,6 +750,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6699.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6715.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6682.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/array-column.php
+++ b/tests/PHPStan/Analyser/data/array-column.php
@@ -20,6 +20,17 @@ function testArrays(array $array): void
 	assertType('array{}', array_column($array, 'column'));
 	assertType('array{}', array_column($array, 'column', 'key'));
 	assertType('array{}', array_column($array, null, 'key'));
+
+	/** @var array<int, array<string, float>> $array */
+	assertType('array<int, float>', array_column($array, 'column', 'key'));
+	/** @var array<int, array<string, bool>> $array */
+	assertType('array<int, bool>', array_column($array, 'column', 'key'));
+	/** @var array<int, array<string, true>> $array */
+	assertType('array<int, true>', array_column($array, 'column', 'key'));
+	/** @var array<int, array<string, null>> $array */
+	assertType('array<\'\'|int, null>', array_column($array, 'column', 'key'));
+	/** @var array<int, array<string, array>> $array */
+	assertType('array<int, array>', array_column($array, 'column', 'key'));
 }
 
 function testConstantArrays(array $array): void
@@ -54,6 +65,17 @@ function testConstantArrays(array $array): void
 	assertType('non-empty-array<int, string>', array_column($array, 'column'));
 	assertType('non-empty-array<string, string>', array_column($array, 'column', 'key'));
 	assertType('non-empty-array<string, array{column: string, key: string}>', array_column($array, null, 'key'));
+
+	/** @var array<int, array{column: string, key: float}> $array */
+	assertType('array<int, string>', array_column($array, 'column', 'key'));
+	/** @var array<int, array{column: string, key: bool}> $array */
+	assertType('array<0|1, string>', array_column($array, 'column', 'key'));
+	/** @var array<int, array{column: string, key: true}> $array */
+	assertType('array<1, string>', array_column($array, 'column', 'key'));
+	/** @var array<int, array{column: string, key: null}> $array */
+	assertType('array<\'\', string>', array_column($array, 'column', 'key'));
+	/** @var array<int, array{column: string, key: array}> $array */
+	assertType('array<int, string>', array_column($array, 'column', 'key'));
 }
 
 function testImprecise(array $array): void {
@@ -84,8 +106,8 @@ function testObjects(array $array): void {
 	assertType('array<string, DOMElement>', array_column($array, null, 'tagName'));
 	assertType('array<int, mixed>', array_column($array, 'foo'));
 	assertType('array<string, mixed>', array_column($array, 'foo', 'tagName'));
-	assertType('array<string>', array_column($array, 'nodeName', 'foo'));
-	assertType('array<DOMElement>', array_column($array, null, 'foo'));
+	assertType('array<int|string, string>', array_column($array, 'nodeName', 'foo'));
+	assertType('array<int|string, DOMElement>', array_column($array, null, 'foo'));
 
 	/** @var non-empty-array<int, DOMElement> $array */
 	assertType('non-empty-array<int, string>', array_column($array, 'nodeName'));
@@ -93,8 +115,8 @@ function testObjects(array $array): void {
 	assertType('non-empty-array<string, DOMElement>', array_column($array, null, 'tagName'));
 	assertType('array<int, mixed>', array_column($array, 'foo'));
 	assertType('array<string, mixed>', array_column($array, 'foo', 'tagName'));
-	assertType('non-empty-array<string>', array_column($array, 'nodeName', 'foo'));
-	assertType('non-empty-array<DOMElement>', array_column($array, null, 'foo'));
+	assertType('non-empty-array<int|string, string>', array_column($array, 'nodeName', 'foo'));
+	assertType('non-empty-array<int|string, DOMElement>', array_column($array, null, 'foo'));
 
 	/** @var array{DOMElement} $array */
 	assertType('array{string}', array_column($array, 'nodeName'));

--- a/tests/PHPStan/Analyser/data/bug-6682.php
+++ b/tests/PHPStan/Analyser/data/bug-6682.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Bug6682;
+
+use function PHPStan\Testing\assertType;
+
+class Example
+{
+    /**
+     * @param array<int, array<string, string|array<string,string>|null>> $data
+     */
+    public function __construct(array $data)
+    {
+        $x = array_column($data, null, 'type');
+		assertType('array<int|string, array<string, array<string, string>|string|null>>', $x);
+    }
+}

--- a/tests/PHPStan/Analyser/data/constant-array-type-set.php
+++ b/tests/PHPStan/Analyser/data/constant-array-type-set.php
@@ -97,4 +97,21 @@ class Foo
 		assertType('non-empty-array<int<0, 4>, bool>', $a);
 	}
 
+	public function doBar6(bool $offset): void
+	{
+		$a = [false, false, false];
+		$a[$offset] = true;
+		assertType('array{bool, bool, false}', $a);
+	}
+
+	/**
+	 * @param true $offset
+	 */
+	public function doBar7(bool $offset): void
+	{
+		$a = [false, false, false];
+		$a[$offset] = true;
+		assertType('array{false, true, false}', $a);
+	}
+
 }


### PR DESCRIPTION
Fixes phpstan/phpstan#6682