### PR TITLE
Avoid additional irrelevant constructor-related checks in `UnusedPrivatePropertyRule`

### DIFF
--- a/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
+++ b/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
@@ -158,13 +158,7 @@ class UnusedPrivatePropertyRule implements Rule
 			}
 		}
 
-		$constructors = [];
-		$classReflection = $scope->getClassReflection();
-		if ($classReflection->hasConstructor()) {
-			$constructors[] = $classReflection->getConstructor()->getName();
-		}
-
-		[$uninitializedProperties] = $node->getUninitializedProperties($scope, $constructors, $this->extensionProvider->getExtensions());
+		[$uninitializedProperties] = $node->getUninitializedProperties($scope, [], $this->extensionProvider->getExtensions());
 
 		$errors = [];
 		foreach ($properties as $name => $data) {


### PR DESCRIPTION
That rule doesn't deal with constructors and setting them to `[]` in `ClassPropertiesNode::getUninitializedProperties` avoids check-overhead in regard to premature access and additional writes of props.

See also https://github.com/phpstan/phpstan-src/pull/1359