### PR TITLE
Fix ObjectType resolving inside bound Closure

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2316,7 +2316,7 @@ class MutatingScope implements Scope
 
 		$originalClass = $this->resolveName($name);
 		if ($this->isInClass()) {
-			if ($this->inClosureBindScopeClass !== null && $this->inClosureBindScopeClass !== 'static' && $originalClass === $this->getClassReflection()->getName()) {
+			if ($this->inClosureBindScopeClass === $originalClass && $this->inClosureBindScopeClass !== 'static') {
 				if ($this->reflectionProvider->hasClass($this->inClosureBindScopeClass)) {
 					return new ThisType($this->reflectionProvider->getClass($this->inClosureBindScopeClass));
 				}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2316,7 +2316,7 @@ class MutatingScope implements Scope
 
 		$originalClass = $this->resolveName($name);
 		if ($this->isInClass()) {
-			if ($this->inClosureBindScopeClass === $originalClass && $this->inClosureBindScopeClass !== 'static') {
+			if ($this->inClosureBindScopeClass === $originalClass) {
 				if ($this->reflectionProvider->hasClass($this->inClosureBindScopeClass)) {
 					return new ThisType($this->reflectionProvider->getClass($this->inClosureBindScopeClass));
 				}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -276,4 +276,10 @@ class ClassConstantRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/class-constant-nullsafe.php'], []);
 	}
 
+	public function testBug7675(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/bug-7675.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-7675.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-7675.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7675;
+
+use Closure;
+use Throwable;
+
+class Handler
+{
+}
+
+class SpladeCore
+{
+	const HEADER_SPLADE = 'x-splade';
+	public static function exceptionHandler(Handler $exceptionHandler): Closure
+	{
+		return Closure::bind(function (Throwable $e, $request) {
+			if (!$request->header(SpladeCore::HEADER_SPLADE)) {
+				return null;
+			}
+
+			return true;
+		}, $exceptionHandler, get_class($exceptionHandler));
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7675

This is my first time dealing with this dynamic Closure binding, but I guess this make sense. Previously it would lead incorrectly to a `ThisType` because `$originalClass === $this->getClassReflection()->getName()` evaluates to true if `$originalClass` is the one where the Closure bind is in.