### PR TITLE
Refactor `UnusedPrivatePropertyRule` to use `ConstructorsHelper`

### DIFF
--- a/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
+++ b/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertiesNode;
 use PHPStan\Node\Property\PropertyRead;
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -31,6 +32,7 @@ class UnusedPrivatePropertyRule implements Rule
 	 * @param string[] $alwaysReadTags
 	 */
 	public function __construct(
+		private ConstructorsHelper $constructorsHelper,
 		private ReadWritePropertiesExtensionProvider $extensionProvider,
 		private array $alwaysWrittenTags,
 		private array $alwaysReadTags,
@@ -158,13 +160,7 @@ class UnusedPrivatePropertyRule implements Rule
 			}
 		}
 
-		$constructors = [];
-		$classReflection = $scope->getClassReflection();
-		if ($classReflection->hasConstructor()) {
-			$constructors[] = $classReflection->getConstructor()->getName();
-		}
-
-		[$uninitializedProperties] = $node->getUninitializedProperties($scope, $constructors, $this->extensionProvider->getExtensions());
+		[$uninitializedProperties] = $node->getUninitializedProperties($scope, $this->constructorsHelper->getConstructors($scope->getClassReflection()), $this->extensionProvider->getExtensions());
 
 		$errors = [];
 		foreach ($properties as $name => $data) {

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\DeadCode;
 
+use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Rules\Properties\DirectReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
@@ -25,6 +26,7 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		return new UnusedPrivatePropertyRule(
+			new ConstructorsHelper([]),
 			new DirectReadWritePropertiesExtensionProvider([
 				new class() implements ReadWritePropertiesExtension {
 


### PR DESCRIPTION
I thought this makes sense for consistency reasons. It looks like, though, that specifying additional constructors for this rule doesn't change anything. I assume because it's only dealing with unused/write-only/read-only props and doesn't care if it's in a constructor or not.
Does this still make sense then?