### PR TITLE
Fix `array_push` with an empty constant array

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1869,9 +1869,14 @@ class NodeScopeResolver
 					}
 
 					if ($prepend) {
+						$keyTypes = $arrayType->getKeyTypes();
 						$valueTypes = $arrayType->getValueTypes();
-						foreach ($valueTypes as $key => $valueType) {
-							$arrayTypeBuilder->setOffsetValueType(null, $valueType, $arrayType->isOptionalKey($key));
+						foreach ($keyTypes as $k => $keyType) {
+							$arrayTypeBuilder->setOffsetValueType(
+								$keyType instanceof ConstantStringType ? $keyType : null,
+								$valueTypes[$k],
+								$arrayType->isOptionalKey($k),
+							);
 						}
 					}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1847,6 +1847,10 @@ class NodeScopeResolver
 				foreach (array_slice($expr->getArgs(), 1) as $callArg) {
 					$callArgType = $scope->getType($callArg->value);
 					if ($callArg->unpack) {
+						if ($callArgType instanceof ConstantArrayType && $callArgType->isEmpty()) {
+							continue;
+						}
+
 						$iterableValueType = $callArgType->getIterableValueType();
 						if ($iterableValueType instanceof UnionType) {
 							foreach ($iterableValueType->getTypes() as $innerType) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -109,7 +109,6 @@ use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -1847,10 +1846,9 @@ class NodeScopeResolver
 				foreach (array_slice($expr->getArgs(), 1) as $callArg) {
 					$callArgType = $scope->getType($callArg->value);
 					if ($callArg->unpack) {
-						if ($callArgType instanceof ConstantArrayType && $callArgType->isEmpty()) {
+						if ($callArgType->isIterableAtLeastOnce()->no()) {
 							continue;
 						}
-
 						$iterableValueType = $callArgType->getIterableValueType();
 						if ($iterableValueType instanceof UnionType) {
 							foreach ($iterableValueType->getTypes() as $innerType) {
@@ -1877,7 +1875,7 @@ class NodeScopeResolver
 						$arrayType = $arrayType->setOffsetValueType(null, $argType);
 					}
 
-					$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, TypeCombinator::intersect($arrayType, new NonEmptyArrayType()));
+					$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, $arrayType);
 				} elseif (count($constantArrays) > 0) {
 					$defaultArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
 					foreach ($argumentTypes as $argType) {
@@ -1891,7 +1889,7 @@ class NodeScopeResolver
 							$arrayType = $arrayType->setOffsetValueType(null, $argType);
 						}
 
-						$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, TypeCombinator::intersect($arrayType, new NonEmptyArrayType()));
+						$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, $arrayType);
 					} else {
 						$arrayTypes = [];
 						foreach ($constantArrays as $constantArray) {

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -2960,7 +2960,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$arrToPush2',
 			],
 			[
-				'array{0: \'lorem\', 1: 5, foo: stdClass, 2: \'test\'}',
+				'array{\'lorem\', 5, stdClass, \'test\'}',
 				'$arrToUnshift',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -2960,7 +2960,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$arrToPush2',
 			],
 			[
-				'array{\'lorem\', 5, stdClass, \'test\'}',
+				'array{0: \'lorem\', 1: 5, foo: stdClass, 2: \'test\'}',
 				'$arrToUnshift',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -561,6 +561,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1870.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5562.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5615.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-unshift.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_map_multiple.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/range-numeric-string.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/missing-closure-native-return-typehint.php');
@@ -838,6 +839,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-push.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-replace.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6889.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6891.php');

--- a/tests/PHPStan/Analyser/data/array-push.php
+++ b/tests/PHPStan/Analyser/data/array-push.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ArrayPush;
+
+use function array_push;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param string[] $a
+ * @param int[] $b
+ * @param non-empty-array<int> $c
+ */
+function arrayPush(array $a, array $b, array $c): void
+{
+	array_push($a, ...$b);
+	assertType('non-empty-array<int|string>', $a);
+
+	array_push($b, ...[]);
+	assertType('array<int>', $b);
+
+	array_push($c, ...[19, 'baz', false]);
+	assertType('non-empty-array<\'baz\'|int|false>', $c);
+}
+
+function arrayPushConstantArray(): void
+{
+	$a = ['foo' => 17, 'a', 'bar' => 18,];
+	array_push($a, ...[19, 'baz', false]);
+	assertType('array{foo: 17, 0: \'a\', bar: 18, 1: 19, 2: \'baz\', 3: false}', $a);
+
+	$b = ['foo' => 17, 'a', 'bar' => 18];
+	array_push($b, 19, 'baz', false);
+	assertType('array{foo: 17, 0: \'a\', bar: 18, 1: 19, 2: \'baz\', 3: false}', $b);
+
+	$c = ['foo' => 17, 'a', 'bar' => 18];
+	array_push($c, ...[]);
+	assertType('array{foo: 17, 0: \'a\', bar: 18}', $c);
+
+	$d = [];
+	array_push($d, ...[]);
+	assertType('array{}', $d);
+
+	$e = [];
+	array_push($e, 19, 'baz', false);
+	assertType('array{19, \'baz\', false}', $e);
+}

--- a/tests/PHPStan/Analyser/data/array-push.php
+++ b/tests/PHPStan/Analyser/data/array-push.php
@@ -9,8 +9,9 @@ use function PHPStan\Testing\assertType;
  * @param string[] $a
  * @param int[] $b
  * @param non-empty-array<int> $c
+ * @param array<int|string> $d
  */
-function arrayPush(array $a, array $b, array $c): void
+function arrayPush(array $a, array $b, array $c, array $d): void
 {
 	array_push($a, ...$b);
 	assertType('non-empty-array<int|string>', $a);
@@ -20,6 +21,11 @@ function arrayPush(array $a, array $b, array $c): void
 
 	array_push($c, ...[19, 'baz', false]);
 	assertType('non-empty-array<\'baz\'|int|false>', $c);
+
+	/** @var array<bool|null> $d1 */
+	$d1 = [];
+	array_push($d, ...$d1);
+	assertType('non-empty-array<bool|int|string|null>', $d);
 }
 
 function arrayPushConstantArray(): void
@@ -43,4 +49,10 @@ function arrayPushConstantArray(): void
 	$e = [];
 	array_push($e, 19, 'baz', false);
 	assertType('array{19, \'baz\', false}', $e);
+
+	$f = [17];
+	/** @var array<bool|null> $f1 */
+	$f1 = [];
+	array_push($f, ...$f1);
+	assertType('non-empty-array<int, bool|int|null>', $f);
 }

--- a/tests/PHPStan/Analyser/data/array-unshift.php
+++ b/tests/PHPStan/Analyser/data/array-unshift.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ArrayUnshift;
+
+use function array_unshift;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param string[] $a
+ * @param int[] $b
+ * @param non-empty-array<int> $c
+ */
+function arrayUnshift(array $a, array $b, array $c): void
+{
+	array_unshift($a, ...$b);
+	assertType('non-empty-array<int|string>', $a);
+
+	array_unshift($b, ...[]);
+	assertType('array<int>', $b);
+
+	array_unshift($c, ...[19, 'baz', false]);
+	assertType('non-empty-array<\'baz\'|int|false>', $c);
+}
+
+function arrayUnshiftConstantArray(): void
+{
+	$a = ['foo' => 17, 'a', 'bar' => 18,];
+	array_unshift($a, ...[19, 'baz', false]);
+	assertType('array{0: 19, 1: \'baz\', 2: false, foo: 17, 3: \'a\', bar: 18}', $a);
+
+	$b = ['foo' => 17, 'a', 'bar' => 18];
+	array_unshift($b, 19, 'baz', false);
+	assertType('array{0: 19, 1: \'baz\', 2: false, foo: 17, 3: \'a\', bar: 18}', $b);
+
+	$c = ['foo' => 17, 'a', 'bar' => 18];
+	array_unshift($c, ...[]);
+	assertType('array{foo: 17, 0: \'a\', bar: 18}', $c);
+
+	$d = [];
+	array_unshift($d, ...[]);
+	assertType('array{}', $d);
+
+	$e = [];
+	array_unshift($e, 19, 'baz', false);
+	assertType('array{19, \'baz\', false}', $e);
+}

--- a/tests/PHPStan/Analyser/data/array-unshift.php
+++ b/tests/PHPStan/Analyser/data/array-unshift.php
@@ -9,8 +9,9 @@ use function PHPStan\Testing\assertType;
  * @param string[] $a
  * @param int[] $b
  * @param non-empty-array<int> $c
+ * @param array<int|string> $d
  */
-function arrayUnshift(array $a, array $b, array $c): void
+function arrayUnshift(array $a, array $b, array $c, array $d): void
 {
 	array_unshift($a, ...$b);
 	assertType('non-empty-array<int|string>', $a);
@@ -20,6 +21,11 @@ function arrayUnshift(array $a, array $b, array $c): void
 
 	array_unshift($c, ...[19, 'baz', false]);
 	assertType('non-empty-array<\'baz\'|int|false>', $c);
+
+	/** @var array<bool|null> $d1 */
+	$d1 = [];
+	array_unshift($d, ...$d1);
+	assertType('non-empty-array<bool|int|string|null>', $d);
 }
 
 function arrayUnshiftConstantArray(): void
@@ -43,4 +49,10 @@ function arrayUnshiftConstantArray(): void
 	$e = [];
 	array_unshift($e, 19, 'baz', false);
 	assertType('array{19, \'baz\', false}', $e);
+
+	$f = [17];
+	/** @var array<bool|null> $f1 */
+	$f1 = [];
+	array_unshift($f, ...$f1);
+	assertType('non-empty-array<int, bool|int|null>', $f);
 }

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -84,7 +84,12 @@ class EmptyRuleTest extends RuleTestCase
 	public function testBug6974(): void
 	{
 		$this->treatPhpDocTypesAsCertain = false;
-		$this->analyse([__DIR__ . '/data/bug-6974.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-6974.php'], [
+			[
+				'Variable $a in empty() always exists and is always falsy.',
+				12,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -81,4 +81,10 @@ class EmptyRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6974(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-6974.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -89,6 +89,10 @@ class EmptyRuleTest extends RuleTestCase
 				'Variable $a in empty() always exists and is always falsy.',
 				12,
 			],
+			[
+				'Variable $a in empty() always exists and is not falsy.',
+				30,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/data/bug-6974.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-6974.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6974;
+
+class A
+{
+	public function test(): void
+	{
+		$a = [];
+		$b = [];
+		array_push($a, ...$b);
+		$c = empty($a) ? 'empty' : 'non-empty';
+	}
+}

--- a/tests/PHPStan/Rules/Variables/data/bug-6974.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-6974.php
@@ -4,9 +4,27 @@ namespace Bug6974;
 
 class A
 {
-	public function test(): void
+	public function test1(): void
 	{
 		$a = [];
+		$b = [];
+		array_push($a, ...$b);
+		$c = empty($a) ? 'empty' : 'non-empty';
+	}
+
+	public function test2(): void
+	{
+		$a = [];
+		/** @var mixed[] $b */
+		$b = [];
+		array_push($a, ...$b);
+		$c = empty($a) ? 'empty' : 'non-empty';
+	}
+
+	public function test3(): void
+	{
+		$a = [];
+		/** @var non-empty-array<mixed> $b */
 		$b = [];
 		array_push($a, ...$b);
 		$c = empty($a) ? 'empty' : 'non-empty';


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6974

While it would previously error with `Variable $a in empty() always exists and is not falsy.`, it errors now with `Variable $a in empty() always exists and is always falsy.`. I think this makes sense, because via empty array variadic parameter basically nothing is pushed onto the empty array, so it stays empty.

The non-empty-array intersections are not needed because `setOffsetValueType` should be doing this internally already.