### PR TITLE
introduced IterativeTrinary

### DIFF
--- a/src/IterativeTrinary.php
+++ b/src/IterativeTrinary.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan;
+
+use Iterator;
+
+final class IterativeTrinary
+{
+
+	/**
+	 * @param Iterator<TrinaryLogic> $it
+	 */
+	public static function and(Iterator $it): TrinaryLogic
+	{
+		$trinaries = [];
+		foreach ($it as $trinary) {
+			if (!$trinary->yes()) {
+				return $trinary;
+			}
+			$trinaries[] = $trinary;
+		}
+
+		return TrinaryLogic::createYes()->and(...$trinaries);
+	}
+
+	/**
+	 * @param Iterator<TrinaryLogic> $it
+	 */
+	public static function or(Iterator $it): TrinaryLogic
+	{
+		$trinaries = [];
+
+		foreach ($it as $trinary) {
+			if ($trinary->yes()) {
+				return $trinary;
+			}
+			$trinaries[] = $trinary;
+		}
+
+		return TrinaryLogic::createNo()->or(...$trinaries);
+	}
+
+}


### PR DESCRIPTION
`IterativeTrinary` allows to evaluate `TrinaryLogic::and()`, `TrinaryLogic::or()` expressions in a way that early returns are supported.

before this PR `TrinaryLogic->and()`,  `TrinaryLogic->or()` operands were evaluated eagerly, which resulted in unnecessary work within the type system.

the patch implements a similar approach to https://github.com/phpstan/phpstan-src/pull/1565 but in a more generic form and meant for easy re-use within the phpstan codebase, which improves performance by ~23% running our reference slow test:
```
blackfire run php vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug5081
```

before profile

![grafik](https://user-images.githubusercontent.com/120441/181525051-7e9f2ece-4eb1-425e-86c9-c4c28fd380bd.png)

before/after comparison

![grafik](https://user-images.githubusercontent.com/120441/181587682-217f1842-a63b-4a0f-8155-16c7632b373b.png)

refs https://github.com/phpstan/phpstan/issues/7666#issuecomment-1195176312

I think there are a few more spots where we could utilize `IterativeTrinary` within the existing Type-classes, but I changed only those relevant for the performance of the mentioned slow-test.
