### PR TITLE
Improve variadic parameter support in `array_merge`

### DIFF
--- a/tests/PHPStan/Analyser/data/array-merge.php
+++ b/tests/PHPStan/Analyser/data/array-merge.php
@@ -13,3 +13,26 @@ function foo(): void
 
 	assertType('array{foo: 17, 0: \'a\', bar: 19, 1: \'b\', 2: \'b\', 3: \'c\'}', $baz);
 }
+
+/**
+ * @param string[][] $foo
+ * @param array<non-empty-array<int>> $bar1
+ * @param non-empty-array<non-empty-array<int>> $bar2
+ * @param non-empty-array<array<int>> $bar3
+ */
+function unpackingArrays(array $foo, array $bar1, array $bar2, array $bar3): void
+{
+	assertType('array<string>', array_merge([], ...$foo));
+	assertType('array<int>', array_merge([], ...$bar1));
+	assertType('non-empty-array<int>', array_merge([], ...$bar2));
+	assertType('array<int>', array_merge([], ...$bar3));
+}
+
+function unpackingConstantArrays(): void
+{
+	assertType('array{}', array_merge([], ...[]));
+	assertType('array{17}', array_merge([], [17]));
+	assertType('array{17}', array_merge([], ...[[17]]));
+	assertType('array{foo: \'bar\', bar: \'baz2\', 0: 17}', array_merge(['foo' => 'bar', 'bar' => 'baz1'], ['bar' => 'baz2', 17]));
+	assertType('array{foo: \'bar\', bar: \'baz2\', 0: 17}', array_merge(['foo' => 'bar', 'bar' => 'baz1'], ...[['bar' => 'baz2', 17]]));
+}


### PR DESCRIPTION
Noticed that there's room to improve because of https://github.com/phpstan/phpstan/issues/7068#issuecomment-1103571118.

Improves 2 things related to variadic parameters
- detection of "all constant arrays"
e.g. `assertType('array{17}', array_merge([], ...[[17]]));` would previously be `non-empty-array<0, 17>`
- detection of nonEmpty arrays
e.g. `assertType('array<int>', array_merge([], ...$bar1));` would previously be `non-empty-array<int>`

Still not happy about the complexity variadic and constant array param handling introduces. Maybe things could get cleaned up a bit in general via some helper utilities for such cases. I could take a look at refactoring this later I guess.