### PR TITLE
Support for class-string $class parameter in is_subclass_of()

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -728,6 +728,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6696.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/filter-iterator-child-class.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/smaller-than-benevolent.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6698.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -26,6 +26,7 @@ use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -66,6 +67,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 		$this->scope = $this->scope->assignVariable('foo', new MixedType());
 		$this->scope = $this->scope->assignVariable('classString', new ClassStringType());
 		$this->scope = $this->scope->assignVariable('genericClassString', new GenericClassStringType(new ObjectType('Bar')));
+		$this->scope = $this->scope->assignVariable('object', new ObjectWithoutClassType());
 	}
 
 	/**
@@ -957,12 +959,55 @@ class TypeSpecifierTest extends PHPStanTestCase
 			],
 			[
 				new FuncCall(new Name('is_subclass_of'), [
+					new Arg(new Variable('object')),
+					new Arg(new Variable('stringOrNull')),
+					new Arg(new Expr\ConstFetch(new Name('false'))),
+				]),
+				[
+					'$object' => 'object',
+				],
+				[],
+			],
+			[
+				new FuncCall(new Name('is_subclass_of'), [
 					new Arg(new Variable('string')),
 					new Arg(new Variable('stringOrNull')),
 					new Arg(new Expr\ConstFetch(new Name('false'))),
 				]),
 				[
 					'$string' => 'object',
+				],
+				[],
+			],
+			[
+				new FuncCall(new Name('is_subclass_of'), [
+					new Arg(new Variable('string')),
+					new Arg(new Variable('genericClassString')),
+				]),
+				[
+					'$string' => 'Bar|class-string<Bar>',
+				],
+				[],
+			],
+			[
+				new FuncCall(new Name('is_subclass_of'), [
+					new Arg(new Variable('object')),
+					new Arg(new Variable('genericClassString')),
+					new Arg(new Expr\ConstFetch(new Name('false'))),
+				]),
+				[
+					'$object' => 'Bar',
+				],
+				[],
+			],
+			[
+				new FuncCall(new Name('is_subclass_of'), [
+					new Arg(new Variable('string')),
+					new Arg(new Variable('genericClassString')),
+					new Arg(new Expr\ConstFetch(new Name('false'))),
+				]),
+				[
+					'$string' => 'Bar',
 				],
 				[],
 			],

--- a/tests/PHPStan/Analyser/data/bug-6698.php
+++ b/tests/PHPStan/Analyser/data/bug-6698.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Analyzer\Bug6698;
+
+use function PHPStan\Testing\assertType;
+
+interface X {
+	/**
+	 * @return iterable<class-string>
+	 */
+	public function getClasses(): iterable;
+}
+
+class Y
+{
+	/** @var X */
+	public $x;
+
+	/**
+	 * @template T of object
+	 *
+	 * @param class-string<T> $type
+	 * @return iterable<class-string<T>>
+	 */
+	public function findImplementations(string $type): iterable
+	{
+		 foreach ($this->x->getClasses() as $class) {
+			if (is_subclass_of($class, $type)) {
+				assertType('class-string<T of object (method Analyzer\Bug6698\Y::findImplementations(), argument)>', $class);
+				yield $class;
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/generic-class-string.php
+++ b/tests/PHPStan/Analyser/data/generic-class-string.php
@@ -20,15 +20,22 @@ function testMixed($a) {
 	if (is_subclass_of($a, 'DateTimeInterface')) {
 		assertType('class-string<DateTimeInterface>|DateTimeInterface', $a);
 		assertType('DateTimeInterface', new $a());
+	} else {
+		assertType('mixed~class-string<DateTimeInterface>|DateTimeInterface', $a);
 	}
 
 	if (is_subclass_of($a, 'DateTimeInterface') || is_subclass_of($a, 'stdClass')) {
 		assertType('class-string<DateTimeInterface>|class-string<stdClass>|DateTimeInterface|stdClass', $a);
 		assertType('DateTimeInterface|stdClass', new $a());
+	} else {
+		// could also exclude stdClass
+		assertType('mixed~class-string<DateTimeInterface>|DateTimeInterface', $a);
 	}
 
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
+	} else {
+		assertType('mixed~class-string<PHPStan\Generics\GenericClassStringType\C>|PHPStan\Generics\GenericClassStringType\C', $a);
 	}
 }
 
@@ -40,6 +47,8 @@ function testObject($a) {
 
 	if (is_subclass_of($a, 'DateTimeInterface')) {
 		assertType('DateTimeInterface', $a);
+	} else {
+		assertType('object~DateTimeInterface', $a);
 	}
 }
 
@@ -52,10 +61,14 @@ function testString($a) {
 	if (is_subclass_of($a, 'DateTimeInterface')) {
 		assertType('class-string<DateTimeInterface>', $a);
 		assertType('DateTimeInterface', new $a());
+	} else {
+		assertType('string', $a);
 	}
 
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
+	} else {
+		assertType('string', $a);
 	}
 }
 
@@ -68,10 +81,14 @@ function testStringObject($a) {
 	if (is_subclass_of($a, 'DateTimeInterface')) {
 		assertType('class-string<DateTimeInterface>|DateTimeInterface', $a);
 		assertType('DateTimeInterface', new $a());
+	} else {
+		assertType('object~DateTimeInterface|string', $a);
 	}
 
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
+	} else {
+		assertType('object~PHPStan\Generics\GenericClassStringType\C|string', $a);
 	}
 }
 
@@ -84,6 +101,29 @@ function testClassString($a) {
 	if (is_subclass_of($a, 'DateTime')) {
 		assertType('class-string<DateTime>', $a);
 		assertType('DateTime', new $a());
+	} else {
+		assertType('class-string<DateTimeInterface>', $a);
+	}
+}
+
+/**
+ * @param object|string $a
+ * @param class-string<\DateTimeInterface> $b
+ */
+function testClassStringAsClassName($a, string $b) {
+	assertType('object', new $a());
+
+	if (is_subclass_of($a, $b)) {
+		assertType('class-string<DateTimeInterface>|DateTimeInterface', $a);
+		assertType('DateTimeInterface', new $a());
+	} else {
+		assertType('object|string', $a);
+	}
+
+	if (is_subclass_of($a, $b, false)) {
+		assertType('DateTimeInterface', $a);
+	} else {
+		assertType('object|string', $a);
 	}
 }
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -448,4 +448,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3766.php'], []);
 	}
 
+	public function testBug6698(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-6698.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-6698.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6698.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Comparison\Bug6698;
+
+interface X {
+	/**
+	 * @return iterable<class-string>
+	 */
+	public function getClasses(): iterable;
+}
+
+class Y
+{
+	/** @var X */
+	public $x;
+
+	/**
+	 * @template T of object
+	 *
+	 * @param class-string<T> $type
+	 * @return iterable<class-string<T>>
+	 */
+	public function findImplementations(string $type): iterable
+	{
+		 foreach ($this->x->getClasses() as $class) {
+			if (is_subclass_of($class, $type)) {
+				yield $class;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds support for $class parameter of type class-string in is_subclass_of().

I tried to unify the logic for the cases when $class is a constant string, a class string, or something else.

I also tried to narrow the specified type when we know that the $object parameter is either a string or an object. For example if the parameter is a string, it will no longer be specified as class-string|object.

There is one caveat: the type specifier extension may now specify the $object parameter as `*NEVER*` in some impossible cases. Is this acceptable ?

This fixes phpstan/phpstan#6698