### PR TITLE
Handle side effects of constructor calls

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1996,7 +1996,7 @@ class NodeScopeResolver
 			$scope = $result->getScope();
 			if ($methodReflection !== null) {
 				$hasSideEffects = $methodReflection->hasSideEffects();
-				if ($hasSideEffects->yes()) {
+				if ($hasSideEffects->yes() || $methodReflection->getName() === '__construct') {
 					$scope = $scope->invalidateExpression($expr->var, true);
 					foreach ($expr->getArgs() as $arg) {
 						$scope = $scope->invalidateExpression($arg->value, true);
@@ -2118,7 +2118,10 @@ class NodeScopeResolver
 			if (
 				$methodReflection !== null
 				&& !$methodReflection->isStatic()
-				&& $methodReflection->hasSideEffects()->yes()
+				&& (
+					$methodReflection->hasSideEffects()->yes()
+					|| $methodReflection->getName() === '__construct'
+				)
 				&& $scopeFunction instanceof MethodReflection
 				&& !$scopeFunction->isStatic()
 				&& $scope->isInClass()
@@ -2131,7 +2134,7 @@ class NodeScopeResolver
 			}
 
 			if ($methodReflection !== null) {
-				if ($methodReflection->hasSideEffects()->yes()) {
+				if ($methodReflection->hasSideEffects()->yes() || $methodReflection->getName() === '__construct') {
 					foreach ($expr->getArgs() as $arg) {
 						$scope = $scope->invalidateExpression($arg->value, true);
 					}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2447,6 +2447,12 @@ class NodeScopeResolver
 							$expr->getArgs(),
 							$constructorReflection->getVariants(),
 						);
+						$hasSideEffects = $constructorReflection->hasSideEffects();
+						if ($hasSideEffects->yes()) {
+							foreach ($expr->getArgs() as $arg) {
+								$scope = $scope->invalidateExpression($arg->value, true);
+							}
+						}
 						$constructorThrowPoint = $this->getConstructorThrowPoint($constructorReflection, $classReflection, $expr, $expr->class, $expr->getArgs(), $scope);
 						if ($constructorThrowPoint !== null) {
 							$throwPoints[] = $constructorThrowPoint;

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -413,10 +413,6 @@ class PhpMethodReflection implements MethodReflection
 			return TrinaryLogic::createFromBoolean(!$this->isPure);
 		}
 
-		if ($isVoid) {
-			return TrinaryLogic::createYes();
-		}
-
 		return TrinaryLogic::createMaybe();
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -265,6 +265,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4343.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/impure-method.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/impure-constructor.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4351.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/var-above-use.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/var-above-declare.php');

--- a/tests/PHPStan/Analyser/data/impure-constructor.php
+++ b/tests/PHPStan/Analyser/data/impure-constructor.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace ImpureConstuctor;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/** @var bool */
+	private $active;
+
+	public function __construct()
+	{
+		$this->active = false;
+	}
+
+	public function getActive(): bool
+	{
+		return $this->active;
+	}
+
+	public function activate(): void
+	{
+		$this->active = true;
+	}
+
+}
+
+
+class ClassWithImpureConstructorNotMarked
+{
+
+	public function __construct(Foo $foo)
+	{
+		$foo->activate();
+	}
+
+}
+
+class ClassWithImpureConstructorMarked
+{
+
+	/**
+	 * @phpstan-impure
+	 */
+	public function __construct(Foo $foo)
+	{
+		$foo->activate();
+	}
+
+}
+
+class ClassWithPureConstructorMarked
+{
+
+	/**
+	 * @phpstan-pure
+	 */
+	public function __construct(Foo $foo)
+	{
+	}
+
+}
+
+class ClassWithImpureConstructorNotMarkedWithoutParameters
+{
+
+	/** @var string */
+	private $lorem;
+
+	public function __construct()
+	{
+		$this->lorem = 'lorem';
+	}
+
+}
+
+class Test
+{
+
+	public function testClassWithImpureConstructorNotMarked()
+	{
+		$foo = new Foo();
+		assertType('bool', $foo->getActive());
+
+		assert(!$foo->getActive());
+		assertType('false', $foo->getActive());
+
+		new ClassWithImpureConstructorNotMarked($foo);
+		assertType('false', $foo->getActive());
+	}
+
+	public function testClassWithImpureConstructorMarked()
+	{
+		$foo = new Foo();
+		assertType('bool', $foo->getActive());
+
+		assert(!$foo->getActive());
+		assertType('false', $foo->getActive());
+
+		new ClassWithImpureConstructorMarked($foo);
+		assertType('bool', $foo->getActive());
+	}
+
+	public function testClassWithPureConstructorMarked()
+	{
+		$foo = new Foo();
+		assertType('bool', $foo->getActive());
+
+		assert(!$foo->getActive());
+		assertType('false', $foo->getActive());
+
+		new ClassWithPureConstructorMarked($foo);
+		assertType('false', $foo->getActive());
+	}
+
+	public function testClassWithImpureConstructorNotMarkedWithoutParameters()
+	{
+		$foo = new Foo();
+		assertType('bool', $foo->getActive());
+
+		assert(!$foo->getActive());
+		assertType('false', $foo->getActive());
+
+		new ClassWithImpureConstructorNotMarkedWithoutParameters();
+		assertType('false', $foo->getActive());
+	}
+
+}


### PR DESCRIPTION
Fixes this original problem: https://phpstan.org/r/9800c2a7-080a-4d22-aeb9-802cd3cd8ce3 - if you pass a property into constructor, you do not know, what happens with it there and of course the state can be changed as in any other method where you pass an object. Marking the constructor as impure does not help: https://phpstan.org/r/e942d9a8-c20a-4b7d-973a-6bca67b5d69b .

Since you cannot return a value from a constructor, all constructors should be impure by the definition from https://phpstan.org/blog/remembering-and-forgetting-returned-values:

> Pure function always returns the same value if its inputs (object state and arguments) are the same, and has no side effects. Impure function has side effects and its return value might change even if the input does not.

Question is whether that is practical default in regards to the code which calls the constructors - probably most of them do not change passed arguments.

There is a possibility to invalidate only with explicit impure annotation - but then this would behave differently than all of the other cases.