### PR TITLE
Fix/issue 6791

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -9,7 +9,7 @@ on:
       - "master"
 
 env:
-  COMPOSER_ROOT_VERSION: "1.4.x-dev"
+  COMPOSER_ROOT_VERSION: "1.5.x-dev"
 
 jobs:
   backward-compatibility:

--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -9,7 +9,7 @@ on:
       - "master"
 
 env:
-  COMPOSER_ROOT_VERSION: "1.4.x-dev"
+  COMPOSER_ROOT_VERSION: "1.5.x-dev"
 
 jobs:
   compiler-tests:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ on:
       - 'compiler/**'
 
 env:
-  COMPOSER_ROOT_VERSION: "1.4.x-dev"
+  COMPOSER_ROOT_VERSION: "1.5.x-dev"
 
 jobs:
   result-cache-e2e-tests:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - "master"
 
 env:
-  COMPOSER_ROOT_VERSION: "1.4.x-dev"
+  COMPOSER_ROOT_VERSION: "1.5.x-dev"
 
 jobs:
   lint:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ on:
       - 'compiler/**'
 
 env:
-  COMPOSER_ROOT_VERSION: "1.4.x-dev"
+  COMPOSER_ROOT_VERSION: "1.5.x-dev"
 
 jobs:
   static-analysis:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
       - 'compiler/**'
 
 env:
-  COMPOSER_ROOT_VERSION: "1.4.x-dev"
+  COMPOSER_ROOT_VERSION: "1.5.x-dev"
 
 jobs:
   tests:

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.4-dev"
+			"dev-master": "1.5-dev"
 		},
 		"patcher": {
 			"search": "patches"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ede0704e050d946882afd2613bdbb349",
+    "content-hash": "1d2be9000b8b91802f4b6d667fa6267d",
     "packages": [
         {
             "name": "clue/block-react",
@@ -2907,12 +2907,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2962,12 +2962,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "React\\Promise\\Stream\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "React\\Promise\\Stream\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3045,12 +3045,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "React\\Promise\\Timer\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3301,12 +3301,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "RingCentral\\Psr7\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "RingCentral\\Psr7\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3594,12 +3594,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3673,12 +3673,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3754,12 +3754,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -3841,12 +3841,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3918,12 +3918,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -3994,12 +3994,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -4073,12 +4073,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php74\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php74\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4153,12 +4153,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -4386,12 +4386,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -4670,12 +4670,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5799,11 +5799,11 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "src/"
-                ],
                 "files": [
                     "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2660,7 +2660,14 @@ class MutatingScope implements Scope
 					continue;
 				}
 
-				return $dynamicFunctionReturnTypeExtension->getTypeFromFunctionCall($functionReflection, $node, $this);
+				$resolvedType = $dynamicFunctionReturnTypeExtension->getTypeFromFunctionCall(
+					$functionReflection,
+					$node,
+					$this,
+				);
+				if ($resolvedType !== null) {
+					return $resolvedType;
+				}
 			}
 
 			return ParametersAcceptorSelector::selectFromArgs(
@@ -5659,7 +5666,16 @@ class MutatingScope implements Scope
 				continue;
 			}
 
-			$resolvedTypes[] = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall($constructorMethod, $methodCall, $this);
+			$resolvedType = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall(
+				$constructorMethod,
+				$methodCall,
+				$this,
+			);
+			if ($resolvedType === null) {
+				continue;
+			}
+
+			$resolvedTypes[] = $resolvedType;
 		}
 
 		if (count($resolvedTypes) > 0) {
@@ -5835,7 +5851,12 @@ class MutatingScope implements Scope
 						continue;
 					}
 
-					$resolvedTypes[] = $dynamicMethodReturnTypeExtension->getTypeFromMethodCall($methodReflection, $methodCall, $this);
+					$resolvedType = $dynamicMethodReturnTypeExtension->getTypeFromMethodCall($methodReflection, $methodCall, $this);
+					if ($resolvedType === null) {
+						continue;
+					}
+
+					$resolvedTypes[] = $resolvedType;
 				}
 			} else {
 				foreach ($this->dynamicReturnTypeExtensionRegistry->getDynamicStaticMethodReturnTypeExtensionsForClass($className) as $dynamicStaticMethodReturnTypeExtension) {
@@ -5843,7 +5864,16 @@ class MutatingScope implements Scope
 						continue;
 					}
 
-					$resolvedTypes[] = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall($methodReflection, $methodCall, $this);
+					$resolvedType = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall(
+						$methodReflection,
+						$methodCall,
+						$this,
+					);
+					if ($resolvedType === null) {
+						continue;
+					}
+
+					$resolvedTypes[] = $resolvedType;
 				}
 			}
 		}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3325,7 +3325,11 @@ class NodeScopeResolver
 				if ($propertyReflection->canChangeTypeAfterAssignment()) {
 					$scope = $scope->assignExpression($var, $assignedExprType);
 				}
-				if (!$propertyReflection->getWritableType()->isSuperTypeOf($assignedExprType)->yes()) {
+				$declaringClass = $propertyReflection->getDeclaringClass();
+				if (
+					$declaringClass->hasNativeProperty($propertyName)
+					&& !$declaringClass->getNativeProperty($propertyName)->getNativeType()->accepts($assignedExprType, true)->yes()
+				) {
 					$throwPoints[] = ThrowPoint::createExplicit($scope, new ObjectType(TypeError::class), $assignedExpr, false);
 				}
 			} else {

--- a/src/Type/DynamicFunctionReturnTypeExtension.php
+++ b/src/Type/DynamicFunctionReturnTypeExtension.php
@@ -12,6 +12,6 @@ interface DynamicFunctionReturnTypeExtension
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool;
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type;
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type;
 
 }

--- a/src/Type/DynamicMethodReturnTypeExtension.php
+++ b/src/Type/DynamicMethodReturnTypeExtension.php
@@ -14,6 +14,6 @@ interface DynamicMethodReturnTypeExtension
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool;
 
-	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type;
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type;
 
 }

--- a/src/Type/DynamicStaticMethodReturnTypeExtension.php
+++ b/src/Type/DynamicStaticMethodReturnTypeExtension.php
@@ -14,6 +14,6 @@ interface DynamicStaticMethodReturnTypeExtension
 
 	public function isStaticMethodSupported(MethodReflection $methodReflection): bool;
 
-	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type;
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type;
 
 }

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -267,4 +267,26 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6791(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			self::markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-6791.php'], [
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				17,
+			],
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				29,
+			],
+			[
+				'Dead catch - TypeError is never thrown in the try block.',
+				33,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6791.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6791.php
@@ -1,0 +1,34 @@
+<?php // lint >= 7.4
+
+namespace Bug6791;
+
+class Foo {
+	/** @var int[]  */
+	public array $intArray;
+	/** @var \Ds\Set<int> */
+	public \Ds\Set $set;
+	/** @var int[]  */
+	public $array;
+}
+
+$foo = new Foo();
+try {
+	$foo->intArray = ["a"];
+} catch (\TypeError $e) {}
+
+try {
+	$foo->set = ["a"];
+} catch (\TypeError $e) {}
+
+try {
+	$foo->set = new \Ds\Set;
+} catch (\TypeError $e) {}
+
+try {
+	$foo->array = ["a"];
+} catch (\TypeError $e) {}
+
+try {
+	$foo->array = "non-array";
+} catch (\TypeError $e) {}
+


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/6791

I implemented `TypeError` throw point in https://github.com/phpstan/phpstan-src/commit/4450e46591a55b6015da48798403ce7b567b90f3 but handled it by writable type.

As in the issue, `TypeError` is only throwed  when the native type is different from the assigned type.
For example,

```php
/** @var int[] */
publice array $array
```
Can assign `string[]` without `TypeError` even if it's an error in PHPStan.
