### PR TITLE
Reindex constant arrays via `shuffle`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1924,6 +1924,17 @@ class NodeScopeResolver
 				$scope = $scope->assignVariable('http_response_header', new ArrayType(new IntegerType(), new StringType()));
 			}
 
+			if (isset($functionReflection) && $functionReflection->getName() === 'shuffle') {
+				$arrayArg = $expr->getArgs()[0]->value;
+				$arrayArgType = $scope->getType($arrayArg);
+
+				if ($arrayArgType instanceof ConstantArrayType) {
+					$arrayArgType = $arrayArgType->getValuesArray()->generalizeToArray();
+				}
+
+				$scope = $scope->specifyExpressionType($arrayArg, $arrayArgType, $arrayArgType);
+			}
+
 			if (
 				isset($functionReflection)
 				&& $functionReflection->getName() === 'array_splice'

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -824,6 +824,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function generalizeToArray(): Type
 	{
+		if ($this->isEmpty()) {
+			return $this;
+		}
+
 		$arrayType = new ArrayType($this->getKeyType(), $this->getItemType());
 		if ($this->isIterableAtLeastOnce()->yes()) {
 			return TypeCombinator::intersect($arrayType, new NonEmptyArrayType());

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -822,6 +822,16 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return new self($this->keyTypes, $valueTypes, $this->nextAutoIndexes, $this->optionalKeys);
 	}
 
+	public function generalizeToArray(): Type
+	{
+		$arrayType = new ArrayType($this->getKeyType(), $this->getItemType());
+		if ($this->isIterableAtLeastOnce()->yes()) {
+			return TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
+		}
+
+		return $arrayType;
+	}
+
 	/**
 	 * @return self
 	 */

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -811,6 +811,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-reverse.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6889.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6891.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/shuffle.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/simplexml.php');
 
 		if (PHP_VERSION_ID >= 80100) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -743,6 +743,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6070.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6108.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1516.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6138.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6174.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5749.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5675.php');

--- a/tests/PHPStan/Analyser/data/bug-6138.php
+++ b/tests/PHPStan/Analyser/data/bug-6138.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6138;
+
+use function PHPStan\Testing\assertType;
+
+$indexed = [
+	1,
+	2,
+	3,
+];
+$associative = [
+	'a' => 1,
+	'b' => 2,
+	'c' => 3,
+];
+$unordered = [
+	0 => 1,
+	3 => 2,
+	42 => 3,
+];
+
+shuffle( $indexed );
+shuffle( $associative );
+shuffle( $unordered );
+
+assertType( 'non-empty-array<int, 0|1|2>', array_keys( $indexed ) );
+assertType( 'non-empty-array<int, 0|1|2>', array_keys( $associative ) );
+assertType( 'non-empty-array<int, 0|1|2>', array_keys( $unordered ) );

--- a/tests/PHPStan/Analyser/data/shuffle.php
+++ b/tests/PHPStan/Analyser/data/shuffle.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace Shuffle;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function normalArrays(array $arr): void
+	{
+		/** @var mixed[] $arr */
+		shuffle($arr);
+		assertType('array', $arr);
+		assertType('array<int, (int|string)>', array_keys($arr));
+		assertType('array<int, mixed>', array_values($arr));
+
+		/** @var non-empty-array<string, int> $arr */
+		shuffle($arr);
+		assertType('non-empty-array<string, int>', $arr);
+		assertType('non-empty-array<int, string>', array_keys($arr));
+		assertType('non-empty-array<int, int>', array_values($arr));
+	}
+
+	public function constantArrays(array $arr): void
+	{
+		/** @var array{} $arr */
+		shuffle($arr);
+		assertType('array{}', $arr);
+		assertType('array{}', array_keys($arr));
+		assertType('array{}', array_values($arr));
+
+		/** @var array{0?: 1, 1?: 2, 2?: 3} $arr */
+		shuffle($arr);
+		assertType('array<0|1|2, 1|2|3>', $arr);
+		assertType('array<int, 0|1|2>', array_keys($arr));
+		assertType('array<int, 1|2|3>', array_values($arr));
+
+		/** @var array{1, 2, 3} $arr */
+		shuffle($arr);
+		assertType('non-empty-array<0|1|2, 1|2|3>', $arr);
+		assertType('non-empty-array<int, 0|1|2>', array_keys($arr));
+		assertType('non-empty-array<int, 1|2|3>', array_values($arr));
+
+		/** @var array{a: 1, b: 2, c: 3} $arr */
+		shuffle($arr);
+		assertType('non-empty-array<0|1|2, 1|2|3>', $arr);
+		assertType('non-empty-array<int, 0|1|2>', array_keys($arr));
+		assertType('non-empty-array<int, 1|2|3>', array_values($arr));
+
+		/** @var array{0: 1, 3: 2, 42: 3} $arr */
+		shuffle($arr);
+		assertType('non-empty-array<0|1|2, 1|2|3>', $arr);
+		assertType('non-empty-array<int, 0|1|2>', array_keys($arr));
+		assertType('non-empty-array<int, 1|2|3>', array_values($arr));
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6138

While this is an improvement I'm not a 100% happy with it, because the constant array still dictates the same order of values after `shuffle`, which is not correct. But generalizing it to a normal array would loose the key order I presume? Better ideas?