### PR TITLE
Added stub files and tests for array_* functions.

### DIFF
--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -61,3 +61,144 @@ function array_udiff(
     array $two,
     callable $three
 ): int {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_diff_uassoc(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_diff_ukey(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_intersect_uassoc(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ *
+ * @return array<TK, TV>
+ */
+function array_intersect_ukey(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ *
+ * @return array<TK, TV>
+ */
+function array_udiff_assoc(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TK, TK): int<-1, 1> $four
+ * @return array<TK, TV>
+ */
+function array_udiff_uassoc(
+    array $one,
+    array $two,
+    callable $three,
+    callable $four
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_uintersect_assoc(
+    array $one,
+    array $two,
+    callable $three,
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TK, TK): int<-1, 1> $four
+ * @return array<TK, TV>
+ */
+function array_uintersect_uassoc(
+    array $one,
+    array $two,
+    callable $three,
+    callable $four
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_uintersect(
+    array $one,
+    array $two,
+    callable $three,
+): array {}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1157,4 +1157,155 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7156.php'], []);
 	}
 
+	public function testArrayDiffUassoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_diff_uassoc.php'], [
+			[
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayDiffUkey(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_diff_ukey.php'], [
+			[
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayIntersectUassoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_intersect_uassoc.php'], [
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayIntersectUkey(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_intersect_ukey.php'], [
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayUdiffAssoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_udiff_assoc.php'], [
+			[
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayUdiffUsssoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_udiff_uassoc.php'], [
+			[
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				28,
+			],
+			[
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				31,
+			],
+			[
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				39,
+			],
+			[
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				42,
+			],
+		]);
+	}
+
+	public function testArrayUintersectAssoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_uintersect_assoc.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayUintersectUassoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_uintersect_uassoc.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				28,
+			],
+			[
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				31,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				39,
+			],
+			[
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				42,
+			],
+		]);
+	}
+
+	public function testArrayUintersect(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_uintersect.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/array_diff_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_diff_uassoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_diff_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_diff_ukey.php
+++ b/tests/PHPStan/Rules/Functions/data/array_diff_ukey.php
@@ -1,0 +1,33 @@
+<?php
+
+array_diff_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_intersect_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_intersect_uassoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_intersect_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_intersect_ukey.php
+++ b/tests/PHPStan/Rules/Functions/data/array_intersect_ukey.php
@@ -1,0 +1,33 @@
+<?php
+
+array_intersect_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_udiff_assoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff_assoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_udiff_assoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_assoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_assoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_assoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_udiff_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff_uassoc.php
@@ -1,0 +1,45 @@
+<?php
+
+array_udiff_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+);
+
+array_udiff_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect.php
@@ -1,0 +1,33 @@
+<?php
+
+array_uintersect(
+	['a', 'b'],
+	['c', 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect(
+	['a', 'b'],
+	['c', 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect_assoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect_assoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_uintersect_assoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_assoc(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_assoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_assoc(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect_uassoc.php
@@ -1,0 +1,45 @@
+<?php
+
+array_uintersect_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+);
+
+array_uintersect_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/7707

functions stubbed:

array_diff_uassoc
array_diff_ukey
array_intersect_uassoc
array_intersect_ukey
array_udiff_assoc
array_udiff_uassoc
array_uintersect_assoc
array_uintersect_uassoc
array_uintersect

whilst adding these, phpstan warned because i didn't add array iterable types for the returns so i've specified them in the stubs, however i noticed [this return type extension plugin](https://github.com/phpstan/phpstan-src/blob/1.8.x/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php#L16) which seems to be overriding them anyway, if theres something i should do instead let me know 