### PR TITLE
Better support for autoloader edge cases

### DIFF
--- a/src/File/FileReader.php
+++ b/src/File/FileReader.php
@@ -4,16 +4,23 @@ namespace PHPStan\File;
 
 use function file_get_contents;
 use function is_file;
+use function stream_resolve_include_path;
 
 class FileReader
 {
 
 	public static function read(string $fileName): string
 	{
-		if (!is_file($fileName)) {
-			throw new CouldNotReadFileException($fileName);
+		$path = $fileName;
+
+		if (!is_file($path)) {
+			$path = stream_resolve_include_path($fileName);
+
+			if ($path === false) {
+				throw new CouldNotReadFileException($fileName);
+			}
 		}
-		$contents = @file_get_contents($fileName);
+		$contents = @file_get_contents($path);
 		if ($contents === false) {
 			throw new CouldNotReadFileException($fileName);
 		}

--- a/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
@@ -3,7 +3,9 @@
 namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 
 use PHPStan\ShouldNotHappenException;
+use function is_file;
 use function stat;
+use function stream_resolve_include_path;
 use function stream_wrapper_register;
 use function stream_wrapper_restore;
 use function stream_wrapper_unregister;
@@ -94,11 +96,15 @@ final class FileReadTrapStreamWrapper
 	 */
 	public function stream_open($path, $mode, $options, &$openedPath): bool
 	{
-		self::$autoloadLocatedFiles[] = $path;
+		$exists = is_file($path) || (stream_resolve_include_path($path) !== false);
+
+		if ($exists) {
+			self::$autoloadLocatedFiles[] = $path;
+		}
 		$this->readFromFile = false;
 		$this->seekPosition = 0;
 
-		return true;
+		return $exists;
 	}
 
 	/**


### PR DESCRIPTION
Support autoloaders that rely on the include path and don't check file existence before trying to include a file.

Autoloaders not checking file existence before trying to include the file need a proper response from `stream_open`. This is something that wouldn't happen with PHP based autoloaders, but C based autoloaders may rely on the return value of `php_stream_open_for_zend_ex()`.

Autoloaders may not always know the exact physical location of the file they need to load, and instead rely on the availability of the file *somewhere* in the include path. In order for phpstan to also find those files, rather than just an `is_file()` check, it would also need to check availability in the include path with `stream_resolve_include_path()`. 

Fixes https://github.com/phpstan/phpstan/issues/7526, which also contains more background info.