### PR TITLE
`str_split` returns an empty array since PHP 8.2

### DIFF
--- a/resources/functionMap_php82delta.php
+++ b/resources/functionMap_php82delta.php
@@ -1,0 +1,29 @@
+<?php // phpcs:ignoreFile
+
+/**
+ * Copied over from https://github.com/phan/phan/blob/8866d6b98be94b37996390da226e8c4befea29aa/src/Phan/Language/Internal/FunctionSignatureMap_php80_delta.php
+ * Copyright (c) 2015 Rasmus Lerdorf
+ * Copyright (c) 2015 Andrew Morrison
+ */
+
+/**
+ * This contains the information needed to convert the function signatures for php 8.0 to php 7.4 (and vice versa)
+ *
+ * This has two sections.
+ * The 'new' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php7.4 or have different signatures in php 8.0.
+ *   If they were just updated, the function/method will be present in the 'added' signatures.
+ * The 'old' signatures contains the signatures that are different in php 7.4.
+ *   Functions are expected to be removed only in major releases of php.
+ *
+ * @see FunctionSignatureMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
+ */
+return [
+	'new' => [
+		'str_split' => ['array<int,string>', 'str'=>'string', 'split_length='=>'positive-int'],
+	],
+	'old' => [
+
+	]
+];

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -196,4 +196,9 @@ class PhpVersion
 		return $this->versionId >= 80200;
 	}
 
+	public function strSplitReturnsEmptyArray(): bool
+	{
+		return $this->versionId >= 80200;
+	}
+
 }

--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -204,6 +204,15 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 				$signatureMap = $this->computeSignatureMap($signatureMap, $php81MapDelta);
 			}
 
+			if ($this->phpVersion->getVersionId() >= 80200) {
+				$php82MapDelta = require __DIR__ . '/../../../resources/functionMap_php82delta.php';
+				if (!is_array($php82MapDelta)) {
+					throw new ShouldNotHappenException('Signature map could not be loaded.');
+				}
+
+				$signatureMap = $this->computeSignatureMap($signatureMap, $php82MapDelta);
+			}
+
 			$this->signatureMap = $signatureMap;
 		}
 

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -90,7 +90,7 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 		$stringType = $scope->getType($functionCall->getArgs()[0]->value);
 
-		return TypeTraverser::map($stringType, static function (Type $type, callable $traverse) use ($encoding, $splitLength, $scope): Type {
+		return TypeTraverser::map($stringType, function (Type $type, callable $traverse) use ($encoding, $splitLength, $scope): Type {
 			if ($type instanceof UnionType || $type instanceof IntersectionType) {
 				return $traverse($type);
 			}
@@ -98,7 +98,7 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 			if (!$type instanceof ConstantStringType) {
 				$returnType = new ArrayType(new IntegerType(), new StringType());
 
-				return $encoding === null
+				return $encoding === null && !$this->phpVersion->strSplitReturnsEmptyArray()
 					? TypeCombinator::intersect($returnType, new NonEmptyArrayType())
 					: $returnType;
 			}

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5138,6 +5138,14 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function dataFunctions(): array
 	{
+		$strSplitDefaultReturnType = 'non-empty-array<int, string>|false';
+		if (PHP_VERSION_ID >= 80000) {
+			$strSplitDefaultReturnType = 'non-empty-array<int, string>';
+		}
+		if (PHP_VERSION_ID >= 80200) {
+			$strSplitDefaultReturnType = 'array<int, string>';
+		}
+
 		return [
 			[
 				'string',
@@ -5328,11 +5336,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$gettimeofdayBenevolent',
 			],
 			[
-				match (true) {
-					PHP_VERSION_ID >= 80200 => 'array<int, string>',
-					PHP_VERSION_ID >= 80000 => 'non-empty-array<int, string>',
-					default => 'non-empty-array<int, string>|false',
-				},
+				$strSplitDefaultReturnType,
 				'$strSplitConstantStringWithoutDefinedParameters',
 			],
 			[
@@ -5356,11 +5360,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$strSplitConstantStringWithFailureSplitLength',
 			],
 			[
-				match (true) {
-					PHP_VERSION_ID >= 80200 => 'array<int, string>',
-					PHP_VERSION_ID >= 80000 => 'non-empty-array<int, string>',
-					default => 'non-empty-array<int, string>|false',
-				},
+				$strSplitDefaultReturnType,
 				'$strSplitConstantStringWithInvalidSplitLengthType',
 			],
 			[
@@ -5368,11 +5368,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$strSplitConstantStringWithVariableStringAndConstantSplitLength',
 			],
 			[
-				match (true) {
-					PHP_VERSION_ID >= 80200 => 'array<int, string>',
-					PHP_VERSION_ID >= 80000 => 'non-empty-array<int, string>',
-					default => 'non-empty-array<int, string>|false',
-				},
+				$strSplitDefaultReturnType,
 				'$strSplitConstantStringWithVariableStringAndVariableSplitLength',
 			],
 			// parse_url

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5328,7 +5328,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$gettimeofdayBenevolent',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				match (true) {
+					PHP_VERSION_ID >= 80200 => 'array<int, string>',
+					PHP_VERSION_ID >= 80000 => 'non-empty-array<int, string>',
+					default => 'non-empty-array<int, string>|false',
+				},
 				'$strSplitConstantStringWithoutDefinedParameters',
 			],
 			[
@@ -5336,7 +5340,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$strSplitConstantStringWithoutDefinedSplitLength',
 			],
 			[
-				'non-empty-array<int, string>',
+				PHP_VERSION_ID < 80200 ? 'non-empty-array<int, string>' : 'array<int, string>',
 				'$strSplitStringWithoutDefinedSplitLength',
 			],
 			[
@@ -5352,7 +5356,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$strSplitConstantStringWithFailureSplitLength',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				match (true) {
+					PHP_VERSION_ID >= 80200 => 'array<int, string>',
+					PHP_VERSION_ID >= 80000 => 'non-empty-array<int, string>',
+					default => 'non-empty-array<int, string>|false',
+				},
 				'$strSplitConstantStringWithInvalidSplitLengthType',
 			],
 			[
@@ -5360,7 +5368,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$strSplitConstantStringWithVariableStringAndConstantSplitLength',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'non-empty-array<int, string>|false' : 'non-empty-array<int, string>',
+				match (true) {
+					PHP_VERSION_ID >= 80200 => 'array<int, string>',
+					PHP_VERSION_ID >= 80000 => 'non-empty-array<int, string>',
+					default => 'non-empty-array<int, string>|false',
+				},
 				'$strSplitConstantStringWithVariableStringAndVariableSplitLength',
 			],
 			// parse_url


### PR DESCRIPTION
Refs: https://github.com/php/php-src/pull/8945

See also https://3v4l.org/XfZO4 and https://3v4l.org/XfZO4/rfc#vgit.master

I never touched the delta files, is this correct like this? One of the tests at least seems to verify it. And the comments in that file are obviously outdated, but I did not touch them because they're like that in other delta files as well.

UPDATE: sorry, was doing too many things at once and forgot to cleanly run make again.. I thought I could avoid nested ternaries with the match expression 😅