### PR TITLE
 Display verbose error message on failed baseline update

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -272,6 +272,12 @@ class AnalyseCommand extends Command
 			}
 			if ($analysisResult->hasInternalErrors()) {
 				$inceptionResult->getStdOutput()->getStyle()->error('An internal error occurred. Baseline could not be generated. Re-run PHPStan without --generate-baseline to see what\'s going on.');
+				if ($output->isVerbose()) {
+					$inceptionResult->getStdOutput()->getStyle()->error(sprintf(
+							"Internal error list:\n-%s",
+							implode("\n-", $analysisResult->getInternalErrors()))
+					);
+				}
 
 				return $inceptionResult->handleReturn(1);
 			}

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -273,10 +273,7 @@ class AnalyseCommand extends Command
 			if ($analysisResult->hasInternalErrors()) {
 				$inceptionResult->getStdOutput()->getStyle()->error('An internal error occurred. Baseline could not be generated. Re-run PHPStan without --generate-baseline to see what\'s going on.');
 				if ($output->isVerbose()) {
-					$inceptionResult->getStdOutput()->getStyle()->error(sprintf(
-							"Internal error list:\n-%s",
-							implode("\n-", $analysisResult->getInternalErrors()))
-					);
+					$inceptionResult->getStdOutput()->getStyle()->error(sprintf("Internal error list:\n-%s", implode("\n-", $analysisResult->getInternalErrors())));
 				}
 
 				return $inceptionResult->handleReturn(1);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6956

## Goal

Display more detailed error message instead of too generic one:
`An internal error occurred. Baseline could not be generated. Re-run PHPStan without --generate-baseline to see what\'s going on.`

