### PR TITLE
is_subclass_of do not infer anything when context is falsy

### DIFF
--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -10,7 +10,6 @@ use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use function count;
 use function strtolower;
@@ -34,17 +33,14 @@ class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeSpecify
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		if (count($node->getArgs()) < 2) {
+		if (!$context->truthy() || count($node->getArgs()) < 2) {
 			return new SpecifiedTypes();
 		}
+
 		$objectOrClassType = $scope->getType($node->getArgs()[0]->value);
 		$classType = $scope->getType($node->getArgs()[1]->value);
 		$allowStringType = isset($node->getArgs()[2]) ? $scope->getType($node->getArgs()[2]->value) : new ConstantBooleanType(true);
 		$allowString = !$allowStringType->equals(new ConstantBooleanType(false));
-
-		if (!$classType instanceof ConstantStringType && !$context->truthy()) {
-			return new SpecifiedTypes([], []);
-		}
 
 		return $this->typeSpecifier->create(
 			$node->getArgs()[0]->value,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -821,6 +821,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-replace.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6889.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6891.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/simplexml.php');
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-6891.php
+++ b/tests/PHPStan/Analyser/data/bug-6891.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6891;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+
+	/**
+	 * @param mixed $context
+	 */
+	public function sayHello($context): bool
+	{
+		if (is_subclass_of($context, HelloWorld::class)) {
+			return true;
+		}
+		assertType('mixed', $context);
+
+		return HelloWorld::class === $context;
+	}
+
+	public function sayHello2(object $context): bool
+	{
+		if (is_subclass_of($context, HelloWorld::class)) {
+			return true;
+		}
+		assertType('object', $context);
+
+		return HelloWorld::class === get_class($context);
+	}
+
+	public function sayHello3(string $context): bool
+	{
+		if (is_subclass_of($context, HelloWorld::class)) {
+			return true;
+		}
+		assertType('string', $context);
+
+		return HelloWorld::class === $context;
+	}
+}

--- a/tests/PHPStan/Analyser/data/generic-class-string.php
+++ b/tests/PHPStan/Analyser/data/generic-class-string.php
@@ -21,21 +21,20 @@ function testMixed($a) {
 		assertType('class-string<DateTimeInterface>|DateTimeInterface', $a);
 		assertType('DateTimeInterface', new $a());
 	} else {
-		assertType('mixed~class-string<DateTimeInterface>|DateTimeInterface', $a);
+		assertType('mixed', $a);
 	}
 
 	if (is_subclass_of($a, 'DateTimeInterface') || is_subclass_of($a, 'stdClass')) {
 		assertType('class-string<DateTimeInterface>|class-string<stdClass>|DateTimeInterface|stdClass', $a);
 		assertType('DateTimeInterface|stdClass', new $a());
 	} else {
-		// could also exclude stdClass
-		assertType('mixed~class-string<DateTimeInterface>|DateTimeInterface', $a);
+		assertType('mixed', $a);
 	}
 
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
 	} else {
-		assertType('mixed~class-string<PHPStan\Generics\GenericClassStringType\C>|PHPStan\Generics\GenericClassStringType\C', $a);
+		assertType('mixed', $a);
 	}
 }
 
@@ -48,7 +47,7 @@ function testObject($a) {
 	if (is_subclass_of($a, 'DateTimeInterface')) {
 		assertType('DateTimeInterface', $a);
 	} else {
-		assertType('object~DateTimeInterface', $a);
+		assertType('object', $a);
 	}
 }
 
@@ -82,13 +81,13 @@ function testStringObject($a) {
 		assertType('class-string<DateTimeInterface>|DateTimeInterface', $a);
 		assertType('DateTimeInterface', new $a());
 	} else {
-		assertType('object~DateTimeInterface|string', $a);
+		assertType('object|string', $a);
 	}
 
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
 	} else {
-		assertType('object~PHPStan\Generics\GenericClassStringType\C|string', $a);
+		assertType('object|string', $a);
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6891