### PR TITLE
Add rule call constructor

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -8,3 +8,4 @@ parameters:
 		arrayUnpacking: true
 		nodeConnectingVisitorCompatibility: false
 		disableRuntimeReflectionProvider: true
+		illegalConstructorMethodCall: true

--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -40,6 +40,12 @@ rules:
 	- PHPStan\Rules\PhpDoc\WrongVariableNameInVarTagRule
 	- PHPStan\Rules\Properties\AccessPrivatePropertyThroughStaticRule
 
+conditionalTags:
+	PHPStan\Rules\Methods\IllegalConstructorMethodCallRule:
+		phpstan.rules.rule: %featureToggles.illegalConstructorMethodCall%
+	PHPStan\Rules\Methods\IllegalConstructorStaticCallRule:
+		phpstan.rules.rule: %featureToggles.illegalConstructorMethodCall%
+
 services:
 	-
 		class: PHPStan\Rules\Classes\MixinRule
@@ -53,6 +59,10 @@ services:
 			reportMaybes: %reportMaybes%
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPStan\Rules\Methods\IllegalConstructorMethodCallRule
+	-
+		class: PHPStan\Rules\Methods\IllegalConstructorStaticCallRule
 	-
 		class: PHPStan\Rules\PhpDoc\InvalidPhpDocVarTagTypeRule
 		arguments:

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -32,6 +32,7 @@ parameters:
 		arrayFilter: false
 		arrayUnpacking: false
 		nodeConnectingVisitorCompatibility: true
+		illegalConstructorMethodCall: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -219,6 +220,7 @@ parametersSchema:
 		arrayFilter: bool(),
 		arrayUnpacking: bool(),
 		nodeConnectingVisitorCompatibility: bool(),
+		illegalConstructorMethodCall: bool(),
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/Rules/Methods/IllegalConstructorMethodCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorMethodCallRule.php
@@ -24,27 +24,10 @@ class IllegalConstructorMethodCallRule implements Rule
 			return [];
 		}
 
-		if ($this->isCollectCallingConstructor($node, $scope)) {
-			return [];
-		}
-
 		return [
 			RuleErrorBuilder::message('Call to __construct() on an existing object is not allowed.')
 				->build(),
 		];
-	}
-
-	private function isCollectCallingConstructor(Node $node, Scope $scope): bool
-	{
-		if (!$node instanceof Node\Expr\MethodCall) {
-			return true;
-		}
-		// __construct should be called from inside constructor
-		if ($scope->getFunction() !== null && $scope->getFunction()->getName() !== '__construct') {
-			return false;
-		}
-		// In constructor, method call is allowed with 'this';
-		return $node->var instanceof Node\Expr\Variable && $node->var->name === 'this';
 	}
 
 }

--- a/src/Rules/Methods/IllegalConstructorMethodCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorMethodCallRule.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+class IllegalConstructorMethodCallRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\MethodCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Identifier || $node->name->name !== '__construct') {
+			return [];
+		}
+
+		return $this->isCollectCallingConstructor($node, $scope)
+			? []
+			: ['__construct() should not be called outside constructor.'];
+	}
+
+	private function isCollectCallingConstructor(Node $node, Scope $scope): bool
+	{
+		if (!$node instanceof Node\Expr\MethodCall) {
+			return true;
+		}
+		// __construct should be called from inside constructor
+		if ($scope->getFunction() !== null && $scope->getFunction()->getName() !== '__construct') {
+			return false;
+		}
+		// In constructor, method call is allowed with 'this';
+		return $node->var instanceof Node\Expr\Variable && $node->var->name === 'this';
+	}
+
+}

--- a/src/Rules/Methods/IllegalConstructorMethodCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorMethodCallRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Methods;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 
 /**
  * @implements Rule<Node\Expr\MethodCall>
@@ -23,9 +24,14 @@ class IllegalConstructorMethodCallRule implements Rule
 			return [];
 		}
 
-		return $this->isCollectCallingConstructor($node, $scope)
-			? []
-			: ['__construct() should not be called outside constructor.'];
+		if ($this->isCollectCallingConstructor($node, $scope)) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message('__construct() should not be called outside constructor.')
+				->build(),
+		];
 	}
 
 	private function isCollectCallingConstructor(Node $node, Scope $scope): bool

--- a/src/Rules/Methods/IllegalConstructorMethodCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorMethodCallRule.php
@@ -20,7 +20,7 @@ class IllegalConstructorMethodCallRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node->name instanceof Node\Identifier || $node->name->name !== '__construct') {
+		if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== '__construct') {
 			return [];
 		}
 

--- a/src/Rules/Methods/IllegalConstructorMethodCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorMethodCallRule.php
@@ -29,7 +29,7 @@ class IllegalConstructorMethodCallRule implements Rule
 		}
 
 		return [
-			RuleErrorBuilder::message('__construct() should not be called outside constructor.')
+			RuleErrorBuilder::message('Call to __construct() on an existing object is not allowed.')
 				->build(),
 		];
 	}

--- a/src/Rules/Methods/IllegalConstructorStaticCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorStaticCallRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Methods;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use function in_array;
 
 /**
@@ -24,9 +25,14 @@ class IllegalConstructorStaticCallRule implements Rule
 			return [];
 		}
 
-		return $this->isCollectCallingConstructor($node, $scope)
-			? []
-			: ['__construct() should not be called outside constructor.'];
+		if ($this->isCollectCallingConstructor($node, $scope)) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message('__construct() should not be called outside constructor.')
+				->build(),
+		];
 	}
 
 	private function isCollectCallingConstructor(Node $node, Scope $scope): bool

--- a/src/Rules/Methods/IllegalConstructorStaticCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorStaticCallRule.php
@@ -30,7 +30,7 @@ class IllegalConstructorStaticCallRule implements Rule
 		}
 
 		return [
-			RuleErrorBuilder::message('__construct() should not be called outside constructor.')
+			RuleErrorBuilder::message('Static call to __construct() is only allowed on a parent class in the constructor.')
 				->build(),
 		];
 	}

--- a/src/Rules/Methods/IllegalConstructorStaticCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorStaticCallRule.php
@@ -52,13 +52,7 @@ class IllegalConstructorStaticCallRule implements Rule
 			return false;
 		}
 
-		if ($node->class->toLowerString() === 'parent') {
-			return true;
-		}
-
-		$className = $scope->resolveName($node->class);
-
-		return $className === $scope->getClassReflection()->getName();
+		return $node->class->toLowerString() === 'parent';
 	}
 
 }

--- a/src/Rules/Methods/IllegalConstructorStaticCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorStaticCallRule.php
@@ -21,7 +21,7 @@ class IllegalConstructorStaticCallRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node->name instanceof Node\Identifier || $node->name->name !== '__construct') {
+		if (!$node->name instanceof Node\Identifier || $node->name->toLowerString() !== '__construct') {
 			return [];
 		}
 

--- a/src/Rules/Methods/IllegalConstructorStaticCallRule.php
+++ b/src/Rules/Methods/IllegalConstructorStaticCallRule.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use function in_array;
+
+/**
+ * @implements Rule<Node\Expr\StaticCall>
+ */
+class IllegalConstructorStaticCallRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\StaticCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->name instanceof Node\Identifier || $node->name->name !== '__construct') {
+			return [];
+		}
+
+		return $this->isCollectCallingConstructor($node, $scope)
+			? []
+			: ['__construct() should not be called outside constructor.'];
+	}
+
+	private function isCollectCallingConstructor(Node $node, Scope $scope): bool
+	{
+		if (!$node instanceof Node\Expr\StaticCall) {
+			return true;
+		}
+		// __construct should be called from inside constructor
+		if ($scope->getFunction() !== null && $scope->getFunction()->getName() !== '__construct') {
+			return false;
+		}
+		// In constructor, static call is allowed with 'self' or 'parent;
+		return $node->class instanceof Node\Name && in_array($node->class->getFirst(), ['self', 'parent'], true);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
@@ -25,7 +25,7 @@ class IllegalConstructorMethodCallRuleTest extends RuleTestCase
 			],
 			[
 				'Call to __construct() on an existing object is not allowed.',
-				56,
+				58,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
@@ -20,11 +20,11 @@ class IllegalConstructorMethodCallRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
 			[
-				'__construct() should not be called outside constructor.',
+				'Call to __construct() on an existing object is not allowed.',
 				16,
 			],
 			[
-				'__construct() should not be called outside constructor.',
+				'Call to __construct() on an existing object is not allowed.',
 				51,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
@@ -21,6 +21,10 @@ class IllegalConstructorMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
 			[
 				'Call to __construct() on an existing object is not allowed.',
+				13,
+			],
+			[
+				'Call to __construct() on an existing object is not allowed.',
 				18,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
@@ -21,11 +21,11 @@ class IllegalConstructorMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
 			[
 				'Call to __construct() on an existing object is not allowed.',
-				16,
+				18,
 			],
 			[
 				'Call to __construct() on an existing object is not allowed.',
-				58,
+				60,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
@@ -25,7 +25,7 @@ class IllegalConstructorMethodCallRuleTest extends RuleTestCase
 			],
 			[
 				'Call to __construct() on an existing object is not allowed.',
-				51,
+				56,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorMethodCallRuleTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<IllegalConstructorMethodCallRule>
+ */
+class IllegalConstructorMethodCallRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new IllegalConstructorMethodCallRule();
+	}
+
+	public function testMethods(): void
+	{
+		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
+			[
+				'__construct() should not be called outside constructor.',
+				16,
+			],
+			[
+				'__construct() should not be called outside constructor.',
+				51,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
@@ -20,11 +20,11 @@ class IllegalConstructorStaticCallRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
 			[
-				'__construct() should not be called outside constructor.',
+				'Static call to __construct() is only allowed on a parent class in the constructor.',
 				29,
 			],
 			[
-				'__construct() should not be called outside constructor.',
+				'Static call to __construct() is only allowed on a parent class in the constructor.',
 				46,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<IllegalConstructorStaticCallRule>
+ */
+class IllegalConstructorStaticCallRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new IllegalConstructorStaticCallRule();
+	}
+
+	public function testMethods(): void
+	{
+		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
+			[
+				'__construct() should not be called outside constructor.',
+				29,
+			],
+			[
+				'__construct() should not be called outside constructor.',
+				46,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
@@ -25,7 +25,11 @@ class IllegalConstructorStaticCallRuleTest extends RuleTestCase
 			],
 			[
 				'Static call to __construct() is only allowed on a parent class in the constructor.',
-				46,
+				47,
+			],
+			[
+				'Static call to __construct() is only allowed on a parent class in the constructor.',
+				48,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
@@ -21,15 +21,15 @@ class IllegalConstructorStaticCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/illegal-constructor-call-rule-test.php'], [
 			[
 				'Static call to __construct() is only allowed on a parent class in the constructor.',
-				29,
+				31,
 			],
 			[
 				'Static call to __construct() is only allowed on a parent class in the constructor.',
-				47,
+				49,
 			],
 			[
 				'Static call to __construct() is only allowed on a parent class in the constructor.',
-				48,
+				50,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/IllegalConstructorStaticCallRuleTest.php
@@ -25,6 +25,14 @@ class IllegalConstructorStaticCallRuleTest extends RuleTestCase
 			],
 			[
 				'Static call to __construct() is only allowed on a parent class in the constructor.',
+				43,
+			],
+			[
+				'Static call to __construct() is only allowed on a parent class in the constructor.',
+				44,
+			],
+			[
+				'Static call to __construct() is only allowed on a parent class in the constructor.',
 				49,
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
+++ b/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
@@ -39,11 +39,13 @@ class ExtendedDateTimeWithSelfCall extends DateTimeImmutable
 			return;
 		}
 		self::__construct($datetime, $timezone);
+		ExtendedDateTimeWithSelfCall::__construct($datetime, $timezone);
 	}
 
 	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
 	{
 		self::__construct($datetime, $timezone);
+		ExtendedDateTimeWithSelfCall::__construct($datetime, $timezone);
 	}
 }
 

--- a/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
+++ b/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
@@ -47,5 +47,13 @@ class ExtendedDateTimeWithSelfCall extends DateTimeImmutable
 	}
 }
 
-$extendedDateTime = new ExtendedDateTimeWithMethodCall('2022/04/12');
-$extendedDateTime->__construct('2022/04/13');
+class Foo
+{
+
+	public function doFoo()
+	{
+		$extendedDateTime = new ExtendedDateTimeWithMethodCall('2022/04/12');
+		$extendedDateTime->__construct('2022/04/13');
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
+++ b/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
@@ -1,8 +1,10 @@
 <?php
 
-class ExtendedDateTimeWithMethodCall extends DateTimeImmutable
+namespace IllegalConstructorMethodCall;
+
+class ExtendedDateTimeWithMethodCall extends \DateTimeImmutable
 {
-	public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null)
+	public function __construct(string $datetime = "now", ?\DateTimeZone $timezone = null)
 	{
 		// Avoid infinite loop
 		if (count(debug_backtrace()) > 1) {
@@ -11,28 +13,28 @@ class ExtendedDateTimeWithMethodCall extends DateTimeImmutable
 		$this->__construct($datetime, $timezone);
 	}
 
-	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
+	public function mutate(string $datetime = "now", ?\DateTimeZone $timezone = null): void
 	{
 		$this->__construct($datetime, $timezone);
 	}
 }
 
-class ExtendedDateTimeWithParentCall extends DateTimeImmutable
+class ExtendedDateTimeWithParentCall extends \DateTimeImmutable
 {
-	public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null)
+	public function __construct(string $datetime = "now", ?\DateTimeZone $timezone = null)
 	{
 		parent::__construct($datetime, $timezone);
 	}
 
-	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
+	public function mutate(string $datetime = "now", ?\DateTimeZone $timezone = null): void
 	{
 		parent::__construct($datetime, $timezone);
 	}
 }
 
-class ExtendedDateTimeWithSelfCall extends DateTimeImmutable
+class ExtendedDateTimeWithSelfCall extends \DateTimeImmutable
 {
-	public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null)
+	public function __construct(string $datetime = "now", ?\DateTimeZone $timezone = null)
 	{
 		// Avoid infinite loop
 		if (count(debug_backtrace()) > 1) {
@@ -42,7 +44,7 @@ class ExtendedDateTimeWithSelfCall extends DateTimeImmutable
 		ExtendedDateTimeWithSelfCall::__construct($datetime, $timezone);
 	}
 
-	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
+	public function mutate(string $datetime = "now", ?\DateTimeZone $timezone = null): void
 	{
 		self::__construct($datetime, $timezone);
 		ExtendedDateTimeWithSelfCall::__construct($datetime, $timezone);

--- a/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
+++ b/tests/PHPStan/Rules/Methods/data/illegal-constructor-call-rule-test.php
@@ -1,0 +1,51 @@
+<?php
+
+class ExtendedDateTimeWithMethodCall extends DateTimeImmutable
+{
+	public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null)
+	{
+		// Avoid infinite loop
+		if (count(debug_backtrace()) > 1) {
+			return;
+		}
+		$this->__construct($datetime, $timezone);
+	}
+
+	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
+	{
+		$this->__construct($datetime, $timezone);
+	}
+}
+
+class ExtendedDateTimeWithParentCall extends DateTimeImmutable
+{
+	public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null)
+	{
+		parent::__construct($datetime, $timezone);
+	}
+
+	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
+	{
+		parent::__construct($datetime, $timezone);
+	}
+}
+
+class ExtendedDateTimeWithSelfCall extends DateTimeImmutable
+{
+	public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null)
+	{
+		// Avoid infinite loop
+		if (count(debug_backtrace()) > 1) {
+			return;
+		}
+		self::__construct($datetime, $timezone);
+	}
+
+	public function mutate(string $datetime = "now", ?DateTimeZone $timezone = null): void
+	{
+		self::__construct($datetime, $timezone);
+	}
+}
+
+$extendedDateTime = new ExtendedDateTimeWithMethodCall('2022/04/12');
+$extendedDateTime->__construct('2022/04/13');


### PR DESCRIPTION
Implementation for phpstan/phpstan/issues/7022.

### Notes

- Check calling __construct more than twice in constructor is out of scope
  Because it is a bit difficult.