### PR TITLE
Fix false positive `UnhandledMatchError` throw point

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2549,6 +2549,7 @@ class NodeScopeResolver
 			$matchScope = $scope;
 			$armNodes = [];
 			$hasDefaultCond = false;
+			$hasAlwaysTrueCond = false;
 			foreach ($expr->arms as $arm) {
 				if ($arm->conds === null) {
 					$hasDefaultCond = true;
@@ -2574,6 +2575,10 @@ class NodeScopeResolver
 					$hasYield = $hasYield || $armCondResult->hasYield();
 					$throwPoints = array_merge($throwPoints, $armCondResult->getThrowPoints());
 					$armCondExpr = new BinaryOp\Identical($expr->cond, $armCond);
+					$armCondType = $armCondResult->getScope()->getType($armCondExpr);
+					if ($armCondType instanceof ConstantBooleanType && $armCondType->getValue()) {
+						$hasAlwaysTrueCond = true;
+					}
 					$armCondScope = $armCondResult->getScope()->filterByFalseyValue($armCondExpr);
 					if ($filteringExpr === null) {
 						$filteringExpr = $armCondExpr;
@@ -2599,7 +2604,7 @@ class NodeScopeResolver
 			}
 
 			$remainingType = $matchScope->getType($expr->cond);
-			if (!$hasDefaultCond && !$remainingType instanceof NeverType) {
+			if (!$hasDefaultCond && !$hasAlwaysTrueCond && !$remainingType instanceof NeverType) {
 				$throwPoints[] = ThrowPoint::createExplicit($scope, new ObjectType(UnhandledMatchError::class), $expr, false);
 			}
 

--- a/tests/PHPStan/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRuleTest.php
@@ -99,6 +99,9 @@ class ThrowsVoidMethodWithExplicitThrowPointRuleTest extends RuleTestCase
 
 	public function testBug6910(): void
 	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
 		$this->missingCheckedExceptionInThrows = false;
 		$this->checkedExceptionClasses = [UnhandledMatchError::class];
 		$this->analyse([__DIR__ . '/data/bug-6910.php'], []);

--- a/tests/PHPStan/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Exceptions;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use ThrowsVoidMethod\MyException;
+use UnhandledMatchError;
 
 /**
  * @extends RuleTestCase<ThrowsVoidMethodWithExplicitThrowPointRule>
@@ -94,6 +95,13 @@ class ThrowsVoidMethodWithExplicitThrowPointRuleTest extends RuleTestCase
 		$this->missingCheckedExceptionInThrows = $missingCheckedExceptionInThrows;
 		$this->checkedExceptionClasses = $checkedExceptionClasses;
 		$this->analyse([__DIR__ . '/data/throws-void-method.php'], $errors);
+	}
+
+	public function testBug6910(): void
+	{
+		$this->missingCheckedExceptionInThrows = false;
+		$this->checkedExceptionClasses = [UnhandledMatchError::class];
+		$this->analyse([__DIR__ . '/data/bug-6910.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRuleTest.php
@@ -6,6 +6,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use ThrowsVoidMethod\MyException;
 use UnhandledMatchError;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ThrowsVoidMethodWithExplicitThrowPointRule>

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6910.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6910.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types = 1); // lint >= 8.0
 
 namespace Bug6910;
 

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6910.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6910.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6910;
+
+class RedFish {}
+
+class BlueFish {}
+
+class Net {
+	public RedFish|BlueFish $heldFish;
+	public int $prop;
+
+	/**
+	 * @throws void
+	 */
+	public function dropFish(): void {
+		match ($this->heldFish instanceof RedFish) {
+			true => 'hello',
+			false => 'world',
+		};
+	}
+
+	/**
+	 * @throws void
+	 * @param 'hello'|'world' $string
+	 */
+	public function issetFish(string $string): void {
+		match ($string === 'hello') {
+			true => 'hello',
+			false => 'world',
+		};
+	}
+
+	/**
+	 * @throws void
+	 */
+	public function anotherFish(bool $bool): void {
+		match ($bool) {
+			true => 'hello',
+			false => 'world',
+		};
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/6910

```php
match ($this->heldFish instanceof RedFish) {
	true => 'hello',
	false => 'world', // $this->heldFish instanceof RedFish === false is always true here
       // $this->heldFish is *NEVER* here but $this->heldFish instanceof RedFish is not
};
```
the logic in `NodeScopeResolver` is only checking whether the remaining type is never and cannot understand that `UnhandledMatchError` is not thrown.

Noticed that most false positive cases like in the tests can be solved by adding a similar logic to 
https://github.com/phpstan/phpstan-src/blob/2b9d2128db146f1bc2972ee68fdaafbc94e651f6/src/Rules/Comparison/MatchExpressionRule.php#L63-L82

If there is a always true condition, `UnhandledMatchError` is not thrown.