### PR TITLE
Extract `ConstructorsHelper`

### DIFF
--- a/build/enum-adapter-errors.neon
+++ b/build/enum-adapter-errors.neon
@@ -201,6 +201,21 @@ parameters:
 			path: ../src/Reflection/ClassReflection.php
 
 		-
+			message: "#^Call to method getMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
+			count: 1
+			path: ../src/Reflection/ConstructorsHelper.php
+
+		-
+			message: "#^Call to method getName\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
+			count: 1
+			path: ../src/Reflection/ConstructorsHelper.php
+
+		-
+			message: "#^Call to method hasMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
+			count: 1
+			path: ../src/Reflection/ConstructorsHelper.php
+
+		-
 			message: "#^Call to method getName\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
 			count: 1
 			path: ../src/Reflection/Native/NativeMethodReflection.php
@@ -284,51 +299,6 @@ parameters:
 			message: "#^Call to method getMethods\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
 			count: 1
 			path: ../src/Rules/Methods/MissingMethodImplementationRule.php
-
-		-
-			message: "#^Call to method getMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
-
-		-
-			message: "#^Call to method getName\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
-
-		-
-			message: "#^Call to method hasMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
-
-		-
-			message: "#^Call to method getMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
-
-		-
-			message: "#^Call to method getName\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
-
-		-
-			message: "#^Call to method hasMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
-
-		-
-			message: "#^Call to method getMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/UninitializedPropertyRule.php
-
-		-
-			message: "#^Call to method getName\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/UninitializedPropertyRule.php
-
-		-
-			message: "#^Call to method hasMethod\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
-			path: ../src/Rules/Properties/UninitializedPropertyRule.php
 
 		-
 			message: "#^Call to method isFinal\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -67,6 +67,7 @@ rules:
 	- PHPStan\Rules\Operators\InvalidAssignVarRule
 	- PHPStan\Rules\Properties\AccessPropertiesInAssignRule
 	- PHPStan\Rules\Properties\AccessStaticPropertiesInAssignRule
+	- PHPStan\Rules\Properties\MissingReadOnlyPropertyAssignRule
 	- PHPStan\Rules\Properties\PropertyAttributesRule
 	- PHPStan\Rules\Properties\ReadOnlyPropertyRule
 	- PHPStan\Rules\Variables\UnsetRule
@@ -178,15 +179,6 @@ services:
 
 	-
 		class: PHPStan\Rules\Properties\MissingReadOnlyByPhpDocPropertyAssignRule
-		arguments:
-			additionalConstructors: %additionalConstructors%
-
-	-
-		class: PHPStan\Rules\Properties\MissingReadOnlyPropertyAssignRule
-		arguments:
-			additionalConstructors: %additionalConstructors%
-		tags:
-			- phpstan.rules.rule
 
 	-
 		class: PHPStan\Rules\Properties\OverridingPropertyRule
@@ -198,8 +190,6 @@ services:
 
 	-
 		class: PHPStan\Rules\Properties\UninitializedPropertyRule
-		arguments:
-			additionalConstructors: %additionalConstructors%
 
 	-
 		class: PHPStan\Rules\Properties\WritingToReadOnlyPropertiesRule
@@ -241,3 +231,8 @@ services:
 			globalTypeAliases: %typeAliases%
 		tags:
 			- phpstan.rules.rule
+
+	-
+		class: PHPStan\Reflection\ConstructorsHelper
+		arguments:
+			additionalConstructors: %additionalConstructors%

--- a/src/Reflection/ConstructorsHelper.php
+++ b/src/Reflection/ConstructorsHelper.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection;
+
+use ReflectionException;
+use function array_key_exists;
+use function explode;
+
+final class ConstructorsHelper
+{
+
+	/** @var array<string, string[]> */
+	private array $additionalConstructorsCache = [];
+
+	/**
+	 * @param list<string> $additionalConstructors
+	 */
+	public function __construct(
+		private array $additionalConstructors,
+	)
+	{
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	public function getConstructors(ClassReflection $classReflection): array
+	{
+		if (array_key_exists($classReflection->getName(), $this->additionalConstructorsCache)) {
+			return $this->additionalConstructorsCache[$classReflection->getName()];
+		}
+		$constructors = [];
+		if ($classReflection->hasConstructor()) {
+			$constructors[] = $classReflection->getConstructor()->getName();
+		}
+
+		$nativeReflection = $classReflection->getNativeReflection();
+		foreach ($this->additionalConstructors as $additionalConstructor) {
+			[$className, $methodName] = explode('::', $additionalConstructor);
+			if (!$nativeReflection->hasMethod($methodName)) {
+				continue;
+			}
+			$nativeMethod = $nativeReflection->getMethod($methodName);
+			if ($nativeMethod->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
+				continue;
+			}
+
+			try {
+				$prototype = $nativeMethod->getPrototype();
+			} catch (ReflectionException) {
+				$prototype = $nativeMethod;
+			}
+
+			if ($prototype->getDeclaringClass()->getName() !== $className) {
+				continue;
+			}
+
+			$constructors[] = $methodName;
+		}
+
+		$this->additionalConstructorsCache[$classReflection->getName()] = $constructors;
+
+		return $constructors;
+	}
+
+}

--- a/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
@@ -5,13 +5,10 @@ namespace PHPStan\Rules\Properties;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertiesNode;
-use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
-use ReflectionException;
-use function array_key_exists;
-use function explode;
 use function sprintf;
 
 /**
@@ -20,14 +17,8 @@ use function sprintf;
 class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 {
 
-	/** @var array<string, string[]> */
-	private array $additionalConstructorsCache = [];
-
-	/**
-	 * @param string[] $additionalConstructors
-	 */
 	public function __construct(
-		private array $additionalConstructors,
+		private ConstructorsHelper $constructorsHelper,
 	)
 	{
 	}
@@ -43,7 +34,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 			throw new ShouldNotHappenException();
 		}
 		$classReflection = $scope->getClassReflection();
-		[$properties, $prematureAccess, $additionalAssigns] = $node->getUninitializedProperties($scope, $this->getConstructors($classReflection), []);
+		[$properties, $prematureAccess, $additionalAssigns] = $node->getUninitializedProperties($scope, $this->constructorsHelper->getConstructors($classReflection), []);
 
 		$errors = [];
 		foreach ($properties as $propertyName => $propertyNode) {
@@ -80,48 +71,6 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 		}
 
 		return $errors;
-	}
-
-	/**
-	 * @return string[]
-	 */
-	private function getConstructors(ClassReflection $classReflection): array
-	{
-		if (array_key_exists($classReflection->getName(), $this->additionalConstructorsCache)) {
-			return $this->additionalConstructorsCache[$classReflection->getName()];
-		}
-		$constructors = [];
-		if ($classReflection->hasConstructor()) {
-			$constructors[] = $classReflection->getConstructor()->getName();
-		}
-
-		$nativeReflection = $classReflection->getNativeReflection();
-		foreach ($this->additionalConstructors as $additionalConstructor) {
-			[$className, $methodName] = explode('::', $additionalConstructor);
-			if (!$nativeReflection->hasMethod($methodName)) {
-				continue;
-			}
-			$nativeMethod = $nativeReflection->getMethod($methodName);
-			if ($nativeMethod->getDeclaringClass()->getName() !== $nativeReflection->getName()) {
-				continue;
-			}
-
-			try {
-				$prototype = $nativeMethod->getPrototype();
-			} catch (ReflectionException) {
-				$prototype = $nativeMethod;
-			}
-
-			if ($prototype->getDeclaringClass()->getName() !== $className) {
-				continue;
-			}
-
-			$constructors[] = $methodName;
-		}
-
-		$this->additionalConstructorsCache[$classReflection->getName()] = $constructors;
-
-		return $constructors;
 	}
 
 }

--- a/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
@@ -5,11 +5,13 @@ namespace PHPStan\Rules\Properties;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\PropertyAssignNode;
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ThisType;
+use function in_array;
 use function sprintf;
 use function strtolower;
 
@@ -19,7 +21,10 @@ use function strtolower;
 class ReadOnlyPropertyAssignRule implements Rule
 {
 
-	public function __construct(private PropertyReflectionFinder $propertyReflectionFinder)
+	public function __construct(
+		private PropertyReflectionFinder $propertyReflectionFinder,
+		private ConstructorsHelper $constructorsHelper,
+	)
 	{
 	}
 
@@ -67,7 +72,10 @@ class ReadOnlyPropertyAssignRule implements Rule
 				throw new ShouldNotHappenException();
 			}
 
-			if (strtolower($scopeMethod->getName()) === '__construct' || strtolower($scopeMethod->getName()) === '__unserialize') {
+			if (
+				in_array($scopeMethod->getName(), $this->constructorsHelper->getConstructors($scopeClassReflection), true)
+				|| strtolower($scopeMethod->getName()) === '__unserialize'
+			) {
 				if (!$scope->getType($propertyFetch->var) instanceof ThisType) {
 					$errors[] = RuleErrorBuilder::message(sprintf('Readonly property %s::$%s is not assigned on $this.', $declaringClass->getDisplayName(), $propertyReflection->getName()))->build();
 				}

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use const PHP_VERSION_ID;
@@ -14,9 +15,11 @@ class MissingReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new MissingReadOnlyByPhpDocPropertyAssignRule([
-			'MissingReadOnlyPropertyAssignPhpDoc\\TestCase::setUp',
-		]);
+		return new MissingReadOnlyByPhpDocPropertyAssignRule(
+			new ConstructorsHelper([
+				'MissingReadOnlyPropertyAssignPhpDoc\\TestCase::setUp',
+			]),
+		);
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use const PHP_VERSION_ID;
@@ -14,9 +15,11 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new MissingReadOnlyPropertyAssignRule([
-			'MissingReadOnlyPropertyAssign\\TestCase::setUp',
-		]);
+		return new MissingReadOnlyPropertyAssignRule(
+			new ConstructorsHelper([
+				'MissingReadOnlyPropertyAssign\\TestCase::setUp',
+			]),
+		);
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 
@@ -13,7 +14,14 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ReadOnlyByPhpDocPropertyAssignRule(new PropertyReflectionFinder());
+		return new ReadOnlyByPhpDocPropertyAssignRule(
+			new PropertyReflectionFinder(),
+			new ConstructorsHelper(
+				[
+					'ReadonlyPropertyAssignPhpDoc\\TestCase::setUp',
+				],
+			),
+		);
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use const PHP_VERSION_ID;
@@ -14,7 +15,14 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ReadOnlyPropertyAssignRule(new PropertyReflectionFinder());
+		return new ReadOnlyPropertyAssignRule(
+			new PropertyReflectionFinder(),
+			new ConstructorsHelper(
+				[
+					'ReadonlyPropertyAssign\\TestCase::setUp',
+				],
+			),
+		);
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -35,9 +36,11 @@ class UninitializedPropertyRuleTest extends RuleTestCase
 
 				},
 			]),
-			[
-				'UninitializedProperty\\TestCase::setUp',
-			],
+			new ConstructorsHelper(
+				[
+					'UninitializedProperty\\TestCase::setUp',
+				],
+			),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
@@ -189,3 +189,19 @@ class Unserialization
 	}
 
 }
+
+class TestCase
+{
+
+	/**
+	 * @var int
+	 * @readonly
+	 */
+	private $foo;
+
+	protected function setUp(): void
+	{
+		$this->foo = 1; // additional constructor - fine
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign.php
@@ -184,3 +184,15 @@ class Unserialization
 	}
 
 }
+
+class TestCase
+{
+
+	private readonly int $foo;
+
+	protected function setUp(): void
+	{
+		$this->foo = 1; // additional constructor - fine
+	}
+
+}


### PR DESCRIPTION
... and make use of it also in `ReadOnlyByPhpDocPropertyAssignRule` and `ReadOnlyPropertyAssignRule`.

Closes https://github.com/phpstan/phpstan/issues/6612