### PR TITLE
Fix inferring template types on intersection types

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -363,7 +363,7 @@ class ArrayType implements Type
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -222,7 +222,7 @@ class CallableType implements CompoundType, ParametersAcceptor
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -320,7 +320,7 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -21,6 +21,7 @@ use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
@@ -765,7 +766,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -121,7 +122,7 @@ class GenericClassStringType extends ClassStringType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -13,6 +13,7 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
@@ -211,7 +212,7 @@ class GenericObjectType extends ObjectType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Generic;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -236,8 +237,10 @@ trait TemplateTypeTrait
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if (!$receivedType instanceof TemplateType && $receivedType instanceof UnionType) {
-			return $receivedType->inferTemplateTypesOn($this);
+		if (!$receivedType instanceof TemplateType && ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType)) {
+			if (!$receivedType instanceof IntersectionType || $this->shouldInferTemplatesOn($receivedType)) {
+				return $receivedType->inferTemplateTypesOn($this);
+			}
 		}
 
 		if (
@@ -268,6 +271,17 @@ trait TemplateTypeTrait
 	public function getVariance(): TemplateTypeVariance
 	{
 		return $this->variance;
+	}
+
+	private function shouldInferTemplatesOn(IntersectionType $type): bool
+	{
+		foreach ($type->getTypes() as $innerType) {
+			if ($innerType instanceof AccessoryType) {
+				return false;
+			}
+		}
+
+		return false;
 	}
 
 	protected function shouldGeneralizeInferredType(): bool

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Type\Generic;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -237,12 +236,6 @@ trait TemplateTypeTrait
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if (!$receivedType instanceof TemplateType && ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType)) {
-			if (!$receivedType instanceof IntersectionType || $this->shouldInferTemplatesOn($receivedType)) {
-				return $receivedType->inferTemplateTypesOn($this);
-			}
-		}
-
 		if (
 			$receivedType instanceof TemplateType
 			&& $this->getBound()->isSuperTypeOf($receivedType->getBound())->yes()
@@ -271,17 +264,6 @@ trait TemplateTypeTrait
 	public function getVariance(): TemplateTypeVariance
 	{
 		return $this->variance;
-	}
-
-	private function shouldInferTemplatesOn(IntersectionType $type): bool
-	{
-		foreach ($type->getTypes() as $innerType) {
-			if ($innerType instanceof AccessoryType) {
-				return false;
-			}
-		}
-
-		return false;
 	}
 
 	protected function shouldGeneralizeInferredType(): bool

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -256,7 +256,7 @@ class IterableType implements CompoundType
 
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
-		if ($receivedType instanceof UnionType) {
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
 			return $receivedType->inferTemplateTypesOn($this);
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -824,6 +824,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6889.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6891.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/simplexml.php');
+
+		if (PHP_VERSION_ID >= 80100) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6904.php');
+		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6917.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-6904.php
+++ b/tests/PHPStan/Analyser/data/bug-6904.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6904;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ */
+interface Collection
+{
+}
+
+
+/**
+ * @template T
+ */
+interface Selectable
+{
+	/** @return T */
+	public function first();
+}
+
+
+class HelloWorld
+{
+	/**
+     * @var Collection<stdClass>&Selectable<stdClass>
+     */
+    public Collection&Selectable $items;
+
+	/**
+     * @param Selectable<TValue> $selectable
+     * @return TValue
+     *
+     * @template TValue
+     */
+    private function matchOne(Selectable $selectable)
+    {
+		return $selectable->first();
+    }
+
+	public function run(): void
+    {
+        assertType('stdClass', $this->matchOne($this->items));
+    }
+}

--- a/tests/PHPStan/Analyser/data/bug-6917.php
+++ b/tests/PHPStan/Analyser/data/bug-6917.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6917;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+/** @phpstan-template T of object */
+interface AdminInterface
+{
+	/** @phpstan-return T */
+	public function getObject(): object;
+}
+
+interface HelloInterface
+{
+	/**
+	 * @phpstan-template T of object
+	 * @phpstan-param AdminInterface<T> $admin
+	 * @phpstan-return T
+	 */
+	public function setAdmin(AdminInterface $admin): object;
+}
+
+class Hello implements HelloInterface
+{
+	/** @inheritdoc */
+	public function setAdmin(AdminInterface $admin): object
+	{
+		return $admin->getObject();
+	}
+}
+
+class MockObject {}
+
+class Foo
+{
+	/**
+     * @var MockObject&AdminInterface<stdClass>
+     */
+    public $admin;
+
+	public function test(): void
+	{
+		$hello = new Hello();
+		assertType('stdClass', $hello->setAdmin($this->admin));
+	}
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2480,4 +2480,28 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+
+	public function testBug6904(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1');
+		}
+
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-6904.php'], []);
+	}
+
+
+	public function testBug6917(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-6917.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-6904.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-6904.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6904Rule;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ */
+interface Collection
+{
+}
+
+
+/**
+ * @template T
+ */
+interface Selectable
+{
+	/** @return T */
+	public function first();
+}
+
+
+class HelloWorld
+{
+	/**
+     * @var Collection<stdClass>&Selectable<stdClass>
+     */
+    public Collection&Selectable $items;
+
+	/**
+     * @param Selectable<TValue> $selectable
+     * @return TValue
+     *
+     * @template TValue
+     */
+    private function matchOne(Selectable $selectable)
+    {
+		return $selectable->first();
+    }
+
+	public function run(): void
+    {
+        assertType('stdClass', $this->matchOne($this->items));
+    }
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-6917.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-6917.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6917Rule;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+/** @phpstan-template T of object */
+interface AdminInterface
+{
+	/** @phpstan-return T */
+	public function getObject(): object;
+}
+
+interface HelloInterface
+{
+	/**
+	 * @phpstan-template T of object
+	 * @phpstan-param AdminInterface<T> $admin
+	 * @phpstan-return T
+	 */
+	public function setAdmin(AdminInterface $admin): object;
+}
+
+class Hello implements HelloInterface
+{
+	/** @inheritdoc */
+	public function setAdmin(AdminInterface $admin): object
+	{
+		return $admin->getObject();
+	}
+}
+
+class MockObject {}
+
+class Foo
+{
+	/**
+     * @var MockObject&AdminInterface<stdClass>
+     */
+    public $admin;
+
+	public function test(): void
+	{
+		$hello = new Hello();
+		assertType('stdClass', $hello->setAdmin($this->admin));
+	}
+}


### PR DESCRIPTION
c877ec1d3e0efdd47800e4c5c5259d49177250e5 was incorrect in hindsight

Closes phpstan/phpstan#6904 and phpstan/phpstan#6917