### PR TITLE
Fix `ConstantArrayType` optional key unsetting via `removeLastElements`

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -573,7 +573,12 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			if ($i >= $newLength) {
 				if ($isOptional) {
 					$optionalKeysRemoved++;
-					unset($optionalKeys[$i]);
+					foreach ($optionalKeys as $key => $value) {
+						if ($value === $i) {
+							unset($optionalKeys[$key]);
+							break;
+						}
+					}
 				}
 
 				$removedKeyType = array_pop($keyTypes);

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -835,6 +835,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug7351(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7351.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-7351.php
+++ b/tests/PHPStan/Analyser/data/bug-7351.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7351;
+
+function value(): string
+{
+	return 'v';
+}
+
+function test(): void
+{
+	$keys = [
+		value(),
+		value(),
+	];
+
+	while (array_pop($keys) !== null) {
+		// do something
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7351

That was a really interesting one. The changes in https://github.com/phpstan/phpstan-src/pull/1352 were triggering it, but that bug was already there and I just seem to have adopted it too.

The problem was that while traversing the array and using `$i` as counter variable, we cannot simply unset the optional key on position `$i` if the array element on that position is going to be removed.
E.g. the array `array{a: 0, b?: 1}` would be represented with the `$optionalKeys` `array{0: 1}` and if if we remove `b` from the original array (which is on position 1) then we don't remove anything from `$optionalKeys`. Instead we have to unset the key of the value `1` (which is actually `0`) to keep the state consistent.

Without this change we ended up with an array with one entry but 2 of them being marked optional and this triggered the fatal error later via `ConstantArrayType::getAllArrays`