### PR TITLE
implement `PregMatchFunctionTypeSpecifyingExtension`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1235,6 +1235,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\PregMatchFunctionTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
+
+	-
 		class: PHPStan\Type\Php\ReflectionClassIsSubclassOfTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
@@ -79,7 +79,6 @@ final class PregMatchFunctionTypeSpecifyingExtension implements FunctionTypeSpec
 
 			if ($weDontKnowFlags || $offsetCapture) {
 				$builder = ConstantArrayTypeBuilder::createEmpty();
-
 				if ($weDontKnowFlags || $unmatchedAsNull) {
 					$builder->setOffsetValueType(new ConstantIntegerType(0), TypeCombinator::addNull(new StringType()));
 				} else {
@@ -87,6 +86,11 @@ final class PregMatchFunctionTypeSpecifyingExtension implements FunctionTypeSpec
 				}
 				$builder->setOffsetValueType(new ConstantIntegerType(1), IntegerRangeType::fromInterval(-1, null));
 				$valueType = $builder->getArray();
+
+				if ($weDontKnowFlags) {
+					$valueType = TypeCombinator::union(TypeCombinator::addNull(new StringType()), $valueType);
+				}
+
 			} elseif ($unmatchedAsNull) {
 				$valueType = TypeCombinator::addNull(new StringType());
 			}

--- a/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\IntegerRangeType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
 use function strtolower;

--- a/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BitwiseFlagHelper;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\TypeCombinator;
+use function strtolower;
+
+final class PregMatchFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	public function __construct(
+		private BitwiseFlagHelper $bitwiseFlagAnalyser,
+	)
+	{
+	}
+
+	private TypeSpecifier $typeSpecifier;
+
+	public function isFunctionSupported(
+		FunctionReflection $functionReflection,
+		FuncCall $node,
+		TypeSpecifierContext $context,
+	): bool
+	{
+		return strtolower($functionReflection->getName()) === 'preg_match'
+			&& !$context->null();
+	}
+
+	public function specifyTypes(
+		FunctionReflection $functionReflection,
+		FuncCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context,
+	): SpecifiedTypes
+	{
+		$args = $node->getArgs();
+		$matchesArg = $args[2]->value ?? null;
+		$optionsExpr = $args[3]->value ?? null;
+
+		if ($matchesArg === null) {
+			return new SpecifiedTypes();
+		}
+
+		if ($context->false()) {
+			return $this->typeSpecifier->create(
+				$matchesArg,
+				new ArrayType(new MixedType(), new MixedType()),
+				$context->negate(),
+				false,
+				$scope,
+			);
+		}
+
+		$valueType = new StringType();
+		if ($optionsExpr !== null) {
+			$unmatchedAsNull = $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'PREG_UNMATCHED_AS_NULL')->yes();
+			$offsetCapture = $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'PREG_OFFSET_CAPTURE')->yes();
+			$weDontKnowFlags = !$unmatchedAsNull && !$offsetCapture;
+
+			$optionsType = $scope->getType($optionsExpr);
+			if ($optionsType instanceof ConstantIntegerType) {
+				$weDontKnowFlags = false;
+			}
+
+			if ($weDontKnowFlags || $offsetCapture) {
+				$builder = ConstantArrayTypeBuilder::createEmpty();
+
+				if ($weDontKnowFlags || $unmatchedAsNull) {
+					$builder->setOffsetValueType(new ConstantIntegerType(0), TypeCombinator::addNull(new StringType()));
+				} else {
+					$builder->setOffsetValueType(new ConstantIntegerType(0), new StringType());
+				}
+				$builder->setOffsetValueType(new ConstantIntegerType(1), IntegerRangeType::fromInterval(-1, null));
+				$valueType = $builder->getArray();
+			} elseif ($unmatchedAsNull) {
+				$valueType = TypeCombinator::addNull(new StringType());
+			}
+		}
+
+		$arrayType = new ArrayType(
+			TypeCombinator::union(new StringType(), IntegerRangeType::fromInterval(0, null)),
+			$valueType,
+		);
+
+		return $this->typeSpecifier->create(
+			$matchesArg,
+			$arrayType,
+			$context,
+			false,
+			$scope,
+		);
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/PregMatchFunctionTypeSpecifyingExtension.php
@@ -38,7 +38,7 @@ final class PregMatchFunctionTypeSpecifyingExtension implements FunctionTypeSpec
 	): bool
 	{
 		return strtolower($functionReflection->getName()) === 'preg_match'
-			&& !$context->null();
+			&& $context->true();
 	}
 
 	public function specifyTypes(
@@ -54,16 +54,6 @@ final class PregMatchFunctionTypeSpecifyingExtension implements FunctionTypeSpec
 
 		if ($matchesArg === null) {
 			return new SpecifiedTypes();
-		}
-
-		if ($context->false()) {
-			return $this->typeSpecifier->create(
-				$matchesArg,
-				new ArrayType(new MixedType(), new MixedType()),
-				$context->negate(),
-				false,
-				$scope,
-			);
 		}
 
 		$valueType = new StringType();

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -361,7 +361,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$testScope,
 				'matches4',
 				TrinaryLogic::createMaybe(),
-				'array',
+				'mixed',
 			],
 			[
 				$testScope,

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -361,7 +361,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$testScope,
 				'matches4',
 				TrinaryLogic::createMaybe(),
-				'mixed',
+				'array',
 			],
 			[
 				$testScope,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -797,6 +797,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/preg-match-type-specifying.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/preg-match-type-specifying.php
+++ b/tests/PHPStan/Analyser/data/preg-match-type-specifying.php
@@ -9,7 +9,7 @@ class Foo {
 	{
 		// we don't know the flags, therefore allow all possible variations.
 		if (preg_match('/^[a-z]+$/', 'foo', $matches, $flags)) {
-			assertType('array<int<0, max>|string, array{string|null, int<-1, max>}>', $matches);
+			assertType('array<int<0, max>|string, array{string|null, int<-1, max>}|string|null>', $matches);
 		} else {
 			assertType('array', $matches);
 		}

--- a/tests/PHPStan/Analyser/data/preg-match-type-specifying.php
+++ b/tests/PHPStan/Analyser/data/preg-match-type-specifying.php
@@ -11,7 +11,7 @@ class Foo {
 		if (preg_match('/^[a-z]+$/', 'foo', $matches, $flags)) {
 			assertType('array<int<0, max>|string, array{string|null, int<-1, max>}|string|null>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 	}
 
@@ -19,48 +19,48 @@ class Foo {
 		if (preg_match('/^[a-z]+$/', 'foo', $matches)) {
 			assertType('array<int<0, max>|string, string>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 		if (preg_match($str, $str, $matches)) {
 			assertType('array<int<0, max>|string, string>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 		if (preg_match('/^[a-z]+$/', 'foo', $matches, 0)) {
 			assertType('array<int<0, max>|string, string>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 
 		if (preg_match('/(?P<name>\w+): (?P<digit>\d+)/', $str, $matches)) {
 			assertType('array<int<0, max>|string, string>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 
 		if (preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL)) {
 			assertType('array<int<0, max>|string, string|null>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 
 		if (preg_match('/(foo)(bar)(baz)/', 'foobarbaz', $matches, PREG_OFFSET_CAPTURE)) {
 			assertType('array<int<0, max>|string, array{string, int<-1, max>}>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 
 		if (preg_match('/(foo)(bar)(baz)/', 'foobarbaz', $matches, PREG_OFFSET_CAPTURE, 2)) {
 			assertType('array<int<0, max>|string, array{string, int<-1, max>}>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 
 		// see https://3v4l.org/TuUp4
 		if (preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE)) {
 			assertType('array<int<0, max>|string, array{string|null, int<-1, max>}>', $matches);
 		} else {
-			assertType('array', $matches);
+			assertType('mixed', $matches);
 		}
 
 		// just testing, our ext won't error on calls with just 2 args

--- a/tests/PHPStan/Analyser/data/preg-match-type-specifying.php
+++ b/tests/PHPStan/Analyser/data/preg-match-type-specifying.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PregMatchTypeSpecifying;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+	public function unknownFlags(int $flags)
+	{
+		// we don't know the flags, therefore allow all possible variations.
+		if (preg_match('/^[a-z]+$/', 'foo', $matches, $flags)) {
+			assertType('array<int<0, max>|string, array{string|null, int<-1, max>}>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+	}
+
+	public function matchVariants(string $str) {
+		if (preg_match('/^[a-z]+$/', 'foo', $matches)) {
+			assertType('array<int<0, max>|string, string>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+		if (preg_match($str, $str, $matches)) {
+			assertType('array<int<0, max>|string, string>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+		if (preg_match('/^[a-z]+$/', 'foo', $matches, 0)) {
+			assertType('array<int<0, max>|string, string>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+
+		if (preg_match('/(?P<name>\w+): (?P<digit>\d+)/', $str, $matches)) {
+			assertType('array<int<0, max>|string, string>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+
+		if (preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL)) {
+			assertType('array<int<0, max>|string, string|null>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+
+		if (preg_match('/(foo)(bar)(baz)/', 'foobarbaz', $matches, PREG_OFFSET_CAPTURE)) {
+			assertType('array<int<0, max>|string, array{string, int<-1, max>}>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+
+		if (preg_match('/(foo)(bar)(baz)/', 'foobarbaz', $matches, PREG_OFFSET_CAPTURE, 2)) {
+			assertType('array<int<0, max>|string, array{string, int<-1, max>}>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+
+		// see https://3v4l.org/TuUp4
+		if (preg_match('/(a)(b)*(c)/', 'ac', $matches, PREG_UNMATCHED_AS_NULL|PREG_OFFSET_CAPTURE)) {
+			assertType('array<int<0, max>|string, array{string|null, int<-1, max>}>', $matches);
+		} else {
+			assertType('array', $matches);
+		}
+
+		// just testing, our ext won't error on calls with just 2 args
+		if (preg_match("/\bweb\b/i", "PHP is the web scripting language of choice.")) {
+			echo "A match was found.";
+		} else {
+			echo "A match was not found.";
+		}
+	}
+}


### PR DESCRIPTION
adding type inference for `$matches` arg of `preg_match` calls.
after this is merged, I will tackle `preg_match_all` in a separate PR.

utilizes the newly added `BitwiseFlagHelper`

refs https://github.com/phpstan/phpstan/issues/6426