### PR TITLE
Use Type::isArray() in InvalidKeyInArrayDimFetchRule

### DIFF
--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -7,9 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 /**
@@ -34,7 +32,7 @@ class InvalidKeyInArrayDimFetchRule implements Rule
 		}
 
 		$varType = $scope->getType($node->var);
-		if (count(TypeUtils::getAnyArrays($varType)) === 0) {
+		if ($varType->isArray()->no()) {
 			return [];
 		}
 

--- a/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
@@ -35,6 +35,10 @@ class InvalidKeyInArrayDimFetchRuleTest extends RuleTestCase
 				'Invalid array key type DateTimeImmutable.',
 				31,
 			],
+			[
+				'Invalid array key type DateTimeImmutable.',
+				41,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
+++ b/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
@@ -35,3 +35,7 @@ $array = doFoo();
 foreach ($array as $i => $val) {
 	echo $array[$i];
 }
+
+/** @var array|null $arrayOrNull */
+$arrayOrNull = doFoo();
+$arrayOrNull[new \DateTimeImmutable()] = 1;


### PR DESCRIPTION
Small cleanup since the same information should be already existing on the type itself.