### PR TITLE
Fix indent for bin/phpstan

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,10 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
+[bin/phpstan]
+indent_style = tab
+indent_size = 4
+
 [*.xml]
 indent_style = tab
 indent_size = 4

--- a/bin/phpstan
+++ b/bin/phpstan
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 (function () {
 	error_reporting(E_ALL);
 	ini_set('display_errors', 'stderr');
-    if (version_compare(PHP_VERSION, '7.4.0', '<')) {
+	if (version_compare(PHP_VERSION, '7.4.0', '<')) {
 		// PHP earlier than 7.4.x with OpCache triggers a bug when we intercept
 		// custom autoloaders' reads to discover file paths. See PHPStan #4881.
 		ini_set('opcache.enable', 'Off');


### PR DESCRIPTION
I had taken 3 minutes to understand this...

<img src="https://user-images.githubusercontent.com/42755/171769527-b42df500-1653-48b0-95ce-4dc6f0836062.png" width=400 />

I also try cs-fix with introduce `<file>bin</file>` into phpcs.xml, but `bin/phpstan` would not be fixed. 
Because,  PHP_CodeSniffer v3 does not support PHP files with no extensions. https://github.com/squizlabs/PHP_CodeSniffer/issues/1754
Also see https://github.com/leonstafford/WhatWouldViktorDo/issues/2

