### PR TITLE
Exclude class-string and string from normalization with TypeCombinator::union()

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -25,6 +25,7 @@ use function array_splice;
 use function array_values;
 use function count;
 use function get_class;
+use function in_array;
 use function is_int;
 use function md5;
 use function usort;
@@ -362,6 +363,12 @@ class TypeCombinator
 			}
 		}
 		if ($a instanceof IntegerRangeType && $b instanceof IntegerRangeType) {
+			return null;
+		}
+
+		if (($a instanceof ClassStringType || $b instanceof ClassStringType) &&
+			in_array('string', [$a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value())], true)
+		) {
 			return null;
 		}
 

--- a/tests/PHPStan/Analyser/data/conditional-types.php
+++ b/tests/PHPStan/Analyser/data/conditional-types.php
@@ -250,3 +250,46 @@ class TestConditionalTypeFromClassScopeGenerics
 	}
 
 }
+
+class Container
+{
+	/**
+	 * @template T
+	 * @param string|class-string<T> $id
+	 * @return ($id is class-string ? T : string)
+	 */
+	public function get(string $id)
+	{
+		if (\class_exists($id)) {
+			/** @var class-string<T> */
+			return new $id;
+		}
+
+		return $id;
+	}
+
+	/**
+	 * @param string|class-string<\DateTimeInterface> $id
+	 * @return ($id is class-string ? \DateTimeInterface : string)
+	 */
+	public function getDateTime(string $id)
+	{
+		if (\is_a($id, \DateTimeInterface::class, true)) {
+			return new $id;
+		}
+
+		return $id;
+	}
+
+}
+
+function (Container $c)
+{
+	assertType('string', $c->get(''));
+	assertType('DateTime', $c->get(\DateTime::class));
+	assertType('DateTimeImmutable', $c->get(\DateTimeImmutable::class));
+	assertType('DateTime', $c->get('DateTime'));
+	assertType('DateTimeInterface', $c->getDateTime(\DateTime::class));
+	assertType('DateTimeInterface', $c->getDateTime(\DateTimeImmutable::class));
+	assertType('DateTimeInterface', $c->getDateTime('DateTime'));
+};

--- a/tests/PHPStan/Analyser/data/generic-class-string.php
+++ b/tests/PHPStan/Analyser/data/generic-class-string.php
@@ -64,10 +64,12 @@ function testString($a) {
 		assertType('string', $a);
 	}
 
+	assertType('class-string<DateTimeInterface>|string', $a);
+
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
 	} else {
-		assertType('string', $a);
+		assertType('class-string<DateTimeInterface>|string', $a);
 	}
 }
 
@@ -84,10 +86,12 @@ function testStringObject($a) {
 		assertType('object|string', $a);
 	}
 
+	assertType('class-string<DateTimeInterface>|object|string', $a);
+
 	if (is_subclass_of($a, C::class)) {
 		assertType('int', $a::f());
 	} else {
-		assertType('object|string', $a);
+		assertType('class-string<DateTimeInterface>|object|string', $a);
 	}
 }
 
@@ -122,7 +126,7 @@ function testClassStringAsClassName($a, string $b) {
 	if (is_subclass_of($a, $b, false)) {
 		assertType('DateTimeInterface', $a);
 	} else {
-		assertType('object|string', $a);
+		assertType('class-string<DateTimeInterface>|object|string', $a);
 	}
 }
 

--- a/tests/PHPStan/Analyser/data/generic-generalization.php
+++ b/tests/PHPStan/Analyser/data/generic-generalization.php
@@ -37,7 +37,7 @@ function testUnbounded(
 	assertType('class-string', unbounded($classString));
 	assertType('class-string<stdClass>', unbounded($genericClassString));
 
-	assertType('string', unbounded(rand(0,1) === 1 ? 'hello' : $classString));
+	assertType('class-string|string', unbounded(rand(0,1) === 1 ? 'hello' : $classString));
 
 	assertType('array{foo: int}', unbounded($arrayShape));
 

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1390,8 +1390,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 					new StringType(),
 					new ClassStringType(),
 				],
-				StringType::class,
-				'string',
+				UnionType::class,
+				'class-string|string',
 			],
 			[
 				[
@@ -1438,8 +1438,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 					new GenericClassStringType(new ObjectType(Exception::class)),
 					new StringType(),
 				],
-				StringType::class,
-				'string',
+				UnionType::class,
+				'class-string<Exception>|string',
 			],
 			[
 				[

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -94,6 +94,7 @@ class UnionTypeTest extends PHPStanTestCase
 		$constantStringType = new ConstantStringType('foo');
 		$constantIntegerType = new ConstantIntegerType(42);
 		$templateTypeScope = TemplateTypeScope::createWithClass('Foo');
+		$classStringType = new ClassStringType();
 
 		$mixedParam = new NativeParameterReflection('foo', false, $mixedType, PassedByReference::createNo(), false, null);
 		$integerParam = new NativeParameterReflection('n', false, $integerType, PassedByReference::createNo(), false, null);
@@ -140,6 +141,7 @@ class UnionTypeTest extends PHPStanTestCase
 		yield [TemplateTypeFactory::create($templateTypeScope, 'T', new ObjectWithoutClassType(), TemplateTypeVariance::createInvariant())];
 		yield [new ThisType($reflectionProvider->getClass('Foo'))];
 		yield [new UnionType([$integerType, $stringType])];
+		yield [new UnionType([$classStringType, $stringType])];
 		yield [new VoidType()];
 	}
 


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/7513

I've changed the spec to meet my use case, but this method may not be optimal. Feel free to close this PR.