### PR TITLE
support positional arguments in sprintf() constant format inference

### DIFF
--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -43,15 +43,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$formatType = $scope->getType($args[0]->value);
 
 		if ($formatType instanceof ConstantStringType) {
-			// simplest format
-			if (preg_match('/^%[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
-				return new IntersectionType([
-					new StringType(),
-					new AccessoryNumericStringType(),
-				]);
-			}
-			// format with positional arguments
-			if (preg_match('/^%[0-9]+\$[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
+			if (preg_match('/^%([0-9]+\$)?[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
 				return new IntersectionType([
 					new StringType(),
 					new AccessoryNumericStringType(),

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -33,7 +33,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
@@ -44,7 +44,12 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 		if ($formatType instanceof ConstantStringType) {
 			// The printf format is %[argnum$][flags][width][.precision]
-			if (preg_match('/^%([0-9]+\$)?[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
+			if (preg_match('/^%([0-9]*\$)?[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue(), $matches) === 1) {
+				// invalid positional argument
+				if ($matches[1] === '0$') {
+					return null;
+				}
+
 				return new IntersectionType([
 					new StringType(),
 					new AccessoryNumericStringType(),

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -43,6 +43,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$formatType = $scope->getType($args[0]->value);
 
 		if ($formatType instanceof ConstantStringType) {
+			// The printf format is %[argnum$][flags][width][.precision]
 			if (preg_match('/^%([0-9]+\$)?[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
 				return new IntersectionType([
 					new StringType(),

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -43,7 +43,15 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$formatType = $scope->getType($args[0]->value);
 
 		if ($formatType instanceof ConstantStringType) {
+			// simplest format
 			if (preg_match('/^%[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
+				return new IntersectionType([
+					new StringType(),
+					new AccessoryNumericStringType(),
+				]);
+			}
+			// format with positional arguments
+			if (preg_match('/^%[0-9]+\$[0-9]*\.?[0-9]+[bdeEfFgGhHouxX]$/', $formatType->getValue()) === 1) {
 				return new IntersectionType([
 					new StringType(),
 					new AccessoryNumericStringType(),

--- a/tests/PHPStan/Analyser/data/bug-7387.php
+++ b/tests/PHPStan/Analyser/data/bug-7387.php
@@ -42,4 +42,21 @@ class HelloWorld
 		assertType('numeric-string', sprintf('%14X', $i));
 
 	}
+
+	public function positionalArgs($mixed, int $i, float $f, string $s) {
+		// https://3v4l.org/vVL0c
+		assertType('non-empty-string', sprintf('%2$14s', $mixed, $i));
+
+		assertType('numeric-string', sprintf('%2$.14F', $mixed, $i));
+		assertType('numeric-string', sprintf('%2$.14F', $mixed, $f));
+		assertType('numeric-string', sprintf('%2$.14F', $mixed, $s));
+
+		assertType('numeric-string', sprintf('%2$1.14F', $mixed, $i));
+		assertType('numeric-string', sprintf('%2$2.14F', $mixed, $f));
+		assertType('numeric-string', sprintf('%2$3.14F', $mixed, $s));
+
+		assertType('numeric-string', sprintf('%2$14F', $mixed, $i));
+		assertType('numeric-string', sprintf('%2$14F', $mixed, $f));
+		assertType('numeric-string', sprintf('%2$14F', $mixed, $s));
+	}
 }

--- a/tests/PHPStan/Analyser/data/bug-7387.php
+++ b/tests/PHPStan/Analyser/data/bug-7387.php
@@ -58,5 +58,11 @@ class HelloWorld
 		assertType('numeric-string', sprintf('%2$14F', $mixed, $i));
 		assertType('numeric-string', sprintf('%2$14F', $mixed, $f));
 		assertType('numeric-string', sprintf('%2$14F', $mixed, $s));
+
+		assertType('numeric-string', sprintf('%10$14F', $mixed, $s));
+	}
+
+	public function invalidPositionalArgFormat($mixed, string $s) {
+		assertType('string', sprintf('%0$14F', $mixed, $s));
 	}
 }


### PR DESCRIPTION
as requested in https://github.com/phpstan/phpstan-src/pull/1410#issuecomment-1152123657

with this PR we still don't support the whole glory of `sprintf()` - but I think we covered most use-cases as of this PR.