### PR TITLE
Improve ConstantArrayType union performance

### DIFF
--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8035,7 +8035,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		return [
 			[
-				'array{i: int<1, max>, j: int, k: int<1, max>, key: DateTimeImmutable, l: 1, m: 5, n?: \'str\'}',
+				'array{i: int<1, max>, j: int, k: int<1, max>, l: 1, m: 5, key: DateTimeImmutable, n?: \'str\'}',
 				'$array',
 			],
 			[
@@ -9038,7 +9038,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		return [
 			[
-				'array<non-empty-array<int|string, array{hitCount: int<0, max>, loadCount: int<0, max>, removeCount: int<0, max>, saveCount: int<0, max>}>>',
+				'array<non-empty-array<int|string, array{saveCount: int<0, max>, removeCount: int<0, max>, loadCount: int<0, max>, hitCount: int<0, max>}>>',
 				'$statistics',
 			],
 		];

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -3967,7 +3967,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		}
 		$resultType = TypeCombinator::union(...$arrays);
 		$this->assertInstanceOf(ConstantArrayType::class, $resultType);
-		$this->assertSame('array{0: string, test?: string, 1?: string, 2?: string, 3?: string, 4?: string}', $resultType->describe(VerbosityLevel::precise()));
+		$this->assertSame('array{0: string, 1?: string, 2?: string, 3?: string, 4?: string, test?: string}', $resultType->describe(VerbosityLevel::precise()));
 	}
 
 }


### PR DESCRIPTION
This gets rid of some complicated code that repeatedly calls `ConstantArrayType::setOffsetValueType` which leads to a new creation of a ConstantArray via the builder which leads to union again and so on. Apparently `ConstantArrayType::mergeWith`, which is used via `reduceArrays`, does already what needs to be done.

There seems to be just one catch: The keys in constant arrays are ordered a bit different in some cases and re-ordering them via e.g. `UnionTypeHelper::sortTypes` is too time-intensive. But if only 3 very dynamic cases are affected I hope that should be fine.

This is a huuuge improvement for https://github.com/phpstan/phpstan/issues/6948

But let's see what CI says first before I cheer too loud..