### PR TITLE
Added check for deprecated bitwise operation with float in php8.1.

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -201,4 +201,9 @@ class PhpVersion
 		return $this->versionId >= 80200;
 	}
 
+	public function deprecatesBitwiseOperationsWithFloat(): bool
+	{
+		return $this->versionId >= 80100;
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Operators;
 
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\Printer\Printer;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -15,11 +16,14 @@ use const PHP_VERSION_ID;
 class InvalidBinaryOperationRuleTest extends RuleTestCase
 {
 
+	private int $phpVersion = PHP_VERSION_ID;
+
 	protected function getRule(): Rule
 	{
 		return new InvalidBinaryOperationRule(
 			new ExprPrinter(new Printer()),
 			new RuleLevelHelper($this->createReflectionProvider(), true, false, true, false),
+			new PhpVersion($this->phpVersion),
 		);
 	}
 
@@ -267,6 +271,55 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 				12,
 			],
 		]);
+	}
+
+	public function testBug7700PHP81(): void
+	{
+		$this->phpVersion = 80100;
+		$this->analyse([__DIR__ . '/data/bug-7700.php'], [
+			[
+				'Binary >> operation between float and int is deprecated in PHP 8.1.',
+				8,
+			],
+			[
+				'Binary << operation between int and float is deprecated in PHP 8.1.',
+				9,
+			],
+			[
+				'Binary & operation between float and int is deprecated in PHP 8.1.',
+				11,
+			],
+			[
+				'Binary & operation between int and float is deprecated in PHP 8.1.',
+				12,
+			],
+			[
+				'Binary | operation between float and int is deprecated in PHP 8.1.',
+				14,
+			],
+			[
+				'Binary | operation between int and float is deprecated in PHP 8.1.',
+				15,
+			],
+			[
+				'Binary ^ operation between float and int is deprecated in PHP 8.1.',
+				17,
+			],
+			[
+				'Binary ^ operation between int and float is deprecated in PHP 8.1.',
+				18,
+			],
+			[
+				'Binary >> operation between float|int and int is deprecated in PHP 8.1.',
+				20,
+			],
+		]);
+	}
+
+	public function testBug7700PHP80(): void
+	{
+		$this->phpVersion = 80000;
+		$this->analyse([__DIR__ . '/data/bug-7700.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Operators/data/bug-7700.php
+++ b/tests/PHPStan/Rules/Operators/data/bug-7700.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+class HelloWorld
+{
+	/** @param int|float $val */
+	public function sayHello($val): void
+	{
+		1.0 >> 22;
+		22 << 1.0;
+
+		1.0 & 22;
+		22 & 1.0;
+
+		1.0 | 22;
+		22 | 1.0;
+
+		1.0 ^ 22;
+		22 ^ 1.0;
+
+		$val >> 1;
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/7700