### PR TITLE
Switch to serialize in FileCacheStorage

### DIFF
--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -318,4 +318,16 @@ class GenericObjectType extends ObjectType
 		);
 	}
 
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function __serialize(): array
+	{
+		return [
+			'className' => $this->getClassName(),
+			'types' => $this->types,
+			'subtractedType' => $this->getSubtractedType(),
+		];
+	}
+
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6896 and most likely also closes https://github.com/phpstan/phpstan/issues/6911

This basically fixes issues with circular references that `var_export` can't handle.
Performance-wise this seems to not change anything, not on cache-write and and also not when only reading from the cache.

If this is fine and has no side-effects I'm missing - in a follow-up I guess all `__set_state` could be removed. Maybe, actually, some of them need should be converted to `__serialize` basically, not sure yet. I'll take a look later I guess, wanted to see what CI says first :)
