### PR TITLE
Consider optional keys in ConstantArrayType removeFirst and removeLast

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -126,6 +126,7 @@ use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
@@ -1813,29 +1814,27 @@ class NodeScopeResolver
 				&& count($expr->getArgs()) >= 1
 			) {
 				$arrayArg = $expr->getArgs()[0]->value;
-				$constantArrays = TypeUtils::getConstantArrays($scope->getType($arrayArg));
+				$arrayArgType = $scope->getType($arrayArg);
 				$scope = $scope->invalidateExpression($arrayArg);
-				if (count($constantArrays) > 0) {
-					$resultArrayTypes = [];
 
-					foreach ($constantArrays as $constantArray) {
-						if ($functionReflection->getName() === 'array_pop') {
-							$resultArrayTypes[] = $constantArray->removeLast();
-						} else {
-							$resultArrayTypes[] = $constantArray->removeFirst();
-						}
+				$functionName = $functionReflection->getName();
+				$arrayArgType = TypeTraverser::map($arrayArgType, static function (Type $type, callable $traverse) use ($functionName): Type {
+					if ($type instanceof UnionType || $type instanceof IntersectionType) {
+						return $traverse($type);
 					}
+					if ($type instanceof ConstantArrayType) {
+						return $functionName === 'array_pop' ? $type->removeLast() : $type->removeFirst();
+					}
+					if ($type->isIterableAtLeastOnce()->yes()) {
+						return $type->toArray();
+					}
+					return $type;
+				});
 
-					$scope = $scope->specifyExpressionType(
-						$arrayArg,
-						TypeCombinator::union(...$resultArrayTypes),
-					);
-				} else {
-					$arrays = TypeUtils::getAnyArrays($scope->getType($arrayArg));
-					if (count($arrays) > 0) {
-						$scope = $scope->specifyExpressionType($arrayArg, TypeCombinator::union(...$arrays));
-					}
-				}
+				$scope = $scope->specifyExpressionType(
+					$arrayArg,
+					$arrayArgType,
+				);
 			}
 
 			if (

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -179,6 +179,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3985.php');
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-shift.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-slice.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3990.php');
@@ -800,6 +801,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-pop.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-push.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-replace.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-reverse.php');

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayPop;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function nonEmpty(array $arr): void
+	{
+		/** @var non-empty-array<string> $arr */
+		assertType('string', array_pop($arr));
+		assertType('array<string>', $arr);
+	}
+
+	public function normalArrays(array $arr): void
+	{
+		/** @var array<int, string> $arr */
+		assertType('string|null', array_pop($arr));
+		assertType('array<int, string>', $arr);
+	}
+
+	public function compoundTypes(array $arr): void
+	{
+		/** @var string[]|int[] $arr */
+		assertType('int|string|null', array_pop($arr));
+		assertType('array<int|string>', $arr);
+	}
+
+	public function constantArrays(array $arr): void
+	{
+		/** @var array{a: 0, b: 1, c: 2} $arr */
+		assertType('2', array_pop($arr));
+		assertType('array{a: 0, b: 1}', $arr);
+	}
+
+	public function constantArraysWithOptionalKeys(array $arr): void
+	{
+		/** @var array{a?: 0, b: 1, c: 2} $arr */
+		assertType('0|2', array_pop($arr)); // should be 2
+		assertType('array{a?: 0, b: 1}', $arr);
+
+		/** @var array{a: 0, b?: 1, c: 2} $arr */
+		assertType('1|2', array_pop($arr)); // should be 2
+		assertType('array{a: 0, b?: 1}', $arr);
+
+		/** @var array{a: 0, b: 1, c?: 2} $arr */
+		assertType('1|2', array_pop($arr));
+		assertType('array{a: 0, b?: 1}', $arr);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayShift;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function nonEmpty(array $arr): void
+	{
+		/** @var non-empty-array<string> $arr */
+		assertType('string', array_shift($arr));
+		assertType('array<string>', $arr);
+	}
+
+	public function normalArrays(array $arr): void
+	{
+		/** @var array<int, string> $arr */
+		assertType('string|null', array_shift($arr));
+		assertType('array<int, string>', $arr);
+	}
+
+	public function compoundTypes(array $arr): void
+	{
+		/** @var string[]|int[] $arr */
+		assertType('int|string|null', array_shift($arr));
+		assertType('array<int|string>', $arr);
+	}
+
+	public function constantArrays(array $arr): void
+	{
+		/** @var array{a: 0, b: 1, c: 2} $arr */
+		assertType('0', array_shift($arr));
+		assertType('array{b: 1, c: 2}', $arr);
+	}
+
+	public function constantArraysWithOptionalKeys(array $arr): void
+	{
+		/** @var array{a?: 0, b: 1, c: 2} $arr */
+		assertType('1', array_shift($arr)); // should be 0|1
+		assertType('array{b?: 1, c: 2}', $arr);
+
+		/** @var array{a: 0, b?: 1, c: 2} $arr */
+		assertType('0', array_shift($arr));
+		assertType('array{b?: 1, c: 2}', $arr);
+
+		/** @var array{a: 0, b: 1, c?: 2} $arr */
+		assertType('0', array_shift($arr));
+		assertType('array{b: 1, c?: 2}', $arr);
+	}
+
+}


### PR DESCRIPTION
... and get rid of `getConstantArrays` in NodeScopeResolver for `array_pop` and `array_shift`.

This seems to be also fixing problems with the optional keys. green test cases from this  PR for comparison with the latest 1.7.x state which is broken IMO
array_pop: https://phpstan.org/r/99745329-2125-46a3-8fe6-ea4afdfc754e
array_shift: https://phpstan.org/r/751ff62d-d672-4ef8-9db1-5abbb6cf4a15

The added tests show that apparently `ArrayPopFunctionReturnTypeExtension` and `ArrayShiftFunctionReturnTypeExtension` are not working correctly either ("should be" comments), but I'd  like to look at that in another PR if that's ok. Maybe a bug somewhere else in ConstantArrayType itself 🤔 But I also have an idea for replacing those getConstantArrays calls as well.

My main motivation is to prepare stuff I can use in the `ConstantArrayType::slice` adaption. But now, since I learned that I can replace some of the potentially badly-scaling array gather & modify in a loop & unify code parts in general, I want to get rid of what I can :D  