### PR TITLE
use faster regular array instead of HasOffsetValueType

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -626,6 +626,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug5081(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5081.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug1388(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1388.php');


### PR DESCRIPTION
to prevent big intersections which can get slow

running `time php bin/phpstan analyze --xdebug --debug test.php` with the content from `bug-5081.php` runs in 7 seconds with this PR.

refs https://github.com/phpstan/phpstan/issues/7666#issuecomment-1200290771