### PR TITLE
Improve return type of `array_fill_keys` for not constant arrays

### DIFF
--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -35,6 +35,18 @@ class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnT
 		$keysType = $scope->getType($functionCall->getArgs()[0]->value);
 		$constantArrays = TypeUtils::getConstantArrays($keysType);
 		if (count($constantArrays) === 0) {
+			if ($keysType->isArray()->yes()) {
+				$itemType = $keysType->getIterableValueType();
+
+				if ((new IntegerType())->isSuperTypeOf($itemType)->no()) {
+					if ($itemType->toString() instanceof ErrorType) {
+						return new ArrayType($itemType, $valueType);
+					}
+
+					return new ArrayType($itemType->toString(), $valueType);
+				}
+			}
+
 			return new ArrayType($keysType->getIterableValueType(), $valueType);
 		}
 

--- a/tests/PHPStan/Analyser/data/array-fill-keys.php
+++ b/tests/PHPStan/Analyser/data/array-fill-keys.php
@@ -50,3 +50,19 @@ function withObjectKey() : array
 	assertType("non-empty-array<string, 'b'>", array_fill_keys([new Bar()], 'b'));
 	assertType("*NEVER*", array_fill_keys([new Baz()], 'b'));
 }
+
+/**
+ * @param Bar[] $foo
+ * @param int[] $bar
+ * @param Foo[] $baz
+ * @param float[] $floats
+ * @param array<int, int|string|bool> $mixed
+ */
+function withNotConstantArray(array $foo, array $bar, array $baz, array $floats, array $mixed): void
+{
+	assertType("array<string, null>", array_fill_keys($foo, null));
+	assertType("array<int, null>", array_fill_keys($bar, null));
+	assertType("array<'foo', null>", array_fill_keys($baz, null));
+	assertType("array<numeric-string, null>", array_fill_keys($floats, null));
+	assertType("array<bool|int|string, null>", array_fill_keys($mixed, null));
+}


### PR DESCRIPTION
This PR adds handling of not constant arrays to ArrayFillKeysFunctionReturnTypeExtension