### PR TITLE
Add @readonly rule that disallows default values

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -6,6 +6,8 @@ conditionalTags:
 		phpstan.rules.rule: %featureToggles.nodeConnectingVisitorRule%
 	PHPStan\Rules\Properties\MissingReadOnlyByPhpDocPropertyAssignRule:
 		phpstan.rules.rule: %featureToggles.readOnlyByPhpDoc%
+	PHPStan\Rules\Properties\ReadOnlyByPhpDocPropertyRule:
+		phpstan.rules.rule: %featureToggles.readOnlyByPhpDoc%
 	PHPStan\Rules\Properties\UninitializedPropertyRule:
 		phpstan.rules.rule: %checkUninitializedProperties%
 	PHPStan\Rules\Methods\ConsistentConstructorRule:
@@ -187,6 +189,9 @@ services:
 			reportMaybes: %reportMaybesInPropertyPhpDocTypes%
 		tags:
 			- phpstan.rules.rule
+
+	-
+		class: PHPStan\Rules\Properties\ReadOnlyByPhpDocPropertyRule
 
 	-
 		class: PHPStan\Rules\Properties\UninitializedPropertyRule

--- a/src/Rules/Properties/ReadOnlyByPhpDocPropertyRule.php
+++ b/src/Rules/Properties/ReadOnlyByPhpDocPropertyRule.php
@@ -27,7 +27,7 @@ class ReadOnlyByPhpDocPropertyRule implements Rule
 
 		$errors = [];
 		if ($node->getDefault() !== null) {
-			 $errors[] = RuleErrorBuilder::message('@readonly property cannot have a default value.')->nonIgnorable()->build();
+			 $errors[] = RuleErrorBuilder::message('@readonly property cannot have a default value.')->build();
 		}
 
 		return $errors;

--- a/src/Rules/Properties/ReadOnlyByPhpDocPropertyRule.php
+++ b/src/Rules/Properties/ReadOnlyByPhpDocPropertyRule.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassPropertyNode>
+ */
+class ReadOnlyByPhpDocPropertyRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return ClassPropertyNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node->isReadOnlyByPhpDoc()) {
+			return [];
+		}
+
+		$errors = [];
+		if ($node->getDefault() !== null) {
+			 $errors[] = RuleErrorBuilder::message('@readonly property cannot have a default value.')->nonIgnorable()->build();
+		}
+
+		return $errors;
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Properties;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ReadOnlyByPhpDocPropertyRule>
@@ -18,6 +19,10 @@ class ReadOnlyByPhpDocPropertyRuleTest extends RuleTestCase
 
 	public function testRule(): void
 	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
 		$this->analyse([__DIR__ . '/data/read-only-property-phpdoc.php'], [
 			[
 				'@readonly property cannot have a default value.',

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyRuleTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ReadOnlyByPhpDocPropertyRule>
+ */
+class ReadOnlyByPhpDocPropertyRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new ReadOnlyByPhpDocPropertyRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/read-only-property-phpdoc.php'], [
+			[
+				'@readonly property cannot have a default value.',
+				21,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ReadOnlyPropertyPhpDoc;
+
+class Foo
+{
+
+	/**
+	 * @readonly
+	 * @var int
+	 */
+	private $foo;
+
+	/** @readonly */
+	private $bar;
+
+	/**
+	 * @readonly
+	 * @var int
+	 */
+	private $baz = 0;
+
+}

--- a/tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.1
 
 namespace ReadOnlyPropertyPhpDoc;
 
@@ -20,4 +20,14 @@ class Foo
 	 */
 	private $baz = 0;
 
+}
+
+final class ErrorResponse
+{
+	public function __construct(
+		/** @readonly */
+		public string $message = ''
+	)
+	{
+	}
 }


### PR DESCRIPTION
The counter-part to `ReadOnlyPropertyRule`. I looked at that one already and thought it deals with only native readonly behaviour, but forbidding default values too might make sense in regard to use `@readonly` for smoother upgrades to native readonly?

E.g. https://phpstan.org/r/0e1cd73e-6a9b-486f-8ae2-1781c0ff2eb4

feel free to just close this if you disagree, I thought it's easier to open the PR instead of starting a discussion / opening an issue :) 