### PR TITLE
Narrow the type for the `mb_ereg_replace_callback()` callable

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -6318,7 +6318,7 @@ return [
 'mb_ereg' => ['int|false', 'pattern'=>'string', 'string'=>'string', '&w_registers='=>'array'],
 'mb_ereg_match' => ['bool', 'pattern'=>'string', 'string'=>'string', 'option='=>'string'],
 'mb_ereg_replace' => ['string|false|null', 'pattern'=>'string', 'replacement'=>'string', 'string'=>'string', 'option='=>'string'],
-'mb_ereg_replace_callback' => ['string|false|null', 'pattern'=>'string', 'callback'=>'callable', 'string'=>'string', 'option='=>'string'],
+'mb_ereg_replace_callback' => ['string|false|null', 'pattern'=>'string', 'callback'=>'callable(array<int|string, string>):string', 'string'=>'string', 'option='=>'string'],
 'mb_ereg_search' => ['bool', 'pattern='=>'string', 'option='=>'string'],
 'mb_ereg_search_getpos' => ['int'],
 'mb_ereg_search_getregs' => ['array|false'],

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -633,6 +633,28 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testMbEregReplaceCallback(): void
+	{
+		$this->analyse([__DIR__ . '/data/mb_ereg_replace_callback.php'], [
+			[
+				'Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(string): string given.',
+				6,
+			],
+			[
+				'Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(string): string given.',
+				13,
+			],
+			[
+				'Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(array): void given.',
+				20,
+			],
+			[
+				'Parameter #2 $callback of function mb_ereg_replace_callback expects callable(array<int|string, string>): string, Closure(): void given.',
+				25,
+			],
+		]);
+	}
+
 	public function testUasortCallback(): void
 	{
 		$this->analyse([__DIR__ . '/data/uasort.php'], [

--- a/tests/PHPStan/Rules/Functions/data/mb_ereg_replace_callback.php
+++ b/tests/PHPStan/Rules/Functions/data/mb_ereg_replace_callback.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+// Incorrect
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function(string $string): string {
+		return $string;
+	},
+	'subject'
+);
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function(string $string) {
+		return $string;
+	},
+	'subject'
+);
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function(array $matches) {},
+	'subject'
+);
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function() {},
+	'subject'
+);
+
+// Correct
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function(array $matches): string {
+		return $matches[0];
+	},
+	'subject'
+);
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function(array $matches) {
+		return $matches[0];
+	},
+	'subject'
+);
+$string = mb_ereg_replace_callback(
+	'pattern',
+	function() {
+		return 'Hello';
+	},
+	'subject'
+);


### PR DESCRIPTION
Everything that was added in #758 for `preg_replace_callback()` also applies to `mb_ereg_replace_callback()`. The parameters and return type for its callback are identical.

* https://www.php.net/manual/en/function.mb-ereg-replace-callback.php
* https://3v4l.org/tIOhH