### PR TITLE
Get stubs from StubFilesProvider

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -470,6 +470,7 @@ services:
 		class: PHPStan\PhpDoc\DefaultStubFilesProvider
 		arguments:
 			stubFiles: %stubFiles%
+			currentWorkingDirectory: %currentWorkingDirectory%
 		autowired:
 			- PHPStan\PhpDoc\StubFilesProvider
 

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -69,7 +69,7 @@ class AnalyseApplication
 				$input,
 			);
 
-			$projectStubFiles = $this->stubFilesProvider->getStubFiles();
+			$projectStubFiles = $this->stubFilesProvider->getProjectStubFiles();
 
 			if ($resultCache->isFullAnalysis() && count($projectStubFiles) !== 0) {
 				$stubErrors = $this->stubValidator->validate($projectStubFiles, $debug);

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -6,6 +6,7 @@ use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\IgnoredErrorHelper;
 use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
 use PHPStan\Internal\BytesHelper;
+use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\PhpDoc\StubValidator;
 use PHPStan\ShouldNotHappenException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,6 +26,7 @@ class AnalyseApplication
 		private ResultCacheManagerFactory $resultCacheManagerFactory,
 		private IgnoredErrorHelper $ignoredErrorHelper,
 		private int $internalErrorsCountLimit,
+		private StubFilesProvider $stubFilesProvider,
 	)
 	{
 	}
@@ -67,10 +69,8 @@ class AnalyseApplication
 				$input,
 			);
 
-			$projectStubFiles = [];
-			if ($projectConfigArray !== null) {
-				$projectStubFiles = $projectConfigArray['parameters']['stubFiles'] ?? [];
-			}
+			$projectStubFiles = $this->stubFilesProvider->getStubFiles();
+
 			if ($resultCache->isFullAnalysis() && count($projectStubFiles) !== 0) {
 				$stubErrors = $this->stubValidator->validate($projectStubFiles, $debug);
 				$intermediateAnalyserResult = new AnalyserResult(

--- a/src/PhpDoc/DefaultStubFilesProvider.php
+++ b/src/PhpDoc/DefaultStubFilesProvider.php
@@ -3,6 +3,9 @@
 namespace PHPStan\PhpDoc;
 
 use PHPStan\DependencyInjection\Container;
+use PHPStan\Internal\ComposerHelper;
+use function array_filter;
+use function strpos;
 
 class DefaultStubFilesProvider implements StubFilesProvider
 {
@@ -10,12 +13,16 @@ class DefaultStubFilesProvider implements StubFilesProvider
 	/** @var string[]|null */
 	private ?array $cachedFiles = null;
 
+	/** @var string[]|null */
+	private ?array $cachedProjectFiles = null;
+
 	/**
 	 * @param string[] $stubFiles
 	 */
 	public function __construct(
 		private Container $container,
 		private array $stubFiles,
+		private string $currentWorkingDirectory,
 	)
 	{
 	}
@@ -35,6 +42,24 @@ class DefaultStubFilesProvider implements StubFilesProvider
 		}
 
 		return $this->cachedFiles = $files;
+	}
+
+	public function getProjectStubFiles(): array
+	{
+		if ($this->cachedProjectFiles !== null) {
+			return $this->cachedProjectFiles;
+		}
+
+		$composerConfig = ComposerHelper::getComposerConfig($this->currentWorkingDirectory);
+
+		if ($composerConfig === null) {
+			return $this->getStubFiles();
+		}
+
+		return $this->cachedProjectFiles = array_filter(
+			$this->getStubFiles(),
+			fn (string $file): bool => strpos($file, ComposerHelper::getVendorDirFromComposerConfig($this->currentWorkingDirectory, $composerConfig)) === false
+		);
 	}
 
 }

--- a/src/PhpDoc/EmptyStubFilesProvider.php
+++ b/src/PhpDoc/EmptyStubFilesProvider.php
@@ -10,4 +10,9 @@ class EmptyStubFilesProvider implements StubFilesProvider
 		return [];
 	}
 
+	public function getProjectStubFiles(): array
+	{
+		return [];
+	}
+
 }

--- a/src/PhpDoc/StubFilesProvider.php
+++ b/src/PhpDoc/StubFilesProvider.php
@@ -8,4 +8,7 @@ interface StubFilesProvider
 	/** @return string[] */
 	public function getStubFiles(): array;
 
+	/** @return string[] */
+	public function getProjectStubFiles(): array;
+
 }


### PR DESCRIPTION
Followup to https://github.com/phpstan/phpstan-src/commit/d3589dc5415f5a639ef68bc9dccd481922df50c5

Currently `1.7.x-dev` still does not validate the stubs loaded from the extension. `AnalyseApplication` was the only place I found that calls `StubValidator::validate` So I thought here the stub files should also be obtained from `StubFilesProvider::getStubFiles`