### PR TITLE
Fix type specification of various string functions with constant strings in a falsey context

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -249,7 +249,8 @@ class TypeSpecifier
 				}
 
 				if (
-					$exprNode instanceof FuncCall
+					$context->truthy()
+					&& $exprNode instanceof FuncCall
 					&& $exprNode->name instanceof Name
 					&& in_array(strtolower($exprNode->name->toString()), ['substr', 'strstr', 'stristr', 'strchr', 'strrchr', 'strtolower', 'strtoupper', 'mb_strtolower', 'mb_strtoupper', 'ucfirst', 'lcfirst', 'ucwords'], true)
 					&& isset($exprNode->getArgs()[0])

--- a/tests/PHPStan/Analyser/data/non-empty-string-substr-specifying.php
+++ b/tests/PHPStan/Analyser/data/non-empty-string-substr-specifying.php
@@ -75,5 +75,10 @@ class Foo {
 		$x = (substr($s, 10) !== 'hallo');
 		assertType('string', $s);
 		var_dump($x);
+
+		$x = 'hallo';
+		if (substr($x, 0, PHP_INT_MAX) !== 'foo') {
+			assertType('\'hallo\'', $x);
+		}
 	}
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -555,4 +555,15 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7166.php'], []);
 	}
 
+	public function testBug7555(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-7555.php'], [
+			[
+				'Strict comparison using === between 2 and 2 will always evaluate to true.',
+				11,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-7555.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7555.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bug7555;
+
+$a = 'ab';
+
+if (substr($a, 0, PHP_INT_MAX) === 'x') {
+	exit(1);
+}
+
+if (strlen($a) === 2) {
+	echo('According to phpstan, this should not print because if will always evaluate to false');
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7555

Apparently this would return that some constant string is surely not e.g. `'ab'` in a falsey scope but at the same time the scope has the info that it surely is `'ab'` in a truthy scope. And that seams lead to a `*NEVER*` type.

The blocks before this one, that deal with a related thing, do it a bit different but very similar, e.g. https://github.com/phpstan/phpstan-src/blob/1.8.0/src/Analyser/TypeSpecifier.php#L237 