### PR TITLE
Run with parallel runner only when `proc_open` is not disabled

### DIFF
--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use function array_filter;
 use function array_values;
 use function count;
+use function function_exists;
 use function is_file;
 
 class AnalyserRunner
@@ -58,7 +59,7 @@ class AnalyserRunner
 
 		if (
 			!$debug
-			&& $allowParallel
+			&& $allowParallel && function_exists('proc_open')
 			&& $mainScript !== null
 			&& $schedule->getNumberOfProcesses() > 0
 		) {

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -59,7 +59,8 @@ class AnalyserRunner
 
 		if (
 			!$debug
-			&& $allowParallel && function_exists('proc_open')
+			&& $allowParallel
+			&& function_exists('proc_open')
 			&& $mainScript !== null
 			&& $schedule->getNumberOfProcesses() > 0
 		) {


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/pull/7488

phpstan already accounts for disabled `proc_open` when detecting available CPU cores