### PR TITLE
Allow multiple dynamic function return type extensions for one function

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2399,6 +2399,7 @@ class MutatingScope implements Scope
 				return new ErrorType();
 			}
 
+			$resolvedTypes = [];
 			$functionReflection = $this->reflectionProvider->getFunction($node->name, $this);
 			foreach ($this->dynamicReturnTypeExtensionRegistry->getDynamicFunctionReturnTypeExtensions() as $dynamicFunctionReturnTypeExtension) {
 				if (!$dynamicFunctionReturnTypeExtension->isFunctionSupported($functionReflection)) {
@@ -2410,9 +2411,15 @@ class MutatingScope implements Scope
 					$node,
 					$this,
 				);
-				if ($resolvedType !== null) {
-					return $resolvedType;
+				if ($resolvedType === null) {
+					continue;
 				}
+
+				$resolvedTypes[] = $resolvedType;
+			}
+
+			if (count($resolvedTypes) > 0) {
+				return TypeCombinator::union(...$resolvedTypes);
 			}
 
 			return ParametersAcceptorSelector::selectFromArgs(


### PR DESCRIPTION
If I'm trying to create new dynamicFunctionReturnTypeExtension for function which already has some extension (e.g. json_decode / json_encode), my extension is never executed because core JsonThrowOnErrorDynamicReturnTypeExtension resolves some type and it is returned.
I believe that all resolved types should be combined. What do you think?