### PR TITLE
Private constructors are allowed to be final

### DIFF
--- a/src/Rules/Methods/FinalPrivateMethodRule.php
+++ b/src/Rules/Methods/FinalPrivateMethodRule.php
@@ -37,6 +37,10 @@ class FinalPrivateMethodRule implements Rule
 			return [];
 		}
 
+		if ($method->getName() === '__construct') {
+			return [];
+		}
+
 		if (!$method->isFinal()->yes() || !$method->isPrivate()) {
 			return [];
 		}

--- a/tests/PHPStan/Rules/Methods/data/final-private-method.php
+++ b/tests/PHPStan/Rules/Methods/data/final-private-method.php
@@ -22,3 +22,12 @@ class Foo
 	}
 
 }
+
+class ConstructorsAreExcluded
+{
+
+	final private function __construct()
+	{
+	}
+
+}


### PR DESCRIPTION
Follow-up / fix, see https://github.com/phpstan/phpstan-src/pull/1490#issuecomment-1179725883

Was also stated on https://wiki.php.net/rfc/inheritance_private_methods but I seemed to have missed that..
>  Due to how common the usage of final private function __construct is and given that the same results cannot be achieved with a protected visibility, an exception to this rule is made for constructors. With this exception, they are the only case where a child class can't override a final private method. 