### PR TITLE
Ignore automerge human readable title

### DIFF
--- a/.github/workflows/merge-bot-pr.yml
+++ b/.github/workflows/merge-bot-pr.yml
@@ -16,7 +16,7 @@ jobs:
         id: waitforstatuschecks
         uses: "WyriHaximus/github-action-wait-for-status@v1"
         with:
-          ignoreActions: automerge
+          ignoreActions: "automerge,Automerge PRs"
           checkInterval: 13
         env:
           GITHUB_TOKEN: "${{ secrets.PHPSTAN_BOT_TOKEN }}"


### PR DESCRIPTION
The way the GitHub REST API works it returns the human readable name of a check status on the comments. Which matches the `name: Automerge PRs` in the workflows, and not the computer readable name we give that job `automerge`.

Refs: https://github.com/WyriHaximus/github-action-wait-for-status/issues/111