### PR TITLE
Support variadic parameter in `array_replace`

### DIFF
--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -38,13 +38,12 @@ class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		$valueTypes = [];
 		$nonEmptyArray = false;
 		foreach ($arrayTypes as $arrayType) {
-			$keyTypes[] = $arrayType->getIterableKeyType();
-			$valueTypes[] = $arrayType->getIterableValueType();
-			if ($nonEmptyArray || !$arrayType->isIterableAtLeastOnce()->yes()) {
-				continue;
+			if (!$nonEmptyArray && $arrayType->isIterableAtLeastOnce()->yes()) {
+				$nonEmptyArray = true;
 			}
 
-			$nonEmptyArray = true;
+			$keyTypes[] = $arrayType->getIterableKeyType();
+			$valueTypes[] = $arrayType->getIterableValueType();
 		}
 
 		$keyType = TypeCombinator::union(...$keyTypes);

--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -24,68 +24,57 @@ class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		$args = $functionCall->getArgs();
+		$arrayTypes = $this->collectArrayTypes($functionCall, $scope);
 
-		if (count($args) < 1) {
+		if (count($arrayTypes) === 0) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
-		$arrayType = $scope->getType($args[0]->value);
-		if ($arrayType->isArray()->yes()) {
-			$resultType = $this->getResultType($functionCall, $scope);
-
-			if ($resultType !== null) {
-				if ($this->returnsNonEmptyArray($functionCall, $scope)) {
-					$resultType = TypeCombinator::intersect($resultType, new NonEmptyArrayType());
-				}
-
-				return $resultType;
-			}
-		}
-
-		return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		return $this->getResultType(...$arrayTypes);
 	}
 
-	private function getResultType(FuncCall $functionCall, Scope $scope): ?Type
+	private function getResultType(Type ...$arrayTypes): Type
 	{
-		$args = $functionCall->getArgs();
-
 		$keyTypes = [];
 		$valueTypes = [];
-		for ($i = 0; $i < count($args); $i++) {
-			$arrayType = $scope->getType($args[$i]->value);
-
-			if (!$arrayType->isArray()->yes()) {
-				return null;
-			}
-
+		$nonEmptyArray = false;
+		foreach ($arrayTypes as $arrayType) {
 			$keyTypes[] = $arrayType->getIterableKeyType();
 			$valueTypes[] = $arrayType->getIterableValueType();
+			if ($nonEmptyArray || !$arrayType->isIterableAtLeastOnce()->yes()) {
+				continue;
+			}
+
+			$nonEmptyArray = true;
 		}
 
 		$keyType = TypeCombinator::union(...$keyTypes);
 		$valueType = TypeCombinator::union(...$valueTypes);
 
-		return new ArrayType($keyType, $valueType);
+		$arrayType = new ArrayType($keyType, $valueType);
+		return $nonEmptyArray
+			? TypeCombinator::intersect($arrayType, new NonEmptyArrayType())
+			: $arrayType;
 	}
 
-	private function returnsNonEmptyArray(FuncCall $functionCall, Scope $scope): bool
+	/**
+	 * @return Type[]
+	 */
+	private function collectArrayTypes(FuncCall $functionCall, Scope $scope): array
 	{
 		$args = $functionCall->getArgs();
 
-		for ($i = 0; $i < count($args); $i++) {
-			$array = $scope->getType($args[$i]->value);
-
-			if (!$array->isArray()->yes()) {
+		$arrayTypes = [];
+		foreach ($args as $arg) {
+			$argType = $scope->getType($arg->value);
+			if (!$argType->isArray()->yes()) {
 				continue;
 			}
 
-			if ($array->isIterableAtLeastOnce()->yes()) {
-				return true;
-			}
+			$arrayTypes[] = $arg->unpack ? $argType->getIterableValueType() : $argType;
 		}
 
-		return false;
+		return $arrayTypes;
 	}
 
 }

--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -22,12 +22,12 @@ class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		return strtolower($functionReflection->getName()) === 'array_replace';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$arrayTypes = $this->collectArrayTypes($functionCall, $scope);
 
 		if (count($arrayTypes) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		return $this->getResultType(...$arrayTypes);
@@ -52,9 +52,7 @@ class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		$valueType = TypeCombinator::union(...$valueTypes);
 
 		$arrayType = new ArrayType($keyType, $valueType);
-		return $nonEmptyArray
-			? TypeCombinator::intersect($arrayType, new NonEmptyArrayType())
-			: $arrayType;
+		return $nonEmptyArray ? TypeCombinator::intersect($arrayType, new NonEmptyArrayType()) : $arrayType;
 	}
 
 	/**

--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;

--- a/tests/PHPStan/Analyser/data/array-replace.php
+++ b/tests/PHPStan/Analyser/data/array-replace.php
@@ -40,6 +40,14 @@ class Foo
 	}
 
 	/**
+	 * @param int[] ...$arrays1
+	 */
+	public function arrayReplaceVariadic(...$arrays1): void
+	{
+		assertType("array<int>", array_replace(...$arrays1));
+	}
+
+	/**
 	 * @param array<int, int|string> $array1
 	 * @param array<int, bool|float> $array2
 	 */

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -510,6 +510,11 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-4803.php'], []);
 	}
 
+	public function testBug7020(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7020.php'], []);
+	}
+
 	public function testBug2573(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-2573-return.php'], []);

--- a/tests/PHPStan/Rules/Methods/data/bug-7020.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-7020.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7020;
+
+class TemplatePaths
+{
+	/**
+	 * @param array<int, string> ...$templatePaths
+	 * @return array<int, string>
+	 */
+	public static function merge(array ...$templatePaths): array
+	{
+		$mergedTemplatePaths = array_replace(...$templatePaths);
+		ksort($mergedTemplatePaths);
+
+		return $mergedTemplatePaths;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7020

It was not my intention to completely refactor this extension, but it kind of happened while adding variadic support, sorry 😅 I normally would try to separate such things in multiple PRs. But the fix needed the refactor, the tests here were good enough and it's all quite local I think. Variadic support is only added via that one line checking `->unpack` CC @staabm 