### PR TITLE
Fix TypeCombinator::union() for intersection of array and template type

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -161,6 +161,9 @@ class TypeCombinator
 				$intermediateArrayType = null;
 				$intermediateAccessoryTypes = [];
 				foreach ($types[$i]->getTypes() as $innerType) {
+					if ($innerType instanceof TemplateType) {
+						continue 2;
+					}
 					if ($innerType instanceof ArrayType) {
 						$intermediateArrayType = $innerType;
 						continue;

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -706,4 +706,10 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7460.php'], []);
 	}
 
+	public function testBug4117(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-4117.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-4117.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-4117.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4117;
+
+use ArrayIterator;
+use IteratorAggregate;
+
+/**
+ * @refactor Refactor utils into base library
+ * @template T of mixed
+ * @implements IteratorAggregate<int, T>
+ */
+class GenericList implements IteratorAggregate
+{
+    /** @var array<int, T> */
+    protected $items = [];
+
+    /**
+     * @return ArrayIterator<int, T>
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->items);
+    }
+
+    /**
+     * @return ?T
+     */
+	public function broken(int $key)
+    {
+        $item = $this->items[$key] ?? null;
+        if ($item) {
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return ?T
+     */
+	public function works(int $key)
+    {
+        $item = $this->items[$key] ?? null;
+
+        return $item;
+    }
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#4117