### PR TITLE
Specifiy `json_decode` default return type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5689,7 +5689,7 @@ return [
 'join' => ['string', 'glue'=>'string', 'pieces'=>'array'],
 'join\'1' => ['string', 'pieces'=>'array'],
 'jpeg2wbmp' => ['bool', 'jpegname'=>'string', 'wbmpname'=>'string', 'dest_height'=>'int', 'dest_width'=>'int', 'threshold'=>'int'],
-'json_decode' => ['mixed', 'json'=>'string', 'assoc='=>'bool', 'depth='=>'positive-int', 'options='=>'int'],
+'json_decode' => ['mixed[]|scalar|stdClass|null', 'json'=>'string', 'assoc='=>'bool', 'depth='=>'positive-int', 'options='=>'int'],
 'json_encode' => ['string|false', 'data'=>'mixed', 'options='=>'int', 'depth='=>'positive-int'],
 'json_last_error' => ['int'],
 'json_last_error_msg' => ['string'],

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8699,15 +8699,15 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'json_encode($mixed,  $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'mixed',
+				'array|bool|float|int|stdClass|string|null',
 				'json_decode($mixed)',
 			],
 			[
-				'mixed',
+				'array|bool|float|int|stdClass|string|null',
 				'json_decode($mixed, false, 512, JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'mixed',
+				'array|bool|float|int|stdClass|string|null',
 				'json_decode($mixed, false, 512, $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
@@ -7,27 +7,27 @@ use function PHPStan\Testing\assertType;
 // @see https://3v4l.org/YFlHF
 function ($mixed) {
 	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY);
-	assertType('mixed~stdClass', $value);
+	assertType('array|bool|float|int|string|null', $value);
 };
 
 function ($mixed) {
 	$flagsAsVariable = JSON_OBJECT_AS_ARRAY;
 
 	$value = json_decode($mixed, null, 512, $flagsAsVariable);
-	assertType('mixed~stdClass', $value);
+	assertType('array|bool|float|int|string|null', $value);
 };
 
 function ($mixed) {
 	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY | JSON_BIGINT_AS_STRING);
-	assertType('mixed~stdClass', $value);
+	assertType('array|bool|float|int|string|null', $value);
 };
 
 function ($mixed) {
 	$value = json_decode($mixed, null);
-	assertType('mixed', $value);
+	assertType('array|bool|float|int|stdClass|string|null', $value);
 };
 
 function ($mixed, $unknownFlags) {
 	$value = json_decode($mixed, null, 512, $unknownFlags);
-	assertType('mixed', $value);
+	assertType('array|bool|float|int|stdClass|string|null', $value);
 };

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type.php
@@ -25,10 +25,10 @@ assertType('array{1, 2, 3}', $value);
 
 function ($mixed) {
 	$value = json_decode($mixed);
-	assertType('mixed', $value);
+	assertType('array|bool|float|int|stdClass|string|null', $value);
 };
 
 function ($mixed) {
 	$value = json_decode($mixed, false);
-	assertType('mixed', $value);
+	assertType('array|bool|float|int|stdClass|string|null', $value);
 };

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
@@ -24,5 +24,5 @@ assertType('array{1, 2, 3}', $value);
 
 function ($mixed) {
 	$value = json_decode($mixed, true);
-	assertType('mixed~stdClass', $value);
+	assertType('array|bool|float|int|string|null', $value);
 };


### PR DESCRIPTION
`mixed` is too vague IMO, this should be fine to specify with more details, see also https://3v4l.org/hEDja
But please somebody double and triple check that I didn't miss anything here. Together with https://github.com/phpstan/phpstan-src/pull/993 this allows us to get rid of `stdClass` for example.

I was also hoping that it would "fix" https://github.com/phpstan/phpstan/issues/7073 but apparently `NonexistentOffsetInArrayDimFetchRule` is not happy with scalar null coalescing access. But not sure if that's coming from that rule or somewhere else CC @rajyan 