### PR TITLE
Limit nested ConstantArrayTypes

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -631,6 +631,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug6948(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6948.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-6948.php
+++ b/tests/PHPStan/Analyser/data/bug-6948.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Bug6948;
+
+$row = [1];
+
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6948

just playing around with this, not quite happy yet..

This adds depth tracking to ConstantArrayType and uses this info in ConstantArrayTypeBuilder to degrade to a general array in case the limit is reached. At least that's how I started and then I found out that the specific issue targeted here, or endless nesting in general, is only improved to some extent by this and needs special handling which is how the "cutoff" adaption was created.