### PR TITLE
add regression test for ArrayAccess and move logic

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3271,21 +3271,22 @@ class NodeScopeResolver
 						$valueToWrite,
 					);
 				}
-
-				if ($originalVar->dim instanceof Variable || $originalVar->dim instanceof Node\Scalar) {
-					$currentVarType = $scope->getType($originalVar);
-					if (!$originalValueToWrite->isSuperTypeOf($currentVarType)->yes()) {
-						$scope = $scope->assignExpression(
-							$originalVar,
-							$originalValueToWrite,
-						);
-					}
-				}
 			} else {
 				if ($var instanceof PropertyFetch || $var instanceof StaticPropertyFetch) {
 					$nodeCallback(new PropertyAssignNode($var, $assignedPropertyExpr, $isAssignOp), $scope);
 				}
 			}
+
+			if ($originalVar->dim instanceof Variable || $originalVar->dim instanceof Node\Scalar) {
+				$currentVarType = $scope->getType($originalVar);
+				if (!$originalValueToWrite->isSuperTypeOf($currentVarType)->yes()) {
+					$scope = $scope->assignExpression(
+						$originalVar,
+						$originalValueToWrite,
+					);
+				}
+			}
+
 		} elseif ($var instanceof PropertyFetch) {
 			$objectResult = $this->processExprNode($var->var, $scope, $nodeCallback, $context);
 			$hasYield = $objectResult->hasYield();

--- a/tests/PHPStan/Analyser/data/offset-value-after-assign.php
+++ b/tests/PHPStan/Analyser/data/offset-value-after-assign.php
@@ -21,4 +21,20 @@ class Foo
 		assertType('string', $a[$i]);
 	}
 
+	/**
+	 * @param \ArrayAccess<int, string> $a
+	 */
+	public function doBar(\ArrayAccess $a, int $i): void
+	{
+		assertType('string|null', $a[$i]);
+
+		$a[$i] = 'foo';
+		assertType('\'foo\'', $a[$i]);
+		assertType('ArrayAccess<int, string>', $a);
+
+		$i = 1;
+		assertType('string|null', $a[$i]);
+		assertType('ArrayAccess<int, string>', $a);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-1903.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-1903.php
@@ -19,4 +19,19 @@ class Test
 		return $this->answersOrder[$qId];
 	}
 
+	/** @var \ArrayAccess */
+	private $arrayAccess = [];
+
+	public function doBar(string $qId): int
+	{
+		if (null !== $this->arrayAccess[$qId]) {
+			return $this->arrayAccess[$qId];
+		}
+
+
+		$this->arrayAccess[$qId] = 5;
+
+		return $this->arrayAccess[$qId];
+	}
+
 }


### PR DESCRIPTION
When I was working with https://github.com/phpstan/phpstan-src/pull/1054
I noticed that https://github.com/phpstan/phpstan-src/commit/0f64ca749f5246a2550dd746cb416b37e2e6ef84 logic may be moved out of `!(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->yes()` block, because it is using `$originalValueToWrite`.

This PR moved the logic and added some regression tests for `ArrayAccess`.