### PR TITLE
Make trait properties and methods first class node citizens

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -500,6 +500,7 @@ class NodeScopeResolver
 						true,
 						$param,
 						false,
+						$scope->isInTrait(),
 					), $methodScope);
 				}
 			}
@@ -628,7 +629,7 @@ class NodeScopeResolver
 			$this->processAttributeGroups($stmt->attrGroups, $classScope, $classStatementsGatherer);
 
 			$this->processStmtNodes($stmt, $stmt->stmts, $classScope, $classStatementsGatherer);
-			$nodeCallback(new ClassPropertiesNode($stmt, $classStatementsGatherer->getProperties(), $classStatementsGatherer->getTraitProperties(), $classStatementsGatherer->getPropertyUsages(), $classStatementsGatherer->getMethodCalls()), $classScope);
+			$nodeCallback(new ClassPropertiesNode($stmt, $classStatementsGatherer->getProperties(), $classStatementsGatherer->getPropertyUsages(), $classStatementsGatherer->getMethodCalls()), $classScope);
 			$nodeCallback(new ClassMethodsNode($stmt, $classStatementsGatherer->getMethods(), $classStatementsGatherer->getMethodCalls()), $classScope);
 			$nodeCallback(new ClassConstantsNode($stmt, $classStatementsGatherer->getConstants(), $classStatementsGatherer->getConstantFetches()), $classScope);
 			$classReflection->evictPrivateSymbols();
@@ -650,6 +651,7 @@ class NodeScopeResolver
 						false,
 						$prop,
 						$isReadOnly,
+						$scope->isInTrait(),
 					),
 					$scope,
 				);

--- a/src/Node/ClassMethod.php
+++ b/src/Node/ClassMethod.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Node;
+
+class ClassMethod
+{
+
+	public function __construct(
+		private \PhpParser\Node\Stmt\ClassMethod $node,
+		private bool $isDeclaredInTrait,
+	)
+	{
+	}
+
+
+	public function getNode(): \PhpParser\Node\Stmt\ClassMethod
+	{
+		return $this->node;
+	}
+
+	public function isDeclaredInTrait(): bool
+	{
+		return $this->isDeclaredInTrait;
+	}
+
+}

--- a/src/Node/ClassMethodsNode.php
+++ b/src/Node/ClassMethodsNode.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Node;
 
 use PhpParser\Node\Stmt\ClassLike;
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeAbstract;
 use PHPStan\Node\Method\MethodCall;
 

--- a/src/Node/ClassPropertiesNode.php
+++ b/src/Node/ClassPropertiesNode.php
@@ -21,7 +21,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use function array_key_exists;
 use function array_keys;
-use function array_merge;
 use function count;
 use function in_array;
 
@@ -31,11 +30,10 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 
 	/**
 	 * @param ClassPropertyNode[] $properties
-	 * @param ClassPropertyNode[] $traitProperties
 	 * @param array<int, PropertyRead|PropertyWrite> $propertyUsages
 	 * @param array<int, MethodCall> $methodCalls
 	 */
-	public function __construct(private ClassLike $class, private array $properties, private array $traitProperties, private array $propertyUsages, private array $methodCalls)
+	public function __construct(private ClassLike $class, private array $properties, private array $propertyUsages, private array $methodCalls)
 	{
 		parent::__construct($class->getAttributes());
 	}
@@ -51,14 +49,6 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 	public function getProperties(): array
 	{
 		return $this->properties;
-	}
-
-	/**
-	 * @return ClassPropertyNode[]
-	 */
-	public function getTraitProperties(): array
-	{
-		return $this->traitProperties;
 	}
 
 	/**
@@ -102,7 +92,7 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 		$classReflection = $scope->getClassReflection();
 
 		$properties = [];
-		foreach (array_merge($this->getProperties(), $this->getTraitProperties()) as $property) {
+		foreach ($this->getProperties() as $property) {
 			if ($property->isStatic()) {
 				continue;
 			}

--- a/src/Node/ClassPropertyNode.php
+++ b/src/Node/ClassPropertyNode.php
@@ -22,6 +22,7 @@ class ClassPropertyNode extends NodeAbstract implements VirtualNode
 		private bool $isPromoted,
 		Node $originalNode,
 		private bool $isReadonlyByPhpDoc,
+		private bool $isDeclaredInTrait,
 	)
 	{
 		parent::__construct($originalNode->getAttributes());
@@ -81,6 +82,11 @@ class ClassPropertyNode extends NodeAbstract implements VirtualNode
 	public function isReadOnlyByPhpDoc(): bool
 	{
 		return $this->isReadonlyByPhpDoc;
+	}
+
+	public function isDeclaredInTrait(): bool
+	{
+		return $this->isDeclaredInTrait;
 	}
 
 	/**

--- a/src/Node/ClassStatementsGatherer.php
+++ b/src/Node/ClassStatementsGatherer.php
@@ -28,10 +28,7 @@ class ClassStatementsGatherer
 	/** @var ClassPropertyNode[] */
 	private array $properties = [];
 
-	/** @var ClassPropertyNode[] */
-	private array $traitProperties = [];
-
-	/** @var Node\Stmt\ClassMethod[] */
+	/** @var ClassMethod[] */
 	private array $methods = [];
 
 	/** @var \PHPStan\Node\Method\MethodCall[] */
@@ -66,15 +63,7 @@ class ClassStatementsGatherer
 	}
 
 	/**
-	 * @return ClassPropertyNode[]
-	 */
-	public function getTraitProperties(): array
-	{
-		return $this->traitProperties;
-	}
-
-	/**
-	 * @return Node\Stmt\ClassMethod[]
+	 * @return ClassMethod[]
 	 */
 	public function getMethods(): array
 	{
@@ -128,7 +117,7 @@ class ClassStatementsGatherer
 		if ($scope->getClassReflection()->getName() !== $this->classReflection->getName()) {
 			return;
 		}
-		if ($node instanceof ClassPropertyNode && !$scope->isInTrait()) {
+		if ($node instanceof ClassPropertyNode) {
 			$this->properties[] = $node;
 			if ($node->isPromoted()) {
 				$this->propertyUsages[] = new PropertyWrite(
@@ -138,18 +127,8 @@ class ClassStatementsGatherer
 			}
 			return;
 		}
-		if ($node instanceof ClassPropertyNode && $scope->isInTrait()) {
-			$this->traitProperties[] = $node;
-			if ($node->isPromoted()) {
-				$this->propertyUsages[] = new PropertyWrite(
-					new PropertyFetch(new Expr\Variable('this'), new Identifier($node->getName())),
-					$scope,
-				);
-			}
-			return;
-		}
-		if ($node instanceof Node\Stmt\ClassMethod && !$scope->isInTrait()) {
-			$this->methods[] = $node;
+		if ($node instanceof Node\Stmt\ClassMethod) {
+			$this->methods[] = new ClassMethod($node, $scope->isInTrait());
 			return;
 		}
 		if ($node instanceof Node\Stmt\ClassConst) {

--- a/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
+++ b/src/Rules/DeadCode/UnusedPrivatePropertyRule.php
@@ -60,6 +60,9 @@ class UnusedPrivatePropertyRule implements Rule
 			if (!$property->isPrivate()) {
 				continue;
 			}
+			if ($property->isDeclaredInTrait()) {
+				continue;
+			}
 
 			$alwaysRead = false;
 			$alwaysWritten = false;


### PR DESCRIPTION
This is basically the refactoring I had in mind in https://github.com/phpstan/phpstan-src/pull/1362

The current state is already a bit weird IMO, in general trait props and methods were ignored when gathering class nodes. Then recently I added trait props to a dedicated array, just to use them also via uninitialized props checks. I did not add them to the normal props because that would lead to annoying new errors via `UnusedPrivatePropertyRule`.
Then just yesterday I added trait property promotion usage to the normal property usage, but ignoring other potential trait prop usages elsewhere. And trait methods are still completely ignored.

So what does this do different now?
Trait props and methods are gathered together with their class counterparts. And rules just use that. Additionally the information if the prop or method came from a trait is also remembered and only that is used to skip trait props / methods in those 2 `UnusedPrivate*` rules, that were annoying.

I think in the long-run this makes more sense and avoids more weird trait problems. But maybe the details could be modified a bit. WDYT?