### PR TITLE
add regression test 

### DIFF
--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -362,4 +362,9 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3171.php'], []);
 	}
 
+	public function testBug4747(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-4747.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-4747.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-4747.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4747;
+
+/**
+ * @param array{a_1: array{int, string}, a_2: array{int, string}, hi: int} $r
+ * @return string
+ */
+function x(array $r, string $d) : string
+{
+	assert($d === '1' || $d === '2');
+
+	return $r['a_' . $d][1];
+}


### PR DESCRIPTION
I checked for the solved issue https://github.com/phpstan/phpstan/issues/4747 you talked about in
https://github.com/phpstan/phpstan-src/pull/1063

and believe it is not from my fix.

I confirmed that this error was fixed with this commit
https://github.com/phpstan/phpstan-src/commit/d5284cec2dc9c589df7b72e3a609fe4494c340f2

Maybe the report from bot is wrong because the Action was failing?
https://github.com/phpstan/phpstan-src/runs/5586761656?check_suite_focus=true

anyway, I added a test!