### PR TITLE
ClassReflection::is to behave like is_a

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -653,7 +653,7 @@ class ClassReflection
 
 	public function is(string $className): bool
 	{
-		return $this->getName() === $className || $this->isSubclassOf($className);
+		return $this->getName() === $className || $this->isSubclassOf($className) || $this->implementsInterface($className);
 	}
 
 	public function isSubclassOf(string $className): bool

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -7,6 +7,7 @@ use Attributes\IsAttribute;
 use Attributes\IsAttribute2;
 use Attributes\IsAttribute3;
 use Attributes\IsNotAttribute;
+use Countable;
 use GenericInheritance\C;
 use HasTraitUse\Bar;
 use HasTraitUse\Baz;
@@ -319,6 +320,7 @@ class ClassReflectionTest extends PHPStanTestCase
 		$this->assertTrue($classReflection->is($className));
 		$this->assertTrue($classReflection->is(PHPStanTestCase::class));
 		$this->assertTrue($classReflection->is(TestCase::class));
+		$this->assertTrue($classReflection->is(Countable::class));
 		$this->assertFalse($classReflection->is(RuleTestCase::class));
 	}
 


### PR DESCRIPTION
Sorry, I missed that, it is [not documented](https://www.php.net/manual/en/function.is-a.php), but it [behaves that way](https://3v4l.org/HmGbd).