### PR TITLE
Add `EmptyIterator` stub.

### DIFF
--- a/stubs/iterable.stub
+++ b/stubs/iterable.stub
@@ -438,16 +438,16 @@ class RegexIterator extends FilterIterator {
 }
 
 /**
- * @template-implements Iterator<void, void>
+ * @template-implements Iterator<never, never>
  */
 class EmptyIterator implements Iterator {
     /**
-     * @return void
+     * @return never
      */
     public function current() {}
 
     /**
-     * @return void
+     * @return never
      */
     public function key() {}
 

--- a/stubs/iterable.stub
+++ b/stubs/iterable.stub
@@ -436,3 +436,23 @@ class RegexIterator extends FilterIterator {
      */
     public function key() {}
 }
+
+/**
+ * @template-implements Iterator<void, void>
+ */
+class EmptyIterator implements Iterator {
+    /**
+     * @return void
+     */
+    public function current() {}
+
+    /**
+     * @return void
+     */
+    public function key() {}
+
+    /**
+     * @return false
+     */
+    public function valid() {}
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -918,6 +918,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4117.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7490.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/remember-possibly-impure-function-values.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/emptyiterator.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/emptyiterator.php
+++ b/tests/PHPStan/Analyser/data/emptyiterator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace EmptyIteratorTest;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function doFoo(\EmptyIterator $it): void
+	{
+		assertType('EmptyIterator', $it);
+		assertType('*NEVER*', $it->key());
+		assertType('*NEVER*', $it->current());
+		assertType('void', $it->next());
+		assertType('false', $it->valid());
+	}
+
+}


### PR DESCRIPTION
Testing this on this file:

```php
<?php declare(strict_types = 1);

use function \PHPStan\dumpType;

$eit = new EmptyIterator();

dumpType($eit->key());
dumpType($eit->current());
dumpType($eit->next());
dumpType($eit->valid());
```

Before:

```
$ bin/phpstan analyse --level=max test.php
Note: Using configuration file /home/devlin/Code/phpstan/phpstan-src/phpstan.neon.dist.
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------- 
  Line   test.php                                                
 ------ -------------------------------------------------------- 
  7      Dumped type: mixed                                      
  8      Dumped type: mixed                                      
  9      Dumped type: void                                       
  9      Result of method EmptyIterator::next() (void) is used.  
  10     Dumped type: bool                                       
 ------ -------------------------------------------------------- 

```

After:

```
$ bin/phpstan analyse --level=max test.php
Note: Using configuration file /home/devlin/Code/phpstan/phpstan-src/phpstan.neon.dist.
 1/1 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------------------- 
  Line   test.php                                                
 ------ -------------------------------------------------------- 
  7      Dumped type: *NEVER*                                    
  8      Dumped type: *NEVER*                                    
  9      Dumped type: void                                       
  9      Result of method EmptyIterator::next() (void) is used.  
  10     Dumped type: false                                      
 ------ -------------------------------------------------------- 
```