### PR TITLE
Specify isA class-string types for falsey context

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1439,6 +1439,9 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
+		class: PHPStan\Type\Php\IsAFunctionTypeSpecifyingHelper
+
+	-
 		class: PHPStan\Type\Php\ArrayIsListFunctionTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension

--- a/src/Type/Php/IsAFunctionTypeSpecifyingHelper.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingHelper.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\Type\ClassStringType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\UnionType;
+
+final class IsAFunctionTypeSpecifyingHelper
+{
+
+	public function determineType(
+		Type $classType,
+		bool $allowString,
+	): Type
+	{
+		return TypeTraverser::map(
+			$classType,
+			static function (Type $type, callable $traverse) use ($allowString): Type {
+				if ($type instanceof UnionType || $type instanceof IntersectionType) {
+					return $traverse($type);
+				}
+				if ($type instanceof ConstantStringType) {
+					if ($allowString) {
+						return TypeCombinator::union(
+							new ObjectType($type->getValue()),
+							new GenericClassStringType(new ObjectType($type->getValue())),
+						);
+					}
+
+					return new ObjectType($type->getValue());
+				}
+				if ($type instanceof GenericClassStringType) {
+					if ($allowString) {
+						return TypeCombinator::union(
+							$type->getGenericType(),
+							$type,
+						);
+					}
+
+					return $type->getGenericType();
+				}
+				if ($allowString) {
+					return TypeCombinator::union(
+						new ObjectWithoutClassType(),
+						new ClassStringType(),
+					);
+				}
+
+				return new ObjectWithoutClassType();
+			},
+		);
+	}
+
+}

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -9,18 +9,9 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
-use PHPStan\Type\Generic\GenericClassStringType;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeTraverser;
-use PHPStan\Type\UnionType;
 use function count;
 use function strtolower;
 
@@ -28,6 +19,12 @@ class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeSpecify
 {
 
 	private TypeSpecifier $typeSpecifier;
+
+	public function __construct(
+		private IsAFunctionTypeSpecifyingHelper $isAFunctionTypeSpecifyingHelper,
+	)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
@@ -48,40 +45,9 @@ class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeSpecify
 			return new SpecifiedTypes([], []);
 		}
 
-		$type = TypeTraverser::map($classType, static function (Type $type, callable $traverse) use ($allowString): Type {
-			if ($type instanceof UnionType || $type instanceof IntersectionType) {
-				return $traverse($type);
-			}
-			if ($type instanceof ConstantStringType) {
-				if ($allowString) {
-					return TypeCombinator::union(
-						new ObjectType($type->getValue()),
-						new GenericClassStringType(new ObjectType($type->getValue())),
-					);
-				}
-				return new ObjectType($type->getValue());
-			}
-			if ($type instanceof GenericClassStringType) {
-				if ($allowString) {
-					return TypeCombinator::union(
-						$type->getGenericType(),
-						$type,
-					);
-				}
-				return $type->getGenericType();
-			}
-			if ($allowString) {
-				return TypeCombinator::union(
-					new ObjectWithoutClassType(),
-					new ClassStringType(),
-				);
-			}
-			return new ObjectWithoutClassType();
-		});
-
 		return $this->typeSpecifier->create(
 			$node->getArgs()[0]->value,
-			$type,
+			$this->isAFunctionTypeSpecifyingHelper->determineType($classType, $allowString),
 			$context,
 			false,
 			$scope,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -726,6 +726,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/countable.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6696.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6704.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/filter-iterator-child-class.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/smaller-than-benevolent.php');
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -445,7 +445,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					)),
 				]),
 				['$foo' => 'static(DateTime)'],
-				['$foo' => '~static(DateTime)'],
+				[],
 			],
 			[
 				new FuncCall(new Name('is_a'), [
@@ -461,7 +461,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Variable('genericClassString')),
 				]),
 				['$foo' => 'Bar'],
-				['$foo' => '~Bar'],
+				[],
 			],
 			[
 				new FuncCall(new Name('is_a'), [
@@ -470,7 +470,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Expr\ConstFetch(new Name('true'))),
 				]),
 				['$foo' => 'class-string<Foo>|Foo'],
-				['$foo' => '~Foo'],
+				['$foo' => '~class-string<Foo>|Foo'],
 			],
 			[
 				new FuncCall(new Name('is_a'), [
@@ -478,7 +478,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Variable('className')),
 					new Arg(new Expr\ConstFetch(new Name('true'))),
 				]),
-				['$foo' => 'class-string<object>|object'],
+				['$foo' => 'class-string|object'],
 				[],
 			],
 			[
@@ -488,7 +488,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Variable('unknown')),
 				]),
 				['$foo' => 'class-string<Foo>|Foo'],
-				['$foo' => '~Foo'],
+				['$foo' => '~class-string<Foo>|Foo'],
 			],
 			[
 				new FuncCall(new Name('is_a'), [
@@ -496,7 +496,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Variable('className')),
 					new Arg(new Variable('unknown')),
 				]),
-				['$foo' => 'class-string<object>|object'],
+				['$foo' => 'class-string|object'],
 				[],
 			],
 			[

--- a/tests/PHPStan/Analyser/data/bug-6704.php
+++ b/tests/PHPStan/Analyser/data/bug-6704.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6704;
+
+use DateTimeImmutable;
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param class-string<DateTimeImmutable>|class-string<stdClass> $a
+ * @param DateTimeImmutable|stdClass $b
+ */
+function foo(string $a, object $b): void
+{
+	if (!is_a($a, stdClass::class, true)) {
+		assertType('class-string<DateTimeImmutable>', $a);
+	}
+
+	if (!is_a($b, stdClass::class)) {
+		assertType('DateTimeImmutable', $b);
+	}
+}

--- a/tests/PHPStan/Analyser/data/is-a.php
+++ b/tests/PHPStan/Analyser/data/is-a.php
@@ -23,6 +23,6 @@ function (string $foo) {
 
 function (string $foo, string $someString) {
 	if (is_a($foo, $someString, true)) {
-		\PHPStan\Testing\assertType('class-string<object>', $foo);
+		\PHPStan\Testing\assertType('class-string', $foo);
 	}
 };


### PR DESCRIPTION
The title is misleading already, sorry. Should be more like "Extract type determination logic from is_subclass_of and use it in is_a" :)

Closes https://github.com/phpstan/phpstan/issues/6704

While I initially was working on another solution, the changes in https://github.com/phpstan/phpstan-src/pull/1039 were finished and I could just completely take them over here. Thank you @arnaud-lb!

`is_a` and `is_subclass_of` seem to be having only 2 differences
- `is_a` has `$allow_string` `false` by default, while `is_subclass_of` has it `true` by default. See https://www.php.net/manual/en/function.is-a.php and https://www.php.net/manual/en/function.is-subclass-of.php
- `is_a` also returns `true` if the object is of the class to check, while `is_subclass_of` doesn't

Because there is still https://github.com/phpstan/phpstan/issues/6305 open, the second one is fine here. For the first one I just changed the default when taking over the changes.