### PR TITLE
Keep non nullability if right expr is `NeverType`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2283,7 +2283,10 @@ class NodeScopeResolver
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();
 			$scope = $result->getScope();
-			$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
+
+			if (!$scope->getType($expr->right) instanceof NeverType) {
+				$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
+			}
 
 			if ($expr->left instanceof PropertyFetch || $expr->left instanceof Expr\NullsafePropertyFetch) {
 				$scope = $this->lookForExitVariableAssign($scope, $expr->left->var);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2284,7 +2284,8 @@ class NodeScopeResolver
 			$throwPoints = $result->getThrowPoints();
 			$scope = $result->getScope();
 
-			if (!$scope->getType($expr->right) instanceof NeverType) {
+			$rightExprType = $scope->getType($expr->right);
+			if (!$rightExprType instanceof NeverType || !$rightExprType->isExplicit()) {
 				$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
 			}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -155,6 +155,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pow.php');
 		if (PHP_VERSION_ID >= 80000 || self::$useStaticReflectionProvider) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-expr.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5351.php');
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-array.php');

--- a/tests/PHPStan/Analyser/data/bug-5351.php
+++ b/tests/PHPStan/Analyser/data/bug-5351.php
@@ -22,7 +22,8 @@ class Foo
 
 	public function doBar(?string $html): void
 	{
-		assertType('string', $html ?? $this->neverReturn());
+		$html ?? $this->neverReturn();
+		assertType('string', $html);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-5351.php
+++ b/tests/PHPStan/Analyser/data/bug-5351.php
@@ -1,0 +1,28 @@
+<?php // lint >= 8.0
+
+namespace Bug5351;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function doFoo(?string $html): void
+	{
+		$html ?? throw new \Exception();
+		assertType('string', $html);
+	}
+
+	/**
+	 * @return never
+	 */
+	public function neverReturn() {
+		throw new \Exception();
+	}
+
+	public function doBar(?string $html): void
+	{
+		assertType('string', $html ?? $this->neverReturn());
+	}
+
+}


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/5351

~~I haven't found yet why the second test case passes without this fix.~~

The test wasn't what I intended. fixed