### PR TITLE
Fix/issue 7144

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4173,9 +4173,12 @@ class MutatingScope implements Scope
 			$constantArrays = TypeUtils::getOldConstantArrays($this->getType($expr->var));
 			if (count($constantArrays) > 0) {
 				$setArrays = [];
-				$dimType = $this->getType($expr->dim);
+				$dimType = ArrayType::castToArrayKeyType($this->getType($expr->dim));
 				foreach ($constantArrays as $constantArray) {
-					$setArrays[] = $constantArray->setOffsetValueType($dimType, $type);
+					$setArrays[] = $constantArray->setOffsetValueType(
+						TypeCombinator::intersect($dimType, $constantArray->getKeyType()),
+						$type,
+					);
 				}
 				$scope = $this->specifyExpressionType(
 					$expr->var,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -911,6 +911,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/constant-array-type-identical.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-str-containing-fns.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6609.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7144.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -912,6 +912,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-str-containing-fns.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6609.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7144.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7144-composer-integration.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7144-composer-integration.php
+++ b/tests/PHPStan/Analyser/data/bug-7144-composer-integration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Bug7144ComposerIntegration;
+
+use function PHPStan\Testing\assertType;
+
+Class Foo {
+	/** @var mixed[] */
+	private static $options = array(
+		'http' => array(
+			'method' => CURLOPT_CUSTOMREQUEST,
+			'content' => CURLOPT_POSTFIELDS,
+			'header' => CURLOPT_HTTPHEADER,
+			'timeout' => CURLOPT_TIMEOUT,
+		),
+		'ssl' => array(
+			'cafile' => CURLOPT_CAINFO,
+			'capath' => CURLOPT_CAPATH,
+			'verify_peer' => CURLOPT_SSL_VERIFYPEER,
+			'verify_peer_name' => CURLOPT_SSL_VERIFYHOST,
+			'local_cert' => CURLOPT_SSLCERT,
+			'local_pk' => CURLOPT_SSLKEY,
+			'passphrase' => CURLOPT_SSLKEYPASSWD,
+		),
+	);
+
+	/**
+	 * @param array{http: array{header: string[], proxy?: string, request_fulluri: bool}, ssl?: mixed[]} $options
+	 */
+	public function test3(array $options): void
+	{
+		$curlHandle = curl_init();
+		foreach (self::$options as $type => $curlOptions) {
+			foreach ($curlOptions as $name => $curlOption) {
+				\PHPStan\Testing\assertType('array{http: array, ssl?: array}', $options);
+				if (isset($options[$type][$name])) {
+					\PHPStan\Testing\assertType('array{http: array, ssl?: array}', $options);
+					if ($type === 'ssl' && $name === 'verify_peer_name') {
+						\PHPStan\Testing\assertType('array{http: array, ssl?: array}', $options);
+						curl_setopt($curlHandle, $curlOption, $options[$type][$name] === true ? 2 : $options[$type][$name]);
+					} else {
+						\PHPStan\Testing\assertType('array{http: array, ssl?: array}', $options);
+						curl_setopt($curlHandle, $curlOption, $options[$type][$name]);
+					}
+				}
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-7144.php
+++ b/tests/PHPStan/Analyser/data/bug-7144.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Bug7144;
+
+use function PHPStan\Testing\assertType;
+
+Class Foo {
+	/**
+	 * @param array{foo?: array<string>, bar?: array<string>} $arr
+	 */
+	public function test1(array $arr): void
+	{
+		foreach (['foo', 'bar'] as $key) {
+			\PHPStan\Testing\assertType('array{foo?: array<string>, bar?: array<string>}', $arr);
+			foreach ($arr[$key] as $x) {}
+		}
+	}
+
+	/**
+	 * @param array{foo?: array<string>, bar?: array<string>} $arr
+	 */
+	public function test2(array $arr): void
+	{
+		foreach (['foo', 'bar', 'baz'] as $key) {
+			\PHPStan\Testing\assertType('array{foo?: array<string>, bar?: array<string>}', $arr);
+		}
+	}
+
+	/**
+	 * @param array{foo?: array<string>, bar?: array<string>} $arr
+	 */
+	public function test3(array $arr): void
+	{
+		foreach (['foo', 'bar', 'baz'] as $key) {
+			\PHPStan\Testing\assertType('array{foo?: array<string>, bar?: array<string>}', $arr);
+			foreach ($arr[$key] as $x) {}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-7144.php
+++ b/tests/PHPStan/Analyser/data/bug-7144.php
@@ -36,4 +36,16 @@ Class Foo {
 			foreach ($arr[$key] as $x) {}
 		}
 	}
+
+	/**
+	 * @param 'foo'|'bar'|'baz' $key
+	 * @param array{foo: array<string>, bar: array<string>} $arr
+	 */
+	public function test4(string $key, array $arr): void
+	{
+		if ($arr[$key] === []) {
+			return;
+		}
+		\PHPStan\Testing\assertType('array{foo: array<string>, bar: array<string>}', $arr);
+	}
 }


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/7144

The root cause of this issue is expressed in this test https://github.com/phpstan/phpstan-src/pull/1299/commits/dc5e8652a1e68f4a3426462db432431cc5fdba6a.

When specifying `ArrayDimFetch` type, it was relying only on `$dimType`, which can be any type as seen in the test.
The type to be specified should be only be a key existing in array`.