### PR TITLE
Test/null safe edge cases

### DIFF
--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -213,7 +213,7 @@ class IssetCheck
 				return null;
 			}
 
-			return RuleErrorBuilder::message(sprintf('Using nullsafe property access %s is unnecessary. Use -> instead.', $operatorDescription))->build();
+			return RuleErrorBuilder::message(sprintf('Using nullsafe property access "?->%s" %s is unnecessary. Use -> instead.', $expr->name->name ?? '(Expression)',  $operatorDescription))->build();
 		}
 
 		return null;

--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -213,7 +213,7 @@ class IssetCheck
 				return null;
 			}
 
-			return RuleErrorBuilder::message(sprintf('Using nullsafe property access "?->%s" %s is unnecessary. Use -> instead.', $expr->name->name ?? '(Expression)',  $operatorDescription))->build();
+			return RuleErrorBuilder::message(sprintf('Using nullsafe property access "?->%s" %s is unnecessary. Use -> instead.', $expr->name->name ?? '(Expression)', $operatorDescription))->build();
 		}
 
 		return null;

--- a/tests/PHPStan/Rules/Properties/data/bug-7109.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7109.php
@@ -59,10 +59,10 @@ class HelloWorld
 		empty($this->getNotNull()?->notFalsy) ?: 6;
 	}
 
-
 	public ?HelloWorld $prop = null;
 	public function edgeCaseWithMethodCall(): void
 	{
+		// only ?->aaa should be reported
 		$this->get()?->prop?->get()?->aaa ?? 'edge';
 		isset($this->get()?->prop?->get()?->aaa) ?: 'edge';
 		empty($this->get()?->prop?->get()?->aaa) ?: 'edge';

--- a/tests/PHPStan/Rules/Properties/data/bug-7109.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7109.php
@@ -58,4 +58,20 @@ class HelloWorld
 	{
 		empty($this->getNotNull()?->notFalsy) ?: 6;
 	}
+
+
+	public ?HelloWorld $prop = null;
+	public function edgeCaseWithMethodCall(): void
+	{
+		$this->get()?->prop?->get()?->aaa ?? 'edge';
+		isset($this->get()?->prop?->get()?->aaa) ?: 'edge';
+		empty($this->get()?->prop?->get()?->aaa) ?: 'edge';
+	}
+
+	public function fetchByExpr(): void
+	{
+		$this?->{'aaa'} ?? 'edge';
+		isset($this?->{'aaa'}) ?: 'edge';
+		empty($this?->{'aaa'}) ?: 'edge';
+	}
 }

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -150,6 +150,14 @@ class EmptyRuleTest extends RuleTestCase
 				'Expression in empty() is not falsy.',
 				59,
 			],
+			[
+				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
+				68,
+			],
+			[
+				'Using nullsafe property access "?->(Expression)" in empty() is unnecessary. Use -> instead.',
+				75,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -131,19 +131,19 @@ class EmptyRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
-				'Using nullsafe property access in empty() is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
 				19,
 			],
 			[
-				'Using nullsafe property access in empty() is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
 				30,
 			],
 			[
-				'Using nullsafe property access in empty() is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" in empty() is unnecessary. Use -> instead.',
 				42,
 			],
 			[
-				'Using nullsafe property access in empty() is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->notFalsy" in empty() is unnecessary. Use -> instead.',
 				54,
 			],
 			[

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -369,11 +369,11 @@ class IssetRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
-				'Using nullsafe property access in isset() is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.',
 				18,
 			],
 			[
-				'Using nullsafe property access in isset() is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.',
 				29,
 			],
 			[

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -380,6 +380,14 @@ class IssetRuleTest extends RuleTestCase
 				'Expression in isset() is not nullable.',
 				41,
 			],
+			[
+				'Using nullsafe property access "?->aaa" in isset() is unnecessary. Use -> instead.',
+				67,
+			],
+			[
+				'Using nullsafe property access "?->(Expression)" in isset() is unnecessary. Use -> instead.',
+				74,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -323,6 +323,14 @@ class NullCoalesceRuleTest extends RuleTestCase
 				'Expression on left side of ?? is not nullable.',
 				40,
 			],
+			[
+				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
+				66,
+			],
+			[
+				'Using nullsafe property access "?->(Expression)" on left side of ?? is unnecessary. Use -> instead.',
+				73,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -312,11 +312,11 @@ class NullCoalesceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
-				'Using nullsafe property access on left side of ?? is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
 				17,
 			],
 			[
-				'Using nullsafe property access on left side of ?? is unnecessary. Use -> instead.',
+				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
 				28,
 			],
 			[


### PR DESCRIPTION
Small improvement in error message, and added some edge cases.

```php
$this->get()?->prop?->get()?->aaa ?? 'edge';
```
Only expression after the method call should be reported (which is working perfect now :+1:)

Proof that the edge case works without null safe
https://3v4l.org/F6RiA