### PR TITLE
Update `FilterIterator` stub.

### DIFF
--- a/stubs/iterable.stub
+++ b/stubs/iterable.stub
@@ -202,7 +202,15 @@ class IteratorIterator implements OuterIterator {
  */
 class FilterIterator extends IteratorIterator
 {
+    /**
+     * @return TValue
+     */
+    public function current() {}
 
+    /**
+     * @return TKey
+     */
+    public function key() {}
 }
 
 /**
@@ -425,14 +433,4 @@ class RegexIterator extends FilterIterator {
      * @param self::MATCH|self::GET_MATCH|self::ALL_MATCHES|self::SPLIT|self::REPLACE $mode
      */
     public function __construct(Iterator $iterator, string $regex, int $mode = self::MATCH, int $flags = 0, int $preg_flags = 0) {}
-
-    /**
-     * @return TValue
-     */
-    public function current() {}
-
-    /**
-     * @return TKey
-     */
-    public function key() {}
 }


### PR DESCRIPTION
Add proper typing for `current` and `key` methods.

The idea is to fix the following: https://phpstan.org/r/f0df1f2a-6824-4300-8c5e-fcf0c4c46b7f
