### PR TITLE
Fix return type of octdec()

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -7992,7 +7992,7 @@ return [
 'ocifetchinto' => ['int|false', 'stmt'=>'', '&w_output'=>'array', 'mode='=>'int'],
 'ocigetbufferinglob' => ['bool'],
 'ocisetbufferinglob' => ['bool', 'flag'=>'bool'],
-'octdec' => ['int', 'octal_number'=>'string'],
+'octdec' => ['int|float', 'octal_number'=>'string'],
 'odbc_autocommit' => ['mixed', 'connection_id'=>'resource', 'onoff='=>'bool'],
 'odbc_binmode' => ['bool', 'result_id'=>'int', 'mode'=>'int'],
 'odbc_close' => ['void', 'connection_id'=>'resource'],


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan-src/pull/1499, https://github.com/phpstan/phpstan-src/pull/1499#issuecomment-1179582874

This problem seems to have been around since I imported the function map from Phan. https://github.com/phpstan/phpstan-src/commit/f486280bf7746e20661f3c917f63749915f1be59

Actually `octdec()` returns int and float from PHP 4. https://3v4l.org/kmR7o