### PR TITLE
Prevent "unable to resolve template type T" in conditional branches

### DIFF
--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -2,13 +2,10 @@
 
 namespace PHPStan\Reflection;
 
-use PHPStan\Type\ConditionalType;
-use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeTraverser;
 use function array_key_exists;
 use function array_merge;
 use function count;
@@ -70,32 +67,8 @@ class GenericParametersAcceptorResolver
 			$typeMap->getTypes(),
 		));
 
-		$originalParametersAcceptor = new FunctionVariant(
-			TemplateTypeMap::createEmpty(),
-			TemplateTypeMap::createEmpty(),
-			$parametersAcceptor->getParameters(),
-			$parametersAcceptor->isVariadic(),
-			TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use ($passedArgs): Type {
-				if ($type instanceof ConditionalTypeForParameter || $type instanceof ConditionalType) {
-					$type = $traverse($type);
-
-					if ($type instanceof ConditionalTypeForParameter && array_key_exists($type->getParameterName(), $passedArgs)) {
-						$type = $type->toConditional($passedArgs[$type->getParameterName()]);
-					}
-
-					if ($type instanceof ConditionalType) {
-						return $type->resolve();
-					}
-
-					return $type;
-				}
-
-				return $traverse($type);
-			}),
-		);
-
 		return new ResolvedFunctionVariant(
-			$originalParametersAcceptor,
+			$parametersAcceptor,
 			$resolvedTemplateTypeMap,
 			$passedArgs,
 		);

--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -2,10 +2,14 @@
 
 namespace PHPStan\Reflection;
 
+use PHPStan\Type\ConditionalType;
+use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeTraverser;
 use function array_key_exists;
 use function array_merge;
 use function count;
@@ -62,12 +66,36 @@ class GenericParametersAcceptorResolver
 			$passedArgs['$' . $param->getName()] = $argType;
 		}
 
+		$resolvedTemplateTypeMap = new TemplateTypeMap(array_merge(
+			$parametersAcceptor->getTemplateTypeMap()->map(static fn (string $name, Type $type): Type => new ErrorType())->getTypes(),
+			$typeMap->getTypes(),
+		));
+
 		return new ResolvedFunctionVariant(
-			$parametersAcceptor,
-			new TemplateTypeMap(array_merge(
-				$parametersAcceptor->getTemplateTypeMap()->map(static fn (string $name, Type $type): Type => new ErrorType())->getTypes(),
-				$typeMap->getTypes(),
-			)),
+			new FunctionVariant(
+				TemplateTypeMap::createEmpty(),
+				TemplateTypeMap::createEmpty(),
+				$parametersAcceptor->getParameters(),
+				$parametersAcceptor->isVariadic(),
+				TypeTraverser::map($parametersAcceptor->getReturnType(), static function (Type $type, callable $traverse) use ($passedArgs): Type {
+					if ($type instanceof ConditionalTypeForParameter || $type instanceof ConditionalType) {
+						$type = $traverse($type);
+
+						if ($type instanceof ConditionalTypeForParameter && array_key_exists($type->getParameterName(), $passedArgs)) {
+							$type = $type->toConditional($passedArgs[$type->getParameterName()]);
+						}
+
+						if ($type instanceof ConditionalType) {
+							return $type->resolve();
+						}
+
+						return $type;
+					}
+
+					return $traverse($type);
+				}),
+			),
+			$resolvedTemplateTypeMap,
 			$passedArgs,
 		);
 	}

--- a/src/Reflection/ResolvedFunctionVariant.php
+++ b/src/Reflection/ResolvedFunctionVariant.php
@@ -73,10 +73,9 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 		$type = $this->returnType;
 
 		if ($type === null) {
-			$type = TypeUtils::resolveTypes(
+			$type = TemplateTypeHelper::resolveTemplateTypes(
 				$this->parametersAcceptor->getReturnType(),
 				$this->resolvedTemplateTypeMap,
-				$this->passedArgs,
 			);
 
 			$this->returnType = $type;

--- a/src/Reflection/ResolvedFunctionVariant.php
+++ b/src/Reflection/ResolvedFunctionVariant.php
@@ -146,13 +146,13 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 	private function resolveConditionalTypes(Type $type): Type
 	{
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
-			if ($type instanceof ConditionalType) {
-				$type = $traverse($type);
+			$type = $traverse($type);
 
-				return $type->resolve();
+			if ($type instanceof ConditionalType) {
+				$type = $type->resolve();
 			}
 
-			return $traverse($type);
+			return $type;
 		});
 	}
 

--- a/src/Reflection/ResolvedFunctionVariant.php
+++ b/src/Reflection/ResolvedFunctionVariant.php
@@ -3,10 +3,16 @@
 namespace PHPStan\Reflection;
 
 use PHPStan\Reflection\Php\DummyParameter;
+use PHPStan\Type\ConditionalType;
+use PHPStan\Type\ConditionalTypeForParameter;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeUtils;
+use function array_key_exists;
 use function array_map;
 
 class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcceptor
@@ -14,6 +20,8 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 
 	/** @var ParameterReflection[]|null */
 	private ?array $parameters = null;
+
+	private ?Type $returnTypeWithUnresolvableTemplateTypes = null;
 
 	private ?Type $returnType = null;
 
@@ -68,15 +76,25 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 		return $this->parametersAcceptor->isVariadic();
 	}
 
+	public function getReturnTypeWithUnresolvableTemplateTypes(): Type
+	{
+		return $this->returnTypeWithUnresolvableTemplateTypes ??=
+			$this->resolveConditionalTypesForParameter(
+				$this->resolveResolvableTemplateTypes($this->parametersAcceptor->getReturnType()),
+			);
+	}
+
 	public function getReturnType(): Type
 	{
 		$type = $this->returnType;
 
 		if ($type === null) {
 			$type = TemplateTypeHelper::resolveTemplateTypes(
-				$this->parametersAcceptor->getReturnType(),
+				$this->getReturnTypeWithUnresolvableTemplateTypes(),
 				$this->resolvedTemplateTypeMap,
 			);
+
+			$type = $this->resolveConditionalTypes($type);
 
 			$this->returnType = $type;
 		}
@@ -98,6 +116,44 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 		$result->returnType = TypeUtils::flattenConditionals($this->getReturnType());
 
 		return $result;
+	}
+
+	private function resolveResolvableTemplateTypes(Type $type): Type
+	{
+		return TypeTraverser::map($type, function (Type $type, callable $traverse): Type {
+			if ($type instanceof TemplateType && !$type->isArgument()) {
+				$newType = $this->resolvedTemplateTypeMap->getType($type->getName());
+				if ($newType !== null && !$newType instanceof ErrorType) {
+					return $newType;
+				}
+			}
+
+			return $traverse($type);
+		});
+	}
+
+	private function resolveConditionalTypesForParameter(Type $type): Type
+	{
+		return TypeTraverser::map($type, function (Type $type, callable $traverse): Type {
+			if ($type instanceof ConditionalTypeForParameter && array_key_exists($type->getParameterName(), $this->passedArgs)) {
+				$type = $type->toConditional($this->passedArgs[$type->getParameterName()]);
+			}
+
+			return $traverse($type);
+		});
+	}
+
+	private function resolveConditionalTypes(Type $type): Type
+	{
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+			if ($type instanceof ConditionalType) {
+				$type = $traverse($type);
+
+				return $type->resolve();
+			}
+
+			return $traverse($type);
+		});
 	}
 
 }

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -7,9 +7,6 @@ use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\Generic\TemplateType;
-use PHPStan\Type\Generic\TemplateTypeMap;
-use function array_key_exists;
 use function array_merge;
 
 /** @api */
@@ -345,45 +342,6 @@ class TypeUtils
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse) {
 			while ($type instanceof ConditionalType || $type instanceof ConditionalTypeForParameter) {
 				$type = $type->getResult();
-			}
-
-			return $traverse($type);
-		});
-	}
-
-	/**
-	 * Replaces template types with standin types, and conditional types with their resolved types
-	 *
-	 * @param array<string, Type> $passedArgs
-	 */
-	public static function resolveTypes(Type $type, TemplateTypeMap $standins, array $passedArgs, bool $keepErrorTypes = false): Type
-	{
-		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($standins, $passedArgs, $keepErrorTypes): Type {
-			if ($type instanceof TemplateType && !$type->isArgument()) {
-				$newType = $standins->getType($type->getName());
-				if ($newType === null) {
-					return $traverse($type);
-				}
-
-				if ($newType instanceof ErrorType && !$keepErrorTypes) {
-					return $traverse($type->getBound());
-				}
-
-				return $newType;
-			}
-
-			if ($type instanceof ConditionalTypeForParameter || $type instanceof ConditionalType) {
-				$type = $traverse($type);
-
-				if ($type instanceof ConditionalTypeForParameter && array_key_exists($type->getParameterName(), $passedArgs)) {
-					$type = $type->toConditional($passedArgs[$type->getParameterName()]);
-				}
-
-				if ($type instanceof ConditionalType) {
-					return $type->resolve();
-				}
-
-				return $type;
 			}
 
 			return $traverse($type);

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -532,6 +532,11 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 				'Parameter #1 $params of static method TemplateTypeInOneBranchOfConditional\DriverManager::getConnection() expects array{wrapperClass?: class-string<TemplateTypeInOneBranchOfConditional\Connection>}, array{wrapperClass: \'stdClass\'} given.',
 				27,
 			],
+			[
+				'Unable to resolve the template type T in call to method static method TemplateTypeInOneBranchOfConditional\DriverManager::getConnection()',
+				27,
+				'See: https://phpstan.org/blog/solving-phpstan-error-unable-to-resolve-template-type',
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -523,4 +523,16 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testTemplateTypeInOneBranchOfConditional(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/template-type-in-one-branch-of-conditional.php'], [
+			[
+				'Parameter #1 $params of static method TemplateTypeInOneBranchOfConditional\DriverManager::getConnection() expects array{wrapperClass?: class-string<TemplateTypeInOneBranchOfConditional\Connection>}, array{wrapperClass: \'stdClass\'} given.',
+				27,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/template-type-in-one-branch-of-conditional.php
+++ b/tests/PHPStan/Rules/Methods/data/template-type-in-one-branch-of-conditional.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace TemplateTypeInOneBranchOfConditional;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+class Connection {}
+
+class ChildConnection extends Connection {}
+
+class DriverManager
+{
+	/**
+	 * @param array{wrapperClass?: class-string<T>} $params
+	 * @phpstan-return ($params is array{wrapperClass:mixed} ? T : Connection)
+	 * @template T of Connection
+	 */
+	public static function getConnection(array $params): Connection {
+		return new Connection();
+	}
+
+	public static function test(): void
+	{
+		assertType(Connection::class, DriverManager::getConnection([]));
+		assertType(ChildConnection::class, DriverManager::getConnection(['wrapperClass' => ChildConnection::class]));
+		assertType(Connection::class, DriverManager::getConnection(['wrapperClass' => stdClass::class]));
+	}
+}


### PR DESCRIPTION
Part of phpstan/phpstan#3853

This prevents the error for template types that are not part of both conditional branches.

It isn't perfect, but I couldn't figure out how to decide which branch would be taken. There is still the error regarding the incorrect passed type in many cases (as shown in the added test case), so it might not be a big deal.