### PR TITLE
Support for relative paths in `editorUrl`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1949,6 +1949,7 @@ services:
 	errorFormatter.table:
 		class: PHPStan\Command\ErrorFormatter\TableErrorFormatter
 		arguments:
+			simpleRelativePathHelper: @simpleRelativePathHelper
 			showTipsOfTheDay: %tipsOfTheDay%
 			editorUrl: %editorUrl%
 

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -79,7 +79,7 @@ class TableErrorFormatter implements ErrorFormatter
 				if (is_string($this->editorUrl)) {
 					$editorFile = $error->getTraitFilePath() ?? $error->getFilePath();
 					$url = str_replace(
-						['%file%', '%rel_file%', '%line%'],
+						['%file%', '%relFile%', '%line%'],
 						[$editorFile, $this->relativePathHelper->getRelativePath($editorFile), (string) $error->getLine()],
 						$this->editorUrl,
 					);

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -7,6 +7,7 @@ use PHPStan\Command\AnalyseCommand;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
+use PHPStan\File\SimpleRelativePathHelper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use function array_map;
 use function count;
@@ -19,6 +20,7 @@ class TableErrorFormatter implements ErrorFormatter
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,
+		private SimpleRelativePathHelper $simpleRelativePathHelper,
 		private CiDetectedErrorFormatter $ciDetectedErrorFormatter,
 		private bool $showTipsOfTheDay,
 		private ?string $editorUrl,
@@ -80,7 +82,7 @@ class TableErrorFormatter implements ErrorFormatter
 					$editorFile = $error->getTraitFilePath() ?? $error->getFilePath();
 					$url = str_replace(
 						['%file%', '%relFile%', '%line%'],
-						[$editorFile, $this->relativePathHelper->getRelativePath($editorFile), (string) $error->getLine()],
+						[$editorFile, $this->simpleRelativePathHelper->getRelativePath($editorFile), (string) $error->getLine()],
 						$this->editorUrl,
 					);
 					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $this->relativePathHelper->getRelativePath($editorFile) . '</>';

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -78,7 +78,11 @@ class TableErrorFormatter implements ErrorFormatter
 				}
 				if (is_string($this->editorUrl)) {
 					$editorFile = $error->getTraitFilePath() ?? $error->getFilePath();
-					$url = str_replace(['%file%', '%line%'], [$editorFile, (string) $error->getLine()], $this->editorUrl);
+					$url = str_replace(
+						['%file%', '%rel_file%', '%line%'],
+						[$editorFile, $this->relativePathHelper->getRelativePath($editorFile), (string) $error->getLine()],
+						$this->editorUrl,
+					);
 					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $this->relativePathHelper->getRelativePath($editorFile) . '</>';
 				}
 				$rows[] = [

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -10,6 +10,7 @@ use PHPStan\Command\ErrorFormatter\TeamcityErrorFormatter;
 use PHPStan\Command\Symfony\SymfonyOutput;
 use PHPStan\File\FuzzyRelativePathHelper;
 use PHPStan\File\NullRelativePathHelper;
+use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -67,10 +68,16 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 		$memoryLimitFile = self::getContainer()->getParameter('memoryLimitFile');
 
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), __DIR__, [], DIRECTORY_SEPARATOR);
-		$errorFormatter = new TableErrorFormatter($relativePathHelper, new CiDetectedErrorFormatter(
-			new GithubErrorFormatter($relativePathHelper),
-			new TeamcityErrorFormatter($relativePathHelper),
-		), false, null);
+		$errorFormatter = new TableErrorFormatter(
+			$relativePathHelper,
+			new SimpleRelativePathHelper(__DIR__),
+			new CiDetectedErrorFormatter(
+				new GithubErrorFormatter($relativePathHelper),
+				new TeamcityErrorFormatter($relativePathHelper),
+			),
+			false,
+			null,
+		);
 		$analysisResult = $analyserApplication->analyse(
 			[$path],
 			true,

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -191,6 +191,19 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		$this->assertStringContainsString('Bar.php', $this->getOutputContent());
 	}
 
+	public function testEditorUrlWithRelativePath(): void
+	{
+		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
+		$formatter = new TableErrorFormatter($relativePathHelper, new CiDetectedErrorFormatter(
+			new GithubErrorFormatter($relativePathHelper),
+			new TeamcityErrorFormatter($relativePathHelper),
+		), false, 'editor://custom/path/%relFile%/%line%');
+		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], false, null, true), $this->getOutput(true));
+
+		$this->assertStringContainsString('editor://custom/path/rel/Foo.php', $this->getOutputContent(true));
+	}
+
 	public function testBug6727(): void
 	{
 		putenv('COLUMNS=30');


### PR DESCRIPTION
This allows running PHPStan within Docker environment and output errors with links to files on the host (`editorUrl` must be configured using actual host's path to the project + `%rel_file%`).

Fixes phpstan/phpstan#7043

---

I decided to use `%rel_file%` because there was `RelativePathHelper` already in the formatter, so it was almost non-invasive. Other options would require much more work and many other files modified.

I wanted to add test for it, but honestly I don't know how to do it 🤔 I created test similar to `TableErrorFormatterTest::testEditorUrlWithTrait()` but flow of outputting errors does not allow to check if `href` added to message is correct - it's missing in the output retrieved with `$this->getOutputContent()`. Anyway, I was able to test it with Docker runtime created locally and it works:

```neon
# phpstan.neon
includes:
	- phpstan.neon.dist

parameters:
	editorUrl: 'phpstorm://open?file=/Volumes/Projects/~Github/phpstan/phpstan-src/%%rel_file%%&line=%%line%%'
```

<img width="856" alt="image" src="https://user-images.githubusercontent.com/600668/173207825-e6efe56a-bab7-4636-9403-db33dce48b71.png">

Screenshot shows PHPStan analysis within Docker container, at the bottom you can see tooltip with href that is shown when mouse cursor is over the activated link - it's proper host's path, not container's one (which is `/etc/phpstan/...`).

FYI: `~/Dev` is a symlink to `/Volumes/Projects/`, if CLI prompt looks suspicious 😉 