### PR TITLE
Don't normalize unresolved generic class strings with string

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -10,6 +10,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateBenevolentUnionType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
@@ -384,6 +385,18 @@ class TypeCombinator
 			if ($isSuperType->yes()) {
 				$b = self::intersectWithSubtractedType($b, $a);
 				return [null, $b];
+			}
+		}
+
+		if ($a instanceof GenericClassStringType && $a->getGenericType() instanceof TemplateType) {
+			if ($b instanceof StringType && !$b instanceof GenericClassStringType) {
+				return null;
+			}
+		}
+
+		if ($b instanceof GenericClassStringType && $b->getGenericType() instanceof TemplateType) {
+			if ($a instanceof StringType && !$a instanceof GenericClassStringType) {
+				return null;
 			}
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -903,6 +903,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7115.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/constant-array-type-identical.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-str-containing-fns.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7141.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7141.php
+++ b/tests/PHPStan/Analyser/data/bug-7141.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bug7141;
+
+use function PHPStan\Testing\assertType;
+
+interface Container
+{
+	/**
+	 * @template T
+	 * @param string|class-string<T> $id
+	 * @return ($id is class-string ? T : mixed)
+	 */
+	public function get(string $id): mixed;
+}
+
+
+function (Container $c) {
+	assertType('mixed', $c->get('test'));
+	assertType('stdClass', $c->get(\stdClass::class));
+};


### PR DESCRIPTION
Bad solution to phpstan/phpstan#7141. I think it's pretty clear that this isn't a road to continue on - this can only get worse when more exceptions pop up.

Keeping conditional types and offset access types in mind, I'm starting to think it might be useful to extract normalizing from `TypeCombinator::union()`, instead only normalizing when consuming the type (e.g. in `Scope::getType()` or error messages). This would also allow resolving conditional types at that moment.

@ondrejmirtes I'd love to hear your thoughts. It's probably a ton of work, but I'd be excited to try.