### PR TITLE
Be more specific about the XHProf sampling type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -13022,7 +13022,7 @@ return [
 'xdiff_string_rabdiff' => ['string', 'old_data'=>'string', 'new_data'=>'string'],
 'xhprof_disable' => ['array'],
 'xhprof_enable' => ['void', 'flags='=>'int', 'options='=>'array'],
-'xhprof_sample_disable' => ['array'],
+'xhprof_sample_disable' => ['array<string,string>'],
 'xhprof_sample_enable' => ['void'],
 'xml_error_string' => ['string', 'code'=>'int'],
 'xml_get_current_byte_index' => ['int', 'parser'=>'resource'],


### PR DESCRIPTION
The `xhprof_sample_disable()` function returns an array of call stack strings keyed by a string representation of the float time of the sample.

Example:

```
array(176) {
  ["1655478412.290000"]=>
  string(139) "main()==>require_once::wordpress/wp-settings.php==>require::wp-includes/default-filters.php==>add_action==>add_filter==>WP_Hook::add_filter"
  ["1655478412.295000"]=>
  string(48) "main()==>require_once::wordpress/wp-settings.php"
  ["1655478412.300000"]=>
  string(48) "main()==>require_once::wordpress/wp-settings.php"
}
```