### PR TITLE
Avoid calling describe on ConstantArrayTypes

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3088,7 +3088,7 @@ class MutatingScope implements Scope
 			throw new ShouldNotHappenException();
 		}
 
-		if ((new ObjectType(ArrayAccess::class))->isSuperTypeOf($offsetAccessibleType)->yes()) {
+		if (!$offsetAccessibleType->isArray()->yes() && (new ObjectType(ArrayAccess::class))->isSuperTypeOf($offsetAccessibleType)->yes()) {
 			return $this->getType(
 				new MethodCall(
 					$arrayDimFetch->var,

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3306,7 +3306,7 @@ class NodeScopeResolver
 				$valueToWrite = $offsetValueType->setOffsetValueType($offsetType, $valueToWrite, $i === 0);
 			}
 
-			if (!(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->yes()) {
+			if ($varType->isArray()->yes() || !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->yes()) {
 				if ($var instanceof Variable && is_string($var->name)) {
 					$scope = $scope->assignVariable($var->name, $valueToWrite);
 				} else {
@@ -3334,7 +3334,7 @@ class NodeScopeResolver
 				}
 			}
 
-			if (!(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
+			if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 				$throwPoints = array_merge($throwPoints, $this->processExprNode(
 					new MethodCall($var, 'offsetSet'),
 					$scope,


### PR DESCRIPTION
As `describe` can get really slow atm with deeply nested arrays, we should avoid calling it when doing `ArrayAccess` supertype checks (describe is used in `ObjectType::isSupertypeOf`). This greatly improves assignments of such nested arrays.

Beware: I did this with one hand and while carrying a baby, so even if CI is green, I'd like to double-check if the logic is right xD