### PR TITLE
Simplify FloatType::accepts handling of CompoundTypes

### DIFF
--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -51,10 +51,7 @@ class FloatType implements Type
 		}
 
 		if ($type instanceof CompoundType) {
-			return $type->isAcceptedBy(new UnionType([
-				$this,
-				new IntegerType(),
-			]), $strictTypes);
+			return $type->isAcceptedBy($this, $strictTypes);
 		}
 
 		return TrinaryLogic::createNo();

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -334,6 +334,10 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 
 	public function testBug6872(): void
 	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6872.php');
 		$this->assertNoErrors($errors);
 	}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -332,6 +332,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug6872(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6872.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug3769(): void
 	{
 		require_once __DIR__ . '/../Rules/Generics/data/bug-3769.php';

--- a/tests/PHPStan/Analyser/data/bug-6872.php
+++ b/tests/PHPStan/Analyser/data/bug-6872.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types = 1); // lint >= 8.0
 
 namespace Bug6872;
 

--- a/tests/PHPStan/Analyser/data/bug-6872.php
+++ b/tests/PHPStan/Analyser/data/bug-6872.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6872;
+
+/**
+ * @template TState of object
+ */
+abstract class Bug6872 {
+	public function __construct() {
+		// empty
+	}
+
+	/**
+	 * @param TState $state
+	 */
+	protected function saveState(object $state): void {
+		$this->set($state);
+	}
+
+	/**
+	 * @param object|array<mixed>|string|float|int|bool|null $value
+	 */
+	public function set(object|array|string|float|int|bool|null $value): mixed {
+		return $value;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6872

The problem is
1. It all starts with a `UnionType::accepts` with a `CompoundType` like e.g. `TemplateObjectWithoutClassType`
1. `UnionType::accepts` calls `accepts` on all inner types via https://github.com/phpstan/phpstan-src/blob/1.4.7/src/Type/UnionType.php#L104
1. If there is a `FloatType` in the union, then it would call `CompoundType::isAcceptedBy` with a newly created `float|int` union
1. the changes introduced in https://github.com/phpstan/phpstan-src/commit/35606f9ce1e933d4a226e8277176760ac9bd9162 would call `UnionType::accepts` (the new float|int one) via https://github.com/phpstan/phpstan-src/commit/35606f9ce1e933d4a226e8277176760ac9bd9162#diff-9085cfd032ca2e4178b6ba4ba9815c7bfffba6f2d5c0cfd06e29d3cb75fa0ecfR123
1. it starts from 1. again

I digged some more, apparently this was introduced in https://github.com/phpstan/phpstan-src/commit/adb4fddc837c2adc98a5aef913632eb033949ffb together with tests. And those tests are still there and green, see https://github.com/phpstan/phpstan-src/blob/1.4.x/tests/PHPStan/Type/FloatTypeTest.php. So the `FloatType` still accepts `int` and `float` and `int|float`. I think this should be fine then.