### PR TITLE
Fix `array_push` / `array_unshift` with `ConstantArrayType` arguments

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1858,17 +1858,23 @@ class NodeScopeResolver
 							if ($callArgType->isIterableAtLeastOnce()->no()) {
 								continue;
 							}
-							if (!$callArgType instanceof ConstantArrayType) {
+
+							if ($callArgType instanceof ConstantArrayType) {
+								$iterableValueTypes = $callArgType->getValueTypes();
+							} else {
+								$iterableValueTypes = [$callArgType->getIterableValueType()];
 								$nonConstantArrayWasUnpacked = true;
 							}
-							$iterableValueType = $callArgType->getIterableValueType();
+
 							$isOptional = !$callArgType->isIterableAtLeastOnce()->yes();
-							if ($iterableValueType instanceof UnionType) {
-								foreach ($iterableValueType->getTypes() as $innerType) {
-									$setOffsetValueType(null, $innerType, $isOptional);
+							foreach ($iterableValueTypes as $iterableValueType) {
+								if ($iterableValueType instanceof UnionType) {
+									foreach ($iterableValueType->getTypes() as $innerType) {
+										$setOffsetValueType(null, $innerType, $isOptional);
+									}
+								} else {
+									$setOffsetValueType(null, $iterableValueType, $isOptional);
 								}
-							} else {
-								$setOffsetValueType(null, $iterableValueType, $isOptional);
 							}
 							continue;
 						}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -794,6 +794,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/preg_filter.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5759.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5783.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5668.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/generics-empty-array.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5757.php');

--- a/tests/PHPStan/Analyser/data/array-push.php
+++ b/tests/PHPStan/Analyser/data/array-push.php
@@ -2,6 +2,8 @@
 
 namespace ArrayPush;
 
+use stdClass;
+
 use function array_push;
 use function PHPStan\Testing\assertType;
 
@@ -55,4 +57,8 @@ function arrayPushConstantArray(): void
 	$f1 = [];
 	array_push($f, ...$f1);
 	assertType('non-empty-array<int, bool|int|null>', $f);
+
+	$g = [new stdClass()];
+	array_push($g, ...[new stdClass(), new stdClass()]);
+	assertType('array{stdClass, stdClass, stdClass}', $g);
 }

--- a/tests/PHPStan/Analyser/data/array-unshift.php
+++ b/tests/PHPStan/Analyser/data/array-unshift.php
@@ -2,6 +2,8 @@
 
 namespace ArrayUnshift;
 
+use stdClass;
+
 use function array_unshift;
 use function PHPStan\Testing\assertType;
 
@@ -55,4 +57,8 @@ function arrayUnshiftConstantArray(): void
 	$f1 = [];
 	array_unshift($f, ...$f1);
 	assertType('non-empty-array<int, bool|int|null>', $f);
+
+	$g = [new stdClass()];
+	array_unshift($g, ...[new stdClass(), new stdClass()]);
+	assertType('array{stdClass, stdClass, stdClass}', $g);
 }

--- a/tests/PHPStan/Analyser/data/bug-5783.php
+++ b/tests/PHPStan/Analyser/data/bug-5783.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Bug5783;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld {}
+
+function foo(): void
+{
+	$a = [new HelloWorld()];
+	assertType('array{Bug5783\HelloWorld}', $a);
+	$b = [new HelloWorld(), new HelloWorld(), new HelloWorld()];
+	assertType('array{Bug5783\HelloWorld, Bug5783\HelloWorld, Bug5783\HelloWorld}', $b);
+
+	array_push($a, ...$b);
+	assertType('array{Bug5783\HelloWorld, Bug5783\HelloWorld, Bug5783\HelloWorld, Bug5783\HelloWorld}', $a);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/5783

moar special handling for my friend and nemesis the constant array type.. Problem was that `getIterableValueType` returns the union of all values which will be e.g. `Foo` for `Foo|Foo`.