### PR TITLE
use a separate resultCache per project config file

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheClearer.php
+++ b/src/Analyser/ResultCache/ResultCacheClearer.php
@@ -17,11 +17,11 @@ class ResultCacheClearer
 	public function clear(): string
 	{
 		$dir = dirname($this->cacheFilePath);
-		if (!is_file($this->cacheFilePath)) {
-			return $dir;
-		}
 
-		@unlink($this->cacheFilePath);
+		$finder = new Finder();
+		foreach ($finder->files()->depth(0)->name('resultCache*.php')->in($dir) as $resultCacheFile) {
+			@unlink($resultCacheFile->getPathname());
+		}
 
 		return $dir;
 	}

--- a/src/Analyser/ResultCache/ResultCacheClearer.php
+++ b/src/Analyser/ResultCache/ResultCacheClearer.php
@@ -4,7 +4,6 @@ namespace PHPStan\Analyser\ResultCache;
 
 use Symfony\Component\Finder\Finder;
 use function dirname;
-use function is_file;
 use function unlink;
 
 class ResultCacheClearer

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -616,7 +616,7 @@ php;
 			(!array_key_exists('tmpDir', $projectConfig['parameters']) || $projectConfig['parameters']['tmpDir'] === null)
 		) {
 
-			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, $this->getPhpstanVersion()])) . '.php';
+			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, $this->getPhpStanVersion()])) . '.php';
 		}
 
 		return $this->cacheFilePath;

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -27,11 +27,13 @@ use function array_merge;
 use function array_unique;
 use function array_values;
 use function count;
+use function dirname;
 use function get_loaded_extensions;
 use function is_array;
 use function is_file;
 use function is_string;
 use function ksort;
+use function md5;
 use function sha1;
 use function sort;
 use function sprintf;
@@ -99,11 +101,10 @@ class ResultCacheManager
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], []);
 		}
 
-		$cacheFilePath = $this->cacheFilePath;
+		$cacheFilePath = $this->getCacheFilePath($resultCacheName, $projectConfigArray);
 		if ($resultCacheName !== null) {
-			$tmpCacheFile = $this->tempResultCachePath . '/' . $resultCacheName . '.php';
-			if (is_file($tmpCacheFile)) {
-				$cacheFilePath = $tmpCacheFile;
+			if (!is_file($cacheFilePath)) {
+				$cacheFilePath = $this->cacheFilePath;
 			}
 		}
 
@@ -578,15 +579,12 @@ php;
 
 		ksort($exportedNodes);
 
-		$file = $this->cacheFilePath;
-		if ($resultCacheName !== null) {
-			$file = $this->tempResultCachePath . '/' . $resultCacheName . '.php';
-		}
-
 		$projectConfigArray = $meta['projectConfig'];
 		if ($projectConfigArray !== null) {
 			$meta['projectConfig'] = Neon::encode($projectConfigArray);
 		}
+
+		$file = $this->getCacheFilePath($resultCacheName, $projectConfigArray);
 
 		FileWriter::write(
 			$file,
@@ -601,6 +599,27 @@ php;
 				var_export($exportedNodes, true),
 			),
 		);
+	}
+
+	/**
+	 * @param mixed[]|null $projectConfig
+	 */
+	private function getCacheFilePath(?string $resultCacheName, ?array $projectConfig): string
+	{
+		if ($resultCacheName !== null) {
+			return $this->tempResultCachePath . '/' . $resultCacheName . '.php';
+		}
+
+		if ($projectConfig !== null &&
+			array_key_exists('parameters', $projectConfig) &&
+			!array_key_exists('resultCachePath', $projectConfig['parameters']) &&
+			(!array_key_exists('tmpDir', $projectConfig['parameters']) || $projectConfig['parameters']['tmpDir'] === null)
+		) {
+
+			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, $this->bootstrapFiles])) . '.php';
+		}
+
+		return $this->cacheFilePath;
 	}
 
 	/**

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -616,7 +616,7 @@ php;
 			(!array_key_exists('tmpDir', $projectConfig['parameters']) || $projectConfig['parameters']['tmpDir'] === null)
 		) {
 
-			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, $this->getPhpStanVersion()])) . '.php';
+			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, ComposerHelper::getPhpStanVersion()])) . '.php';
 		}
 
 		return $this->cacheFilePath;

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -616,7 +616,7 @@ php;
 			(!array_key_exists('tmpDir', $projectConfig['parameters']) || $projectConfig['parameters']['tmpDir'] === null)
 		) {
 
-			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, $this->bootstrapFiles])) . '.php';
+			return dirname($this->cacheFilePath) . '/resultCache-' . md5(Neon::encode([$this->analysedPaths, $this->getPhpstanVersion()])) . '.php';
 		}
 
 		return $this->cacheFilePath;

--- a/tests/e2e/ResultCacheEndToEndTest.php
+++ b/tests/e2e/ResultCacheEndToEndTest.php
@@ -10,9 +10,11 @@ use PHPStan\File\SimpleRelativePathHelper;
 use PHPUnit\Framework\TestCase;
 use function array_map;
 use function chdir;
+use function count;
 use function escapeshellarg;
 use function exec;
 use function file_put_contents;
+use function glob;
 use function implode;
 use function ksort;
 use function sort;
@@ -134,6 +136,15 @@ class ResultCacheEndToEndTest extends TestCase
 
 		$this->assertFileExists(sys_get_temp_dir() . '/phpstan/myResultCacheFile.php');
 		$this->assertResultCache(__DIR__ . '/resultCache_1.php', sys_get_temp_dir() . '/phpstan/myResultCacheFile.php');
+	}
+
+	public function testSeparateResultCachePath(): void
+	{
+		$this->runPhpstan(0, __DIR__ . '/phpstan_separate_cache.neon');
+
+		$resultCacheFiles = glob(sys_get_temp_dir() . '/phpstan/resultCache-*.php');
+		$this->assertNotFalse($resultCacheFiles);
+		$this->assertTrue(count($resultCacheFiles) > 0);
 	}
 
 	/**

--- a/tests/e2e/phpstan_separate_cache.neon
+++ b/tests/e2e/phpstan_separate_cache.neon
@@ -1,0 +1,7 @@
+# test whether a config, which does not define tmpDir or resultCachePath, will get a separate md5-hashed result cache
+
+includes:
+	- baseline.neon
+
+parameters:
+	level: 2


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/7379
closes https://github.com/phpstan/phpstan/issues/7601

With this patch we see analysis time dropped to ~5 seconds from previous 2-3 minutes in mono-repo projects, which contain several phpstan.neon files.