### PR TITLE
Set return type for ReflectionParameter::getType to ReflectionNamedType

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -9815,7 +9815,7 @@ return [
 'ReflectionParameter::getDefaultValueConstantName' => ['?string'],
 'ReflectionParameter::getName' => ['string'],
 'ReflectionParameter::getPosition' => ['int'],
-'ReflectionParameter::getType' => ['ReflectionType|null'],
+'ReflectionParameter::getType' => ['ReflectionNamedType|null'],
 'ReflectionParameter::hasType' => ['bool'],
 'ReflectionParameter::isArray' => ['bool'],
 'ReflectionParameter::isCallable' => ['bool'],


### PR DESCRIPTION
Since PHP 7.1, this function will return `ReflectionNamedType|null` instead.

See: https://www.php.net/manual/en/reflectionparameter.gettype.php#refsect1-reflectionparameter.gettype-examples