### PR TITLE
Add ClassReflection->is() shortcut

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -639,6 +639,11 @@ class ClassReflection
 		return $this->anonymousFilename !== null;
 	}
 
+	public function is(string $className): bool
+	{
+		return $this->getName() === $className || $this->isSubclassOf($className);
+	}
+
 	public function isSubclassOf(string $className): bool
 	{
 		if (isset($this->subclasses[$className])) {

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -311,7 +311,7 @@ class ClassReflectionTest extends PHPStanTestCase
 
 	public function testIs(): void
 	{
-		$className = get_class($this);
+		$className = static::class;
 
 		$reflectionProvider = $this->createReflectionProvider();
 		$classReflection = $reflectionProvider->getClass($className);

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -28,7 +28,9 @@ use NestedTraits\BazChild;
 use NestedTraits\BazTrait;
 use NestedTraits\NoTrait;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\IntegerType;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use WrongClassConstantFile\SecuredRouter;
 use function array_map;
@@ -305,6 +307,19 @@ class ClassReflectionTest extends PHPStanTestCase
 		$reflectionProvider = $this->createReflectionProvider();
 		$enum = $reflectionProvider->getClass('PHPStan\Fixture\TestEnum');
 		$this->assertInstanceOf(IntegerType::class, $enum->getBackedEnumType());
+	}
+
+	public function testIs(): void
+	{
+		$className = get_class($this);
+
+		$reflectionProvider = $this->createReflectionProvider();
+		$classReflection = $reflectionProvider->getClass($className);
+
+		$this->assertTrue($classReflection->is($className));
+		$this->assertTrue($classReflection->is(PHPStanTestCase::class));
+		$this->assertTrue($classReflection->is(TestCase::class));
+		$this->assertFalse($classReflection->is(RuleTestCase::class));
 	}
 
 }


### PR DESCRIPTION
Since is_a function was forbidden in recent phpstan version, it is quite handy to have some single-call replacement.