### PR TITLE
Implement `@phpstan-consistent-constructor`

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -11,3 +11,4 @@ parameters:
 		disableCheckMissingIterableValueType: true
 		strictUnnecessaryNullsafePropertyFetch: true
 		looseComparison: true
+		consistentConstructor: true

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -6,6 +6,8 @@ conditionalTags:
 		phpstan.rules.rule: %featureToggles.nodeConnectingVisitorRule%
 	PHPStan\Rules\Properties\UninitializedPropertyRule:
 		phpstan.rules.rule: %checkUninitializedProperties%
+	PHPStan\Rules\Methods\ConsistentConstructorRule:
+		phpstan.rules.rule: %featureToggles.consistentConstructor%
 
 rules:
 	- PHPStan\Rules\Api\ApiInstantiationRule
@@ -110,6 +112,9 @@ services:
 			checkPhpDocMethodSignatures: %checkPhpDocMethodSignatures%
 		tags:
 			- phpstan.rules.rule
+
+	-
+		class: PHPStan\Rules\Methods\ConsistentConstructorRule
 
 	-
 		class: PHPStan\Rules\Missing\MissingReturnRule

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -37,6 +37,7 @@ parameters:
 		disableCheckMissingIterableValueType: false
 		strictUnnecessaryNullsafePropertyFetch: false
 		looseComparison: false
+		consistentConstructor: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -210,7 +211,8 @@ parametersSchema:
 		illegalConstructorMethodCall: bool(),
 		disableCheckMissingIterableValueType: bool(),
 		strictUnnecessaryNullsafePropertyFetch: bool(),
-		looseComparison: bool()
+		looseComparison: bool(),
+		consistentConstructor: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -893,6 +893,9 @@ services:
 			reportStatic: %reportStaticMethodSignatures%
 
 	-
+		class: PHPStan\Rules\Methods\MethodParameterComparisonHelper
+
+	-
 		class: PHPStan\Rules\MissingTypehintCheck
 		arguments:
 			checkMissingIterableValueType: %checkMissingIterableValueType%

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -452,6 +452,19 @@ class PhpDocNodeResolver
 		return false;
 	}
 
+	public function resolveHasConsistentConstructor(PhpDocNode $phpDocNode): bool
+	{
+		foreach (['@consistent-constructor', '@phpstan-consistent-constructor', '@psalm-consistent-constructor'] as $tagName) {
+			$tags = $phpDocNode->getTagsByName($tagName);
+
+			if (count($tags) > 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private function shouldSkipType(string $tagName, Type $type): bool
 	{
 		if (strpos($tagName, '@psalm-') !== 0) {

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -96,6 +96,8 @@ class ResolvedPhpDocBlock
 	/** @var bool|'notLoaded'|null */
 	private bool|string|null $isPure = 'notLoaded';
 
+	private ?bool $hasConsistentConstructor = null;
+
 	private function __construct()
 	{
 	}
@@ -153,6 +155,7 @@ class ResolvedPhpDocBlock
 		$self->isInternal = false;
 		$self->isFinal = false;
 		$self->isPure = null;
+		$self->hasConsistentConstructor = false;
 
 		return $self;
 	}
@@ -197,6 +200,7 @@ class ResolvedPhpDocBlock
 		$result->isInternal = $this->isInternal();
 		$result->isFinal = $this->isFinal();
 		$result->isPure = $this->isPure();
+		$result->hasConsistentConstructor = $this->hasConsistentConstructor();
 
 		return $result;
 	}
@@ -505,6 +509,16 @@ class ResolvedPhpDocBlock
 			);
 		}
 		return $this->isFinal;
+	}
+
+	public function hasConsistentConstructor(): bool
+	{
+		if ($this->hasConsistentConstructor === null) {
+			$this->hasConsistentConstructor = $this->phpDocNodeResolver->resolveHasConsistentConstructor(
+				$this->phpDocNode,
+			);
+		}
+		return $this->hasConsistentConstructor;
 	}
 
 	public function getTemplateTypeMap(): TemplateTypeMap

--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -36,6 +36,7 @@ use PHPStan\Rules\Generics\TemplateTypeCheck;
 use PHPStan\Rules\Generics\TraitTemplateTypeRule;
 use PHPStan\Rules\Generics\VarianceCheck;
 use PHPStan\Rules\Methods\ExistingClassesInTypehintsRule;
+use PHPStan\Rules\Methods\MethodParameterComparisonHelper;
 use PHPStan\Rules\Methods\MethodSignatureRule;
 use PHPStan\Rules\Methods\MissingMethodParameterTypehintRule;
 use PHPStan\Rules\Methods\MissingMethodReturnTypehintRule;
@@ -149,7 +150,7 @@ class StubValidator
 			new ExistingClassesInTypehintsRule($functionDefinitionCheck),
 			new \PHPStan\Rules\Functions\ExistingClassesInTypehintsRule($functionDefinitionCheck),
 			new ExistingClassesInPropertiesRule($reflectionProvider, $classCaseSensitivityCheck, $unresolvableTypeHelper, $phpVersion, true, false),
-			new OverridingMethodRule($phpVersion, new MethodSignatureRule(true, true), true),
+			new OverridingMethodRule($phpVersion, new MethodSignatureRule(true, true), true, new MethodParameterComparisonHelper($phpVersion)),
 
 			// level 2
 			new ClassAncestorsRule($genericAncestorsCheck, $crossCheckInterfacesHelper),

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -79,6 +79,8 @@ class ClassReflection
 
 	private ?bool $isFinal = null;
 
+	private ?bool $hasConsistentConstructor = null;
+
 	private ?TemplateTypeMap $templateTypeMap = null;
 
 	private ?TemplateTypeMap $activeTemplateTypeMap = null;
@@ -1017,6 +1019,16 @@ class ClassReflection
 		}
 
 		return $this->isFinal;
+	}
+
+	public function hasConsistentConstructor(): bool
+	{
+		if ($this->hasConsistentConstructor === null) {
+			$resolvedPhpDoc = $this->getResolvedPhpDoc();
+			$this->hasConsistentConstructor = $resolvedPhpDoc !== null && $resolvedPhpDoc->hasConsistentConstructor();
+		}
+
+		return $this->hasConsistentConstructor;
 	}
 
 	public function isFinalByKeyword(): bool

--- a/src/Rules/Classes/NewStaticRule.php
+++ b/src/Rules/Classes/NewStaticRule.php
@@ -53,6 +53,10 @@ class NewStaticRule implements Rule
 			return [];
 		}
 
+		if ($constructor->getDeclaringClass()->hasConsistentConstructor()) {
+			return [];
+		}
+
 		if ($constructor instanceof PhpMethodReflection) {
 			if ($constructor->isFinal()->yes()) {
 				return [];

--- a/src/Rules/Methods/ConsistentConstructorRule.php
+++ b/src/Rules/Methods/ConsistentConstructorRule.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodPrototypeReflection;
+use PHPStan\Reflection\Php\PhpMethodFromParserNodeReflection;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use function strtolower;
+
+/** @implements Rule<InClassMethodNode> */
+class ConsistentConstructorRule implements Rule
+{
+
+	public function __construct(
+		private MethodParameterComparisonHelper $methodParameterComparisonHelper,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return InClassMethodNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$method = $scope->getFunction();
+
+		if (! $method instanceof PhpMethodFromParserNodeReflection) {
+			throw new ShouldNotHappenException();
+		}
+
+		if (strtolower($method->getName()) !== '__construct') {
+			return [];
+		}
+
+		$parent = $method->getDeclaringClass()->getParentClass();
+
+		if ($parent === null) {
+			return [];
+		}
+
+		if (! $parent->hasConstructor() || ! $parent->hasConsistentConstructor()) {
+			return [];
+		}
+
+		$parentConstructor = $parent->getConstructor();
+
+		if (! $parentConstructor instanceof PhpMethodReflection) {
+			return [];
+		}
+
+		return $this->methodParameterComparisonHelper->compare($this->getMethodPrototypeReflection($parentConstructor, $parent), $method);
+	}
+
+	private function getMethodPrototypeReflection(PhpMethodReflection $methodReflection, ClassReflection $classReflection): MethodPrototypeReflection
+	{
+		return new MethodPrototypeReflection(
+			$methodReflection->getName(),
+			$classReflection,
+			$methodReflection->isStatic(),
+			$methodReflection->isPrivate(),
+			$methodReflection->isPublic(),
+			$methodReflection->isAbstract(),
+			$methodReflection->isFinal()->yes(),
+			$classReflection->getNativeMethod($methodReflection->getName())->getVariants(),
+			null,
+		);
+	}
+
+}

--- a/src/Rules/Methods/MethodParameterComparisonHelper.php
+++ b/src/Rules/Methods/MethodParameterComparisonHelper.php
@@ -1,0 +1,310 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\MethodPrototypeReflection;
+use PHPStan\Reflection\ParameterReflectionWithPhpDocs;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\Php\PhpMethodFromParserNodeReflection;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VerbosityLevel;
+use Traversable;
+use function array_key_exists;
+use function array_slice;
+use function count;
+use function sprintf;
+
+class MethodParameterComparisonHelper
+{
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	/**
+	 * @return RuleError[]
+	 */
+	public function compare(MethodPrototypeReflection $prototype, PhpMethodFromParserNodeReflection $method): array
+	{
+		/** @var RuleError[] $messages */
+		$messages = [];
+		$prototypeVariant = $prototype->getVariants()[0];
+
+		$methodVariant = ParametersAcceptorSelector::selectSingle($method->getVariants());
+		$methodParameters = $methodVariant->getParameters();
+
+		$prototypeAfterVariadic = false;
+		foreach ($prototypeVariant->getParameters() as $i => $prototypeParameter) {
+			if (!array_key_exists($i, $methodParameters)) {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Method %s::%s() overrides method %s::%s() but misses parameter #%d $%s.',
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$prototype->getName(),
+					$i + 1,
+					$prototypeParameter->getName(),
+				))->nonIgnorable()->build();
+				continue;
+			}
+
+			$methodParameter = $methodParameters[$i];
+			if ($prototypeParameter->passedByReference()->no()) {
+				if (!$methodParameter->passedByReference()->no()) {
+					$messages[] = RuleErrorBuilder::message(sprintf(
+						'Parameter #%d $%s of method %s::%s() is passed by reference but parameter #%d $%s of method %s::%s() is not passed by reference.',
+						$i + 1,
+						$methodParameter->getName(),
+						$method->getDeclaringClass()->getDisplayName(),
+						$method->getName(),
+						$i + 1,
+						$prototypeParameter->getName(),
+						$prototype->getDeclaringClass()->getDisplayName(),
+						$prototype->getName(),
+					))->nonIgnorable()->build();
+				}
+			} elseif ($methodParameter->passedByReference()->no()) {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s of method %s::%s() is not passed by reference but parameter #%d $%s of method %s::%s() is passed by reference.',
+					$i + 1,
+					$methodParameter->getName(),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$i + 1,
+					$prototypeParameter->getName(),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$prototype->getName(),
+				))->nonIgnorable()->build();
+			}
+
+			if ($prototypeParameter->isVariadic()) {
+				$prototypeAfterVariadic = true;
+				if (!$methodParameter->isVariadic()) {
+					if (!$methodParameter->isOptional()) {
+						if (count($methodParameters) !== $i + 1) {
+							$messages[] = RuleErrorBuilder::message(sprintf(
+								'Parameter #%d $%s of method %s::%s() is not optional.',
+								$i + 1,
+								$methodParameter->getName(),
+								$method->getDeclaringClass()->getDisplayName(),
+								$method->getName(),
+							))->nonIgnorable()->build();
+							continue;
+						}
+
+						$messages[] = RuleErrorBuilder::message(sprintf(
+							'Parameter #%d $%s of method %s::%s() is not variadic but parameter #%d $%s of method %s::%s() is variadic.',
+							$i + 1,
+							$methodParameter->getName(),
+							$method->getDeclaringClass()->getDisplayName(),
+							$method->getName(),
+							$i + 1,
+							$prototypeParameter->getName(),
+							$prototype->getDeclaringClass()->getDisplayName(),
+							$prototype->getName(),
+						))->nonIgnorable()->build();
+						continue;
+					} elseif (count($methodParameters) === $i + 1) {
+						$messages[] = RuleErrorBuilder::message(sprintf(
+							'Parameter #%d $%s of method %s::%s() is not variadic.',
+							$i + 1,
+							$methodParameter->getName(),
+							$method->getDeclaringClass()->getDisplayName(),
+							$method->getName(),
+						))->nonIgnorable()->build();
+					}
+				}
+			} elseif ($methodParameter->isVariadic()) {
+				if ($this->phpVersion->supportsLessOverridenParametersWithVariadic()) {
+					$remainingPrototypeParameters = array_slice($prototypeVariant->getParameters(), $i);
+					foreach ($remainingPrototypeParameters as $j => $remainingPrototypeParameter) {
+						if (!$remainingPrototypeParameter instanceof ParameterReflectionWithPhpDocs) {
+							continue;
+						}
+						if ($methodParameter->getNativeType()->isSuperTypeOf($remainingPrototypeParameter->getNativeType())->yes()) {
+							continue;
+						}
+
+						$messages[] = RuleErrorBuilder::message(sprintf(
+							'Parameter #%d ...$%s (%s) of method %s::%s() is not contravariant with parameter #%d $%s (%s) of method %s::%s().',
+							$i + 1,
+							$methodParameter->getName(),
+							$methodParameter->getNativeType()->describe(VerbosityLevel::typeOnly()),
+							$method->getDeclaringClass()->getDisplayName(),
+							$method->getName(),
+							$i + $j + 1,
+							$remainingPrototypeParameter->getName(),
+							$remainingPrototypeParameter->getNativeType()->describe(VerbosityLevel::typeOnly()),
+							$prototype->getDeclaringClass()->getDisplayName(),
+							$prototype->getName(),
+						))->nonIgnorable()->build();
+					}
+					break;
+				}
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s of method %s::%s() is variadic but parameter #%d $%s of method %s::%s() is not variadic.',
+					$i + 1,
+					$methodParameter->getName(),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$i + 1,
+					$prototypeParameter->getName(),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$prototype->getName(),
+				))->nonIgnorable()->build();
+				continue;
+			}
+
+			if ($prototypeParameter->isOptional() && !$methodParameter->isOptional()) {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s of method %s::%s() is required but parameter #%d $%s of method %s::%s() is optional.',
+					$i + 1,
+					$methodParameter->getName(),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$i + 1,
+					$prototypeParameter->getName(),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$prototype->getName(),
+				))->nonIgnorable()->build();
+			}
+
+			$methodParameterType = $methodParameter->getNativeType();
+
+			if (!$prototypeParameter instanceof ParameterReflectionWithPhpDocs) {
+				continue;
+			}
+
+			$prototypeParameterType = $prototypeParameter->getNativeType();
+			if (!$this->phpVersion->supportsParameterTypeWidening()) {
+				if (!$methodParameterType->equals($prototypeParameterType)) {
+					$messages[] = RuleErrorBuilder::message(sprintf(
+						'Parameter #%d $%s (%s) of method %s::%s() does not match parameter #%d $%s (%s) of method %s::%s().',
+						$i + 1,
+						$methodParameter->getName(),
+						$methodParameterType->describe(VerbosityLevel::typeOnly()),
+						$method->getDeclaringClass()->getDisplayName(),
+						$method->getName(),
+						$i + 1,
+						$prototypeParameter->getName(),
+						$prototypeParameterType->describe(VerbosityLevel::typeOnly()),
+						$prototype->getDeclaringClass()->getDisplayName(),
+						$prototype->getName(),
+					))->nonIgnorable()->build();
+				}
+				continue;
+			}
+
+			if ($this->isTypeCompatible($methodParameterType, $prototypeParameterType, $this->phpVersion->supportsParameterContravariance())) {
+				continue;
+			}
+
+			if ($this->phpVersion->supportsParameterContravariance()) {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s (%s) of method %s::%s() is not contravariant with parameter #%d $%s (%s) of method %s::%s().',
+					$i + 1,
+					$methodParameter->getName(),
+					$methodParameterType->describe(VerbosityLevel::typeOnly()),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$i + 1,
+					$prototypeParameter->getName(),
+					$prototypeParameterType->describe(VerbosityLevel::typeOnly()),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$prototype->getName(),
+				))->nonIgnorable()->build();
+			} else {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s (%s) of method %s::%s() is not compatible with parameter #%d $%s (%s) of method %s::%s().',
+					$i + 1,
+					$methodParameter->getName(),
+					$methodParameterType->describe(VerbosityLevel::typeOnly()),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$i + 1,
+					$prototypeParameter->getName(),
+					$prototypeParameterType->describe(VerbosityLevel::typeOnly()),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$prototype->getName(),
+				))->nonIgnorable()->build();
+			}
+		}
+
+		if (!isset($i)) {
+			$i = -1;
+		}
+
+		foreach ($methodParameters as $j => $methodParameter) {
+			if ($j <= $i) {
+				continue;
+			}
+
+			if (
+				$j === count($methodParameters) - 1
+				&& $prototypeAfterVariadic
+				&& !$methodParameter->isVariadic()
+			) {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s of method %s::%s() is not variadic.',
+					$j + 1,
+					$methodParameter->getName(),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+				))->nonIgnorable()->build();
+				continue;
+			}
+
+			if (!$methodParameter->isOptional()) {
+				$messages[] = RuleErrorBuilder::message(sprintf(
+					'Parameter #%d $%s of method %s::%s() is not optional.',
+					$j + 1,
+					$methodParameter->getName(),
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+				))->nonIgnorable()->build();
+				continue;
+			}
+		}
+
+		return $messages;
+	}
+
+	public function isTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsContravariance): bool
+	{
+		if ($methodParameterType instanceof MixedType) {
+			return true;
+		}
+
+		if (!$supportsContravariance) {
+			if (TypeCombinator::containsNull($methodParameterType)) {
+				$prototypeParameterType = TypeCombinator::removeNull($prototypeParameterType);
+			}
+			$methodParameterType = TypeCombinator::removeNull($methodParameterType);
+			if ($methodParameterType->equals($prototypeParameterType)) {
+				return true;
+			}
+
+			if ($methodParameterType instanceof IterableType) {
+				if ($prototypeParameterType instanceof ArrayType) {
+					return true;
+				}
+				if ($prototypeParameterType instanceof ObjectType && $prototypeParameterType->getClassName() === Traversable::class) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		return $methodParameterType->isSuperTypeOf($prototypeParameterType)->yes();
+	}
+
+}

--- a/src/Rules/Methods/OverridingMethodRule.php
+++ b/src/Rules/Methods/OverridingMethodRule.php
@@ -8,23 +8,14 @@ use PHPStan\Node\InClassMethodNode;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodPrototypeReflection;
-use PHPStan\Reflection\ParameterReflectionWithPhpDocs;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpMethodFromParserNodeReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\IterableType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
-use Traversable;
-use function array_key_exists;
-use function array_slice;
+use function array_merge;
 use function count;
 use function sprintf;
 use function strtolower;
@@ -39,6 +30,7 @@ class OverridingMethodRule implements Rule
 		private PhpVersion $phpVersion,
 		private MethodSignatureRule $methodSignatureRule,
 		private bool $checkPhpDocMethodSignatures,
+		private MethodParameterComparisonHelper $methodParameterComparisonHelper,
 	)
 	{
 	}
@@ -151,7 +143,7 @@ class OverridingMethodRule implements Rule
 			&& !$this->hasReturnTypeWillChangeAttribute($node->getOriginalNode())
 		) {
 
-			if (!$this->isTypeCompatible($prototype->getTentativeReturnType(), $methodVariant->getNativeReturnType(), true)) {
+			if (!$this->methodParameterComparisonHelper->isTypeCompatible($prototype->getTentativeReturnType(), $methodVariant->getNativeReturnType(), true)) {
 				$messages[] = RuleErrorBuilder::message(sprintf(
 					'Return type %s of method %s::%s() is not covariant with tentative return type %s of method %s::%s().',
 					$methodReturnType->describe(VerbosityLevel::typeOnly()),
@@ -164,238 +156,7 @@ class OverridingMethodRule implements Rule
 			}
 		}
 
-		$prototypeAfterVariadic = false;
-		foreach ($prototypeVariant->getParameters() as $i => $prototypeParameter) {
-			if (!array_key_exists($i, $methodParameters)) {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Method %s::%s() overrides method %s::%s() but misses parameter #%d $%s.',
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$prototype->getDeclaringClass()->getDisplayName(),
-					$prototype->getName(),
-					$i + 1,
-					$prototypeParameter->getName(),
-				))->nonIgnorable()->build();
-				continue;
-			}
-
-			$methodParameter = $methodParameters[$i];
-			if ($prototypeParameter->passedByReference()->no()) {
-				if (!$methodParameter->passedByReference()->no()) {
-					$messages[] = RuleErrorBuilder::message(sprintf(
-						'Parameter #%d $%s of method %s::%s() is passed by reference but parameter #%d $%s of method %s::%s() is not passed by reference.',
-						$i + 1,
-						$methodParameter->getName(),
-						$method->getDeclaringClass()->getDisplayName(),
-						$method->getName(),
-						$i + 1,
-						$prototypeParameter->getName(),
-						$prototype->getDeclaringClass()->getDisplayName(),
-						$prototype->getName(),
-					))->nonIgnorable()->build();
-				}
-			} elseif ($methodParameter->passedByReference()->no()) {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s of method %s::%s() is not passed by reference but parameter #%d $%s of method %s::%s() is passed by reference.',
-					$i + 1,
-					$methodParameter->getName(),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$i + 1,
-					$prototypeParameter->getName(),
-					$prototype->getDeclaringClass()->getDisplayName(),
-					$prototype->getName(),
-				))->nonIgnorable()->build();
-			}
-
-			if ($prototypeParameter->isVariadic()) {
-				$prototypeAfterVariadic = true;
-				if (!$methodParameter->isVariadic()) {
-					if (!$methodParameter->isOptional()) {
-						if (count($methodParameters) !== $i + 1) {
-							$messages[] = RuleErrorBuilder::message(sprintf(
-								'Parameter #%d $%s of method %s::%s() is not optional.',
-								$i + 1,
-								$methodParameter->getName(),
-								$method->getDeclaringClass()->getDisplayName(),
-								$method->getName(),
-							))->nonIgnorable()->build();
-							continue;
-						}
-
-						$messages[] = RuleErrorBuilder::message(sprintf(
-							'Parameter #%d $%s of method %s::%s() is not variadic but parameter #%d $%s of method %s::%s() is variadic.',
-							$i + 1,
-							$methodParameter->getName(),
-							$method->getDeclaringClass()->getDisplayName(),
-							$method->getName(),
-							$i + 1,
-							$prototypeParameter->getName(),
-							$prototype->getDeclaringClass()->getDisplayName(),
-							$prototype->getName(),
-						))->nonIgnorable()->build();
-						continue;
-					} elseif (count($methodParameters) === $i + 1) {
-						$messages[] = RuleErrorBuilder::message(sprintf(
-							'Parameter #%d $%s of method %s::%s() is not variadic.',
-							$i + 1,
-							$methodParameter->getName(),
-							$method->getDeclaringClass()->getDisplayName(),
-							$method->getName(),
-						))->nonIgnorable()->build();
-					}
-				}
-			} elseif ($methodParameter->isVariadic()) {
-				if ($this->phpVersion->supportsLessOverridenParametersWithVariadic()) {
-					$remainingPrototypeParameters = array_slice($prototypeVariant->getParameters(), $i);
-					foreach ($remainingPrototypeParameters as $j => $remainingPrototypeParameter) {
-						if (!$remainingPrototypeParameter instanceof ParameterReflectionWithPhpDocs) {
-							continue;
-						}
-						if ($methodParameter->getNativeType()->isSuperTypeOf($remainingPrototypeParameter->getNativeType())->yes()) {
-							continue;
-						}
-
-						$messages[] = RuleErrorBuilder::message(sprintf(
-							'Parameter #%d ...$%s (%s) of method %s::%s() is not contravariant with parameter #%d $%s (%s) of method %s::%s().',
-							$i + 1,
-							$methodParameter->getName(),
-							$methodParameter->getNativeType()->describe(VerbosityLevel::typeOnly()),
-							$method->getDeclaringClass()->getDisplayName(),
-							$method->getName(),
-							$i + $j + 1,
-							$remainingPrototypeParameter->getName(),
-							$remainingPrototypeParameter->getNativeType()->describe(VerbosityLevel::typeOnly()),
-							$prototype->getDeclaringClass()->getDisplayName(),
-							$prototype->getName(),
-						))->nonIgnorable()->build();
-					}
-					break;
-				}
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s of method %s::%s() is variadic but parameter #%d $%s of method %s::%s() is not variadic.',
-					$i + 1,
-					$methodParameter->getName(),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$i + 1,
-					$prototypeParameter->getName(),
-					$prototype->getDeclaringClass()->getDisplayName(),
-					$prototype->getName(),
-				))->nonIgnorable()->build();
-				continue;
-			}
-
-			if ($prototypeParameter->isOptional() && !$methodParameter->isOptional()) {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s of method %s::%s() is required but parameter #%d $%s of method %s::%s() is optional.',
-					$i + 1,
-					$methodParameter->getName(),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$i + 1,
-					$prototypeParameter->getName(),
-					$prototype->getDeclaringClass()->getDisplayName(),
-					$prototype->getName(),
-				))->nonIgnorable()->build();
-			}
-
-			$methodParameterType = $methodParameter->getNativeType();
-
-			if (!$prototypeParameter instanceof ParameterReflectionWithPhpDocs) {
-				continue;
-			}
-
-			$prototypeParameterType = $prototypeParameter->getNativeType();
-			if (!$this->phpVersion->supportsParameterTypeWidening()) {
-				if (!$methodParameterType->equals($prototypeParameterType)) {
-					$messages[] = RuleErrorBuilder::message(sprintf(
-						'Parameter #%d $%s (%s) of method %s::%s() does not match parameter #%d $%s (%s) of method %s::%s().',
-						$i + 1,
-						$methodParameter->getName(),
-						$methodParameterType->describe(VerbosityLevel::typeOnly()),
-						$method->getDeclaringClass()->getDisplayName(),
-						$method->getName(),
-						$i + 1,
-						$prototypeParameter->getName(),
-						$prototypeParameterType->describe(VerbosityLevel::typeOnly()),
-						$prototype->getDeclaringClass()->getDisplayName(),
-						$prototype->getName(),
-					))->nonIgnorable()->build();
-				}
-				continue;
-			}
-
-			if ($this->isTypeCompatible($methodParameterType, $prototypeParameterType, $this->phpVersion->supportsParameterContravariance())) {
-				continue;
-			}
-
-			if ($this->phpVersion->supportsParameterContravariance()) {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s (%s) of method %s::%s() is not contravariant with parameter #%d $%s (%s) of method %s::%s().',
-					$i + 1,
-					$methodParameter->getName(),
-					$methodParameterType->describe(VerbosityLevel::typeOnly()),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$i + 1,
-					$prototypeParameter->getName(),
-					$prototypeParameterType->describe(VerbosityLevel::typeOnly()),
-					$prototype->getDeclaringClass()->getDisplayName(),
-					$prototype->getName(),
-				))->nonIgnorable()->build();
-			} else {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s (%s) of method %s::%s() is not compatible with parameter #%d $%s (%s) of method %s::%s().',
-					$i + 1,
-					$methodParameter->getName(),
-					$methodParameterType->describe(VerbosityLevel::typeOnly()),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$i + 1,
-					$prototypeParameter->getName(),
-					$prototypeParameterType->describe(VerbosityLevel::typeOnly()),
-					$prototype->getDeclaringClass()->getDisplayName(),
-					$prototype->getName(),
-				))->nonIgnorable()->build();
-			}
-		}
-
-		if (!isset($i)) {
-			$i = -1;
-		}
-
-		foreach ($methodParameters as $j => $methodParameter) {
-			if ($j <= $i) {
-				continue;
-			}
-
-			if (
-				$j === count($methodParameters) - 1
-				&& $prototypeAfterVariadic
-				&& !$methodParameter->isVariadic()
-			) {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s of method %s::%s() is not variadic.',
-					$j + 1,
-					$methodParameter->getName(),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-				))->nonIgnorable()->build();
-				continue;
-			}
-
-			if (!$methodParameter->isOptional()) {
-				$messages[] = RuleErrorBuilder::message(sprintf(
-					'Parameter #%d $%s of method %s::%s() is not optional.',
-					$j + 1,
-					$methodParameter->getName(),
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-				))->nonIgnorable()->build();
-				continue;
-			}
-		}
+		$messages = array_merge($messages, $this->methodParameterComparisonHelper->compare($prototype, $method));
 
 		if (!$prototypeVariant instanceof FunctionVariantWithPhpDocs) {
 			return $this->addErrors($messages, $node, $scope);
@@ -403,7 +164,7 @@ class OverridingMethodRule implements Rule
 
 		$prototypeReturnType = $prototypeVariant->getNativeReturnType();
 
-		if (!$this->isTypeCompatible($prototypeReturnType, $methodReturnType, $this->phpVersion->supportsReturnCovariance())) {
+		if (!$this->methodParameterComparisonHelper->isTypeCompatible($prototypeReturnType, $methodReturnType, $this->phpVersion->supportsReturnCovariance())) {
 			if ($this->phpVersion->supportsReturnCovariance()) {
 				$messages[] = RuleErrorBuilder::message(sprintf(
 					'Return type %s of method %s::%s() is not covariant with return type %s of method %s::%s().',
@@ -428,36 +189,6 @@ class OverridingMethodRule implements Rule
 		}
 
 		return $this->addErrors($messages, $node, $scope);
-	}
-
-	private function isTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsContravariance): bool
-	{
-		if ($methodParameterType instanceof MixedType) {
-			return true;
-		}
-
-		if (!$supportsContravariance) {
-			if (TypeCombinator::containsNull($methodParameterType)) {
-				$prototypeParameterType = TypeCombinator::removeNull($prototypeParameterType);
-			}
-			$methodParameterType = TypeCombinator::removeNull($methodParameterType);
-			if ($methodParameterType->equals($prototypeParameterType)) {
-				return true;
-			}
-
-			if ($methodParameterType instanceof IterableType) {
-				if ($prototypeParameterType instanceof ArrayType) {
-					return true;
-				}
-				if ($prototypeParameterType instanceof ObjectType && $prototypeParameterType->getClassName() === Traversable::class) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
-		return $methodParameterType->isSuperTypeOf($prototypeParameterType)->yes();
 	}
 
 	/**

--- a/src/Rules/Methods/OverridingMethodRule.php
+++ b/src/Rules/Methods/OverridingMethodRule.php
@@ -135,7 +135,6 @@ class OverridingMethodRule implements Rule
 
 		$methodVariant = ParametersAcceptorSelector::selectSingle($method->getVariants());
 		$methodReturnType = $methodVariant->getNativeReturnType();
-		$methodParameters = $methodVariant->getParameters();
 
 		if (
 			$this->phpVersion->hasTentativeReturnTypes()

--- a/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
+++ b/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
@@ -40,6 +40,7 @@ class InvalidPHPStanDocTagRule implements Rule
 		'@phpstan-property',
 		'@phpstan-property-read',
 		'@phpstan-property-write',
+		'@phpstan-consistent-constructor',
 	];
 
 	public function __construct(private Lexer $phpDocLexer, private PhpDocParser $phpDocParser)

--- a/tests/PHPStan/Rules/Classes/NewStaticRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/NewStaticRuleTest.php
@@ -34,4 +34,9 @@ class NewStaticRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRuleWithConsistentConstructor(): void
+	{
+		$this->analyse([__DIR__ . '/data/new-static-consistent-constructor.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/new-static-consistent-constructor.php
+++ b/tests/PHPStan/Rules/Classes/data/new-static-consistent-constructor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NewStaticConsistentConstructor;
+
+/** @phpstan-consistent-constructor  */
+class ParentClass
+{
+	public function __construct()
+	{
+	}
+
+	public function doFoo(): void
+	{
+		$foo = new static();
+	}
+}
+
+class Child extends ParentClass
+{
+	public function doBar(): void
+	{
+		$bar = new static();
+	}
+}
+

--- a/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
@@ -27,6 +27,10 @@ class ConsistentConstructorRuleTest extends RuleTestCase
 				'Method ConsistentConstructor\Foo2::__construct() overrides method ConsistentConstructor\Foo1::__construct() but misses parameter #1 $a.',
 				32,
 			],
+			[
+				'Parameter #1 $i of method ConsistentConstructor\ParentWithoutConstructorChildWithConstructorRequiredParams::__construct() is not optional.',
+				58,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
@@ -4,6 +4,8 @@ namespace PHPStan\Rules\Methods;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use function sprintf;
+use const PHP_VERSION_ID;
 
 /** @extends RuleTestCase<ConsistentConstructorRule> */
 class ConsistentConstructorRuleTest extends RuleTestCase
@@ -18,7 +20,7 @@ class ConsistentConstructorRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/consistent-constructor.php'], [
 			[
-				'Parameter #1 $b (int) of method ConsistentConstructor\Bar2::__construct() is not contravariant with parameter #1 $b (string) of method ConsistentConstructor\Bar::__construct().',
+				sprintf('Parameter #1 $b (int) of method ConsistentConstructor\Bar2::__construct() is not %s with parameter #1 $b (string) of method ConsistentConstructor\Bar::__construct().', PHP_VERSION_ID >= 70400 ? 'contravariant' : 'compatible'),
 				13,
 			],
 			[
@@ -30,7 +32,10 @@ class ConsistentConstructorRuleTest extends RuleTestCase
 
 	public function testRuleNoErrors(): void
 	{
-		$this->analyse([__DIR__ . '/data/consistent-constructor-no-errors.php'], []);
+		$this->analyse(
+			[__DIR__ . '/data/consistent-constructor-no-errors.php'],
+			PHP_VERSION_ID < 70400 ? [['Parameter #1 $b (ConsistentConstructorNoErrors\A) of method ConsistentConstructorNoErrors\Baz::__construct() is not compatible with parameter #1 $b (ConsistentConstructorNoErrors\B) of method ConsistentConstructorNoErrors\Foo::__construct().', 49]] : [],
+		);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<ConsistentConstructorRule> */
+class ConsistentConstructorRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ConsistentConstructorRule(self::getContainer()->getByType(MethodParameterComparisonHelper::class));
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/consistent-constructor.php'], [
+			[
+				'Parameter #1 $b (int) of method ConsistentConstructor\Bar2::__construct() is not contravariant with parameter #1 $b (string) of method ConsistentConstructor\Bar::__construct().',
+				13,
+			],
+			[
+				'Method ConsistentConstructor\Foo2::__construct() overrides method ConsistentConstructor\Foo1::__construct() but misses parameter #1 $a.',
+				32,
+			],
+		]);
+	}
+
+	public function testRuleNoErrors(): void
+	{
+		$this->analyse([__DIR__ . '/data/consistent-constructor-no-errors.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -19,10 +19,13 @@ class MethodSignatureRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$phpVersion = new PhpVersion(PHP_VERSION_ID);
+
 		return new OverridingMethodRule(
-			new PhpVersion(PHP_VERSION_ID),
+			$phpVersion,
 			new MethodSignatureRule($this->reportMaybes, $this->reportStatic),
 			true,
+			new MethodParameterComparisonHelper($phpVersion),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
@@ -19,10 +19,13 @@ class OverridingMethodRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$phpVersion = new PhpVersion($this->phpVersionId);
+
 		return new OverridingMethodRule(
-			new PhpVersion($this->phpVersionId),
+			$phpVersion,
 			new MethodSignatureRule(true, true),
 			false,
+			new MethodParameterComparisonHelper($phpVersion),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/consistent-constructor-no-errors.php
+++ b/tests/PHPStan/Rules/Methods/data/consistent-constructor-no-errors.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ConsistentConstructorNoErrors;
+
+class NoParent
+{
+	public function __construct(int $a)
+	{
+	}
+}
+
+class ParentWithNoConstructor {}
+
+class ParentWithNoConstructorChild extends ParentWithNoConstructor
+{
+	public function __construct(int $a)
+	{
+	}
+}
+
+/** @phpstan-consistent-constructor */
+class ParentWithConstructor
+{
+	public function __construct(int $a)
+	{
+	}
+}
+
+class ParentWithConstructorChild extends ParentWithConstructor
+{
+	public function __construct(int $b)
+	{
+	}
+}
+
+class A {}
+class B extends A {}
+
+/** @phpstan-consistent-constructor */
+class Foo
+{
+
+	public function __construct(B $b) {}
+}
+
+class Baz extends Foo
+{
+
+	public function __construct(A $b) {}
+}

--- a/tests/PHPStan/Rules/Methods/data/consistent-constructor.php
+++ b/tests/PHPStan/Rules/Methods/data/consistent-constructor.php
@@ -33,3 +33,30 @@ class Foo2 extends Foo1
 	{
 	}
 }
+
+/** @phpstan-consistent-constructor */
+class ParentWithoutConstructor {}
+
+class ParentWithoutConstructorChildWithoutConstructor extends ParentWithoutConstructor{}
+
+class ParentWithoutConstructorChildWithConstructor extends ParentWithoutConstructor
+{
+	public function __construct()
+	{
+	}
+}
+
+class ParentWithoutConstructorChildWithConstructorOptionalParams extends ParentWithoutConstructor
+{
+	public function __construct(int $i = 1)
+	{
+	}
+}
+
+class ParentWithoutConstructorChildWithConstructorRequiredParams extends ParentWithoutConstructor
+{
+	public function __construct(int $i)
+	{
+	}
+}
+

--- a/tests/PHPStan/Rules/Methods/data/consistent-constructor.php
+++ b/tests/PHPStan/Rules/Methods/data/consistent-constructor.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ConsistentConstructor;
+
+/** @phpstan-consistent-constructor */
+class Bar
+{
+	public function __construct(string $b) {}
+}
+
+class Bar2 extends Bar
+{
+	public function __construct(int $b) {}
+}
+
+
+class Foo
+{
+	public function __construct() {}
+}
+
+/** @phpstan-consistent-constructor */
+class Foo1 extends Foo
+{
+	public function __construct(int $a)
+	{
+	}
+}
+
+class Foo2 extends Foo1
+{
+	public function __construct()
+	{
+	}
+}


### PR DESCRIPTION
This PR adds a new tag called `@phpstan-consistent-constructor` and a rule to enforce it.

I wasn't sure which level this rule should be in, so for now I added it to level 0. But I can change it to correct one.

There are not many test cases because same things are covered by `OverridingMethodRule` tests. I only tested relevant stuff for this rule. But of course I can add more test cases, if there is an edge case we need to cover.