### PR TITLE
added `ArrayReplaceFunctionReturnTypeExtension`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -998,6 +998,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\ArrayReplaceFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\ArrayReverseFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
+use function strtolower;
+
+class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return strtolower($functionReflection->getName()) === 'array_replace';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	{
+		$args = $functionCall->getArgs();
+
+		if (count($args) < 1) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$arrayType = $scope->getType($args[0]->value);
+		if ($arrayType->isArray()->yes()) {
+			$resultType = $this->getResultType($functionCall, $scope);
+
+			if ($resultType !== null) {
+				if ($this->returnsNonEmptyArray($functionCall, $scope)) {
+					$resultType = TypeCombinator::intersect($resultType, new NonEmptyArrayType());
+				}
+
+				return $resultType;
+			}
+		}
+
+		return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+	}
+
+	private function getResultType(FuncCall $functionCall, Scope $scope): ?Type
+	{
+		$args = $functionCall->getArgs();
+
+		$arrayType = $scope->getType($args[0]->value);
+		$keyTypes = [$arrayType->getIterableKeyType()];
+		$valueTypes = [$arrayType->getIterableValueType()];
+
+		for ($i = 1; $i < count($args); $i++) {
+			$replaceArray = $scope->getType($args[$i]->value);
+
+			if (!$replaceArray->isArray()->yes()) {
+				return null;
+			}
+
+			$keyTypes[] = $replaceArray->getIterableKeyType();
+			$valueTypes[] = $replaceArray->getIterableValueType();
+		}
+
+		$keyType = TypeCombinator::union(...$keyTypes);
+		$valueType = TypeCombinator::union(...$valueTypes);
+
+		return new ArrayType($keyType, $valueType);
+	}
+
+	private function returnsNonEmptyArray(FuncCall $functionCall, Scope $scope): bool
+	{
+		$args = $functionCall->getArgs();
+
+		for ($i = 0; $i < count($args); $i++) {
+			$array = $scope->getType($args[$i]->value);
+
+			if (!$array->isArray()->yes()) {
+				continue;
+			}
+
+			if ($array->isIterableAtLeastOnce()->yes()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -50,19 +50,17 @@ class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 	{
 		$args = $functionCall->getArgs();
 
-		$arrayType = $scope->getType($args[0]->value);
-		$keyTypes = [$arrayType->getIterableKeyType()];
-		$valueTypes = [$arrayType->getIterableValueType()];
+		$keyTypes = [];
+		$valueTypes = [];
+		for ($i = 0; $i < count($args); $i++) {
+			$arrayType = $scope->getType($args[$i]->value);
 
-		for ($i = 1; $i < count($args); $i++) {
-			$replaceArray = $scope->getType($args[$i]->value);
-
-			if (!$replaceArray->isArray()->yes()) {
+			if (!$arrayType->isArray()->yes()) {
 				return null;
 			}
 
-			$keyTypes[] = $replaceArray->getIterableKeyType();
-			$valueTypes[] = $replaceArray->getIterableValueType();
+			$keyTypes[] = $arrayType->getIterableKeyType();
+			$valueTypes[] = $arrayType->getIterableValueType();
 		}
 
 		$keyType = TypeCombinator::union(...$keyTypes);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -803,6 +803,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-replace.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NonEmptyArrayReplace;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	/**
+	 * @param array $array1
+	 * @param array $array2
+	 */
+	public function arrayReplace($array1, $array2): void
+	{
+		assertType("array", array_replace($array1, []));
+		assertType("array", array_replace([], $array1));
+		assertType("array", array_replace($array1, $array2));
+	}
+
+	/**
+	 * @param int[] $array1
+	 * @param string[] $array2
+	 */
+	public function arrayReplaceSimple($array1, $array2): void
+	{
+		assertType("array<int>", array_merge($array1, $array1));
+		assertType("array<int|string>", array_merge($array1, $array2));
+		assertType("array<int|string>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array{foo: '1', bar: '2'} $array1
+	 * @param array{foo: '1', bar: '4'} $array2
+	 */
+	public function arrayReplaceArrayShapes($array1, $array2): void
+	{
+		assertType("non-empty-array<'bar'|'foo', '1'|'2'>", array_replace($array1));
+		assertType("non-empty-array<'bar'|'foo', '1'|'2'>", array_replace([], $array1));
+		assertType("non-empty-array<'bar'|'foo', '1'|'2'|'4'>", array_replace($array1, $array2));
+	}
+
+	/**
+	 * @param array<int, int|string> $array1
+	 * @param array<int, bool|float> $array2
+	 */
+	public function arrayReplaceUnionType($array1, $array2): void
+	{
+		assertType("array<int, int|string>", array_merge($array1, $array1));
+		assertType("array<int, bool|float|int|string>", array_merge($array1, $array2));
+		assertType("array<int, bool|float|int|string>", array_merge($array2, $array1));
+	}
+
+	/**
+	 * @param array<int, array{bar: '2'}|array{foo: '1'}> $array1
+	 * @param array<int, array{bar: '3'}|array{foo: '2'}> $array2
+	 */
+	public function arrayReplaceUnionTypeArrayShapes($array1, $array2): void
+	{
+		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_merge($array1, $array1));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array1, $array2));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array2, $array1));
+	}
+}

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -18,17 +18,6 @@ class Foo
 	}
 
 	/**
-	 * @param int[] $array1
-	 * @param string[] $array2
-	 */
-	public function arrayReplaceSimple($array1, $array2): void
-	{
-		assertType("array<int>", array_merge($array1, $array1));
-		assertType("array<int|string>", array_merge($array1, $array2));
-		assertType("array<int|string>", array_merge($array2, $array1));
-	}
-
-	/**
 	 * @param array{foo: '1', bar: '2'} $array1
 	 * @param array{foo: '1', bar: '4'} $array2
 	 */

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -34,9 +34,9 @@ class Foo
 	 */
 	public function arrayReplaceUnionType($array1, $array2): void
 	{
-		assertType("array<int, int|string>", array_merge($array1, $array1));
-		assertType("array<int, bool|float|int|string>", array_merge($array1, $array2));
-		assertType("array<int, bool|float|int|string>", array_merge($array2, $array1));
+		assertType("array<int, int|string>", array_replace($array1, $array1));
+		assertType("array<int, bool|float|int|string>", array_replace($array1, $array2));
+		assertType("array<int, bool|float|int|string>", array_replace($array2, $array1));
 	}
 
 	/**
@@ -45,8 +45,8 @@ class Foo
 	 */
 	public function arrayReplaceUnionTypeArrayShapes($array1, $array2): void
 	{
-		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_merge($array1, $array1));
-		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array1, $array2));
-		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_merge($array2, $array1));
+		assertType("array<int, array{bar: '2'}|array{foo: '1'}>", array_replace($array1, $array1));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_replace($array1, $array2));
+		assertType("array<int, array{bar: '2'|'3'}|array{foo: '1'|'2'}>", array_replace($array2, $array1));
 	}
 }

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -29,6 +29,17 @@ class Foo
 	}
 
 	/**
+	 * @param int[] $array1
+	 * @param string[] $array2
+	 */
+	public function arrayReplaceSimple($array1, $array2): void
+	{
+		assertType("array<int>", array_replace($array1, $array1));
+		assertType("array<int|string>", array_replace($array1, $array2));
+		assertType("array<int|string>", array_replace($array2, $array1));
+	}
+
+	/**
 	 * @param array<int, int|string> $array1
 	 * @param array<int, bool|float> $array2
 	 */

--- a/tests/PHPStan/Analyser/data/non-empty-array.php
+++ b/tests/PHPStan/Analyser/data/non-empty-array.php
@@ -49,6 +49,11 @@ class Foo
 		assertType('non-empty-array', array_merge($array, []));
 		assertType('non-empty-array', array_merge($array, $array));
 
+		assertType('non-empty-array', array_replace($array));
+		assertType('non-empty-array', array_replace([], $array));
+		assertType('non-empty-array', array_replace($array, []));
+		assertType('non-empty-array', array_replace($array, $array));
+
 		assertType('non-empty-array<int|string, (int|string)>', array_flip($array));
 		assertType('non-empty-array<string, (int|string)>', array_flip($stringArray));
 	}


### PR DESCRIPTION
Tried to built a simpler variant for the `array_replace` extension, which hopefully does not suffer from the perf problems which lead to [reverting the first revision. ](https://github.com/phpstan/phpstan/issues/5327#issuecomment-908136609)

My primary motivation was to cover a `non-empty-array` return type.. if the inference itself is too costly I could reduce the extension to only judge about the non-empty-ness


I re-used the tests from https://github.com/phpstan/phpstan-src/pull/696

closes https://github.com/phpstan/phpstan/issues/5327
closes https://github.com/phpstan/phpstan-src/pull/696