### PR TITLE
Specfiy root expression from type specifying extensions

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -691,7 +691,7 @@ class TypeSpecifier
 						continue;
 					}
 
-					return $extension->specifyTypes($functionReflection, $expr, $scope, $context);
+					return $this->specifyRootExpr($extension->specifyTypes($functionReflection, $expr, $scope, $context), $scope, $context);
 				}
 
 				if (count($expr->getArgs()) > 0) {
@@ -719,7 +719,7 @@ class TypeSpecifier
 							continue;
 						}
 
-						return $extension->specifyTypes($methodReflection, $expr, $scope, $context);
+						return $this->specifyRootExpr($extension->specifyTypes($methodReflection, $expr, $scope, $context), $scope, $context);
 					}
 
 					if (count($expr->getArgs()) > 0) {
@@ -753,7 +753,7 @@ class TypeSpecifier
 							continue;
 						}
 
-						return $extension->specifyTypes($staticMethodReflection, $expr, $scope, $context);
+						return $this->specifyRootExpr($extension->specifyTypes($staticMethodReflection, $expr, $scope, $context), $scope, $context);
 					}
 				}
 
@@ -1419,6 +1419,23 @@ class TypeSpecifier
 		}
 
 		return array_merge(...$extensionsForClass);
+	}
+
+	private function specifyRootExpr(SpecifiedTypes $specifiedTypes, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+	{
+		$rootExpr = $specifiedTypes->getRootExpr();
+		if ($rootExpr === null || $context->null()) {
+			return $specifiedTypes;
+		}
+
+		$rootExprType = $scope->getType($rootExpr);
+		if (!$rootExprType instanceof BooleanType || $rootExprType instanceof ConstantBooleanType) {
+			return $specifiedTypes;
+		}
+
+		return $specifiedTypes->unionWith(
+			$this->create($rootExpr, new ConstantBooleanType(true), $context),
+		);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -532,7 +532,16 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
-		$this->analyse([__DIR__ . '/data/non-empty-string-impossible-type.php'], []);
+		$this->analyse([__DIR__ . '/data/non-empty-string-impossible-type.php'], [
+			[
+				'Call to function str_contains() with non-empty-string and \'foo\' will always evaluate to true.',
+				26,
+			],
+			[
+				'Call to function str_contains() with non-empty-string and \'foo\' will always evaluate to true.',
+				36,
+			],
+		]);
 	}
 
 	public function testBug2755(): void

--- a/tests/PHPStan/Rules/Comparison/data/non-empty-string-impossible-type.php
+++ b/tests/PHPStan/Rules/Comparison/data/non-empty-string-impossible-type.php
@@ -19,4 +19,30 @@ class Foo {
 
 		return ctype_lower($shortClassName[2]);
 	}
+
+	public function strContains(string $a, string $b, string $c, string $d, string $e): void
+	{
+		if (str_contains($a, 'foo')) {
+			if (str_contains($a, 'foo')) {
+			}
+		}
+
+		if (!str_contains($b, 'foo')) {
+			if (!str_contains($b, 'foo')) {
+			}
+		}
+
+		if (str_contains($c, 'foo')) {
+			if (!str_contains($c, 'foo')) {
+			}
+		}
+
+		if (!str_contains($d, 'foo')) {
+			if (str_contains($d, 'foo')) {
+			}
+		}
+
+		if (str_contains($e, 'bar')) {
+		}
+	}
 }


### PR DESCRIPTION
This is a follow-up of the introduction of the root expression feature https://github.com/phpstan/phpstan-src/pull/1254

And it improves the `StrContainingTypeSpecifyingExtension`, the only extension where we currently make use of a `FAUX_FUNCTION` https://github.com/phpstan/phpstan-src/pull/1068 to specify additional infos we cannot model with the type system (in case of `str_contains` that e.g. "foo" is inside some string, which we specify a non-empty-string).
UPDATE: this was a bit weirder than I thought at first to adapt because the extension supports functions that evaluate to a boolean and also others that don't and cannot be supported by what this PR adds.

The idea behind this PR is that if extensions specify a root expression, that resolves to a `BooleanType` (which the `ImpossibleCheckTypeHelper` basically ignores now to avoid false positives), we can specify that as `ConstantBooleanType(true)`. This includes the previously mentioned `FAUX_FUNCTION` that is used to make the TypeSpecifier aware of the additional unknown info. What this effectively does is, whenever the exact same expression, with the exact same `FAUX_FUNCTION` is resolved again, it resolves to `true`and produces an impossible type error.
That means that we can now detect cases where calls with the exact same "unknown information" were made multiple times.

This also helps me simplify the logic I want to add to the webmozart-assert extension to specify various `non-empty-string` assertions without missing those impossible types :) In case this generic adaption does not make much sense, I guess I'd only specify those types in the webmozart-assert extension which is also fine.