### PR TITLE
Use a single line spacing between class members and functions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -96,6 +96,17 @@
 			</property>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing">
+		<properties>
+			<property name="linesCountBetweenMembers" value="1"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.MethodSpacing">
+		<properties>
+			<property name="minLinesCount" value="1"/>
+			<property name="maxLinesCount" value="1"/>
+		</properties>
+	</rule>
 	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
 	<rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
@@ -124,13 +135,6 @@
 	<rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
 	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
 	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
-	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
-		<properties>
-			<property name="spacing" value="1" />
-			<property name="spacingBeforeFirst" value="1"/>
-			<property name="spacingAfterLast" value="1"/>
-		</properties>
-	</rule>
 	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
 		<exclude-pattern>src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php</exclude-pattern>
 	</rule>

--- a/src/Node/ClassMethod.php
+++ b/src/Node/ClassMethod.php
@@ -12,7 +12,6 @@ class ClassMethod
 	{
 	}
 
-
 	public function getNode(): \PhpParser\Node\Stmt\ClassMethod
 	{
 		return $this->node;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -226,6 +226,7 @@ class ParametersAcceptorSelector
 
 		return $has;
 	}
+
 	/**
 	 * @param array<int|string, Type> $types
 	 * @param ParametersAcceptor[] $parametersAcceptors

--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -44,6 +44,7 @@ class StaticMethodCallCheck
 	)
 	{
 	}
+
 	/**
 	 * @param Name|Expr $class
 	 * @return array{RuleError[], MethodReflection|null}

--- a/src/Rules/Operators/InvalidAssignVarRule.php
+++ b/src/Rules/Operators/InvalidAssignVarRule.php
@@ -58,7 +58,6 @@ class InvalidAssignVarRule implements Rule
 		return [];
 	}
 
-
 	private function containsNonAssignableExpression(Expr $expr): bool
 	{
 		if ($expr instanceof Expr\Variable) {

--- a/src/Type/Constant/ConstantIntegerType.php
+++ b/src/Type/Constant/ConstantIntegerType.php
@@ -32,7 +32,6 @@ class ConstantIntegerType extends IntegerType implements ConstantScalarType
 		return $this->value;
 	}
 
-
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
 		if ($type instanceof self) {

--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -146,18 +146,15 @@ class IntegerRangeType extends IntegerType implements CompoundType
 		return $this->min;
 	}
 
-
 	public function getMax(): ?int
 	{
 		return $this->max;
 	}
 
-
 	public function describe(VerbosityLevel $level): string
 	{
 		return sprintf('int<%s, %s>', $this->min ?? 'min', $this->max ?? 'max');
 	}
-
 
 	public function shift(int $amount): Type
 	{
@@ -193,7 +190,6 @@ class IntegerRangeType extends IntegerType implements CompoundType
 		return self::fromInterval($min, $max);
 	}
 
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof parent) {
@@ -206,7 +202,6 @@ class IntegerRangeType extends IntegerType implements CompoundType
 
 		return TrinaryLogic::createNo();
 	}
-
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
@@ -266,7 +261,6 @@ class IntegerRangeType extends IntegerType implements CompoundType
 	{
 		return $type instanceof self && $this->min === $type->min && $this->max === $type->max;
 	}
-
 
 	public function generalize(GeneralizePrecision $precision): Type
 	{

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -29,7 +29,6 @@ trait JustNullableTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
-
 	public function isSuperTypeOf(Type $type): TrinaryLogic
 	{
 		if ($type instanceof self) {

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -146,7 +146,6 @@ class ObjectWithoutClassType implements SubtractableType
 		return $this->subtractedType;
 	}
 
-
 	public function traverse(callable $cb): Type
 	{
 		$subtractedType = $this->subtractedType !== null ? $cb($this->subtractedType) : null;

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -153,7 +153,6 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return $type;
 	}
 
-
 	private function determineExactType(Type $in, int $filterValue): ?Type
 	{
 		if (($filterValue === $this->getConstant('FILTER_VALIDATE_BOOLEAN') && $in instanceof BooleanType)
@@ -207,7 +206,6 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 
 		return null;
 	}
-
 
 	private function hasFlag(int $flag, ?Node\Arg $expression, Scope $scope): bool
 	{

--- a/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsArrayFunctionTypeSpecifyingExtension.php
@@ -24,7 +24,6 @@ class IsArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 	{
 	}
 
-
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
 		return strtolower($functionReflection->getName()) === 'is_array'

--- a/src/Type/Php/SimpleXMLElementClassPropertyReflectionExtension.php
+++ b/src/Type/Php/SimpleXMLElementClassPropertyReflectionExtension.php
@@ -18,7 +18,6 @@ class SimpleXMLElementClassPropertyReflectionExtension implements PropertiesClas
 		return $classReflection->getName() === 'SimpleXMLElement' || $classReflection->isSubclassOf('SimpleXMLElement');
 	}
 
-
 	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
 		return new SimpleXMLElementProperty($classReflection, new BenevolentUnionType([new ObjectType($classReflection->getName()), new NullType()]));

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -6896,7 +6896,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		];
 	}
 
-
 	public function dataForLoopVariables(): array
 	{
 		return [
@@ -6932,8 +6931,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			],
 		];
 	}
-
-
 
 	/**
 	 * @dataProvider dataLoopVariables

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -135,7 +135,6 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 		$this->assertSame(trim(Neon::encode(['parameters' => ['ignoreErrors' => $expected]], Neon::BLOCK)), trim($this->getOutputContent()), sprintf('%s: output do not match', $message));
 	}
 
-
 	public function testFormatErrorMessagesRegexEscape(): void
 	{
 		$formatter = new BaselineNeonErrorFormatter(new SimpleRelativePathHelper(self::DIRECTORY_PATH));

--- a/tests/PHPStan/Rules/Arrays/OffsetAccessAssignmentRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/OffsetAccessAssignmentRuleTest.php
@@ -129,7 +129,6 @@ class OffsetAccessAssignmentRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/new-offset-stub.php'], []);
 	}
 
-
 	public function testRuleWithNullsafeVariant(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -34,7 +34,6 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		return $this->treatPhpDocTypesAsCertain;
 	}
 
-
 	public function testRule(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -420,7 +420,6 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
-
 	public function testPutCsvWithStringable(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2418,7 +2418,6 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
-
 	public function testBug6904(): void
 	{
 		if (PHP_VERSION_ID < 80100) {
@@ -2431,7 +2430,6 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/bug-6904.php'], []);
 	}
-
 
 	public function testBug6917(): void
 	{
@@ -2468,7 +2466,6 @@ class CallMethodsRuleTest extends RuleTestCase
 			],
 		]);
 	}
-
 
 	public function testConditionalComplexTemplates(): void
 	{

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -629,7 +629,6 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6023.php'], []);
 	}
 
-
 	public function testBug5065(): void
 	{
 		$this->checkExplicitMixed = false;

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -673,7 +673,6 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4808.php'], []);
 	}
 
-
 	public function testBug5868(): void
 	{
 		if (PHP_VERSION_ID < 80000) {


### PR DESCRIPTION
Turns out this was partly covered via `Squiz.WhiteSpace.FunctionSpacing` but it looks like it did not limit it to 1, or was not really working, not sure. Anyways, I checked it, that sniff is not needed anymore now. I replaced it with `SlevomatCodingStandard.Classes.ClassMemberSpacing` and `SlevomatCodingStandard.Classes.MethodSpacing`