### PR TITLE
Fix/issue 7000 2

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4173,11 +4173,11 @@ class MutatingScope implements Scope
 			$constantArrays = TypeUtils::getOldConstantArrays($this->getType($expr->var));
 			if (count($constantArrays) > 0) {
 				$setArrays = [];
-				$dimType = $this->getType($expr->dim);
+				$dimType = ArrayType::castToArrayKeyType($this->getType($expr->dim));
 				if (!$dimType instanceof UnionType) {
 					foreach ($constantArrays as $constantArray) {
 						$setArrays[] = $constantArray->setOffsetValueType(
-							TypeCombinator::intersect(ArrayType::castToArrayKeyType($dimType), $constantArray->getKeyType()),
+							TypeCombinator::intersect($dimType, $constantArray->getKeyType()),
 							$type,
 						);
 					}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4174,26 +4174,18 @@ class MutatingScope implements Scope
 			if (count($constantArrays) > 0) {
 				$setArrays = [];
 				$dimType = $this->getType($expr->dim);
-				if ($dimType instanceof UnionType) {
-					$dimTypes = $dimType->getTypes();
-				} else {
-					$dimTypes = [$dimType];
-				}
-				foreach ($constantArrays as $constantArray) {
-					foreach ($dimTypes as $innerType) {
-						if ($constantArray->hasOffsetValueType($innerType)->no()) {
-							continue;
-						}
+				if (!$dimType instanceof UnionType) {
+					foreach ($constantArrays as $constantArray) {
 						$setArrays[] = $constantArray->setOffsetValueType(
-							TypeCombinator::intersect(ArrayType::castToArrayKeyType($innerType), $constantArray->getKeyType()),
-							$dimType instanceof UnionType ? TypeCombinator::intersect($type, $constantArray->getOffsetValueType($innerType)) : $type,
+							TypeCombinator::intersect(ArrayType::castToArrayKeyType($dimType), $constantArray->getKeyType()),
+							$type,
 						);
 					}
+					$scope = $this->specifyExpressionType(
+						$expr->var,
+						TypeCombinator::union(...$setArrays),
+					);
 				}
-				$scope = $this->specifyExpressionType(
-					$expr->var,
-					TypeCombinator::union(...$setArrays),
-				);
 			}
 		}
 

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
@@ -83,7 +83,7 @@ class NonexistentOffsetInArrayDimFetchRule implements Rule
 			return [];
 		}
 
-		if ($dimType === null) {
+		if ($dimType === null || $scope->isSpecified($node)) {
 			return [];
 		}
 

--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -86,13 +86,9 @@ class IssetCheck
 				)->build();
 			}
 
-			if ($hasOffsetValue->maybe()) {
-				return null;
-			}
-
 			// If offset is cannot be null, store this error message and see if one of the earlier offsets is.
 			// E.g. $array['a']['b']['c'] ?? null; is a valid coalesce if a OR b or C might be null.
-			if ($hasOffsetValue->yes()) {
+			if ($hasOffsetValue->yes() || $scope->isSpecified($expr)) {
 				if ($error !== null) {
 					return $error;
 				}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -879,6 +879,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3853.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/conditional-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/constant-array-optional-set.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7000.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6383.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-3284.php');
 

--- a/tests/PHPStan/Analyser/data/bug-7000.php
+++ b/tests/PHPStan/Analyser/data/bug-7000.php
@@ -12,7 +12,7 @@ class Foo
 		$composer = array();
 		foreach (array('require', 'require-dev') as $linkType) {
 			if (isset($composer[$linkType])) {
-				assertType('array{require?: array<string, string>, require-dev?: array<string, string>}&non-empty-array', $composer);
+				assertType('array{require?: array<string, string>, require-dev?: array<string, string>}', $composer);
 				foreach ($composer[$linkType] as $x) {}
 			}
 		}

--- a/tests/PHPStan/Analyser/data/bug-7000.php
+++ b/tests/PHPStan/Analyser/data/bug-7000.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug7000;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function doBar(): void
+	{
+		/** @var array{require?: array<string, string>, require-dev?: array<string, string>} $composer */
+		$composer = array();
+		foreach (array('require', 'require-dev') as $linkType) {
+			if (isset($composer[$linkType])) {
+				assertType('array{require?: array<string, string>, require-dev?: array<string, string>}&non-empty-array', $composer);
+				foreach ($composer[$linkType] as $x) {}
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-7000.php
+++ b/tests/PHPStan/Analyser/data/bug-7000.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bug7000;
+namespace Bug7000Analyser;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -395,4 +395,9 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6508(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6508.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -387,7 +387,12 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	public function testBug7000(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-7000.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-7000.php'], [
+			[
+				"Offset 'require'|'require-dev' does not exist on array{require?: array<string, string>, require-dev?: array<string, string>}.",
+				16,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -385,4 +385,9 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4885.php'], []);
 	}
 
+	public function testBug7000(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7000.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-6508.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-6508.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bug6508;
+
+class Foo
+{
+	/**
+	 * @param array{
+	 *   type1?: array{bool: bool},
+	 *   type2?: array{bool: bool}
+	 * } $types
+	 * @param 'type1'|'type2' $type
+	 */
+	function test(array $types, string $type): void
+	{
+		if (isset($types[$type]) && $types[$type]['bool']) {}
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/bug-7000.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-7000.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7000;
+
+class Foo
+{
+	public function doBar(): void
+	{
+		/** @var array{require?: array<string, string>, require-dev?: array<string, string>} $composer */
+		$composer = array();
+		/** @var 'require'|'require-dev' $foo */
+		$foo = '';
+		foreach (array('require', 'require-dev') as $linkType) {
+			if (isset($composer[$linkType])) {
+				foreach ($composer[$linkType] as $x) {} // should not report error
+				foreach ($composer[$foo] as $x) {} // should report error. It can be $linkType = 'require', $foo = 'require-dev'
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-7190.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7190.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Bug7190;
+
+interface MyObject {
+	public function getId(): int;
+}
+
+class HelloWorld
+{
+	/**
+	 * @param array<int, int> $array
+	 */
+	public function sayHello(array $array, MyObject $object): int
+	{
+		if (!isset($array[$object->getId()])) {
+			return 1;
+		}
+
+		return $array[$object->getId()] ?? 2;
+	}
+}

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -334,4 +334,21 @@ class NullCoalesceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7190(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = false;
+
+		$this->analyse([__DIR__ . '/../Properties/data/bug-7190.php'], [
+			[
+				'Offset int on array<int, int> on left side of ?? always exists and is not nullable.',
+				20,
+			],
+		]);
+	}
+
 }


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/6508
fixes https://github.com/phpstan/phpstan/issues/7000
fixes https://github.com/phpstan/phpstan/issues/7190
see https://github.com/phpstan/phpstan-src/pull/1299

This is (a little hacky) solution to solve `isset` expression specifying now.

There are two problems in `specifyExpressionType` for `ArrayDimFetch` (that cannot be solved easily I think) now.

1. Specifying `ArrayDimFetch` with the same type of the current value can change the type in some cases

ex. https://phpstan.org/r/941b7692-8141-4fee-a410-303706ad0abf
```php
Class Foo {	
	/**
	 * @param 'id'|'name' $key
	 * @param array{id:int, name:string} $data
	 */
	public function test2(string $key, array $data): void {
		if (isset($data[$key])) {
			\PHPStan\Testing\assertType('array{id: int, name: string}', $data);
		}
	}
}
```
this case was skipped before https://github.com/phpstan/phpstan-src/pull/1307/commits/c0bf9153bc4b1f9713d833d1487c756a7a9b5bbf, but the current implementation of type specifying changes the type to 'array{id: int|string, name: int|string}'

2. revertNonNullability cannot revert the non nullability correctly. https://github.com/phpstan/phpstan-src/blob/58b6023fa79d6335ed60b0644d80cd55757e5c34/src/Analyser/NodeScopeResolver.php#L1593-L1607

A - (specify B) >  -(specify A)> !== A

For example, we cannot know whether the offset was marked as required or not before the specification. (maybe https://github.com/phpstan/phpstan/issues/7224 is related to this problem)

array{ 'optional'?: string|null } - (specify non null) > array{ 'optional': string } - (specify null) > 
array{ 'optional': string|null } - (specify non null) > array{ 'optional': string }  - (specify null) >

I had to skip $dimType with `UnionType` https://github.com/phpstan/phpstan-src/commit/bd2eb4e6839a694c7f13c2e5d856efbccc63828c because of these reasons (for now).