### PR TITLE
Do not ignore traits in ClassStatementsGatherer

### DIFF
--- a/src/Node/ClassStatementsGatherer.php
+++ b/src/Node/ClassStatementsGatherer.php
@@ -117,7 +117,7 @@ class ClassStatementsGatherer
 		if ($scope->getClassReflection()->getName() !== $this->classReflection->getName()) {
 			return;
 		}
-		if ($node instanceof ClassPropertyNode && !$scope->isInTrait()) {
+		if ($node instanceof ClassPropertyNode) {
 			$this->properties[] = $node;
 			if ($node->isPromoted()) {
 				$this->propertyUsages[] = new PropertyWrite(
@@ -127,7 +127,7 @@ class ClassStatementsGatherer
 			}
 			return;
 		}
-		if ($node instanceof Node\Stmt\ClassMethod && !$scope->isInTrait()) {
+		if ($node instanceof Node\Stmt\ClassMethod) {
 			$this->methods[] = $node;
 			return;
 		}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -363,7 +363,8 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug4288(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4288.php');
-		$this->assertNoErrors($errors);
+		$this->assertCount(1, $errors);
+		$this->assertSame('Property Bug4288\MyClass::$test is never read, only written.', $errors[0]->getMessage());
 
 		$reflectionProvider = $this->createReflectionProvider();
 		$class = $reflectionProvider->getClass(MyClass::class);

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -104,9 +104,11 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 				__DIR__ . '/traits/TraitWithTypeSpecification.php',
 			],
 		);
-		$this->assertCount(1, $errors);
-		$this->assertStringContainsString('Access to an undefined property', $errors[0]->getMessage());
-		$this->assertSame(18, $errors[0]->getLine());
+		$this->assertCount(2, $errors);
+		$this->assertStringContainsString('$string is never read, only written.', $errors[0]->getMessage());
+		$this->assertSame(9, $errors[0]->getLine());
+		$this->assertStringContainsString('Access to an undefined property', $errors[1]->getMessage());
+		$this->assertSame(18, $errors[1]->getLine());
 	}
 
 	public function testDuplicateMethodDefinition(): void

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
@@ -40,6 +40,10 @@ class UnusedPrivateMethodRuleTest extends RuleTestCase
 				'Method UnusedPrivateMethod\Lorem::doBaz() is unused.',
 				97,
 			],
+			[
+				'Method UnusedPrivateMethod\UsingFooTrait::doBar() is unused.',
+				133,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -170,7 +170,13 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 	{
 		$this->alwaysWrittenTags = [];
 		$this->alwaysReadTags = [];
-		$this->analyse([__DIR__ . '/data/private-property-trait.php'], []);
+		$this->analyse([__DIR__ . '/data/private-property-trait.php'], [
+			[
+				'Property UnusedPropertyTrait\ClassUsingTrait::$prop2 is unused.',
+				10,
+				'See: https://phpstan.org/developing-extensions/always-read-written-properties',
+			],
+		]);
 	}
 
 	public function testBug3636(): void


### PR DESCRIPTION
This makes sense IMO since traits can be seen as copy/paste helpers, but most-likely I'm missing the reason why they were ignored there in the first place. To not be too annoying maybe with generic traits and multiple private helper methods and so? Mostly I want to find out what CI thinks about this..

This would also be the basis to fix `ClassPropertiesNode::getUninitializedProperties` by including trait props too, which in term fixes various trait-related readonly / uninitialized property rules.