### PR TITLE
Fix/specifier bug

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3401,7 +3401,7 @@ class MutatingScope implements Scope
 				[],
 				$this->afterExtractCall,
 				$this->parentScope,
-			);
+			)->invalidateExpression($expr);
 		} elseif ($expr instanceof Expr\ArrayDimFetch && $expr->dim !== null) {
 			return $this->specifyExpressionType(
 				$expr->var,
@@ -3499,7 +3499,7 @@ class MutatingScope implements Scope
 				$this->inFunctionCallsStack,
 				$this->afterExtractCall,
 				$this->parentScope,
-			);
+			)->invalidateExpression($expr);
 		} elseif ($expr instanceof Expr\ArrayDimFetch && $expr->dim !== null) {
 			$constantArrays = TypeUtils::getOldConstantArrays($this->getType($expr->var));
 			if (count($constantArrays) > 0) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -267,12 +267,6 @@ class TypeSpecifier
 						);
 					}
 				}
-
-				if (
-					$constantType instanceof ConstantStringType
-				) {
-					\PHPStan\dumpType($constantType->getValue());
-				}
 			}
 
 			$rightType = $scope->getType($expr->right);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -267,6 +267,12 @@ class TypeSpecifier
 						);
 					}
 				}
+
+				if (
+					$constantType instanceof ConstantStringType
+				) {
+					\PHPStan\dumpType($constantType->getValue());
+				}
 			}
 
 			$rightType = $scope->getType($expr->right);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -905,6 +905,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-strcasing-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/conditional-complex-templates.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7374.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1396.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-1396.php
+++ b/tests/PHPStan/Analyser/data/bug-1396.php
@@ -2,8 +2,6 @@
 
 namespace Bug1396;
 
-use PhpParser\Node;
-use PhpParser\Node\Expr;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 use function PHPStan\Testing\assertType;
@@ -18,7 +16,7 @@ class TypeSpecifier2
 	): SpecifiedTypes
 	{
 		if ($constantType->getValue() === null) {
-			return $this->create();
+			return new SpecifiedTypes();
 		}
 
 		if (
@@ -26,12 +24,5 @@ class TypeSpecifier2
 		) {
 			assertType('string', $constantType->getValue());
 		}
-	}
-
-	/** @api */
-	public function create(
-	): SpecifiedTypes
-	{
-		return new SpecifiedTypes();
 	}
 }

--- a/tests/PHPStan/Analyser/data/bug-1396.php
+++ b/tests/PHPStan/Analyser/data/bug-1396.php
@@ -11,31 +11,20 @@ use function PHPStan\Testing\assertType;
 class TypeSpecifier2
 {
 	/**
-	 * @param (Expr|ConstantScalarType)[]|null $expressions
 	 * @api
 	 */
 	public function specifyTypesInCondition(
-		Expr $expr,
-			 $expressions
+		ConstantScalarType $constantType
 	): SpecifiedTypes
 	{
-		if ($expr instanceof Node\Expr\BinaryOp\Identical) {
-			if ($expressions !== null) {
-				/** @var Expr $exprNode */
-				$exprNode = $expressions[0];
-				/** @var ConstantScalarType $constantType */
-				$constantType = $expressions[1];
+		if ($constantType->getValue() === null) {
+			return $this->create();
+		}
 
-				if ($constantType->getValue() === null) {
-					return $this->create();
-				}
-
-				if (
-					$constantType instanceof ConstantStringType
-				) {
-					assertType('string', $constantType->getValue());
-				}
-			}
+		if (
+			$constantType instanceof ConstantStringType
+		) {
+			assertType('string', $constantType->getValue());
 		}
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-1396.php
+++ b/tests/PHPStan/Analyser/data/bug-1396.php
@@ -8,9 +8,6 @@ use function PHPStan\Testing\assertType;
 
 class TypeSpecifier2
 {
-	/**
-	 * @api
-	 */
 	public function specifyTypesInCondition(
 		ConstantScalarType $constantType
 	): SpecifiedTypes

--- a/tests/PHPStan/Analyser/data/bug-1396.php
+++ b/tests/PHPStan/Analyser/data/bug-1396.php
@@ -6,9 +6,9 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 use function PHPStan\Testing\assertType;
 
-class TypeSpecifier2
+class HelloWorld
 {
-	public function specifyTypesInCondition(
+	public function doFoo(
 		ConstantScalarType $constantType
 	): SpecifiedTypes
 	{

--- a/tests/PHPStan/Analyser/data/bug-1396.php
+++ b/tests/PHPStan/Analyser/data/bug-1396.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace Bug1396;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantScalarType;
+use function PHPStan\Testing\assertType;
+
+class TypeSpecifier2
+{
+	/**
+	 * @param (Expr|ConstantScalarType)[]|null $expressions
+	 * @api
+	 */
+	public function specifyTypesInCondition(
+		Expr $expr,
+			 $expressions
+	): SpecifiedTypes
+	{
+		if ($expr instanceof Node\Expr\BinaryOp\Identical) {
+			if ($expressions !== null) {
+				/** @var Expr $exprNode */
+				$exprNode = $expressions[0];
+				/** @var ConstantScalarType $constantType */
+				$constantType = $expressions[1];
+
+				if ($constantType->getValue() === null) {
+					return $this->create();
+				}
+
+				if (
+					$constantType instanceof ConstantStringType
+				) {
+					assertType('string', $constantType->getValue());
+				}
+			}
+		}
+	}
+
+	/** @api */
+	public function create(
+	): SpecifiedTypes
+	{
+		return new SpecifiedTypes();
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan-src/pull/1396

`$moreSpecificTypes` related to variable types should be invalidated when variable type has changed.
I think these process (invalidating `$moreSpecificTypes` and `$conditionalExpressions`) can be refactored to one method, I'd do it in another pull request  