### PR TITLE
Simplify non-empty-array removal in array_push/array_unshift

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1921,7 +1921,7 @@ class NodeScopeResolver
 								return;
 							}
 
-							$arrayType = TypeCombinator::union(...TypeUtils::getArrays($arrayType));
+							$arrayType = new ArrayType($arrayType->getIterableKeyType(), $arrayType->getIterableValueType());
 						},
 					);
 				}


### PR DESCRIPTION
The previous way I did that was just an overkill and hard to read. This is already the else branch that deals with generic arrays only. Since this just recently made problems it is luckily relatively well tested.