### PR TITLE
Add support for integer ranges in strtotime() with constant strings

### DIFF
--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5250,26 +5250,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$microtimeBenevolent',
 			],
 			[
-				'int',
-				'$strtotimeNow',
-			],
-			[
-				'false',
-				'$strtotimeInvalid',
-			],
-			[
-				'int|false',
-				'$strtotimeUnknown',
-			],
-			[
-				'(int|false)',
-				'$strtotimeUnknown2',
-			],
-			[
-				'int|false',
-				'$strtotimeCrash',
-			],
-			[
 				'-1',
 				'$versionCompare1',
 			],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -45,6 +45,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_INT_SIZE === 8) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/random-int.php');
 		}
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/strtotime-return-type-extensions.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-return-type-extensions.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-key.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/intersection-static.php');

--- a/tests/PHPStan/Analyser/data/functions.php
+++ b/tests/PHPStan/Analyser/data/functions.php
@@ -6,12 +6,6 @@ $microtimeFloat = microtime(true);
 $microtimeDefault = microtime(null);
 $microtimeBenevolent = microtime($undefined);
 
-$strtotimeNow = strtotime('now');
-$strtotimeInvalid = strtotime('4 qm');
-$strtotimeUnknown = strtotime(doFoo() ? 'now': '4 qm');
-$strtotimeUnknown2 = strtotime($undefined);
-$strtotimeCrash = strtotime();
-
 $versionCompare1 = version_compare('7.0.0', '7.0.1');
 $versionCompare2 = version_compare('7.0.0', doFoo() ? '7.0.1' : '6.0.0');
 $versionCompare3 = version_compare(doFoo() ? '7.0.0' : '6.0.5', doBar() ? '7.0.1' : '6.0.0');

--- a/tests/PHPStan/Analyser/data/strtotime-return-type-extensions.php
+++ b/tests/PHPStan/Analyser/data/strtotime-return-type-extensions.php
@@ -4,8 +4,8 @@ namespace ClosureReturnTypeExtensionsNamespace;
 
 use function PHPStan\Testing\assertType;
 
-$strtotimeNow = strtotime('2022-03-03 12:00:00 UTC');
-assertType('int<1646308801, max>', $strtotimeNow);
+$strtotimeNow = strtotime('now');
+assertType('int<1, max>', $strtotimeNow);
 
 $strtotimeInvalid = strtotime('4 qm');
 assertType('false', $strtotimeInvalid);
@@ -20,10 +20,10 @@ $strtotimeCrash = strtotime();
 assertType('int|false', $strtotimeCrash);
 
 $strtotimeWithBase = strtotime('+2 days', time());
-assertType('int|false', $strtotimeWithBase);
+assertType('int', $strtotimeWithBase);
 
 $strtotimePositiveInt = strtotime('1990-01-01 12:00:00 UTC');
-assertType('int<631195201, max>', $strtotimePositiveInt);
+assertType('int<1, max>', $strtotimePositiveInt);
 
 $strtotimeNegativeInt = strtotime('1969-12-31 12:00:00 UTC');
-assertType('int<-43199, max>', $strtotimeNegativeInt);
+assertType('int', $strtotimeNegativeInt);

--- a/tests/PHPStan/Analyser/data/strtotime-return-type-extensions.php
+++ b/tests/PHPStan/Analyser/data/strtotime-return-type-extensions.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ClosureReturnTypeExtensionsNamespace;
+
+use function PHPStan\Testing\assertType;
+
+$strtotimeNow = strtotime('2022-03-03 12:00:00 UTC');
+assertType('int<1646308801, max>', $strtotimeNow);
+
+$strtotimeInvalid = strtotime('4 qm');
+assertType('false', $strtotimeInvalid);
+
+$strtotimeUnknown = strtotime(rand(0, 1) === 0 ? 'now': '4 qm');
+assertType('int|false', $strtotimeUnknown);
+
+$strtotimeUnknown2 = strtotime($undefined);
+assertType('(int|false)', $strtotimeUnknown2);
+
+$strtotimeCrash = strtotime();
+assertType('int|false', $strtotimeCrash);
+
+$strtotimeWithBase = strtotime('+2 days', time());
+assertType('int|false', $strtotimeWithBase);
+
+$strtotimePositiveInt = strtotime('1990-01-01 12:00:00 UTC');
+assertType('int<631195201, max>', $strtotimePositiveInt);
+
+$strtotimeNegativeInt = strtotime('1969-12-31 12:00:00 UTC');
+assertType('int<-43199, max>', $strtotimeNegativeInt);


### PR DESCRIPTION
I migrated the existing tests from legacy tests, I hope this makes sense.

I am trying to pass strtotime() to a `positive-int` param and figured this should just work :)

The ranges are always `int<$oldestResolvedTime, max>` as time flows forward, the result may increase but should not decrease.