### PR TITLE
Add `@no-named-arguments` check to MethodSignatureRule

### DIFF
--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -110,6 +110,11 @@ class AnnotationMethodReflection implements ExtendedMethodReflection
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function acceptsNamedArguments(): bool
+	{
+		return true;
+	}
+
 	public function getDocComment(): ?string
 	{
 		return null;

--- a/src/Reflection/ExtendedMethodReflection.php
+++ b/src/Reflection/ExtendedMethodReflection.php
@@ -16,4 +16,6 @@ namespace PHPStan\Reflection;
 interface ExtendedMethodReflection extends MethodReflection
 {
 
+	public function acceptsNamedArguments(): bool;
+
 }

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -137,6 +137,11 @@ class NativeMethodReflection implements ExtendedMethodReflection
 		return $this->hasSideEffects;
 	}
 
+	public function acceptsNamedArguments(): bool
+	{
+		return true;
+	}
+
 	private function isVoid(): bool
 	{
 		foreach ($this->variants as $variant) {

--- a/src/Reflection/Php/EnumCasesMethodReflection.php
+++ b/src/Reflection/Php/EnumCasesMethodReflection.php
@@ -105,4 +105,9 @@ class EnumCasesMethodReflection implements ExtendedMethodReflection
 		return TrinaryLogic::createNo();
 	}
 
+	public function acceptsNamedArguments(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -705,6 +705,7 @@ class PhpClassReflectionExtension
 		$isInternal = $resolvedPhpDoc->isInternal();
 		$isFinal = $resolvedPhpDoc->isFinal();
 		$isPure = $resolvedPhpDoc->isPure();
+		$acceptsNamedArguments = $resolvedPhpDoc->acceptsNamedArguments();
 
 		return $this->methodReflectionFactory->create(
 			$declaringClass,
@@ -719,6 +720,7 @@ class PhpClassReflectionExtension
 			$isInternal,
 			$isFinal,
 			$isPure,
+			$acceptsNamedArguments,
 		);
 	}
 

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -78,6 +78,7 @@ class PhpMethodReflection implements ExtendedMethodReflection
 		private bool $isInternal,
 		private bool $isFinal,
 		private ?bool $isPure,
+		private bool $acceptsNamedArguments,
 	)
 	{
 	}
@@ -417,6 +418,11 @@ class PhpMethodReflection implements ExtendedMethodReflection
 		}
 
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function acceptsNamedArguments(): bool
+	{
+		return $this->acceptsNamedArguments;
 	}
 
 }

--- a/src/Reflection/Php/PhpMethodReflectionFactory.php
+++ b/src/Reflection/Php/PhpMethodReflectionFactory.php
@@ -26,6 +26,7 @@ interface PhpMethodReflectionFactory
 		bool $isInternal,
 		bool $isFinal,
 		?bool $isPure = null,
+		bool $acceptsNamedArguments = true,
 	): PhpMethodReflection;
 
 }

--- a/src/Reflection/WrappedExtendedMethodReflection.php
+++ b/src/Reflection/WrappedExtendedMethodReflection.php
@@ -82,4 +82,9 @@ class WrappedExtendedMethodReflection implements ExtendedMethodReflection
 		return $this->method->hasSideEffects();
 	}
 
+	public function acceptsNamedArguments(): bool
+	{
+		return true;
+	}
+
 }

--- a/src/Rules/Methods/MethodSignatureRule.php
+++ b/src/Rules/Methods/MethodSignatureRule.php
@@ -67,6 +67,16 @@ class MethodSignatureRule implements Rule
 		$errors = [];
 		$declaringClass = $method->getDeclaringClass();
 		foreach ($this->collectParentMethods($methodName, $method->getDeclaringClass()) as $parentMethod) {
+			if ($parentMethod->acceptsNamedArguments() && ! $method->acceptsNamedArguments()) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'Method %s::%s() should accept named arguments as method %s::%s() does',
+					$method->getDeclaringClass()->getDisplayName(),
+					$method->getName(),
+					$parentMethod->getDeclaringClass()->getDisplayName(),
+					$parentMethod->getName(),
+				))->build();
+			}
+
 			$parentVariants = $parentMethod->getVariants();
 			if (count($parentVariants) !== 1) {
 				continue;

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -374,4 +374,20 @@ class MethodSignatureRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testOverridenMethodWithNoNamedArguments(): void
+	{
+		$this->reportMaybes = true;
+		$this->reportStatic = true;
+		$this->analyse([__DIR__ . '/data/no-named-arguments.php'], [
+			[
+				'Method NoNamedArguments\Baz::namedArgumentsInParent() should accept named arguments as method NoNamedArguments\Foo::namedArgumentsInParent() does',
+				10,
+			],
+			[
+				'Method NoNamedArguments\Baz::namedArgumentsInInterface() should accept named arguments as method NoNamedArguments\Bar::namedArgumentsInInterface() does',
+				15,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/no-named-arguments.php
+++ b/tests/PHPStan/Rules/Methods/data/no-named-arguments.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace NoNamedArguments;
+
+class Baz extends Foo implements Bar
+{
+	/**
+	 * @no-named-arguments
+	 */
+	public function namedArgumentsInParent(float ...$args) {}
+
+	/**
+	 * @no-named-arguments
+	 */
+	public function namedArgumentsInInterface(float ...$args) {}
+}
+
+abstract class Foo
+{
+	abstract public function namedArgumentsInParent(float ...$args);
+}
+
+interface Bar
+{
+	public function namedArgumentsInInterface();
+}


### PR DESCRIPTION
Add a check preventing a child method from declaring `@no-named-arguments` when the parent method does not.