### PR TITLE
Add test for "instantiate type from class string" using New_ expr

### DIFF
--- a/tests/PHPStan/Analyser/DynamicReturnTypeExtensionTypeInferenceTest.php
+++ b/tests/PHPStan/Analyser/DynamicReturnTypeExtensionTypeInferenceTest.php
@@ -19,6 +19,7 @@ class DynamicReturnTypeExtensionTypeInferenceTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-compound-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/dynamic-method-return-getsingle-conditional.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7344.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7391b.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/TestDynamicReturnTypeExtensions.php
+++ b/tests/PHPStan/Analyser/data/TestDynamicReturnTypeExtensions.php
@@ -4,6 +4,7 @@ namespace PHPStan\Tests;
 
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\Dummy\ChangedTypeMethodReflection;
@@ -239,4 +240,26 @@ class Bug7344DynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 		return new IntegerType();
 	}
 
+}
+
+class Bug7391BDynamicStaticMethodReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+	public function getClass(): string
+	{
+		return \Bug7391B\Foo::class;
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'm';
+	}
+
+	public function getTypeFromStaticMethodCall(
+		MethodReflection $methodReflection,
+		StaticCall $methodCall,
+		Scope $scope
+	): Type {
+		// return instantiated type from class string
+		return $scope->getType(new New_($methodCall->class));
+	}
 }

--- a/tests/PHPStan/Analyser/data/bug-7391b.php
+++ b/tests/PHPStan/Analyser/data/bug-7391b.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7391B;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function __construct(int $needsAtLeastOneArg) {
+		assertType('int', $needsAtLeastOneArg);
+	}
+
+	public static function m() {
+		assertType('Bug7391B\Foo', self::m());
+		assertType('static(Bug7391B\Foo)', static::m());
+		assertType('Bug7391B\Foo', (self::class)::m());
+		assertType('static(Bug7391B\Foo)', (static::class)::m());
+		assertType('Bug7391B\Foo', get_class(new self(2))::m());
+		assertType('Bug7391B\Foo', get_class(new static(2))::m());
+
+		throw new \Error('For static analysis only, return type is resolved purely by DynamicStaticMethodReturnTypeExtension');
+	}
+}
+
+function () {
+	assertType('Bug7391B\Foo', Foo::m());
+	assertType('Bug7391B\Foo', (Foo::class)::m());
+	$fooCl = Foo::class;
+	assertType('Bug7391B\Foo', get_class(new $fooCl(2))::m());
+};

--- a/tests/PHPStan/Analyser/dynamic-return-type.neon
+++ b/tests/PHPStan/Analyser/dynamic-return-type.neon
@@ -35,3 +35,7 @@ services:
 		class: PHPStan\Tests\Bug7344DynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: PHPStan\Tests\Bug7391BDynamicStaticMethodReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicStaticMethodReturnTypeExtension


### PR DESCRIPTION
original issue: https://github.com/phpstan/phpstan/issues/7391, related discussion https://github.com/phpstan/phpstan-src/pull/1416#issuecomment-1155787778

the correct way to resolve class/string type to object type (to instantiation type in general) seems to be `$scope->getType(new New_($methodCall->class))`

the proposed tests assert it works in all possible cases and `$scope->getType(new New_...` does not throw when no args are passed even if the constructor requires to do so