### PR TITLE
Remove unneeded continue in `array_push` / `array_unset` arg handling

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1841,10 +1841,6 @@ class NodeScopeResolver
 					foreach ($callArgs as $callArg) {
 						$callArgType = $scope->getType($callArg->value);
 						if ($callArg->unpack) {
-							if ($callArgType->isIterableAtLeastOnce()->no()) {
-								continue;
-							}
-
 							if ($callArgType instanceof ConstantArrayType) {
 								$iterableValueTypes = $callArgType->getValueTypes();
 							} else {


### PR DESCRIPTION
The code here is already complex enough..

Was introduced in https://github.com/phpstan/phpstan-src/pull/1210, I'm not a 100% sure why it is not needed anymore, but I guess because of the optional constant array adaptions I did later there and in the builder, most likely combined with what was fixed in the constant array super-type-checks today.
I had a weird feeling when I added it, so this confirms that ;)