### PR TITLE
Fix huge union types result from "+"-array-merge operation

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1317,7 +1317,7 @@ class MutatingScope implements Scope
 				$leftCount = count($leftConstantArrays);
 				$rightCount = count($rightConstantArrays);
 				if ($leftCount > 0 && $rightCount > 0
-					&& (($leftCount + $rightCount) < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
+					&& ($leftCount + $rightCount < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
 					$resultTypes = [];
 					foreach ($rightConstantArrays as $rightConstantArray) {
 						foreach ($leftConstantArrays as $leftConstantArray) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1314,8 +1314,10 @@ class MutatingScope implements Scope
 				$leftConstantArrays = TypeUtils::getConstantArrays($leftType);
 				$rightConstantArrays = TypeUtils::getConstantArrays($rightType);
 
-				if (count($leftConstantArrays) > 0 && count($rightConstantArrays) > 0
-					&& (count($leftConstantArrays) + count($rightConstantArrays) < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
+				$leftCount = count($leftConstantArrays);
+				$rightCount = count($rightConstantArrays);
+				if ($leftCount > 0 && $rightCount > 0
+					&& (($leftCount + $rightCount) < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
 					$resultTypes = [];
 					foreach ($rightConstantArrays as $rightConstantArray) {
 						foreach ($leftConstantArrays as $leftConstantArray) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1314,7 +1314,8 @@ class MutatingScope implements Scope
 				$leftConstantArrays = TypeUtils::getConstantArrays($leftType);
 				$rightConstantArrays = TypeUtils::getConstantArrays($rightType);
 
-				if (count($leftConstantArrays) > 0 && count($rightConstantArrays) > 0) {
+				if (count($leftConstantArrays) > 0 && count($rightConstantArrays) > 0
+					&& (count($leftConstantArrays) + count($rightConstantArrays) < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
 					$resultTypes = [];
 					foreach ($rightConstantArrays as $rightConstantArray) {
 						foreach ($leftConstantArrays as $leftConstantArray) {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -248,6 +248,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame(36, $error->getLine());
 	}
 
+	public function testBug6936(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6936.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug3405(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3405.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -838,6 +838,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-fill-keys.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6917.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6936-limit.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-6936-limit.php
+++ b/tests/PHPStan/Analyser/data/bug-6936-limit.php
@@ -40,10 +40,13 @@ class Foo
 		if (rand(0,1)) {
 			$arr[] = 'h';
 		}
+
+		assertType("array{0: 1|'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h', 1: 2|'b', 2: 3|'c', 3?: 'd', 4?: 'e', 5?: 'f', 6?: 'g', 7?: 'h'}", $arr + $arr2);
 		if (rand(0,1)) {
 			$arr[] = 'i';
 		}
 
+		// fallback to a less precise form, which reduces the union-type size
 		assertType("non-empty-array<0|1|2|3|4|5|6|7|8, 1|2|3|'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'|'i'>", $arr + $arr2);
 	}
 }

--- a/tests/PHPStan/Analyser/data/bug-6936-limit.php
+++ b/tests/PHPStan/Analyser/data/bug-6936-limit.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Bug6936Limits;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	/**
+	 * @return void
+	 */
+	public function testLimits():void
+	{
+		$arr2 = [1,2,3];
+
+		$arr = [];
+		if (rand(0,1)) {
+			$arr[] = 'a';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'b';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'c';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'd';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'e';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'f';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'g';
+		}
+
+		assertType("array{0: 1|'a'|'b'|'c'|'d'|'e'|'f'|'g', 1: 2|'b', 2: 3|'c', 3?: 'd', 4?: 'e', 5?: 'f', 6?: 'g'}", $arr + $arr2);
+		if (rand(0,1)) {
+			$arr[] = 'h';
+		}
+		if (rand(0,1)) {
+			$arr[] = 'i';
+		}
+
+		assertType("non-empty-array<0|1|2|3|4|5|6|7|8, 1|2|3|'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'|'i'>", $arr + $arr2);
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-6936.php
+++ b/tests/PHPStan/Analyser/data/bug-6936.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Bug6936;
+
+class clxAuftragController
+{
+	public function save_auftrag_changes():void
+	{
+		foreach ($_POST['adansch'] as $avkid => $adansch) {
+			$aktueller_endkunde = new x();
+			$avk = new avk();
+			$change = 0;
+			$col = [];
+			if ($adansch['telefon'] != $aktueller_endkunde->telefon && '' != $adansch['telefon']) {
+				$col['telefon'] = $adansch['telefon'];
+				$change = 1;
+			}
+			if ($adansch['email'] != $aktueller_endkunde->email && '' != $adansch['email']) {
+				$col['email'] = $adansch['email'];
+				$change = 1;
+			}
+			if ($adansch['fa_gruendungsjahr'] != $aktueller_endkunde->fa_gruendungsjahr) {
+				$col['fa_gruendungsjahr'] = $adansch['fa_gruendungsjahr'];
+				$change = 1;
+			}
+			if ($adansch['fa_geschaeftsfuehrer'] != $aktueller_endkunde->fa_geschaeftsfuehrer) {
+				$col['fa_geschaeftsfuehrer'] = $adansch['fa_geschaeftsfuehrer'];
+				$change = 1;
+			}
+			if ($adansch['handelregnr'] != $aktueller_endkunde->handelregnr) {
+				$col['handelregnr'] = $adansch['handelregnr'];
+				$change = 1;
+			}
+			if ($adansch['amtsgericht'] != $aktueller_endkunde->amtsgericht) {
+				$col['amtsgericht'] = $adansch['amtsgericht'];
+				$change = 1;
+			}
+			if ($adansch['ustid'] != $aktueller_endkunde->ustid) {
+				$col['ustid'] = $adansch['ustid'];
+				$change = 1;
+			}
+			if ($adansch['ustnr'] != $aktueller_endkunde->ustnr) {
+				$col['ustnr'] = $adansch['ustnr'];
+				$change = 1;
+			}
+
+			if ($adansch['firma'] != $aktueller_endkunde->firma) {
+				$col['firma'] = $adansch['firma'];
+				$change = 1;
+			}
+
+			if (1 == $change) {
+				// MobisHelper::createXmlDataJob("ada",(int)$aktueller_endkunde->adaid, $col);
+				if (!isset($_SENDJOB[$avk->avkid]['ada'][$aktueller_endkunde->adaid])) {
+					$_SENDJOB[$avk->avkid]['ada'][$aktueller_endkunde->adaid] = [];
+				}
+
+				$_SENDJOB[$avk->avkid]['ada'][$aktueller_endkunde->adaid] = $_SENDJOB[$avk->avkid]['ada'][$aktueller_endkunde->adaid] + $col;
+			}
+		}
+	}
+}
+
+
+class x {
+	/**
+	 * @var int
+	 */
+	public $adaid;
+	/**
+	 * @var string
+	 */
+	public $telefon;
+	/**
+	 * @var string
+	 */
+	public $email;
+	/**
+	 * @var string
+	 */
+	public $fa_gruendungsjahr;
+	/**
+	 * @var string
+	 */
+	public $fa_geschaeftsfuehrer;
+	/**
+	 * @var string
+	 */
+	public $handelregnr;
+	/**
+	 * @var string
+	 */
+	public $amtsgericht;
+	/**
+	 * @var string
+	 */
+	public $ustid;
+	/**
+	 * @var string
+	 */
+	public $ustnr;
+	/**
+	 * @var string
+	 */
+	public $firma;
+}
+class avk {
+	/**
+	 * @var int
+	 */
+	public $avkid;
+}


### PR DESCRIPTION
with the fix we apply the limit already used in `ConstantArrayTypeBuilder` also to the merge-process when analyzing constant-arrays beeing merged by the `+`-operator.

without the fix, the provided testcase runs 2-4 minutes. with the fix it runs in 3-5 seconds.

closes https://github.com/phpstan/phpstan/issues/6936