### PR TITLE
Fix Array_ expr type resolving with unpacked array items

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -455,7 +455,7 @@ class InitializerExprTypeResolver
 				} else {
 					$arrayBuilder->degradeToGeneralArray();
 
-					$offsetType = !(new StringType())->isSuperTypeOf($valueType->getIterableKeyType())->no() && $this->phpVersion->supportsArrayUnpackingWithStringKeys()
+					$offsetType = $this->phpVersion->supportsArrayUnpackingWithStringKeys() && !(new StringType())->isSuperTypeOf($valueType->getIterableKeyType())->no()
 						? $valueType->getIterableKeyType()
 						: new IntegerType();
 					$arrayBuilder->setOffsetValueType($offsetType, $valueType->getIterableValueType(), !$valueType->isIterableAtLeastOnce()->yes());

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -454,11 +454,12 @@ class InitializerExprTypeResolver
 					}
 				} else {
 					$arrayBuilder->degradeToGeneralArray();
+					$optional = !$valueType->isIterableAtLeastOnce()->yes() && !$valueType->getIterableValueType()->isIterableAtLeastOnce()->yes();
 
 					if (! (new StringType())->isSuperTypeOf($valueType->getIterableKeyType())->no() && $this->phpVersion->supportsArrayUnpackingWithStringKeys()) {
-						$arrayBuilder->setOffsetValueType($valueType->getIterableKeyType(), $valueType->getIterableValueType());
+						$arrayBuilder->setOffsetValueType($valueType->getIterableKeyType(), $valueType->getIterableValueType(), $optional);
 					} else {
-						$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType(), !$valueType->isIterableAtLeastOnce()->yes() && !$valueType->getIterableValueType()->isIterableAtLeastOnce()->yes());
+						$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType(), $optional);
 					}
 				}
 			} else {

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -454,13 +454,11 @@ class InitializerExprTypeResolver
 					}
 				} else {
 					$arrayBuilder->degradeToGeneralArray();
-					$optional = !$valueType->isIterableAtLeastOnce()->yes() && !$valueType->getIterableValueType()->isIterableAtLeastOnce()->yes();
 
-					if (! (new StringType())->isSuperTypeOf($valueType->getIterableKeyType())->no() && $this->phpVersion->supportsArrayUnpackingWithStringKeys()) {
-						$arrayBuilder->setOffsetValueType($valueType->getIterableKeyType(), $valueType->getIterableValueType(), $optional);
-					} else {
-						$arrayBuilder->setOffsetValueType(new IntegerType(), $valueType->getIterableValueType(), $optional);
-					}
+					$offsetType = !(new StringType())->isSuperTypeOf($valueType->getIterableKeyType())->no() && $this->phpVersion->supportsArrayUnpackingWithStringKeys()
+						? $valueType->getIterableKeyType()
+						: new IntegerType();
+					$arrayBuilder->setOffsetValueType($offsetType, $valueType->getIterableValueType(), !$valueType->isIterableAtLeastOnce()->yes());
 				}
 			} else {
 				$arrayBuilder->setOffsetValueType(

--- a/tests/PHPStan/Analyser/data/array-unpacking-string-keys.php
+++ b/tests/PHPStan/Analyser/data/array-unpacking-string-keys.php
@@ -20,7 +20,7 @@ function foo(array $a, array $b)
 {
 	$c = [...$a, ...$b];
 
-	assertType('non-empty-array<int|string, int>', $c);
+	assertType('array<int|string, int>', $c);
 }
 
 /**
@@ -31,7 +31,7 @@ function bar(array $a, array $b)
 {
 	$c = [...$a, ...$b];
 
-	assertType('non-empty-array<int>', $c);
+	assertType('array<int>', $c);
 }
 
 /**
@@ -42,5 +42,27 @@ function baz(array $a, array $b)
 {
 	$c = [...$a, ...$b];
 
-	assertType('non-empty-array<string, int>', $c);
+	assertType('array<string, int>', $c);
+}
+
+/**
+ * @param non-empty-array<string, int> $a
+ * @param array<int, int> $b
+ */
+function nonEmptyArray1(array $a, array $b)
+{
+	$c = [...$a, ...$b];
+
+	assertType('non-empty-array<int|string, int>', $c);
+}
+
+/**
+ * @param array<string, int> $a
+ * @param non-empty-array<int, int> $b
+ */
+function nonEmptyArray2(array $a, array $b)
+{
+	$c = [...$a, ...$b];
+
+	assertType('non-empty-array<int|string, int>', $c);
 }

--- a/tests/PHPStan/Analyser/data/bug-5287-php81.php
+++ b/tests/PHPStan/Analyser/data/bug-5287-php81.php
@@ -19,7 +19,7 @@ function foo(array $arr): void
 function foo2(array $arr): void
 {
 	$arrSpread = [...$arr];
-	assertType('non-empty-array<int, non-empty-array>', $arrSpread);
+	assertType('array<int, non-empty-array>', $arrSpread);
 }
 
 /**

--- a/tests/PHPStan/Analyser/data/bug-5287.php
+++ b/tests/PHPStan/Analyser/data/bug-5287.php
@@ -19,7 +19,7 @@ function foo(array $arr): void
 function foo2(array $arr): void
 {
 	$arrSpread = [...$arr];
-	assertType('non-empty-array<int, non-empty-array>', $arrSpread);
+	assertType('array<int, non-empty-array>', $arrSpread);
 }
 
 /**

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -177,4 +177,12 @@ class EmptyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7424.php'], []);
 	}
 
+	public function testBug7724(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = false;
+
+		$this->analyse([__DIR__ . '/data/bug-7724.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-7724.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-7724.php
@@ -1,0 +1,22 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug7724;
+
+$array = [];
+
+/**
+ * @return int[]
+ */
+function getElements(): array {
+	$empty = rand(0, 1);
+
+	return $empty ? [] : [1];
+}
+
+$array = [...$array, ...getElements()];
+
+if (false === empty($array)) {
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7724

The problem was the missing `$optional` arg for the  ConstantArrayTypeBuilder::setOffsetValueType for the first conditional handling string keys. Unpacked array item values are always optional in that context as long as the array is not iterable at least once.

UPDATE: One more thing was looking weird to me which I fixed in the second commit. I removed the check of `$valueType->getIterableValueType()->isIterableAtLeastOnce()` which goes too far if I'm not mistaken. As the iterableValueType does not influence the outer array non-emptyness basically. See the affected test files for bug-5287