### PR TITLE
added truthy-string as an alias for non-falsy-string

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -243,6 +243,7 @@ class TypeNodeResolver
 					new AccessoryNonEmptyStringType(),
 				]);
 
+			case 'truthy-string':
 			case 'non-falsy-string':
 				return new IntersectionType([
 					new StringType(),

--- a/tests/PHPStan/Analyser/data/non-falsy-string.php
+++ b/tests/PHPStan/Analyser/data/non-falsy-string.php
@@ -7,9 +7,12 @@ use function PHPStan\Testing\assertType;
 class Foo {
 	/**
 	 * @param non-falsy-string $nonFalseyString
+	 * @param truthy-string $truthyString
 	 */
-	public function bar($nonFalseyString) {
+	public function bar($nonFalseyString, $truthyString) {
 		assertType('int<min, -1>|int<1, max>', (int) $nonFalseyString);
+		// truthy-string is an alias for non-falsy-string
+		assertType('non-falsy-string', $truthyString);
 	}
 
 	function removeZero(string $s) {


### PR DESCRIPTION
on [twitter there was a discussion going](https://twitter.com/seldaek/status/1552583227893743616) on whether this type should better be named `truthy-string` instead (and keep `'non-falsy-string'` as a deprecated alias).

psalm maintainer agreed on the name: https://twitter.com/orklah/status/1552706224541638660