### PR TITLE
Retain left and right types in equal expression

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -317,6 +317,9 @@ class TypeSpecifier
 				if ($types !== null) {
 					return $types;
 				}
+
+				return $this->create($expr->left, $exprLeftType, $context, false, $scope)->normalize($scope)
+					->intersectWith($this->create($expr->right, $exprRightType, $context, false, $scope)->normalize($scope));
 			}
 
 		} elseif ($expr instanceof Node\Expr\BinaryOp\NotIdentical) {
@@ -437,7 +440,10 @@ class TypeSpecifier
 
 			$leftTypes = $this->create($expr->left, $leftType, $context, false, $scope);
 			$rightTypes = $this->create($expr->right, $rightType, $context, false, $scope);
-			return $context->true() ? $leftTypes->unionWith($rightTypes) : $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($scope));
+
+			return $context->true()
+				? $leftTypes->unionWith($rightTypes)
+				: $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($scope));
 		} elseif ($expr instanceof Node\Expr\BinaryOp\NotEqual) {
 			return $this->specifyTypesInCondition(
 				$scope,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -434,6 +434,10 @@ class TypeSpecifier
 			) {
 				return $this->specifyTypesInCondition($scope, new Expr\BinaryOp\Identical($expr->left, $expr->right), $context);
 			}
+
+			$leftTypes = $this->create($expr->left, $leftType, $context, false, $scope);
+			$rightTypes = $this->create($expr->right, $rightType, $context, false, $scope);
+			return $context->true() ? $leftTypes->unionWith($rightTypes) : $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($scope));
 		} elseif ($expr instanceof Node\Expr\BinaryOp\NotEqual) {
 			return $this->specifyTypesInCondition(
 				$scope,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -649,6 +649,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/weird-array_key_exists-issue.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/equal.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/identical.php');
 
 		if (PHP_VERSION_ID >= 80000) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5698-php8.php');

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -22,7 +22,9 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
@@ -68,6 +70,8 @@ class TypeSpecifierTest extends PHPStanTestCase
 		$this->scope = $this->scope->assignVariable('classString', new ClassStringType());
 		$this->scope = $this->scope->assignVariable('genericClassString', new GenericClassStringType(new ObjectType('Bar')));
 		$this->scope = $this->scope->assignVariable('object', new ObjectWithoutClassType());
+		$this->scope = $this->scope->assignVariable('int', new IntegerType());
+		$this->scope = $this->scope->assignVariable('float', new FloatType());
 	}
 
 	/**
@@ -1119,6 +1123,34 @@ class TypeSpecifierTest extends PHPStanTestCase
 				[
 					'$foo' => 'mixed~non-empty-string',
 				],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_numeric', 'int'),
+					new Expr\BinaryOp\Equal(
+						new Variable('int'),
+						new Expr\Cast\Int_(new Variable('int')),
+					),
+				),
+				[
+					'$int' => 'int',
+					'(int) $int' => 'int',
+				],
+				[],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_numeric', 'float'),
+					new Expr\BinaryOp\Equal(
+						new Variable('float'),
+						new Expr\Cast\Int_(new Variable('float')),
+					),
+				),
+				[
+					'$float' => 'float',
+					'(int) $float' => 'int',
+				],
+				[],
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/data/equal.php
+++ b/tests/PHPStan/Analyser/data/equal.php
@@ -65,4 +65,26 @@ class Foo
 		assertType('array', $a);
 	}
 
+	public function stdClass(\stdClass $a, \stdClass $b): void
+	{
+		if ($a == $b) {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		} else {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		}
+
+		if ($a != $b) {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		} else {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		}
+
+		assertType('stdClass', $a);
+		assertType('stdClass', $b);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/equal.php
+++ b/tests/PHPStan/Analyser/data/equal.php
@@ -67,6 +67,18 @@ class Foo
 
 	public function stdClass(\stdClass $a, \stdClass $b): void
 	{
+		if ($a == $a) {
+			assertType('stdClass', $a);
+		} else {
+			assertType('*NEVER*', $a);
+		}
+
+		if ($b != $b) {
+			assertType('*NEVER*', $b);
+		} else {
+			assertType('stdClass', $b);
+		}
+
 		if ($a == $b) {
 			assertType('stdClass', $a);
 			assertType('stdClass', $b);

--- a/tests/PHPStan/Analyser/data/identical.php
+++ b/tests/PHPStan/Analyser/data/identical.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace TypeSpecifierIdentical;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function foo(\stdClass $a, \stdClass $b): void
+	{
+		if ($a === $a) {
+			assertType('stdClass', $a);
+		} else {
+			assertType('*NEVER*', $a);
+		}
+
+		if ($b !== $b) {
+			assertType('*NEVER*', $b);
+		} else {
+			assertType('stdClass', $b);
+		}
+
+		assertType('stdClass', $a);
+		assertType('stdClass', $b);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/identical.php
+++ b/tests/PHPStan/Analyser/data/identical.php
@@ -21,6 +21,22 @@ class Foo
 			assertType('stdClass', $b);
 		}
 
+		if ($a === $b) {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		} else {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		}
+
+		if ($a !== $b) {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		} else {
+			assertType('stdClass', $a);
+			assertType('stdClass', $b);
+		}
+
 		assertType('stdClass', $a);
 		assertType('stdClass', $b);
 	}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -72,6 +72,14 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isSame() with stdClass and stdClass will always evaluate to true.',
 				78,
 			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with stdClass and stdClass will always evaluate to false.',
+				81,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with *NEVER* and stdClass will always evaluate to false.',
+				84,
+			],
 		]);
 	}
 


### PR DESCRIPTION
This is not really changing much.. It's an adaption very similar to https://github.com/phpstan/phpstan-src/pull/1021

`Equal` expressions are, among other things, converted to `Identical` expressions if possible for the left and right types. If not, then no types at all are specified. This change modifies that, so that at least the left and right types are retained.

The first new test case was already working (because `$int == (int) $int`) is safe to be converted to an Identical expression. The second new test case is affected by this change, previously no types at all were specified. I'm mostly doing this so that we have more type information and strict impossible checks, as reported in e.g. https://github.com/phpstan/phpstan-webmozart-assert/issues/32, do not fail 