### PR TITLE
Add DOMXPath stub and make DOMNodeList implement IteratorAggregate

### DIFF
--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -91,11 +91,10 @@ class DOMXPath
     public function evaluate($expression, $contextNode, $registerNodeNS) {}
 
     /**
-     * @template TNode as DOMNode
      * @param string $expression
      * @param DOMNode|null $contextNode
      * @param boolean $registerNodeNS
-     * @return DOMNodeList<TNode>|false
+     * @return DOMNodeList<DOMNode>|false
      */
     public function query($expression, $contextNode, $registerNodeNS) {}
 

--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -91,21 +91,24 @@ class DOMXPath
     public function evaluate($expression, $contextNode, $registerNodeNS) {}
 
     /**
+     * @template TNode as DOMNode
      * @param string $expression
      * @param DOMNode|null $contextNode
      * @param boolean $registerNodeNS
-     * @return DOMNodeList|false
+     * @return DOMNodeList<TNode>|false
      */
     public function query($expression, $contextNode, $registerNodeNS) {}
 
     /**
      * @param string $prefix
      * @param string $namespace
+     * @return boolean
      */
     public function registerNamespace($prefix, $namespace) {}
 
     /**
      * @param string|array|null $restrict
+     * @return void
      */
     public function registerPhpFunctions($restrict) {}
 

--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -55,16 +55,59 @@ class DOMElement extends DOMNode
 
 /**
  * @template-covariant TNode as DOMNode
- * @implements Traversable<int, TNode>
+ * @implements IteratorAggregate<int, TNode>
  */
-class DOMNodeList implements Traversable
+class DOMNodeList implements IteratorAggregate, Countable
 {
+
+    /** @var int */
+    public $length;
+
+    /**
+     * @return int
+     */
+    public function count() {}
 
 	/**
 	 * @param int $index
 	 * @return TNode|null
 	 */
 	public function item ($index) {}
+
+}
+
+class DOMXPath
+{
+
+	/** @var DOMDocument */
+	public $document;
+
+    /**
+     * @param string $expression
+     * @param DOMNode|null $contextNode
+     * @param boolean $registerNodeNS
+     * @return boolean
+     */
+    public function evaluate($expression, $contextNode, $registerNodeNS) {}
+
+    /**
+     * @param string $expression
+     * @param DOMNode|null $contextNode
+     * @param boolean $registerNodeNS
+     * @return DOMNodeList|false
+     */
+    public function query($expression, $contextNode, $registerNodeNS) {}
+
+    /**
+     * @param string $prefix
+     * @param string $namespace
+     */
+    public function registerNamespace($prefix, $namespace) {}
+
+    /**
+     * @param string|array|null $restrict
+     */
+    public function registerPhpFunctions($restrict) {}
 
 }
 

--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -58,7 +58,7 @@ class DOMElement extends DOMNode
  * @implements Traversable<int, TNode>
  * @implements IteratorAggregate<int, TNode>
  */
-class DOMNodeList implements IteratorAggregate, Countable
+class DOMNodeList implements Traversable, IteratorAggregate, Countable
 {
 
     /** @var int */

--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -55,6 +55,7 @@ class DOMElement extends DOMNode
 
 /**
  * @template-covariant TNode as DOMNode
+ * @implements Traversable<int, TNode>
  * @implements IteratorAggregate<int, TNode>
  */
 class DOMNodeList implements IteratorAggregate, Countable

--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -107,7 +107,7 @@ class DOMXPath
     public function registerNamespace($prefix, $namespace) {}
 
     /**
-     * @param string|array|null $restrict
+     * @param callable-string|array<callable-string>|null $restrict
      * @return void
      */
     public function registerPhpFunctions($restrict) {}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -775,6 +775,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-6635.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -775,7 +775,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-6635.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-6748.php
+++ b/tests/PHPStan/Analyser/data/bug-6748.php
@@ -6,17 +6,17 @@ use function PHPStan\Testing\assertType;
 
 class Foo
 {
-    /** @param \DOMNodeList<\DOMNode> $list */
-    public function iterateNodes ($list): void
-    {
-        foreach($list as $item) {
-            assertType('DOMNode', $item);
-        }
-    }
+	/** @param \DOMNodeList<\DOMNode> $list */
+	public function iterateNodes ($list): void
+	{
+		foreach($list as $item) {
+			assertType('DOMNode', $item);
+		}
+	}
 
-    /** @param \DOMXPath $path */
-    public function xPathQuery ($path)
-    {
-        assertType('DOMNodeList<DOMNode>|false', $path->query(''));
-    }
+	/** @param \DOMXPath $path */
+	public function xPathQuery ($path)
+	{
+		assertType('DOMNodeList<DOMNode>|false', $path->query(''));
+	}
 }

--- a/tests/PHPStan/Analyser/data/bug-6748.php
+++ b/tests/PHPStan/Analyser/data/bug-6748.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bug6748;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+    /** @param \DOMNodeList<\DOMNode> $list */
+    public function iterateNodes ($list): void
+    {
+        foreach($list as $item) {
+            assertType('DOMNode', $item);
+        }
+    }
+
+    /** @param \DOMXPath $path */
+    public function xPathQuery ($path)
+    {
+        assertType('DOMNodeList<DOMNode>|false', $path->query(''));
+    }
+}


### PR DESCRIPTION
Per PHP Docs

https://www.php.net/manual/en/class.domnodelist.php#domnodelist.changelog

"DOMNodeList implements IteratorAggregate now. Previously, Traversable
was implemented instead"

This appears to be causing a failure to recognize that items of the
list must be of type DOMNode within foreach loops iterating over the
DOMNodeList. This change fixes that.

fixes phpstan/phpstan#6748