### PR TITLE
Retain accessory string types in generics

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -363,7 +363,7 @@ class ArrayType implements Type
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -218,7 +218,7 @@ class CallableType implements CompoundType, ParametersAcceptor
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -316,7 +316,7 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -21,7 +21,6 @@ use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerRangeType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
@@ -766,7 +765,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -6,7 +6,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -122,7 +121,7 @@ class GenericClassStringType extends ClassStringType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -13,7 +13,6 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
@@ -212,7 +211,7 @@ class GenericObjectType extends ObjectType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -231,7 +231,7 @@ trait TemplateTypeTrait
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if (!$receivedType instanceof TemplateType && ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType)) {
+		if (!$receivedType instanceof TemplateType && $receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -515,17 +515,6 @@ class IntersectionType implements CompoundType
 		return $types;
 	}
 
-	public function inferTemplateTypesOn(Type $templateType): TemplateTypeMap
-	{
-		$types = TemplateTypeMap::createEmpty();
-
-		foreach ($this->types as $type) {
-			$types = $types->intersect($templateType->inferTemplateTypes($type));
-		}
-
-		return $types;
-	}
-
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
 		$references = [];

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -252,7 +252,7 @@ class IterableType implements CompoundType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+		if ($receivedType instanceof UnionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -339,6 +339,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug6301(): void
+	{
+		require_once __DIR__ . '/../Rules/Generics/data/bug-6301.php';
+		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Generics/data/bug-6301.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug3922(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3922-integration.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -308,8 +308,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		require_once __DIR__ . '/../Rules/Generics/data/bug-3769.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
-
-		require_once __DIR__ . '/../Rules/Generics/data/bug-6301.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-6301.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/instanceof-class-string.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -309,6 +309,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		require_once __DIR__ . '/../Rules/Generics/data/bug-3769.php';
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
 
+		require_once __DIR__ . '/../Rules/Generics/data/bug-6301.php';
+		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-6301.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/instanceof-class-string.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4498.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4587.php');

--- a/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
@@ -56,10 +56,4 @@ class FunctionTemplateTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3769.php'], []);
 	}
 
-	public function testBug6301(): void
-	{
-		require_once __DIR__ . '/data/bug-6301.php';
-		$this->analyse([__DIR__ . '/data/bug-6301.php'], []);
-	}
-
 }

--- a/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
@@ -56,4 +56,10 @@ class FunctionTemplateTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3769.php'], []);
 	}
 
+	public function testBug6301(): void
+	{
+		require_once __DIR__ . '/data/bug-6301.php';
+		$this->analyse([__DIR__ . '/data/bug-6301.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Generics/data/bug-6301.php
+++ b/tests/PHPStan/Rules/Generics/data/bug-6301.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bug6301;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @template T of string
+	 * @param T $s
+	 * @return T
+	 */
+	public function str($s)
+	{
+		return $s;
+	}
+
+	/**
+	 * @param non-empty-string $nonEmpty
+	 * @param numeric-string $numericString
+	 * @param literal-string $literalString
+	 */
+	public function foo(int $i, $nonEmpty, $numericString, $literalString):void {
+		assertType('numeric-string', $this->str((string) $i));
+		assertType('non-empty-string', $this->str($nonEmpty));
+		assertType('numeric-string', $this->str($numericString));
+		assertType('literal-string', $this->str($literalString));
+	}
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2112,10 +2112,10 @@ class CallMethodsRuleTest extends RuleTestCase
 				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, class-string> given.',
 				72,
 			],
-			/*[
+			[
 				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, literal-string> given.',
 				85,
-			],*/
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/bug-5372.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5372.php
@@ -81,7 +81,7 @@ class Foo
 		$this->takesStrings($newCol);
 
 		$newCol = $col->map2(static fn(string $var): string => $literalString);
-		assertType('Bug5372\Collection<int, string>', $newCol); // should be literal-string
+		assertType('Bug5372\Collection<int, literal-string>', $newCol);
 		$this->takesStrings($newCol);
 	}
 


### PR DESCRIPTION
Seems to fix phpstan/phpstan#6301. Inferring template types on intersection types is problematic because the bound type may not necessarily be a super type of all sub types of the passed intersection type.