### PR TITLE
Fix node scope resolving of array/list expression assignments

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3467,7 +3467,7 @@ class NodeScopeResolver
 				}
 
 				$itemScope = $scope;
-				if ($arrayItem->value instanceof ArrayDimFetch && $arrayItem->value->dim === null) {
+				if ($enterExpressionAssign) {
 					$itemScope = $itemScope->enterExpressionAssign($arrayItem->value);
 				}
 				$itemScope = $this->lookForSetAllowedUndefinedExpressions($itemScope, $arrayItem->value);

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivatePropertyRuleTest.php
@@ -118,6 +118,16 @@ class UnusedPrivatePropertyRuleTest extends RuleTestCase
 				$tip,
 			],
 			[
+				'Property UnusedPrivateProperty\ArrayAssign::$foo is never read, only written.',
+				162,
+				$tip,
+			],
+			[
+				'Property UnusedPrivateProperty\ListAssign::$foo is never read, only written.',
+				191,
+				$tip,
+			],
+			[
 				'Property UnusedPrivateProperty\WriteToCollection::$collection1 is never read, only written.',
 				221,
 				$tip,

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -104,6 +104,15 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7119(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-7119.php'], []);
+	}
+
 	public function testBug7314(): void
 	{
 		if (PHP_VERSION_ID < 80100) {

--- a/tests/PHPStan/Rules/Properties/data/bug-7119.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7119.php
@@ -1,0 +1,23 @@
+<?php // lint >= 8.1
+declare(strict_types=1);
+
+namespace Bug7119;
+
+final class FooBar
+{
+	private readonly mixed $value;
+
+	/**
+	 * @param array{value: mixed} $data
+	 */
+	public function __construct(array $data)
+	{
+		//$this->value = $data['value']; // This triggers no PHPStan error.
+		['value' => $this->value] = $data; // This triggers PHPStan error.
+	}
+
+	public function getValue(): mixed
+	{
+		return $this->value;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7119

By always calling `Scope::enterExpressionAssign` when `$enterExpressionAssign` is set, `ClassStatementsGatherer::gatherNodes` can correctly skip creating `PropertyRead` on assignments in https://github.com/phpstan/phpstan-src/blob/1.7.11/src/Node/ClassStatementsGatherer.php#L186.

If I'm not completely confused by array destructuring assignments now, then the 2 new reported errors from `UnusedPrivatePropertyRuleTest` were previously missed and should be correct.