### PR TITLE
Fix array_filter narrowing with explicit null callback

### DIFF
--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -32,7 +32,6 @@ use PHPStan\Type\TypeUtils;
 use function array_map;
 use function count;
 use function is_string;
-use function strtolower;
 
 class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -63,7 +62,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 			]);
 		}
 
-		if ($callbackArg === null || ($callbackArg instanceof ConstFetch && strtolower($callbackArg->name->parts[0]) === 'null')) {
+		if ($callbackArg === null) {
 			return TypeCombinator::union(
 				...array_map([$this, 'removeFalsey'], TypeUtils::getArrays($arrayArgType)),
 			);

--- a/tests/PHPStan/Analyser/data/array-filter.php
+++ b/tests/PHPStan/Analyser/data/array-filter.php
@@ -30,8 +30,8 @@ function withoutCallback(array $map1, array $map2, array $map3): void
 	assertType('array<string, float|int<min, -1>|int<1, max>|non-empty-string|true>', $filtered1);
 
 	$filtered2 = array_filter($map2, null, ARRAY_FILTER_USE_KEY);
-	assertType('array<string, float|int<min, -1>|int<1, max>|non-empty-string|true>', $filtered2);
+	assertType('array<string, bool|float|int|string>', $filtered2);
 
 	$filtered3 = array_filter($map3, null, ARRAY_FILTER_USE_BOTH);
-	assertType('array<string, float|int<min, -1>|int<1, max>|non-empty-string|true>', $filtered3);
+	assertType('array<string, bool|float|int|string>', $filtered3);
 }


### PR DESCRIPTION
Turns out this is not supported and even throws a warning in PHP < 8. This change just removes the handling of such cases.

See https://github.com/phpstan/phpstan-src/pull/1077#issuecomment-1070976006 / https://github.com/phpstan/phpstan-src/pull/1077#issuecomment-1070980648 and https://3v4l.org/Cj17A