### PR TITLE
Make ReadWritePropertiesExtensionProvider part of API

### DIFF
--- a/src/Rules/Properties/ReadWritePropertiesExtensionProvider.php
+++ b/src/Rules/Properties/ReadWritePropertiesExtensionProvider.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+/** @api */
 interface ReadWritePropertiesExtensionProvider
 {
 


### PR DESCRIPTION
Custom rules as such https://github.com/shipmonk-rnd/phpstan-rules/blob/master/src/Rule/UselessPrivatePropertyNullabilityRule.php need access to registered ReadWritePropertiesExtension[] for seamless configuration.