### PR TITLE
Feature/undefined expression allowed

### DIFF
--- a/src/Analyser/DirectScopeFactory.php
+++ b/src/Analyser/DirectScopeFactory.php
@@ -51,6 +51,7 @@ class DirectScopeFactory implements ScopeFactory
 	 * @param VariableTypeHolder[] $moreSpecificTypes
 	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
 	 * @param array<string, true> $currentlyAssignedExpressions
+	 * @param array<string, bool> $currentlyAllowedUndefinedExpressions
 	 * @param array<string, Type> $nativeExpressionTypes
 	 * @param array<(FunctionReflection|MethodReflection)> $inFunctionCallsStack
 	 *
@@ -68,6 +69,7 @@ class DirectScopeFactory implements ScopeFactory
 		?ParametersAcceptor $anonymousFunctionReflection = null,
 		bool $inFirstLevelStatement = true,
 		array $currentlyAssignedExpressions = [],
+		array $currentlyAllowedUndefinedExpressions = [],
 		array $nativeExpressionTypes = [],
 		array $inFunctionCallsStack = [],
 		bool $afterExtractCall = false,
@@ -102,6 +104,7 @@ class DirectScopeFactory implements ScopeFactory
 			$anonymousFunctionReflection,
 			$inFirstLevelStatement,
 			$currentlyAssignedExpressions,
+			$currentlyAllowedUndefinedExpressions,
 			$nativeExpressionTypes,
 			$inFunctionCallsStack,
 			$this->dynamicConstantNames,

--- a/src/Analyser/LazyScopeFactory.php
+++ b/src/Analyser/LazyScopeFactory.php
@@ -42,6 +42,7 @@ class LazyScopeFactory implements ScopeFactory
 	 * @param VariableTypeHolder[] $moreSpecificTypes
 	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
 	 * @param array<string, true> $currentlyAssignedExpressions
+	 * @param array<string, bool> $currentlyAllowedUndefinedExpressions
 	 * @param array<string, Type> $nativeExpressionTypes
 	 * @param array<(FunctionReflection|MethodReflection)> $inFunctionCallsStack
 	 *
@@ -59,6 +60,7 @@ class LazyScopeFactory implements ScopeFactory
 		?ParametersAcceptor $anonymousFunctionReflection = null,
 		bool $inFirstLevelStatement = true,
 		array $currentlyAssignedExpressions = [],
+		array $currentlyAllowedUndefinedExpressions = [],
 		array $nativeExpressionTypes = [],
 		array $inFunctionCallsStack = [],
 		bool $afterExtractCall = false,
@@ -93,6 +95,7 @@ class LazyScopeFactory implements ScopeFactory
 			$anonymousFunctionReflection,
 			$inFirstLevelStatement,
 			$currentlyAssignedExpressions,
+			$currentlyAllowedUndefinedExpressions,
 			$nativeExpressionTypes,
 			$inFunctionCallsStack,
 			$this->dynamicConstantNames,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4148,7 +4148,9 @@ class MutatingScope implements Scope
 	{
 		$exprString = $this->getNodeKey($expr);
 		$currentlyAllowedUndefinedExpressions = $this->currentlyAllowedUndefinedExpressions;
-		$currentlyAllowedUndefinedExpressions[$exprString] = $isAllowed;
+		if (!array_key_exists($exprString, $currentlyAllowedUndefinedExpressions)) {
+			$currentlyAllowedUndefinedExpressions[$exprString] = $isAllowed;
+		}
 
 		return $this->scopeFactory->create(
 			$this->context,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4147,10 +4147,11 @@ class MutatingScope implements Scope
 	public function setAllowedUndefinedExpression(Expr $expr, bool $isAllowed): self
 	{
 		$exprString = $this->getNodeKey($expr);
-		$currentlyAllowedUndefinedExpressions = $this->currentlyAllowedUndefinedExpressions;
-		if (!array_key_exists($exprString, $currentlyAllowedUndefinedExpressions)) {
-			$currentlyAllowedUndefinedExpressions[$exprString] = $isAllowed;
+		if (array_key_exists($exprString, $this->currentlyAllowedUndefinedExpressions)) {
+			return $this;
 		}
+		$currentlyAllowedUndefinedExpressions = $this->currentlyAllowedUndefinedExpressions;
+		$currentlyAllowedUndefinedExpressions[$exprString] = $isAllowed;
 
 		return $this->scopeFactory->create(
 			$this->context,

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1508,7 +1508,7 @@ class NodeScopeResolver
 			$scope = $scope->setAllowedUndefinedExpression($expr, $isAllowed);
 		}
 		if (!$expr instanceof Variable) {
-			return $this->lookForVariableAssignCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->setAllowedUndefinedExpression($expr, $isAllowed));
+			return $this->lookForVariableCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->setAllowedUndefinedExpression($expr, $isAllowed));
 		}
 
 		return $scope;
@@ -1520,7 +1520,7 @@ class NodeScopeResolver
 			$scope = $scope->unsetAllowedUndefinedExpression($expr);
 		}
 		if (!$expr instanceof Variable) {
-			return $this->lookForVariableAssignCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->unsetAllowedUndefinedExpression($expr));
+			return $this->lookForVariableCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->unsetAllowedUndefinedExpression($expr));
 		}
 
 		return $scope;
@@ -1529,7 +1529,7 @@ class NodeScopeResolver
 	/**
 	 * @param Closure(MutatingScope $scope, Expr $expr): MutatingScope $callback
 	 */
-	private function lookForVariableAssignCallback(MutatingScope $scope, Expr $expr, Closure $callback): MutatingScope
+	private function lookForVariableCallback(MutatingScope $scope, Expr $expr, Closure $callback): MutatingScope
 	{
 		if ($expr instanceof Variable) {
 			$scope = $callback($scope, $expr);
@@ -1538,12 +1538,12 @@ class NodeScopeResolver
 				$scope = $callback($scope, $expr);
 			}
 
-			$scope = $this->lookForVariableAssignCallback($scope, $expr->var, $callback);
+			$scope = $this->lookForVariableCallback($scope, $expr->var, $callback);
 		} elseif ($expr instanceof PropertyFetch || $expr instanceof Expr\NullsafePropertyFetch) {
-			$scope = $this->lookForVariableAssignCallback($scope, $expr->var, $callback);
+			$scope = $this->lookForVariableCallback($scope, $expr->var, $callback);
 		} elseif ($expr instanceof StaticPropertyFetch) {
 			if ($expr->class instanceof Expr) {
-				$scope = $this->lookForVariableAssignCallback($scope, $expr->class, $callback);
+				$scope = $this->lookForVariableCallback($scope, $expr->class, $callback);
 			}
 		} elseif ($expr instanceof Array_ || $expr instanceof List_) {
 			foreach ($expr->items as $item) {
@@ -1551,7 +1551,7 @@ class NodeScopeResolver
 					continue;
 				}
 
-				$scope = $this->lookForVariableAssignCallback($scope, $item->value, $callback);
+				$scope = $this->lookForVariableCallback($scope, $item->value, $callback);
 			}
 		}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2290,7 +2290,12 @@ class NodeScopeResolver
 			);
 		} elseif ($expr instanceof Coalesce) {
 			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->left, false);
-			$scope = $this->lookForEnterAllowedUndefinedVariable($nonNullabilityResult->getScope(), $expr->left, true);
+			if ($expr->left instanceof PropertyFetch || $expr->left instanceof Expr\NullsafePropertyFetch || $expr->left instanceof StaticPropertyFetch) {
+				$scope = $nonNullabilityResult->getScope()->setAllowedUndefinedExpression($expr->left, false);
+			} else {
+				$scope = $nonNullabilityResult->getScope();
+			}
+			$scope = $this->lookForEnterAllowedUndefinedVariable($scope, $expr->left, true);
 			$result = $this->processExprNode($expr->left, $scope, $nodeCallback, $context->enterDeep());
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1325,9 +1325,9 @@ class NodeScopeResolver
 			$hasYield = false;
 			$throwPoints = [];
 			foreach ($stmt->vars as $var) {
-				$scope = $this->lookForEnterVariableAssign($scope, $var);
+				$scope = $this->lookForEnterAllowedUndefinedVariable($scope, $var, true);
 				$scope = $this->processExprNode($var, $scope, $nodeCallback, ExpressionContext::createDeep())->getScope();
-				$scope = $this->lookForExitVariableAssign($scope, $var);
+				$scope = $this->lookForExitAllowedUndefinedVariable($scope, $var);
 				$scope = $scope->unsetExpression($var);
 			}
 		} elseif ($stmt instanceof Node\Stmt\Use_) {
@@ -1344,9 +1344,9 @@ class NodeScopeResolver
 				if (!$var instanceof Variable) {
 					throw new ShouldNotHappenException();
 				}
-				$scope = $this->lookForEnterVariableAssign($scope, $var);
+				$scope = $this->lookForEnterAllowedUndefinedVariable($scope, $var, true);
 				$this->processExprNode($var, $scope, $nodeCallback, ExpressionContext::createDeep());
-				$scope = $this->lookForExitVariableAssign($scope, $var);
+				$scope = $this->lookForExitAllowedUndefinedVariable($scope, $var);
 
 				if (!is_string($var->name)) {
 					continue;
@@ -1502,25 +1502,25 @@ class NodeScopeResolver
 		);
 	}
 
-	private function lookForEnterVariableAssign(MutatingScope $scope, Expr $expr): MutatingScope
+	private function lookForEnterAllowedUndefinedVariable(MutatingScope $scope, Expr $expr, bool $isAllowed): MutatingScope
 	{
 		if (!$expr instanceof ArrayDimFetch || $expr->dim !== null) {
-			$scope = $scope->enterExpressionAssign($expr);
+			$scope = $scope->setAllowedUndefinedExpression($expr, $isAllowed);
 		}
 		if (!$expr instanceof Variable) {
-			return $this->lookForVariableAssignCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->enterExpressionAssign($expr));
+			return $this->lookForVariableAssignCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->setAllowedUndefinedExpression($expr, $isAllowed));
 		}
 
 		return $scope;
 	}
 
-	private function lookForExitVariableAssign(MutatingScope $scope, Expr $expr): MutatingScope
+	private function lookForExitAllowedUndefinedVariable(MutatingScope $scope, Expr $expr): MutatingScope
 	{
 		if (!$expr instanceof ArrayDimFetch || $expr->dim !== null) {
-			$scope = $scope->exitExpressionAssign($expr);
+			$scope = $scope->unsetAllowedUndefinedExpression($expr);
 		}
 		if (!$expr instanceof Variable) {
-			return $this->lookForVariableAssignCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->exitExpressionAssign($expr));
+			return $this->lookForVariableAssignCallback($scope, $expr, static fn (MutatingScope $scope, Expr $expr): MutatingScope => $scope->unsetAllowedUndefinedExpression($expr));
 		}
 
 		return $scope;
@@ -2290,18 +2290,7 @@ class NodeScopeResolver
 			);
 		} elseif ($expr instanceof Coalesce) {
 			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->left, false);
-
-			if ($expr->left instanceof PropertyFetch || $expr->left instanceof Expr\NullsafePropertyFetch) {
-				$scope = $this->lookForEnterVariableAssign($nonNullabilityResult->getScope(), $expr->left->var);
-			} elseif ($expr->left instanceof StaticPropertyFetch) {
-				if ($expr->left->class instanceof Expr) {
-					$scope = $this->lookForEnterVariableAssign($nonNullabilityResult->getScope(), $expr->left->class);
-				} else {
-					$scope = $nonNullabilityResult->getScope();
-				}
-			} else {
-				$scope = $this->lookForEnterVariableAssign($nonNullabilityResult->getScope(), $expr->left);
-			}
+			$scope = $this->lookForEnterAllowedUndefinedVariable($nonNullabilityResult->getScope(), $expr->left, true);
 			$result = $this->processExprNode($expr->left, $scope, $nodeCallback, $context->enterDeep());
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();
@@ -2311,16 +2300,7 @@ class NodeScopeResolver
 			if (!$rightExprType instanceof NeverType || !$rightExprType->isExplicit()) {
 				$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
 			}
-
-			if ($expr->left instanceof PropertyFetch || $expr->left instanceof Expr\NullsafePropertyFetch) {
-				$scope = $this->lookForExitVariableAssign($scope, $expr->left->var);
-			} elseif ($expr->left instanceof StaticPropertyFetch) {
-				if ($expr->left->class instanceof Expr) {
-					$scope = $this->lookForExitVariableAssign($scope, $expr->left->class);
-				}
-			} else {
-				$scope = $this->lookForExitVariableAssign($scope, $expr->left);
-			}
+			$scope = $this->lookForExitAllowedUndefinedVariable($scope, $expr->left);
 			$result = $this->processExprNode($expr->right, $scope, $nodeCallback, $context->enterDeep());
 			$scope = $result->getScope()->mergeWith($scope);
 			$hasYield = $hasYield || $result->hasYield();
@@ -2383,26 +2363,26 @@ class NodeScopeResolver
 			}
 		} elseif ($expr instanceof Expr\Empty_) {
 			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->expr, true);
-			$scope = $this->lookForEnterVariableAssign($nonNullabilityResult->getScope(), $expr->expr);
+			$scope = $this->lookForEnterAllowedUndefinedVariable($nonNullabilityResult->getScope(), $expr->expr, true);
 			$result = $this->processExprNode($expr->expr, $scope, $nodeCallback, $context->enterDeep());
 			$scope = $result->getScope();
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();
 			$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
-			$scope = $this->lookForExitVariableAssign($scope, $expr->expr);
+			$scope = $this->lookForExitAllowedUndefinedVariable($scope, $expr->expr);
 		} elseif ($expr instanceof Expr\Isset_) {
 			$hasYield = false;
 			$throwPoints = [];
 			$nonNullabilityResults = [];
 			foreach ($expr->vars as $var) {
 				$nonNullabilityResult = $this->ensureNonNullability($scope, $var, true);
-				$scope = $this->lookForEnterVariableAssign($nonNullabilityResult->getScope(), $var);
+				$scope = $this->lookForEnterAllowedUndefinedVariable($nonNullabilityResult->getScope(), $var, true);
 				$result = $this->processExprNode($var, $scope, $nodeCallback, $context->enterDeep());
 				$scope = $result->getScope();
 				$hasYield = $hasYield || $result->hasYield();
 				$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
 				$nonNullabilityResults[] = $nonNullabilityResult;
-				$scope = $this->lookForExitVariableAssign($scope, $var);
+				$scope = $this->lookForExitAllowedUndefinedVariable($scope, $var);
 			}
 			foreach (array_reverse($nonNullabilityResults) as $nonNullabilityResult) {
 				$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
@@ -3448,7 +3428,7 @@ class NodeScopeResolver
 				if ($arrayItem->value instanceof ArrayDimFetch && $arrayItem->value->dim === null) {
 					$itemScope = $itemScope->enterExpressionAssign($arrayItem->value);
 				}
-				$itemScope = $this->lookForEnterVariableAssign($itemScope, $arrayItem->value);
+				$itemScope = $this->lookForEnterAllowedUndefinedVariable($itemScope, $arrayItem->value, true);
 				$itemResult = $this->processExprNode($arrayItem, $itemScope, $nodeCallback, $context->enterDeep());
 				$hasYield = $hasYield || $itemResult->hasYield();
 				$throwPoints = array_merge($throwPoints, $itemResult->getThrowPoints());

--- a/src/Analyser/Scope.php
+++ b/src/Analyser/Scope.php
@@ -102,6 +102,8 @@ interface Scope extends ClassMemberAccessAnswerer
 
 	public function isInExpressionAssign(Expr $expr): bool;
 
+	public function isUndefinedExpressionAllowed(Expr $expr): bool;
+
 	public function filterByTruthyValue(Expr $expr): self;
 
 	public function filterByFalseyValue(Expr $expr): self;

--- a/src/Analyser/ScopeFactory.php
+++ b/src/Analyser/ScopeFactory.php
@@ -17,6 +17,7 @@ interface ScopeFactory
 	 * @param VariableTypeHolder[] $moreSpecificTypes
 	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
 	 * @param array<string, true> $currentlyAssignedExpressions
+	 * @param array<string, bool> $currentlyAllowedUndefinedExpressions
 	 * @param array<string, Type> $nativeExpressionTypes
 	 * @param array<MethodReflection|FunctionReflection> $inFunctionCallsStack
 	 *
@@ -34,6 +35,7 @@ interface ScopeFactory
 		?ParametersAcceptor $anonymousFunctionReflection = null,
 		bool $inFirstLevelStatement = true,
 		array $currentlyAssignedExpressions = [],
+		array $currentlyAllowedUndefinedExpressions = [],
 		array $nativeExpressionTypes = [],
 		array $inFunctionCallsStack = [],
 		bool $afterExtractCall = false,

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
@@ -83,7 +83,7 @@ class NonexistentOffsetInArrayDimFetchCheck
 		}
 
 		if ($report) {
-			if ($scope->isInExpressionAssign($var)) {
+			if ($scope->isInExpressionAssign($var) || $scope->isUndefinedExpressionAllowed($var)) {
 				return [];
 			}
 

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
@@ -56,7 +56,7 @@ class NonexistentOffsetInArrayDimFetchRule implements Rule
 
 		$isOffsetAccessible = $isOffsetAccessibleType->isOffsetAccessible();
 
-		if ($scope->isInExpressionAssign($node) && $isOffsetAccessible->yes()) {
+		if (($scope->isInExpressionAssign($node) || $scope->isUndefinedExpressionAllowed($node)) && $isOffsetAccessible->yes()) {
 			return [];
 		}
 

--- a/src/Rules/Properties/AccessPropertiesRule.php
+++ b/src/Rules/Properties/AccessPropertiesRule.php
@@ -78,7 +78,7 @@ class AccessPropertiesRule implements Rule
 			return [];
 		}
 
-		if (!$type->canAccessProperties()->yes()) {
+		if ($type->canAccessProperties()->no() || $type->canAccessProperties()->maybe() && !$scope->isUndefinedExpressionAllowed($node)) {
 			return [
 				RuleErrorBuilder::message(sprintf(
 					'Cannot access property $%s on %s.',
@@ -86,6 +86,10 @@ class AccessPropertiesRule implements Rule
 					$type->describe(VerbosityLevel::typeOnly()),
 				))->build(),
 			];
+		}
+
+		if ($scope->isUndefinedExpressionAllowed($node)) {
+			return [];
 		}
 
 		if (!$type->hasProperty($name)->yes()) {

--- a/src/Rules/Properties/AccessStaticPropertiesRule.php
+++ b/src/Rules/Properties/AccessStaticPropertiesRule.php
@@ -164,7 +164,7 @@ class AccessStaticPropertiesRule implements Rule
 			return [];
 		}
 
-		if (!$classType->canAccessProperties()->yes()) {
+		if ($classType->canAccessProperties()->no() || $classType->canAccessProperties()->maybe() && !$scope->isUndefinedExpressionAllowed($node)) {
 			return array_merge($messages, [
 				RuleErrorBuilder::message(sprintf(
 					'Cannot access static property $%s on %s.',
@@ -172,6 +172,10 @@ class AccessStaticPropertiesRule implements Rule
 					$typeForDescribe->describe(VerbosityLevel::typeOnly()),
 				))->build(),
 			]);
+		}
+
+		if ($scope->isUndefinedExpressionAllowed($node)) {
+			return [];
 		}
 
 		if (!$classType->hasProperty($name)->yes()) {

--- a/src/Rules/Variables/DefinedVariableRule.php
+++ b/src/Rules/Variables/DefinedVariableRule.php
@@ -45,7 +45,7 @@ class DefinedVariableRule implements Rule
 			}
 		}
 
-		if ($scope->isInExpressionAssign($node)) {
+		if ($scope->isInExpressionAssign($node) || $scope->isUndefinedExpressionAllowed($node)) {
 			return [];
 		}
 

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -122,16 +122,6 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 				$tip,
 			],
 			[
-				'Property UnusedPrivateProperty\ArrayAssign::$foo is never read, only written.',
-				162,
-				$tip,
-			],
-			[
-				'Property UnusedPrivateProperty\ListAssign::$foo is never read, only written.',
-				191,
-				$tip,
-			],
-			[
 				'Property UnusedPrivateProperty\WriteToCollection::$collection1 is never read, only written.',
 				221,
 				$tip,
@@ -248,18 +238,7 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 
 		$this->alwaysWrittenTags = [];
 		$this->alwaysReadTags = [];
-		$this->analyse([__DIR__ . '/data/bug-5337.php'], [
-			[
-				'Property Bug5337\Clazz::$prefix is never read, only written.',
-				7,
-				'See: https://phpstan.org/developing-extensions/always-read-written-properties',
-			],
-			[
-				'Property Bug5337\Foo::$field is unused.',
-				20,
-				'See: https://phpstan.org/developing-extensions/always-read-written-properties',
-			],
-		]);
+		$this->analyse([__DIR__ . '/data/bug-5337.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -241,4 +241,26 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5337.php'], []);
 	}
 
+	public function testBug5971(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->alwaysWrittenTags = [];
+		$this->alwaysReadTags = [];
+		$this->analyse([__DIR__ . '/data/bug-5971.php'], []);
+	}
+
+	public function testBug6107(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->alwaysWrittenTags = [];
+		$this->alwaysReadTags = [];
+		$this->analyse([__DIR__ . '/data/bug-6107.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/data/bug-5971.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-5971.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Bug5971;
+
+class TestEmpty
+{
+	private ?array $test;
+
+	public function write(): void
+	{
+		$this->test = [];
+	}
+
+	public function read(): bool
+	{
+		return empty($this->test);
+	}
+}
+
+class TestIsset
+{
+	private ?string $test;
+
+	public function write(string $string): void
+	{
+		$this->test = $string;
+	}
+
+	public function read(): bool
+	{
+		return isset($this->test);
+	}
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-6107.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-6107.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Bug6107;
+
+class Test
+{
+	private ?\stdClass $item;
+
+	public function __construct(?\stdClass $item)
+	{
+		$this->item = $item;
+	}
+
+	public function handle(): void
+	{
+		$value = $this->item->value ?? 'custom value';
+	}
+}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -553,4 +553,28 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6566.php'], []);
 	}
 
+	public function testBug6899(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-6899.php'], [
+			[
+				'Cannot access property $prop on string.',
+				13,
+			],
+			[
+				'Cannot access property $prop on string.',
+				14,
+			],
+			[
+				'Cannot access property $prop on string.',
+				15,
+			],
+			[
+				'Cannot access property $prop on object|string.', // open issue https://github.com/phpstan/phpstan/issues/3659, https://github.com/phpstan/phpstan/issues/6026
+				25,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-6899.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-6899.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug6899;
+
+class HelloWorld
+{
+	/**
+	 * @param string $string
+	 * @return void
+	 */
+	public function foo($string): void
+	{
+		isset($string->prop);
+		$string->prop ?? "";
+		empty($string->prop);
+	}
+
+	/**
+	 * @param string|object $maybeString
+	 * @return void
+	 */
+	public function bar($maybeString): void
+	{
+		isset($maybeString->prop);
+		$maybeString->prop ?? "";
+		empty($maybeString->prop);
+	}
+}


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/6107
fixes https://github.com/phpstan/phpstan/issues/5971
fixes https://github.com/phpstan/phpstan/issues/5337
fixes https://github.com/phpstan/phpstan/issues/6899

This PR introduces a new method `isUndefinedExpressionAllowed` to `Scope` interface and new property `currentlyAllowedUndefinedExpression`  of `MutatingScope`.

Currently, access to undefined property is allowed in assign. In `Isset_` and `Empty_` it is simulating an assign by `lookForEnterExpressionAssign` to avoid undefined propeties, but it changes from read access to write access which are causing false positives/negatives like issues in above.
The purpose of this feature is to separate `isInExpressionAssign` and undefined property to avoid those issues.
Also, this feature can make allowing/disallowing undefined expressions much more flexibly like https://github.com/phpstan/phpstan-src/pull/1174/commits/59d89a58c3949c2f812df44b2bcb7f7a2fa03367
(this line is added for backwards compatibility that `Coalesce` doesn't allow dynamic properties)
and may be easier to make strict analysis after `#[AllowDynamicProperties]` is introduced in PHP 8.2 :)
https://github.com/phpstan/phpstan-src/pull/1104#issuecomment-1080559786
