### PR TITLE
Change impossible match arms to not contribute to the expressions' resulting union type

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1525,6 +1525,7 @@ class MutatingScope implements Scope
 				$filteringExpr = null;
 				foreach ($arm->conds as $armCond) {
 					$armCondExpr = new BinaryOp\Identical($cond, $armCond);
+
 					if ($filteringExpr === null) {
 						$filteringExpr = $armCondExpr;
 						continue;
@@ -1533,8 +1534,12 @@ class MutatingScope implements Scope
 					$filteringExpr = new BinaryOp\BooleanOr($filteringExpr, $armCondExpr);
 				}
 
-				$truthyScope = $matchScope->filterByTruthyValue($filteringExpr);
-				$types[] = $truthyScope->getType($arm->body);
+				$filteringExprType = $matchScope->getType($filteringExpr);
+
+				if (!(new ConstantBooleanType(false))->isSuperTypeOf($filteringExprType)->yes()) {
+					$truthyScope = $matchScope->filterByTruthyValue($filteringExpr);
+					$types[] = $truthyScope->getType($arm->body);
+				}
 
 				$matchScope = $matchScope->filterByFalseyValue($filteringExpr);
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -926,6 +926,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7550.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7580.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/this-subtractable.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/match-expression-inference.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/match-expression-inference.php
+++ b/tests/PHPStan/Analyser/data/match-expression-inference.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace MatchExpressionInference;
+
+use function PHPStan\Testing\assertType;
+
+class Test{
+	public function test(): string
+	{
+		$foo = match(1) {
+			1 => 'one',
+			2 => 'two',
+		};
+
+		assertType("'one'", $foo);
+
+		return $foo;
+	}
+}


### PR DESCRIPTION
Let me know if there's something i can do better!

went down the wrong rabbit hole for hours trying to modify the NodeScopeResolver, is there any docs / resources that would be good to learn about how scopes / type inference works internally @ondrejmirtes ? something like that video of Jan talking about types you posted the other day?