### PR TITLE
Fix `in_array` non-empty-array type specification

### DIFF
--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -71,21 +71,28 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 			|| count(TypeUtils::getEnumCaseObjects($needleType)) > 0
 		) {
 			if ($context->truthy()) {
-				$arrayType = TypeCombinator::intersect(
-					new ArrayType(new MixedType(), TypeCombinator::union($arrayValueType, $needleType)),
-					new NonEmptyArrayType(),
-				);
+				$arrayValueType = TypeCombinator::union($arrayValueType, $needleType);
 			} else {
-				$arrayType = new ArrayType(new MixedType(), TypeCombinator::remove($arrayValueType, $needleType));
+				$arrayValueType = TypeCombinator::remove($arrayValueType, $needleType);
 			}
 
-				$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
-					$node->getArgs()[1]->value,
-					$arrayType,
-					TypeSpecifierContext::createTrue(),
-					false,
-					$scope,
-				));
+			$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
+				$node->getArgs()[1]->value,
+				new ArrayType(new MixedType(), $arrayValueType),
+				TypeSpecifierContext::createTrue(),
+				false,
+				$scope,
+			));
+		}
+
+		if ($context->truthy() && $arrayType->isArray()->yes()) {
+			$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
+				$node->getArgs()[1]->value,
+				TypeCombinator::intersect($arrayType, new NonEmptyArrayType()),
+				$context,
+				false,
+				$scope,
+			));
 		}
 
 		return $specifiedTypes;

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -587,4 +587,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6443.php'], []);
 	}
 
+	public function testBug7684(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = false;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-7684.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -583,4 +583,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7684(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = false;
+		$this->analyse([__DIR__ . '/data/bug-7684.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-7684.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7684.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7684;
+
+class SomeClass
+{
+	public function someFunction(int ...$someIntArray): void
+	{
+		$arr = [];
+		foreach ($someIntArray as $val) {
+			if (in_array($val, $arr, true) === true) {
+				continue;
+			}
+
+			$arr[] = $val;
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7684

"Unsimplifies" what I oversimplified in https://github.com/phpstan/phpstan-src/pull/1510, sorry :)

I did not get it at first, but it makes sense I suppose. My simplification only added non-empty-array to the **new** array type, but not the **old** one (which might be different than what we create manually inside the extension).

Also fixed the indentation of a block which was off.. 