### PR TITLE
Feature/match expression throws tag

### DIFF
--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -96,6 +96,10 @@ class MatchExpressionRuleTest extends RuleTestCase
 				'Match expression does not handle remaining value: true',
 				90,
 			],
+			[
+				'Match expression does not handle remaining values: int<min, 0>|int<2, max>',
+				168,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -176,7 +176,7 @@ class MatchExpressionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6115.php'], [
 			[
 				'Match expression does not handle remaining value: 3',
-				28,
+				32,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/data/bug-6115.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6115.php
@@ -2,56 +2,63 @@
 
 namespace Bug6115;
 
-$array = [1, 2, 3];
-try {
-	foreach ($array as $value) {
-		$b = match ($value) {
-			1 => 0,
-			2 => 1,
-		};
-	}
-} catch (\UnhandledMatchError $e) {
-}
-
-try {
-	foreach ($array as $value) {
-		$b = match ($value) {
-			1 => 0,
-			2 => 1,
-		};
-	}
-} catch (\Error $e) {
-}
-
-try {
-	foreach ($array as $value) {
-		$b = match ($value) {
-			1 => 0,
-			2 => 1,
-		};
-	}
-} catch (\Exception $e) {
-}
-
-try {
-	foreach ($array as $value) {
-		$b = match ($value) {
-			1 => 0,
-			2 => 1,
-		};
-	}
-} catch (\UnhandledMatchError|\Exception $e) {
-}
-
-try {
-	try {
-		foreach ($array as $value) {
-			$b = match ($value) {
-				1 => 0,
-				2 => 1,
-			};
+class Foo
+{
+	public function bar()
+	{
+		$array = [1, 2, 3];
+		try {
+			foreach ($array as $value) {
+				$b = match ($value) {
+					1 => 0,
+					2 => 1,
+				};
+			}
+		} catch (\UnhandledMatchError $e) {
 		}
-	} catch (\Exception $e) {
+
+		try {
+			foreach ($array as $value) {
+				$b = match ($value) {
+					1 => 0,
+					2 => 1,
+				};
+			}
+		} catch (\Error $e) {
+		}
+
+		try {
+			foreach ($array as $value) {
+				$b = match ($value) {
+					1 => 0,
+					2 => 1,
+				};
+			}
+		} catch (\Exception $e) {
+		}
+
+		try {
+			foreach ($array as $value) {
+				$b = match ($value) {
+					1 => 0,
+					2 => 1,
+				};
+			}
+		} catch (\UnhandledMatchError|\Exception $e) {
+		}
+
+		try {
+			try {
+				foreach ($array as $value) {
+					$b = match ($value) {
+						1 => 0,
+						2 => 1,
+					};
+				}
+			} catch (\Exception $e) {
+			}
+		} catch (\UnhandledMatchError $e) {
+		}
 	}
-} catch (\UnhandledMatchError $e) {}
+}
 

--- a/tests/PHPStan/Rules/Comparison/data/match-expr.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-expr.php
@@ -138,3 +138,35 @@ class BarConstants
 
 
 }
+
+class ThrowsTag {
+	/**
+	 * @throws \UnhandledMatchError
+	 */
+	public function foo(int $bar): void
+	{
+		$str = match($bar) {
+			1 => 'test'
+		};
+	}
+
+	/**
+	 * @throws \Error
+	 */
+	public function bar(int $bar): void
+	{
+		$str = match($bar) {
+			1 => 'test'
+		};
+	}
+
+	/**
+	 * @throws \Exception
+	 */
+	public function baz(int $bar): void
+	{
+		$str = match($bar) {
+			1 => 'test'
+		};
+	}
+}


### PR DESCRIPTION
This PR implements additional feature to ignore remaining value for `MatchExpressionRule` if the `UnhandledMatchError` is explicitly noticed in `@throws` tag.

https://github.com/phpstan/phpstan-src/pull/1056#issuecomment-1073683847