### PR TITLE
Fix Closure::bind() with $newScope = null

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -995,7 +995,7 @@ return [
 'closelog' => ['bool'],
 'Closure::__construct' => ['void'],
 'Closure::__invoke' => ['', '...args='=>''],
-'Closure::bind' => ['Closure', 'old'=>'Closure', 'to'=>'?object', 'scope='=>'object|string'],
+'Closure::bind' => ['Closure', 'old'=>'Closure', 'to'=>'?object', 'scope='=>'object|string|null'],
 'Closure::bindTo' => ['Closure', 'new'=>'?object', 'newscope='=>'object|string'],
 'Closure::call' => ['', 'to'=>'object', '...parameters='=>''],
 'Closure::fromCallable' => ['Closure', 'callable'=>'callable'],

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -524,4 +524,11 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7489(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-7489.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-7489.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-7489.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7489;
+
+\Closure::bind(function () {
+}, null, null)();


### PR DESCRIPTION
Fix phpstan/phpstan#7489