### PR TITLE
Fix `json_decode` error return type

### DIFF
--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -51,16 +51,16 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 		Scope $scope,
 	): Type
 	{
-		$argumentPosition = $this->argumentPositions[$functionReflection->getName()];
+		$functionName = $functionReflection->getName();
+		$argumentPosition = $this->argumentPositions[$functionName];
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		if (!isset($functionCall->getArgs()[$argumentPosition])) {
 			return $defaultReturnType;
 		}
 
 		$optionsExpr = $functionCall->getArgs()[$argumentPosition]->value;
-		$constrictedReturnType = TypeCombinator::remove($defaultReturnType, new ConstantBooleanType(false));
-		if ($this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'JSON_THROW_ON_ERROR')->yes()) {
-			return $constrictedReturnType;
+		if ($functionName === 'json_encode' && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'JSON_THROW_ON_ERROR')->yes()) {
+			return TypeCombinator::remove($defaultReturnType, new ConstantBooleanType(false));
 		}
 
 		return $defaultReturnType;

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -51,15 +51,14 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 		Scope $scope,
 	): Type
 	{
-		$functionName = $functionReflection->getName();
-		$argumentPosition = $this->argumentPositions[$functionName];
+		$argumentPosition = $this->argumentPositions[$functionReflection->getName()];
 		$defaultReturnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		if (!isset($functionCall->getArgs()[$argumentPosition])) {
 			return $defaultReturnType;
 		}
 
 		$optionsExpr = $functionCall->getArgs()[$argumentPosition]->value;
-		if ($functionName === 'json_encode' && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'JSON_THROW_ON_ERROR')->yes()) {
+		if ($functionReflection->getName() === 'json_encode' && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'JSON_THROW_ON_ERROR')->yes()) {
 			return TypeCombinator::remove($defaultReturnType, new ConstantBooleanType(false));
 		}
 

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8727,11 +8727,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'json_decode($mixed)',
 			],
 			[
-				'mixed~false',
+				'mixed',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'mixed~false',
+				'mixed',
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[


### PR DESCRIPTION
Looks like the previous code assumed that both `json_encode` and `json_decode` do **not** return false in case of an error **and** `JSON_THROW_ON_ERROR` is set. But actually, the error return value for `json_decode` is `null`.

https://www.php.net/manual/en/function.json-decode.php
>  Returns the value encoded in json in appropriate PHP type. Values true, false and null are returned as true, false and null respectively. null is returned if the json cannot be decoded or if the encoded data is deeper than the nesting limit. 

Atm this  does not change much, but I'd like to narrow down the return types there even more in 1.6, if possible.

Also: I guess I would have used a private constant, but went with the property for consistency.