### PR TITLE
Fix variadic parameter subject types in conditional return types

### DIFF
--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -2,8 +2,10 @@
 
 namespace PHPStan\Reflection;
 
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
@@ -59,7 +61,9 @@ class GenericParametersAcceptorResolver
 
 			$paramType = $param->getType();
 			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType));
-			$passedArgs['$' . $param->getName()] = $argType;
+
+			$passedArgType = $param->isVariadic() ? new ArrayType(new MixedType(), $argType) : $argType;
+			$passedArgs['$' . $param->getName()] = $passedArgType;
 		}
 
 		$resolvedTemplateTypeMap = new TemplateTypeMap(array_merge(

--- a/src/Rules/PhpDoc/ConditionalReturnTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/ConditionalReturnTypeRuleHelper.php
@@ -5,9 +5,11 @@ namespace PHPStan\Rules\PhpDoc;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\ConditionalType;
 use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\VerbosityLevel;
@@ -52,7 +54,11 @@ class ConditionalReturnTypeRuleHelper
 					$errors[] = RuleErrorBuilder::message(sprintf('Conditional return type references unknown parameter $%s.', $parameterName))->build();
 					continue;
 				}
-				$subjectType = $parametersByName[$parameterName]->getType();
+				$parameter = $parametersByName[$parameterName];
+				$subjectType = $parameter->getType();
+				if ($parameter->isVariadic()) {
+					$subjectType = new ArrayType(new MixedType(), $subjectType);
+				}
 			}
 
 			$targetType = $conditionalType->getTarget();

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -903,6 +903,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-strstr-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-strrchr-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/conditional-complex-templates.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7234.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7234.php
+++ b/tests/PHPStan/Analyser/data/bug-7234.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bug7234;
+
+use function PHPStan\Testing\assertType;
+
+class Expr {
+
+    /**
+     * @template T of string
+     * @param T ...$x
+     * @return ($x is array<literal-string> ? literal-string&non-empty-string : string)
+     */
+    public function countDistinct(...$x) {
+		return 'COUNT(DISTINCT ' . implode(', ', func_get_args()) . ')';
+    }
+
+}
+
+class QueryBuilder {
+
+    /**
+     * @return Expr
+     */
+    public function expr() {
+		return new Expr();
+    }
+
+}
+
+function (QueryBuilder $qb, $value) {
+	assertType('literal-string&non-empty-string', $qb->expr()->countDistinct('A', 'B', 'C'));
+	assertType('string', $qb->expr()->countDistinct($value, 'B', 'C'));
+	assertType('string', $qb->expr()->countDistinct('A', $value, 'C'));
+};

--- a/tests/PHPStan/Rules/PhpDoc/FunctionConditionalReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/FunctionConditionalReturnTypeRuleTest.php
@@ -60,6 +60,14 @@ class FunctionConditionalReturnTypeRuleTest extends RuleTestCase
 				'Condition "int is not string" in conditional return type is always true.',
 				117,
 			],
+			[
+				'Condition "array<int> is int" in conditional return type is always false.',
+				125,
+			],
+			[
+				'Condition "array<int> is array<int>" in conditional return type is always true.',
+				133,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/function-conditional-return-type.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/function-conditional-return-type.php
@@ -118,3 +118,19 @@ function fill11(int $i): array
 {
 
 }
+
+/**
+ * @return ($i is int ? non-empty-array : array)
+ */
+function fill12(int ...$i): array
+{
+
+}
+
+/**
+ * @return ($i is array<int> ? non-empty-array : array)
+ */
+function fill13(int ...$i): array
+{
+
+}


### PR DESCRIPTION
Fix for phpstan/phpstan#7234. Not _super_ convinced this is a good idea, but writing `($x is int ...)` for a variadic `$x` seems wrong as well.