### PR TITLE
Fix/issue 5351 2

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -795,9 +795,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6790.php');
 		}
 
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4885.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4885.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -797,6 +797,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6584.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4885.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-4885.php
+++ b/tests/PHPStan/Analyser/data/bug-4885.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bug4885;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	/** @param array{word?: string} $data */
+	public function sayHello(array $data): void
+	{
+		echo ($data['word'] ?? throw new \RuntimeException('bye')) . ', World!';
+		assertType('array{word: string}', $data);
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-4885.php
+++ b/tests/PHPStan/Analyser/data/bug-4885.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug4885;
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -367,4 +367,9 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4747.php'], []);
 	}
 
+	public function testBug4885(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-4885.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -369,6 +369,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	public function testBug4885(): void
 	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
 		$this->analyse([__DIR__ . '/data/bug-4885.php'], []);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/data/bug-4885.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-4885.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bug4885;
+
+class Foo
+{
+	/** @param array{word?: string} $data */
+	public function sayHello(array $data): void
+	{
+		echo ($data['word'] ?? throw new \RuntimeException('bye')) . ', World!';
+		echo 'Again, the word was: ' . $data['word'];
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/bug-4885.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-4885.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug4885;
 


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/4885

Issue was not fixed by https://github.com/phpstan/phpstan-src/pull/1063, because`ensureShallowNonNullability` is not handling optional keys. This PR specifies type for `ArrayDimFetch` to make the `nonNullable` scope more precise.