### PR TITLE
Support `ConstantArrayType` callables with union values

### DIFF
--- a/src/Rules/DeadCode/UnusedPrivateMethodRule.php
+++ b/src/Rules/DeadCode/UnusedPrivateMethodRule.php
@@ -120,31 +120,29 @@ class UnusedPrivateMethodRule implements Rule
 				if (!$arrayType instanceof ConstantArrayType) {
 					continue;
 				}
-				$typeAndMethod = $arrayType->findTypeAndMethodName();
-				if ($typeAndMethod === null) {
-					continue;
+				foreach ($arrayType->findTypeAndMethodNames() as $typeAndMethod) {
+					if ($typeAndMethod->isUnknown()) {
+						return [];
+					}
+					if (!$typeAndMethod->getCertainty()->yes()) {
+						return [];
+					}
+					$calledOnType = $typeAndMethod->getType();
+					if ($classType->isSuperTypeOf($calledOnType)->no()) {
+						continue;
+					}
+					if ($calledOnType instanceof MixedType) {
+						continue;
+					}
+					$inMethod = $arrayScope->getFunction();
+					if (!$inMethod instanceof MethodReflection) {
+						continue;
+					}
+					if ($inMethod->getName() === $typeAndMethod->getMethod()) {
+						continue;
+					}
+					unset($methods[$typeAndMethod->getMethod()]);
 				}
-				if ($typeAndMethod->isUnknown()) {
-					return [];
-				}
-				if (!$typeAndMethod->getCertainty()->yes()) {
-					return [];
-				}
-				$calledOnType = $typeAndMethod->getType();
-				if ($classType->isSuperTypeOf($calledOnType)->no()) {
-					continue;
-				}
-				if ($calledOnType instanceof MixedType) {
-					continue;
-				}
-				$inMethod = $arrayScope->getFunction();
-				if (!$inMethod instanceof MethodReflection) {
-					continue;
-				}
-				if ($inMethod->getName() === $typeAndMethod->getMethod()) {
-					continue;
-				}
-				unset($methods[$typeAndMethod->getMethod()]);
 			}
 		}
 

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -137,6 +137,14 @@ class CallCallablesRuleTest extends RuleTestCase
 				'Trying to invoke array{\'CallCallables\\\\CallableInForeach\', \'bar\'|\'foo\'} but it might not be a callable.',
 				179,
 			],
+			[
+				'Trying to invoke array{\'CallCallables\\\\ConstantArrayUnionCallables\'|\'DateTimeImmutable\', \'doFoo\'} but it might not be a callable.',
+				205,
+			],
+			[
+				'Trying to invoke array{\'CallCallables\\\ConstantArrayUnionCallables\', \'doBaz\'|\'doFoo\'} but it might not be a callable.',
+				212,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1123,4 +1123,9 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6781.php'], []);
 	}
 
+	public function testBug2343(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-2343.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-2343.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-2343.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug2343;
+
+class A {
+	public static function say(string $name, int $age) {
+		echo "Name: {$name}, Age: {$age}\n";
+	}
+
+	public static function bye(string $name, int $age) {
+		echo "Bye, Name: {$name}, Age: {$age}\n";
+	}
+
+	public static function all() {
+		$name = 'Jack';
+		$age = 20;
+		$functions = [
+			'say',
+			'bye'
+		];
+
+		foreach ($functions as $function) {
+			call_user_func([__CLASS__, $function], $name, $age);
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/callables.php
+++ b/tests/PHPStan/Rules/Functions/data/callables.php
@@ -186,3 +186,51 @@ class CallableInForeach
 	}
 
 }
+
+class ConstantArrayUnionCallables
+{
+
+	public function doFoo(): void
+	{
+	}
+
+	public function doBar(): void
+	{
+	}
+
+	public function invalidClass(): void
+	{
+		$class = rand(0, 1) ? __CLASS__ : \DateTimeImmutable::class;
+		$callable = [$class, 'doFoo'];
+		$callable();
+	}
+
+	public function invalidMethod(): void
+	{
+		$method = rand(0, 1) ? 'doFoo' : 'doBaz';
+		$callable = [__CLASS__, $method];
+		$callable();
+	}
+
+	public function classAndMethodValid(): void
+	{
+		$class = rand(0, 1) ? __CLASS__ : ConstantArrayUnionCallablesTest::class;
+		$method = rand(0, 1) ? 'doFoo' : 'doBar';
+		$callable = [$class, $method];
+		$callable();
+	}
+
+}
+
+class ConstantArrayUnionCallablesTest
+{
+
+	public function doFoo(): void
+	{
+	}
+
+	public function doBar(): void
+	{
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/2343

I basically just transformed `findTypeAndMethodName(): ?ConstantArrayTypeAndMethod` to `findTypeAndMethodNames(): ConstantArrayTypeAndMethod[]`.