### PR TITLE
Fix/native type specification

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3428,13 +3428,11 @@ class MutatingScope implements Scope
 			$variableTypes = $this->getVariableTypes();
 			$variableTypes[$variableName] = VariableTypeHolder::createYes($type);
 
-			if ($nativeType === null) {
-				$nativeType = $type;
-			}
-
 			$nativeTypes = $this->nativeExpressionTypes;
 			$exprString = sprintf('$%s', $variableName);
-			$nativeTypes[$exprString] = $nativeType;
+			if ($nativeType !== null) {
+				$nativeTypes[$exprString] = $nativeType;
+			}
 
 			$conditionalExpressions = [];
 			foreach ($this->conditionalExpressions as $conditionalExprString => $holders) {
@@ -3518,7 +3516,7 @@ class MutatingScope implements Scope
 			$scope = $this->invalidateExpression($expr);
 		}
 
-		return $scope->specifyExpressionType($expr, $type);
+		return $scope->specifyExpressionType($expr, $type, $type);
 	}
 
 	public function invalidateExpression(Expr $expressionToInvalidate, bool $requireMoreCharacters = false): self
@@ -3665,16 +3663,11 @@ class MutatingScope implements Scope
 		) {
 			return $this;
 		}
-		$typeAfterRemove = TypeCombinator::remove($exprType, $typeToRemove);
-		$scope = $this->specifyExpressionType(
+		return $this->specifyExpressionType(
 			$expr,
-			$typeAfterRemove,
+			TypeCombinator::remove($exprType, $typeToRemove),
+			TypeCombinator::remove($this->getNativeType($expr), $typeToRemove),
 		);
-		if ($expr instanceof Variable && is_string($expr->name)) {
-			$scope->nativeExpressionTypes[sprintf('$%s', $expr->name)] = TypeCombinator::remove($this->getNativeType($expr), $typeToRemove);
-		}
-
-		return $scope;
 	}
 
 	/**
@@ -3752,11 +3745,11 @@ class MutatingScope implements Scope
 			$type = $typeSpecification['type'];
 			$originalExprType = $this->getType($expr);
 			if ($typeSpecification['sure']) {
-				$scope = $scope->specifyExpressionType($expr, $specifiedTypes->shouldOverwrite() ? $type : TypeCombinator::intersect($type, $originalExprType));
-
-				if ($expr instanceof Variable && is_string($expr->name)) {
-					$scope->nativeExpressionTypes[sprintf('$%s', $expr->name)] = $specifiedTypes->shouldOverwrite() ? $type : TypeCombinator::intersect($type, $this->getNativeType($expr));
-				}
+				$scope = $scope->specifyExpressionType(
+					$expr,
+					$specifiedTypes->shouldOverwrite() ? $type : TypeCombinator::intersect($type, $originalExprType),
+					$specifiedTypes->shouldOverwrite() ? $type : TypeCombinator::intersect($type, $this->getNativeType($expr)),
+				);
 			} else {
 				$scope = $scope->removeTypeFromExpression($expr, $type);
 			}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1806,6 +1806,7 @@ class NodeScopeResolver
 				$scope = $scope->specifyExpressionType(
 					$arrayArg,
 					$arrayArgType,
+					$arrayArgType,
 				);
 			}
 
@@ -1891,7 +1892,7 @@ class NodeScopeResolver
 					);
 				}
 
-				$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, $arrayType);
+				$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType($arrayArg, $arrayType, $arrayType);
 			}
 
 			if (
@@ -1914,6 +1915,7 @@ class NodeScopeResolver
 				}
 				$scope = $scope->invalidateExpression($arrayArg)->specifyExpressionType(
 					$arrayArg,
+					new ArrayType($arrayArgType->getIterableKeyType(), $valueType),
 					new ArrayType($arrayArgType->getIterableKeyType(), $valueType),
 				);
 			}

--- a/tests/PHPStan/Analyser/data/bug-4099.php
+++ b/tests/PHPStan/Analyser/data/bug-4099.php
@@ -28,14 +28,14 @@ class Foo
 
 		if (!array_key_exists('inner', $arr['key'])) {
 			assertType('array{key: *NEVER*}', $arr);
-			//assertNativeType('array(\'key\' => mixed)', $arr);
+			assertNativeType('array&hasOffset(\'key\')', $arr);
 			assertType('*NEVER*', $arr['key']);
-			//assertNativeType('mixed', $arr['key']);
+			assertNativeType('mixed', $arr['key']);
 			throw new \Exception('need key.inner');
 		}
 
 		assertType('array{key: array{inner: mixed}}', $arr);
-		assertNativeType('array{key: array{inner: mixed}}', $arr);
+		assertNativeType('array&hasOffset(\'key\')', $arr);
 	}
 
 }


### PR DESCRIPTION
There are lot of `specifyExpressionType` that is not correct to use type as native type.

https://github.com/phpstan/phpstan-src/blob/4889a27ab8c1b7458f0efcbc82f39e7e77ec8086/src/Analyser/MutatingScope.php#L3376-L3379
https://github.com/phpstan/phpstan-src/blob/4889a27ab8c1b7458f0efcbc82f39e7e77ec8086/src/Analyser/MutatingScope.php#L3485-L3488
https://github.com/phpstan/phpstan-src/blob/4889a27ab8c1b7458f0efcbc82f39e7e77ec8086/src/Analyser/NodeScopeResolver.php#L3618

This PR changes to specify native types only if specified separately.