### PR TITLE
Fix Identical type specification of constant types

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -304,7 +304,10 @@ class TypeSpecifier
 			$types = null;
 			$exprLeftType = $scope->getType($expr->left);
 			$exprRightType = $scope->getType($expr->right);
-			if ($exprLeftType instanceof ConstantType || $exprLeftType instanceof EnumCaseObjectType) {
+			if (
+				$exprLeftType instanceof ConstantType && !$exprRightType->equals($exprLeftType) && $exprRightType->isSuperTypeOf($exprLeftType)->yes()
+				|| $exprLeftType instanceof EnumCaseObjectType
+			) {
 				$types = $this->create(
 					$expr->right,
 					$exprLeftType,
@@ -314,7 +317,10 @@ class TypeSpecifier
 					$rootExpr,
 				);
 			}
-			if ($exprRightType instanceof ConstantType || $exprRightType instanceof EnumCaseObjectType) {
+			if (
+				$exprRightType instanceof ConstantType && !$exprLeftType->equals($exprRightType) && $exprLeftType->isSuperTypeOf($exprRightType)->yes()
+				|| $exprRightType instanceof EnumCaseObjectType
+			) {
 				$leftType = $this->create(
 					$expr->left,
 					$exprRightType,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -305,7 +305,7 @@ class TypeSpecifier
 			$exprLeftType = $scope->getType($expr->left);
 			$exprRightType = $scope->getType($expr->right);
 			if (
-				$exprLeftType instanceof ConstantType && !$exprRightType->equals($exprLeftType) && $exprRightType->isSuperTypeOf($exprLeftType)->yes()
+				($exprLeftType instanceof ConstantType && !$exprRightType->equals($exprLeftType) && $exprRightType->isSuperTypeOf($exprLeftType)->yes())
 				|| $exprLeftType instanceof EnumCaseObjectType
 			) {
 				$types = $this->create(
@@ -318,7 +318,7 @@ class TypeSpecifier
 				);
 			}
 			if (
-				$exprRightType instanceof ConstantType && !$exprLeftType->equals($exprRightType) && $exprLeftType->isSuperTypeOf($exprRightType)->yes()
+				($exprRightType instanceof ConstantType && !$exprLeftType->equals($exprRightType) && $exprLeftType->isSuperTypeOf($exprRightType)->yes())
 				|| $exprRightType instanceof EnumCaseObjectType
 			) {
 				$leftType = $this->create(

--- a/tests/PHPStan/Analyser/data/identical.php
+++ b/tests/PHPStan/Analyser/data/identical.php
@@ -72,4 +72,31 @@ class Bar
 
 	}
 
+	public function doBar(array $arr1, array $arr2): void
+	{
+		/**
+		 * @var array{foo: bool, bar: int} $arr1
+		 * @var array{foo: bool, bar: int} $arr2
+		 */
+		if ($arr1 === $arr2) {
+			assertType('array{foo: bool, bar: int}', $arr1);
+			assertType('array{foo: bool, bar: int}', $arr2);
+		} else {
+			assertType('array{foo: bool, bar: int}', $arr1);
+			assertType('array{foo: bool, bar: int}', $arr2);
+		}
+
+		/**
+		 * @var array{foo: true, bar: 17} $arr1
+		 * @var array{foo: bool, bar: int} $arr2
+		 */
+		if ($arr1 === $arr2) {
+			assertType('array{foo: true, bar: 17}', $arr1);
+			assertType('array{foo: true, bar: 17}', $arr2);
+		} else {
+			assertType('array{foo: true, bar: 17}', $arr1);
+			assertType('array{foo: bool, bar: int}', $arr2);
+		}
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -566,4 +566,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7257(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = false;
+		$this->analyse([__DIR__ . '/data/bug-7257.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-7257.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7257.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7257;
+
+function rangesInConflict(): bool
+{
+	$ranges1 = array_filter([
+		(int) rand(0,10),
+		(int) rand(0,10),
+		(int) rand(0,10),
+		(int) rand(0,10),
+	]);
+
+	$ranges2 = array_filter([
+		(int) rand(0,10),
+		(int) rand(0,10),
+		(int) rand(0,10),
+		(int) rand(0,10),
+	]);
+
+	$sorted = array_filter([
+		(int) rand(0,10),
+		(int) rand(0,10),
+		(int) rand(0,10),
+		(int) rand(0,10),
+	]);
+
+	sort($sorted);
+
+	return !($sorted === $ranges1 || $sorted === $ranges2);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7257

This was not working correctly because e.g. a `ConstantArrayType` cannot be safely used to strictly specify the other (left or right) type in the Identical comparison without further checks.

The problem with the linked issue was that it would have the same types on the left and right side and basically cancel out the types in a falsey scope (the right side of the `||` for e.g. `$sorted` leading to a `NeverType`), see https://phpstan.org/r/f560aac6-602f-45a0-8115-bb94f7142f79. Which explains why it works if only truthy scopes (via variable assignments) work around that. 