### PR TITLE
Avoid describing ConstantArrayType values twice

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -758,8 +758,9 @@ class ConstantArrayType extends ArrayType implements ConstantType
 					}
 				}
 
-				$items[] = sprintf('%s%s: %s', $keyDescription, $isOptional ? '?' : '', $valueType->describe($level));
-				$values[] = $valueType->describe($level);
+				$valueTypeDescription = $valueType->describe($level);
+				$items[] = sprintf('%s%s: %s', $keyDescription, $isOptional ? '?' : '', $valueTypeDescription);
+				$values[] = $valueTypeDescription;
 			}
 
 			$append = '';


### PR DESCRIPTION
First baby-step to making nested `ConstantArrayType` handling faster.

I noticed that `describe` is really slow for deeply nested constant arrays. So not calling describe for them twice can make quite a difference. For "normal" constant arrays I guess this is not more than a micro optimisation.

Don't expect any immediate follow-up PRs please.. `describe` (which is used for super type checks too AFAIK) seems to be quite an important bit to improve and there is more to do here, but it is for sure not everything that is making the nested constant arrays slow.