### PR TITLE
Prevent redundant messages about missing iterable types in conditional target/subject

### DIFF
--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -10,6 +10,8 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\ConditionalType;
+use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
@@ -21,6 +23,7 @@ use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeWithClassName;
 use Traversable;
 use function array_keys;
+use function array_merge;
 use function in_array;
 use function sprintf;
 
@@ -69,6 +72,15 @@ class MissingTypehintCheck
 				return $type;
 			}
 			if ($type instanceof AccessoryType) {
+				return $type;
+			}
+			if ($type instanceof ConditionalType || $type instanceof ConditionalTypeForParameter) {
+				$iterablesWithMissingValueTypehint = array_merge(
+					$iterablesWithMissingValueTypehint,
+					$this->getIterableTypesWithMissingValueTypehint($type->getIf()),
+					$this->getIterableTypesWithMissingValueTypehint($type->getElse()),
+				);
+
 				return $type;
 			}
 			if ($type->isIterable()->yes()) {

--- a/src/Type/ConditionalType.php
+++ b/src/Type/ConditionalType.php
@@ -36,6 +36,16 @@ final class ConditionalType implements CompoundType, LateResolvableType
 		return $this->target;
 	}
 
+	public function getIf(): Type
+	{
+		return $this->if;
+	}
+
+	public function getElse(): Type
+	{
+		return $this->else;
+	}
+
 	public function isNegated(): bool
 	{
 		return $this->negated;

--- a/src/Type/ConditionalTypeForParameter.php
+++ b/src/Type/ConditionalTypeForParameter.php
@@ -36,6 +36,16 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 		return $this->target;
 	}
 
+	public function getIf(): Type
+	{
+		return $this->if;
+	}
+
+	public function getElse(): Type
+	{
+		return $this->else;
+	}
+
 	public function isNegated(): bool
 	{
 		return $this->negated;

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -602,15 +602,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		}
 
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6896.php');
-		$this->assertCount(4, $errors);
+		$this->assertCount(3, $errors);
 		$this->assertSame('Generic type IteratorIterator<(int|string), mixed> in PHPDoc tag @return does not specify all template types of class IteratorIterator: TKey, TValue, TIterator', $errors[0]->getMessage());
 		$this->assertSame(38, $errors[0]->getLine());
-		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() return type has no value type specified in iterable type array.', $errors[1]->getMessage());
+		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() return type with generic class Bug6896\XIterator does not specify its types: TKey, TValue', $errors[1]->getMessage());
 		$this->assertSame(38, $errors[1]->getLine());
-		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() return type with generic class Bug6896\XIterator does not specify its types: TKey, TValue', $errors[2]->getMessage());
-		$this->assertSame(38, $errors[2]->getLine());
-		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() should return array<TRandKey of (int|string), TRandVal>|Bug6896\XIterator<TRandKey of (int|string), TRandVal>|(iterable<TRandKey of (int|string), TRandVal>&LimitIterator)|IteratorIterator<TRandKey of (int|string), TRandVal> but returns TRandList of array<TRandKey of (int|string), TRandVal>|Traversable<TRandKey of (int|string), TRandVal>.', $errors[3]->getMessage());
-		$this->assertSame(42, $errors[3]->getLine());
+		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() should return array<TRandKey of (int|string), TRandVal>|Bug6896\XIterator<TRandKey of (int|string), TRandVal>|(iterable<TRandKey of (int|string), TRandVal>&LimitIterator)|IteratorIterator<TRandKey of (int|string), TRandVal> but returns TRandList of array<TRandKey of (int|string), TRandVal>|Traversable<TRandKey of (int|string), TRandVal>.', $errors[2]->getMessage());
+		$this->assertSame(42, $errors[2]->getLine());
 	}
 
 	public function testBug6940(): void
@@ -771,6 +769,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertCount(1, $errors);
 		$this->assertSame('Method Bug7214\HelloWorld::getFoo() has no return type specified.', $errors[0]->getMessage());
 		$this->assertSame(6, $errors[0]->getLine());
+	}
+
+	public function testBug7215(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7215.php');
+		$this->assertNoErrors($errors);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7215.php
+++ b/tests/PHPStan/Analyser/data/bug-7215.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7215;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @param array<T,mixed> $array
+ * @return (T is int ? ($array is non-empty-array ? non-empty-list<numeric-string> : list<numeric-string>) : ($array is non-empty-array ? non-empty-list<numeric-string> : list<string>))
+*/
+function keysAsString(array $array): array
+{
+	$keys = [];
+
+	foreach ($array as $k => $_) {
+		$keys[] = (string)$k;
+	}
+
+	return $keys;
+}
+
+function () {
+	assertType('array<int, numeric-string>', keysAsString([]));
+	assertType('non-empty-array<int, numeric-string>', keysAsString(['' => '']));
+};


### PR DESCRIPTION
Fixes phpstan/phpstan#7215