### PR TITLE
Support `@immutable` phpdoc

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3854,7 +3854,7 @@ class NodeScopeResolver
 		$isInternal = false;
 		$isFinal = false;
 		$isPure = false;
-		$isReadOnly = false;
+		$isReadOnly = $scope->isInClass() && $scope->getClassReflection()->isImmutable();
 		$docComment = $node->getDocComment() !== null
 			? $node->getDocComment()->getText()
 			: null;
@@ -3961,7 +3961,7 @@ class NodeScopeResolver
 			$isInternal = $resolvedPhpDoc->isInternal();
 			$isFinal = $resolvedPhpDoc->isFinal();
 			$isPure = $resolvedPhpDoc->isPure();
-			$isReadOnly = $resolvedPhpDoc->isReadOnly();
+			$isReadOnly = $isReadOnly || $resolvedPhpDoc->isReadOnly();
 		}
 
 		return [$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $isReadOnly, $docComment];

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -465,6 +465,19 @@ class PhpDocNodeResolver
 		return false;
 	}
 
+	public function resolveIsImmutable(PhpDocNode $phpDocNode): bool
+	{
+		foreach (['@immutable', '@psalm-immutable', '@phpstan-immutable'] as $tagName) {
+			$tags = $phpDocNode->getTagsByName($tagName);
+
+			if (count($tags) > 0) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public function resolveHasConsistentConstructor(PhpDocNode $phpDocNode): bool
 	{
 		foreach (['@consistent-constructor', '@phpstan-consistent-constructor', '@psalm-consistent-constructor'] as $tagName) {

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -98,6 +98,8 @@ class ResolvedPhpDocBlock
 
 	private ?bool $isReadOnly = null;
 
+	private ?bool $isImmutable = null;
+
 	private ?bool $hasConsistentConstructor = null;
 
 	private function __construct()
@@ -563,6 +565,16 @@ class ResolvedPhpDocBlock
 			);
 		}
 		return $this->isReadOnly;
+	}
+
+	public function isImmutable(): bool
+	{
+		if ($this->isImmutable === null) {
+			$this->isImmutable = $this->phpDocNodeResolver->resolveIsImmutable(
+				$this->phpDocNode,
+			);
+		}
+		return $this->isImmutable;
 	}
 
 	/**

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -85,6 +85,8 @@ class ClassReflection
 
 	private ?bool $isFinal = null;
 
+	private ?bool $isImmutable = null;
+
 	private ?bool $hasConsistentConstructor = null;
 
 	private ?TemplateTypeMap $templateTypeMap = null;
@@ -1027,6 +1029,16 @@ class ClassReflection
 		}
 
 		return $this->isFinal;
+	}
+
+	public function isImmutable(): bool
+	{
+		if ($this->isImmutable === null) {
+			$resolvedPhpDoc = $this->getResolvedPhpDoc();
+			$this->isImmutable = $resolvedPhpDoc !== null && $resolvedPhpDoc->isImmutable();
+		}
+
+		return $this->isImmutable;
 	}
 
 	public function hasConsistentConstructor(): bool

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -220,7 +220,7 @@ class PhpClassReflectionExtension
 		$deprecatedDescription = null;
 		$isDeprecated = false;
 		$isInternal = false;
-		$isReadOnlyByPhpDoc = false;
+		$isReadOnlyByPhpDoc = $classReflection->isImmutable();
 
 		if (
 			$includingAnnotations
@@ -326,7 +326,7 @@ class PhpClassReflectionExtension
 			$deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag() !== null ? $resolvedPhpDoc->getDeprecatedTag()->getMessage() : null;
 			$isDeprecated = $resolvedPhpDoc->isDeprecated();
 			$isInternal = $resolvedPhpDoc->isInternal();
-			$isReadOnlyByPhpDoc = $resolvedPhpDoc->isReadOnly();
+			$isReadOnlyByPhpDoc = $isReadOnlyByPhpDoc || $resolvedPhpDoc->isReadOnly();
 		}
 
 		if (

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -57,6 +57,22 @@ class MissingReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 				'Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\AssignOp::$bar.',
 				94,
 			],
+			[
+				'Class MissingReadOnlyPropertyAssignPhpDoc\Immutable has an uninitialized @readonly property $unassigned. Assign it in the constructor.',
+				119,
+			],
+			[
+				'Class MissingReadOnlyPropertyAssignPhpDoc\Immutable has an uninitialized @readonly property $unassigned2. Assign it in the constructor.',
+				121,
+			],
+			[
+				'Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\Immutable::$readBeforeAssigned.',
+				131,
+			],
+			[
+				'@readonly property MissingReadOnlyPropertyAssignPhpDoc\Immutable::$doubleAssigned is already assigned.',
+				135,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRefRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRefRuleTest.php
@@ -31,6 +31,14 @@ class ReadOnlyByPhpDocPropertyAssignRefRuleTest extends RuleTestCase
 				'@readonly property ReadOnlyPropertyAssignRefPhpDoc\Foo::$bar is assigned by reference.',
 				34,
 			],
+			[
+				'@readonly property ReadOnlyPropertyAssignRefPhpDoc\Immutable::$foo is assigned by reference.',
+				51,
+			],
+			[
+				'@readonly property ReadOnlyPropertyAssignRefPhpDoc\Immutable::$bar is assigned by reference.',
+				52,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -87,6 +87,10 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.',
 				164,
 			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Immutable::$foo is assigned outside of the constructor.',
+				227,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
@@ -109,3 +109,35 @@ class AssignRef
 	}
 
 }
+
+/** @phpstan-immutable */
+class Immutable
+{
+
+	private int $assigned;
+
+	private int $unassigned;
+
+	private int $unassigned2;
+
+	private int $readBeforeAssigned;
+
+	private int $doubleAssigned;
+
+	public function __construct()
+	{
+		$this->assigned = 1;
+
+		echo $this->readBeforeAssigned;
+		$this->readBeforeAssigned = 1;
+
+		$this->doubleAssigned = 1;
+		$this->doubleAssigned = 2;
+	}
+
+	public function setUnassigned2(int $i): void
+	{
+		$this->unassigned2 = $i;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
@@ -205,3 +205,26 @@ class TestCase
 	}
 
 }
+
+/** @phpstan-immutable */
+class Immutable
+{
+
+	/** @var int */
+	private $foo;
+
+	protected $bar;
+
+	public $baz;
+
+	public function __construct(int $foo)
+	{
+		$this->foo = $foo; // constructor - fine
+	}
+
+	public function setFoo(int $foo): void
+	{
+		$this->foo = $foo; // setter - report
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign-ref-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign-ref-phpdoc.php
@@ -35,3 +35,21 @@ class Bar
 	}
 
 }
+
+/** @phpstan-immutable */
+class Immutable
+{
+
+	/** @var int */
+	private $foo;
+
+	/** @var int */
+	public $bar;
+
+	public function doFoo()
+	{
+		$foo = &$this->foo;
+		$bar = &$this->bar;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/uninitialized-property-readonly-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/uninitialized-property-readonly-phpdoc.php
@@ -28,3 +28,16 @@ class Bar
 	}
 
 }
+
+/** @phpstan-immutable */
+class Immutable
+{
+
+	private int $bar;
+
+	public function __construct()
+	{
+
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/4600

See also https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-immutable

first draft, not sure about some edge cases yet. e.g. inheritance. most likely more tests are needed in a dedicated file maybe

does also not support traits because it looks like traits are currently not fully working with native or phpdoc readonly (e.g. readonly property in trait, missing assignment in class that uses that trait). maybe a good follow-up / separate feature/fix? I created https://github.com/phpstan/phpstan/issues/7271

I'm also still not sure if this should be also settable via `@readonly` on class-level maybe too?