### PR TITLE
Fix/coalesce simulate ternary 2

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2305,9 +2305,9 @@ class NodeScopeResolver
 			$rightResult = $this->processExprNode($expr->right, $rightScope, $nodeCallback, $context->enterDeep());
 			$rightExprType = $scope->getType($expr->right);
 			if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
-				$scope = $condScope->filterByTruthyValue(new Expr\Isset_([$expr->left]));
+				$scope = $scope->filterByTruthyValue(new Expr\Isset_([$expr->left]));
 			} else {
-				$scope = $condScope->mergeWith($rightResult->getScope());
+				$scope = $scope->mergeWith($rightResult->getScope());
 			}
 
 			$hasYield = $condResult->hasYield() || $rightResult->hasYield();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2289,27 +2289,29 @@ class NodeScopeResolver
 				static fn (): MutatingScope => $rightResult->getScope()->filterByFalseyValue($expr),
 			);
 		} elseif ($expr instanceof Coalesce) {
+			// backwards compatibility: coalesce doesn't allow dynamic properties
 			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->left, false);
 			if ($expr->left instanceof PropertyFetch || $expr->left instanceof Expr\NullsafePropertyFetch || $expr->left instanceof StaticPropertyFetch) {
-				$scope = $nonNullabilityResult->getScope()->setAllowedUndefinedExpression($expr->left, false);
+				$condScope = $nonNullabilityResult->getScope()->setAllowedUndefinedExpression($expr->left, false);
 			} else {
-				$scope = $nonNullabilityResult->getScope();
+				$condScope = $nonNullabilityResult->getScope();
 			}
-			$scope = $this->lookForEnterAllowedUndefinedVariable($scope, $expr->left, true);
-			$result = $this->processExprNode($expr->left, $scope, $nodeCallback, $context->enterDeep());
-			$hasYield = $result->hasYield();
-			$throwPoints = $result->getThrowPoints();
-			$scope = $result->getScope();
-
-			$rightExprType = $scope->getType($expr->right);
-			if (!$rightExprType instanceof NeverType || !$rightExprType->isExplicit()) {
-				$scope = $this->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
-			}
+			$condScope = $this->lookForEnterAllowedUndefinedVariable($condScope, $expr->left, true);
+			$condResult = $this->processExprNode($expr->left, $condScope, $nodeCallback, $context->enterDeep());
+			$scope = $this->revertNonNullability($condResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 			$scope = $this->lookForExitAllowedUndefinedVariable($scope, $expr->left);
-			$result = $this->processExprNode($expr->right, $scope, $nodeCallback, $context->enterDeep());
-			$scope = $result->getScope()->mergeWith($scope);
-			$hasYield = $hasYield || $result->hasYield();
-			$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
+
+			$rightScope = $scope->filterByFalseyValue(new Expr\Isset_([$expr->left]));
+			$rightResult = $this->processExprNode($expr->right, $rightScope, $nodeCallback, $context->enterDeep());
+			$rightExprType = $scope->getType($expr->right);
+			if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
+				$scope = $condScope->filterByTruthyValue(new Expr\Isset_([$expr->left]));
+			} else {
+				$scope = $condScope->mergeWith($rightResult->getScope());
+			}
+
+			$hasYield = $condResult->hasYield() || $rightResult->hasYield();
+			$throwPoints = array_merge($condResult->getThrowPoints(), $rightResult->getThrowPoints());
 		} elseif ($expr instanceof BinaryOp) {
 			$result = $this->processExprNode($expr->left, $scope, $nodeCallback, $context->enterDeep());
 			$scope = $result->getScope();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2307,7 +2307,7 @@ class NodeScopeResolver
 			if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 				$scope = $scope->filterByTruthyValue(new Expr\Isset_([$expr->left]));
 			} else {
-				$scope = $scope->mergeWith($rightResult->getScope());
+				$scope = $scope->filterByTruthyValue(new Expr\Isset_([$expr->left]))->mergeWith($rightResult->getScope());
 			}
 
 			$hasYield = $condResult->hasYield() || $rightResult->hasYield();

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -822,6 +822,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_VERSION_ID >= 80000) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6251.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6870.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4885.php');
 		}
 
 		if (PHP_VERSION_ID >= 80100) {

--- a/tests/PHPStan/Analyser/data/bug-4885.php
+++ b/tests/PHPStan/Analyser/data/bug-4885.php
@@ -1,0 +1,22 @@
+<?php // lint >= 8.0
+
+namespace Bug4885;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	/** @param array{word?: string} $data */
+	public function sayHello(array $data): void
+	{
+		echo ($data['word'] ?? throw new \RuntimeException('bye')) . ', World!';
+		assertType('array{word: string}', $data);
+	}
+
+	/** @param array{word?: string|null} $data */
+	public function sayHi(array $data): void
+	{
+		echo ($data['word'] ?? throw new \RuntimeException('bye')) . ', World!';
+		assertType('array{word: string}', $data);
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -367,4 +367,13 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4747.php'], []);
 	}
 
+	public function testBug4885(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-4885.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-4885.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-4885.php
@@ -1,0 +1,13 @@
+<?php // lint >= 8.0
+
+namespace Bug4885;
+
+class Foo
+{
+	/** @param array{word?: string} $data */
+	public function sayHello(array $data): void
+	{
+		echo ($data['word'] ?? throw new \RuntimeException('bye')) . ', World!';
+		echo 'Again, the word was: ' . $data['word'];
+	}
+}


### PR DESCRIPTION
Sorry for cluttering up PRs.

Simulating `Isset_` by `processExprNode` like https://github.com/phpstan/phpstan-src/pull/1192 caused some other problems.

Same scope can be achieved by using `filterByTruthy/FalseyScope` with `isset`. Hope this works