### PR TITLE
Add StaticTypeFactory to the public API

### DIFF
--- a/src/Type/StaticTypeFactory.php
+++ b/src/Type/StaticTypeFactory.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 
+/** @api */
 class StaticTypeFactory
 {
 


### PR DESCRIPTION
This change would allow extensions to safely check against truthy and falsey types. AFAIK PHPStan currently does not provide any other way to do this, officially. Additionally, this code seems to not change very often as it has remained unchanged since October 2020.