### PR TITLE
Array after `array_push` / `array_unshift` call can still be empty

### DIFF
--- a/tests/PHPStan/Analyser/data/array-push.php
+++ b/tests/PHPStan/Analyser/data/array-push.php
@@ -13,10 +13,14 @@ use function PHPStan\Testing\assertType;
  * @param non-empty-array<int> $c
  * @param array<int|string> $d
  */
-function arrayPush(array $a, array $b, array $c, array $d): void
+function arrayPush(array $a, array $b, array $c, array $d, array $arr): void
 {
 	array_push($a, ...$b);
-	assertType('non-empty-array<int|string>', $a);
+	assertType('array<int|string>', $a);
+
+	/** @var non-empty-array<string> $arr */
+	array_push($arr, ...$b);
+	assertType('non-empty-array<int|string>', $arr);
 
 	array_push($b, ...[]);
 	assertType('array<int>', $b);
@@ -27,7 +31,7 @@ function arrayPush(array $a, array $b, array $c, array $d): void
 	/** @var array<bool|null> $d1 */
 	$d1 = [];
 	array_push($d, ...$d1);
-	assertType('non-empty-array<bool|int|string|null>', $d);
+	assertType('array<bool|int|string|null>', $d);
 }
 
 function arrayPushConstantArray(): void

--- a/tests/PHPStan/Analyser/data/array-unshift.php
+++ b/tests/PHPStan/Analyser/data/array-unshift.php
@@ -13,10 +13,14 @@ use function PHPStan\Testing\assertType;
  * @param non-empty-array<int> $c
  * @param array<int|string> $d
  */
-function arrayUnshift(array $a, array $b, array $c, array $d): void
+function arrayUnshift(array $a, array $b, array $c, array $d, array $arr): void
 {
 	array_unshift($a, ...$b);
-	assertType('non-empty-array<int|string>', $a);
+	assertType('array<int|string>', $a);
+
+	/** @var non-empty-array<string> $arr */
+	array_push($arr, ...$b);
+	assertType('non-empty-array<int|string>', $arr);
 
 	array_unshift($b, ...[]);
 	assertType('array<int>', $b);
@@ -27,7 +31,7 @@ function arrayUnshift(array $a, array $b, array $c, array $d): void
 	/** @var array<bool|null> $d1 */
 	$d1 = [];
 	array_unshift($d, ...$d1);
-	assertType('non-empty-array<bool|int|string|null>', $d);
+	assertType('array<bool|int|string|null>', $d);
 }
 
 function arrayUnshiftConstantArray(): void

--- a/tests/PHPStan/Analyser/data/array-unshift.php
+++ b/tests/PHPStan/Analyser/data/array-unshift.php
@@ -19,7 +19,7 @@ function arrayUnshift(array $a, array $b, array $c, array $d, array $arr): void
 	assertType('array<int|string>', $a);
 
 	/** @var non-empty-array<string> $arr */
-	array_push($arr, ...$b);
+	array_unshift($arr, ...$b);
 	assertType('non-empty-array<int|string>', $arr);
 
 	array_unshift($b, ...[]);

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -169,4 +169,12 @@ class EmptyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7318.php'], []);
 	}
 
+	public function testBug7424(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = false;
+
+		$this->analyse([__DIR__ . '/data/bug-7424.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-7424.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-7424.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bug7424;
+
+class Test
+{
+	public function run(): void
+	{
+		$data = $this->getInitData();
+
+		array_push($data, ...$this->getExtra());
+
+		if (empty($data)) {
+			return;
+		}
+
+		echo 'Proceeding to process data';
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function getInitData(): array
+	{
+		return [];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	protected function getExtra(): array
+	{
+		return [];
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7424

The problem was that `ArrayType::setOffsetValueType` always makes arrays non-empty, which is not wanted in this case (if `optional` is `true` in the callback). And the solution here for simplicity reasons is to basically remove `NonEmptyArrayType` from the result again if either optional is false or the original array was already not iterable at least once before setting the offset.
An alternative might be to add an `$optional` arg to `setOffsetValueType`, but I'm not sure about the impact of that yet.