### PR TITLE
Don't generalize template types

### DIFF
--- a/src/Type/Generic/TemplateArrayType.php
+++ b/src/Type/Generic/TemplateArrayType.php
@@ -29,9 +29,4 @@ final class TemplateArrayType extends ArrayType implements TemplateType
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateBooleanType.php
+++ b/src/Type/Generic/TemplateBooleanType.php
@@ -29,9 +29,4 @@ final class TemplateBooleanType extends BooleanType implements TemplateType
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateConstantArrayType.php
+++ b/src/Type/Generic/TemplateConstantArrayType.php
@@ -29,9 +29,4 @@ final class TemplateConstantArrayType extends ConstantArrayType implements Templ
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateConstantIntegerType.php
+++ b/src/Type/Generic/TemplateConstantIntegerType.php
@@ -29,9 +29,4 @@ final class TemplateConstantIntegerType extends ConstantIntegerType implements T
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateConstantStringType.php
+++ b/src/Type/Generic/TemplateConstantStringType.php
@@ -29,9 +29,4 @@ final class TemplateConstantStringType extends ConstantStringType implements Tem
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateFloatType.php
+++ b/src/Type/Generic/TemplateFloatType.php
@@ -29,9 +29,4 @@ final class TemplateFloatType extends FloatType implements TemplateType
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateIntegerType.php
+++ b/src/Type/Generic/TemplateIntegerType.php
@@ -29,9 +29,4 @@ final class TemplateIntegerType extends IntegerType implements TemplateType
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateKeyOfType.php
+++ b/src/Type/Generic/TemplateKeyOfType.php
@@ -43,9 +43,4 @@ final class TemplateKeyOfType extends KeyOfType implements TemplateType
 		);
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateStringType.php
+++ b/src/Type/Generic/TemplateStringType.php
@@ -29,9 +29,4 @@ final class TemplateStringType extends StringType implements TemplateType
 		$this->bound = $bound;
 	}
 
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return false;
-	}
-
 }

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Type\Generic;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
@@ -242,12 +241,6 @@ trait TemplateTypeTrait
 		$map = $this->getBound()->inferTemplateTypes($receivedType);
 		$resolvedBound = TypeUtils::resolveLateResolvableTypes(TemplateTypeHelper::resolveTemplateTypes($this->getBound(), $map));
 		if ($resolvedBound->isSuperTypeOf($receivedType)->yes()) {
-			if ($this->shouldGeneralizeInferredType()) {
-				$generalizedType = $receivedType->generalize(GeneralizePrecision::templateArgument());
-				if ($resolvedBound->isSuperTypeOf($generalizedType)->yes()) {
-					$receivedType = $generalizedType;
-				}
-			}
 			return (new TemplateTypeMap([
 				$this->name => $receivedType,
 			]))->union($map);
@@ -269,11 +262,6 @@ trait TemplateTypeTrait
 	public function getStrategy(): TemplateTypeStrategy
 	{
 		return $this->strategy;
-	}
-
-	protected function shouldGeneralizeInferredType(): bool
-	{
-		return true;
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -123,7 +123,7 @@ class TemplateTypeVariance
 		}
 
 		if ($this->invariant()) {
-			return TrinaryLogic::createFromBoolean($a->equals($b));
+			return $a->isSuperTypeOf($b)->and($b->isSuperTypeOf($a));
 		}
 
 		if ($this->covariant()) {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -766,11 +766,11 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 
 		$errors = $this->runAnalyse(__DIR__ . '/data/discussion-7124.php');
 		$this->assertCount(4, $errors);
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, int=): bool, Closure(int, bool): bool given.', $errors[0]->getMessage());
+		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, 0|1|2=): bool, Closure(int, bool): bool given.', $errors[0]->getMessage());
 		$this->assertSame(38, $errors[0]->getLine());
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, int=): bool, Closure(int): bool given.', $errors[1]->getMessage());
+		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, 0|1|2=): bool, Closure(int): bool given.', $errors[1]->getMessage());
 		$this->assertSame(45, $errors[1]->getLine());
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(int): bool, Closure(bool): bool given.', $errors[2]->getMessage());
+		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(0|1|2): bool, Closure(bool): bool given.', $errors[2]->getMessage());
 		$this->assertSame(52, $errors[2]->getLine());
 		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool): bool, Closure(int): bool given.', $errors[3]->getMessage());
 		$this->assertSame(59, $errors[3]->getLine());
@@ -1042,6 +1042,18 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		}
 
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8147.php');
+		$this->assertNoErrors($errors);
+	}
+
+	public function testBug6653(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6653.php');
+		$this->assertNoErrors($errors);
+	}
+
+	public function testBug5592(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5592.php');
 		$this->assertNoErrors($errors);
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1085,6 +1085,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8169.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7519.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8087.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7301.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/assert-class-type.php
+++ b/tests/PHPStan/Analyser/data/assert-class-type.php
@@ -33,10 +33,10 @@ class HelloWorld {
 
 function () {
 	$a = new HelloWorld(123);
-	assertType('AssertClassType\\HelloWorld<int>', $a);
+	assertType('AssertClassType\\HelloWorld<123>', $a);
 
 	$b = $_GET['value'];
 	$a->assert($b);
 
-	assertType('int', $b);
+	assertType('123', $b);
 };

--- a/tests/PHPStan/Analyser/data/bug-3351.php
+++ b/tests/PHPStan/Analyser/data/bug-3351.php
@@ -10,7 +10,7 @@ class HelloWorld
 		$b = [1, 2, 3];
 
 		$c = $this->combine($a, $b);
-		assertType('array<string, int>|false', $c);
+		assertType("array<'a'|'b'|'c', 1|2|3>|false", $c);
 
 		assertType('array{a: 1, b: 2, c: 3}', array_combine($a, $b));
 	}

--- a/tests/PHPStan/Analyser/data/bug-4545.php
+++ b/tests/PHPStan/Analyser/data/bug-4545.php
@@ -33,7 +33,7 @@ class Foo
 		foreach ($intersect as $key) {
 			assertType('TValue1 (method Bug4545\Foo::compareMaps(), argument)', $firstMap->get($key));
 			assertType('TValue2 (method Bug4545\Foo::compareMaps(), argument)', $secondMap->get($key));
-			assertType('int|TValue2 (method Bug4545\Foo::compareMaps(), argument)', $secondMap->get($key, 1));
+			assertType('1|TValue2 (method Bug4545\Foo::compareMaps(), argument)', $secondMap->get($key, 1));
 		}
 
 		return $keys;

--- a/tests/PHPStan/Analyser/data/bug-5592.php
+++ b/tests/PHPStan/Analyser/data/bug-5592.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Bug5592;
+
+/**
+ * @param \Ds\Map<\Ds\Hashable, numeric-string> $map
+ * @return numeric-string
+ */
+function mapGet(\Ds\Map $map, \Ds\Hashable $key): string
+{
+	return $map->get($key, '0');
+}

--- a/tests/PHPStan/Analyser/data/bug-6433.php
+++ b/tests/PHPStan/Analyser/data/bug-6433.php
@@ -14,7 +14,7 @@ class Foo
 {
 
 	function x(): void {
-		assertType('Ds\Set<Bug6433\E>', new Set([E::A, E::B]));
+		assertType('Ds\Set<Bug6433\E::A|Bug6433\E::B>', new Set([E::A, E::B]));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-6653.php
+++ b/tests/PHPStan/Analyser/data/bug-6653.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6653;
+
+class HelloWorld
+{
+	/**
+     * @return array<string, int>|false
+     */
+	public function sayHello()
+	{
+		$test = $this->getTest();
+		return $this->filterEvent('sayHello', $test);
+	}
+
+	/**
+	 * @template TValue of mixed
+	 * @param TValue $value
+	 * @return TValue
+	 */
+	private function filterEvent(string $eventName, $value)
+	{
+		// do event
+		return $value;
+	}
+
+	/**
+     * @return array<string, int>|false
+     */
+	private function getTest()
+	{
+		$failure = random_int(0, PHP_INT_MAX) % 2 ? true : false;
+		if ($failure === true) {
+			return false;
+		}
+		return ['foo' => 123];
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-6695.php
+++ b/tests/PHPStan/Analyser/data/bug-6695.php
@@ -11,7 +11,7 @@ enum Foo: int
 
 	public function toCollection(): void
 	{
-		assertType('Bug6695\Collection<int, Bug6695\Foo>', $this->collect(self::cases()));
+		assertType('Bug6695\Collection<0|1, Bug6695\Foo::BAR|Bug6695\Foo::BAZ>', $this->collect(self::cases()));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7068.php
+++ b/tests/PHPStan/Analyser/data/bug-7068.php
@@ -18,8 +18,8 @@ class Foo
 
 	public function doFoo(): void
 	{
-		assertType('array<int>', $this->merge([1, 2], [3, 4], [5]));
-		assertType('array<int|string>', $this->merge([1, 2], ['foo', 'bar']));
+		assertType('array<1|2|3|4|5>', $this->merge([1, 2], [3, 4], [5]));
+		assertType("array<1|2|'bar'|'foo'>", $this->merge([1, 2], ['foo', 'bar']));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-7078.php
+++ b/tests/PHPStan/Analyser/data/bug-7078.php
@@ -33,5 +33,5 @@ interface Param {
 
 function (Param $p) {
 	$result = $p->get(new TypeDefault(1), new TypeDefault('a'));
-	assertType('int|string', $result);
+	assertType("1|'a'", $result);
 };

--- a/tests/PHPStan/Analyser/data/bug-7301.php
+++ b/tests/PHPStan/Analyser/data/bug-7301.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7301;
+
+use Closure;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TReturn
+ * @param Closure(): TReturn $closure
+ * @return TReturn
+ */
+function templated($closure)
+{
+	return $closure();
+}
+
+function () {
+	/**
+	 * @var Closure(): array<non-empty-string, mixed>
+	 */
+	$arg = function () {
+		return ['key' => 'value'];
+	};
+
+	$result = templated($arg);
+
+	assertType('array<non-empty-string, mixed>', $result);
+};

--- a/tests/PHPStan/Analyser/data/bug-7788.php
+++ b/tests/PHPStan/Analyser/data/bug-7788.php
@@ -30,5 +30,5 @@ final class Props
 }
 
 function () {
-	assertType('int', (new Props(['title' => 'test', 'value' => 30]))->getProp('value', 0));
+	assertType('0|30', (new Props(['title' => 'test', 'value' => 30]))->getProp('value', 0));
 };

--- a/tests/PHPStan/Analyser/data/ext-ds.php
+++ b/tests/PHPStan/Analyser/data/ext-ds.php
@@ -56,7 +56,7 @@ class Foo
 	{
 		$a = new Map([1 => new A()]);
 
-		assertType('Ds\Map<int|string, ExtDs\A|ExtDs\B>', $a->merge(['a' => new B()]));
+		assertType("Ds\Map<1|'a', ExtDs\A|ExtDs\B>", $a->merge(['a' => new B()]));
 	}
 
 	public function mapUnion() : void
@@ -64,7 +64,7 @@ class Foo
 		$a = new Map([1 => new A()]);
 		$b = new Map(['a' => new B()]);
 
-		assertType('Ds\Map<int|string, ExtDs\A|ExtDs\B>', $a->union($b));
+		assertType("Ds\Map<1|'a', ExtDs\A|ExtDs\B>", $a->union($b));
 	}
 
 	public function mapXor() : void
@@ -72,7 +72,7 @@ class Foo
 		$a = new Map([1 => new A()]);
 		$b = new Map(['a' => new B()]);
 
-		assertType('Ds\Map<int|string, ExtDs\A|ExtDs\B>', $a->xor($b));
+		assertType("Ds\Map<1|'a', ExtDs\A|ExtDs\B>", $a->xor($b));
 	}
 
 	public function setMerge() : void

--- a/tests/PHPStan/Analyser/data/first-class-callables.php
+++ b/tests/PHPStan/Analyser/data/first-class-callables.php
@@ -44,12 +44,12 @@ class GenericFoo
 	public function doBar()
 	{
 		$f = $this->doFoo(...);
-		assertType('int', $f(1));
-		assertType('string', $f('foo'));
+		assertType('1', $f(1));
+		assertType("'foo'", $f('foo'));
 
 		$g = \Closure::fromCallable([$this, 'doFoo']);
-		assertType('int', $g(1));
-		assertType('string', $g('foo'));
+		assertType('1', $g(1));
+		assertType("'foo'", $g('foo'));
 	}
 
 	public function doBaz()

--- a/tests/PHPStan/Analyser/data/generic-generalization.php
+++ b/tests/PHPStan/Analyser/data/generic-generalization.php
@@ -32,17 +32,17 @@ function testUnbounded(
 	string $numericString,
 	string $nonEmptyString
 ): void {
-	assertType('string', unbounded('hello'));
-	assertType('string', unbounded('stdClass'));
+	assertType("'hello'", unbounded('hello'));
+	assertType("'stdClass'", unbounded('stdClass'));
 	assertType('class-string', unbounded($classString));
 	assertType('class-string<stdClass>', unbounded($genericClassString));
 
-	assertType('string', unbounded(rand(0,1) === 1 ? 'hello' : $classString));
+	assertType("'hello'|class-string", unbounded(rand(0,1) === 1 ? 'hello' : $classString));
 
-	assertType('array{foo: int}', unbounded($arrayShape));
+	assertType('array{foo: 42}', unbounded($arrayShape));
 
-	assertType('string', unbounded($numericString));
-	assertType('string', unbounded($nonEmptyString));
+	assertType('numeric-string', unbounded($numericString));
+	assertType('non-empty-string', unbounded($nonEmptyString));
 }
 
 /**

--- a/tests/PHPStan/Analyser/data/generic-unions.php
+++ b/tests/PHPStan/Analyser/data/generic-unions.php
@@ -54,9 +54,9 @@ class Foo
 
 		assertType('string|null', $this->doBar($nullableString));
 
-		assertType('int', $this->doBaz(1));
-		assertType('string', $this->doBaz('foo'));
-		assertType('float', $this->doBaz(1.2));
+		assertType('1', $this->doBaz(1));
+		assertType("'foo'", $this->doBaz('foo'));
+		assertType('1.2', $this->doBaz(1.2));
 		assertType('string', $this->doBaz($stringOrInt));
 	}
 
@@ -114,22 +114,22 @@ function getWithDefaultCallable($key, $default = null)
 	return $default;
 }
 
-assertType('int|null', getWithDefault(3));
-assertType('int|null', getWithDefaultCallable(3));
-assertType('int|string', getWithDefault(3, 'foo'));
-assertType('int|string', getWithDefaultCallable(3, 'foo'));
-assertType('int|string', getWithDefault(3, function () {
+assertType('3|null', getWithDefault(3));
+assertType('3|null', getWithDefaultCallable(3));
+assertType("3|'foo'", getWithDefault(3, 'foo'));
+assertType("3|'foo'", getWithDefaultCallable(3, 'foo'));
+assertType("3|'foo'", getWithDefault(3, function () {
 	return 'foo';
 }));
-assertType('int|string', getWithDefaultCallable(3, function () {
+assertType("3|'foo'", getWithDefaultCallable(3, function () {
 	return 'foo';
 }));
-assertType('GenericUnions\Foo|int', getWithDefault(3, function () {
+assertType('3|GenericUnions\Foo', getWithDefault(3, function () {
 	return new Foo;
 }));
-assertType('GenericUnions\Foo|int', getWithDefaultCallable(3, function () {
+assertType('3|GenericUnions\Foo', getWithDefaultCallable(3, function () {
 	return new Foo;
 }));
-assertType('GenericUnions\Foo|int', getWithDefault(3, new Foo));
-assertType('GenericUnions\Foo|int', getWithDefaultCallable(3, new Foo));
-assertType('int|string', getWithDefaultCallable(3, new InvokableClass));
+assertType('3|GenericUnions\Foo', getWithDefault(3, new Foo));
+assertType('3|GenericUnions\Foo', getWithDefaultCallable(3, new Foo));
+assertType('3|string', getWithDefaultCallable(3, new InvokableClass));

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -97,7 +97,7 @@ function testD($int, $float, $intFloat)
 	assertType('DateTime|int', d($int, new \DateTime()));
 	assertType('DateTime|float|int', d($intFloat, new \DateTime()));
 	assertType('array{}|DateTime', d([], new \DateTime()));
-	assertType('array{blabla: string}|DateTime', d(['blabla' => 'barrrr'], new \DateTime()));
+	assertType("array{blabla: 'barrrr'}|DateTime", d(['blabla' => 'barrrr'], new \DateTime()));
 }
 
 /**
@@ -150,7 +150,7 @@ function testF($arrayOfInt, $callableOrNull)
 	assertType('Closure(int): numeric-string', function (int $a): string {
 		return (string)$a;
 	});
-	assertType('array<string>', f($arrayOfInt, function (int $a): string {
+	assertType('array<numeric-string>', f($arrayOfInt, function (int $a): string {
 		return (string)$a;
 	}));
 	assertType('Closure(mixed): string', function ($a): string {
@@ -717,9 +717,9 @@ class Factory
 function testClasses()
 {
 	$a = new A(1);
-	assertType('PHPStan\Generics\FunctionsAssertType\A<int>', $a);
-	assertType('int', $a->get());
-	assertType('int', $a->b);
+	assertType('PHPStan\Generics\FunctionsAssertType\A<1>', $a);
+	assertType('1', $a->get());
+	assertType('1', $a->b);
 
 	$a = new AOfDateTime();
 	assertType('PHPStan\Generics\FunctionsAssertType\AOfDateTime', $a);
@@ -727,9 +727,9 @@ function testClasses()
 	assertType('DateTime', $a->b);
 
 	$b = new B(1);
-	assertType('PHPStan\Generics\FunctionsAssertType\B<int>', $b);
-	assertType('int', $b->get());
-	assertType('int', $b->b);
+	assertType('PHPStan\Generics\FunctionsAssertType\B<1>', $b);
+	assertType('1', $b->get());
+	assertType('1', $b->b);
 
 	$c = new CofI();
 	assertType('PHPStan\Generics\FunctionsAssertType\CofI', $c);
@@ -763,7 +763,7 @@ function testClasses()
 
 	$factory = new Factory(new \DateTime(), new A(1));
 	assertType(
-		'array{DateTime, PHPStan\\Generics\\FunctionsAssertType\\A<int>, string, PHPStan\\Generics\\FunctionsAssertType\\A<DateTime>}',
+		"array{DateTime, PHPStan\\Generics\\FunctionsAssertType\\A<1>, '', PHPStan\\Generics\\FunctionsAssertType\\A<DateTime>}",
 		$factory->create(new \DateTime(), '', new A(new \DateTime()))
 	);
 }
@@ -934,9 +934,9 @@ function () {
 	assertType('array{}', $stdEmpty->getAll());
 
 	$std = new StdClassCollection([new \stdClass()]);
-	assertType('PHPStan\Generics\FunctionsAssertType\StdClassCollection<int, stdClass>', $std);
-	assertType('PHPStan\Generics\FunctionsAssertType\StdClassCollection<int, stdClass>', $std->returnStatic());
-	assertType('array<int, stdClass>', $std->getAll());
+	assertType('PHPStan\Generics\FunctionsAssertType\StdClassCollection<0, stdClass>', $std);
+	assertType('PHPStan\Generics\FunctionsAssertType\StdClassCollection<0, stdClass>', $std->returnStatic());
+	assertType('array<0, stdClass>', $std->getAll());
 };
 
 class ClassWithMethodCachingIssue
@@ -1405,7 +1405,7 @@ function (\Throwable $e): void {
 
 function (): void {
 	$array = ['a' => 1, 'b' => 2];
-	assertType('array{a: int, b: int}', a($array));
+	assertType('array{a: 1, b: 2}', a($array));
 };
 
 
@@ -1544,8 +1544,8 @@ function (): void {
 	assertType('array{1: true}', arrayBound1([1 => true]));
 	assertType('array{\'a\', \'b\', \'c\'}', arrayBound2(range('a', 'c')));
 	assertType('array<string>', arrayBound2([1, 2, 3]));
-	assertType('array{bool, bool, bool}', arrayBound3([true, false, true]));
-	assertType('array{array{a: string}, array{b: string}, array{c: string}}', arrayBound4([['a' => 'a'], ['b' => 'b'], ['c' => 'c']]));
+	assertType('array{true, false, true}', arrayBound3([true, false, true]));
+	assertType("array{array{a: 'a'}, array{b: 'b'}, array{c: 'c'}}", arrayBound4([['a' => 'a'], ['b' => 'b'], ['c' => 'c']]));
 	assertType('array<string>', arrayBound5(range('a', 'c')));
 };
 

--- a/tests/PHPStan/Analyser/data/inherit-phpdoc-merging-template.php
+++ b/tests/PHPStan/Analyser/data/inherit-phpdoc-merging-template.php
@@ -32,7 +32,7 @@ class Bar extends Foo
 
 	public function doBar()
 	{
-		assertType('array<string>|int', $this->doFoo(1, 'hahaha'));
+		assertType("1|array<'hahaha'>", $this->doFoo(1, 'hahaha'));
 	}
 
 }
@@ -75,7 +75,7 @@ class Sit extends Foo
 
 	public function doBar()
 	{
-		assertType('array<InheritDocMergingTemplate\U>|int', $this->doFoo(1, 'hahaha'));
+		assertType('1|array<InheritDocMergingTemplate\U>', $this->doFoo(1, 'hahaha'));
 	}
 
 }
@@ -92,7 +92,7 @@ class Amet extends Foo
 
 	public function doBar()
 	{
-		assertType('array<string>|int', $this->doFoo(1, 'hahaha'));
+		assertType("1|array<'hahaha'>", $this->doFoo(1, 'hahaha'));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/native-reflection-default-values.php
+++ b/tests/PHPStan/Analyser/data/native-reflection-default-values.php
@@ -7,5 +7,5 @@ use function PHPStan\Testing\assertType;
 function () {
 	assertType('ArrayObject<*NEVER*, *NEVER*>', new \ArrayObject());
 	assertType('ArrayObject<*NEVER*, *NEVER*>', new \ArrayObject([]));
-	assertType('ArrayObject<string, int>', new \ArrayObject(['key' => 1]));
+	assertType("ArrayObject<'key', 1>", new \ArrayObject(['key' => 1]));
 };

--- a/tests/PHPStan/Analyser/data/nested-generic-incomplete-constructor.php
+++ b/tests/PHPStan/Analyser/data/nested-generic-incomplete-constructor.php
@@ -30,6 +30,6 @@ class Foo
 function (): void {
 	$foo = new Foo(1);
 	//assertType('NestedGenericIncompleteConstructor\Foo<int, int>', $foo);
-	assertType('int', $foo->t);
-	assertType('int', $foo->u);
+	assertType('1', $foo->t);
+	assertType('1', $foo->u);
 };

--- a/tests/PHPStan/Analyser/data/self-out.php
+++ b/tests/PHPStan/Analyser/data/self-out.php
@@ -6,7 +6,7 @@ use function PHPStan\dumpType;
 use function PHPStan\Testing\assertType;
 
 /**
- * @template T
+ * @template-covariant T
  */
 class a {
     /**
@@ -68,24 +68,24 @@ class b extends a {
 function () {
 	$i = new a(123);
 	// OK - $i is a<123>
-	assertType('SelfOut\\a<int>', $i);
+	assertType('SelfOut\\a<123>', $i);
 	assertType('void', $i->test());
 
 	$i->addData(321);
 	// OK - $i is a<123|321>
-	assertType('SelfOut\\a<int>', $i);
+	assertType('SelfOut\\a<123|321>', $i);
 	assertType('void', $i->test());
 
 	$i->setData("test");
 	// IfThisIsMismatch - Class is not a<int> as required
-	assertType('SelfOut\\a<string>', $i);
+	assertType("SelfOut\\a<'test'>", $i);
 	assertType('*NEVER*', $i->test());
 };
 
 function () {
 	$i = new b(123);
-	assertType('SelfOut\\b<int>', $i);
+	assertType('SelfOut\\b<123>', $i);
 
 	$i->addData(321);
-	assertType('SelfOut\\a<int>', $i);
+	assertType('SelfOut\\a<123|321>', $i);
 };

--- a/tests/PHPStan/Analyser/data/self-out.php
+++ b/tests/PHPStan/Analyser/data/self-out.php
@@ -6,7 +6,7 @@ use function PHPStan\dumpType;
 use function PHPStan\Testing\assertType;
 
 /**
- * @template-covariant T
+ * @template T
  */
 class a {
     /**

--- a/tests/PHPStan/Analyser/data/template-null-bound.php
+++ b/tests/PHPStan/Analyser/data/template-null-bound.php
@@ -21,6 +21,6 @@ class Foo
 
 function (Foo $f, ?int $i): void {
 	assertType('null', $f->doFoo(null));
-	assertType('int', $f->doFoo(1));
+	assertType('1', $f->doFoo(1));
 	assertType('int|null', $f->doFoo($i));
 };

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -14,7 +14,6 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -316,7 +315,11 @@ class GenericParametersAcceptorResolverTest  extends PHPStanTestCase
 						),
 						new DummyParameter(
 							'b',
-							new IntegerType(),
+							new UnionType([
+								new ConstantIntegerType(1),
+								new ConstantIntegerType(2),
+								new ConstantIntegerType(3),
+							]),
 							false,
 							PassedByReference::createNo(),
 							true,
@@ -324,7 +327,11 @@ class GenericParametersAcceptorResolverTest  extends PHPStanTestCase
 						),
 					],
 					false,
-					new IntegerType(),
+					new UnionType([
+						new ConstantIntegerType(1),
+						new ConstantIntegerType(2),
+						new ConstantIntegerType(3),
+					]),
 				),
 			],
 			'missing args' => [
@@ -405,10 +412,10 @@ class GenericParametersAcceptorResolverTest  extends PHPStanTestCase
 					TemplateTypeMap::createEmpty(),
 					null,
 					[
-						new DummyParameter('str', new StringType(), false, null, false, null),
+						new DummyParameter('str', new ConstantStringType('foooooo'), false, null, false, null),
 					],
 					false,
-					new StringType(),
+					new ConstantStringType('foooooo'),
 				),
 			],
 		];

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -550,15 +550,15 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_reduce.php'], [
 			[
-				'Parameter #2 $callback of function array_reduce expects callable(string, int): string, Closure(string, string): string given.',
+				'Parameter #2 $callback of function array_reduce expects callable(string, 1|2|3): string, Closure(string, string): string given.',
 				5,
 			],
 			[
-				'Parameter #2 $callback of function array_reduce expects callable(string|null, int): string|null, Closure(string, int): non-empty-string given.',
+				'Parameter #2 $callback of function array_reduce expects callable(non-empty-string|null, 1|2|3): non-empty-string|null, Closure(string, int): non-empty-string given.',
 				13,
 			],
 			[
-				'Parameter #2 $callback of function array_reduce expects callable(string|null, int): string|null, Closure(string, int): non-empty-string given.',
+				'Parameter #2 $callback of function array_reduce expects callable(non-empty-string|null, 1|2|3): non-empty-string|null, Closure(string, int): non-empty-string given.',
 				22,
 			],
 		]);
@@ -568,15 +568,15 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_reduce_arrow.php'], [
 			[
-				'Parameter #2 $callback of function array_reduce expects callable(string, int): string, Closure(string, string): string given.',
+				'Parameter #2 $callback of function array_reduce expects callable(string, 1|2|3): string, Closure(string, string): string given.',
 				5,
 			],
 			[
-				'Parameter #2 $callback of function array_reduce expects callable(string|null, int): string|null, Closure(string, int): non-empty-string given.',
+				'Parameter #2 $callback of function array_reduce expects callable(non-empty-string|null, 1|2|3): non-empty-string|null, Closure(string, int): non-empty-string given.',
 				11,
 			],
 			[
-				'Parameter #2 $callback of function array_reduce expects callable(string|null, int): string|null, Closure(string, int): non-empty-string given.',
+				'Parameter #2 $callback of function array_reduce expects callable(non-empty-string|null, 1|2|3): non-empty-string|null, Closure(string, int): non-empty-string given.',
 				18,
 			],
 		]);
@@ -622,11 +622,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_udiff.php'], [
 			[
-				'Parameter #3 $data_comp_func of function array_udiff expects callable(int, int): int<-1, 1>, Closure(string, string): string given.',
+				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int<-1, 1>, Closure(string, string): string given.',
 				6,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_udiff expects callable(int, int): int<-1, 1>, Closure(int, int): non-falsy-string given.',
+				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int<-1, 1>, Closure(int, int): non-falsy-string given.',
 				14,
 			],
 			[
@@ -692,7 +692,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/uasort.php'], [
 			[
-				'Parameter #2 $callback of function uasort expects callable(int, int): int, Closure(string, string): 1 given.',
+				'Parameter #2 $callback of function uasort expects callable(1|2|3, 1|2|3): int, Closure(string, string): 1 given.',
 				7,
 			],
 		]);
@@ -702,7 +702,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/uasort_arrow.php'], [
 			[
-				'Parameter #2 $callback of function uasort expects callable(int, int): int, Closure(string, string): 1 given.',
+				'Parameter #2 $callback of function uasort expects callable(1|2|3, 1|2|3): int, Closure(string, string): 1 given.',
 				7,
 			],
 		]);
@@ -712,7 +712,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/usort.php'], [
 			[
-				'Parameter #2 $callback of function usort expects callable(int, int): int, Closure(string, string): 1 given.',
+				'Parameter #2 $callback of function usort expects callable(1|2|3, 1|2|3): int, Closure(string, string): 1 given.',
 				14,
 			],
 		]);
@@ -722,7 +722,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/usort_arrow.php'], [
 			[
-				'Parameter #2 $callback of function usort expects callable(int, int): int, Closure(string, string): 1 given.',
+				'Parameter #2 $callback of function usort expects callable(1|2|3, 1|2|3): int, Closure(string, string): 1 given.',
 				14,
 			],
 		]);
@@ -732,7 +732,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/uksort.php'], [
 			[
-				'Parameter #2 $callback of function uksort expects callable(string, string): int, Closure(stdClass, stdClass): 1 given.',
+				"Parameter #2 \$callback of function uksort expects callable('one'|'three'|'two', 'one'|'three'|'two'): int, Closure(stdClass, stdClass): 1 given.",
 				14,
 			],
 			[
@@ -746,7 +746,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/uksort_arrow.php'], [
 			[
-				'Parameter #2 $callback of function uksort expects callable(string, string): int, Closure(stdClass, stdClass): 1 given.',
+				"Parameter #2 \$callback of function uksort expects callable('one'|'three'|'two', 'one'|'three'|'two'): int, Closure(stdClass, stdClass): 1 given.",
 				14,
 			],
 			[

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -105,7 +105,7 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->checkNullables = true;
 		$this->analyse([__DIR__ . '/data/bug-2723.php'], [
 			[
-				'Function Bug2723\baz() should return Bug2723\Bar<Bug2723\Foo<T4>> but returns Bug2723\BarOfFoo<string>.',
+				"Function Bug2723\baz() should return Bug2723\Bar<Bug2723\Foo<T4>> but returns Bug2723\BarOfFoo<'hello'>.",
 				55,
 			],
 		]);

--- a/tests/PHPStan/Rules/Generics/data/bug-3769.php
+++ b/tests/PHPStan/Rules/Generics/data/bug-3769.php
@@ -70,8 +70,8 @@ function stringBound(string $a)
 }
 
 function (): void {
-	$a = assertType('int', mixedBound(1));
-	$a = assertType('string', mixedBound('str'));
+	$a = assertType('1', mixedBound(1));
+	$a = assertType("'str'", mixedBound('str'));
 	$a = assertType('1', intBound(1));
 	$a = assertType('\'str\'', stringBound('str'));
 };

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleNoBleedingEdgeTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleNoBleedingEdgeTest.php
@@ -35,7 +35,7 @@ class CallMethodsRuleNoBleedingEdgeTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/generics-infer-collection.php'], [
 			[
-				'Parameter #1 $c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<int, string> given.',
+				"Parameter #1 \$c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<0|1, 'bar'|'foo'> given.",
 				43,
 			],
 		]);
@@ -46,7 +46,7 @@ class CallMethodsRuleNoBleedingEdgeTest extends RuleTestCase
 		$this->checkExplicitMixed = false;
 		$this->analyse([__DIR__ . '/data/generics-infer-collection.php'], [
 			[
-				'Parameter #1 $c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<int, string> given.',
+				"Parameter #1 \$c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<0|1, 'bar'|'foo'> given.",
 				43,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2149,15 +2149,23 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->checkUnionTypes = true;
 		$this->analyse([__DIR__ . '/data/bug-5372.php'], [
 			[
-				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, class-string> given.',
+				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<0|1, non-falsy-string> given.',
+				64,
+			],
+			[
+				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<0|1, class-string> given.',
 				68,
 			],
 			[
-				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, class-string> given.',
+				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<0|1, class-string> given.',
 				72,
 			],
 			[
-				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<int, literal-string> given.',
+				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<0|1, literal-string> given.',
+				81,
+			],
+			[
+				'Parameter #1 $list of method Bug5372\Foo::takesStrings() expects Bug5372\Collection<int, string>, Bug5372\Collection<0|1, literal-string> given.',
 				85,
 			],
 		]);
@@ -2480,7 +2488,7 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/generics-infer-collection.php'], [
 			[
-				'Parameter #1 $c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<int, string> given.',
+				"Parameter #1 \$c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<0|1, 'bar'|'foo'> given.",
 				43,
 			],
 			[
@@ -2506,7 +2514,7 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = false;
 		$this->analyse([__DIR__ . '/data/generics-infer-collection.php'], [
 			[
-				'Parameter #1 $c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<int, string> given.',
+				"Parameter #1 \$c of method GenericsInferCollection\Foo::doBar() expects GenericsInferCollection\ArrayCollection<int, int>, GenericsInferCollection\ArrayCollection<0|1, 'bar'|'foo'> given.",
 				43,
 			],
 		]);
@@ -2557,6 +2565,10 @@ class CallMethodsRuleTest extends RuleTestCase
 			[
 				'Parameter #2 $v of method UnresolvableParameter\HelloWorld::foo() contains unresolvable type.',
 				19,
+			],
+			[
+				'Parameter #2 $v of method UnresolvableParameter\HelloWorld::foo() expects 1, 0 given.',
+				21,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -316,7 +316,7 @@ class MethodSignatureRuleTest extends RuleTestCase
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-4707.php'], [
 			[
-				'Return type (list<Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be compatible with return type (list<Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()',
+				'Return type (list<Bug4707\Row2>) of method Bug4707\Block2::getChildren() should be covariant with return type (list<Bug4707\ChildNodeInterface<static(Bug4707\ParentNodeInterface)>>) of method Bug4707\ParentNodeInterface::getChildren()',
 				38,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -435,16 +435,20 @@ class ReturnTypeRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-4590.php'], [
 			[
-				'Method Bug4590\\Controller::test1() should return Bug4590\\OkResponse<array<string, string>> but returns Bug4590\\OkResponse<array{ok: string}>.',
+				"Method Bug4590\\Controller::test1() should return Bug4590\\OkResponse<array<string, string>> but returns Bug4590\\OkResponse<array{ok: 'hello'}>.",
 				39,
 			],
 			[
-				'Method Bug4590\\Controller::test2() should return Bug4590\\OkResponse<array<int, string>> but returns Bug4590\\OkResponse<array{string}>.',
+				"Method Bug4590\\Controller::test2() should return Bug4590\\OkResponse<array<int, string>> but returns Bug4590\\OkResponse<array{'hello'}>.",
 				47,
 			],
 			[
-				'Method Bug4590\\Controller::test3() should return Bug4590\\OkResponse<array<string>> but returns Bug4590\\OkResponse<array{string}>.',
+				"Method Bug4590\\Controller::test3() should return Bug4590\\OkResponse<array<string>> but returns Bug4590\\OkResponse<array{'hello'}>.",
 				55,
+			],
+			[
+				"Method Bug4590\\Controller::test4() should return Bug4590\\OkResponse<string> but returns Bug4590\\OkResponse<'hello'>.",
+				63,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/data/bug-5372.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5372.php
@@ -57,18 +57,18 @@ class Foo
 	public function doFoo(string $classString)
 	{
 		$col = new Collection(['foo', 'bar']);
-		assertType('Bug5372\Collection<int, string>', $col);
+		assertType("Bug5372\Collection<0|1, 'bar'|'foo'>", $col);
 
 		$newCol = $col->map(static fn(string $var): string => $var . 'bar');
-		assertType('Bug5372\Collection<int, string>', $newCol);
+		assertType('Bug5372\Collection<0|1, non-falsy-string>', $newCol);
 		$this->takesStrings($newCol);
 
 		$newCol = $col->map(static fn(string $var): string => $classString);
-		assertType('Bug5372\Collection<int, class-string>', $newCol);
+		assertType('Bug5372\Collection<0|1, class-string>', $newCol);
 		$this->takesStrings($newCol);
 
 		$newCol = $col->map2(static fn(string $var): string => $classString);
-		assertType('Bug5372\Collection<int, class-string>', $newCol);
+		assertType('Bug5372\Collection<0|1, class-string>', $newCol);
 		$this->takesStrings($newCol);
 	}
 
@@ -77,11 +77,11 @@ class Foo
 	{
 		$col = new Collection(['foo', 'bar']);
 		$newCol = $col->map(static fn(string $var): string => $literalString);
-		assertType('Bug5372\Collection<int, string>', $newCol);
+		assertType('Bug5372\Collection<0|1, literal-string>', $newCol);
 		$this->takesStrings($newCol);
 
 		$newCol = $col->map2(static fn(string $var): string => $literalString);
-		assertType('Bug5372\Collection<int, literal-string>', $newCol);
+		assertType('Bug5372\Collection<0|1, literal-string>', $newCol);
 		$this->takesStrings($newCol);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/bug-5757.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5757.php
@@ -22,7 +22,7 @@ class Foo
 
 	public function doFoo()
 	{
-		assertType('iterable<array<int>>', Helper::chunk([1], 3));
+		assertType('iterable<array<1>>', Helper::chunk([1], 3));
 		assertType('iterable<array<*NEVER*>>', Helper::chunk([], 3));
 	}
 

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleNoBleedingEdgeTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleNoBleedingEdgeTest.php
@@ -24,7 +24,7 @@ class TypesAssignedToPropertiesRuleNoBleedingEdgeTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/generic-object-unspecified-template-types.php'], [
 			[
-				'Property GenericObjectUnspecifiedTemplateTypes\Bar::$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, string>.',
+				"Property GenericObjectUnspecifiedTemplateTypes\Bar::\$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<0|1, 'bar'|'foo'>.",
 				67,
 			],
 		]);
@@ -35,7 +35,7 @@ class TypesAssignedToPropertiesRuleNoBleedingEdgeTest extends RuleTestCase
 		$this->checkExplicitMixed = false;
 		$this->analyse([__DIR__ . '/data/generic-object-unspecified-template-types.php'], [
 			[
-				'Property GenericObjectUnspecifiedTemplateTypes\Bar::$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, string>.',
+				"Property GenericObjectUnspecifiedTemplateTypes\Bar::\$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<0|1, 'bar'|'foo'>.",
 				67,
 			],
 		]);

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -387,7 +387,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 				13,
 			],
 			[
-				'Property GenericObjectUnspecifiedTemplateTypes\Bar::$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, string>.',
+				"Property GenericObjectUnspecifiedTemplateTypes\Bar::\$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<0|1, 'bar'|'foo'>.",
 				67,
 			],
 		]);
@@ -398,7 +398,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = false;
 		$this->analyse([__DIR__ . '/data/generic-object-unspecified-template-types.php'], [
 			[
-				'Property GenericObjectUnspecifiedTemplateTypes\Bar::$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, string>.',
+				"Property GenericObjectUnspecifiedTemplateTypes\Bar::\$ints (GenericObjectUnspecifiedTemplateTypes\ArrayCollection<int, int>) does not accept GenericObjectUnspecifiedTemplateTypes\ArrayCollection<0|1, 'bar'|'foo'>.",
 				67,
 			],
 		]);

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -50,7 +50,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 			'same class, different type args' => [
 				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
 				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			'same class, one naked' => [
 				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
@@ -65,7 +65,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 			'implementation with @extends with different type args' => [
 				new GenericObjectType(B\I::class, [new ObjectType('DateTimeInteface')]),
 				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			'invariant with equals types' => [
 				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
@@ -75,12 +75,12 @@ class GenericObjectTypeTest extends PHPStanTestCase
 			'invariant with sub type' => [
 				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')]),
 				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			'invariant with super type' => [
 				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')]),
 				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')]),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			'covariant with equals types' => [
 				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTime')]),
@@ -175,7 +175,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 			'same class, different type args' => [
 				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
 				new GenericObjectType(A\A::class, [new ObjectType('DateTime')]),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			'same class, one naked' => [
 				new GenericObjectType(A\A::class, [new ObjectType('DateTimeInterface')]),
@@ -190,7 +190,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 			'implementation with @extends with different type args' => [
 				new GenericObjectType(B\I::class, [new ObjectType('DateTimeInteface')]),
 				new GenericObjectType(B\IImpl::class, [new ObjectType('DateTime')]),
-				TrinaryLogic::createNo(),
+				TrinaryLogic::createMaybe(),
 			],
 			'generic object accepts normal object of same type' => [
 				new GenericObjectType(Traversable::class, [new MixedType(true), new ObjectType('DateTimeInteface')]),


### PR DESCRIPTION
A little experiment to see what happens. Psalm doesn't generalize template types either, because a `@var` is easy enough to write.