### PR TITLE
Delay resolving conditional types

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -90,6 +90,7 @@ use PHPStan\Type\GenericTypeVariableResolver;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\LateResolvableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NonexistentParentClassType;
@@ -574,7 +575,7 @@ class MutatingScope implements Scope
 		$key = $this->getNodeKey($node);
 
 		if (!array_key_exists($key, $this->resolvedTypes)) {
-			$this->resolvedTypes[$key] = $this->resolveType($node);
+			$this->resolvedTypes[$key] = $this->resolveLateResolvableTypes($this->resolveType($node));
 		}
 		return $this->resolvedTypes[$key];
 	}
@@ -6008,6 +6009,19 @@ class MutatingScope implements Scope
 		}
 
 		return IntegerRangeType::fromInterval($min, $max);
+	}
+
+	private function resolveLateResolvableTypes(Type $type): Type
+	{
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+			$type = $traverse($type);
+
+			if ($type instanceof LateResolvableType) {
+				$type = $type->resolve();
+			}
+
+			return $type;
+		});
 	}
 
 }

--- a/src/Reflection/ResolvedFunctionVariant.php
+++ b/src/Reflection/ResolvedFunctionVariant.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Reflection;
 
 use PHPStan\Reflection\Php\DummyParameter;
-use PHPStan\Type\ConditionalType;
 use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateType;
@@ -94,8 +93,6 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 				$this->resolvedTemplateTypeMap,
 			);
 
-			$type = $this->resolveConditionalTypes($type);
-
 			$this->returnType = $type;
 		}
 
@@ -140,19 +137,6 @@ class ResolvedFunctionVariant implements ParametersAcceptor, SingleParametersAcc
 			}
 
 			return $traverse($type);
-		});
-	}
-
-	private function resolveConditionalTypes(Type $type): Type
-	{
-		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
-			$type = $traverse($type);
-
-			if ($type instanceof ConditionalType) {
-				$type = $type->resolve();
-			}
-
-			return $type;
 		});
 	}
 

--- a/src/Type/LateResolvableType.php
+++ b/src/Type/LateResolvableType.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+/** @api */
+interface LateResolvableType
+{
+
+	public function resolve(): Type;
+
+}

--- a/tests/PHPStan/Analyser/data/conditional-types.php
+++ b/tests/PHPStan/Analyser/data/conditional-types.php
@@ -112,9 +112,9 @@ abstract class Test
 	 */
 	public function testDeterministicParameter($foo, $bar, $baz): void
 	{
-		assertType('(true is true ? string : bool)', $foo);
-		assertType('(5 is int<4, 6> ? string : bool)', $bar);
-		assertType('(5 is not int<0, 4> ? (4 is bool ? float : string) : bool)', $baz);
+		assertType('string', $foo);
+		assertType('string', $bar);
+		assertType('string', $baz);
 	}
 
 	/**
@@ -125,7 +125,7 @@ abstract class Test
 	public function testConditionalInParameter(int $foo, int $bar): void
 	{
 		assertType('TInt of int (method ConditionalTypes\Test::testConditionalInParameter(), argument)', $foo);
-		assertType('(TInt of int (method ConditionalTypes\Test::testConditionalInParameter(), argument) is 5 ? int<0, 10> : int<10, 100>)', $bar);
+		assertType('int<0, 100>', $bar);
 	}
 
 	/**


### PR DESCRIPTION
This is in preparation for phpstan/phpstan#7094 - index access types are very much like conditional types in that they can only be truly resolved when all template parameters are resolved. For conditional types this was fairly easy because we only really care about return types, but index access types could be used more widely.

This also opens up using conditional types everywhere else, though they make little sense.

Just wanted to get some thoughs on this :)