### PR TITLE
Improve unresolve template type checks for complex conditional types

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -355,7 +355,7 @@ class FunctionCallParametersCheck
 				TypeTraverser::map(
 					$parametersAcceptor->getReturnTypeWithUnresolvableTemplateTypes(),
 					static function (Type $type, callable $traverse) use (&$returnTemplateTypes): Type {
-						if ($type instanceof ConditionalType) {
+						while ($type instanceof ConditionalType && $type->isResolvable()) {
 							$type = $type->resolve();
 						}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -902,6 +902,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7341.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-strstr-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-strrchr-specifying.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/conditional-complex-templates.php');
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2469,4 +2469,14 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+
+	public function testConditionalComplexTemplates(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = false;
+		$this->analyse([__DIR__ . '/data/conditional-complex-templates.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/conditional-complex-templates.php
+++ b/tests/PHPStan/Rules/Methods/data/conditional-complex-templates.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ConditionalComplexTemplates;
+
+use function PHPStan\Testing\assertType;
+
+/** @template T */
+interface PromiseInterface
+{
+    /**
+     * @template TFulfilled of mixed
+	 * @template TRejected of mixed
+     * @param (callable(T): TFulfilled)|null $onFulfilled
+     * @param (callable(mixed): TRejected)|null $onRejected
+     * @return PromiseInterface<(
+	 *   $onFulfilled is not null
+	 *     ? ($onRejected is not null ? TFulfilled|TRejected : TFulfilled)
+	 *     : ($onRejected is not null ? TRejected : T)
+	 * )>
+     */
+    public function then(callable $onFulfilled = null, callable $onRejected = null);
+}
+
+/**
+ * @param PromiseInterface<true> $promise
+ */
+function test(PromiseInterface $promise): void
+{
+	$passThroughBoolFn = static fn (bool $bool): bool => $bool;
+
+	assertType('ConditionalComplexTemplates\PromiseInterface<bool>', $promise->then($passThroughBoolFn));
+	assertType('ConditionalComplexTemplates\PromiseInterface<bool>', $promise->then()->then($passThroughBoolFn));
+}


### PR DESCRIPTION
While trying to provide a correct return type for https://github.com/phpstan/phpstan/discussions/7371#discussioncomment-2858931 I noticed that there were some spurious errors.