### PR TITLE
PHP8.2: silence warnings about deprecated encodings from mb_list_encodings()

### DIFF
--- a/src/Type/Php/MbFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/MbFunctionsReturnTypeExtension.php
@@ -51,7 +51,7 @@ class MbFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtensi
 		$supportedEncodings = [];
 		if (function_exists('mb_list_encodings')) {
 			foreach (mb_list_encodings() as $encoding) {
-				$aliases = mb_encoding_aliases($encoding);
+				$aliases = @mb_encoding_aliases($encoding);
 				if ($aliases === false) {
 					throw new ShouldNotHappenException();
 				}

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -43,7 +43,7 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 		$supportedEncodings = [];
 		if (function_exists('mb_list_encodings')) {
 			foreach (mb_list_encodings() as $encoding) {
-				$aliases = mb_encoding_aliases($encoding);
+				$aliases = @mb_encoding_aliases($encoding);
 				if ($aliases === false) {
 					throw new ShouldNotHappenException();
 				}


### PR DESCRIPTION
php8.2 will raise warnings and suggesting alternatives:

> Use of QPrint, Base64, Uuencode, and HTML-ENTITIES 'text encodings' is
> deprecated for all Mbstring functions.


```
$ php -v
PHP 8.2.0-dev (cli) (built: Mar 17 2022 07:27:45) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.0-dev, Copyright (c) Zend Technologies
$ bin/phpstan
Deprecated: mb_encoding_aliases(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in /home/easteregg/src/phpstan-src/src/Type/Php/MbFunctionsReturnTypeExtension.php on line 54
Deprecated: mb_encoding_aliases(): Handling Uuencode via mbstring is deprecated; use convert_uuencode/convert_uudecode instead in /home/easteregg/src/phpstan-src/src/Type/Php/MbFunctionsReturnTypeExtension.php on line 54
Deprecated: mb_encoding_aliases(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in /home/easteregg/src/phpstan-src/src/Type/Php/MbFunctionsReturnTypeExtension.php on line 54
Deprecated: mb_encoding_aliases(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in /home/easteregg/src/phpstan-src/src/Type/Php/MbFunctionsReturnTypeExtension.php on line 54
Deprecated: mb_encoding_aliases(): Handling Base64 via mbstring is deprecated; use base64_encode/base64_decode instead in /home/easteregg/src/phpstan-src/src/Type/Php/StrSplitFunctionReturnTypeExtension.php on line 46
Deprecated: mb_encoding_aliases(): Handling Uuencode via mbstring is deprecated; use convert_uuencode/convert_uudecode instead in /home/easteregg/src/phpstan-src/src/Type/Php/StrSplitFunctionReturnTypeExtension.php on line 46
Deprecated: mb_encoding_aliases(): Handling HTML entities via mbstring is deprecated; use htmlspecialchars, htmlentities, or mb_encode_numericentity/mb_decode_numericentity instead in /home/easteregg/src/phpstan-src/src/Type/Php/StrSplitFunctionReturnTypeExtension.php on line 46
Deprecated: mb_encoding_aliases(): Handling QPrint via mbstring is deprecated; use quoted_printable_encode/quoted_printable_decode instead in /home/easteregg/src/phpstan-src/src/Type/Php/StrSplitFunctionReturnTypeExtension.php on line 46
```

let me know if this is an adequate solution or if there is any other thing i can improve here.