### PR TITLE
use conditional parameter for is_a() via stub

### DIFF
--- a/src/Analyser/DirectScopeFactory.php
+++ b/src/Analyser/DirectScopeFactory.php
@@ -23,6 +23,9 @@ use function is_a;
 class DirectScopeFactory implements ScopeFactory
 {
 
+	/**
+	 * @param class-string $scopeClass
+	 */
 	public function __construct(
 		private string $scopeClass,
 		private ReflectionProvider $reflectionProvider,

--- a/src/Analyser/LazyScopeFactory.php
+++ b/src/Analyser/LazyScopeFactory.php
@@ -24,6 +24,9 @@ class LazyScopeFactory implements ScopeFactory
 
 	private bool $explicitMixedInUnknownGenericNew;
 
+	/**
+	 * @param class-string $scopeClass
+	 */
 	public function __construct(
 		private string $scopeClass,
 		private Container $container,

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @param ($allow_string is false ? object : object|class-string) $object_or_class
+ * @param ($allow_string is false ? object : object|string) $object_or_class
  * @param class-string $class
  * @param bool $allow_string
  * @return ($allow_string is false ? ($object_or_class is object ? bool : false) : bool)

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @param mixed $object_or_class
+ * @param ($allow_string is false ? object : object|class-string) $object_or_class
  * @param class-string $class
  * @param bool $allow_string
  * @return ($allow_string is false ? ($object_or_class is object ? bool : false) : bool)

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -951,7 +951,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 	public function testBug4371(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-4371.php'], [
+		$errors = [
 			[
 				'Parameter #1 $object_or_class of function is_a expects object, string given.',
 				14,
@@ -960,7 +960,23 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #1 $object_or_class of function is_a expects object, string given.',
 				22,
 			],
-		]);
+		];
+		
+		if (PHP_VERSION_ID < 80000) {
+			// php 7.x had different parameter names
+			$errors = [
+				[
+					'Parameter #1 object_or_string of function is_a expects object, string given.',
+					14,
+				],
+				[
+					'Parameter #1 object_or_string of function is_a expects object, string given.',
+					22,
+				],
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-4371.php'], $errors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -966,11 +966,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			// php 7.x had different parameter names
 			$errors = [
 				[
-					'Parameter #1 object_or_string of function is_a expects object, string given.',
+					'Parameter #1 $object_or_string of function is_a expects object, string given.',
 					14,
 				],
 				[
-					'Parameter #1 object_or_string of function is_a expects object, string given.',
+					'Parameter #1 $object_or_string of function is_a expects object, string given.',
 					22,
 				],
 			];

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -959,7 +959,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			[
 				'Parameter #1 $object_or_class of function is_a expects object, string given.',
 				22,
-			]
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -961,7 +961,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				22,
 			],
 		];
-		
+
 		if (PHP_VERSION_ID < 80000) {
 			// php 7.x had different parameter names
 			$errors = [

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -949,4 +949,18 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7017.php'], $errors);
 	}
 
+	public function testBug4371(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-4371.php'], [
+			[
+				'Parameter #1 $object_or_class of function is_a expects object, string given.',
+				14,
+			],
+			[
+				'Parameter #1 $object_or_class of function is_a expects object, string given.',
+				22,
+			]
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-4371.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-4371.php
@@ -28,9 +28,7 @@ class Hello {
 
 	public function allFine() {
 		if(is_a(Bar::class, Foo::class, true)) { // no error
-			echo "This will never be true";
-		} else {
-			echo "NO";
+			echo "All good";
 		}
 	}
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-4371.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-4371.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4371;
+
+class Foo {
+}
+
+class Bar extends Foo {
+
+}
+
+class Hello {
+	public function foo() {
+		if(is_a(Bar::class, Foo::class)) {
+			echo "This will never be true";
+		} else {
+			echo "NO";
+		}
+	}
+
+	public function bar() {
+		if(is_a(Bar::class, Foo::class, false)) {
+			echo "This will never be true";
+		} else {
+			echo "NO";
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-4371.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-4371.php
@@ -11,7 +11,7 @@ class Bar extends Foo {
 
 class Hello {
 	public function foo() {
-		if(is_a(Bar::class, Foo::class)) {
+		if(is_a(Bar::class, Foo::class)) { // should error
 			echo "This will never be true";
 		} else {
 			echo "NO";
@@ -19,7 +19,15 @@ class Hello {
 	}
 
 	public function bar() {
-		if(is_a(Bar::class, Foo::class, false)) {
+		if(is_a(Bar::class, Foo::class, false)) { // should error
+			echo "This will never be true";
+		} else {
+			echo "NO";
+		}
+	}
+
+	public function allFine() {
+		if(is_a(Bar::class, Foo::class, true)) { // no error
 			echo "This will never be true";
 		} else {
 			echo "NO";


### PR DESCRIPTION
is_a: if third argument is false then do not allow string in first argument

refs https://github.com/phpstan/phpstan/issues/4371