### PR TITLE
Do not generalize class-string during template type inference

### DIFF
--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -184,6 +185,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 	public function traverse(callable $cb): Type
 	{
 		return $this;
+	}
+
+	public function generalize(GeneralizePrecision $precision): Type
+	{
+		return new StringType();
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
@@ -180,6 +181,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 	public function traverse(callable $cb): Type
 	{
 		return $this;
+	}
+
+	public function generalize(GeneralizePrecision $precision): Type
+	{
+		return new StringType();
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
@@ -179,6 +180,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 	public function traverse(callable $cb): Type
 	{
 		return $this;
+	}
+
+	public function generalize(GeneralizePrecision $precision): Type
+	{
+		return new StringType();
 	}
 
 	public static function __set_state(array $properties): Type

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
@@ -28,6 +29,7 @@ class HasMethodType implements AccessoryType, CompoundType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct(private string $methodName)

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -11,6 +11,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
@@ -30,6 +31,7 @@ class HasOffsetType implements CompoundType, AccessoryType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct(private Type $offsetType)

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
@@ -23,6 +24,7 @@ class HasPropertyType implements AccessoryType, CompoundType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct(private string $propertyName)

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -10,6 +10,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
@@ -28,6 +29,7 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -18,6 +18,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -36,6 +37,7 @@ class ArrayType implements Type
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	private Type $keyType;
 

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -27,6 +28,7 @@ class BooleanType implements Type
 	use UndecidedComparisonTypeTrait;
 	use NonGenericTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
@@ -34,6 +35,7 @@ class CallableType implements CompoundType, ParametersAcceptor
 	use TruthyBooleanTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @var array<int, ParameterReflection> */
 	private array $parameters;

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -22,6 +22,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
@@ -39,6 +40,7 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 	use UndecidedComparisonTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	private ObjectType $objectType;
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -625,6 +625,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			return $this;
 		}
 
+		if ($precision->isTemplateArgument()) {
+			return $this->traverse(static fn (Type $type) => $type->generalize($precision));
+		}
+
 		$arrayType = new ArrayType(
 			TypeUtils::generalizeType($this->getKeyType(), $precision),
 			TypeUtils::generalizeType($this->getItemType(), $precision),

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -7,6 +7,7 @@ use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -28,6 +29,7 @@ class FloatType implements Type
 	use NonGenericTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/src/Type/GeneralizePrecision.php
+++ b/src/Type/GeneralizePrecision.php
@@ -7,6 +7,7 @@ class GeneralizePrecision
 
 	private const LESS_SPECIFIC = 1;
 	private const MORE_SPECIFIC = 2;
+	private const TEMPLATE_ARGUMENT = 3;
 
 	/** @var self[] */
 	private static array $registry;
@@ -33,9 +34,25 @@ class GeneralizePrecision
 		return self::create(self::MORE_SPECIFIC);
 	}
 
+	/** @api */
+	public static function templateArgument(): self
+	{
+		return self::create(self::TEMPLATE_ARGUMENT);
+	}
+
+	public function isLessSpecific(): bool
+	{
+		return $this->value === self::LESS_SPECIFIC;
+	}
+
 	public function isMoreSpecific(): bool
 	{
 		return $this->value === self::MORE_SPECIFIC;
+	}
+
+	public function isTemplateArgument(): bool
+	{
+		return $this->value === self::TEMPLATE_ARGUMENT;
 	}
 
 }

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -2,11 +2,7 @@
 
 namespace PHPStan\Type\Generic;
 
-use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\ConstantType;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\GeneralizePrecision;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 
@@ -58,25 +54,6 @@ class TemplateTypeHelper
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
 			if ($type instanceof TemplateType) {
 				return $traverse($type->toArgument());
-			}
-
-			return $traverse($type);
-		});
-	}
-
-	public static function generalizeType(Type $type): Type
-	{
-		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
-			if ($type instanceof ConstantType && !$type instanceof ConstantArrayType) {
-				return $type->generalize(GeneralizePrecision::lessSpecific());
-			}
-
-			if ($type->isNonEmptyString()->yes()) {
-				return new StringType();
-			}
-
-			if ($type->isLiteralString()->yes()) {
-				return new StringType();
 			}
 
 			return $traverse($type);

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Generic;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -194,7 +195,7 @@ trait TemplateTypeTrait
 		$resolvedBound = TemplateTypeHelper::resolveTemplateTypes($this->getBound(), $map);
 		if ($resolvedBound->isSuperTypeOf($receivedType)->yes()) {
 			return (new TemplateTypeMap([
-				$this->name => $this->shouldGeneralizeInferredType() ? TemplateTypeHelper::generalizeType($receivedType) : $receivedType,
+				$this->name => $this->shouldGeneralizeInferredType() ? $receivedType->generalize(GeneralizePrecision::templateArgument()) : $receivedType,
 			]))->union($map);
 		}
 

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -6,6 +6,7 @@ use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -25,6 +26,7 @@ class IntegerType implements Type
 	use UndecidedComparisonTypeTrait;
 	use NonGenericTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -22,6 +22,8 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
+use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use function array_map;
 use function count;
 use function implode;
@@ -33,6 +35,9 @@ use function substr;
 /** @api */
 class IntersectionType implements CompoundType
 {
+
+	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @var Type[] */
 	private array $types;

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -12,6 +12,7 @@ use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use Traversable;
@@ -27,6 +28,7 @@ class IterableType implements CompoundType
 	use MaybeOffsetAccessibleTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct(

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -19,6 +19,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use function sprintf;
@@ -29,6 +30,7 @@ class MixedType implements CompoundType, SubtractableType
 
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	private ?Type $subtractedType;
 

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -25,6 +26,7 @@ class NeverType implements CompoundType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct(private bool $isExplicit = false)

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
@@ -29,6 +30,7 @@ class NonexistentParentClassType implements Type
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	public function describe(VerbosityLevel $level): string
 	{

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -33,6 +33,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use Traversable;
@@ -50,6 +51,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	private const EXTRA_OFFSET_CLASSES = ['SimpleXMLElement', 'DOMNodeList', 'Threaded'];
 

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -15,6 +16,7 @@ class ObjectWithoutClassType implements SubtractableType
 	use ObjectTypeTrait;
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	private ?Type $subtractedType;
 

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -26,6 +27,7 @@ class ResourceType implements Type
 	use UndecidedComparisonTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -17,6 +17,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use function array_keys;
@@ -31,6 +32,7 @@ class StaticType implements TypeWithClassName, SubtractableType
 
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	private ?Type $subtractedType;
 

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -13,6 +13,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 
@@ -21,6 +22,7 @@ class StrictMixedType implements CompoundType
 
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	public function getReferencedClasses(): array
 	{

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -26,6 +27,7 @@ class StringType implements Type
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonGenericTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/src/Type/Traits/NonGeneralizableTypeTrait.php
+++ b/src/Type/Traits/NonGeneralizableTypeTrait.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\Type\GeneralizePrecision;
+use PHPStan\Type\Type;
+
+trait NonGeneralizableTypeTrait
+{
+
+	public function generalize(GeneralizePrecision $precision): Type
+	{
+		return $this->traverse(static fn (Type $type) => $type->generalize($precision));
+	}
+
+}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -157,6 +157,8 @@ interface Type
 	 */
 	public function tryRemove(Type $typeToRemove): ?Type;
 
+	public function generalize(GeneralizePrecision $precision): Type;
+
 	/**
 	 * @param mixed[] $properties
 	 */

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -116,13 +116,7 @@ class TypeUtils
 
 	public static function generalizeType(Type $type, GeneralizePrecision $precision): Type
 	{
-		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($precision): Type {
-			if ($type instanceof ConstantType) {
-				return $type->generalize($precision);
-			}
-
-			return $traverse($type);
-		});
+		return $type->generalize($precision);
 	}
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -22,6 +22,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateUnionType;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use function array_map;
 use function count;
 use function implode;
@@ -31,6 +32,8 @@ use function strpos;
 /** @api */
 class UnionType implements CompoundType
 {
+
+	use NonGeneralizableTypeTrait;
 
 	/** @var Type[] */
 	private array $types;

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -24,6 +25,7 @@ class VoidType implements Type
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonRemoveableTypeTrait;
+	use NonGeneralizableTypeTrait;
 
 	/** @api */
 	public function __construct()

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -33,6 +33,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-class-string.php');
 
+		require_once __DIR__ . '/data/generic-generalization.php';
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-generalization.php');
+
 		require_once __DIR__ . '/data/instanceof.php';
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/date.php');

--- a/tests/PHPStan/Analyser/data/generic-generalization.php
+++ b/tests/PHPStan/Analyser/data/generic-generalization.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace PHPStan\Generics\GenericGeneralization;
+
+use function PHPStan\Testing\assertType;
+
+interface I {}
+interface J {}
+
+/**
+ * @template T
+ * @param T $arg
+ * @return T
+ */
+function unbounded($arg)
+{
+	return $arg;
+}
+
+/**
+ * @param class-string $classString
+ * @param class-string<\stdClass> $genericClassString
+ * @param array{foo: 42} $arrayShape
+ * @param numeric-string $numericString
+ * @param non-empty-string $nonEmptyString
+ */
+function testUnbounded(
+	string $classString,
+	string $genericClassString,
+	string $string,
+	array $arrayShape,
+	string $numericString,
+	string $nonEmptyString
+): void {
+	assertType('string', unbounded('hello'));
+	assertType('string', unbounded('stdClass'));
+	assertType('class-string', unbounded($classString));
+	assertType('class-string<stdClass>', unbounded($genericClassString));
+
+	assertType('string', unbounded(rand(0,1) === 1 ? 'hello' : $classString));
+
+	assertType('array{foo: int}', unbounded($arrayShape));
+
+	assertType('string', unbounded($numericString));
+	assertType('string', unbounded($nonEmptyString));
+}
+
+/**
+ * @template T of string
+ * @param T $arg
+ * @return T
+ */
+function boundToString($arg)
+{
+	return $arg;
+}
+
+/**
+ * @param class-string $classString
+ * @param class-string<\stdClass> $genericClassString
+ * @param non-empty-string $nonEmptyString
+ */
+function testBoundToString(
+	string $classString,
+	string $genericClassString,
+	string $nonEmptyString,
+	string $string
+): void {
+	assertType('\'hello\'', boundToString('hello'));
+	assertType('\'stdClass\'', boundToString('stdClass'));
+	assertType('class-string', boundToString($classString));
+	assertType('class-string<stdClass>', boundToString($genericClassString));
+
+	assertType('\'hello\'|class-string', boundToString(rand(0,1) === 1 ? 'hello' : $classString));
+}

--- a/tests/PHPStan/Rules/Api/ApiClassImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Api/ApiClassImplementsRuleTest.php
@@ -32,12 +32,12 @@ class ApiClassImplementsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/class-implements-out-of-phpstan.php'], [
 			[
 				'Implementing PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.',
-				16,
+				17,
 				$tip,
 			],
 			[
 				'Implementing PHPStan\Type\Type is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.',
-				50,
+				51,
 				$tip,
 			],
 		]);

--- a/tests/PHPStan/Rules/Api/data/class-implements-out-of-phpstan.php
+++ b/tests/PHPStan/Rules/Api/data/class-implements-out-of-phpstan.php
@@ -8,6 +8,7 @@ use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionThrowTypeExtension;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\TemplateTypeReference;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Type;
@@ -287,6 +288,11 @@ class Baz implements Type
 	public function traverse(callable $cb): \PHPStan\Type\Type
 	{
 		// TODO: Implement traverse() method.
+	}
+
+	public function generalize(GeneralizePrecision $precision): Type
+	{
+		// TODO: Implement generalize() method.
 	}
 
 	public function tryRemove(Type $typeToRemove): ?Type

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2106,6 +2106,10 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5372.php'], [
 			[
 				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, class-string> given.',
+				68,
+			],
+			[
+				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, class-string> given.',
 				72,
 			],
 			/*[

--- a/tests/PHPStan/Rules/Methods/data/bug-5372.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5372.php
@@ -64,7 +64,7 @@ class Foo
 		$this->takesStrings($newCol);
 
 		$newCol = $col->map(static fn(string $var): string => $classString);
-		assertType('Bug5372\Collection<int, string>', $newCol);
+		assertType('Bug5372\Collection<int, class-string>', $newCol);
 		$this->takesStrings($newCol);
 
 		$newCol = $col->map2(static fn(string $var): string => $classString);


### PR DESCRIPTION
This prevents generalization of `class-string` types during template type inference.

Fixes https://github.com/phpstan/phpstan/issues/6505

Note:

I'm now wondering if we should generalize inferred types at all. Generalization allows expressions such as `new Foo(1)` to be inferred as `Foo<int>` rather than `Foo<1>`, which is useful. However, sometimes we may actually want a `Foo<1>`, and the current behavior makes this impossible.

It could be useful to be able to create a `Foo<non-empty-string>`, a `Foo<numeric-string>`, or a `Foo<int<100,200>>`.

If we stopped generalizing at all, a `new Foo(1)` would infer to `Foo<1>`, and `new Collection([1,2,3])` would infer to `Collection<1|2|3>`, which is less useful in most case, but it gives the control to the user. The user would be able to generalize the type manually, like this:
```
/** @var int[] $elems */
$elems = [1, 2, 3];
new Collection($elems);
```
or like this:
```
/** @param int[] $elems */
function makeCollection($elems) {
    return new Collection($elems);
}
```