### PR TITLE
Dont report unsafe static if constructor is in both parent and interface

### DIFF
--- a/src/Rules/Classes/NewStaticRule.php
+++ b/src/Rules/Classes/NewStaticRule.php
@@ -57,6 +57,12 @@ class NewStaticRule implements Rule
 			return [];
 		}
 
+		foreach ($classReflection->getImmediateInterfaces() as $interface) {
+			if ($interface->hasConstructor()) {
+				return [];
+			}
+		}
+
 		if ($constructor instanceof PhpMethodReflection) {
 			if ($constructor->isFinal()->yes()) {
 				return [];

--- a/tests/PHPStan/Rules/Classes/data/new-static.php
+++ b/tests/PHPStan/Rules/Classes/data/new-static.php
@@ -115,3 +115,33 @@ class ClassExtendingAbstractConstructor extends AbstractConstructor
 	}
 
 }
+
+interface FooInterface
+{
+	public function __construct();
+}
+
+interface BarInterface extends FooInterface {}
+
+class VendorFoo
+{
+	public function __construct()
+	{
+	}
+}
+
+class Foo extends VendorFoo implements FooInterface
+{
+	static function build()
+	{
+		return new static();
+	}
+}
+
+class Bar extends VendorFoo implements BarInterface
+{
+	static function build()
+	{
+		return new static();
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/6007