### PR TITLE
Implement template type inference from conditional return type

### DIFF
--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection;
 
+use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Type;
@@ -60,6 +61,17 @@ class GenericParametersAcceptorResolver
 			$paramType = $param->getType();
 			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType));
 			$passedArgs['$' . $param->getName()] = $argType;
+		}
+
+		$returnType = $parametersAcceptor->getReturnType();
+		if (
+			$returnType instanceof ConditionalTypeForParameter
+			&& !$returnType->isNegated()
+			&& array_key_exists($returnType->getParameterName(), $passedArgs)
+		) {
+			$paramType = $returnType->getTarget();
+			$argType = $passedArgs[$returnType->getParameterName()];
+			$typeMap = $typeMap->union($paramType->inferTemplateTypes($argType));
 		}
 
 		$resolvedTemplateTypeMap = new TemplateTypeMap(array_merge(

--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -98,6 +98,10 @@ class GenericClassStringType extends ClassStringType
 				$isSuperType = $genericType->isSuperTypeOf($objectType);
 			}
 
+			if (!$type->isClassString()) {
+				$isSuperType = $isSuperType->and(TrinaryLogic::createMaybe());
+			}
+
 			return $isSuperType;
 		} elseif ($type instanceof self) {
 			return $this->type->isSuperTypeOf($type->type);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1030,6 +1030,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7954.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7993.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7141.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-6687.php
+++ b/tests/PHPStan/Analyser/data/bug-6687.php
@@ -28,7 +28,7 @@ class Bug6687
 	function baz(string $a): void
 	{
 		if ($a === BAZ || is_subclass_of($a, BAZ)) {
-			assertType('class-string<BAZ>', $a);
+			assertType("'BAZ'|class-string<BAZ>", $a);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-7141.php
+++ b/tests/PHPStan/Analyser/data/bug-7141.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7141;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+interface Container
+{
+    /**
+     * @template T
+     * @return ($id is class-string<T> ? T : mixed)
+     */
+    public function get(string $id): mixed;
+}
+
+
+function(Container $c) {
+	assertType('mixed', $c->get('test'));
+	assertType('stdClass', $c->get(stdClass::class));
+};

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -294,4 +294,14 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/true-typehint.php'], $errors);
 	}
 
+	public function testConditionalReturnType(): void
+	{
+		$this->analyse([__DIR__ . '/data/conditional-return-type.php'], [
+			[
+				'Template type T of function FunctionConditionalReturnType\notGet() is not referenced in a parameter.',
+				17,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/conditional-return-type.php
+++ b/tests/PHPStan/Rules/Functions/data/conditional-return-type.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace FunctionConditionalReturnType;
+
+/**
+ * @template T
+ * @return ($id is class-string<T> ? T : mixed)
+ */
+function get(string $id): mixed
+{
+}
+
+/**
+ * @template T
+ * @return ($id is not class-string<T> ? T : mixed)
+ */
+function notGet(string $id): mixed
+{
+}

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -309,4 +309,14 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/true-typehint.php'], $errors);
 	}
 
+	public function testConditionalReturnType(): void
+	{
+		$this->analyse([__DIR__ . '/data/conditional-return-type.php'], [
+			[
+				'Template type T of method MethodConditionalReturnType\Container::notGet() is not referenced in a parameter.',
+				17,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/conditional-return-type.php
+++ b/tests/PHPStan/Rules/Methods/data/conditional-return-type.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace MethodConditionalReturnType;
+
+interface Container
+{
+	/**
+	 * @template T
+	 * @return ($id is class-string<T> ? T : mixed)
+	 */
+	function get(string $id): mixed;
+
+	/**
+	 * @template T
+	 * @return ($id is not class-string<T> ? T : mixed)
+	 */
+	function notGet(string $id): mixed;
+}


### PR DESCRIPTION
Fix for phpstan/phpstan#7141. This does not actually work yet, but fixing it in an obvious way breaks other tests