### PR TITLE
Improve `in_array` extension to get rid of related impossible check adaptions

### DIFF
--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -33,9 +33,12 @@ class HasOffsetType implements CompoundType, AccessoryType
 	use NonRemoveableTypeTrait;
 	use NonGeneralizableTypeTrait;
 
+	private Type $offsetValueType;
+
 	/** @api */
-	public function __construct(private Type $offsetType)
+	public function __construct(private Type $offsetType, ?Type $offsetValueType = null)
 	{
+		$this->offsetValueType = $offsetValueType ?? new MixedType();
 	}
 
 	public function getOffsetType(): Type
@@ -64,7 +67,8 @@ class HasOffsetType implements CompoundType, AccessoryType
 			return TrinaryLogic::createYes();
 		}
 		return $type->isOffsetAccessible()
-			->and($type->hasOffsetValueType($this->offsetType));
+			->and($type->hasOffsetValueType($this->offsetType))
+			->and($this->offsetValueType->isSuperTypeOf($type->getOffsetValueType($this->offsetType)));
 	}
 
 	public function isSubTypeOf(Type $otherType): TrinaryLogic
@@ -110,7 +114,7 @@ class HasOffsetType implements CompoundType, AccessoryType
 
 	public function getOffsetValueType(Type $offsetType): Type
 	{
-		return new MixedType();
+		return $this->offsetValueType;
 	}
 
 	public function setOffsetValueType(?Type $offsetType, Type $valueType, bool $unionValues = true): Type

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -114,7 +114,7 @@ class HasOffsetType implements CompoundType, AccessoryType
 
 	public function getOffsetValueType(Type $offsetType): Type
 	{
-		return $this->offsetValueType;
+		return $offsetType->equals($this->offsetType) ? $this->offsetValueType : new ErrorType();
 	}
 
 	public function setOffsetValueType(?Type $offsetType, Type $valueType, bool $unionValues = true): Type

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -29,6 +29,7 @@ use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_keys;
@@ -530,6 +531,23 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		return new ArrayType($this->getKeyType(), $this->getItemType());
+	}
+
+	public function getOffsetType(Type $offsetValueType): Type
+	{
+		return TypeTraverser::map($offsetValueType, function (Type $type, callable $traverse): Type {
+			if ($type instanceof UnionType || $type instanceof IntersectionType) {
+				return $traverse($type);
+			}
+
+			foreach ($this->valueTypes as $i => $valueType) {
+				if ($valueType->equals($type)) {
+					return $this->keyTypes[$i];
+				}
+			}
+
+			return new ErrorType(); // undefined offset value
+		});
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -29,7 +29,6 @@ use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_keys;
@@ -531,23 +530,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		return new ArrayType($this->getKeyType(), $this->getItemType());
-	}
-
-	public function getOffsetType(Type $offsetValueType): Type
-	{
-		return TypeTraverser::map($offsetValueType, function (Type $type, callable $traverse): Type {
-			if ($type instanceof UnionType || $type instanceof IntersectionType) {
-				return $traverse($type);
-			}
-
-			foreach ($this->valueTypes as $i => $valueType) {
-				if ($valueType->equals($type)) {
-					return $this->keyTypes[$i];
-				}
-			}
-
-			return new ErrorType(); // undefined offset value
-		});
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -491,6 +491,39 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return new ErrorType(); // undefined offset
 	}
 
+	public function getOffsetType(Type $offsetValueType): Type
+	{
+		$matchingOffsetTypes = [];
+		$all = true;
+		foreach ($this->valueTypes as $i => $valueType) {
+			if ($valueType->isSuperTypeOf($offsetValueType)->no()) {
+				$all = false;
+				continue;
+			}
+
+			$matchingOffsetTypes[] = $this->keyTypes[$i];
+		}
+
+		if ($all) {
+			if (count($this->keyTypes) === 0) {
+				return new ErrorType();
+			}
+
+			return $this->getIterableKeyType();
+		}
+
+		if (count($matchingOffsetTypes) > 0) {
+			$type = TypeCombinator::union(...$matchingOffsetTypes);
+			if ($type instanceof ErrorType) {
+				return new MixedType();
+			}
+
+			return $type;
+		}
+
+		return new ErrorType(); // undefined offset value
+	}
+
 	public function setOffsetValueType(?Type $offsetType, Type $valueType, bool $unionValues = true): Type
 	{
 		$builder = ConstantArrayTypeBuilder::createFromConstantArray($this);

--- a/tests/PHPStan/Analyser/data/bug-7153.php
+++ b/tests/PHPStan/Analyser/data/bug-7153.php
@@ -25,7 +25,7 @@ function () {
 	assertType('array{string, string|null}', $data);
 
 	if (in_array(null, $data, true)) {
-		assertType('array{string, string|null}', $data);
+		assertType('array{string, null}', $data);
 		throw new Exception();
 	}
 

--- a/tests/PHPStan/Analyser/data/in-array-non-empty.php
+++ b/tests/PHPStan/Analyser/data/in-array-non-empty.php
@@ -14,7 +14,7 @@ class HelloWorld
 	public function sayHello(array $array): void
 	{
 		if(in_array("thing", $array, true)){
-			assertType('non-empty-array<int, string>&hasOffset(int)', $array);
+			assertType('non-empty-array<int, string>&hasOffset(mixed)', $array);
 		}
 	}
 
@@ -22,7 +22,7 @@ class HelloWorld
 	public function nonConstantNeedle(int $needle, array $haystack): void
 	{
 		if (in_array($needle, $haystack, true)) {
-			assertType('non-empty-array<int>&hasOffset((int|string))', $haystack);
+			assertType('non-empty-array<int>&hasOffset(mixed)', $haystack);
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/data/in-array-non-empty.php
+++ b/tests/PHPStan/Analyser/data/in-array-non-empty.php
@@ -14,7 +14,7 @@ class HelloWorld
 	public function sayHello(array $array): void
 	{
 		if(in_array("thing", $array, true)){
-			assertType('non-empty-array<int, string>', $array);
+			assertType('non-empty-array<int, string>&hasOffset(int)', $array);
 		}
 	}
 
@@ -22,7 +22,7 @@ class HelloWorld
 	public function nonConstantNeedle(int $needle, array $haystack): void
 	{
 		if (in_array($needle, $haystack, true)) {
-			assertType('non-empty-array<int>', $haystack);
+			assertType('non-empty-array<int>&hasOffset((int|string))', $haystack);
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/data/in-array.php
+++ b/tests/PHPStan/Analyser/data/in-array.php
@@ -10,12 +10,14 @@ class Foo
 	 * @param string $r
 	 * @param $mixed
 	 * @param string[] $strings
+	 * @param string[] $moreStrings
 	 */
 	public function doFoo(
 		string $s,
 		string $r,
 		$mixed,
-		array $strings
+		array $strings,
+		array $moreStrings
 	)
 	{
 		if (!in_array($s, ['foo', 'bar'], true)) {
@@ -26,7 +28,7 @@ class Foo
 			return;
 		}
 
-		if (in_array($r, $strings, true)) {
+		if (in_array($r, $moreStrings, true)) {
 			return;
 		}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -109,6 +109,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					244,
 				],
 				[
+					'Call to function in_array() with arguments \'bar\'|\'foo\', array{\'foo\', \'bar\'} and true will always evaluate to true.',
+					248,
+				],
+				[
 					'Call to function in_array() with arguments \'foo\', array{\'foo\'} and true will always evaluate to true.',
 					252,
 				],
@@ -238,11 +242,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					890,
 				],
 				[
-					'Call to function in_array() with arguments \'foo\', array{0?: \'foo\'}&non-empty-array and true will always evaluate to true.',
+					'Call to function in_array() with arguments \'foo\', array{\'foo\'} and true will always evaluate to true.',
 					896,
 				],
 				[
-					'Call to function in_array() with arguments \'foo\', array{0?: *NEVER*} and true will always evaluate to false.',
+					'Call to function in_array() with arguments \'foo\', array and true will always evaluate to false.',
 					900,
 				],
 			],
@@ -342,7 +346,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					693,
 				],
 				[
-					'Call to function in_array() with arguments \'foo\', array{0?: *NEVER*} and true will always evaluate to false.',
+					'Call to function in_array() with arguments \'foo\', array and true will always evaluate to false.',
 					900,
 				],
 			],

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -109,6 +109,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					244,
 				],
 				[
+					'Call to function in_array() with arguments \'bar\'|\'foo\', array{\'foo\', \'bar\'} and true will always evaluate to true.',
+					248,
+				],
+				[
 					'Call to function in_array() with arguments \'foo\', array{\'foo\'} and true will always evaluate to true.',
 					252,
 				],
@@ -474,6 +478,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 			[
 				'Call to function in_array() with arguments \'a\', non-empty-array<int, \'a\'> and true will always evaluate to true.',
 				39,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 			[
 				'Call to function in_array() with arguments \'b\', non-empty-array<int, \'a\'> and true will always evaluate to false.',
@@ -482,6 +487,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 			[
 				'Call to function in_array() with arguments int, array{} and true will always evaluate to false.',
 				47,
+			],
+			[
+				'Call to function in_array() with arguments int, array<int, string> and true will always evaluate to false.',
+				61,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -549,7 +549,12 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
-		$this->analyse([__DIR__ . '/data/slevomat-cs-in-array.php'], []);
+		$this->analyse([__DIR__ . '/data/slevomat-cs-in-array.php'], [
+			[
+				'Call to function in_array() with arguments \'abstract methods\'|\'constructor\'|\'destructor\'|\'final methods\'|\'magic methods\'|\'private constants\'|\'private methods\'|\'private properties\'|\'private static…\'|\'private static…\'|\'protected abstract…\'|\'protected constants\'|\'protected final…\'|\'protected methods\'|\'protected properties\'|\'protected static…\'|\'protected static…\'|\'protected static…\'|\'protected static…\'|\'public abstract…\'|\'public constants\'|\'public final methods\'|\'public methods\'|\'public properties\'|\'public static…\'|\'public static final…\'|\'public static…\'|\'public static…\'|\'static constructors\'|\'static methods\'|\'static properties\', array{0: \'final methods\'|\'private static…\'|\'protected final…\'|\'public abstract…\'|\'public constants\'|\'public final methods\'|\'public static…\'|\'static constructors\'|\'static properties\', 1: \'abstract methods\'|\'private methods\'|\'protected abstract…\'|\'protected constants\'|\'protected final…\'|\'protected static…\'|\'protected static…\'|\'public properties\'|\'public static final…\', 2?: \'private constants\'|\'private static…\'|\'protected abstract…\'|\'protected properties\'|\'protected static…\'|\'public abstract…\'|\'public static…\'|\'public static final…\'|\'static methods\', 3?: \'constructor\'|\'private properties\'|\'protected static…\'|\'protected static…\'|\'public static…\', 4?: \'destructor\'|\'protected static…\'|\'protected static…\'|\'public static…\', 5?: \'protected methods\'|\'public methods\'|\'public static…\', 6?: \'protected methods\'|\'protected static…\', 7?: \'private methods\'|\'private static…\', ...} and true will always evaluate to true.',
+				132,
+			],
+		]);
 	}
 
 	public function testNonEmptySpecifiedString(): void

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -241,6 +241,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					'Call to function in_array() with arguments \'foo\', array{0?: \'foo\'}&non-empty-array and true will always evaluate to true.',
 					896,
 				],
+				[
+					'Call to function in_array() with arguments \'foo\', array{0?: *NEVER*} and true will always evaluate to false.',
+					900,
+				],
 			],
 		);
 	}
@@ -336,6 +340,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				[
 					'Call to function is_numeric() with \'blabla\' will always evaluate to false.',
 					693,
+				],
+				[
+					'Call to function in_array() with arguments \'foo\', array{0?: *NEVER*} and true will always evaluate to false.',
+					900,
 				],
 			],
 		);

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -109,10 +109,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					244,
 				],
 				[
-					'Call to function in_array() with arguments \'bar\'|\'foo\', array{\'foo\', \'bar\'} and true will always evaluate to true.',
-					248,
-				],
-				[
 					'Call to function in_array() with arguments \'foo\', array{\'foo\'} and true will always evaluate to true.',
 					252,
 				],
@@ -478,7 +474,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 			[
 				'Call to function in_array() with arguments \'a\', non-empty-array<int, \'a\'> and true will always evaluate to true.',
 				39,
-				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 			[
 				'Call to function in_array() with arguments \'b\', non-empty-array<int, \'a\'> and true will always evaluate to false.',

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -233,6 +233,14 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					'Call to function property_exists() with CheckTypeFunctionCall\Bug2221 and \'foo\' will always evaluate to true.',
 					786,
 				],
+				[
+					'Call to function in_array() with arguments \'foo\', non-empty-array<string> and true will always evaluate to true.',
+					890,
+				],
+				[
+					'Call to function in_array() with arguments \'foo\', array{0?: \'foo\'}&non-empty-array and true will always evaluate to true.',
+					896,
+				],
 			],
 		);
 	}

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -867,7 +867,7 @@ class InArray2
 	/** @param non-empty-array<int, int> $haystack */
 	public function nonConstants(int $needle, array $haystack): void
 	{
-		if (in_array($needle, $haystack, true)) {
+		if (in_array($needle, $haystack, true)) { // bool
 
 		}
 	}
@@ -875,7 +875,7 @@ class InArray2
 	/** @param array{'self', string} $haystack */
 	public function slevomatCsBug(string $needle, array $haystack): void
 	{
-		if (in_array($needle, $haystack, true)) {
+		if (in_array($needle, $haystack, true)) { // bool
 
 		}
 	}
@@ -886,14 +886,18 @@ class InArray2
 	 */
 	public function triggersIfArrayIsNarrowedDownTwiceWithConstant(array $genericHaystack, array $constantHaystack): void
 	{
-		if (in_array('foo', $genericHaystack, true)) {
-			if (in_array('foo', $genericHaystack, true)) {
+		if (in_array('foo', $genericHaystack, true)) { // bool
+			if (in_array('foo', $genericHaystack, true)) { // true
 
 			}
 		}
 
-		if (in_array('foo', $constantHaystack, true)) {
-			if (in_array('foo', $constantHaystack, true)) {
+		if (in_array('foo', $constantHaystack, true)) { // bool
+			if (in_array('foo', $constantHaystack, true)) { // true
+
+			}
+		} else {
+			if (in_array('foo', $constantHaystack, true)) { // false
 
 			}
 		}

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -860,3 +860,16 @@ class ArraySearch
 	}
 
 }
+
+class InArray2
+{
+
+	/** @param non-empty-array<int, int> $haystack */
+	public function checkWithNonConstants(int $needle, array $haystack): void
+	{
+		if (in_array($needle, $haystack, true)) {
+
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -865,7 +865,15 @@ class InArray2
 {
 
 	/** @param non-empty-array<int, int> $haystack */
-	public function checkWithNonConstants(int $needle, array $haystack): void
+	public function nonConstants(int $needle, array $haystack): void
+	{
+		if (in_array($needle, $haystack, true)) {
+
+		}
+	}
+
+	/** @param array{'self', string} $haystack */
+	public function slevomatCsBug(string $needle, array $haystack): void
 	{
 		if (in_array($needle, $haystack, true)) {
 

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -880,4 +880,23 @@ class InArray2
 		}
 	}
 
+	/**
+	 * @param array<string> $genericHaystack
+	 * @param array{0?: 'foo'} $constantHaystack
+	 */
+	public function triggersIfArrayIsNarrowedDownTwiceWithConstant(array $genericHaystack, array $constantHaystack): void
+	{
+		if (in_array('foo', $genericHaystack, true)) {
+			if (in_array('foo', $genericHaystack, true)) {
+
+			}
+		}
+
+		if (in_array('foo', $constantHaystack, true)) {
+			if (in_array('foo', $constantHaystack, true)) {
+
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6705

Almost all of the problems were solved by adding the `$offsetValueType` information to `HasOffset`. This way it is now possible to e.g. specify a type `non-empty-array<int, int>&hasOffset(int, 17)` which tells us that the generic array consists of ints AND has at least one entry with the value 17. (but if the type is dumped/printed the hasOffset is not showing the offset value to e.g. not mess up baselines..).