### PR TITLE
handle invalid parameter lists in ArgumentsNormalizer

### DIFF
--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -84,10 +84,6 @@ final class ArgumentsNormalizer
 		$signatureParameters = $parametersAcceptor->getParameters();
 		$callArgs = $callLike->getArgs();
 
-		if (count($callArgs) === 0) {
-			return [];
-		}
-
 		$hasNamedArgs = false;
 		foreach ($callArgs as $arg) {
 			if ($arg->name !== null) {
@@ -95,7 +91,22 @@ final class ArgumentsNormalizer
 				break;
 			}
 		}
+
 		if (!$hasNamedArgs) {
+			$requiredArgsCount = 0;
+			foreach($signatureParameters as $parameter) {
+				if ($parameter->isOptional()) {
+					continue;
+				}
+
+				$requiredArgsCount++;
+			}
+
+			// required arguments are missing
+			if (count($callArgs) < $requiredArgsCount) {
+				return null;
+			}
+
 			return $callArgs;
 		}
 

--- a/tests/PHPStan/Analyser/ArgumentsNormalizerTest.php
+++ b/tests/PHPStan/Analyser/ArgumentsNormalizerTest.php
@@ -186,4 +186,21 @@ final class ArgumentsNormalizerTest extends PHPStanTestCase
 		$this->assertSame(0, $reorderedArgs[1]->value->value);
 	}
 
+	public function testRegularCallMissingRequiredArgs(): void
+	{
+		$funcName = new Name('json_encode');
+		$reflectionProvider = self::getContainer()->getByType(NativeFunctionReflectionProvider::class);
+		$functionReflection = $reflectionProvider->findFunctionReflection('json_encode');
+		if ($functionReflection === null) {
+			throw new ShouldNotHappenException();
+		}
+		$parameterAcceptor = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants());
+
+		$args = [];
+		$funcCall = new FuncCall($funcName, $args);
+
+		$funcCall = ArgumentsNormalizer::reorderFuncArguments($parameterAcceptor, $funcCall);
+		$this->assertNull($funcCall);
+	}
+
 }


### PR DESCRIPTION
implement remaining details mentioned in https://github.com/phpstan/phpstan-src/pull/1305#issuecomment-1124874931

> And similarly, if someone calls foo(1, 2) (named arguments were not used, but some required arguments are missing), we can also return null to prevent some nasty bugs in the extensions.