### PR TITLE
Do not consider arrays with an unknown class string to be a callback

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -395,7 +395,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		if ($classOrObject instanceof ConstantStringType) {
 			$reflectionProvider = ReflectionProviderStaticAccessor::getInstance();
 			if (!$reflectionProvider->hasClass($classOrObject->getValue())) {
-				return ConstantArrayTypeAndMethod::createUnknown();
+				return null;
 			}
 			$type = new ObjectType($reflectionProvider->getClass($classOrObject->getValue())->getName());
 		} elseif ($classOrObject instanceof GenericClassStringType) {

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
@@ -76,4 +76,18 @@ class UnusedPrivateMethodRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7389(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7389.php'], [
+			[
+				'Method Bug7389\HelloWorld::getTest() is unused.',
+				11,
+			],
+			[
+				'Method Bug7389\HelloWorld::getTest1() is unused.',
+				23,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/data/bug-7389.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-7389.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7389;
+
+class HelloWorld
+{
+	/**
+	 * @param string $test test
+	 * @return array<string>
+	 */
+	private function getTest(string $test): array
+	{
+		return [
+			'',
+			'',
+		];
+	}
+
+	/**
+	 * @param string $test test
+	 * @return string
+	 */
+	private function getTest1(string $test): string
+	{
+		return 'test1';
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7389

E.g. `['', '']` was considered to be an unknown callable which messes up `UnusedPrivateMethodRuleTest`. I was not sure about this, I guess if people only scan parts of their code, this  could turn out to be a problem? But as this is considered bad-practice anyways, maybe this is fine.
Let me know if I missed something.