### PR TITLE
Fix "missing return" for void/never conditional return types

### DIFF
--- a/src/Rules/Missing/MissingReturnRule.php
+++ b/src/Rules/Missing/MissingReturnRule.php
@@ -16,6 +16,7 @@ use PHPStan\Type\GenericTypeVariableResolver;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
@@ -64,6 +65,8 @@ class MissingReturnRule implements Rule
 		} else {
 			throw new ShouldNotHappenException();
 		}
+
+		$returnType = TypeUtils::resolveLateResolvableTypes($returnType);
 
 		$isVoidSuperType = $returnType->isSuperTypeOf(new VoidType());
 		if ($isVoidSuperType->yes() && !$returnType instanceof MixedType) {

--- a/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
+++ b/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
@@ -286,4 +286,11 @@ class MissingReturnRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7384(): void
+	{
+		$this->checkExplicitMixedMissingReturn = true;
+		$this->checkPhpDocMissingReturn = true;
+		$this->analyse([__DIR__ . '/data/bug-7384.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Missing/data/bug-7384.php
+++ b/tests/PHPStan/Rules/Missing/data/bug-7384.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7384;
+
+class Cl
+{
+    /**
+     * @return void
+     */
+    public static function assertTrueSimple(bool $v): void
+    {
+		if (!$v) {
+			throw new \Error('Value is not true');
+		}
+	}
+
+    /**
+     * @return ($v is true ? void : never)
+     */
+    public static function assertTrue(bool $v): void
+    {
+		if (!$v) {
+			throw new \Error('Value is not true');
+		}
+	}
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#7384