### PR TITLE
db2_last_insert_id may return NULL

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1675,7 +1675,7 @@ return [
 'db2_free_result' => ['bool', 'stmt'=>'resource'],
 'db2_free_stmt' => ['bool', 'stmt'=>'resource'],
 'db2_get_option' => ['string|false', 'resource'=>'resource', 'option'=>'string'],
-'db2_last_insert_id' => ['string', 'resource'=>'resource'],
+'db2_last_insert_id' => ['string|null', 'resource'=>'resource'],
 'db2_lob_read' => ['string|false', 'stmt'=>'resource', 'colnum'=>'int', 'length'=>'int'],
 'db2_next_result' => ['resource|false', 'stmt'=>'resource'],
 'db2_num_fields' => ['int|false', 'stmt'=>'resource'],


### PR DESCRIPTION
See https://github.com/JetBrains/phpstorm-stubs/pull/1158 and the [source code](https://github.com/php/pecl-database-ibm_db2/blob/19850ece1954bb24f433ea2286f447a7b6c85da0/ibm_db2.c#L7457-L7462):
```c
/* Returning last insert ID (if any), or otherwise NULL */
if (last_id[0] != '\0') {
    ZEND_RETURN_STRING(last_id, 0);
} else {
    RETURN_NULL();
}
```