### PR TITLE
Remove undefined constants from scope

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3434,7 +3434,12 @@ class MutatingScope implements Scope
 		if ($expr instanceof ConstFetch) {
 			$constantTypes = $this->constantTypes;
 			$constantName = new FullyQualified($expr->name->toString());
-			$constantTypes[$constantName->toCodeString()] = $type;
+
+			if ($type instanceof NeverType) {
+				unset($constantTypes[$constantName->toCodeString()]);
+			} else {
+				$constantTypes[$constantName->toCodeString()] = $type;
+			}
 
 			return $this->scopeFactory->create(
 				$this->context,

--- a/tests/PHPStan/Rules/Constants/ConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ConstantRuleTest.php
@@ -28,10 +28,11 @@ class ConstantRuleTest extends RuleTestCase
 				10,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
-			/*[
+			[
 				'Constant DEFINED_CONSTANT_IF not found.',
 				21,
-			],*/
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
 		]);
 	}
 


### PR DESCRIPTION
Constants are currently added to the scope if e.g. `defined()` is used and passed around, but never removed anymore. Which this PR changes.

The constants are added to the scope via
- a `ConstFetch` expression that is specified in https://github.com/phpstan/phpstan-src/blob/1.8.2/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php#L55
- from now on we're in `MutatingScope` where either `specifyExpressionType` or `removeTypeFromExpression` is called depending on sure or sureNotType which is effectively depending on truthy/falsey context
- `specifyExpressionType` is adding the constants to the scope in https://github.com/phpstan/phpstan-src/blob/1.8.2/src/Analyser/MutatingScope.php#L3434-L3458
- `removeTypeFromExpression` is calling `specifyExpressionType` again with the removed type (in the constant example with e.g. `!defined()` leading to a `NeverType`)
- the constant was previously simply set again, now it is properly removed

(Specified)Type-wise this doesn't change anything, but `ConstantRule` explicitly verifies if a constant is in the scope and not which type it has. And this rule is working a bit better now I think.