### PR TITLE
skip test when ext-ds is not loaded

### DIFF
--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Exceptions;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use function extension_loaded;
 use const PHP_VERSION_ID;
 
 /**

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -273,6 +273,10 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 			self::markTestSkipped('Test requires PHP 7.4.');
 		}
 
+		if (!extension_loaded('ds')) {
+			self::markTestSkipped('Test requires ext-ds.');
+		}
+
 		$this->analyse([__DIR__ . '/data/bug-6791.php'], [
 			[
 				'Dead catch - TypeError is never thrown in the try block.',


### PR DESCRIPTION
fixes

```
1) PHPStan\Rules\Exceptions\CatchWithUnthrownExceptionRuleTest::testBug6791
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'17: Dead catch - TypeError is never thrown in the try block.
-29: Dead catch - TypeError is never thrown in the try block.
-33: Dead catch - TypeError is never thrown in the try block.
+'-1: Class Ds\Set not found.
+    💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
```