### PR TITLE
Handle false return in substr with PHP < 8

### DIFF
--- a/src/Type/Php/SubstrDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SubstrDynamicReturnTypeExtension.php
@@ -27,7 +27,7 @@ class SubstrDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExten
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
@@ -55,7 +55,7 @@ class SubstrDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExten
 			}
 		}
 
-		return new StringType();
+		return null;
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -475,8 +475,15 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5219.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/strval.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-next.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-replace-functions.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-substr.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-substr-pre-80.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3981.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4711.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/sscanf.php');

--- a/tests/PHPStan/Analyser/data/non-empty-string-substr-pre-80.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string-substr-pre-80.php
@@ -15,7 +15,7 @@ class Foo
 	 */
 	public function doSubstr(string $s, $nonEmpty, $positiveInt, $postiveRange, $negativeRange): void
 	{
-		assertType('string', substr($s, 5));
+		assertType('(string|false)', substr($s, 5));
 
 		assertType('(string|false)', substr($s, -5));
 		assertType('non-empty-string', substr($nonEmpty, -5));

--- a/tests/PHPStan/Analyser/data/non-empty-string-substr-pre-80.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string-substr-pre-80.php
@@ -30,4 +30,5 @@ class Foo
 		assertType('(string|false)', substr($s, 0, $positiveInt));
 		assertType('non-empty-string', substr($nonEmpty, 0, $positiveInt));
 	}
+
 }

--- a/tests/PHPStan/Analyser/data/non-empty-string-substr-pre-80.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string-substr-pre-80.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace NonEmptyStringSubstr;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param non-empty-string $nonEmpty
+	 * @param positive-int $positiveInt
+	 * @param 1|2|3 $postiveRange
+	 * @param -1|-2|-3 $negativeRange
+	 */
+	public function doSubstr(string $s, $nonEmpty, $positiveInt, $postiveRange, $negativeRange): void
+	{
+		assertType('string', substr($s, 5));
+
+		assertType('(string|false)', substr($s, -5));
+		assertType('non-empty-string', substr($nonEmpty, -5));
+		assertType('non-empty-string', substr($nonEmpty, $negativeRange));
+
+		assertType('(string|false)', substr($s, 0, 5));
+		assertType('non-empty-string', substr($nonEmpty, 0, 5));
+		assertType('non-empty-string', substr($nonEmpty, 0, $postiveRange));
+
+		assertType('(string|false)', substr($nonEmpty, 0, -5));
+
+		assertType('(string|false)', substr($s, 0, $positiveInt));
+		assertType('non-empty-string', substr($nonEmpty, 0, $positiveInt));
+	}
+}

--- a/tests/PHPStan/Analyser/data/non-empty-string-substr.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string-substr.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace NonEmptyStringSubstr;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param non-empty-string $nonEmpty
+	 * @param positive-int $positiveInt
+	 * @param 1|2|3 $postiveRange
+	 * @param -1|-2|-3 $negativeRange
+	 */
+	public function doSubstr(string $s, $nonEmpty, $positiveInt, $postiveRange, $negativeRange): void
+	{
+		assertType('string', substr($s, 5));
+
+		assertType('string', substr($s, -5));
+		assertType('non-empty-string', substr($nonEmpty, -5));
+		assertType('non-empty-string', substr($nonEmpty, $negativeRange));
+
+		assertType('string', substr($s, 0, 5));
+		assertType('non-empty-string', substr($nonEmpty, 0, 5));
+		assertType('non-empty-string', substr($nonEmpty, 0, $postiveRange));
+
+		assertType('string', substr($nonEmpty, 0, -5));
+
+		assertType('string', substr($s, 0, $positiveInt));
+		assertType('non-empty-string', substr($nonEmpty, 0, $positiveInt));
+	}
+}

--- a/tests/PHPStan/Analyser/data/non-empty-string-substr.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string-substr.php
@@ -30,4 +30,5 @@ class Foo
 		assertType('string', substr($s, 0, $positiveInt));
 		assertType('non-empty-string', substr($nonEmpty, 0, $positiveInt));
 	}
+
 }

--- a/tests/PHPStan/Analyser/data/non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string.php
@@ -134,29 +134,6 @@ class Foo
 		}
 	}
 
-	/**
-	 * @param non-empty-string $nonEmpty
-	 * @param positive-int $positiveInt
-	 * @param 1|2|3 $postiveRange
-	 * @param -1|-2|-3 $negativeRange
-	 */
-	public function doSubstr(string $s, $nonEmpty, $positiveInt, $postiveRange, $negativeRange): void
-	{
-		assertType('string', substr($s, 5));
-
-		assertType('string', substr($s, -5));
-		assertType('non-empty-string', substr($nonEmpty, -5));
-		assertType('non-empty-string', substr($nonEmpty, $negativeRange));
-
-		assertType('string', substr($s, 0, 5));
-		assertType('non-empty-string', substr($nonEmpty, 0, 5));
-		assertType('non-empty-string', substr($nonEmpty, 0, $postiveRange));
-
-		assertType('string', substr($nonEmpty, 0, -5));
-
-		assertType('string', substr($s, 0, $positiveInt));
-		assertType('non-empty-string', substr($nonEmpty, 0, $positiveInt));
-	}
 }
 
 class ImplodingStrings

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -509,6 +509,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 
 		if (PHP_VERSION_ID < 80000) {
 			$this->analyse([__DIR__ . '/data/bug-6939.php'], []);
+			return;
 		}
 
 		$this->analyse([__DIR__ . '/data/bug-6939.php'], [

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -503,4 +503,20 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6939(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+
+		if (PHP_VERSION_ID < 80000) {
+			$this->analyse([__DIR__ . '/data/bug-6939.php'], []);
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-6939.php'], [
+			[
+				'Strict comparison using === between string and false will always evaluate to false.',
+				10,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-6939.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6939.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6939;
+
+class HelloWorld
+{
+	public static function read(int $pos, int $bytes): string
+	{
+		$data = substr('', $pos, $bytes);
+		return $data === false ? '' : $data;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6939

https://www.php.net/manual/en/function.substr.php#refsect1-function.substr-changelog

Initially I duplicated the benevolent union from the stubs and added a new method to `PhpVersion`, buuuut let's see if #1061 takes care of that :)

Related: 9ee914ba