### PR TITLE
inline calls in TrinaryLogic to reduce method call overhead

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -28,22 +28,23 @@ class TrinaryLogic
 
 	public static function createYes(): self
 	{
-		return self::create(self::YES);
+		return self::$registry[self::YES] ??= new self(self::YES);
 	}
 
 	public static function createNo(): self
 	{
-		return self::create(self::NO);
+		return self::$registry[self::NO] ??= new self(self::NO);
 	}
 
 	public static function createMaybe(): self
 	{
-		return self::create(self::MAYBE);
+		return self::$registry[self::MAYBE] ??= new self(self::MAYBE);
 	}
 
 	public static function createFromBoolean(bool $value): self
 	{
-		return self::create($value ? self::YES : self::NO);
+		$yesNo = $value ? self::YES : self::NO;
+		return self::$registry[$yesNo] ??= new self($yesNo);
 	}
 
 	private static function create(int $value): self


### PR DESCRIPTION
looking at perf profiles of the slow test https://github.com/phpstan/phpstan-src/commit/d33454d17333bc953d7399e8f6851f237a0bb37d we can see TrinaryLogic creation is a major cost.

with this PR I propose to "duplicate" a few lines of code to reduce the callstack in this very perf critical path

with blackfire I can see a 30% perf improvement before/after this PR when running
```
blackfire run php vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug5081
```

![grafik](https://user-images.githubusercontent.com/120441/181519478-603cde4c-8771-4623-a75b-adf400dc742b.png)

refs https://github.com/phpstan/phpstan/issues/7666#issuecomment-1195176312

the perf improvement is also visible when running plain
```
time vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php
```

before this PR 15-17secs; after 13-15 secs

env
```
php -v
PHP 8.1.2 (cli) (built: Jul 21 2022 12:10:37) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.2, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.2, Copyright (c), by Zend Technologies
    with blackfire v1.80.0~linux-x64-non_zts81, https://blackfire.io, by Blackfire
```