### PR TITLE
Do not overwrite promoted property PHPDoc with constructor PHPDoc

### DIFF
--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -290,6 +290,19 @@ class PhpClassReflectionExtension
 			} elseif (isset($varTags[$propertyName])) {
 				$phpDocType = $varTags[$propertyName]->getType();
 			}
+
+			if (!isset($phpDocBlockClassReflection)) {
+				throw new ShouldNotHappenException();
+			}
+
+			$phpDocType = $phpDocType !== null ? TemplateTypeHelper::resolveTemplateTypes(
+				$phpDocType,
+				$phpDocBlockClassReflection->getActiveTemplateTypeMap(),
+			) : null;
+			$deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag() !== null ? $resolvedPhpDoc->getDeprecatedTag()->getMessage() : null;
+			$isDeprecated = $resolvedPhpDoc->isDeprecated();
+			$isInternal = $resolvedPhpDoc->isInternal();
+			$isReadOnlyByPhpDoc = $isReadOnlyByPhpDoc || $resolvedPhpDoc->isReadOnly();
 		}
 
 		if ($phpDocType === null) {
@@ -313,20 +326,6 @@ class PhpClassReflectionExtension
 					$phpDocType = $paramTags[$propertyReflection->getName()]->getType();
 				}
 			}
-		}
-
-		if ($resolvedPhpDoc !== null) {
-			if (!isset($phpDocBlockClassReflection)) {
-				throw new ShouldNotHappenException();
-			}
-			$phpDocType = $phpDocType !== null ? TemplateTypeHelper::resolveTemplateTypes(
-				$phpDocType,
-				$phpDocBlockClassReflection->getActiveTemplateTypeMap(),
-			) : null;
-			$deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag() !== null ? $resolvedPhpDoc->getDeprecatedTag()->getMessage() : null;
-			$isDeprecated = $resolvedPhpDoc->isDeprecated();
-			$isInternal = $resolvedPhpDoc->isInternal();
-			$isReadOnlyByPhpDoc = $isReadOnlyByPhpDoc || $resolvedPhpDoc->isReadOnly();
 		}
 
 		if (

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -300,7 +300,7 @@ class PhpClassReflectionExtension
 				if ($nativeClassReflection->getConstructor() !== null) {
 					$positionalParameterNames = array_map(static fn (ReflectionParameter $parameter): string => $parameter->getName(), $nativeClassReflection->getConstructor()->getParameters());
 				}
-				$resolvedPhpDoc = $this->phpDocInheritanceResolver->resolvePhpDocForMethod(
+				$resolvedConstructorPhpDoc = $this->phpDocInheritanceResolver->resolvePhpDocForMethod(
 					$constructorDocComment,
 					$declaringClassReflection->getFileName(),
 					$declaringClassReflection,
@@ -308,7 +308,7 @@ class PhpClassReflectionExtension
 					$constructorName,
 					$positionalParameterNames,
 				);
-				$paramTags = $resolvedPhpDoc->getParamTags();
+				$paramTags = $resolvedConstructorPhpDoc->getParamTags();
 				if (isset($paramTags[$propertyReflection->getName()])) {
 					$phpDocType = $paramTags[$propertyReflection->getName()]->getType();
 				}

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Properties;
 use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ReadOnlyByPhpDocPropertyAssignRule>
@@ -90,6 +91,20 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Immutable::$foo is assigned outside of the constructor.',
 				227,
+			],
+		]);
+	}
+
+	public function testBug7361(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-7361.php'], [
+			[
+				'@readonly property Bug7361\Example::$foo is assigned outside of the constructor.',
+				12,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Properties/data/bug-7361.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7361.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug7361;
+
+class Example {
+	public function __construct(
+		/** @readonly */
+		public int $foo
+	) {}
+
+	public function doStuff(): void {
+		$this->foo = 7;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7361

If I understood the code here correctly, the constructor PHPDoc is only needed to get the  `$phpDocType` for a property (it's actually only resolved if `$phpDocType` is null). Currently though, it overwrites `$resolvedPhpDoc` completely, also e.g. `@readonly`, meaning that at the moment it would be possible to add `@readonly` to the constructor making all promoted props readonly, which is weird I guess? And, on the other hand of course, if there's no constructor PHPDoc, then it basically resets the promoted prop PHPDoc, ignoring e.g. `@readonly` as it was the case in the linked bug.

I have to admit though, that I'm not using promoted properties heavily, maybe I'm missing something..