### PR TITLE
Do not call TypeSpecifier::specifyTypesInCondition with a non-null context in case the original context is null

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -175,7 +175,7 @@ class TypeSpecifier
 				$exprNode = $expressions[0];
 				/** @var ConstantScalarType $constantType */
 				$constantType = $expressions[1];
-				if ($constantType->getValue() === false) {
+				if (!$context->null() && $constantType->getValue() === false) {
 					$types = $this->create($exprNode, $constantType, $context, false, $scope, $rootExpr);
 					return $types->unionWith($this->specifyTypesInCondition(
 						$scope,
@@ -185,7 +185,7 @@ class TypeSpecifier
 					));
 				}
 
-				if ($constantType->getValue() === true) {
+				if (!$context->null() && $constantType->getValue() === true) {
 					$types = $this->create($exprNode, $constantType, $context, false, $scope, $rootExpr);
 					return $types->unionWith($this->specifyTypesInCondition(
 						$scope,
@@ -339,7 +339,7 @@ class TypeSpecifier
 				$exprNode = $expressions[0];
 				/** @var ConstantScalarType $constantType */
 				$constantType = $expressions[1];
-				if ($constantType->getValue() === false || $constantType->getValue() === null) {
+				if (!$context->null() && ($constantType->getValue() === false || $constantType->getValue() === null)) {
 					return $this->specifyTypesInCondition(
 						$scope,
 						$exprNode,
@@ -348,7 +348,7 @@ class TypeSpecifier
 					);
 				}
 
-				if ($constantType->getValue() === true) {
+				if (!$context->null() && $constantType->getValue() === true) {
 					return $this->specifyTypesInCondition(
 						$scope,
 						$exprNode,

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -528,4 +528,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7166(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-7166.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-7166.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7166.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7166;
+
+use function PHPStan\dumpType;
+
+class HelloWorld
+{
+	public static function print(
+		string $value
+	): void {
+		$isSingleLine = strpos($value, "\n") === false;
+		dumpType($value);
+		$hasLeadingSpace = $value !== '' && ($value[0] === ' ' || $value[0] === '\t');
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7166

The title is a bit cryptic, the problems are scope "negations" via `Identical` and `Equal` expression handling like e.g. https://github.com/phpstan/phpstan-src/blob/1.6.4/src/Analyser/TypeSpecifier.php#L183