### PR TITLE
Implement `@phpstan-consistent-templates`

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -47,3 +47,4 @@ parameters:
 		callUserFunc: true
 		finalByPhpDoc: true
 		magicConstantOutOfContext: true
+		consistentTemplates: true

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -82,6 +82,7 @@ parameters:
 		callUserFunc: false
 		finalByPhpDoc: false
 		magicConstantOutOfContext: false
+		consistentTemplates: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -905,6 +906,8 @@ services:
 
 	-
 		class: PHPStan\Rules\Generics\GenericObjectTypeCheck
+		arguments:
+			reportConsistentTemplates: %featureToggles.consistentTemplates%
 
 	-
 		class: PHPStan\Rules\Generics\TemplateTypeCheck

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -77,6 +77,7 @@ parametersSchema:
 		callUserFunc: bool()
 		finalByPhpDoc: bool()
 		magicConstantOutOfContext: bool()
+		consistentTemplates: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -549,6 +549,19 @@ class PhpDocNodeResolver
 		return count($finalTags) > 0;
 	}
 
+	public function resolveHasConsistentTemplates(PhpDocNode $phpDocNode): bool
+	{
+		foreach (['@consistent-templates', '@phpstan-consistent-templates', '@psalm-consistent-templates'] as $tagName) {
+			$tags = $phpDocNode->getTagsByName($tagName);
+
+			if (count($tags) > 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public function resolveIsPure(PhpDocNode $phpDocNode): bool
 	{
 		foreach ($phpDocNode->getTags() as $phpDocTagNode) {

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -128,6 +128,8 @@ class ResolvedPhpDocBlock
 
 	private ?bool $acceptsNamedArguments = null;
 
+	private ?bool $hasConsistentTemplates = null;
+
 	private function __construct()
 	{
 	}
@@ -196,6 +198,7 @@ class ResolvedPhpDocBlock
 		$self->isAllowedPrivateMutation = false;
 		$self->hasConsistentConstructor = false;
 		$self->acceptsNamedArguments = true;
+		$self->hasConsistentTemplates = false;
 
 		return $self;
 	}
@@ -256,6 +259,7 @@ class ResolvedPhpDocBlock
 		$result->isAllowedPrivateMutation = $this->isAllowedPrivateMutation();
 		$result->hasConsistentConstructor = $this->hasConsistentConstructor();
 		$result->acceptsNamedArguments = $acceptsNamedArguments;
+		$result->hasConsistentTemplates = $this->hasConsistentTemplates();
 
 		return $result;
 	}
@@ -669,6 +673,16 @@ class ResolvedPhpDocBlock
 			);
 		}
 		return $this->acceptsNamedArguments;
+	}
+
+	public function hasConsistentTemplates(): bool
+	{
+		if ($this->hasConsistentTemplates === null) {
+			$this->hasConsistentTemplates = $this->phpDocNodeResolver->resolveHasConsistentTemplates(
+				$this->phpDocNode,
+			);
+		}
+		return $this->hasConsistentTemplates;
 	}
 
 	public function getTemplateTypeMap(): TemplateTypeMap

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -67,6 +67,7 @@ use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Helper\GetTemplateTypeType;
+use PHPStan\Type\Generic\GenericStaticType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
@@ -742,6 +743,22 @@ class TypeNodeResolver
 			}
 
 			return new ErrorType();
+		} elseif ($mainTypeName === 'static') {
+			if (count($genericTypes) > 0) {
+				$className = $nameScope->getClassName();
+
+				if ($className === null) {
+					return new ErrorType();
+				}
+
+				if ($this->getReflectionProvider()->hasClass($className)) {
+					$classReflection = $this->getReflectionProvider()->getClass($className);
+
+					if ($classReflection->hasConsistentTemplates()) {
+						return new GenericStaticType($classReflection, $genericTypes);
+					}
+				}
+			}
 		}
 
 		$mainType = $this->resolveIdentifierTypeNode($typeNode->type, $nameScope);

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -94,6 +94,8 @@ class ClassReflection
 
 	private ?bool $hasConsistentConstructor = null;
 
+	private ?bool $hasConsistentTemplates = null;
+
 	private ?TemplateTypeMap $templateTypeMap = null;
 
 	private ?TemplateTypeMap $activeTemplateTypeMap = null;
@@ -1158,6 +1160,16 @@ class ClassReflection
 		}
 
 		return $this->hasConsistentConstructor;
+	}
+
+	public function hasConsistentTemplates(): bool
+	{
+		if ($this->hasConsistentTemplates === null) {
+			$resolvedPhpDoc = $this->getResolvedPhpDoc();
+			$this->hasConsistentTemplates = $resolvedPhpDoc !== null && $resolvedPhpDoc->hasConsistentTemplates();
+		}
+
+		return $this->hasConsistentTemplates;
 	}
 
 	public function isFinalByKeyword(): bool

--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
@@ -215,6 +215,7 @@ class IncompatiblePhpDocTypeRule implements Rule
 
 					$errors[] = $errorBuilder->build();
 				}
+
 			}
 		}
 

--- a/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
+++ b/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
@@ -52,6 +52,7 @@ class InvalidPHPStanDocTagRule implements Rule
 		'@phpstan-allow-private-mutation',
 		'@phpstan-readonly',
 		'@phpstan-readonly-allow-private-mutation',
+		'@phpstan-consistent-templates',
 	];
 
 	public function __construct(

--- a/src/Type/Generic/GenericStaticType.php
+++ b/src/Type/Generic/GenericStaticType.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeWithClassName;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+use function array_map;
+use function implode;
+use function sprintf;
+use function var_dump;
+
+class GenericStaticType extends StaticType
+{
+
+	/**
+	 * @param array<int, Type> $types
+	 */
+	public function __construct(ClassReflection $classReflection, private array $types, ?Type $subtractedType = null)
+	{
+		parent::__construct($classReflection, $subtractedType);
+	}
+
+	/** @return array<int, Type> */
+	public function getTypes(): array
+	{
+		return $this->types;
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return sprintf(
+			'static(%s<%s>)',
+			$this->getClassReflection()->getName(),
+			implode(', ', array_map(static fn (Type $type): string => $type->describe($level), $this->types)),
+		);
+	}
+
+	public function changeBaseClass(ClassReflection $classReflection): GenericStaticType
+	{
+		return new self($classReflection, $this->getTypes(), $this->getSubtractedType());
+	}
+
+	public function getStaticObjectType(): ObjectType
+	{
+		var_dump('GenericStaticType::getStaticObjectType');
+		exit;
+		if ($this->staticObjectType === null) {
+			if ($this->getClassReflection()->isGeneric()) {
+				return $this->staticObjectType = new GenericObjectType(
+					$this->getClassReflection()->getName(),
+					$this->getTypes(),
+					$this->getSubtractedType(),
+				);
+			}
+
+			return $this->staticObjectType = new ObjectType($this->getClassReflection()->getName(), $this->getSubtractedType(), $this->getClassReflection());
+		}
+
+		return $this->staticObjectType;
+	}
+
+	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
+	{
+		var_dump('GenericStaticType::inferTemplateTypes');
+		exit;
+		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {
+			return $receivedType->inferTemplateTypesOn($this);
+		}
+
+		if (!$receivedType instanceof TypeWithClassName) {
+			return TemplateTypeMap::createEmpty();
+		}
+
+		$ancestor = $receivedType->getAncestorWithClassName($this->getClassName());
+
+		if ($ancestor === null) {
+			return TemplateTypeMap::createEmpty();
+		}
+		$ancestorClassReflection = $ancestor->getClassReflection();
+		if ($ancestorClassReflection === null) {
+			return TemplateTypeMap::createEmpty();
+		}
+
+		$otherTypes = $ancestorClassReflection->typeMapToList($ancestorClassReflection->getActiveTemplateTypeMap());
+		$typeMap = TemplateTypeMap::createEmpty();
+
+		foreach ($this->getTypes() as $i => $type) {
+			$other = $otherTypes[$i] ?? new ErrorType();
+			$typeMap = $typeMap->union($type->inferTemplateTypes($other));
+		}
+
+		return $typeMap;
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		var_dump('GenericStaticType::getReferencedTemplateTypes');
+		exit;
+		$classReflection = $this->getClassReflection();
+
+		if ($classReflection !== null) {
+			$typeList = $classReflection->typeMapToList($classReflection->getTemplateTypeMap());
+		} else {
+			$typeList = [];
+		}
+
+		$references = [];
+
+		foreach ($this->types as $i => $type) {
+			$variance = $positionVariance->compose(
+				isset($typeList[$i]) && $typeList[$i] instanceof TemplateType
+					? $typeList[$i]->getVariance()
+					: TemplateTypeVariance::createInvariant(),
+			);
+			foreach ($type->getReferencedTemplateTypes($variance) as $reference) {
+				$references[] = $reference;
+			}
+		}
+
+		return $references;
+	}
+
+	/**
+	 * @param Type[] $types
+	 */
+	protected function recreate(ClassReflection $classReflection, array $types, ?Type $subtractedType): self
+	{
+		return new self(
+			$classReflection,
+			$types,
+			$subtractedType,
+		);
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 */
+	public static function __set_state(array $properties): Type
+	{
+		return new self(
+			$properties['classReflection'],
+			$properties['types'],
+			$properties['subtractedType'] ?? null,
+		);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -2,9 +2,7 @@
 
 namespace PHPStan\Analyser;
 
-use EnumTypeAssertions\Foo;
 use PHPStan\Testing\TypeInferenceTestCase;
-use stdClass;
 use function define;
 use function extension_loaded;
 use const PHP_INT_SIZE;
@@ -1411,6 +1409,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5961.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10189.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10317.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/consistent-templates-static.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5512.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-5512.php
+++ b/tests/PHPStan/Analyser/data/bug-5512.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Bug5512;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ * @phpstan-consistent-templates
+ */
+class Collection {
+	/**
+	 * @var array<TKey, TValue>
+	 */
+	protected $items = [];
+
+	/**
+	 * Create a new collection.
+	 *
+	 * @param  array<TKey, TValue>  $items
+	 * @return void
+	 */
+	public function __construct($items)
+	{
+		$this->items = $items;
+	}
+
+	/**
+	 * @template TMakeKey of array-key
+	 * @template TMakeValue
+	 *
+	 * @param  array<TMakeKey, TMakeValue>  $items
+	 * @return static<TMakeKey, TMakeValue>
+	 */
+	public static function make($items)
+	{
+		return new static($items);
+	}
+}
+
+
+/**
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @extends Collection<TKey, TValue>
+ */
+class CustomCollection extends Collection {}
+
+
+/** @param CustomCollection<int, string> $collection */
+function foo(CustomCollection $collection) {
+	//assertType('Bug5512\CustomCollection<int, int>', CustomCollection::make([1]));
+	assertType('Bug5512\CustomCollection<int, int>', $collection::make([1,2,3,4]));
+}

--- a/tests/PHPStan/Analyser/data/consistent-templates-static.php
+++ b/tests/PHPStan/Analyser/data/consistent-templates-static.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConsistentTemplatesStatic;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @phpstan-consistent-templates
+ */
+class A
+{
+	/** @return static<T> */
+	public function doFoo()
+	{
+		return new static();
+	}
+
+	/** @return static<T> */
+	public static function doBaz()
+	{
+		return new static();
+	}
+}
+
+/**
+ * @template T
+ * @extends A<T>
+ */
+class B extends A
+{
+	public function doBar()
+	{
+		assertType('ConsistentTemplatesStatic\B<T (class ConsistentTemplatesStatic\B, argument)>', $this->doFoo());
+		assertType('ConsistentTemplatesStatic\B<T (class ConsistentTemplatesStatic\B, argument)>', B::doBaz());
+	}
+}
+
+/** @param B<int> $b */
+function doFoo(B $b)
+{
+	assertType('ConsistentTemplatesStatic\B<int>', $b->doFoo());
+	assertType('ConsistentTemplatesStatic\B<mixed>', B::doBaz());
+}
+

--- a/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
@@ -281,4 +281,42 @@ class ClassAncestorsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8473.php'], []);
 	}
 
+	public function testConsistentTemplates(): void
+	{
+		$this->analyse([__DIR__ . '/data/consistent-templates.php'], [
+			[
+				'Class ConsistentTemplates\ClassWithTwoTemplates should have same amount of template tags as ConsistentTemplates\ConsistentFoo. 1 expected but 2 found.',
+				16,
+			],
+			[
+				'Class ConsistentTemplates\ClassExtendingWithNonTemplateType has non-template types in @extends tag but ConsistentTemplates\ConsistentFoo has consistent templates.',
+				22,
+			],
+			[
+				'Class ConsistentTemplates\ClassWithTwoTemplatesI should have same amount of template tags as ConsistentTemplates\ConsistentBar. 1 expected but 2 found.',
+				35,
+			],
+			[
+				'Class ConsistentTemplates\ClassExtendingWithNonTemplateTypeI has non-template types in @implements tag but ConsistentTemplates\ConsistentBar has consistent templates.',
+				41,
+			],
+			[
+				'Class ConsistentTemplates\Baz should have same amount of template tags as ConsistentTemplates\ConsistentFoo. 1 expected but 0 found.',
+				47,
+			],
+			[
+				'Class ConsistentTemplates\Baz has non-template types in @extends tag but ConsistentTemplates\ConsistentFoo has consistent templates.',
+				47,
+			],
+			[
+				'Class ConsistentTemplates\Baz should have same amount of template tags as ConsistentTemplates\ConsistentBar. 1 expected but 0 found.',
+				47,
+			],
+			[
+				'Class ConsistentTemplates\Baz has non-template types in @implements tag but ConsistentTemplates\ConsistentBar has consistent templates.',
+				47,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Generics/data/consistent-templates.php
+++ b/tests/PHPStan/Rules/Generics/data/consistent-templates.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConsistentTemplates;
+
+/**
+ * @template T
+ * @phpstan-consistent-templates
+ */
+class ConsistentFoo {}
+
+/**
+ * @template T
+ * @template K
+ * @extends ConsistentFoo<T>
+ */
+class ClassWithTwoTemplates extends ConsistentFoo {}
+
+/**
+ * @template T
+ * @extends ConsistentFoo<int>
+ */
+class ClassExtendingWithNonTemplateType extends ConsistentFoo {}
+
+/**
+ * @template T
+ * @phpstan-consistent-templates
+ */
+interface ConsistentBar {}
+
+/**
+ * @template T
+ * @template K
+ * @implements ConsistentBar<T>
+ */
+class ClassWithTwoTemplatesI implements ConsistentBar {}
+
+/**
+ * @template T
+ * @implements ConsistentBar<int>
+ */
+class ClassExtendingWithNonTemplateTypeI implements ConsistentBar {}
+
+/**
+ * @extends ConsistentFoo<int>
+ * @implements ConsistentBar<int>
+ */
+class Baz extends ConsistentFoo implements ConsistentBar {}
+
+/** @extends ClassWithTwoTemplates<int, string> */
+class NoErrorForGrandparent extends ClassWithTwoTemplates {}

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -14,11 +14,13 @@ use const PHP_VERSION_ID;
 class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 {
 
+	private bool $reportConsistentTemplates = false;
+
 	protected function getRule(): Rule
 	{
 		return new IncompatiblePhpDocTypeRule(
 			self::getContainer()->getByType(FileTypeMapper::class),
-			new GenericObjectTypeCheck(),
+			new GenericObjectTypeCheck($this->reportConsistentTemplates),
 			new UnresolvableTypeHelper(),
 		);
 	}
@@ -289,6 +291,29 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 	public function testBug10097(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-10097.php'], []);
+	}
+
+	public function testGenericStaticReturnType(): void
+	{
+		$this->reportConsistentTemplates = true;
+
+		$this->analyse([__DIR__ . '/data/generic-static-return-type.php'], [
+			[
+				'Unsafe usage of static(GenericStaticReturnType\ClassWithNoConsistentTemplatesTag<string, int>) type in PHPDoc tag. Consider adding \'@phpstan-consistent-templates\' to the class.',
+				12,
+			],
+			[
+				'Type string in generic type static(GenericStaticReturnType\ClassWithConsistentTemplatesTag<string>) in PHPDoc tag @return is not subtype of template type T of int of class GenericStaticReturnType\ClassWithConsistentTemplatesTag.',
+				25,
+			],
+		]);
+	}
+
+	public function testGenericStaticReturnTypeDontReport(): void
+	{
+		$this->reportConsistentTemplates = false;
+
+		$this->analyse([__DIR__ . '/data/generic-static-return-type-dont-report.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-static-return-type-dont-report.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-static-return-type-dont-report.php
@@ -1,0 +1,16 @@
+<?php // lint >= 8.0
+
+namespace GenericStaticReturnTypeDontReport;
+
+/**
+ * @template T
+ * @template K
+ */
+class ClassWithNoConsistentTemplatesTag
+{
+	/** @return static<string, int> */
+	public function notChecked(): static
+	{
+		return new static();
+	}
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-static-return-type.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-static-return-type.php
@@ -1,0 +1,29 @@
+<?php // lint >= 8.0
+
+namespace GenericStaticReturnType;
+
+/**
+ * @template T
+ * @template K
+ */
+class ClassWithNoConsistentTemplatesTag
+{
+	/** @return static<string, int> */
+	public function notChecked(): static
+	{
+		return new static();
+	}
+}
+
+/**
+ * @template T of int
+ * @phpstan-consistent-templates
+ */
+class ClassWithConsistentTemplatesTag
+{
+	/** @return static<string> */
+	public function doFoo(): static
+	{
+		return new static();
+	}
+}


### PR DESCRIPTION
This PR adds a new tag `@phpstan-consistent-templates` and new checks for it. Fixes one part of https://github.com/phpstan/phpstan/issues/5512

There are some parts I am not sure of.
- Naming of the `hasConsistentTemplates` Everything else, like `internal`, `final`, has naming with `isXX`. But `isConsistentTemplates` did not make sense to me.
- Wording of the error messages. I am open to suggestions to improve/change the error messages.
- Currently all variants of the tag is supported. Is this good?
- Currently it is implemented in a way that the errors will only appear if the class has `@extends` or `@implements` tag. Just  `class Foo extends Bar` will not produce these errors even `Bar` has `@phpstan-consistent-templates`


<details>

<summary>Lastly, there is this edge case. </summary>

```php

<?php

/**
 * @template T
 * @template K
 * @psalm-consistent-templates
 */
class Bar {}

/**
 * @template T
 * @psalm-consistent-templates
 */
interface Foo {}

/**
 * @template T
 * @template K
 * @extends Bar<T, K>
 * @implements Foo<T>
 */
class Baz extends Bar implements Foo {}
```


</details>

Basically if a class both extends and implements something, and if those parent classes have different number of template types, the child class can never satisfy both.
