### PR TITLE
Fix Closure::bindTo() with $newScope = null

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -996,7 +996,7 @@ return [
 'Closure::__construct' => ['void'],
 'Closure::__invoke' => ['', '...args='=>''],
 'Closure::bind' => ['Closure', 'old'=>'Closure', 'to'=>'?object', 'scope='=>'object|string|null'],
-'Closure::bindTo' => ['Closure', 'new'=>'?object', 'newscope='=>'object|string'],
+'Closure::bindTo' => ['Closure', 'new'=>'?object', 'newscope='=>'object|string|null'],
 'Closure::call' => ['', 'to'=>'object', '...parameters='=>''],
 'Closure::fromCallable' => ['Closure', 'callable'=>'callable'],
 'clusterObj::convertToString' => ['string'],

--- a/tests/PHPStan/Rules/Methods/data/bug-7489.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-7489.php
@@ -4,3 +4,6 @@ namespace Bug7489;
 
 \Closure::bind(function () {
 }, null, null)();
+
+(function () {
+})->bindTo(null, null)();


### PR DESCRIPTION
related with https://github.com/phpstan/phpstan-src/pull/1446 change