### PR TITLE
reproduce specifier bug

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1335,6 +1335,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9293.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/nullsafe-vs-scalar.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8517.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1396.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-1396.php
+++ b/tests/PHPStan/Analyser/data/bug-1396.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug1396;
+
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantScalarType;
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function doFoo(
+		ConstantScalarType $constantType
+	): SpecifiedTypes
+	{
+		assertType('bool|float|int|string|null', $constantType->getValue());
+
+		if ($constantType->getValue() === null) {
+			return new SpecifiedTypes();
+		}
+
+		assertType('bool|float|int|string', $constantType->getValue());
+
+		if (
+			$constantType instanceof ConstantStringType
+		) {
+			assertType('string', $constantType->getValue());
+		}
+		assertType('bool|float|int|string', $constantType->getValue());
+	}
+}


### PR DESCRIPTION
with https://github.com/phpstan/phpstan-src/pull/1383/files#r887647098 I was running into this bug.

the problem is, that phpstan should dump the type `string` but reports `bool|float|int|string` for the `dumpType` call seen here:

```
$ php bin/phpstan analyze src/Analyser/TypeSpecifier.php
Note: Using configuration file C:\dvl\Workspace\phpstan-src-staabm\phpstan.neon.dist.
 1/1 [============================] 100%

 ------ ------------------------------------
  Line   TypeSpecifier.php
 ------ ------------------------------------
  274    Dumped type: bool|float|int|string
 ------ ------------------------------------
```

I am not yet sure how to debug this issue further. I also tried reproducing the case in a smaler repro script, but this did not work out yet.

any ideas/hints?