### PR TITLE
Fix the combination of `Generator` and `new static` (issue #6494)

### DIFF
--- a/src/Rules/Generators/YieldFromTypeRule.php
+++ b/src/Rules/Generators/YieldFromTypeRule.php
@@ -85,6 +85,8 @@ class YieldFromTypeRule implements Rule
 		}
 		if (!$this->ruleLevelHelper->accepts($returnType->getIterableValueType(), $exprType->getIterableValueType(), $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($returnType->getIterableValueType(), $exprType->getIterableValueType());
+
+			// TODO: This might have the same issue?
 			$messages[] = RuleErrorBuilder::message(sprintf(
 				'Generator expects value type %s, %s given.',
 				$returnType->getIterableValueType()->describe($verbosityLevel),

--- a/src/Rules/Generators/YieldTypeRule.php
+++ b/src/Rules/Generators/YieldTypeRule.php
@@ -14,6 +14,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 use function sprintf;
+//use function strpos; TODO: remove
 
 /**
  * @implements Rule<Node\Expr\Yield_>
@@ -71,6 +72,27 @@ class YieldTypeRule implements Rule
 		}
 		if (!$this->ruleLevelHelper->accepts($returnType->getIterableValueType(), $valueType, $scope->isDeclareStrictTypes())) {
 			$verbosityLevel = VerbosityLevel::getRecommendedLevelByType($returnType->getIterableValueType(), $valueType);
+
+			// TODO: cleanup
+			/* Disabled to let testing pass
+			if (strpos($returnType->describe(VerbosityLevel::precise()), 'Bug6494') !== false) {
+				echo "\nStart YieldTypeRule\n";
+
+				echo 'Function return type class: ' . $returnType::class . "\n";
+				// PHPStan\Type\Generic\GenericObjectType
+
+				echo 'Function return type: ' . $returnType->describe(VerbosityLevel::precise()) . "\n";
+				// Generator<int, static(Bug6494\Base), void, void>
+
+				echo 'Function return iterable value type: ' . $returnType->getIterableValueType()->describe(VerbosityLevel::precise()) . "\n";
+				// Generator<int, static(Bug6494\Base), void, void>
+				// Which is the same as $returnType, incorrect!
+
+				echo 'Value type: ' . $valueType->describe(VerbosityLevel::precise()) . "\n";
+				// static(Bug6494\Base)
+			}
+			*/
+
 			$messages[] = RuleErrorBuilder::message(sprintf(
 				'Generator expects value type %s, %s given.',
 				$returnType->getIterableValueType()->describe($verbosityLevel),

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -738,12 +738,17 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			if ($tValue !== null) {
 				if (!$tValue instanceof MixedType || $tValue->isExplicitMixed()) {
 					$classReflection = $this->getClassReflection();
-					if ($classReflection === null) {
+					if ($classReflection === null || $classReflection->getName() === 'Generator') {
 						return $tValue;
 					}
 
 					return TypeTraverser::map($tValue, static function (Type $type, callable $traverse) use ($classReflection): Type {
+						// Turning this off will make Bug4267 fail (static really needs to be resolved)
 						if ($type instanceof StaticType) {
+
+							// For $classReflection===Generator and $type===Something this line will return Generator<int, Something, void, void>
+							// This wrapping with a Generator is incorrect right?
+							// Issue introduced in: https://github.com/phpstan/phpstan-src/commit/a2acf64f793976a21f22babbfc27318a60fea4fa
 							return $type->changeBaseClass($classReflection)->getStaticObjectType();
 						}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -506,6 +506,15 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug6494(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6494.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug6253(): void
 	{
 		$errors = $this->runAnalyse(

--- a/tests/PHPStan/Analyser/data/bug-6494.php
+++ b/tests/PHPStan/Analyser/data/bug-6494.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug6494;
+
+use function PHPStan\Testing\assertType;
+
+// To get rid of warnings about using new static()
+interface SomeInterface {
+	public function __construct();
+}
+
+class Base implements SomeInterface {
+
+	public function __construct() {}
+
+	/**
+	 * @return \Generator<int, static, void, void>
+	 */
+	public static function instances() {
+		yield new static();
+	}
+}
+
+function (): void {
+	foreach ((new Base())::instances() as $h) {
+		assertType(Base::class, $h);
+	}
+};
+
+class Extension extends Base {
+
+}
+
+function (): void {
+	foreach ((new Extension())::instances() as $h) {
+		assertType(Extension::class, $h);
+	}
+};


### PR DESCRIPTION
I debugged https://github.com/phpstan/phpstan/issues/6494 for a bit and have a more clear picture of where this goes wrong.

(posted this on the issue page initially, moved to a pull request to make discussion easier)

1. I added `tests/PHPStan/Analyser/data/bug-6494.php` that reproduces the issue
2. Updated `tests/PHPStan/Analyser/AnalyserIntegrationTest.php` to run the new test case
3. The issue resides in `src/Rules/Generators/YieldTypeRule.php`, which checks that type of the `yield ...` expression matches the type specified as the value type in the `Generator` the function should return. In code this means comparing `$valueType` to  `$returnType->getIterableValueType()`.
    - `$valueType` = `static(Bug6494\Base)`, which indeed matches the defintion of `Generator<int, static, void, void>`
    - `$returnType` = `Generator<int, static(Bug6494\Base), void, void>`, which correctly matches the phpdoc definition of the function
    - `$returnType->getIterableValueType()` = `Generator<int, static(Bug6494\Base), void, void>`, as well, which is incorrect and should have been only `static(Bug6494\Base)`
4. `getIterableValueType()` is implemented in `src/Type/ObjectType.php`, the implementation of it has changed in https://github.com/phpstan/phpstan-src/commit/a2acf64f793976a21f22babbfc27318a60fea4fa, which caused this issue it looks like.
5. As a rough fix I have disabled the new code for the `Generator` case, while keeping it for the `Traversable`/`Iterator` cases. With this fix all tests pass.

I'm not convinced this solution is 100% correct, do you know if I'm on the right track @ondrejmirtes?