### PR TITLE
Normalize named arguments

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2402,6 +2402,13 @@ class MutatingScope implements Scope
 			}
 
 			$functionReflection = $this->reflectionProvider->getFunction($node->name, $this);
+			$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+				$this,
+				$node->getArgs(),
+				$functionReflection->getVariants(),
+			);
+			$node = NamedArgumentsHelper::reorderFuncArguments($parametersAcceptor, $node);
+
 			foreach ($this->dynamicReturnTypeExtensionRegistry->getDynamicFunctionReturnTypeExtensions() as $dynamicFunctionReturnTypeExtension) {
 				if (!$dynamicFunctionReturnTypeExtension->isFunctionSupported($functionReflection)) {
 					continue;
@@ -2417,11 +2424,7 @@ class MutatingScope implements Scope
 				}
 			}
 
-			return ParametersAcceptorSelector::selectFromArgs(
-				$this,
-				$node->getArgs(),
-				$functionReflection->getVariants(),
-			)->getReturnType();
+			return $parametersAcceptor->getReturnType();
 		}
 
 		return new MixedType();

--- a/src/Analyser/NamedArgumentsHelper.php
+++ b/src/Analyser/NamedArgumentsHelper.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Constant\ConstantArrayType;
+use function array_key_exists;
+use function count;
+use function ksort;
+
+final class NamedArgumentsHelper
+{
+
+	public static function reorderFuncArguments(
+		ParametersAcceptor $parametersAcceptor,
+		FuncCall $functionCall,
+	): FuncCall
+	{
+		return new FuncCall(
+			$functionCall->name,
+			self::reorderArgs($parametersAcceptor, $functionCall),
+			$functionCall->getAttributes(),
+		);
+	}
+
+	public static function reorderMethodArguments(
+		ParametersAcceptor $parametersAcceptor,
+		MethodCall $methodCall,
+	): MethodCall
+	{
+		return new MethodCall(
+			$methodCall->var,
+			$methodCall->name,
+			self::reorderArgs($parametersAcceptor, $methodCall),
+			$methodCall->getAttributes(),
+		);
+	}
+
+	public static function reorderStaticCallArguments(
+		ParametersAcceptor $parametersAcceptor,
+		StaticCall $staticCall,
+	): StaticCall
+	{
+		return new StaticCall(
+			$staticCall->class,
+			$staticCall->name,
+			self::reorderArgs($parametersAcceptor, $staticCall),
+			$staticCall->getAttributes(),
+		);
+	}
+
+	/**
+	 * @return array<int, Arg>
+	 */
+	private static function reorderArgs(ParametersAcceptor $parametersAcceptor, CallLike $callLike): array
+	{
+		$signatureParameters = $parametersAcceptor->getParameters();
+		$callArgs = $callLike->getArgs();
+
+		if (count($callArgs) === 0) {
+			return [];
+		}
+
+		$hasNamedArgs = false;
+		foreach ($callArgs as $arg) {
+			if ($arg->name !== null) {
+				$hasNamedArgs = true;
+				break;
+			}
+		}
+		if (!$hasNamedArgs) {
+			return $callArgs;
+		}
+
+		$reorderedArgs = [];
+		$argumentPositions = [];
+		foreach ($signatureParameters as $i => $parameter) {
+			$argumentPositions[$parameter->getName()] = $i;
+
+			if (!$parameter->isOptional()) {
+				continue;
+			}
+
+			$defaultValue = $parameter->getDefaultValue();
+			if ($defaultValue === null) {
+				if (!$parameter->isVariadic()) {
+					throw new ShouldNotHappenException('A optional parameter must have a default value');
+				}
+				$defaultValue = new ConstantArrayType([], []);
+			}
+			$reorderedArgs[$i] = new Arg(
+				new TypeExpr($defaultValue),
+			);
+		}
+
+		foreach ($callArgs as $i => $arg) {
+			if ($arg->name === null) {
+				// add regular args as is
+				$reorderedArgs[$i] = $arg;
+			} elseif (array_key_exists($arg->name->toString(), $argumentPositions)) {
+				// order named args into the position the signature expects them
+				$reorderedArgs[$argumentPositions[$arg->name->toString()]] = $arg;
+			}
+		}
+
+		ksort($reorderedArgs);
+
+		return $reorderedArgs;
+	}
+
+}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1997,6 +1997,8 @@ class NodeScopeResolver
 						$expr->getArgs(),
 						$methodReflection->getVariants(),
 					);
+
+					$expr = NamedArgumentsHelper::reorderMethodArguments($parametersAcceptor, $expr);
 					$methodThrowPoint = $this->getMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
 					if ($methodThrowPoint !== null) {
 						$throwPoints[] = $methodThrowPoint;
@@ -2077,6 +2079,8 @@ class NodeScopeResolver
 							$expr->getArgs(),
 							$methodReflection->getVariants(),
 						);
+
+						$expr = NamedArgumentsHelper::reorderStaticCallArguments($parametersAcceptor, $expr);
 						$methodThrowPoint = $this->getStaticMethodThrowPoint($methodReflection, $expr, $scope);
 						if ($methodThrowPoint !== null) {
 							$throwPoints[] = $methodThrowPoint;
@@ -2700,6 +2704,10 @@ class NodeScopeResolver
 		MutatingScope $scope,
 	): ?ThrowPoint
 	{
+		if ($parametersAcceptor !== null) {
+			$funcCall = NamedArgumentsHelper::reorderFuncArguments($parametersAcceptor, $funcCall);
+		}
+
 		foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicFunctionThrowTypeExtensions() as $extension) {
 			if (!$extension->isFunctionSupported($functionReflection)) {
 				continue;

--- a/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionTest.php
+++ b/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionTest.php
@@ -3,13 +3,19 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use const PHP_VERSION_ID;
 
 class DynamicMethodThrowTypeExtensionTest extends TypeInferenceTestCase
 {
 
 	public function dataFileAsserts(): iterable
 	{
+		if (PHP_VERSION_ID < 80000) {
+			return [];
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-throw-type-extension.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-throw-type-extension-named-args.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/DynamicReturnTypeExtensionTypeInferenceTest.php
+++ b/tests/PHPStan/Analyser/DynamicReturnTypeExtensionTypeInferenceTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use const PHP_VERSION_ID;
 
 class DynamicReturnTypeExtensionTypeInferenceTest extends TypeInferenceTestCase
 {
@@ -10,6 +11,11 @@ class DynamicReturnTypeExtensionTypeInferenceTest extends TypeInferenceTestCase
 	public function dataAsserts(): iterable
 	{
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-types.php');
+
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-types-named-args.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-compound-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-getsingle-conditional.php');
 	}

--- a/tests/PHPStan/Analyser/NamedArgumentsHelperTest.php
+++ b/tests/PHPStan/Analyser/NamedArgumentsHelperTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\SignatureMap\NativeFunctionReflectionProvider;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use const PHP_VERSION_ID;
+
+final class NamedArgumentsHelperTest extends PHPStanTestCase
+{
+
+	/**
+	 * function call, all arguments named and given in order
+	 */
+	public function testArgumentReorderAllNamed(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$funcName = new Name('json_encode');
+		$reflectionProvider = self::getContainer()->getByType(NativeFunctionReflectionProvider::class);
+		$functionReflection = $reflectionProvider->findFunctionReflection('json_encode');
+		if ($functionReflection === null) {
+			throw new ShouldNotHappenException();
+		}
+		$parameterAcceptor = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+
+		$args = [
+			new Arg(
+				new LNumber(0),
+				false,
+				false,
+				[],
+				new Identifier('flags'),
+			),
+			new Arg(
+				new String_('my json value'),
+				false,
+				false,
+				[],
+				new Identifier('value'),
+			),
+		];
+		$funcCall = new FuncCall($funcName, $args);
+
+		$funcCall = NamedArgumentsHelper::reorderFuncArguments($parameterAcceptor, $funcCall);
+		$reorderedArgs = $funcCall->getArgs();
+		$this->assertCount(3, $reorderedArgs);
+
+		$this->assertArrayHasKey(0, $reorderedArgs);
+		$this->assertNotNull($reorderedArgs[0]->name);
+		$this->assertSame('value', $reorderedArgs[0]->name->toString());
+
+		$this->assertArrayHasKey(1, $reorderedArgs);
+		$this->assertNotNull($reorderedArgs[1]->name);
+		$this->assertSame('flags', $reorderedArgs[1]->name->toString());
+
+		// "depths" arg was added with its default value based on the signature
+		$this->assertArrayHasKey(2, $reorderedArgs);
+		$this->assertInstanceOf(TypeExpr::class, $reorderedArgs[2]->value);
+		$this->assertInstanceOf(ConstantIntegerType::class, $reorderedArgs[2]->value->getExprType());
+		$this->assertSame(512, $reorderedArgs[2]->value->getExprType()->getValue());
+	}
+
+	/**
+	 * function call, all args named, not in order
+	 */
+	public function testArgumentReorderAllNamedWithSkipped(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$funcName = new Name('json_encode');
+		$reflectionProvider = self::getContainer()->getByType(NativeFunctionReflectionProvider::class);
+		$functionReflection = $reflectionProvider->findFunctionReflection('json_encode');
+		if ($functionReflection === null) {
+			throw new ShouldNotHappenException();
+		}
+		$parameterAcceptor = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+
+		$args = [
+			new Arg(
+				new LNumber(128),
+				false,
+				false,
+				[],
+				new Identifier('depth'),
+			),
+			new Arg(
+				new String_('my json value'),
+				false,
+				false,
+				[],
+				new Identifier('value'),
+			),
+		];
+		$funcCall = new FuncCall($funcName, $args);
+
+		$funcCall = NamedArgumentsHelper::reorderFuncArguments($parameterAcceptor, $funcCall);
+		$reorderedArgs = $funcCall->getArgs();
+		$this->assertCount(3, $reorderedArgs);
+
+		$this->assertArrayHasKey(0, $reorderedArgs);
+		$this->assertNotNull($reorderedArgs[0]->name);
+		$this->assertSame('value', $reorderedArgs[0]->name->toString());
+
+		// "flags" arg was added with its default value based on the signature
+		$this->assertArrayHasKey(1, $reorderedArgs);
+		$this->assertInstanceOf(TypeExpr::class, $reorderedArgs[1]->value);
+		$this->assertInstanceOf(ConstantIntegerType::class, $reorderedArgs[1]->value->getExprType());
+		$this->assertSame(0, $reorderedArgs[1]->value->getExprType()->getValue());
+
+		$this->assertArrayHasKey(2, $reorderedArgs);
+		$this->assertNotNull($reorderedArgs[2]->name);
+		$this->assertSame('depth', $reorderedArgs[2]->name->toString());
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -48,6 +48,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		require_once __DIR__ . '/data/instanceof.php';
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/named-arguments.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/date.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/instanceof.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/integer-range-types.php');

--- a/tests/PHPStan/Analyser/data/dynamic-method-return-types-named-args.php
+++ b/tests/PHPStan/Analyser/data/dynamic-method-return-types-named-args.php
@@ -1,0 +1,26 @@
+<?php // lint >= 8.0
+
+namespace DynamicMethodReturnTypesNamespace;
+
+use function PHPStan\Testing\assertType;
+
+class FooNamedArgs
+{
+
+	public function __construct()
+	{
+	}
+
+	public function doFoo()
+	{
+		$em = new EntityManager();
+		$iem = new InheritedEntityManager();
+
+		assertType('DynamicMethodReturnTypesNamespace\Foo', $em->getByPrimary(className: \DynamicMethodReturnTypesNamespace\Foo::class));
+		assertType('DynamicMethodReturnTypesNamespace\Foo', $iem->getByPrimary(className: \DynamicMethodReturnTypesNamespace\Foo::class));
+
+		assertType('DynamicMethodReturnTypesNamespace\Foo', \DynamicMethodReturnTypesNamespace\EntityManager::createManagerForEntity(className: \DynamicMethodReturnTypesNamespace\Foo::class));
+		assertType('DynamicMethodReturnTypesNamespace\Foo', \DynamicMethodReturnTypesNamespace\InheritedEntityManager::createManagerForEntity(className: \DynamicMethodReturnTypesNamespace\Foo::class));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/dynamic-method-throw-type-extension-named-args.php
+++ b/tests/PHPStan/Analyser/data/dynamic-method-throw-type-extension-named-args.php
@@ -1,0 +1,123 @@
+<?php // lint >= 8.0
+
+namespace DynamicMethodThrowTypeExtensionNamedArgs;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodThrowTypeExtension;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\Type;
+use function PHPStan\Testing\assertVariableCertainty;
+
+class MethodThrowTypeExtension implements DynamicMethodThrowTypeExtension
+{
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'throwOrNot';
+	}
+
+	public function getThrowTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+	{
+		if (count($methodCall->args) < 1) {
+			return $methodReflection->getThrowType();
+		}
+
+		$argType = $scope->getType($methodCall->args[0]->value);
+		if ((new ConstantBooleanType(true))->isSuperTypeOf($argType)->yes()) {
+			return $methodReflection->getThrowType();
+		}
+
+		return null;
+	}
+
+}
+
+class StaticMethodThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'staticThrowOrNot';
+	}
+
+	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+	{
+		if (count($methodCall->args) < 1) {
+			return $methodReflection->getThrowType();
+		}
+
+		$argType = $scope->getType($methodCall->args[0]->value);
+		if ((new ConstantBooleanType(true))->isSuperTypeOf($argType)->yes()) {
+			return $methodReflection->getThrowType();
+		}
+
+		return null;
+	}
+
+}
+
+class Foo
+{
+
+	/** @throws \Exception */
+	public function throwOrNot(bool $need): int
+	{
+		if ($need) {
+			throw new \Exception();
+		}
+
+		return 1;
+	}
+
+	/** @throws \Exception */
+	public static function staticThrowOrNot(bool $need): int
+	{
+		if ($need) {
+			throw new \Exception();
+		}
+
+		return 1;
+	}
+
+	public function doFoo1()
+	{
+		try {
+			$result = $this->throwOrNot(need: true);
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createMaybe(), $result);
+		}
+	}
+
+	public function doFoo2()
+	{
+		try {
+			$result = $this->throwOrNot(need: false);
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createYes(), $result);
+		}
+	}
+
+	public function doFoo3()
+	{
+		try {
+			$result = self::staticThrowOrNot(need: true);
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createMaybe(), $result);
+		}
+	}
+
+	public function doFoo4()
+	{
+		try {
+			$result = self::staticThrowOrNot(need: false);
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createYes(), $result);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/named-arguments.php
+++ b/tests/PHPStan/Analyser/data/named-arguments.php
@@ -1,0 +1,14 @@
+<?php // lint >= 8.0
+
+namespace NamedArguments;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function array_search() {
+		$haystack = ['a', 'b', 'c'];
+		$needle = 'c';
+		assertType('2', array_search(strict: true, needle: $needle, haystack: $haystack));
+	}
+}

--- a/tests/PHPStan/Analyser/dynamic-throw-type-extension.neon
+++ b/tests/PHPStan/Analyser/dynamic-throw-type-extension.neon
@@ -8,3 +8,14 @@ services:
 		class: DynamicMethodThrowTypeExtension\StaticMethodThrowTypeExtension
 		tags:
 			- phpstan.dynamicStaticMethodThrowTypeExtension
+
+	-
+		class: DynamicMethodThrowTypeExtensionNamedArgs\MethodThrowTypeExtension
+		tags:
+			- phpstan.dynamicMethodThrowTypeExtension
+
+	-
+		class: DynamicMethodThrowTypeExtensionNamedArgs\StaticMethodThrowTypeExtension
+		tags:
+			- phpstan.dynamicStaticMethodThrowTypeExtension
+

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -144,6 +144,15 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4863.php'], []);
 	}
 
+	public function testBug5866(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-5866.php'], []);
+	}
+
 	public function testBug4814(): void
 	{
 		if (PHP_VERSION_ID < 70300) {

--- a/tests/PHPStan/Rules/Exceptions/data/bug-5866.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-5866.php
@@ -1,0 +1,44 @@
+<?php // lint >= 8.0
+
+namespace Bug5866;
+
+use InvalidArgumentException;
+use JsonException;
+
+class Foo
+{
+
+	/**
+	 * @param string $contents
+	 */
+	public function decode($contents) {
+		try {
+			$parsed = json_decode($contents, true, flags: JSON_BIGINT_AS_STRING | JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+		} catch (JsonException $exception) {
+			throw new InvalidArgumentException('Unable to decode contents');
+		}
+	}
+
+	/**
+	 * @param string $contents
+	 */
+	public function decode2($contents) {
+		try {
+			$parsed = json_decode($contents, depth: 123, flags: JSON_BIGINT_AS_STRING | JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR, associative: true,);
+		} catch (JsonException $exception) {
+			throw new InvalidArgumentException('Unable to decode contents');
+		}
+	}
+
+	/**
+	 * @param string $contents
+	 */
+	public function encode($contents) {
+		try {
+			$encoded = json_encode($contents, depth: 2, flags: JSON_BIGINT_AS_STRING | JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
+		} catch (JsonException $exception) {
+			throw new InvalidArgumentException('Unable to encode contents');
+		}
+	}
+
+}


### PR DESCRIPTION
Supersedes https://github.com/phpstan/phpstan-src/pull/750

/cc @staabm This isn't yet ready for prime-time. For one, I don't think that some extension types are called with the reordered arguments. Let's take dynamic method return type extensions for example:

```php
		foreach (TypeUtils::getDirectClassNames($typeWithMethod) as $className) {
			if ($methodCall instanceof MethodCall) {
				foreach ($this->dynamicReturnTypeExtensionRegistry->getDynamicMethodReturnTypeExtensionsForClass($className) as $dynamicMethodReturnTypeExtension) {
					if (!$dynamicMethodReturnTypeExtension->isMethodSupported($methodReflection)) {
						continue;
					}

					$resolvedType = $dynamicMethodReturnTypeExtension->getTypeFromMethodCall($methodReflection, $methodCall, $this);
					if ($resolvedType === null) {
						continue;
					}

					$resolvedTypes[] = $resolvedType;
				}
			} else {
				foreach ($this->dynamicReturnTypeExtensionRegistry->getDynamicStaticMethodReturnTypeExtensionsForClass($className) as $dynamicStaticMethodReturnTypeExtension) {
					if (!$dynamicStaticMethodReturnTypeExtension->isStaticMethodSupported($methodReflection)) {
						continue;
					}

					$resolvedType = $dynamicStaticMethodReturnTypeExtension->getTypeFromStaticMethodCall(
						$methodReflection,
						$methodCall,
						$this,
					);
					if ($resolvedType === null) {
						continue;
					}

					$resolvedTypes[] = $resolvedType;
				}
			}
		}
```

No indication of usage of NamedArgumentsHelper.

Additionally, it looks like that in some cases, the arguments are not indexed from zero. Which can be seen from these errors:

```
1230) PHPStan\Analyser\LegacyNodeScopeResolverTest::testPhp74Functions with data set #26 ('non-empty-array<int, string>', '$mbStrSplitConstantStringWith...coding')
Undefined array key 0

/Users/ondrej/Development/phpstan/src/Type/Php/StrSplitFunctionReturnTypeExtension.php:87
```

Would you be able to bring this over the finish line? Thanks.