### PR TITLE
more precise getenv() signature

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3325,7 +3325,7 @@ return [
 'getcwd' => ['non-empty-string|false'],
 'getdate' => ['array{seconds: int<0, 59>, minutes: int<0, 59>, hours: int<0, 23>, mday: int<1, 31>, wday: int<0, 6>, mon: int<1, 12>, year: int, yday: int<0, 365>, weekday: "Monday"|"Tuesday"|"Wednesday"|"Thursday"|"Friday"|"Saturday"|"Sunday", month: "January"|"February"|"March"|"April"|"May"|"June"|"July"|"August"|"September"|"October"|"November"|"December", 0: int}', 'timestamp='=>'int'],
 'getenv' => ['string|false', 'varname'=>'string', 'local_only='=>'bool'],
-'getenv\'1' => ['string[]'],
+'getenv\'1' => ['array<string, string>'],
 'gethostbyaddr' => ['string|false', 'ip_address'=>'string'],
 'gethostbyname' => ['string', 'hostname'=>'string'],
 'gethostbynamel' => ['array|false', 'hostname'=>'string'],

--- a/tests/PHPStan/Analyser/data/bug-4538.php
+++ b/tests/PHPStan/Analyser/data/bug-4538.php
@@ -12,6 +12,6 @@ class Foo
 	public function bar(string $index): void
 	{
 		assertType('string|false', getenv($index));
-		assertType('array<string>', getenv());
+		assertType('array<string, string>', getenv());
 	}
 }


### PR DESCRIPTION
on my way working thru the psalm stubs with conditional types.

found this one, which doesn't need a conditional type on phpstan-side

https://phpstan.org/r/41c8a989-5c2d-4588-8186-3029085c1d4b
https://3v4l.org/WPkcQ

inspired by psalm stub

https://github.com/vimeo/psalm/blob/c209c66263ab24b04e5034d7160befc55af8d610/stubs/CoreGenericFunctions.phpstub#L493