### PR TITLE
Fix memory error when trying to represent big literal string types

### DIFF
--- a/src/Type/Php/StrRepeatFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrRepeatFunctionReturnTypeExtension.php
@@ -17,6 +17,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
 use function str_repeat;
+use function strlen;
 
 class StrRepeatFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -48,7 +49,11 @@ class StrRepeatFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 			return new NeverType();
 		}
 
-		if ($inputType instanceof ConstantStringType && $multiplierType instanceof ConstantIntegerType) {
+		if ($inputType instanceof ConstantStringType &&
+			$multiplierType instanceof ConstantIntegerType &&
+			// don't generate type too big to avoid hitting memory limit
+			strlen($inputType->getValue()) * $multiplierType->getValue() < 100
+		) {
 			return new ConstantStringType(str_repeat($inputType->getValue(), $multiplierType->getValue()));
 		}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -569,6 +569,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug6866(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6866.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-6866.php
+++ b/tests/PHPStan/Analyser/data/bug-6866.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Bug6866;
+
+function f(): string
+{
+	// This would hit the memory limit if it was resolved as a ConstantStringType
+	return str_repeat('abcdefghij', 1000000000);
+}

--- a/tests/PHPStan/Analyser/data/literal-string.php
+++ b/tests/PHPStan/Analyser/data/literal-string.php
@@ -27,6 +27,11 @@ class Foo
 		assertType('literal-string', str_repeat($literalString, 10));
 		assertType("''", str_repeat('', 10));
 		assertType("'foofoofoofoofoofoofoofoofoofoo'", str_repeat('foo', 10));
+		assertType(
+			"'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'",
+			str_repeat('a', 99)
+		);
+		assertType('literal-string&non-empty-string', str_repeat('a', 100));
 		assertType("'?,?,?,'", str_repeat('?,', 3));
 		assertType("*NEVER*", str_repeat('?,', -3));
 


### PR DESCRIPTION
return a non-empty-string type instead when length is > 100

fix https://github.com/phpstan/phpstan/issues/6866