### PR TITLE
Simplify InArrayFunctionTypeSpecifyingExtension

### DIFF
--- a/tests/PHPStan/Analyser/data/in-array-non-empty.php
+++ b/tests/PHPStan/Analyser/data/in-array-non-empty.php
@@ -17,4 +17,12 @@ class HelloWorld
 			assertType('non-empty-array<int, string>', $array);
 		}
 	}
+
+	/** @param array<int> $haystack */
+	public function nonConstantNeedle(int $needle, array $haystack): void
+	{
+		if (in_array($needle, $haystack, true)) {
+			assertType('non-empty-array<int>', $haystack);
+		}
+	}
 }


### PR DESCRIPTION
I know this is not changing much, but I'm currently looking at improving the impossible checks there and had this change lying around and wanted to throw it out already. if that makes sense..

It mostly moves the last specifying block (for a non-empty-array haystack) inside the haystack specifying block. this feels like one thing less to worry for me that might mess things up and hopefully it helps when I have to add more checks. but so far this stuff only lead to headaches.. :)