### PR TITLE
Add failing test cases

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -167,10 +167,6 @@ class TypeSpecifier
 				return $this->create($exprNode, new ObjectWithoutClassType(), $context, false, $scope);
 			}
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Identical) {
-			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
-				return new SpecifiedTypes();
-			}
-
 			$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);
 			if ($expressions !== null) {
 				/** @var Expr $exprNode */
@@ -263,6 +259,12 @@ class TypeSpecifier
 				);
 			}
 
+			$exprLeftType = $scope->getType($expr->left);
+			$exprRightType = $scope->getType($expr->right);
+			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike && !$exprLeftType instanceof ConstantType && !$exprRightType instanceof ConstantType) {
+				return new SpecifiedTypes();
+			}
+
 			if ($context->true()) {
 				$type = TypeCombinator::intersect($scope->getType($expr->right), $scope->getType($expr->left));
 				$leftTypes = $this->create($expr->left, $type, $context, false, $scope);
@@ -278,9 +280,6 @@ class TypeSpecifier
 					$rightTypes = $this->create($expr->right, $never, $contextForTypes, false, $scope);
 					return $leftTypes->unionWith($rightTypes);
 				}
-
-				$exprLeftType = $scope->getType($expr->left);
-				$exprRightType = $scope->getType($expr->right);
 
 				$types = null;
 
@@ -333,10 +332,6 @@ class TypeSpecifier
 				$context,
 			);
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Equal) {
-			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
-				return new SpecifiedTypes();
-			}
-
 			$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);
 			if ($expressions !== null) {
 				/** @var Expr $exprNode */
@@ -362,6 +357,9 @@ class TypeSpecifier
 
 			$leftType = $scope->getType($expr->left);
 			$rightType = $scope->getType($expr->right);
+			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike && !$leftType instanceof ConstantType && !$rightType instanceof ConstantType) {
+				return new SpecifiedTypes();
+			}
 
 			$leftBooleanType = $leftType->toBoolean();
 			if ($leftBooleanType instanceof ConstantBooleanType && $rightType instanceof BooleanType) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -259,12 +259,6 @@ class TypeSpecifier
 				);
 			}
 
-			$exprLeftType = $scope->getType($expr->left);
-			$exprRightType = $scope->getType($expr->right);
-			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike && !$exprLeftType instanceof ConstantType && !$exprRightType instanceof ConstantType) {
-				return new SpecifiedTypes();
-			}
-
 			if ($context->true()) {
 				$type = TypeCombinator::intersect($scope->getType($expr->right), $scope->getType($expr->left));
 				$leftTypes = $this->create($expr->left, $type, $context, false, $scope);
@@ -280,6 +274,9 @@ class TypeSpecifier
 					$rightTypes = $this->create($expr->right, $never, $contextForTypes, false, $scope);
 					return $leftTypes->unionWith($rightTypes);
 				}
+
+				$exprLeftType = $scope->getType($expr->left);
+				$exprRightType = $scope->getType($expr->right);
 
 				$types = null;
 
@@ -321,8 +318,10 @@ class TypeSpecifier
 					return $types;
 				}
 
-				return $this->create($expr->left, $exprLeftType, $context, false, $scope)->normalize($scope)
-					->intersectWith($this->create($expr->right, $exprRightType, $context, false, $scope)->normalize($scope));
+				if ($expr->left instanceof Expr\Variable && $expr->right instanceof Expr\Variable) {
+					return $this->create($expr->left, $exprLeftType, $context, false, $scope)->normalize($scope)
+						->intersectWith($this->create($expr->right, $exprRightType, $context, false, $scope)->normalize($scope));
+				}
 			}
 
 		} elseif ($expr instanceof Node\Expr\BinaryOp\NotIdentical) {
@@ -357,9 +356,6 @@ class TypeSpecifier
 
 			$leftType = $scope->getType($expr->left);
 			$rightType = $scope->getType($expr->right);
-			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike && !$leftType instanceof ConstantType && !$rightType instanceof ConstantType) {
-				return new SpecifiedTypes();
-			}
 
 			$leftBooleanType = $leftType->toBoolean();
 			if ($leftBooleanType instanceof ConstantBooleanType && $rightType instanceof BooleanType) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -167,6 +167,10 @@ class TypeSpecifier
 				return $this->create($exprNode, new ObjectWithoutClassType(), $context, false, $scope);
 			}
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Identical) {
+			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
+				return new SpecifiedTypes([], []);
+			}
+
 			$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);
 			if ($expressions !== null) {
 				/** @var Expr $exprNode */
@@ -259,10 +263,6 @@ class TypeSpecifier
 				);
 			}
 
-			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
-				return new SpecifiedTypes([], []);
-			}
-
 			if ($context->true()) {
 				$type = TypeCombinator::intersect($scope->getType($expr->right), $scope->getType($expr->left));
 				$leftTypes = $this->create($expr->left, $type, $context, false, $scope);
@@ -333,6 +333,10 @@ class TypeSpecifier
 				$context,
 			);
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Equal) {
+			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
+				return new SpecifiedTypes([], []);
+			}
+
 			$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);
 			if ($expressions !== null) {
 				/** @var Expr $exprNode */
@@ -358,10 +362,6 @@ class TypeSpecifier
 
 			$leftType = $scope->getType($expr->left);
 			$rightType = $scope->getType($expr->right);
-
-			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
-				return new SpecifiedTypes([], []);
-			}
 
 			$leftBooleanType = $leftType->toBoolean();
 			if ($leftBooleanType instanceof ConstantBooleanType && $rightType instanceof BooleanType) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -262,6 +262,15 @@ class TypeSpecifier
 			$exprLeftType = $scope->getType($expr->left);
 			$exprRightType = $scope->getType($expr->right);
 
+			$identicalType = $scope->getType($expr);
+			if ($identicalType instanceof ConstantBooleanType && !$context->null()) {
+				$never = new NeverType();
+				$contextForTypes = $identicalType->getValue() ? $context->negate() : $context;
+				$leftTypes = $this->create($expr->left, $never, $contextForTypes, false, $scope);
+				$rightTypes = $this->create($expr->right, $never, $contextForTypes, false, $scope);
+				return $leftTypes->unionWith($rightTypes);
+			}
+
 			$types = null;
 
 			if (
@@ -300,15 +309,6 @@ class TypeSpecifier
 
 			if ($types !== null) {
 				return $types;
-			}
-
-			$identicalType = $scope->getType($expr);
-			if ($identicalType instanceof ConstantBooleanType && !$context->null()) {
-				$never = new NeverType();
-				$contextForTypes = $identicalType->getValue() ? $context->negate() : $context;
-				$leftTypes = $this->create($expr->left, $never, $contextForTypes, false, $scope);
-				$rightTypes = $this->create($expr->right, $never, $contextForTypes, false, $scope);
-				return $leftTypes->unionWith($rightTypes);
 			}
 
 			if ($expr->left instanceof Expr\Variable || $expr->right instanceof Expr\Variable) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -168,7 +168,7 @@ class TypeSpecifier
 			}
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Identical) {
 			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
-				return new SpecifiedTypes([], []);
+				return new SpecifiedTypes();
 			}
 
 			$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);
@@ -334,7 +334,7 @@ class TypeSpecifier
 			);
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Equal) {
 			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
-				return new SpecifiedTypes([], []);
+				return new SpecifiedTypes();
 			}
 
 			$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -259,6 +259,10 @@ class TypeSpecifier
 				);
 			}
 
+			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
+				return new SpecifiedTypes([], []);
+			}
+
 			if ($context->true()) {
 				$type = TypeCombinator::intersect($scope->getType($expr->right), $scope->getType($expr->left));
 				$leftTypes = $this->create($expr->left, $type, $context, false, $scope);
@@ -354,6 +358,10 @@ class TypeSpecifier
 
 			$leftType = $scope->getType($expr->left);
 			$rightType = $scope->getType($expr->right);
+
+			if ($expr->left instanceof Expr\CallLike && $expr->right instanceof Expr\CallLike) {
+				return new SpecifiedTypes([], []);
+			}
 
 			$leftBooleanType = $leftType->toBoolean();
 			if ($leftBooleanType instanceof ConstantBooleanType && $rightType instanceof BooleanType) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -311,13 +311,17 @@ class TypeSpecifier
 				return $types;
 			}
 
-			$furtherSpecificationPossible = static function (Expr $expr): bool {
+			$furtherSpecificationPossible = static function (Expr $expr) use (&$furtherSpecificationPossible): bool {
 				if ($expr instanceof Expr\Variable) {
 					return true;
 				}
 
-				if ($expr instanceof ArrayDimFetch && $expr->var instanceof Expr\Variable) {
-					return true;
+				if ($expr instanceof Expr\Cast) {
+					return $furtherSpecificationPossible($expr->expr);
+				}
+
+				if ($expr instanceof ArrayDimFetch) {
+					return $furtherSpecificationPossible($expr->var);
 				}
 
 				return false;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -316,10 +316,6 @@ class TypeSpecifier
 					return true;
 				}
 
-				if ($expr instanceof Expr\Cast) {
-					return $furtherSpecificationPossible($expr->expr);
-				}
-
 				if ($expr instanceof ArrayDimFetch) {
 					return $furtherSpecificationPossible($expr->var);
 				}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -303,7 +303,7 @@ class TypeSpecifier
 			}
 
 			$identicalType = $scope->getType($expr);
-			if ($identicalType instanceof ConstantBooleanType && $context->false()) {
+			if ($identicalType instanceof ConstantBooleanType && !$context->null()) {
 				$never = new NeverType();
 				$contextForTypes = $identicalType->getValue() ? $context->negate() : $context;
 				$leftTypes = $this->create($expr->left, $never, $contextForTypes, false, $scope);
@@ -311,16 +311,12 @@ class TypeSpecifier
 				return $leftTypes->unionWith($rightTypes);
 			}
 
-			if (
-				$expr->left instanceof Expr\Variable || $expr->right instanceof Expr\Variable
-				|| $expr->left instanceof Node\Scalar || $expr->right instanceof Node\Scalar
-			) {
+			if ($expr->left instanceof Expr\Variable || $expr->right instanceof Expr\Variable) {
 				if ($context->true()) {
 					$type = TypeCombinator::intersect($scope->getType($expr->right), $scope->getType($expr->left));
 					$leftTypes = $this->create($expr->left, $type, $context, false, $scope);
 					$rightTypes = $this->create($expr->right, $type, $context, false, $scope);
 					return $leftTypes->unionWith($rightTypes);
-
 				}
 
 				return $this->create($expr->left, $leftType, $context, false, $scope)->normalize($scope)
@@ -445,10 +441,7 @@ class TypeSpecifier
 			$leftTypes = $this->create($expr->left, $leftType, $context, false, $scope);
 			$rightTypes = $this->create($expr->right, $rightType, $context, false, $scope);
 
-			if (
-				$expr->left instanceof Expr\Variable || $expr->right instanceof Expr\Variable
-				|| $expr->left instanceof Node\Scalar || $expr->right instanceof Node\Scalar
-			) {
+			if ($expr->left instanceof Expr\Variable || $expr->right instanceof Expr\Variable) {
 				return $context->true()
 					? $leftTypes->unionWith($rightTypes)
 					: $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($scope));

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -554,7 +554,6 @@ class TypeSpecifierTest extends PHPStanTestCase
 				),
 				[
 					'$foo' => '123',
-					123 => '123',
 				],
 				['$foo' => '~123'],
 			],

--- a/tests/PHPStan/Analyser/data/equal.php
+++ b/tests/PHPStan/Analyser/data/equal.php
@@ -99,4 +99,14 @@ class Foo
 		assertType('stdClass', $b);
 	}
 
+	/**
+	 * @param array{a: string, b: array{c: string|null}} $a
+	 */
+	public function arrayOffset(array $a): void
+	{
+		if (strlen($a['a']) > 0 && $a['a'] === $a['b']['c']) {
+			assertType('array{a: non-empty-string, b: array{c: non-empty-string}}', $a);
+		}
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/identical.php
+++ b/tests/PHPStan/Analyser/data/identical.php
@@ -41,4 +41,14 @@ class Foo
 		assertType('stdClass', $b);
 	}
 
+	/**
+	 * @param array{a: string, b: array{c: string|null}} $a
+	 */
+	public function arrayOffset(array $a): void
+	{
+		if (strlen($a['a']) > 0 && $a['a'] === $a['b']['c']) {
+			assertType('array{a: non-empty-string, b: array{c: non-empty-string}}', $a);
+		}
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -164,7 +164,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				443,
 			],
 			[
-				'Offset \'feature_pretty…\' does not exist on array{version: string, commit: string|null, pretty_version: string|null, feature_version: non-empty-string, feature_pretty_version?: string|null}.',
+				'Offset \'feature_pretty…\' does not exist on array{version: non-empty-string, commit: string|null, pretty_version: string|null, feature_version: non-empty-string, feature_pretty_version?: string|null}.',
 				504,
 			],
 		]);

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -163,6 +163,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Cannot access offset \'foo\' on array|int.',
 				443,
 			],
+			[
+				'Offset \'feature_pretty…\' does not exist on array{version: string, commit: string|null, pretty_version: string|null, feature_version: non-empty-string, feature_pretty_version?: string|null}.',
+				504,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/data/nonexistent-offset.php
+++ b/tests/PHPStan/Rules/Arrays/data/nonexistent-offset.php
@@ -485,3 +485,26 @@ class MessageDescriptorTest
 	}
 
 }
+
+/**
+ * @phpstan-type Version array{version: string, commit: string|null, pretty_version: string|null, feature_version?: string|null, feature_pretty_version?: string|null}
+ */
+class VersionGuesser
+{
+	/**
+	 * @param array $versionData
+	 *
+	 * @phpstan-param Version $versionData
+	 *
+	 * @return array
+	 * @phpstan-return Version
+	 */
+	private function postprocess(array $versionData): array
+	{
+		if (!empty($versionData['feature_version']) && $versionData['feature_version'] === $versionData['version'] && $versionData['feature_pretty_version'] === $versionData['pretty_version']) {
+			unset($versionData['feature_version'], $versionData['feature_pretty_version']);
+		}
+
+		return $versionData;
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -112,6 +112,22 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isNotSame() with 1 and stdClass will always evaluate to true.',
 				130,
 			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with \'1\' and stdClass will always evaluate to false.',
+				133,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with \'1\' and stdClass will always evaluate to true.',
+				136,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with array{\'a\', \'b\'} and array{1, 2} will always evaluate to false.',
+				139,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with array{\'a\', \'b\'} and array{1, 2} will always evaluate to true.',
+				142,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -80,6 +80,10 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isSame() with *NEVER* and stdClass will always evaluate to false.',
 				84,
 			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with \'foo\' and \'foo\' will always evaluate to true.',
+				101,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -88,6 +88,30 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isNotSame() with \'foo\' and \'foo\' will always evaluate to false.',
 				104,
 			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with array{} and array{} will always evaluate to true.',
+				113,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with array{} and array{} will always evaluate to false.',
+				116,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with array{1, 3} and array{1, 3} will always evaluate to true.',
+				119,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with array{1, 3} and array{1, 3} will always evaluate to false.',
+				122,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isSame() with 1 and stdClass will always evaluate to false.',
+				126,
+			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with 1 and stdClass will always evaluate to true.',
+				130,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -84,6 +84,10 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isSame() with \'foo\' and \'foo\' will always evaluate to true.',
 				101,
 			],
+			[
+				'Call to method ImpossibleMethodCall\Foo::isNotSame() with \'foo\' and \'foo\' will always evaluate to false.',
+				104,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -98,12 +98,10 @@ class Foo
 		if ($this->isNotSame(self::createStdClass('b'), self::createStdClass('b'))) {
 
 		}
-		$std3 = new \stdClass();
-		if ($this->isSame($std3, self::createStdClass('c'))) {
+		if ($this->isSame(self::returnFoo(), self::returnFoo())) {
 
 		}
-		$std4 = new \stdClass();
-		if ($this->isNotSame($std4, self::createStdClass('d'))) {
+		if ($this->isNotSame(self::returnFoo(), self::returnFoo())) {
 
 		}
 	}
@@ -116,6 +114,14 @@ class Foo
 	public static function createStdClass(string $foo): \stdClass
 	{
 		return new \stdClass();
+	}
+
+	/**
+	 * @return 'foo'
+	 */
+	public static function returnFoo(): string
+	{
+		return 'foo';
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -92,11 +92,30 @@ class Foo
 
 			}
 		}
+		if ($this->isSame(self::createStdClass('a'), self::createStdClass('a'))) {
+
+		}
+		if ($this->isNotSame(self::createStdClass('b'), self::createStdClass('b'))) {
+
+		}
+		$std3 = new \stdClass();
+		if ($this->isSame($std3, self::createStdClass('c'))) {
+
+		}
+		$std4 = new \stdClass();
+		if ($this->isNotSame($std4, self::createStdClass('d'))) {
+
+		}
 	}
 
 	public function nullableInt(): ?int
 	{
 
+	}
+
+	public static function createStdClass(string $foo): \stdClass
+	{
+		return new \stdClass();
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -110,6 +110,26 @@ class Foo
 		if ($this->isNotSame(self::createStdClass('b')->foo, self::createStdClass('b')->foo)) {
 
 		}
+		if ($this->isSame([], [])) {
+
+		}
+		if ($this->isNotSame([], [])) {
+
+		}
+		if ($this->isSame([1, 3], [1, 3])) {
+
+		}
+		if ($this->isNotSame([1, 3], [1, 3])) {
+
+		}
+		$std3 = new \stdClass();
+		if ($this->isSame(1, $std3)) {
+
+		}
+		$std4 = new \stdClass();
+		if ($this->isNotSame(1, $std4)) {
+
+		}
 	}
 
 	public function nullableInt(): ?int

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -130,6 +130,18 @@ class Foo
 		if ($this->isNotSame(1, $std4)) {
 
 		}
+		if ($this->isSame('1', new \stdClass())) {
+
+		}
+		if ($this->isNotSame('1', new \stdClass())) {
+
+		}
+		if ($this->isSame(['a', 'b'], [1, 2])) {
+
+		}
+		if ($this->isNotSame(['a', 'b'], [1, 2])) {
+
+		}
 	}
 
 	public function nullableInt(): ?int

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -98,10 +98,10 @@ class Foo
 		if ($this->isNotSame(self::createStdClass('b'), self::createStdClass('b'))) {
 
 		}
-		if ($this->isSame(self::returnFoo(), self::returnFoo())) {
+		if ($this->isSame(self::returnFoo('a'), self::returnFoo('a'))) {
 
 		}
-		if ($this->isNotSame(self::returnFoo(), self::returnFoo())) {
+		if ($this->isNotSame(self::returnFoo('b'), self::returnFoo('b'))) {
 
 		}
 	}
@@ -119,7 +119,7 @@ class Foo
 	/**
 	 * @return 'foo'
 	 */
-	public static function returnFoo(): string
+	public static function returnFoo(string $foo): string
 	{
 		return 'foo';
 	}

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -104,6 +104,12 @@ class Foo
 		if ($this->isNotSame(self::returnFoo('b'), self::returnFoo('b'))) {
 
 		}
+		if ($this->isSame(self::createStdClass('a')->foo, self::createStdClass('a')->foo)) {
+
+		}
+		if ($this->isNotSame(self::createStdClass('b')->foo, self::createStdClass('b')->foo)) {
+
+		}
 	}
 
 	public function nullableInt(): ?int


### PR DESCRIPTION
Took me forever to just create those tests. The reason was that I used only `createStdClass()` before and it never failed for the `isNotSame`. The reason for that was https://github.com/phpstan/phpstan-src/blob/1.4.8/src/Rules/Comparison/ImpossibleCheckTypeHelper.php#L191 because the expression `createStdClass()` was already specified in the scope from the `isSame`.. Which is why I added those strings.

The `isNotSame` was broken by https://github.com/phpstan/phpstan-src/pull/1046
But the `isSame` was already broken before. The problem is the true scope intersection of types just a bit further up.

Limiting it to variable nodes would break `isSame(1, 3)` expressions. Apparently limiting it to *not* being `CallLike` nodes seems to do the trick, but this feels still wrong to me.

Leaving this here for now and I'll come back to it after having a thought.

Refs https://github.com/phpstan/phpstan-phpunit/issues/120 and https://github.com/phpstan/phpstan-webmozart-assert/pull/122