### PR TITLE
Use ReadWritePropertiesExtensions in `MissingReadOnlyPropertyAssignRule`

### DIFF
--- a/build/ignore-by-php-version.neon.php
+++ b/build/ignore-by-php-version.neon.php
@@ -13,6 +13,7 @@ if (PHP_VERSION_ID >= 80100) {
 	$includes[] = __DIR__ . '/baseline-8.1.neon';
 } else {
 	$includes[] = __DIR__ . '/enums.neon';
+	$includes[] = __DIR__ . '/readonly-property.neon';
 }
 
 if (PHP_VERSION_ID >= 70400) {

--- a/build/readonly-property.neon
+++ b/build/readonly-property.neon
@@ -1,0 +1,3 @@
+parameters:
+	excludePaths:
+		- ../tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php

--- a/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
@@ -19,6 +19,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 
 	public function __construct(
 		private ConstructorsHelper $constructorsHelper,
+		private ReadWritePropertiesExtensionProvider $extensionProvider,
 	)
 	{
 	}
@@ -34,7 +35,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 			throw new ShouldNotHappenException();
 		}
 		$classReflection = $scope->getClassReflection();
-		[$properties, $prematureAccess, $additionalAssigns] = $node->getUninitializedProperties($scope, $this->constructorsHelper->getConstructors($classReflection), []);
+		[$properties, $prematureAccess, $additionalAssigns] = $node->getUninitializedProperties($scope, $this->constructorsHelper->getConstructors($classReflection), $this->extensionProvider->getExtensions());
 
 		$errors = [];
 		foreach ($properties as $propertyName => $propertyNode) {

--- a/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
@@ -19,6 +19,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 
 	public function __construct(
 		private ConstructorsHelper $constructorsHelper,
+		private ReadWritePropertiesExtensionProvider $extensionProvider,
 	)
 	{
 	}
@@ -34,7 +35,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 			throw new ShouldNotHappenException();
 		}
 		$classReflection = $scope->getClassReflection();
-		[$properties, $prematureAccess, $additionalAssigns] = $node->getUninitializedProperties($scope, $this->constructorsHelper->getConstructors($classReflection), []);
+		[$properties, $prematureAccess, $additionalAssigns] = $node->getUninitializedProperties($scope, $this->constructorsHelper->getConstructors($classReflection), $this->extensionProvider->getExtensions());
 
 		$errors = [];
 		foreach ($properties as $propertyName => $propertyNode) {

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\Rules\Properties;
 
 use PHPStan\Reflection\ConstructorsHelper;
+use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use function in_array;
 use const PHP_VERSION_ID;
 
 /**
@@ -18,6 +20,32 @@ class MissingReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 		return new MissingReadOnlyByPhpDocPropertyAssignRule(
 			new ConstructorsHelper([
 				'MissingReadOnlyPropertyAssignPhpDoc\\TestCase::setUp',
+			]),
+			new DirectReadWritePropertiesExtensionProvider([
+				new class() implements ReadWritePropertiesExtension {
+
+					public function isAlwaysRead(PropertyReflection $property, string $propertyName): bool
+					{
+						return $this->isEntityId($property, $propertyName);
+					}
+
+					public function isAlwaysWritten(PropertyReflection $property, string $propertyName): bool
+					{
+						return $this->isEntityId($property, $propertyName);
+					}
+
+					public function isInitialized(PropertyReflection $property, string $propertyName): bool
+					{
+						return $this->isEntityId($property, $propertyName);
+					}
+
+					private function isEntityId(PropertyReflection $property, string $propertyName): bool
+					{
+						return $property->getDeclaringClass()->getName() === 'MissingReadOnlyPropertyAssignPhpDoc\\Entity'
+							&& in_array($propertyName, ['id'], true);
+					}
+
+				},
 			]),
 		);
 	}

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\Rules\Properties;
 
 use PHPStan\Reflection\ConstructorsHelper;
+use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use function in_array;
 use const PHP_VERSION_ID;
 
 /**
@@ -18,6 +20,32 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		return new MissingReadOnlyPropertyAssignRule(
 			new ConstructorsHelper([
 				'MissingReadOnlyPropertyAssign\\TestCase::setUp',
+			]),
+			new DirectReadWritePropertiesExtensionProvider([
+				new class() implements ReadWritePropertiesExtension {
+
+					public function isAlwaysRead(PropertyReflection $property, string $propertyName): bool
+					{
+						return $this->isEntityId($property, $propertyName);
+					}
+
+					public function isAlwaysWritten(PropertyReflection $property, string $propertyName): bool
+					{
+						return $this->isEntityId($property, $propertyName);
+					}
+
+					public function isInitialized(PropertyReflection $property, string $propertyName): bool
+					{
+						return $this->isEntityId($property, $propertyName);
+					}
+
+					private function isEntityId(PropertyReflection $property, string $propertyName): bool
+					{
+						return $property->getDeclaringClass()->getName() === 'MissingReadOnlyPropertyAssign\\Entity'
+							&& in_array($propertyName, ['id'], true);
+					}
+
+				},
 			]),
 		);
 	}

--- a/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign-phpdoc.php
@@ -196,3 +196,12 @@ class FooTraitClass
 	}
 
 }
+
+
+class Entity
+{
+
+	/** @readonly */
+	private int $id; // does not complain about being uninitialized because of a ReadWritePropertiesExtension
+
+}

--- a/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign.php
+++ b/tests/PHPStan/Rules/Properties/data/missing-readonly-property-assign.php
@@ -153,3 +153,10 @@ class FooTraitClass
 	}
 
 }
+
+class Entity
+{
+
+	private readonly int $id; // does not complain about being uninitialized because of a ReadWritePropertiesExtension
+
+}


### PR DESCRIPTION
.. and `MissingReadOnlyByPhpDocPropertyAssignRuleTest`.

_Should close_ https://github.com/phpstan/phpstan/issues/6632
_Should close_ https://github.com/phpstan/phpstan/issues/7337

I kept it simple and chose a similar testing approach as `UnusedPrivatePropertyRuleTest` uses. I also double-checked - these 2 classes were the only ones were `ClassPropertiesNode::getUninitializedProperties` was used _without_ passing extensions.

A dedicated test-case in the doctrine extension using `readonly` might be a good idea too maybe? I assume there are already cases where the `ReadWritePropertiesExtension` from there is used.

