### PR TITLE
Fix `ConstantArrayType` creation for `preg_split` with `PREG_SPLIT_OFFSET_CAPTURE`

### DIFF
--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -40,7 +40,7 @@ class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		if ($flagsArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagsArg->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE')->yes()) {
 			$type = new ArrayType(
 				new IntegerType(),
-				new ConstantArrayType([new ConstantIntegerType(0), new ConstantIntegerType(1)], [new StringType(), IntegerRangeType::fromInterval(0, null)]),
+				new ConstantArrayType([new ConstantIntegerType(0), new ConstantIntegerType(1)], [new StringType(), IntegerRangeType::fromInterval(0, null)], [2]),
 			);
 			return TypeCombinator::union($type, new ConstantBooleanType(false));
 		}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -872,7 +872,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug7554(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7554.php');
-		$this->assertNoErrors($errors);
+		$this->assertCount(3, $errors);
 	}
 
 	/**

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -2,8 +2,11 @@
 
 namespace PHPStan\Type\Constant;
 
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\VerbosityLevel;
 use PHPUnit\Framework\TestCase;
 
@@ -96,6 +99,18 @@ class ConstantArrayTypeBuilderTest extends TestCase
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(17));
 		$this->assertSame('array{0: 17|bool|null, 1?: 17|null, 2?: 17}', $builder->getArray()->describe(VerbosityLevel::precise()));
+	}
+
+	public function testBug7554(): void
+	{
+		$builder = ConstantArrayTypeBuilder::createFromConstantArray(new ConstantArrayType(
+			[new ConstantIntegerType(0), new ConstantIntegerType(1)],
+			[new StringType(), IntegerRangeType::fromInterval(0, null)]
+		));
+
+		$this->expectException(ShouldNotHappenException::class);
+		$this->expectExceptionMessage('Internal error.');
+		$builder->setOffsetValueType(new ConstantIntegerType(1), new IntegerRangeType(0, null));
 	}
 
 }


### PR DESCRIPTION
Refs: https://github.com/phpstan/phpstan-src/pull/1484

Looks like it was forgotten to explicitly specifiy `$nextAutoIndexes` correctly in that edge case. And then it falls back to `[0]` which can break the `ConstantArrayTypeBuilder` (since the array keys `0` and `1` are explicitly specified already).

I quickly looked through most of the other ConstantArrayType creations but did not find any more problems.

Fyi the 3 errors, that looked fine to me, are
```
Emitted errors:
- Method Bug7554\Readline::_bindControlB() has parameter $line with no type specified
  in /home/martin/PhpstormProjects/phpstan-src/tests/PHPStan/Analyser/data/bug-7554.php on line 11

- Parameter #1 $value of function count expects array|Countable, array<int, array<int, int<0, max>|string>>|false given
  in /home/martin/PhpstormProjects/phpstan-src/tests/PHPStan/Analyser/data/bug-7554.php on line 25

- Cannot access offset int<1, max> on array<int, array{string, int<0, max>}>|false
  in /home/martin/PhpstormProjects/phpstan-src/tests/PHPStan/Analyser/data/bug-7554.php on line 26

``` 