### PR TITLE
Consider `MixedType` explicitness in `MethodParameterComparisonHelper::isTypeCompatible`

### DIFF
--- a/src/Rules/Methods/MethodParameterComparisonHelper.php
+++ b/src/Rules/Methods/MethodParameterComparisonHelper.php
@@ -372,6 +372,10 @@ class MethodParameterComparisonHelper
 	public function isTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsContravariance): bool
 	{
 		if ($methodParameterType instanceof MixedType) {
+			if ($prototypeParameterType instanceof MixedType) {
+				return !$methodParameterType->isExplicitMixed() || $prototypeParameterType->isExplicitMixed();
+			}
+
 			return true;
 		}
 

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -376,9 +376,18 @@ class MethodSignatureRuleTest extends RuleTestCase
 
 	public function testBug7652(): void
 	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
 		$this->reportMaybes = true;
 		$this->reportStatic = true;
 		$this->analyse([__DIR__ . '/data/bug-7652.php'], [
+			[
+				'Return type mixed of method Bug7652\Options::offsetGet() is not covariant with tentative return type mixed of method ArrayAccess::offsetGet().',
+				23,
+				'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
+			],
 			[
 				'Parameter #1 $offset (TOffset of key-of<TArray of array>) of method Bug7652\Options::offsetSet() should be contravariant with parameter $offset (key-of<array>|null) of method ArrayAccess<key-of<TArray of array>,value-of<TArray of array>>::offsetSet()',
 				30,

--- a/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
@@ -481,6 +481,31 @@ class OverridingMethodRuleTest extends RuleTestCase
 						40,
 						'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
 					],
+					[
+						'Return type mixed of method TentativeReturnTypes\UntypedIterator::current() is not covariant with tentative return type mixed of method Iterator::current().',
+						75,
+						'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
+					],
+					[
+						'Return type mixed of method TentativeReturnTypes\UntypedIterator::next() is not covariant with tentative return type void of method Iterator::next().',
+						79,
+						'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
+					],
+					[
+						'Return type mixed of method TentativeReturnTypes\UntypedIterator::key() is not covariant with tentative return type mixed of method Iterator::key().',
+						83,
+						'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
+					],
+					[
+						'Return type mixed of method TentativeReturnTypes\UntypedIterator::valid() is not covariant with tentative return type bool of method Iterator::valid().',
+						87,
+						'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
+					],
+					[
+						'Return type mixed of method TentativeReturnTypes\UntypedIterator::rewind() is not covariant with tentative return type void of method Iterator::rewind().',
+						91,
+						'Make it covariant, or use the #[\ReturnTypeWillChange] attribute to temporarily suppress the error.',
+					],
 				],
 			],
 		];

--- a/tests/PHPStan/Rules/Methods/data/tentative-return-types.php
+++ b/tests/PHPStan/Rules/Methods/data/tentative-return-types.php
@@ -43,3 +43,53 @@ class Lorem implements \IteratorAggregate
 	}
 
 }
+
+class TypedIterator implements \Iterator
+{
+
+	public function current(): mixed
+	{
+	}
+
+	public function next(): void
+	{
+	}
+
+	public function key(): mixed
+	{
+	}
+
+	public function valid(): bool
+	{
+	}
+
+	public function rewind(): void
+	{
+	}
+
+}
+
+class UntypedIterator implements \Iterator
+{
+
+	public function current()
+	{
+	}
+
+	public function next()
+	{
+	}
+
+	public function key()
+	{
+	}
+
+	public function valid()
+	{
+	}
+
+	public function rewind()
+	{
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7415

Doesn't feel like the most elegant solution though.. I played around a bit with `MixedType::isSuperTypeOf` but did not find something better unfortunately.