### PR TITLE
Add rule that disallows final private methods

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -70,6 +70,7 @@ rules:
 	- PHPStan\Rules\Methods\CallMethodsRule
 	- PHPStan\Rules\Methods\CallStaticMethodsRule
 	- PHPStan\Rules\Methods\ExistingClassesInTypehintsRule
+	- PHPStan\Rules\Methods\FinalPrivateMethodRule
 	- PHPStan\Rules\Methods\MethodCallableRule
 	- PHPStan\Rules\Methods\MissingMethodImplementationRule
 	- PHPStan\Rules\Methods\MethodAttributesRule

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -186,4 +186,9 @@ class PhpVersion
 		return $this->versionId < 70300;
 	}
 
+	public function producesWarningForFinalPrivateMethods(): bool
+	{
+		return $this->versionId >= 80000;
+	}
+
 }

--- a/src/Rules/Methods/FinalPrivateMethodRule.php
+++ b/src/Rules/Methods/FinalPrivateMethodRule.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\Php\PhpMethodFromParserNodeReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function sprintf;
+
+/** @implements Rule<InClassMethodNode> */
+class FinalPrivateMethodRule implements Rule
+{
+
+	public function __construct(
+		private PhpVersion $phpVersion,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return InClassMethodNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$method = $scope->getFunction();
+		if (!$method instanceof PhpMethodFromParserNodeReflection) {
+			return [];
+		}
+
+		if (!$this->phpVersion->producesWarningForFinalPrivateMethods()) {
+			return [];
+		}
+
+		if (!$method->isFinal()->yes() || !$method->isPrivate()) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Private method %s::%s() cannot be final as it is never overridden by other classes.',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName(),
+			))->build(),
+		];
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/FinalPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/FinalPrivateMethodRuleTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<FinalPrivateMethodRule> */
+class FinalPrivateMethodRuleTest extends RuleTestCase
+{
+
+	private int $phpVersionId;
+
+	protected function getRule(): Rule
+	{
+		return new FinalPrivateMethodRule(
+			new PhpVersion($this->phpVersionId),
+		);
+	}
+
+	public function dataRule(): array
+	{
+		return [
+			[
+				70400,
+				[],
+			],
+			[
+				80000,
+				[
+					[
+						'Private method FinalPrivateMethod\Foo::foo() cannot be final as it is never overridden by other classes.',
+						8,
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataRule
+	 * @param mixed[] $errors
+	 */
+	public function testRule(int $phpVersion, array $errors): void
+	{
+		$this->phpVersionId = $phpVersion;
+		$this->analyse([__DIR__ . '/data/final-private-method.php'], $errors);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/final-private-method.php
+++ b/tests/PHPStan/Rules/Methods/data/final-private-method.php
@@ -1,0 +1,24 @@
+<?php // lint >= 7.4
+
+namespace FinalPrivateMethod;
+
+class Foo
+{
+
+	final private function foo(): void
+	{
+	}
+
+	final protected function bar(): void
+	{
+	}
+
+	final public function baz(): void
+	{
+	}
+
+	private function foobar(): void
+	{
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7507

Refs: https://wiki.php.net/rfc/inheritance_private_methods

Is this going in the right direction? I'm unsure about a few details, e.g.
- is bleeding edge needed?
- is the php version check needed?
- is it ok to be ignorable? (it's "only" a warning after all)