### PR TITLE
Fix/issue 7318

### DIFF
--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -89,10 +89,6 @@ class IssetCheck
 			// If offset is cannot be null, store this error message and see if one of the earlier offsets is.
 			// E.g. $array['a']['b']['c'] ?? null; is a valid coalesce if a OR b or C might be null.
 			if ($hasOffsetValue->yes() || $scope->isSpecified($expr)) {
-				if ($error !== null) {
-					return $error;
-				}
-
 				if (!$this->checkAdvancedIsset) {
 					return null;
 				}

--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -93,7 +93,7 @@ class IssetCheck
 					return null;
 				}
 
-				$error = $this->generateError($type->getOffsetValueType($dimType), sprintf(
+				$error ??= $this->generateError($type->getOffsetValueType($dimType), sprintf(
 					'Offset %s on %s %s always exists and',
 					$dimType->describe(VerbosityLevel::value()),
 					$type->describe(VerbosityLevel::value()),

--- a/tests/PHPStan/Rules/Properties/data/bug-7318.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7318.php
@@ -17,5 +17,17 @@ class HelloWorld
 
 		if (empty($types['Bar']['prop']['unique'])) {
 		}
+
+		/** @var array{Bar: array{prop: array{unique: boolean}}} $types */
+		$types = ['Bar' => ['prop' => ['unique' => true]]];
+
+		if ($types['Bar']['prop']['unique'] ?? false) {
+		}
+
+		if (isset($types['Bar']['prop']['unique'])) {
+		}
+
+		if (empty($types['Bar']['prop']['unique'])) {
+		}
 	}
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-7318.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7318.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7318;
+
+class HelloWorld
+{
+	public function test(): void
+	{
+		/** @var array<string, array{prop: array{unique: boolean}}> $types */
+		$types = ['Foo' => ['prop' => ['unique' => true]]];
+
+		if ($types['Bar']['prop']['unique'] ?? false) {
+		}
+
+		if (isset($types['Bar']['prop']['unique'])) {
+		}
+
+		if (empty($types['Bar']['prop']['unique'])) {
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -161,4 +161,12 @@ class EmptyRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7318(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -384,4 +384,12 @@ class IssetRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7318(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -389,7 +389,12 @@ class IssetRuleTest extends RuleTestCase
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->strictUnnecessaryNullsafePropertyFetch = true;
 
-		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], []);
+		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], [
+			[
+				"Offset 'unique' on array{unique: bool} in isset() always exists and is not nullable.",
+				27,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -339,4 +339,12 @@ class NullCoalesceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7318(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -344,7 +344,12 @@ class NullCoalesceRuleTest extends RuleTestCase
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->strictUnnecessaryNullsafePropertyFetch = true;
 
-		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], []);
+		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], [
+			[
+				"Offset 'unique' on array{unique: bool} on left side of ?? always exists and is not nullable.",
+				24,
+			],
+		]);
 	}
 
 }


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/7318

Currently isset with

```php
$arr[maybe][yes]
```

is working, but 

```php
$arr[maybe][yes][yes]
```
is not.

For `$hasOffsetValue->yes()` check, we have to recursively check until ArrayDImFetch ends.

Same thing can happen with 
```php
$arr[no][yes][yes]
```
but I believe I cant make this example, because if the first offset access is `$hasOffsetValue->no()`, the subsequent offset would be  `$hasOffsetValue->no()`  too.