### PR TITLE
Fix IntegerRange-FloatType subtype detection

### DIFF
--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -233,7 +233,7 @@ class IntegerRangeType extends IntegerType implements CompoundType
 			return TrinaryLogic::createMaybe();
 		}
 
-		if ($type instanceof parent) {
+		if ($type instanceof parent || $type instanceof FloatType) {
 			return TrinaryLogic::createMaybe();
 		}
 

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -159,10 +159,6 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 					426,
 				],
 				[
-					'Strict comparison using === between (int<min, 0>|int<2, max>|string) and 1.0 will always evaluate to false.',
-					464,
-				],
-				[
 					'Strict comparison using === between (int<min, 0>|int<2, max>|string) and stdClass will always evaluate to false.',
 					466,
 				],
@@ -331,10 +327,6 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 				[
 					'Strict comparison using !== between null and null will always evaluate to false.',
 					408,
-				],
-				[
-					'Strict comparison using === between (int<min, 0>|int<2, max>|string) and 1.0 will always evaluate to false.',
-					464,
 				],
 				[
 					'Strict comparison using === between (int<min, 0>|int<2, max>|string) and stdClass will always evaluate to false.',


### PR DESCRIPTION
Still not sure about the strict comparison of IntegerRange and Float unfortunately. That should stay false I guess argh

Inspired by https://github.com/phpstan/phpstan-webmozart-assert/pull/120