### PR TITLE
ExtendedMethodReflection

### DIFF
--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -4,14 +4,14 @@ namespace PHPStan\Reflection\Annotations;
 
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\FunctionVariant;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 
-class AnnotationMethodReflection implements MethodReflection
+class AnnotationMethodReflection implements ExtendedMethodReflection
 {
 
 	/** @var FunctionVariant[]|null */

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Reflection\Annotations;
 
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\Generic\TemplateTypeHelper;
@@ -11,7 +12,7 @@ use function count;
 class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflectionExtension
 {
 
-	/** @var MethodReflection[][] */
+	/** @var ExtendedMethodReflection[][] */
 	private array $methods = [];
 
 	public function hasMethod(ClassReflection $classReflection, string $methodName): bool
@@ -27,6 +28,9 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 		return isset($this->methods[$classReflection->getCacheKey()][$methodName]);
 	}
 
+	/**
+	 * @return ExtendedMethodReflection
+	 */
 	public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
 	{
 		return $this->methods[$classReflection->getCacheKey()][$methodName];
@@ -36,7 +40,7 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 		ClassReflection $classReflection,
 		ClassReflection $declaringClass,
 		string $methodName,
-	): ?MethodReflection
+	): ?ExtendedMethodReflection
 	{
 		$methodTags = $classReflection->getMethodTags();
 		if (isset($methodTags[$methodName])) {

--- a/src/Reflection/ExtendedMethodReflection.php
+++ b/src/Reflection/ExtendedMethodReflection.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection;
+
+/**
+ * The purpose of this interface is to be able to
+ * answer more questions about methods
+ * without breaking backward compatibility
+ * with existing MethodsClassReflectionExtension.
+ *
+ * Developers are meant to only use the MethodReflection
+ * and its methods in their code.
+ *
+ * Methods on ExtendedMethodReflection are subject to change.
+ */
+interface ExtendedMethodReflection extends MethodReflection
+{
+
+}

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -4,8 +4,8 @@ namespace PHPStan\Reflection\Native;
 
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodPrototypeReflection;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Reflection\Php\BuiltinMethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -16,7 +16,7 @@ use PHPStan\Type\VoidType;
 use ReflectionException;
 use function strtolower;
 
-class NativeMethodReflection implements MethodReflection
+class NativeMethodReflection implements ExtendedMethodReflection
 {
 
 	/**

--- a/src/Reflection/Php/EnumCasesMethodReflection.php
+++ b/src/Reflection/Php/EnumCasesMethodReflection.php
@@ -4,15 +4,15 @@ namespace PHPStan\Reflection\Php;
 
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\FunctionVariant;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
 
-class EnumCasesMethodReflection implements MethodReflection
+class EnumCasesMethodReflection implements ExtendedMethodReflection
 {
 
 	public function __construct(private ClassReflection $declaringClass, private Type $returnType)

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -19,6 +19,7 @@ use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\Annotations\AnnotationsMethodsClassReflectionExtension;
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
@@ -68,10 +69,10 @@ class PhpClassReflectionExtension
 	/** @var PhpPropertyReflection[][] */
 	private array $nativeProperties = [];
 
-	/** @var MethodReflection[][] */
+	/** @var ExtendedMethodReflection[][] */
 	private array $methodsIncludingAnnotations = [];
 
-	/** @var MethodReflection[][] */
+	/** @var ExtendedMethodReflection[][] */
 	private array $nativeMethods = [];
 
 	/** @var array<string, array<string, Type>> */
@@ -375,6 +376,9 @@ class PhpClassReflectionExtension
 		return $classReflection->getNativeReflection()->hasMethod($methodName);
 	}
 
+	/**
+	 * @return ExtendedMethodReflection
+	 */
 	public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
 	{
 		if (isset($this->methodsIncludingAnnotations[$classReflection->getCacheKey()][$methodName])) {
@@ -411,7 +415,7 @@ class PhpClassReflectionExtension
 		return false;
 	}
 
-	public function getNativeMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+	public function getNativeMethod(ClassReflection $classReflection, string $methodName): ExtendedMethodReflection
 	{
 		if (isset($this->nativeMethods[$classReflection->getCacheKey()][$methodName])) {
 			return $this->nativeMethods[$classReflection->getCacheKey()][$methodName];
@@ -450,7 +454,7 @@ class PhpClassReflectionExtension
 		ClassReflection $classReflection,
 		BuiltinMethodReflection $methodReflection,
 		bool $includingAnnotations,
-	): MethodReflection
+	): ExtendedMethodReflection
 	{
 		if ($includingAnnotations && $this->annotationsMethodsClassReflectionExtension->hasMethod($classReflection, $methodReflection->getName())) {
 			$hierarchyDistances = $classReflection->getClassHierarchyDistances();

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -13,10 +13,10 @@ use PHPStan\Parser\FunctionCallStatementFinder;
 use PHPStan\Parser\Parser;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\FunctionVariantWithPhpDocs;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\MethodPrototypeReflection;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParameterReflectionWithPhpDocs;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
@@ -44,7 +44,7 @@ use function time;
 use const PHP_VERSION_ID;
 
 /** @api */
-class PhpMethodReflection implements MethodReflection
+class PhpMethodReflection implements ExtendedMethodReflection
 {
 
 	/** @var PhpParameterReflection[]|null */

--- a/src/Reflection/WrappedExtendedMethodReflection.php
+++ b/src/Reflection/WrappedExtendedMethodReflection.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+class WrappedExtendedMethodReflection implements ExtendedMethodReflection
+{
+
+	public function __construct(private MethodReflection $method)
+	{
+	}
+
+	public function getDeclaringClass(): ClassReflection
+	{
+		return $this->method->getDeclaringClass();
+	}
+
+	public function isStatic(): bool
+	{
+		return $this->method->isStatic();
+	}
+
+	public function isPrivate(): bool
+	{
+		return $this->method->isPrivate();
+	}
+
+	public function isPublic(): bool
+	{
+		return $this->method->isPublic();
+	}
+
+	public function getDocComment(): ?string
+	{
+		return $this->method->getDocComment();
+	}
+
+	public function getName(): string
+	{
+		return $this->method->getName();
+	}
+
+	public function getPrototype(): ClassMemberReflection
+	{
+		return $this->method->getPrototype();
+	}
+
+	public function getVariants(): array
+	{
+		return $this->method->getVariants();
+	}
+
+	public function isDeprecated(): TrinaryLogic
+	{
+		return $this->method->isDeprecated();
+	}
+
+	public function getDeprecatedDescription(): ?string
+	{
+		return $this->method->getDeprecatedDescription();
+	}
+
+	public function isFinal(): TrinaryLogic
+	{
+		return $this->method->isFinal();
+	}
+
+	public function isInternal(): TrinaryLogic
+	{
+		return $this->method->isInternal();
+	}
+
+	public function getThrowType(): ?Type
+	{
+		return $this->method->getThrowType();
+	}
+
+	public function hasSideEffects(): TrinaryLogic
+	{
+		return $this->method->hasSideEffects();
+	}
+
+}

--- a/src/Rules/Methods/MethodSignatureRule.php
+++ b/src/Rules/Methods/MethodSignatureRule.php
@@ -6,7 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ParameterReflectionWithPhpDocs;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
@@ -120,7 +120,7 @@ class MethodSignatureRule implements Rule
 	}
 
 	/**
-	 * @return MethodReflection[]
+	 * @return ExtendedMethodReflection[]
 	 */
 	private function collectParentMethods(string $methodName, ClassReflection $class): array
 	{


### PR DESCRIPTION
FYI @rvanvelzen @jrmajor This is my answer to have we can extend what method can tell us about themselves without breaking backward compatibility.

Right now MethodReflection is being used in custom MethodsClassReflectionExtension so we can't add new methods on it. But that doesn't prevent us to work with ExtendedMethodReflection in PHPStan internals.

I imagine that methods like `acceptsNamedArguments()` and `getAsserts()` could be added on ExtendedMethodReflection.