### PR TITLE
Allow undefined property fetch of ObjectWithoutClassType in Coalesce

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3909,9 +3909,6 @@ class MutatingScope implements Scope
 	public function setAllowedUndefinedExpression(Expr $expr, bool $isAllowed): self
 	{
 		$exprString = $this->getNodeKey($expr);
-		if (array_key_exists($exprString, $this->currentlyAllowedUndefinedExpressions)) {
-			return $this;
-		}
 		$currentlyAllowedUndefinedExpressions = $this->currentlyAllowedUndefinedExpressions;
 		$currentlyAllowedUndefinedExpressions[$exprString] = $isAllowed;
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -127,7 +127,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\StringType;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2311,16 +2311,7 @@ class NodeScopeResolver
 			);
 		} elseif ($expr instanceof Coalesce) {
 			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->left, false);
-			// backwards compatibility: coalesce doesn't allow dynamic properties
-			if ($expr->left instanceof PropertyFetch || $expr->left instanceof Expr\NullsafePropertyFetch) {
-				$propertyHolderType = $scope->getType($expr->left->var);
-				$condScope = $nonNullabilityResult->getScope()->setAllowedUndefinedExpression($expr->left, $propertyHolderType->isSuperTypeOf(new ObjectWithoutClassType())->yes());
-			} elseif ($expr->left instanceof StaticPropertyFetch) {
-				$condScope = $nonNullabilityResult->getScope()->setAllowedUndefinedExpression($expr->left, false);
-			} else {
-				$condScope = $nonNullabilityResult->getScope();
-			}
-			$condScope = $this->lookForEnterAllowedUndefinedVariable($condScope, $expr->left, true);
+			$condScope = $this->lookForEnterAllowedUndefinedVariable($nonNullabilityResult->getScope(), $expr->left, true);
 			$condResult = $this->processExprNode($expr->left, $condScope, $nodeCallback, $context->enterDeep());
 			$scope = $this->revertNonNullability($condResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 			$scope = $this->lookForExitAllowedUndefinedVariable($scope, $expr->left);

--- a/tests/PHPStan/Levels/data/coalesce-2.json
+++ b/tests/PHPStan/Levels/data/coalesce-2.json
@@ -1,7 +1,0 @@
-[
-    {
-        "message": "Access to an undefined property ReflectionClass::$nonexistent.",
-        "line": 11,
-        "ignorable": true
-    }
-]

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -577,4 +577,34 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6026(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-6026.php'], []);
+	}
+
+	public function testBug3659(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-3659.php'], []);
+	}
+
+	public function testDynamicProperties(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/dynamic-properties.php'], [
+			[
+				'Access to an undefined property DynamicProperties\Foo::$dynamicProperty.',
+				11,
+			],
+			[
+				'Access to an undefined property DynamicProperties\Bar::$dynamicProperty.',
+				16,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -570,4 +570,12 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/dynamic-properties.php'], []);
 	}
 
+
+	public function testBug4559(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-4559.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -130,18 +130,6 @@ class AccessPropertiesRuleTest extends RuleTestCase
 					250,
 				],
 				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					264,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					266,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					270,
-				],
-				[
 					'Cannot access property $bar on TestAccessProperties\NullCoalesce|null.',
 					272,
 				],
@@ -270,18 +258,6 @@ class AccessPropertiesRuleTest extends RuleTestCase
 				[
 					'Access to an undefined property TestAccessProperties\FooAccessProperties::$dolor.',
 					250,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					264,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					266,
-				],
-				[
-					'Access to an undefined property TestAccessProperties\NullCoalesce::$bar.',
-					270,
 				],
 				[
 					'Cannot access property $bar on TestAccessProperties\NullCoalesce|null.',
@@ -591,16 +567,7 @@ class AccessPropertiesRuleTest extends RuleTestCase
 	{
 		$this->checkThisOnly = false;
 		$this->checkUnionTypes = true;
-		$this->analyse([__DIR__ . '/data/dynamic-properties.php'], [
-			[
-				'Access to an undefined property DynamicProperties\Foo::$dynamicProperty.',
-				11,
-			],
-			[
-				'Access to an undefined property DynamicProperties\Bar::$dynamicProperty.',
-				16,
-			],
-		]);
+		$this->analyse([__DIR__ . '/data/dynamic-properties.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -570,10 +570,6 @@ class AccessPropertiesRuleTest extends RuleTestCase
 				'Cannot access property $prop on string.',
 				15,
 			],
-			[
-				'Cannot access property $prop on object|string.', // open issue https://github.com/phpstan/phpstan/issues/3659, https://github.com/phpstan/phpstan/issues/6026
-				25,
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
@@ -207,4 +207,9 @@ class AccessStaticPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5143.php'], []);
 	}
 
+	public function testBug6809(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6809.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-3659.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-3659.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bug3659;
+
+class Foo
+{
+	public function func1(object $obj): void
+	{
+		$this->func2($obj->someProperty ?? null);
+	}
+
+	public function func2(?string $param): void
+	{
+		echo $param ?? 'test';
+	}
+}
+

--- a/tests/PHPStan/Rules/Properties/data/bug-4559.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-4559.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4559;
+
+class HelloWorld
+{
+	public function doBar()
+	{
+		$response = json_decode('');
+		if (isset($response->error->code)) {
+			echo $response->error->message ?? '';
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-6026.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-6026.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bug6026;
+
+class Foo {
+	/**
+	 * @param resource $theResource
+	 * @return bool
+	 */
+	public function Process($theResource) : bool
+	{
+		$bucket = \stream_bucket_make_writeable($theResource);
+		if ( $bucket === null )
+		{
+			return false;
+		}
+		$bucketLen = $bucket->datalen ?? 0;
+		$bucketLen = isset($bucket->datalen) ? $bucket->datalen : 0;
+
+		return true;
+	}
+}
+

--- a/tests/PHPStan/Rules/Properties/data/bug-6809.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-6809.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6809;
+
+trait SomeTrait {
+	public function __construct() {
+		$isClassCool = static::$coolClass ?? true;
+	}
+}
+
+class HelloWorld
+{
+	use SomeTrait;
+}

--- a/tests/PHPStan/Rules/Properties/data/dynamic-properties.php
+++ b/tests/PHPStan/Rules/Properties/data/dynamic-properties.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DynamicProperties;
+
+class Bar {}
+
+class Foo {
+	public function doBar() {
+		isset($this->dynamicProperty);
+		empty($this->dynamicProperty);
+		$this->dynamicProperty ?? 'test'; // dynamic properties are not allowed in coalesce
+
+		$bar = new Bar();
+		isset($bar->dynamicProperty);
+		empty($bar->dynamicProperty);
+		$bar->dynamicProperty ?? 'test';
+	}
+}
+

--- a/tests/PHPStan/Rules/Properties/data/dynamic-properties.php
+++ b/tests/PHPStan/Rules/Properties/data/dynamic-properties.php
@@ -8,7 +8,7 @@ class Foo {
 	public function doBar() {
 		isset($this->dynamicProperty);
 		empty($this->dynamicProperty);
-		$this->dynamicProperty ?? 'test'; // dynamic properties are not allowed in coalesce
+		$this->dynamicProperty ?? 'test';
 
 		$bar = new Bar();
 		isset($bar->dynamicProperty);


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/3659
fixes https://github.com/phpstan/phpstan/issues/6026
fixes https://github.com/phpstan/phpstan/issues/6809
fixes https://github.com/phpstan/phpstan/issues/4559

~~This PR relaxes the condition of `UndefinedExpressionAllowed` for `Coalesce` slightly, to allow undefined property fetch of `ObjectWithoutClassType` in `Coalesce`.~~

~~This can be useful in cases like~~
```php
class HelloWorld
{
    public function test(string $data): void
    {
        $obj = json_decode($data);
        if (!is_object($obj)) {
            return;
        }
        $val = $obj->prop ?? "test";
    }
}
```
~~which currently reports an error https://phpstan.org/r/fbf356da-5a24-43a3-a5a2-1638afa9dd99~~

~~As seen in https://github.com/rajyan/phpstan-src/blob/c6b6aa702554e5ff14591bae130f842ebd51357e/tests/PHPStan/Rules/Properties/data/dynamic-properties.php#L7-L18 the current behavior for dynamic properties in `Coalesce` is kept as is.~~

Changed to fix by making coalesce and isset consistent.