### PR TITLE
optimize `HasOffsetValueType->isSuperTypeOf()` for performance

### DIFF
--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -70,9 +70,15 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		if ($this->equals($type)) {
 			return TrinaryLogic::createYes();
 		}
-		return $type->isOffsetAccessible()
-			->and($type->hasOffsetValueType($this->offsetType))
-			->and($this->valueType->isSuperTypeOf($type->getOffsetValueType($this->offsetType)));
+
+		if (!$type->isOffsetAccessible()->yes()) {
+			return TrinaryLogic::createNo();
+		}
+		if (!$type->hasOffsetValueType($this->offsetType)->yes()) {
+			return TrinaryLogic::createNo();
+		}
+
+		return $this->valueType->isSuperTypeOf($type->getOffsetValueType($this->offsetType));
 	}
 
 	public function isSubTypeOf(Type $otherType): TrinaryLogic


### PR DESCRIPTION
the Trinary-construction via `->and()` in `HasOffsetValueType->isSuperTypeOf()` requires php to call into all methods involved to finally combine the results via `and()`. even if earlier expression resolve to `NO` other subsequent calls need to be evaluated.

I rewrote the logic to return early instead which improves performance by ~20% when running
```
blackfire run php vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug5081
```

before profile

![grafik](https://user-images.githubusercontent.com/120441/181525051-7e9f2ece-4eb1-425e-86c9-c4c28fd380bd.png)

before/after comparison

![grafik](https://user-images.githubusercontent.com/120441/181531367-272d9d75-02e2-4f9a-9342-8de6801a3e6e.png)


refs https://github.com/phpstan/phpstan/issues/7666#issuecomment-1195176312