### PR TITLE
Fix curl_getinfo($ch, CURLINFO_CONTENT_TYPE)

### DIFF
--- a/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
@@ -93,7 +93,7 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'CURLINFO_SSL_VERIFYRESULT' => $integerType,
 			'CURLINFO_CONTENT_LENGTH_DOWNLOAD' => $floatType,
 			'CURLINFO_CONTENT_LENGTH_UPLOAD' => $floatType,
-			'CURLINFO_CONTENT_TYPE' => $stringType,
+			'CURLINFO_CONTENT_TYPE' => $stringFalseType,
 			'CURLINFO_PRIVATE' => $stringFalseType,
 			'CURLINFO_RESPONSE_CODE' => $integerType,
 			'CURLINFO_HTTP_CONNECTCODE' => $integerType,

--- a/tests/PHPStan/Analyser/data/curl_getinfo.php
+++ b/tests/PHPStan/Analyser/data/curl_getinfo.php
@@ -44,7 +44,7 @@ class Foo
 		assertType('int', curl_getinfo($handle, CURLINFO_SSL_VERIFYRESULT));
 		assertType('float', curl_getinfo($handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD));
 		assertType('float', curl_getinfo($handle, CURLINFO_CONTENT_LENGTH_UPLOAD));
-		assertType('string', curl_getinfo($handle, CURLINFO_CONTENT_TYPE));
+		assertType('string|false', curl_getinfo($handle, CURLINFO_CONTENT_TYPE));
 		assertType('string|false', curl_getinfo($handle, CURLINFO_PRIVATE));
 		assertType('int', curl_getinfo($handle, CURLINFO_RESPONSE_CODE));
 		assertType('int', curl_getinfo($handle, CURLINFO_HTTP_CONNECTCODE));


### PR DESCRIPTION
This returns `string|false`. `false` is returned if the header is not
set.

I suspect some of the other dynamic types for this function are also
wrong in similar cases, but I have only verified this one.

Closes https://github.com/phpstan/phpstan/issues/6929.