### PR TITLE
Support string accessory types in BitwiseNot

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -62,7 +62,6 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
-use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
@@ -695,6 +694,8 @@ class MutatingScope implements Scope
 					if ($type->isNonEmptyString()->yes()) {
 						$accessories[] = new AccessoryNonEmptyStringType();
 					}
+					// it is not useful to apply numeric and literal strings here.
+					// numeric string isn't certainly kept numeric: 3v4l.org/JERDB
 
 					return TypeCombinator::intersect(...$accessories);
 				}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -695,12 +695,6 @@ class MutatingScope implements Scope
 					if ($type->isNonEmptyString()->yes()) {
 						$accessories[] = new AccessoryNonEmptyStringType();
 					}
-					if ($type->isLiteralString()->yes()) {
-						$accessories[] = new AccessoryLiteralStringType();
-					}
-					if ($type->isNumericString()->yes()) {
-						$accessories[] = new AccessoryNumericStringType();
-					}
 
 					return TypeCombinator::intersect(...$accessories);
 				}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -62,6 +62,7 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
@@ -687,8 +688,21 @@ class MutatingScope implements Scope
 				if ($type instanceof ConstantStringType) {
 					return new ConstantStringType(~$type->getValue());
 				}
-				if ($type instanceof StringType) {
-					return new StringType();
+				if ($type->isString()->yes()) {
+					$accessories = [
+						new StringType(),
+					];
+					if ($type->isNonEmptyString()->yes()) {
+						$accessories[] = new AccessoryNonEmptyStringType();
+					}
+					if ($type->isLiteralString()->yes()) {
+						$accessories[] = new AccessoryLiteralStringType();
+					}
+					if ($type->isNumericString()->yes()) {
+						$accessories[] = new AccessoryNumericStringType();
+					}
+
+					return TypeCombinator::intersect(...$accessories);
 				}
 				if ($type instanceof IntegerType || $type instanceof FloatType) {
 					return new IntegerType(); //no const types here, result depends on PHP_INT_SIZE

--- a/tests/PHPStan/Analyser/data/bitwise-not.php
+++ b/tests/PHPStan/Analyser/data/bitwise-not.php
@@ -6,15 +6,11 @@ use function PHPStan\Testing\assertType;
 
 /**
  * @param string|int $stringOrInt
- * @param numeric-string $numericString
- * @param literal-string $literalString
  * @param non-empty-string $nonEmptyString
  */
 function foo(int $int, string $string, float $float, $stringOrInt, $numericString, $literalString, string $nonEmptyString) : void{
 	assertType('int', ~$int);
 	assertType('string', ~$string);
-	assertType('non-empty-string&numeric-string', ~$numericString);
-	assertType('literal-string', ~$literalString);
 	assertType('non-empty-string', ~$nonEmptyString);
 	assertType('int', ~$float);
 	assertType('int|string', ~$stringOrInt);

--- a/tests/PHPStan/Analyser/data/bitwise-not.php
+++ b/tests/PHPStan/Analyser/data/bitwise-not.php
@@ -6,10 +6,16 @@ use function PHPStan\Testing\assertType;
 
 /**
  * @param string|int $stringOrInt
+ * @param numeric-string $numericString
+ * @param literal-string $literalString
+ * @param non-empty-string $nonEmptyString
  */
-function foo(int $int, string $string, float $float, $stringOrInt) : void{
+function foo(int $int, string $string, float $float, $stringOrInt, $numericString, $literalString, string $nonEmptyString) : void{
 	assertType('int', ~$int);
 	assertType('string', ~$string);
+	assertType('non-empty-string&numeric-string', ~$numericString);
+	assertType('literal-string', ~$literalString);
+	assertType('non-empty-string', ~$nonEmptyString);
 	assertType('int', ~$float);
 	assertType('int|string', ~$stringOrInt);
 	assertType("'" . (~"abc") . "'", ~"abc");

--- a/tests/PHPStan/Analyser/data/bitwise-not.php
+++ b/tests/PHPStan/Analyser/data/bitwise-not.php
@@ -8,7 +8,7 @@ use function PHPStan\Testing\assertType;
  * @param string|int $stringOrInt
  * @param non-empty-string $nonEmptyString
  */
-function foo(int $int, string $string, float $float, $stringOrInt, $numericString, $literalString, string $nonEmptyString) : void{
+function foo(int $int, string $string, float $float, $stringOrInt, string $nonEmptyString) : void{
 	assertType('int', ~$int);
 	assertType('string', ~$string);
 	assertType('non-empty-string', ~$nonEmptyString);


### PR DESCRIPTION
On my way to kill `instanceof StringType` cases