### PR TITLE
Guard Equal expression specification with empty array on both sides

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -379,14 +379,16 @@ class TypeSpecifier
 			}
 
 			if (
-				$rightType->isArray()->yes()
+				!$context->null()
+				&& $rightType->isArray()->yes()
 				&& $leftType instanceof ConstantArrayType && $leftType->isEmpty()
 			) {
 				return $this->create($expr->right, new NonEmptyArrayType(), $context->negate(), false, $scope);
 			}
 
 			if (
-				$leftType->isArray()->yes()
+				!$context->null()
+				&& $leftType->isArray()->yes()
 				&& $rightType instanceof ConstantArrayType && $rightType->isEmpty()
 			) {
 				return $this->create($expr->left, new NonEmptyArrayType(), $context->negate(), false, $scope);

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -619,6 +619,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertCount(6, $errors);
 	}
 
+	public function testBug6940(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6940.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-6940.php
+++ b/tests/PHPStan/Analyser/data/bug-6940.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6940;
+
+use function PHPStan\Testing\assertType;
+
+class Bug6940
+{
+
+	public function foo(): void
+	{
+		$b = [] == [];
+		assertType('bool', $b);
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6940

Context is null here.

Related: 2bef413d, e40eff0a

Let me know what the preferred target branch is, PHPStan is moving too fast, I can't keep up xD