### PR TITLE
Use `SimpleRelativePathHelper` for `@betterReflectionProvider`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1889,6 +1889,8 @@ services:
 		class: PHPStan\Reflection\BetterReflection\BetterReflectionProvider
 		arguments:
 			reflector: @betterReflectionReflector
+			# see: https://github.com/phpstan/phpstan/issues/6650
+			relativePathHelper: @simpleRelativePathHelper
 		autowired: false
 
 	-


### PR DESCRIPTION
It will use proper file path in `getAnonymousClassReflection()` and create valid `class@anonymous/%s:%s` entries in baseline files.

Fixes phpstan/phpstan#6650

@ondrejmirtes I wanted to test in on our codebase but unfortunately I can't add this DI mapping inside PHAR 😉 Should it be covered by some tests? I got 2 errors in tests locally, but not related to this change, so I create PR anyway and will see on Github Actions if it's OK.