### PR TITLE
Enforce optional parameters in callable types

### DIFF
--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -146,7 +146,12 @@ class CallableType implements CompoundType, ParametersAcceptor
 			fn (): string => sprintf(
 				'callable(%s): %s',
 				implode(', ', array_map(
-					static fn (ParameterReflection $param): string => sprintf('%s%s', $param->isVariadic() ? '...' : '', $param->getType()->describe($level)),
+					static fn (ParameterReflection $param): string => sprintf(
+						'%s%s%s',
+						$param->isVariadic() ? '...' : '',
+						$param->getType()->describe($level),
+						$param->isOptional() && !$param->isVariadic() ? '=' : '',
+					),
 					$this->getParameters(),
 				)),
 				$this->returnType->describe($level),

--- a/src/Type/CallableTypeHelper.php
+++ b/src/Type/CallableTypeHelper.php
@@ -29,6 +29,11 @@ class CallableTypeHelper
 
 			$ourParameter = $ourParameters[$i];
 			$ourParameterType = $ourParameter->getType();
+
+			if ($ourParameter->isOptional() && !$theirParameter->isOptional()) {
+				return TrinaryLogic::createNo();
+			}
+
 			if ($treatMixedAsAny) {
 				$isSuperType = $theirParameter->getType()->accepts($ourParameterType, true);
 			} else {

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -150,7 +150,15 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 			static fn (): string => 'Closure',
 			fn (): string => sprintf(
 				'Closure(%s): %s',
-				implode(', ', array_map(static fn (ParameterReflection $parameter): string => sprintf('%s%s', $parameter->isVariadic() ? '...' : '', $parameter->getType()->describe($level)), $this->parameters)),
+				implode(', ', array_map(
+					static fn (ParameterReflection $param): string => sprintf(
+						'%s%s%s',
+						$param->isVariadic() ? '...' : '',
+						$param->getType()->describe($level),
+						$param->isOptional() && !$param->isVariadic() ? '=' : '',
+					),
+					$this->parameters,
+				)),
 				$this->returnType->describe($level),
 			),
 		);

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -763,9 +763,9 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 
 		$errors = $this->runAnalyse(__DIR__ . '/data/discussion-7124.php');
 		$this->assertCount(4, $errors);
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, int): bool, Closure(int, bool): bool given.', $errors[0]->getMessage());
+		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, int=): bool, Closure(int, bool): bool given.', $errors[0]->getMessage());
 		$this->assertSame(38, $errors[0]->getLine());
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, int): bool, Closure(int): bool given.', $errors[1]->getMessage());
+		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, int=): bool, Closure(int): bool given.', $errors[1]->getMessage());
 		$this->assertSame(45, $errors[1]->getLine());
 		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(int): bool, Closure(bool): bool given.', $errors[2]->getMessage());
 		$this->assertSame(52, $errors[2]->getLine());
@@ -839,6 +839,14 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7351.php');
 		$this->assertNoErrors($errors);
+	}
+
+	public function testBug7320(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7320.php');
+		$this->assertCount(1, $errors);
+		$this->assertSame('Parameter #1 $c of function Bug7320\foo expects callable(int=): void, Closure(int): void given.', $errors[0]->getMessage());
+		$this->assertSame(13, $errors[0]->getLine());
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7320.php
+++ b/tests/PHPStan/Analyser/data/bug-7320.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7320;
+
+/**
+ * @param callable(int=): void $c
+ */
+function foo(callable $c): void {
+	$c();
+}
+
+function () {
+	foo(function (int $a): void {});
+};


### PR DESCRIPTION
Fixes phpstan/phpstan#7320