### PR TITLE
Specify explicit mixed array type via `is_array`

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -3,6 +3,7 @@ parameters:
 		bleedingEdge: true
 		skipCheckGenericClasses: []
 		explicitMixedInUnknownGenericNew: true
+		explicitMixedViaIsArray: true
 		arrayFilter: true
 	stubFiles:
 		- ../stubs/bleedingEdge/Countable.stub

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -28,6 +28,7 @@ parameters:
 			- FilterIterator
 			- RecursiveCallbackFilterIterator
 		explicitMixedInUnknownGenericNew: false
+		explicitMixedViaIsArray: false
 		arrayFilter: false
 	fileExtensions:
 		- php
@@ -212,6 +213,7 @@ parametersSchema:
 		disableRuntimeReflectionProvider: bool(),
 		skipCheckGenericClasses: listOf(string()),
 		explicitMixedInUnknownGenericNew: bool(),
+		explicitMixedViaIsArray: bool(),
 		arrayFilter: bool(),
 	])
 	fileExtensions: listOf(string())
@@ -1424,6 +1426,8 @@ services:
 		class: PHPStan\Type\Php\IsArrayFunctionTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
+		arguments:
+			explicitMixed: %featureToggles.explicitMixedViaIsArray%
 
 	-
 		class: PHPStan\Type\Php\IsBoolFunctionTypeSpecifyingExtension

--- a/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
@@ -20,6 +20,11 @@ class IsArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 
 	private TypeSpecifier $typeSpecifier;
 
+	public function __construct(private bool $explicitMixed)
+	{
+	}
+
+
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
 		return strtolower($functionReflection->getName()) === 'is_array'
@@ -35,7 +40,7 @@ class IsArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 			throw new ShouldNotHappenException();
 		}
 
-		return $this->typeSpecifier->create($node->getArgs()[0]->value, new ArrayType(new MixedType(true), new MixedType(true)), $context, false, $scope);
+		return $this->typeSpecifier->create($node->getArgs()[0]->value, new ArrayType(new MixedType($this->explicitMixed), new MixedType($this->explicitMixed)), $context, false, $scope);
 	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
@@ -35,7 +35,7 @@ class IsArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 			throw new ShouldNotHappenException();
 		}
 
-		return $this->typeSpecifier->create($node->getArgs()[0]->value, new ArrayType(new MixedType(), new MixedType()), $context, false, $scope);
+		return $this->typeSpecifier->create($node->getArgs()[0]->value, new ArrayType(new MixedType(true), new MixedType(true)), $context, false, $scope);
 	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -327,13 +327,17 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	{
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/bug-5744.php'], [
-			/*[
+			[
 				'Cannot access offset \'permission\' on mixed.',
 				16,
-			],*/
+			],
 			[
 				'Cannot access offset \'permission\' on mixed.',
 				29,
+			],
+			[
+				'Cannot access offset \'permission\' on mixed.',
+				39,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -503,4 +503,24 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5757.php'], []);
 	}
 
+	public function testDiscussion7004(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/discussion-7004.php'], [
+			[
+				'Parameter #1 $data of static method Discussion7004\Foo::fromArray1() expects array<array{newsletterName: string, subscriberCount: int}>, array given.',
+				46,
+			],
+			[
+				'Parameter #1 $data of static method Discussion7004\Foo::fromArray2() expects array{array{newsletterName: string, subscriberCount: int}}, array given.',
+				47,
+			],
+			[
+				'Parameter #1 $data of static method Discussion7004\Foo::fromArray3() expects array{newsletterName: string, subscriberCount: int}, array given.',
+				48,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/discussion-7004.php
+++ b/tests/PHPStan/Rules/Methods/data/discussion-7004.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace Discussion7004;
+
+use function PHPStan\testing\assertType;
+
+class Foo
+{
+	/**
+	 * @param array<array{newsletterName: string, subscriberCount: int}> $data
+	 */
+	public static function fromArray1(array $data): void
+	{
+		assertType('array<array{newsletterName: string, subscriberCount: int}>', $data);
+	}
+
+	/**
+	 * @param array{array{newsletterName: string, subscriberCount: int}} $data
+	 */
+	public static function fromArray2(array $data): void
+	{
+		assertType('array{array{newsletterName: string, subscriberCount: int}}', $data);
+	}
+
+	/**
+	 * @param array{newsletterName: string, subscriberCount: int} $data
+	 */
+	public static function fromArray3(array $data): void
+	{
+		assertType('array{newsletterName: string, subscriberCount: int}', $data);
+	}
+}
+
+class Bar
+{
+	/**
+	 * @param mixed $data
+	 */
+	public function doSomething($data): void
+	{
+		if (!is_array($data)) {
+			return;
+		}
+
+		assertType('array', $data);
+		Foo::fromArray1($data);
+		Foo::fromArray2($data);
+		Foo::fromArray3($data);
+	}
+}


### PR DESCRIPTION
Relates to https://github.com/phpstan/phpstan/discussions/7004

Fixes strict array shape / mixed handling with level 9, e.g. https://phpstan.org/r/77a8e65b-dd07-4c4b-bc8c-76a32243d553

The `discussion-7004.php` is not adhering to standards.. let me know if this should be renamed, or if I should create an issue or so.

UPDATE: moved behind a feature toggle that is only enabled in bleedingEdge, as discussed, to avoid wreaking havoc on level 9 :)