### PR TITLE
Do not invert const expressions in specified types

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -712,6 +712,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6672.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6687.php');
 
 		require_once __DIR__ . '/data/countable.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/countable.php');

--- a/tests/PHPStan/Analyser/data/bug-6687.php
+++ b/tests/PHPStan/Analyser/data/bug-6687.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6687;
+
+use DateTimeImmutable;
+
+use function PHPStan\Testing\assertType;
+
+const BAZ = 'BAZ';
+
+class Bug6687
+{
+
+	function foo(string $a): void
+	{
+		if ($a === DateTimeImmutable::class || is_subclass_of($a, DateTimeImmutable::class)) {
+			assertType('class-string<DateTimeImmutable>', $a);
+		}
+	}
+
+	function bar(string $a): void
+	{
+		if ($a === 'FOO' || is_subclass_of($a, 'FOO')) {
+			assertType('class-string<FOO>', $a);
+		}
+	}
+
+	function baz(string $a): void
+	{
+		if ($a === BAZ || is_subclass_of($a, BAZ)) {
+			assertType('class-string<BAZ>', $a);
+		}
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6687

Could very well be that I missed some expression types here or this is actually more complex than I thought :/

Context: Inversion is used in e.g. a `BooleanOr` expression when determining the left and right types. The left types are inversed and used in a filtered scope when determining the right types. This is how PHPStan knows for example that if there is a `is_string($a)` on the left side `$a` cannot be a string anymore on the right side. BUT this does not play nice with constant or scalar expressions like `ClassConstFetch` or `String_` which will have the same type on either side.