### PR TITLE
Fix `array_merge` with numeric keys

### DIFF
--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
@@ -64,7 +65,7 @@ class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunctionRet
 					$isOptional = in_array($k, $optionalKeys, true);
 
 					$newArrayBuilder->setOffsetValueType(
-						$keyType,
+						$keyType instanceof ConstantIntegerType ? null : $keyType,
 						$valueTypes[$k],
 						$isOptional,
 					);

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4727,7 +4727,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_values($generalStringKeys)',
 			],
 			[
-				'array{foo: stdClass, 1: stdClass}',
+				'array{foo: stdClass, 0: stdClass}',
 				'array_merge($stringOrIntegerKeys)',
 			],
 			[
@@ -4743,15 +4743,15 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_merge($stringOrIntegerKeys, $generalStringKeys)',
 			],
 			[
-				'array{foo: stdClass, bar: stdClass, 1: stdClass}',
+				'array{foo: stdClass, bar: stdClass, 0: stdClass}',
 				'array_merge($stringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				"array{foo: 'foo', 1: stdClass, bar: stdClass}",
+				"array{foo: 'foo', 0: stdClass, bar: stdClass}",
 				'array_merge($stringOrIntegerKeys, $stringKeys)',
 			],
 			[
-				"array{color: 'green', 0: 'a', 1: 'b', shape: 'trapezoid', 2: 4}",
+				"array{color: 'green', 0: 2, 1: 4, 2: 'a', 3: 'b', shape: 'trapezoid', 4: 4}",
 				'array_merge(array("color" => "red", 2, 4), array("a", "b", "color" => "green", "shape" => "trapezoid", 4))',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -309,6 +309,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-flip.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-map.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-map-closure.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-merge.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-sum.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-plus.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4573.php');

--- a/tests/PHPStan/Analyser/data/array-merge.php
+++ b/tests/PHPStan/Analyser/data/array-merge.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ArrayMerge;
+
+use function array_merge;
+use function PHPStan\Testing\assertType;
+
+function foo(): void
+{
+	$foo = ['foo' => 17, 'a', 'bar' => 18, 'b'];
+	$bar = [99 => 'b', 'bar' => 19, 98 => 'c'];
+	$baz = array_merge($foo, $bar);
+
+	assertType('array{foo: 17, 0: \'a\', bar: 19, 1: \'b\', 2: \'b\', 3: \'c\'}', $baz);
+}


### PR DESCRIPTION
Found by luck. I'm surprised nobody noticed yet since 2018 :O
Currently numeric keys are simply overwritten / set directly without renumbering.

https://www.php.net/manual/en/function.array-merge.php
>  Merges the elements of one or more arrays together so that the values of one are appended to the end of the previous one. It returns the resulting array.

> If the input arrays have the same string keys, then the later value for that key will overwrite the previous one. If, however, the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended.

> Values in the input arrays with numeric keys will be renumbered with incrementing keys starting from zero in the result array. 

https://3v4l.org/fYp4K