### PR TITLE
Fix Node::getType() returning an incorrect value for some nodes

### DIFF
--- a/src/Node/ClassConstantsNode.php
+++ b/src/Node/ClassConstantsNode.php
@@ -43,7 +43,7 @@ class ClassConstantsNode extends NodeAbstract implements VirtualNode
 
 	public function getType(): string
 	{
-		return 'PHPStan_Node_ClassPropertiesNode';
+		return 'PHPStan_Node_ClassConstantsNode';
 	}
 
 	/**

--- a/src/Node/MethodReturnStatementsNode.php
+++ b/src/Node/MethodReturnStatementsNode.php
@@ -60,7 +60,7 @@ class MethodReturnStatementsNode extends NodeAbstract implements ReturnStatement
 
 	public function getType(): string
 	{
-		return 'PHPStan_Node_FunctionReturnStatementsNode';
+		return 'PHPStan_Node_MethodReturnStatementsNode';
 	}
 
 	/**


### PR DESCRIPTION
`ClassConstantsNode::getType()` and `ClassPropertiesNode::getType()` return the same value: `PHPStan_Node_ClassPropertiesNode`. 
`FunctionReturnStatementsNode::getType()` and `MethodReturnStatementsNode::getType()` return the same value: `PHPStan_Node_FunctionReturnStatementsNode`.
Based on other Node class's getType() retval, the value seems to be unique for each node class and is derived from the class's FQN. Moreover, the two pairs of nodes are isolated (independent) from one another.