### PR TITLE
Fix `ConstantArrayTypeBuilder` optional keys via `setOffsetValueType`

### DIFF
--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -9,9 +9,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function array_filter;
-use function array_key_exists;
 use function array_map;
-use function array_splice;
 use function array_unique;
 use function array_values;
 use function count;
@@ -85,8 +83,8 @@ class ConstantArrayTypeBuilder
 
 					$this->valueTypes[$i] = TypeCombinator::union($this->valueTypes[$i], $valueType);
 
-					if (!$optional && array_key_exists($i, $this->optionalKeys)) {
-						array_splice($this->optionalKeys, $i, 1);
+					if (!$hasOptional && !$optional) {
+						$this->optionalKeys = array_values(array_filter($this->optionalKeys, static fn (int $index): bool => $index !== $i));
 					}
 
 					/** @var int|float $newAutoIndex */

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -9,7 +9,9 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function array_filter;
+use function array_key_exists;
 use function array_map;
+use function array_splice;
 use function array_unique;
 use function array_values;
 use function count;
@@ -82,6 +84,10 @@ class ConstantArrayTypeBuilder
 					}
 
 					$this->valueTypes[$i] = TypeCombinator::union($this->valueTypes[$i], $valueType);
+
+					if (!$optional && array_key_exists($i, $this->optionalKeys)) {
+						array_splice($this->optionalKeys, $i, 1);
+					}
 
 					/** @var int|float $newAutoIndex */
 					$newAutoIndex = $keyType->getValue() + 1;

--- a/tests/PHPStan/Analyser/data/constant-array-optional-set.php
+++ b/tests/PHPStan/Analyser/data/constant-array-optional-set.php
@@ -108,7 +108,7 @@ class Baz
 		assertType('array{0: \'lorem\', 1: stdClass, 2: 1, 3: 1|2, 4: 1|3, 5?: 2|3, 6?: 3}', $unshiftedConditionalArray + $conditionalArray);
 
 		$conditionalArray[] = 4;
-		assertType('array{0: 1, 1: 1, 2: 1, 3?: 2|4, 4?: 3, 5?: 4}', $conditionalArray);
+		assertType('array{0: 1, 1: 1, 2: 1, 3: 2|4, 4?: 3, 5?: 4}', $conditionalArray);
 	}
 
 }

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Type\Constant;
 
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\VerbosityLevel;
 use PHPUnit\Framework\TestCase;
 
@@ -80,6 +82,20 @@ class ConstantArrayTypeBuilderTest extends TestCase
 		$this->assertInstanceOf(ConstantArrayType::class, $array);
 		$this->assertSame('array{\'foo\', \'bar\'}', $array->describe(VerbosityLevel::precise()));
 		$this->assertSame([2], $array->getNextAutoIndexes());
+	}
+
+	public function testAppendingOptionalKeys(): void
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		$builder->setOffsetValueType(null, new BooleanType(), true);
+		$this->assertSame('array{0?: bool}', $builder->getArray()->describe(VerbosityLevel::precise()));
+
+		$builder->setOffsetValueType(null, new NullType(), true);
+		$this->assertSame('array{0?: bool|null, 1?: null}', $builder->getArray()->describe(VerbosityLevel::precise()));
+
+		$builder->setOffsetValueType(null, new ConstantIntegerType(17));
+		$this->assertSame('array{0: 17|bool|null, 1?: 17|null, 2?: 17}', $builder->getArray()->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -29,7 +29,7 @@ class ConstantArrayTypeBuilderTest extends TestCase
 		$builder->setOffsetValueType(null, new ConstantIntegerType(3));
 		$array3 = $builder->getArray();
 		$this->assertInstanceOf(ConstantArrayType::class, $array3);
-		$this->assertSame('array{0: 1, 1?: 2|3, 2?: 3}', $array3->describe(VerbosityLevel::precise()));
+		$this->assertSame('array{0: 1, 1: 2|3, 2?: 3}', $array3->describe(VerbosityLevel::precise()));
 		$this->assertSame([2, 3], $array3->getNextAutoIndexes());
 
 		$this->assertTrue($array3->isKeysSupersetOf($array2));
@@ -40,19 +40,19 @@ class ConstantArrayTypeBuilderTest extends TestCase
 		$builder->setOffsetValueType(null, new ConstantIntegerType(4));
 		$array4 = $builder->getArray();
 		$this->assertInstanceOf(ConstantArrayType::class, $array4);
-		$this->assertSame('array{0: 1, 1?: 2|3, 2?: 3|4, 3?: 4}', $array4->describe(VerbosityLevel::precise()));
+		$this->assertSame('array{0: 1, 1: 2|3, 2: 3|4, 3?: 4}', $array4->describe(VerbosityLevel::precise()));
 		$this->assertSame([3, 4], $array4->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(3), new ConstantIntegerType(5), true);
 		$array5 = $builder->getArray();
 		$this->assertInstanceOf(ConstantArrayType::class, $array5);
-		$this->assertSame('array{0: 1, 1?: 2|3, 2?: 3|4, 3?: 4|5}', $array5->describe(VerbosityLevel::precise()));
+		$this->assertSame('array{0: 1, 1: 2|3, 2: 3|4, 3?: 4|5}', $array5->describe(VerbosityLevel::precise()));
 		$this->assertSame([3, 4], $array5->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(3), new ConstantIntegerType(6));
 		$array6 = $builder->getArray();
 		$this->assertInstanceOf(ConstantArrayType::class, $array6);
-		$this->assertSame('array{0: 1, 1?: 2|3, 2?: 3|4, 3: 6}', $array6->describe(VerbosityLevel::precise()));
+		$this->assertSame('array{1, 2|3, 3|4, 6}', $array6->describe(VerbosityLevel::precise()));
 		$this->assertSame([4], $array6->getNextAutoIndexes());
 	}
 


### PR DESCRIPTION
Sounds like a bigger general problem, but I figure it is more of an edge case. Found while working on something else. E.g. when building an array from scratch via
```php
$builder = ConstantArrayTypeBuilder::createEmpty();
$builder->setOffsetValueType(null, new BooleanType(), true);
$builder->setOffsetValueType(null, new NullType(), true);
$builder->setOffsetValueType(null, new ConstantIntegerType(17));
$array = $builder->getArray();
``` 

I am expecting the result type to be `array{0: 17|bool|null, 1?: 17|null, 2?: 17}` because the last appended value is not optional any more. But it was still `array{0?: 17|bool|null, 1?: 17|null, 2?: 17}`. This PR fixes this. That exact example is added as test case.