### PR TITLE
Fix/issue 3171 dynamic properties

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1577,7 +1577,7 @@ class NodeScopeResolver
 	private function ensureNonNullability(MutatingScope $scope, Expr $expr): EnsuredNonNullabilityResult
 	{
 		$specifiedExpressions = [];
-		$scope = $this->lookForExpressionCallback($scope, $expr, function($scope, $expr) use (&$specifiedExpressions) {
+		$scope = $this->lookForExpressionCallback($scope, $expr, function ($scope, $expr) use (&$specifiedExpressions) {
 			$result = $this->ensureShallowNonNullability($scope, $expr);
 			foreach ($result->getSpecifiedExpressions() as $specifiedExpression) {
 				$specifiedExpressions[] = $specifiedExpression;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1587,7 +1587,9 @@ class NodeScopeResolver
 				$specifiedExpressions[] = $specifiedExpression;
 			}
 
-			if ($exprToSpecify instanceof PropertyFetch) {
+			if ($exprToSpecify instanceof ArrayDimFetch && $exprToSpecify->dim !== null) {
+				$exprToSpecify = $exprToSpecify->var;
+			} elseif ($exprToSpecify instanceof PropertyFetch) {
 				$exprToSpecify = $exprToSpecify->var;
 			} elseif ($exprToSpecify instanceof StaticPropertyFetch && $exprToSpecify->class instanceof Expr) {
 				$exprToSpecify = $exprToSpecify->class;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1576,7 +1576,7 @@ class NodeScopeResolver
 		return new EnsuredNonNullabilityResult($scope, []);
 	}
 
-	private function ensureNonNullability(MutatingScope $scope, Expr $expr, bool $findMethods): EnsuredNonNullabilityResult
+	private function ensureNonNullability(MutatingScope $scope, Expr $expr): EnsuredNonNullabilityResult
 	{
 		$exprToSpecify = $expr;
 		$specifiedExpressions = [];
@@ -2306,7 +2306,7 @@ class NodeScopeResolver
 				static fn (): MutatingScope => $rightResult->getScope()->filterByFalseyValue($expr),
 			);
 		} elseif ($expr instanceof Coalesce) {
-			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->left, false);
+			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->left);
 			$condScope = $this->lookForSetAllowedUndefinedExpressions($nonNullabilityResult->getScope(), $expr->left);
 			$condResult = $this->processExprNode($expr->left, $condScope, $nodeCallback, $context->enterDeep());
 			$scope = $this->revertNonNullability($condResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
@@ -2380,7 +2380,7 @@ class NodeScopeResolver
 				$throwPoints = $result->getThrowPoints();
 			}
 		} elseif ($expr instanceof Expr\Empty_) {
-			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->expr, true);
+			$nonNullabilityResult = $this->ensureNonNullability($scope, $expr->expr);
 			$scope = $this->lookForSetAllowedUndefinedExpressions($nonNullabilityResult->getScope(), $expr->expr);
 			$result = $this->processExprNode($expr->expr, $scope, $nodeCallback, $context->enterDeep());
 			$scope = $result->getScope();
@@ -2393,7 +2393,7 @@ class NodeScopeResolver
 			$throwPoints = [];
 			$nonNullabilityResults = [];
 			foreach ($expr->vars as $var) {
-				$nonNullabilityResult = $this->ensureNonNullability($scope, $var, true);
+				$nonNullabilityResult = $this->ensureNonNullability($scope, $var);
 				$scope = $this->lookForSetAllowedUndefinedExpressions($nonNullabilityResult->getScope(), $var);
 				$result = $this->processExprNode($var, $scope, $nodeCallback, $context->enterDeep());
 				$scope = $result->getScope();

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -510,10 +510,6 @@ class AccessPropertiesRuleTest extends RuleTestCase
 					'Cannot access property $selfOrNull on TestAccessProperties\RevertNonNullabilityForIsset|null.',
 					402,
 				],
-				[
-					'Access to an undefined property stdClass|null::$array.',
-					412,
-				],
 			],
 		);
 	}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -840,4 +840,12 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3171.php'], []);
 	}
 
+	public function testBug3171OnDynamicProperties(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->checkDynamicProperties = true;
+		$this->analyse([__DIR__ . '/data/bug-3171.php'], []);
+	}
+
 }


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/3171 completly

The error was suppressed by https://github.com/phpstan/phpstan-src/pull/1234
but still happening if `checkDynamicProperties` is enabled.
https://phpstan.org/r/7092e4dc-cfed-4fcf-810a-7ad5e3b9555e 

It is because, `ensureNonNullability` was not traversing on `ArrayDimFetch`. https://github.com/phpstan/phpstan-src/commit/d4505361914a181b3595a703a25105b0d876cf5c.
Also, I think the logic for `ensureNonNullability` and `allowedUndefinedExpression` should be consistent with each other, so refactored `ensureNonNullability` by using `lookForExpressionCallback`.

As I mentioned in https://github.com/phpstan/phpstan-src/pull/1234/commits/a624060bffaa182b05cacfe9e67b22169f359f5c
there is one more possible false positive, property fetch on `Class|false` (or something like `false` that doesn't accept fetching properties), but I think it is too complicate to solve now.

When property fetch is called inside isset, the isset truthy scope is more specific than non-null, it can say "the fetched var has a `!hasProperty->no()` type". Similar type specification is possible in `ArrayDimFetch` too. (adding this level of specification can solve issues like https://github.com/phpstan/phpstan/issues/7073, but maybe too much)