### PR TITLE
Fix array_walk callback parameters

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -378,6 +378,11 @@ services:
 			- phpstan.parser.richParserNodeVisitor
 
 	-
+		class: PHPStan\Parser\ArrayWalkArgVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor
+
+	-
 		class: PHPStan\Parser\NewAssignedToPropertyVisitor
 		tags:
 			- phpstan.parser.richParserNodeVisitor

--- a/src/Parser/ArrayWalkArgVisitor.php
+++ b/src/Parser/ArrayWalkArgVisitor.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parser;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+class ArrayWalkArgVisitor extends NodeVisitorAbstract
+{
+
+	public function enterNode(Node $node): ?Node
+	{
+		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+			$functionName = $node->name->toLowerString();
+			if ($functionName === 'array_walk') {
+				$args = $node->getArgs();
+				if (isset($args[0])) {
+					$args[0]->setAttribute('isArrayWalkArg', true);
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -142,6 +142,36 @@ class ParametersAcceptorSelector
 					),
 				];
 			}
+
+			if (isset($args[0]) && (bool) $args[0]->getAttribute('isArrayWalkArg')) {
+				$arrayWalkParameters = [
+					new DummyParameter('item', self::getIterableValueType($scope->getType($args[0]->value)), false, PassedByReference::createReadsArgument(), false, null),
+					new DummyParameter('key', self::getIterableKeyType($scope->getType($args[0]->value)), false, PassedByReference::createNo(), false, null),
+				];
+				if (isset($args[2])) {
+					$arrayWalkParameters[] = new DummyParameter('arg', $scope->getType($args[2]->value), false, PassedByReference::createNo(), false, null);
+				}
+
+				$acceptor = $parametersAcceptors[0];
+				$parameters = $acceptor->getParameters();
+				$parameters[1] = new NativeParameterReflection(
+					$parameters[1]->getName(),
+					$parameters[1]->isOptional(),
+					new CallableType($arrayWalkParameters, new MixedType(), false),
+					$parameters[1]->passedByReference(),
+					$parameters[1]->isVariadic(),
+					$parameters[1]->getDefaultValue(),
+				);
+				$parametersAcceptors = [
+					new FunctionVariant(
+						$acceptor->getTemplateTypeMap(),
+						$acceptor->getResolvedTemplateTypeMap(),
+						$parameters,
+						$acceptor->isVariadic(),
+						$acceptor->getReturnType(),
+					),
+				];
+			}
 		}
 
 		if (count($parametersAcceptors) === 1) {

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -17,23 +17,6 @@ function array_reduce(
 ) {}
 
 /**
- * @template TKey of array-key
- * @template TValue of mixed
- * @template TUser of mixed
- *
- * @param array<TKey, TValue> $one
- * @param callable(TValue, TKey, TUser=): mixed $two
- * @param TUser $three
- *
- * @return true
- */
-function array_walk(
-    array &$one,
-    callable $two,
-    $three = null
-): bool {}
-
-/**
  * @template T of mixed
  *
  * @param array<T> $one

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -587,12 +587,16 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_walk.php'], [
 			[
-				'Parameter #2 $callback of function array_walk expects callable(int, string, mixed): mixed, Closure(stdClass, float): \'\' given.',
+				'Parameter #2 $callback of function array_walk expects callable(1|2, \'bar\'|\'foo\'): mixed, Closure(stdClass, float): \'\' given.',
 				6,
 			],
 			[
-				'Parameter #2 $callback of function array_walk expects callable(int, string, string): mixed, Closure(int, string, int): \'\' given.',
+				'Parameter #2 $callback of function array_walk expects callable(1|2, \'bar\'|\'foo\', \'extra\'): mixed, Closure(int, string, int): \'\' given.',
 				14,
+			],
+			[
+				'Parameter #2 $callback of function array_walk expects callable(1|2, \'bar\'|\'foo\'): mixed, Closure(int, string, int): \'\' given.',
+				23,
 			],
 		]);
 	}
@@ -601,12 +605,16 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_walk_arrow.php'], [
 			[
-				'Parameter #2 $callback of function array_walk expects callable(int, string, mixed): mixed, Closure(stdClass, float): \'\' given.',
+				'Parameter #2 $callback of function array_walk expects callable(1|2, \'bar\'|\'foo\'): mixed, Closure(stdClass, float): \'\' given.',
 				6,
 			],
 			[
-				'Parameter #2 $callback of function array_walk expects callable(int, string, string): mixed, Closure(int, string, int): \'\' given.',
+				'Parameter #2 $callback of function array_walk expects callable(1|2, \'bar\'|\'foo\', \'extra\'): mixed, Closure(int, string, int): \'\' given.',
 				12,
+			],
+			[
+				'Parameter #2 $callback of function array_walk expects callable(1|2, \'bar\'|\'foo\'): mixed, Closure(int, string, int): \'\' given.',
+				19,
 			],
 		]);
 	}


### PR DESCRIPTION
While working on phpstan/phpstan-src#1354 I noticed that the callback parameters for `array_walk` were not completely correct.

As noted in the documentation:
> If the optional `arg` parameter is supplied, it will be passed as the third parameter to the `callback`.

This is hard to express in the stubs so I used a similar approach as exists for `array_map` and `array_filter`.