### PR TITLE
e2e test resultCachePath

### DIFF
--- a/tests/e2e/phpstan_resultcachepath.neon
+++ b/tests/e2e/phpstan_resultcachepath.neon
@@ -1,0 +1,5 @@
+includes:
+	- baseline.neon
+
+parameters:
+	resultCachePath: %tmpDir%/myResultCacheFile.php


### PR DESCRIPTION
add a e2e test for the `resultCachePath` parameter to prevent regressions in https://github.com/phpstan/phpstan-src/pull/1469.
I had the impression this feature is currently not covered by tests.

to cover the case mentioned in https://github.com/phpstan/phpstan/issues/7379#issuecomment-1164150916