### PR TITLE
Suppress is_file warnings from entry file

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -84,7 +84,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 	/** @var array<callable>|false $autoloadFunctionsBefore */
 	$autoloadFunctionsBefore = spl_autoload_functions();
 
-	if (is_file($autoloaderInWorkingDirectory)) {
+	if (@is_file($autoloaderInWorkingDirectory)) {
 		$composerAutoloaderProjectPaths[] = dirname($autoloaderInWorkingDirectory, 2);
 
 		require_once $autoloaderInWorkingDirectory;
@@ -93,7 +93,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 	$autoloadProjectAutoloaderFile = function (string $file) use (&$composerAutoloaderProjectPaths): void {
 		$path = dirname(__DIR__) . $file;
 		if (!extension_loaded('phar')) {
-			if (is_file($path)) {
+			if (@is_file($path)) {
 				$composerAutoloaderProjectPaths[] = dirname($path, 2);
 
 				require_once $path;
@@ -101,14 +101,14 @@ use Symfony\Component\Console\Helper\ProgressBar;
 		} else {
 			$pharPath = \Phar::running(false);
 			if ($pharPath === '') {
-				if (is_file($path)) {
+				if (@is_file($path)) {
 					$composerAutoloaderProjectPaths[] = dirname($path, 2);
 
 					require_once $path;
 				}
 			} else {
 				$path = dirname($pharPath) . $file;
-				if (is_file($path)) {
+				if (@is_file($path)) {
 					$composerAutoloaderProjectPaths[] = dirname($path, 2);
 
 					require_once $path;


### PR DESCRIPTION
Upper than project directory might be inaccessible.

see https://github.com/phpstan/phpstan/runs/7020331951?check_suite_focus=true#step:6:394