### PR TITLE
Skip test requiring the ds extension

### DIFF
--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Exceptions;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use function extension_loaded;
 use const PHP_VERSION_ID;
 
 /**
@@ -271,6 +272,10 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 	{
 		if (PHP_VERSION_ID < 70400) {
 			self::markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		if (!extension_loaded('ds')) {
+			self::markTestSkipped('Test requires the DS extension.');
 		}
 
 		$this->analyse([__DIR__ . '/data/bug-6791.php'], [


### PR DESCRIPTION
I recently noticed that the phpstan tests are not green for me anymore on my local machine.

Is this OK, should the test be adapted or is my setup weird (since nobody seemed to have complained yet)? Not sure if the ds extension is that common, apparently not? https://3v4l.org/aUsM0
@rajyan 