### PR TITLE
Improve dead code detection after nested function calls with conditional never return type

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1661,11 +1661,9 @@ class NodeScopeResolver
 			return $expr;
 		}
 
-		if ($expr instanceof Expr\CallLike || $expr instanceof Expr\Match_) {
-			$exprType = $scope->getType($expr);
-			if ($exprType instanceof NeverType && $exprType->isExplicit()) {
-				return $expr;
-			}
+		$exprType = $scope->getType($expr);
+		if ($exprType instanceof NeverType && $exprType->isExplicit()) {
+			return $expr;
 		}
 
 		return null;

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -120,4 +120,15 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4370.php'], []);
 	}
 
+	public function testBug7188(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-7188.php'], [
+			[
+				'Unreachable statement - code above always terminates.',
+				22,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/data/bug-7188.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-7188.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7188;
+
+use Exception;
+
+/**
+ * @param int $x
+ * @return ($x is 0 ? never : float)
+ */
+function inverse($x): float
+{
+	if ($x===0) {
+		throw new Exception('Division durch Null.');
+	}
+
+	return 1/$x;
+}
+
+function () {
+	$result = inverse(0);
+	echo "expect to unreachable\n";
+};


### PR DESCRIPTION
Partial solution for phpstan/phpstan#7188: check expressions for terminating calls a bit more aggressively.