### PR TITLE
Fix handling of `str_split` / `mb_str_split` string arg compound types + default return type for `mb_str_split`

### DIFF
--- a/build/baseline-8.0.neon
+++ b/build/baseline-8.0.neon
@@ -16,7 +16,7 @@ parameters:
 			path: ../src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between non-empty-array<int, string> and false will always evaluate to false\\.$#"
+			message: "#^Strict comparison using \\=\\=\\= between array<int, string> and false will always evaluate to false\\.$#"
 			count: 1
 			path: ../src/Type/Php/StrSplitFunctionReturnTypeExtension.php
 

--- a/resources/functionMap_php74delta.php
+++ b/resources/functionMap_php74delta.php
@@ -39,7 +39,7 @@ return [
 		'FFI::typeof' => ['FFI\CType', '&ptr'=>'FFI\CData'],
 		'FFI::type' => ['FFI\CType', 'type'=>'string'],
 		'get_mangled_object_vars' => ['array', 'obj'=>'object'],
-		'mb_str_split' => ['non-empty-array<int,string>|false', 'str'=>'string', 'split_length='=>'int', 'encoding='=>'string'],
+		'mb_str_split' => ['array<int,string>|false', 'str'=>'string', 'split_length='=>'int', 'encoding='=>'string'],
 		'password_algos' => ['array<int, string>'],
 		'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'string|null', 'options='=>'array'],
 		'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'string|null', 'options='=>'array'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -74,7 +74,7 @@ return [
 		'imagescale' => ['false|object', 'im'=>'resource', 'new_width'=>'int', 'new_height='=>'int', 'method='=>'int'],
 		'ldap_set_rebind_proc' => ['bool', 'ldap'=>'resource', 'callback'=>'?callable'],
 		'mb_decode_numericentity' => ['string|false', 'string'=>'string', 'convmap'=>'array', 'encoding='=>'string'],
-		'mb_str_split' => ['non-empty-array<int,string>', 'str'=>'string', 'split_length='=>'positive-int', 'encoding='=>'string'],
+		'mb_str_split' => ['array<int,string>', 'str'=>'string', 'split_length='=>'positive-int', 'encoding='=>'string'],
 		'mb_strlen' => ['0|positive-int', 'str'=>'string', 'encoding='=>'string'],
 		'mktime' => ['int|false', 'hour'=>'int', 'minute='=>'int', 'second='=>'int', 'month='=>'int', 'day='=>'int', 'year='=>'int'],
 		'odbc_exec' => ['resource|false', 'connection_id'=>'resource', 'query'=>'string'],

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -96,17 +96,18 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 			}
 
 			if (!$type instanceof ConstantStringType) {
-				return TypeCombinator::intersect(
-					new ArrayType(new IntegerType(), new StringType()),
-					new NonEmptyArrayType(),
-				);
+				$returnType = new ArrayType(new IntegerType(), new StringType());
+
+				return $encoding === null
+					? TypeCombinator::intersect($returnType, new NonEmptyArrayType())
+					: $returnType;
 			}
 
 			$stringValue = $type->getValue();
 
-			$items = $encoding !== null
-				? mb_str_split($stringValue, $splitLength, $encoding)
-				: str_split($stringValue, $splitLength);
+			$items = $encoding === null
+				? str_split($stringValue, $splitLength)
+				: mb_str_split($stringValue, $splitLength, $encoding);
 			if ($items === false) {
 				throw new ShouldNotHappenException();
 			}

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8716,7 +8716,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		return [
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithoutDefinedParameters',
 			],
 			[
@@ -8724,7 +8724,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithoutDefinedSplitLength',
 			],
 			[
-				'non-empty-array<int, string>',
+				'array<int, string>',
 				'$mbStrSplitStringWithoutDefinedSplitLength',
 			],
 			[
@@ -8740,7 +8740,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithFailureSplitLength',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithInvalidSplitLengthType',
 			],
 			[
@@ -8748,7 +8748,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithVariableStringAndConstantSplitLength',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithVariableStringAndVariableSplitLength',
 			],
 			[
@@ -8760,7 +8760,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithOneSplitLengthAndInvalidEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithOneSplitLengthAndVariableEncoding',
 			],
 			[
@@ -8772,7 +8772,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithGreaterSplitLengthThanStringLengthAndInvalidEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithGreaterSplitLengthThanStringLengthAndVariableEncoding',
 			],
 			[
@@ -8788,7 +8788,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithFailureSplitLengthAndVariableEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithInvalidSplitLengthTypeAndValidEncoding',
 			],
 			[
@@ -8796,7 +8796,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithInvalidSplitLengthTypeAndInvalidEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithInvalidSplitLengthTypeAndVariableEncoding',
 			],
 			[
@@ -8808,11 +8808,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithVariableStringAndConstantSplitLengthAndInvalidEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithVariableStringAndConstantSplitLengthAndVariableEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithVariableStringAndVariableSplitLengthAndValidEncoding',
 			],
 			[
@@ -8820,7 +8820,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithVariableStringAndVariableSplitLengthAndInvalidEncoding',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80000 ? 'array<int, string>|false' : 'array<int, string>',
 				'$mbStrSplitConstantStringWithVariableStringAndVariableSplitLengthAndVariableEncoding',
 			],
 		];

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5356,7 +5356,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$strSplitConstantStringWithInvalidSplitLengthType',
 			],
 			[
-				'non-empty-array<int, string>',
+				'array{\'a\'|\'g\', \'b\'|\'h\', \'c\'|\'i\', \'d\'|\'j\', \'e\'|\'k\', \'f\'|\'l\'}',
 				'$strSplitConstantStringWithVariableStringAndConstantSplitLength',
 			],
 			[
@@ -8744,7 +8744,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithInvalidSplitLengthType',
 			],
 			[
-				'non-empty-array<int, string>',
+				'array{\'a\'|\'g\', \'b\'|\'h\', \'c\'|\'i\', \'d\'|\'j\', \'e\'|\'k\', \'f\'|\'l\'}',
 				'$mbStrSplitConstantStringWithVariableStringAndConstantSplitLength',
 			],
 			[
@@ -8800,7 +8800,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$mbStrSplitConstantStringWithInvalidSplitLengthTypeAndVariableEncoding',
 			],
 			[
-				'non-empty-array<int, string>',
+				'array{\'a\'|\'g\', \'b\'|\'h\', \'c\'|\'i\', \'d\'|\'j\', \'e\'|\'k\', \'f\'|\'l\'}',
 				'$mbStrSplitConstantStringWithVariableStringAndConstantSplitLengthAndValidEncoding',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -923,6 +923,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/emptyiterator.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/collected-data.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7550.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7580.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7580.php
+++ b/tests/PHPStan/Analyser/data/bug-7580.php
@@ -15,4 +15,4 @@ assertType('array{}|array{\'x\'}', mb_str_split($v, 1));
 function x(): string { throw new \Exception(); };
 $v = x();
 assertType('string', $v);
-assertType('non-empty-array<int, string>', mb_str_split($v, 1));
+assertType('array<int, string>', mb_str_split($v, 1));

--- a/tests/PHPStan/Analyser/data/bug-7580.php
+++ b/tests/PHPStan/Analyser/data/bug-7580.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7580;
+
+use function PHPStan\Testing\assertType;
+
+assertType('array{}', mb_str_split('', 1));
+
+assertType('array{\'x\'}', mb_str_split('x', 1));
+
+$v = (string) (mt_rand() === 0 ? '' : 'x');
+assertType('\'\'|\'x\'', $v);
+assertType('array{}|array{\'x\'}', mb_str_split($v, 1));
+
+function x(): string { throw new \Exception(); };
+$v = x();
+assertType('string', $v);
+assertType('non-empty-array<int, string>', mb_str_split($v, 1));

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -92,4 +92,23 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7580(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-7580.php'], [
+			[
+				'Ternary operator condition is always false.',
+				6,
+			],
+			[
+				'Ternary operator condition is always true.',
+				9,
+			],
+			[
+				'Ternary operator condition is always true.',
+				20,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -104,10 +104,6 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 				'Ternary operator condition is always true.',
 				9,
 			],
-			[
-				'Ternary operator condition is always true.',
-				20,
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/bug-7580.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7580.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7580;
+
+print_r(mb_str_split('', 1));
+print_r(mb_str_split('', 1) ?: ['']);
+
+print_r(mb_str_split('x', 1));
+print_r(mb_str_split('x', 1) ?: ['']);
+
+$v = (string) (mt_rand() === 0 ? '' : 'x');
+\PHPStan\dumpType($v);
+print_r(mb_str_split($v, 1));
+print_r(mb_str_split($v, 1) ?: ['']); // there must be no phpstan error for this line
+
+function x(): string { throw new \Exception(); };
+$v = x();
+\PHPStan\dumpType($v);
+print_r(mb_str_split($v, 1));
+print_r(mb_str_split($v, 1) ?: ['']); // there must be no phpstan error for this line


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7580

There were 2 issues basically which is why I split this into 2 commits
- `str_split` / `mb_str_split` did not handle compound types for the string type correctly (e.g. union of constant strings)
- `mb_str_split` can actually return an empty array. This was adapted in https://github.com/phpstan/phpstan-src/pull/633 which is based on a psalm adaption, but psalm actually reverted it back in https://github.com/vimeo/psalm/pull/6493 because `str_split` and `mb_str_split` differ in behaviour there. See also https://3v4l.org/r6sMe

`StrSplitFunctionReturnTypeExtension` could need a bit more cleanup, but I wanted to avoid rewriting it here.. Maybe I'll adapt some more in follow-ups.