### PR TITLE
Fixed double reporting of promoted properties.

### DIFF
--- a/src/Rules/Properties/MissingPropertyTypehintRule.php
+++ b/src/Rules/Properties/MissingPropertyTypehintRule.php
@@ -36,7 +36,13 @@ final class MissingPropertyTypehintRule implements Rule
 		}
 
 		$propertyReflection = $scope->getClassReflection()->getNativeProperty($node->getName());
+
+		if ($propertyReflection->isPromoted()) {
+			return [];
+		}
+
 		$propertyType = $propertyReflection->getReadableType();
+
 		if ($propertyType instanceof MixedType && !$propertyType->isExplicitMixed()) {
 			return [
 				RuleErrorBuilder::message(sprintf(

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -122,4 +122,15 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/filter-iterator-child-class.php'], []);
 	}
 
+	public function testBug7662(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7662.php'], [
+			[
+				'Method Bug7662\Foo::__construct() has parameter $bar with no value type specified in iterable type array.',
+				6,
+				MissingTypehintCheck::MISSING_ITERABLE_VALUE_TYPE_TIP,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-7662.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-7662.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7662;
+
+class Foo {
+	public function __construct(public array $bar) {}
+}

--- a/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -62,17 +62,7 @@ class MissingPropertyTypehintRuleTest extends RuleTestCase
 
 	public function testPromotedProperties(): void
 	{
-		$this->analyse([__DIR__ . '/data/promoted-properties-missing-typehint.php'], [
-			[
-				'Property PromotedPropertiesMissingTypehint\Foo::$lorem has no type specified.',
-				15,
-			],
-			[
-				'Property PromotedPropertiesMissingTypehint\Foo::$ipsum type has no value type specified in iterable type array.',
-				16,
-				MissingTypehintCheck::MISSING_ITERABLE_VALUE_TYPE_TIP,
-			],
-		]);
+		$this->analyse([__DIR__ . '/data/promoted-properties-missing-typehint.php'], []);
 	}
 
 }


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/7662

this could be a bit heavy handed, but my rationale is that the `MissingPropertyTypehintRule` will not surface anything that the `MissingMethodParameterTypehintRule` wont when analyzing promoted property definitions.