### PR TITLE
Add throw point for division

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2940,11 +2940,18 @@ class MutatingScope implements Scope
 		}
 
 		if ($node instanceof Node\Expr\BinaryOp\Div || $node instanceof Node\Expr\AssignOp\Div) {
+			if ($rightNumberValue === 0 || $rightNumberValue === 0.0) {
+				return new ErrorType();
+			}
 			return $this->getTypeFromValue($leftNumberValue / $rightNumberValue);
 		}
 
 		if ($node instanceof Node\Expr\BinaryOp\Mod || $node instanceof Node\Expr\AssignOp\Mod) {
-			return $this->getTypeFromValue(((int) $leftNumberValue) % ((int) $rightNumberValue));
+			$rightIntegerValue = (int) $rightNumberValue;
+			if ($rightIntegerValue === 0) {
+				return new ErrorType();
+			}
+			return $this->getTypeFromValue(((int) $leftNumberValue) % $rightIntegerValue);
 		}
 
 		if ($node instanceof Expr\BinaryOp\ShiftLeft || $node instanceof Expr\AssignOp\ShiftLeft) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2314,7 +2314,7 @@ class NodeScopeResolver
 			$result = $this->processExprNode($expr->right, $scope, $nodeCallback, $context->enterDeep());
 			if (
 				($expr instanceof BinaryOp\Div || $expr instanceof BinaryOp\Mod) &&
-				!$scope->getType($expr->right)->toInteger()->isSuperTypeOf(new ConstantIntegerType(0))->no()
+				!$scope->getType($expr->right)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
 			) {
 				$throwPoints[] = ThrowPoint::createExplicit($scope, new ObjectType(DivisionByZeroError::class), $expr, false);
 			}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1747,6 +1747,12 @@ class NodeScopeResolver
 			$scope = $result->getScope();
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();
+			if (
+				($expr instanceof Expr\AssignOp\Div || $expr instanceof Expr\AssignOp\Mod) &&
+				!$scope->getType($expr->expr)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
+			) {
+				$throwPoints[] = ThrowPoint::createExplicit($scope, new ObjectType(DivisionByZeroError::class), $expr, false);
+			}
 		} elseif ($expr instanceof FuncCall) {
 			$parametersAcceptor = null;
 			$functionReflection = null;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2314,7 +2314,7 @@ class NodeScopeResolver
 			$result = $this->processExprNode($expr->right, $scope, $nodeCallback, $context->enterDeep());
 			if (
 				($expr instanceof BinaryOp\Div || $expr instanceof BinaryOp\Mod) &&
-				!$scope->getType($expr->right)->isSuperTypeOf(new ConstantIntegerType(0))->no()
+				!$scope->getType($expr->right)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
 			) {
 				$throwPoints[] = ThrowPoint::createExplicit($scope, new ObjectType(DivisionByZeroError::class), $expr, false);
 			}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2314,7 +2314,7 @@ class NodeScopeResolver
 			$result = $this->processExprNode($expr->right, $scope, $nodeCallback, $context->enterDeep());
 			if (
 				($expr instanceof BinaryOp\Div || $expr instanceof BinaryOp\Mod) &&
-				!$scope->getType($expr->right)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
+				!$scope->getType($expr->right)->toInteger()->isSuperTypeOf(new ConstantIntegerType(0))->no()
 			) {
 				$throwPoints[] = ThrowPoint::createExplicit($scope, new ObjectType(DivisionByZeroError::class), $expr, false);
 			}

--- a/src/Parallel/Scheduler.php
+++ b/src/Parallel/Scheduler.php
@@ -13,6 +13,8 @@ class Scheduler
 
 	/**
 	 * @param positive-int $jobSize
+	 * @param positive-int $maximumNumberOfProcesses
+	 * @param positive-int $minimumNumberOfJobsPerProcess
 	 */
 	public function __construct(
 		private int $jobSize,

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -73,6 +73,8 @@ class SchedulerTest extends TestCase
 	/**
 	 * @dataProvider dataSchedule
 	 * @param positive-int $jobSize
+	 * @param positive-int $maximumNumberOfProcesses
+	 * @param positive-int $minimumNumberOfJobsPerProcess
 	 * @param 0|positive-int $numberOfFiles
 	 * @param array<int> $expectedJobSizes
 	 */

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -334,4 +334,34 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6349(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6349.php'], [
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				29,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				33,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				44,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				48,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				74,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				78,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -361,6 +361,14 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				78,
 			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				121,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				125,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -355,11 +355,11 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 			],
 			[
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
-				74,
+				106,
 			],
 			[
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
-				78,
+				110,
 			],
 			[
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
@@ -368,6 +368,15 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 			[
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				125,
+			],
+			// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				139,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				143,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -378,6 +378,47 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				143,
 			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				172,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				176,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				187,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				191,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				249,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				253,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				264,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				268,
+			],
+			// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				282,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				286,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -355,14 +355,6 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 			],
 			[
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
-				74,
-			],
-			[
-				'Dead catch - DivisionByZeroError is never thrown in the try block.',
-				78,
-			],
-			[
-				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				121,
 			],
 			[

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -369,12 +369,13 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				125,
 			],
-			// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
 			[
+				// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				139,
 			],
 			[
+				// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				143,
 			],
@@ -410,12 +411,13 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				268,
 			],
-			// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
 			[
+				// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				282,
 			],
 			[
+				// throw point not implemented yet, because there is no way to narrow float value by !== 0.0
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				286,
 			],

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -355,6 +355,14 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 			],
 			[
 				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				74,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
+				78,
+			],
+			[
+				'Dead catch - DivisionByZeroError is never thrown in the try block.',
 				121,
 			],
 			[

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
@@ -242,7 +242,7 @@ class TestAssignOp
 	/**
 	 * @param '1' $value
 	 */
-	public function numericNonZeroString(string $value): void
+	public function numericNonZeroString($val, string $value): void
 	{
 		try {
 			$val /= $value;
@@ -257,7 +257,7 @@ class TestAssignOp
 	/**
 	 * @param float $value
 	 */
-	public function floatValue(float $value): void
+	public function floatValue($val, float $value): void
 	{
 		try {
 			$val /= $value;
@@ -272,7 +272,7 @@ class TestAssignOp
 	/**
 	 * @param float $value
 	 */
-	public function floatNonZeroValue(float $value): void
+	public function floatNonZeroValue($val, float $value): void
 	{
 		if ($value === 0.0) {
 			return;

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
@@ -95,4 +95,34 @@ class HelloWorld
 			return 0.0;
 		}
 	}
+
+	/**
+	 * @param '0' $value
+	 */
+	public function numericZeroString(string $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param '1' $value
+	 */
+	public function numericNonZeroString(string $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
 }

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6349;
+
+class HelloWorld
+{
+	/**
+	 * @param int $value
+	 */
+	public function integer(int $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param int<min, -1>|int<1, max> $value
+	 */
+	public function nonZeroIntegerRange1(int $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param int<min, -1> $value
+	 */
+	public function nonZeroIntegerRange2(int $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param int<min, 1> $value
+	 */
+	public function zeroIncludedIntegerRange(int $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param float $values
+	 */
+	public function floatValue(float $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param array<string, int> $values
+	 */
+	public function sayHello(array $values): float
+	{
+		try {
+			return 99 / $values['a'];
+		} catch (\DivisionByZeroError $e) {
+			return 0.0;
+		}
+		try {
+			return 99 % $values['a'];
+		} catch (\DivisionByZeroError $e) {
+			return 0.0;
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
@@ -2,7 +2,7 @@
 
 namespace Bug6349;
 
-class HelloWorld
+class TestBinaryOp
 {
 	/**
 	 * @param int $value
@@ -140,6 +140,149 @@ class HelloWorld
 		}
 		try {
 			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+}
+
+class TestAssignOp
+{
+	/**
+	 * @param int $value
+	 */
+	public function integer($val, int $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param int<min, -1>|int<1, max> $value
+	 */
+	public function nonZeroIntegerRange1($val, int $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param int<min, -1> $value
+	 */
+	public function nonZeroIntegerRange2($val, int $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param int<min, 1> $value
+	 */
+	public function zeroIncludedIntegerRange($val, int $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param array<string, int> $values
+	 */
+	public function sayHello($val, array $values): float
+	{
+		try {
+			return $val /= $values['a'];
+		} catch (\DivisionByZeroError $e) {
+			return 0.0;
+		}
+		try {
+			return $val %= $values['a'];
+		} catch (\DivisionByZeroError $e) {
+			return 0.0;
+		}
+	}
+
+	/**
+	 * @param '0' $value
+	 */
+	public function numericZeroString($val, string $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param '1' $value
+	 */
+	public function numericNonZeroString(string $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param float $value
+	 */
+	public function floatValue(float $value): void
+	{
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param float $value
+	 */
+	public function floatNonZeroValue(float $value): void
+	{
+		if ($value === 0.0) {
+			return;
+		}
+		try {
+			$val /= $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			$val %= $value;
 		} catch (\DivisionByZeroError $e) {
 		}
 	}

--- a/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-6349.php
@@ -65,21 +65,6 @@ class HelloWorld
 	}
 
 	/**
-	 * @param float $values
-	 */
-	public function floatValue(float $value): void
-	{
-		try {
-			99 / $value;
-		} catch (\DivisionByZeroError $e) {
-		}
-		try {
-			99 % $value;
-		} catch (\DivisionByZeroError $e) {
-		}
-	}
-
-	/**
 	 * @param array<string, int> $values
 	 */
 	public function sayHello(array $values): float
@@ -116,6 +101,39 @@ class HelloWorld
 	 */
 	public function numericNonZeroString(string $value): void
 	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param float $value
+	 */
+	public function floatValue(float $value): void
+	{
+		try {
+			99 / $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+		try {
+			99 % $value;
+		} catch (\DivisionByZeroError $e) {
+		}
+	}
+
+	/**
+	 * @param float $value
+	 */
+	public function floatNonZeroValue(float $value): void
+	{
+		if ($value === 0.0) {
+			return;
+		}
 		try {
 			99 / $value;
 		} catch (\DivisionByZeroError $e) {


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/6349

Implemented throw point for zero value div/mod `DivisionByZeroError`.
I didn't implemented it for `float`, because currently there is no way to narrow float value as non-zero float.

I'm not satisfied enough with https://github.com/phpstan/phpstan-src/pull/1280/commits/01c2761e31460d77d62c53b86d7221c77d1fd67d
zero value `ConstantScalarType` would not be passed to `calculateFromScalars` because it's handled here https://github.com/phpstan/phpstan-src/blob/55b995235ea6959289189f66893c69344fafb5a2/src/Analyser/MutatingScope.php#L989-L1022 
Although, this commit might not be redundant, because using `calculateFromScalars` in other places may cause `DivisionByZeroError`.
