### PR TITLE
Fix constant array comparison for optional keys

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2282,8 +2282,6 @@ class MutatingScope implements Scope
 		$resultType = new ConstantBooleanType(true);
 
 		foreach ($leftKeyTypes as $i => $leftKeyType) {
-			unset($leftKeyTypes[$i]);
-
 			$leftOptional = $leftType->isOptionalKey($i);
 			if ($leftOptional) {
 				$resultType = new BooleanType();
@@ -2296,7 +2294,6 @@ class MutatingScope implements Scope
 				continue;
 			}
 
-			$rightOptional = false;
 			$found = false;
 			foreach ($rightKeyTypes as $j => $rightKeyType) {
 				unset($rightKeyTypes[$j]);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2286,6 +2286,7 @@ class MutatingScope implements Scope
 
 		$leftValueTypes = $leftType->getValueTypes();
 		$rightValueTypes = $rightType->getValueTypes();
+		$resultType = new ConstantBooleanType(true);
 		foreach ($leftKeyTypes as $i => $keyType) {
 			$rightKeyType = $rightKeyTypes[$i];
 			if (!$keyType->equals($rightKeyType)) {
@@ -2298,9 +2299,10 @@ class MutatingScope implements Scope
 			if ($leftIdenticalToRight instanceof ConstantBooleanType && !$leftIdenticalToRight->getValue()) {
 				return new ConstantBooleanType(false);
 			}
+			$resultType = TypeCombinator::union($resultType, $leftIdenticalToRight);
 		}
 
-		return new ConstantBooleanType(true);
+		return $resultType->toBoolean();
 	}
 
 	private function resolveConcatType(Expr\BinaryOp\Concat|Expr\AssignOp\Concat $node): Type

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -130,6 +130,11 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $this->optionalKeys;
 	}
 
+	public function hasOptionalKeys(): bool
+	{
+		return count($this->optionalKeys) > 0;
+	}
+
 	/**
 	 * @return self[]
 	 */

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -130,11 +130,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $this->optionalKeys;
 	}
 
-	public function hasOptionalKeys(): bool
-	{
-		return count($this->optionalKeys) > 0;
-	}
-
 	/**
 	 * @return self[]
 	 */

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -819,6 +819,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame(30, $errors[2]->getLine());
 	}
 
+	public function testBug7248(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7248.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-7248.php
+++ b/tests/PHPStan/Analyser/data/bug-7248.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7248;
+
+/**
+ * @phpstan-type A array{
+ *     data?: array<string, mixed>,
+ *     extensions?: array<string, mixed>
+ * }
+ */
+class HelloWorld
+{
+    /**
+     * @phpstan-return A
+     */
+    public function toArray(): array {
+		return [];
+	}
+}
+
+function () {
+	$hw = new HelloWorld;
+	assert(['extensions' => ['foo' => 'bar']] === $hw->toArray());
+};

--- a/tests/PHPStan/Analyser/data/constant-array-type-identical.php
+++ b/tests/PHPStan/Analyser/data/constant-array-type-identical.php
@@ -21,8 +21,8 @@ class Foo
 		assertType('false', [1] === [2]);
 		assertType('false', [1] !== [1]);
 		assertType('true', [1] !== [2]);
-		assertType('true', [$s] === [$s]);
-		assertType('false', [$s] !== [$s]);
+		assertType('bool', [$s] === [$s]);
+		assertType('bool', [$s] !== [$s]);
 
 		$a = [1];
 		if (doFoo()) {
@@ -49,6 +49,24 @@ class Foo
 
 		assertType('bool', $a === $b);
 		assertType('bool', $a !== $b);
+	}
+
+	/**
+	 * @param array{a?: int} $a
+	 * @param array{b?: int} $b
+	 */
+	function doBar(array $a, array $b): void
+	{
+		assertType('bool', $a === $b);
+	}
+
+	/**
+	 * @param array{c: int, d?: int} $a
+	 * @param array{e: int, f?: int} $b
+	 */
+	function doBaz(array $a, array $b): void
+	{
+		assertType('false', $a === $b);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/constant-array-type-identical.php
+++ b/tests/PHPStan/Analyser/data/constant-array-type-identical.php
@@ -58,6 +58,10 @@ class Foo
 	function doBar(array $a, array $b): void
 	{
 		assertType('bool', $a === $b);
+		assertType('bool', $a == $b);
+
+		assertType('bool', $a !== $b);
+		assertType('bool', $a != $b);
 	}
 
 	/**
@@ -67,6 +71,10 @@ class Foo
 	function doBaz(array $a, array $b): void
 	{
 		assertType('false', $a === $b);
+		assertType('false', $a == $b);
+
+		assertType('true', $a !== $b);
+		assertType('true', $a != $b);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/constant-array-type-identical.php
+++ b/tests/PHPStan/Analyser/data/constant-array-type-identical.php
@@ -21,8 +21,8 @@ class Foo
 		assertType('false', [1] === [2]);
 		assertType('false', [1] !== [1]);
 		assertType('true', [1] !== [2]);
-		assertType('bool', [$s] === [$s]);
-		assertType('bool', [$s] !== [$s]);
+		assertType('true', [$s] === [$s]);
+		assertType('false', [$s] !== [$s]);
 
 		$a = [1];
 		if (doFoo()) {


### PR DESCRIPTION
Fixes phpstan/phpstan#7248. When optional keys are involved it's never certain whether to values are equal.