### PR TITLE
Don't auto-resolve conditional types

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -453,7 +453,7 @@ class TypeNodeResolver
 
 	private function resolveConditionalTypeNode(ConditionalTypeNode $typeNode, NameScope $nameScope): Type
 	{
-		return ConditionalType::create(
+		return new ConditionalType(
 			$this->resolve($typeNode->subjectType, $nameScope),
 			$this->resolve($typeNode->targetType, $nameScope),
 			$this->resolve($typeNode->if, $nameScope),

--- a/src/Type/ConditionalType.php
+++ b/src/Type/ConditionalType.php
@@ -16,7 +16,7 @@ final class ConditionalType implements CompoundType
 	use ConditionalTypeTrait;
 	use NonGeneralizableTypeTrait;
 
-	private function __construct(
+	public function __construct(
 		private Type $subject,
 		private Type $target,
 		Type $if,
@@ -69,18 +69,7 @@ final class ConditionalType implements CompoundType
 		);
 	}
 
-	public static function create(
-		Type $subject,
-		Type $target,
-		Type $if,
-		Type $else,
-		bool $negated,
-	): Type
-	{
-		return (new self($subject, $target, $if, $else, $negated))->resolve();
-	}
-
-	private function resolve(): Type
+	public function resolve(): Type
 	{
 		$isSuperType = $this->target->isSuperTypeOf($this->subject);
 
@@ -108,7 +97,7 @@ final class ConditionalType implements CompoundType
 			return $this;
 		}
 
-		return self::create($subject, $target, $if, $else, $this->negated);
+		return new self($subject, $target, $if, $else, $this->negated);
 	}
 
 	private function isResolved(): bool

--- a/src/Type/ConditionalTypeForParameter.php
+++ b/src/Type/ConditionalTypeForParameter.php
@@ -34,7 +34,7 @@ final class ConditionalTypeForParameter implements CompoundType
 
 	public function toConditional(Type $subject): Type
 	{
-		return ConditionalType::create(
+		return new ConditionalType(
 			$subject,
 			$this->target,
 			$this->if,

--- a/tests/PHPStan/Analyser/data/conditional-types.php
+++ b/tests/PHPStan/Analyser/data/conditional-types.php
@@ -112,9 +112,9 @@ abstract class Test
 	 */
 	public function testDeterministicParameter($foo, $bar, $baz): void
 	{
-		assertType('string', $foo);
-		assertType('string', $bar);
-		assertType('string', $baz);
+		assertType('(true is true ? string : bool)', $foo);
+		assertType('(5 is int<4, 6> ? string : bool)', $bar);
+		assertType('(5 is not int<0, 4> ? (4 is bool ? float : string) : bool)', $baz);
 	}
 
 	/**


### PR DESCRIPTION
Auto-resolving seems very useful, but doesn't allow inspecting the original type