### PR TITLE
Mark `Memcached::HAVE_*` constants as dynamic

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -121,6 +121,12 @@ parameters:
 		- ICONV_IMPL
 		- LIBXML_VERSION
 		- LIBXML_DOTTED_VERSION
+		- Memcached::HAVE_ENCODING
+		- Memcached::HAVE_IGBINARY
+		- Memcached::HAVE_JSON
+		- Memcached::HAVE_MSGPACK
+		- Memcached::HAVE_SASL
+		- Memcached::HAVE_SESSION
 		- PHP_VERSION
 		- PHP_MAJOR_VERSION
 		- PHP_MINOR_VERSION


### PR DESCRIPTION
Fixes: https://github.com/phpstan/phpstan/issues/6263 (together with https://github.com/JetBrains/phpstorm-stubs/pull/1339 which is already included in 1.5).

Adding these directly to default configuration, so that it will work out of the box.