### PR TITLE
Generate only 1, not 2 newlines at the end of baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -419,3 +419,4 @@ parameters:
 			"""
 			count: 1
 			path: tests/PHPStan/Rules/Arrays/AppendedArrayKeyTypeRuleTest.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -419,4 +419,3 @@ parameters:
 			"""
 			count: 1
 			path: tests/PHPStan/Rules/Arrays/AppendedArrayKeyTypeRuleTest.php
-

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -11,6 +11,7 @@ use PHPStan\Command\ErrorFormatter\TableErrorFormatter;
 use PHPStan\Command\Symfony\SymfonyOutput;
 use PHPStan\Command\Symfony\SymfonyStyle;
 use PHPStan\File\CouldNotWriteFileException;
+use PHPStan\File\FileReader;
 use PHPStan\File\FileWriter;
 use PHPStan\File\ParentDirectoryRelativePathHelper;
 use PHPStan\File\PathNotFoundException;
@@ -32,6 +33,7 @@ use function implode;
 use function is_array;
 use function is_bool;
 use function is_dir;
+use function is_file;
 use function is_string;
 use function mkdir;
 use function pathinfo;
@@ -279,10 +281,12 @@ class AnalyseCommand extends Command
 			$baselineFileDirectory = dirname($generateBaselineFile);
 			$baselineErrorFormatter = new BaselineNeonErrorFormatter(new ParentDirectoryRelativePathHelper($baselineFileDirectory));
 
+			$existingBaselineContent = is_file($generateBaselineFile) ? FileReader::read($generateBaselineFile) : '';
+
 			$streamOutput = $this->createStreamOutput();
 			$errorConsoleStyle = new ErrorsConsoleStyle(new StringInput(''), $streamOutput);
 			$baselineOutput = new SymfonyOutput($streamOutput, new SymfonyStyle($errorConsoleStyle));
-			$baselineErrorFormatter->formatErrors($analysisResult, $baselineOutput);
+			$baselineErrorFormatter->formatErrors($analysisResult, $baselineOutput, $existingBaselineContent);
 
 			$stream = $streamOutput->getStream();
 			rewind($stream);

--- a/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
@@ -9,6 +9,7 @@ use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
 use function ksort;
 use function preg_quote;
+use function substr;
 use const SORT_STRING;
 
 class BaselineNeonErrorFormatter
@@ -24,11 +25,7 @@ class BaselineNeonErrorFormatter
 	): int
 	{
 		if (!$analysisResult->hasErrors()) {
-			$output->writeRaw(Neon::encode([
-				'parameters' => [
-					'ignoreErrors' => [],
-				],
-			], Neon::BLOCK));
+			$output->writeRaw($this->getNeon([]));
 			return 0;
 		}
 
@@ -63,13 +60,21 @@ class BaselineNeonErrorFormatter
 			}
 		}
 
-		$output->writeRaw(Neon::encode([
-			'parameters' => [
-				'ignoreErrors' => $errorsToOutput,
-			],
-		], Neon::BLOCK));
+		$output->writeRaw($this->getNeon($errorsToOutput));
 
 		return 1;
+	}
+
+	/**
+	 * @param array<int, array{message: string, count: int, path: string}> $ignoreErrors
+	 */
+	private function getNeon(array $ignoreErrors): string
+	{
+		return Neon::encode([
+			'parameters' => [
+				'ignoreErrors' => $ignoreErrors,
+			],
+		], Neon::BLOCK);
 	}
 
 }

--- a/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/BaselineNeonErrorFormatter.php
@@ -7,6 +7,7 @@ use Nette\Neon\Neon;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
+use PHPStan\ShouldNotHappenException;
 use function ksort;
 use function preg_quote;
 use function substr;
@@ -70,11 +71,17 @@ class BaselineNeonErrorFormatter
 	 */
 	private function getNeon(array $ignoreErrors): string
 	{
-		return Neon::encode([
+		$neon = Neon::encode([
 			'parameters' => [
 				'ignoreErrors' => $ignoreErrors,
 			],
 		], Neon::BLOCK);
+
+		if (substr($neon, -2) !== "\n\n") {
+			throw new ShouldNotHappenException();
+		}
+
+		return substr($neon, 0, -1);
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -363,6 +363,24 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			'existingBaselineContent' => '',
 			'expectedNewlinesCount' => 1,
 		];
+
+		yield 'empty existing baseline, no new errors' => [
+			'errors' => [],
+			'existingBaselineContent' => '',
+			'expectedNewlinesCount' => 1,
+		];
+
+		yield 'empty existing baseline with a newline, no new errors' => [
+			'errors' => [],
+			'existingBaselineContent' => "\n",
+			'expectedNewlinesCount' => 1,
+		];
+
+		yield 'empty existing baseline with 2 newlines, no new errors' => [
+			'errors' => [],
+			'existingBaselineContent' => "\n\n",
+			'expectedNewlinesCount' => 2,
+		];
 	}
 
 	/**

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -350,8 +350,8 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			throw new ShouldNotHappenException();
 		}
 
-		Assert::assertSame("\n\n", substr($content, -2));
-		Assert::assertNotSame("\n", substr($content, -3, 1));
+		Assert::assertSame("\n", substr($content, -1));
+		Assert::assertNotSame("\n", substr($content, -2, 1));
 	}
 
 }


### PR DESCRIPTION
We have noticed, that baseline has two newlines at the end of file, which is weird because the convention for most text based files is to have one. I believe PHPStan follows it as well, even for neon, e.g.: https://github.com/phpstan/phpstan-src/blob/831469c9c406f18e537dd8c46b8b9b28a3897450/build/phpstan.neon .

But baseline is generated using `Neon::encode()` and this puts two newlines at the end of file. From my research I believe this is due to the fact that the encoding puts empty lines between array items and there is no exception for the last one.

I do not believe that changing this in `Neon` is desirable - too big of a change for too little gain. Plus if it were to be omitted only after the last item, it could lead to uneven results with concatenating multiple separately encoded neons etc. On the other hand in PHPStan we already know the structure of the whole file, so we can solve it here easily.

I included measures not to change the baseline file if this would be the only change in order to prevent bugging people with it. It will disappear with the next "real" change.