### PR TITLE
`array_keys` losses array-shape on `HasOffsetType`

### DIFF
--- a/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
+use function strtolower;
 
 class ArrayValuesFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -797,7 +797,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6859.php');
+		
+		if (PHP_VERSION_ID >= 70400) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6859.php');
+		}
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -797,7 +797,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
-		yield from $this->gatherAssertTypes(__DIR__ .'/data/bug-6859.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6859.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -795,12 +795,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6790.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
-		
 		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6859.php');
 		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -797,6 +797,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
+		yield from $this->gatherAssertTypes(__DIR__ .'/data/bug-6859.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-6859.php
+++ b/tests/PHPStan/Analyser/data/bug-6859.php
@@ -29,16 +29,6 @@ class HelloWorld
 	{
 		if (array_key_exists("someParam", $body)) {
 			assertType('non-empty-array<int, mixed>', array_values($body));
-
-			$someKeys = array_filter(
-				array_values($body),
-				fn ($key) => preg_match("/^somePattern[0-9]+$/", $key)
-			);
-
-			if (count($someKeys) > 0) {
-				return 1;
-			}
-			return 0;
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/data/bug-6859.php
+++ b/tests/PHPStan/Analyser/data/bug-6859.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
 
 namespace Bug6859;
 

--- a/tests/PHPStan/Analyser/data/bug-6859.php
+++ b/tests/PHPStan/Analyser/data/bug-6859.php
@@ -9,14 +9,14 @@ class HelloWorld
 	public function f($body)
 	{
 		if (array_key_exists("someParam", $body)) {
-			assertType('array{someParam: mixed}', array_keys($body));
+			assertType('non-empty-array<int, (int|string)>', array_keys($body));
 
 			$someKeys = array_filter(
 				array_keys($body),
 				fn ($key) => preg_match("/^somePattern[0-9]+$/", $key)
 			);
 
-			assertType('array', $someKeys);
+			assertType('array<int, (int|string)>', $someKeys);
 
 			if (count($someKeys) > 0) {
 				return 1;

--- a/tests/PHPStan/Analyser/data/bug-6859.php
+++ b/tests/PHPStan/Analyser/data/bug-6859.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6859;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function f($body)
+	{
+		if (array_key_exists("someParam", $body)) {
+			assertType('array{someParam: mixed}', array_keys($body));
+
+			$someKeys = array_filter(
+				array_keys($body),
+				fn ($key) => preg_match("/^somePattern[0-9]+$/", $key)
+			);
+
+			assertType('array', $someKeys);
+
+			if (count($someKeys) > 0) {
+				return 1;
+			}
+			return 0;
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-6859.php
+++ b/tests/PHPStan/Analyser/data/bug-6859.php
@@ -6,7 +6,7 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
-	public function f($body)
+	public function keys($body)
 	{
 		if (array_key_exists("someParam", $body)) {
 			assertType('non-empty-array<int, (int|string)>', array_keys($body));
@@ -17,6 +17,23 @@ class HelloWorld
 			);
 
 			assertType('array<int, (int|string)>', $someKeys);
+
+			if (count($someKeys) > 0) {
+				return 1;
+			}
+			return 0;
+		}
+	}
+
+	public function values($body)
+	{
+		if (array_key_exists("someParam", $body)) {
+			assertType('non-empty-array<int, mixed>', array_values($body));
+
+			$someKeys = array_filter(
+				array_values($body),
+				fn ($key) => preg_match("/^somePattern[0-9]+$/", $key)
+			);
 
 			if (count($someKeys) > 0) {
 				return 1;


### PR DESCRIPTION
the return-type extension is taking this path 

https://github.com/phpstan/phpstan-src/blob/984fbcf11dfe00a5e1ed4c129ab6896710e60a1d/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php#L36

and tries to intersect a `Array<int, __benevolent<int|string>>` with a `HasOffsetType` of `ConstantStringType`

![grafik](https://user-images.githubusercontent.com/120441/159042653-fc1dca07-f9eb-4125-995d-b128205456cb.png)


which results in a `NeverType` 

https://github.com/phpstan/phpstan-src/blob/984fbcf11dfe00a5e1ed4c129ab6896710e60a1d/src/Type/TypeCombinator.php#L841-L843


closes https://github.com/phpstan/phpstan/issues/6859

