### PR TITLE
Use trait properties in uninitialized props checks

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -642,7 +642,7 @@ class NodeScopeResolver
 
 			$classStatementsGatherer = new ClassStatementsGatherer($classReflection, $nodeCallback);
 			$this->processStmtNodes($stmt, $stmt->stmts, $classScope, $classStatementsGatherer);
-			$nodeCallback(new ClassPropertiesNode($stmt, $classStatementsGatherer->getProperties(), $classStatementsGatherer->getPropertyUsages(), $classStatementsGatherer->getMethodCalls()), $classScope);
+			$nodeCallback(new ClassPropertiesNode($stmt, $classStatementsGatherer->getProperties(), $classStatementsGatherer->getTraitProperties(), $classStatementsGatherer->getPropertyUsages(), $classStatementsGatherer->getMethodCalls()), $classScope);
 			$nodeCallback(new ClassMethodsNode($stmt, $classStatementsGatherer->getMethods(), $classStatementsGatherer->getMethodCalls()), $classScope);
 			$nodeCallback(new ClassConstantsNode($stmt, $classStatementsGatherer->getConstants(), $classStatementsGatherer->getConstantFetches()), $classScope);
 			$classReflection->evictPrivateSymbols();

--- a/src/Node/ClassPropertiesNode.php
+++ b/src/Node/ClassPropertiesNode.php
@@ -21,6 +21,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use function array_key_exists;
 use function array_keys;
+use function array_merge;
 use function count;
 use function in_array;
 
@@ -30,10 +31,11 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 
 	/**
 	 * @param ClassPropertyNode[] $properties
+	 * @param ClassPropertyNode[] $traitProperties
 	 * @param array<int, PropertyRead|PropertyWrite> $propertyUsages
 	 * @param array<int, MethodCall> $methodCalls
 	 */
-	public function __construct(private ClassLike $class, private array $properties, private array $propertyUsages, private array $methodCalls)
+	public function __construct(private ClassLike $class, private array $properties, private array $traitProperties, private array $propertyUsages, private array $methodCalls)
 	{
 		parent::__construct($class->getAttributes());
 	}
@@ -49,6 +51,14 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 	public function getProperties(): array
 	{
 		return $this->properties;
+	}
+
+	/**
+	 * @return ClassPropertyNode[]
+	 */
+	public function getTraitProperties(): array
+	{
+		return $this->traitProperties;
 	}
 
 	/**
@@ -92,7 +102,7 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 		$classReflection = $scope->getClassReflection();
 
 		$properties = [];
-		foreach ($this->getProperties() as $property) {
+		foreach (array_merge($this->getProperties(), $this->getTraitProperties()) as $property) {
 			if ($property->isStatic()) {
 				continue;
 			}

--- a/src/Node/ClassStatementsGatherer.php
+++ b/src/Node/ClassStatementsGatherer.php
@@ -28,6 +28,9 @@ class ClassStatementsGatherer
 	/** @var ClassPropertyNode[] */
 	private array $properties = [];
 
+	/** @var ClassPropertyNode[] */
+	private array $traitProperties = [];
+
 	/** @var Node\Stmt\ClassMethod[] */
 	private array $methods = [];
 
@@ -60,6 +63,14 @@ class ClassStatementsGatherer
 	public function getProperties(): array
 	{
 		return $this->properties;
+	}
+
+	/**
+	 * @return ClassPropertyNode[]
+	 */
+	public function getTraitProperties(): array
+	{
+		return $this->traitProperties;
 	}
 
 	/**
@@ -125,6 +136,10 @@ class ClassStatementsGatherer
 					$scope,
 				);
 			}
+			return;
+		}
+		if ($node instanceof ClassPropertyNode && $scope->isInTrait()) {
+			$this->traitProperties[] = $node;
 			return;
 		}
 		if ($node instanceof Node\Stmt\ClassMethod && !$scope->isInTrait()) {

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -73,6 +73,22 @@ class MissingReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 				'@readonly property MissingReadOnlyPropertyAssignPhpDoc\Immutable::$doubleAssigned is already assigned.',
 				135,
 			],
+			[
+				'Class MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass has an uninitialized @readonly property $unassigned. Assign it in the constructor.',
+				156,
+			],
+			[
+				'Class MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass has an uninitialized @readonly property $unassigned2. Assign it in the constructor.',
+				159,
+			],
+			[
+				'Access to an uninitialized @readonly property MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass::$readBeforeAssigned.',
+				188,
+			],
+			[
+				'@readonly property MissingReadOnlyPropertyAssignPhpDoc\FooTraitClass::$doubleAssigned is already assigned.',
+				192,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -57,6 +57,22 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 				'Access to an uninitialized readonly property MissingReadOnlyPropertyAssign\AssignOp::$bar.',
 				87,
 			],
+			[
+				'Class MissingReadOnlyPropertyAssign\FooTraitClass has an uninitialized readonly property $unassigned. Assign it in the constructor.',
+				114,
+			],
+			[
+				'Class MissingReadOnlyPropertyAssign\FooTraitClass has an uninitialized readonly property $unassigned2. Assign it in the constructor.',
+				116,
+			],
+			[
+				'Access to an uninitialized readonly property MissingReadOnlyPropertyAssign\FooTraitClass::$readBeforeAssigned.',
+				145,
+			],
+			[
+				'Readonly property MissingReadOnlyPropertyAssign\FooTraitClass::$doubleAssigned is already assigned.',
+				149,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
@@ -67,6 +67,14 @@ class UninitializedPropertyRuleTest extends RuleTestCase
 				'Class UninitializedProperty\TestExtension has an uninitialized property $uninited. Give it default value or assign it in the constructor.',
 				122,
 			],
+			[
+				'Class UninitializedProperty\FooTraitClass has an uninitialized property $bar. Give it default value or assign it in the constructor.',
+				157,
+			],
+			[
+				'Class UninitializedProperty\FooTraitClass has an uninitialized property $baz. Give it default value or assign it in the constructor.',
+				159,
+			],
 		]);
 	}
 
@@ -85,6 +93,20 @@ class UninitializedPropertyRuleTest extends RuleTestCase
 	{
 		// reported by a different rule
 		$this->analyse([__DIR__ . '/data/uninitialized-property-readonly-phpdoc.php'], []);
+	}
+
+	public function testBug7219(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7219.php'], [
+			[
+				'Class Bug7219\Foo has an uninitialized property $id. Give it default value or assign it in the constructor.',
+				8,
+			],
+			[
+				'Class Bug7219\Foo has an uninitialized property $email. Give it default value or assign it in the constructor.',
+				15,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-7219.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7219.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1); // lint >= 7.4
+
+namespace Bug7219;
+
+class Foo
+{
+
+	public int $id;
+	private ?string $val = null;
+	use EmailTrait;
+}
+
+trait EmailTrait
+{
+	protected string $email; // not initialized
+
+	public function getEmail(): string
+	{
+		return $this->email;
+	}
+
+
+	public function setEmail(string $email): void
+	{
+		$this->email = $email;
+	}
+}
+
+$foo = new Foo();
+echo $foo->getEmail(); // error Typed property must not be accessed before initialization
+echo $foo->id;

--- a/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
@@ -141,3 +141,58 @@ class Immutable
 	}
 
 }
+
+trait FooTrait
+{
+
+	/** @readonly */
+	private int $assigned;
+
+	private int $unassignedButNotReadOnly;
+
+	private int $readBeforeAssignedNotReadOnly;
+
+	/** @readonly */
+	private int $unassigned;
+
+	/** @readonly */
+	private int $unassigned2;
+
+	/** @readonly */
+	private int $readBeforeAssigned;
+
+	/** @readonly */
+	private int $doubleAssigned;
+
+	private int $doubleAssignedNotReadOnly;
+
+	public function setUnassigned2(int $i): void
+	{
+		$this->unassigned2 = $i;
+	}
+
+}
+
+class FooTraitClass
+{
+
+	use FooTrait;
+
+	public function __construct()
+	{
+		$this->assigned = 1;
+
+		echo $this->readBeforeAssignedNotReadOnly;
+		$this->readBeforeAssignedNotReadOnly = 1;
+
+		echo $this->readBeforeAssigned;
+		$this->readBeforeAssigned = 1;
+
+		$this->doubleAssigned = 1;
+		$this->doubleAssigned = 2;
+
+		$this->doubleAssignedNotReadOnly = 1;
+		$this->doubleAssignedNotReadOnly = 2;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign.php
+++ b/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign.php
@@ -101,3 +101,55 @@ class AssignRef
 	}
 
 }
+
+trait FooTrait
+{
+
+	private readonly int $assigned;
+
+	private int $unassignedButNotReadOnly;
+
+	private int $readBeforeAssignedNotReadOnly;
+
+	private readonly int $unassigned;
+
+	private readonly int $unassigned2;
+
+	private readonly int $readBeforeAssigned;
+
+	private readonly int $doubleAssigned;
+
+	private int $doubleAssignedNotReadOnly;
+
+	public function setUnassigned2(int $i): void
+	{
+		$this->unassigned2 = $i;
+	}
+
+}
+
+class FooTraitClass
+{
+
+	use FooTrait;
+
+	public function __construct(
+		private readonly int $promoted,
+	)
+	{
+		$this->assigned = 1;
+
+		echo $this->readBeforeAssignedNotReadOnly;
+		$this->readBeforeAssignedNotReadOnly = 1;
+
+		echo $this->readBeforeAssigned;
+		$this->readBeforeAssigned = 1;
+
+		$this->doubleAssigned = 1;
+		$this->doubleAssigned = 2;
+
+		$this->doubleAssignedNotReadOnly = 1;
+		$this->doubleAssignedNotReadOnly = 2;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/uninitialized-property.php
+++ b/tests/PHPStan/Rules/Properties/data/uninitialized-property.php
@@ -148,3 +148,31 @@ class ImplicitArrayCreation2
 	}
 
 }
+
+trait FooTrait
+{
+
+	private int $foo;
+
+	private int $bar;
+
+	private int $baz;
+
+	public function setBaz()
+	{
+		$this->baz = 1;
+	}
+
+}
+
+class FooTraitClass
+{
+
+	use FooTrait;
+
+	public function __construct()
+	{
+		$this->foo = 1;
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7219

Less invasive approach of https://github.com/phpstan/phpstan-src/pull/1339

Open question: is the error message fine like that, what if the trait and class are in different files? Was there already a special way of dealing with this or is it dealt with already?