### PR TITLE
Remove unnecessary ConstantArrayType::getKeyType

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -192,15 +192,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $return;
 	}
 
-	public function getKeyType(): Type
-	{
-		if (count($this->keyTypes) > 1) {
-			return new UnionType($this->keyTypes);
-		}
-
-		return parent::getKeyType();
-	}
-
 	/**
 	 * @return array<int, ConstantIntegerType|ConstantStringType>
 	 */


### PR DESCRIPTION
This is not needed because `keyTypes` is never modified directly inside the class. E.g. `setOffsetValueType` is using `ConstantArrayTypeBuilder`, which creates a new `ConstantArrayType`, which unions the keys again before passing them to the `ArrayType` parent. Meaning, `parent::getKeyType` is always save to use and contains the latest union already.

So this saves another union operation there and should, in theory, improve performance. But the problematic scenarios that I have lying around seem to be not affected by it and therefore I can't deliver a good-looking before/after comparison. But anyways, unnecessary code is unnecessary code :)