### PR TITLE
Invalidate openssl_error_string after openssl function calls

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -407,6 +407,89 @@ class MutatingScope implements Scope
 		);
 	}
 
+	public function afterOpenSslCall(string $openSslFunctionName): self
+	{
+		$moreSpecificTypes = $this->moreSpecificTypes;
+
+		if (in_array($openSslFunctionName, [
+			'openssl_cipher_iv_length',
+			'openssl_cms_decrypt',
+			'openssl_cms_encrypt',
+			'openssl_cms_read',
+			'openssl_cms_sign',
+			'openssl_cms_verify',
+			'openssl_csr_export_to_file',
+			'openssl_csr_export',
+			'openssl_csr_get_public_key',
+			'openssl_csr_get_subject',
+			'openssl_csr_new',
+			'openssl_csr_sign',
+			'openssl_decrypt',
+			'openssl_dh_compute_key',
+			'openssl_digest',
+			'openssl_encrypt',
+			'openssl_get_curve_names',
+			'openssl_get_privatekey',
+			'openssl_get_publickey',
+			'openssl_open',
+			'openssl_pbkdf2',
+			'openssl_pkcs12_export_to_file',
+			'openssl_pkcs12_export',
+			'openssl_pkcs12_read',
+			'openssl_pkcs7_decrypt',
+			'openssl_pkcs7_encrypt',
+			'openssl_pkcs7_read',
+			'openssl_pkcs7_sign',
+			'openssl_pkcs7_verify',
+			'openssl_pkey_derive',
+			'openssl_pkey_export_to_file',
+			'openssl_pkey_export',
+			'openssl_pkey_get_private',
+			'openssl_pkey_get_public',
+			'openssl_pkey_new',
+			'openssl_private_decrypt',
+			'openssl_private_encrypt',
+			'openssl_public_decrypt',
+			'openssl_public_encrypt',
+			'openssl_random_pseudo_bytes',
+			'openssl_seal',
+			'openssl_sign',
+			'openssl_spki_export_challenge',
+			'openssl_spki_export',
+			'openssl_spki_new',
+			'openssl_spki_verify',
+			'openssl_verify',
+			'openssl_x509_checkpurpose',
+			'openssl_x509_export_to_file',
+			'openssl_x509_export',
+			'openssl_x509_fingerprint',
+			'openssl_x509_read',
+			'openssl_x509_verify',
+		], true)) {
+			unset($moreSpecificTypes['\openssl_error_string()']);
+		}
+
+		return $this->scopeFactory->create(
+			$this->context,
+			$this->isDeclareStrictTypes(),
+			$this->constantTypes,
+			$this->getFunction(),
+			$this->getNamespace(),
+			$this->getVariableTypes(),
+			$moreSpecificTypes,
+			$this->conditionalExpressions,
+			$this->inClosureBindScopeClass,
+			$this->anonymousFunctionReflection,
+			$this->isInFirstLevelStatement(),
+			$this->currentlyAssignedExpressions,
+			$this->currentlyAllowedUndefinedExpressions,
+			$this->nativeExpressionTypes,
+			$this->inFunctionCallsStack,
+			$this->afterExtractCall,
+			$this->parentScope,
+		);
+	}
+
 	/** @api */
 	public function hasVariableType(string $variableName): TrinaryLogic
 	{

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -158,6 +158,7 @@ use function is_array;
 use function is_int;
 use function is_string;
 use function sprintf;
+use function str_starts_with;
 use function strtolower;
 use function trim;
 use const PHP_VERSION_ID;
@@ -1947,6 +1948,10 @@ class NodeScopeResolver
 
 			if (isset($functionReflection) && ($functionReflection->getName() === 'clearstatcache' || $functionReflection->getName() === 'unlink')) {
 				$scope = $scope->afterClearstatcacheCall();
+			}
+
+			if (isset($functionReflection) && str_starts_with($functionReflection->getName(), 'openssl')) {
+				$scope = $scope->afterOpenSslCall($functionReflection->getName());
 			}
 
 			if (isset($functionReflection) && $functionReflection->hasSideEffects()->yes()) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -869,6 +869,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/value-of-generic.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/key-of-generic.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7106.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7106.php
+++ b/tests/PHPStan/Analyser/data/bug-7106.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug7106;
+
+use function PHPStan\Testing\assertType;
+use function openssl_error_string;
+
+Class Example
+{
+    public function openSslError(string $signature): string
+    {
+        assertType('string|false', openssl_error_string());
+
+        if (false === \openssl_error_string()) {
+            assertType('false', openssl_error_string());
+            openssl_sign('1', $signature, '');
+            assertType('string|false', openssl_error_string());
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7106

I looked in the PHP manual, and added every `openssl` functions that could fail.