### PR TITLE
Execute / lint `ReadOnlyByPhpDocPropertyRuleTest` starting  with PHP …

### DIFF
--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyRuleTest.php
@@ -19,8 +19,8 @@ class ReadOnlyByPhpDocPropertyRuleTest extends RuleTestCase
 
 	public function testRule(): void
 	{
-		if (PHP_VERSION_ID < 80100) {
-			$this->markTestSkipped('Test requires PHP 8.1.');
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
 		}
 
 		$this->analyse([__DIR__ . '/data/read-only-property-phpdoc.php'], [

--- a/tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/read-only-property-phpdoc.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.1
+<?php // lint >= 8.0
 
 namespace ReadOnlyPropertyPhpDoc;
 


### PR DESCRIPTION
…8 instead of 8.1

ah, I hit enter too early. Wanted to change the title still :)

This is a tiny follow-up of https://github.com/phpstan/phpstan-src/pull/1391. As Ondrej mentioned there - the test only uses promoted properties.