### PR TITLE
refactor `$conditionalExpressions`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4494,7 +4494,7 @@ class MutatingScope implements Scope
 					}
 
 					if (!$typeGuards[$conditionExprString]->equals($conditionalType)) {
-						continue 2;
+						continue;
 					}
 
 					$matchingConditions[$conditionExprString] = $conditionalType;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3490,11 +3490,12 @@ class NodeScopeResolver
 				$conditionalExpressions[$exprString] = [];
 			}
 
-			$conditionalExpressions[$exprString][] = new ConditionalExpressionHolder([
+			$holder = new ConditionalExpressionHolder([
 				'$' . $variableName => $variableType,
 			], VariableTypeHolder::createYes(
 				TypeCombinator::intersect($scope->getType($expr), $exprType),
 			));
+			$conditionalExpressions[$exprString][$holder->getKey()] = $holder;
 		}
 
 		return $conditionalExpressions;
@@ -3518,11 +3519,12 @@ class NodeScopeResolver
 				$conditionalExpressions[$exprString] = [];
 			}
 
-			$conditionalExpressions[$exprString][] = new ConditionalExpressionHolder([
+			$holder = new ConditionalExpressionHolder([
 				'$' . $variableName => $variableType,
 			], VariableTypeHolder::createYes(
 				TypeCombinator::remove($scope->getType($expr), $exprType),
 			));
+			$conditionalExpressions[$exprString][$holder->getKey()] = $holder;
 		}
 
 		return $conditionalExpressions;
@@ -3689,9 +3691,10 @@ class NodeScopeResolver
 			$conditionalHolders = [];
 			foreach ($iterateeType->getKeyTypes() as $i => $keyType) {
 				$valueType = $iterateeType->getValueTypes()[$i];
-				$conditionalHolders[] = new ConditionalExpressionHolder([
+				$holder = new ConditionalExpressionHolder([
 					'$' . $stmt->keyVar->name => $keyType,
 				], new VariableTypeHolder($valueType, TrinaryLogic::createYes()));
+				$conditionalHolders[$holder->getKey()] = $holder;
 			}
 
 			$scope = $scope->addConditionalExpressions(

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -962,10 +962,11 @@ class TypeSpecifier
 					$holders[$exprString] = [];
 				}
 
-				$holders[$exprString][] = new ConditionalExpressionHolder(
+				$holder = new ConditionalExpressionHolder(
 					$conditionExpressionTypes,
 					new VariableTypeHolder(TypeCombinator::remove($scope->getType($expr), $type), TrinaryLogic::createYes()),
 				);
+				$holders[$exprString][$holder->getKey()] = $holder;
 			}
 
 			return $holders;

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -140,15 +140,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 				66,
 			],
 			[
-				'Property PropertiesFromArrayIntoObject\Foo::$float_test (float) does not accept float|int|string.',
-				69,
-			],
-			[
-				'Property PropertiesFromArrayIntoObject\Foo::$foo (string) does not accept float|int|string.',
-				69,
-			],
-			[
-				'Property PropertiesFromArrayIntoObject\Foo::$lall (int) does not accept float|int|string.',
+				'Property PropertiesFromArrayIntoObject\Foo::$lall (int) does not accept string.',
 				69,
 			],
 			[


### PR DESCRIPTION
Working on https://github.com/phpstan/phpstan/issues/3677 and half way done.

* https://github.com/phpstan/phpstan-src/pull/1270/commits/218bd363ebf0d39873c2df70b716d634ee1ce998
If my understanding is correct, the logic in merge of `conditionalExpressions` in `filterBySpecifiedTypes` should be consistent with https://github.com/phpstan/phpstan-src/blob/0b3bfebebdeb3be2fbdcef5c2ba98a2885875228/src/Analyser/MutatingScope.php#L4784-L4786 
so `continue 2` should be `continue`. I'm not sure enough with the fix yet, but the fixed test looks better to me. 
Also, this example (coalesce -> coalesce, coalesce -> ternary) is fixed with this change. 
```php
		if ($first || $second) {
			echo ($first ?? $second)->getValue();
			echo ($first ?? $second)->getValue();
		}
		if ($first || $second) {
			echo ($first ?? $second)->getValue();
			echo ($first ?: $second)->getValue();
		}
```

these cases are not fixed yet. (ternary -> ternary, ternary -> coalesce)
```php
		if ($first || $second) {
			echo ($first ?: $second)->getValue();
			echo ($first ?? $second)->getValue();
		}
		if ($first || $second) {
			echo ($first ?: $second)->getValue();
			echo ($first ?: $second)->getValue();
		}
```

* https://github.com/phpstan/phpstan-src/pull/1270/commits/4b22f3c76fa063cc83f98e26885a12c7b235a381

While investigating this issue, I noticed some inconsistencies in keys of `$conditionalExpressions`.
I fixed to set key from `$holder->getKey()` like in https://github.com/phpstan/phpstan-src/blob/f8be122188aa6721cec9872bd61676ee150a5311/src/Analyser/MutatingScope.php#L4514-L4515 , because it is used here https://github.com/phpstan/phpstan-src/blob/0b3bfebebdeb3be2fbdcef5c2ba98a2885875228/src/Analyser/MutatingScope.php#L4737-L4741
