### PR TITLE
Support constant string/int as template bound

### DIFF
--- a/src/Rules/Generics/TemplateTypeCheck.php
+++ b/src/Rules/Generics/TemplateTypeCheck.php
@@ -13,6 +13,8 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateType;
@@ -101,7 +103,9 @@ class TemplateTypeCheck
 				$boundTypeClass !== MixedType::class
 				&& $boundTypeClass !== ConstantArrayType::class
 				&& $boundTypeClass !== ArrayType::class
+				&& $boundTypeClass !== ConstantStringType::class
 				&& $boundTypeClass !== StringType::class
+				&& $boundTypeClass !== ConstantIntegerType::class
 				&& $boundTypeClass !== IntegerType::class
 				&& $boundTypeClass !== FloatType::class
 				&& $boundTypeClass !== BooleanType::class

--- a/src/Type/Generic/TemplateConstantIntegerType.php
+++ b/src/Type/Generic/TemplateConstantIntegerType.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
+use PHPStan\Type\Type;
+
+/** @api */
+final class TemplateConstantIntegerType extends ConstantIntegerType implements TemplateType
+{
+
+	/** @use TemplateTypeTrait<ConstantIntegerType> */
+	use TemplateTypeTrait;
+	use UndecidedComparisonCompoundTypeTrait;
+
+	public function __construct(
+		TemplateTypeScope $scope,
+		TemplateTypeStrategy $templateTypeStrategy,
+		TemplateTypeVariance $templateTypeVariance,
+		string $name,
+		ConstantIntegerType $bound,
+	)
+	{
+		parent::__construct($bound->getValue());
+		$this->scope = $scope;
+		$this->strategy = $templateTypeStrategy;
+		$this->variance = $templateTypeVariance;
+		$this->name = $name;
+		$this->bound = $bound;
+	}
+
+	public function traverse(callable $cb): Type
+	{
+		$newBound = $cb($this->getBound());
+		if ($this->getBound() !== $newBound && $newBound instanceof ConstantIntegerType) {
+			return new self(
+				$this->scope,
+				$this->strategy,
+				$this->variance,
+				$this->name,
+				$newBound,
+			);
+		}
+
+		return $this;
+	}
+
+	protected function shouldGeneralizeInferredType(): bool
+	{
+		return false;
+	}
+
+}

--- a/src/Type/Generic/TemplateConstantStringType.php
+++ b/src/Type/Generic/TemplateConstantStringType.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
+use PHPStan\Type\Type;
+
+/** @api */
+final class TemplateConstantStringType extends ConstantStringType implements TemplateType
+{
+
+	/** @use TemplateTypeTrait<ConstantStringType> */
+	use TemplateTypeTrait;
+	use UndecidedComparisonCompoundTypeTrait;
+
+	public function __construct(
+		TemplateTypeScope $scope,
+		TemplateTypeStrategy $templateTypeStrategy,
+		TemplateTypeVariance $templateTypeVariance,
+		string $name,
+		ConstantStringType $bound,
+	)
+	{
+		parent::__construct($bound->getValue());
+		$this->scope = $scope;
+		$this->strategy = $templateTypeStrategy;
+		$this->variance = $templateTypeVariance;
+		$this->name = $name;
+		$this->bound = $bound;
+	}
+
+	public function traverse(callable $cb): Type
+	{
+		$newBound = $cb($this->getBound());
+		if ($this->getBound() !== $newBound && $newBound instanceof ConstantStringType) {
+			return new self(
+				$this->scope,
+				$this->strategy,
+				$this->variance,
+				$this->name,
+				$newBound,
+			);
+		}
+
+		return $this;
+	}
+
+	protected function shouldGeneralizeInferredType(): bool
+	{
+		return false;
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -7,6 +7,8 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
@@ -55,8 +57,16 @@ final class TemplateTypeFactory
 			return new TemplateStringType($scope, $strategy, $variance, $name, $bound);
 		}
 
+		if ($bound instanceof ConstantStringType && ($boundClass === ConstantStringType::class || $bound instanceof TemplateType)) {
+			return new TemplateConstantStringType($scope, $strategy, $variance, $name, $bound);
+		}
+
 		if ($bound instanceof IntegerType && ($boundClass === IntegerType::class || $bound instanceof TemplateType)) {
 			return new TemplateIntegerType($scope, $strategy, $variance, $name, $bound);
+		}
+
+		if ($bound instanceof ConstantIntegerType && ($boundClass === ConstantIntegerType::class || $bound instanceof TemplateType)) {
+			return new TemplateConstantIntegerType($scope, $strategy, $variance, $name, $bound);
 		}
 
 		if ($bound instanceof FloatType && ($boundClass === FloatType::class || $bound instanceof TemplateType)) {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -841,6 +841,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug7381(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7381.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -905,6 +905,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-strcasing-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/conditional-complex-templates.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7374.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/template-constant-bound.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7381.php
+++ b/tests/PHPStan/Analyser/data/bug-7381.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7381;
+
+/**
+ * @template T of array<string, mixed>
+ */
+trait AttributeTrait
+{
+    /**
+     * @template K of key-of<T>
+     * @param K $key
+     * @return T[K]|null
+     */
+    public function getAttribute(string $key)
+    {
+        return $this->getAttributes()[$key] ?? null;
+    }
+}
+
+/**
+ * @phpstan-type Attrs array{foo?: string}
+ */
+class Foo {
+    /** @use AttributeTrait<Attrs> */
+	use AttributeTrait;
+
+	/** @return Attrs */
+	public function getAttributes(): array
+	{
+		return [];
+	}
+}
+
+/**
+ * @phpstan-type Attrs array{foo?: string, bar?: string}
+ */
+class Bar {
+    /** @use AttributeTrait<Attrs> */
+	use AttributeTrait;
+
+	/** @return Attrs */
+	public function getAttributes(): array
+	{
+		return [];
+	}
+}

--- a/tests/PHPStan/Analyser/data/template-constant-bound.php
+++ b/tests/PHPStan/Analyser/data/template-constant-bound.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace TemplateConstantBound;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T1 of 'foo'
+ * @template T2 of 5
+ * @param T1 $foo
+ * @param T2 $bar
+ */
+function foo(string $foo, int $bar): void
+{
+	assertType("T1 of 'foo' (function TemplateConstantBound\\foo(), argument)", $foo);
+	assertType('T2 of 5 (function TemplateConstantBound\foo(), argument)', $bar);
+}

--- a/tests/PHPStan/Rules/Generics/data/class-template.php
+++ b/tests/PHPStan/Rules/Generics/data/class-template.php
@@ -79,3 +79,19 @@ new /** @template TypeAlias */ class
 {
 
 };
+
+/**
+ * @template T of 'string'
+ */
+class Sit
+{
+
+}
+
+/**
+ * @template T of 5
+ */
+class Amet
+{
+
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#7381. In general constant string/int bounds don't make much sense, but they can appear when `key-of<T>` is resolved.