### PR TITLE
Fix issue #7755 about lost @phpstan-type 

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -1264,10 +1264,6 @@ class ClassReflection
 
 	public function getResolvedPhpDoc(): ?ResolvedPhpDocBlock
 	{
-		if ($this->stubPhpDocBlock !== null) {
-			return $this->stubPhpDocBlock;
-		}
-
 		$fileName = $this->getFileName();
 		if (is_bool($this->reflectionDocComment)) {
 			$docComment = $this->reflection->getDocComment();
@@ -1275,10 +1271,22 @@ class ClassReflection
 		}
 
 		if ($this->reflectionDocComment === null) {
-			return null;
+			return $this->stubPhpDocBlock;
 		}
 
-		return $this->fileTypeMapper->getResolvedPhpDoc($fileName, $this->getName(), null, null, $this->reflectionDocComment);
+		$fileResolvedPhpdoc = $this->fileTypeMapper->getResolvedPhpDoc(
+			$fileName,
+			$this->getName(),
+			null,
+			null,
+			$this->reflectionDocComment,
+		);
+
+		if ($this->stubPhpDocBlock === null) {
+			return $fileResolvedPhpdoc;
+		}
+
+		return $this->stubPhpDocBlock->fillWith($fileResolvedPhpdoc);
 	}
 
 	private function getFirstExtendsTag(): ?ExtendsTag

--- a/tests/PHPStan/Analyser/PhpstanTypeStubFileTest.php
+++ b/tests/PHPStan/Analyser/PhpstanTypeStubFileTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class PhpstanTypeStubFileTest extends TypeInferenceTestCase
+{
+
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/phpstan-type-stub-files.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/phpstanTypeStubFiles.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/phpstan-type-stub-files.php
+++ b/tests/PHPStan/Analyser/data/phpstan-type-stub-files.php
@@ -5,10 +5,22 @@ namespace PhpstanTypeStubFiles;
 use function PHPStan\Testing\assertType;
 
 /**
+ * @phpstan-template T of object
+ */
+class Bar
+{
+	/** @var T|null */
+	public $object;
+}
+
+/**
  * @phpstan-type AnotherType = array{foo: int}
  * @phpstan-type CustomType = array{foo: string}
+ *
+ * @phpstan-template T of object
+ * @phpstan-extends Bar<object>
  */
-class Foo
+class Foo extends Bar
 {
 	/** @var CustomType */
 	public $array;
@@ -16,11 +28,18 @@ class Foo
 	/** @var string */
 	public $string;
 
+	/** @var object */
+	public $template;
+
 	/** @param int $test1 */
 	public function test($test1, $test2): void {
+		/** @var Foo<\DateTime> $foo */
 		$foo = new Foo();
+
 		assertType('array{foo: string}', $foo->array);
 		assertType('string', $foo->string);
+		assertType('DateTime|null', $foo->object);
+		assertType('DateTime', $foo->template);
 		assertType('int', $test1);
 		assertType('array<string>', $test2);
 	}

--- a/tests/PHPStan/Analyser/data/phpstan-type-stub-files.php
+++ b/tests/PHPStan/Analyser/data/phpstan-type-stub-files.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpstanTypeStubFiles;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @phpstan-type AnotherType = array{foo: int}
+ * @phpstan-type CustomType = array{foo: string}
+ */
+class Foo
+{
+	/** @var CustomType */
+	public $array;
+
+	public function test(): void {
+		$foo = new Foo();
+		assertType('array{foo: string}', $foo->array);
+	}
+}

--- a/tests/PHPStan/Analyser/data/phpstan-type-stub-files.php
+++ b/tests/PHPStan/Analyser/data/phpstan-type-stub-files.php
@@ -13,8 +13,15 @@ class Foo
 	/** @var CustomType */
 	public $array;
 
-	public function test(): void {
+	/** @var string */
+	public $string;
+
+	/** @param int $test1 */
+	public function test($test1, $test2): void {
 		$foo = new Foo();
 		assertType('array{foo: string}', $foo->array);
+		assertType('string', $foo->string);
+		assertType('int', $test1);
+		assertType('array<string>', $test2);
 	}
 }

--- a/tests/PHPStan/Analyser/phpstanTypeStub.stub
+++ b/tests/PHPStan/Analyser/phpstanTypeStub.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpstanTypeStubFiles;
+
+/**
+ * @phpstan-type AnotherType = array{foo: int}
+ */
+class Foo
+{
+}

--- a/tests/PHPStan/Analyser/phpstanTypeStub.stub
+++ b/tests/PHPStan/Analyser/phpstanTypeStub.stub
@@ -3,7 +3,13 @@
 namespace PhpstanTypeStubFiles;
 
 /**
+ * This shouldn't change anything.
  */
 class Foo
 {
+	/** This shouldn't change anything. */
+	public $string;
+
+	/** @param array<string> $test2 */
+	public function test($test1, $test2): void;
 }

--- a/tests/PHPStan/Analyser/phpstanTypeStub.stub
+++ b/tests/PHPStan/Analyser/phpstanTypeStub.stub
@@ -3,7 +3,6 @@
 namespace PhpstanTypeStubFiles;
 
 /**
- * @phpstan-type AnotherType = array{foo: int}
  */
 class Foo
 {

--- a/tests/PHPStan/Analyser/phpstanTypeStub.stub
+++ b/tests/PHPStan/Analyser/phpstanTypeStub.stub
@@ -3,12 +3,16 @@
 namespace PhpstanTypeStubFiles;
 
 /**
- * This shouldn't change anything.
+ * @phpstan-template T of object
+ * @phpstan-extends Bar<\DateTime>
  */
-class Foo
+class Foo extends Bar
 {
 	/** This shouldn't change anything. */
 	public $string;
+
+	/** @var T */
+	public $template;
 
 	/** @param array<string> $test2 */
 	public function test($test1, $test2): void;

--- a/tests/PHPStan/Analyser/phpstanTypeStubFiles.neon
+++ b/tests/PHPStan/Analyser/phpstanTypeStubFiles.neon
@@ -1,0 +1,3 @@
+parameters:
+	stubFiles:
+		- phpstanTypeStub.stub


### PR DESCRIPTION
Reproducer for https://github.com/phpstan/phpstan/issues/7755 with a proposal of fix.

Prior to this PR, only the stub was used if found.
Now I try to merge both the `ResolvedPhpDocBlock` from the stub and the `ResolvedPhpDocBlock` from the file.

For tag like `@param`, `@return`, `@throws`, `@var`, I follow the same strategy than the `merge` method. So I tried to use the stub definition and if not found, I use the original file (like it was a parent).

For tag like `@type`, `@import-type`,  `@extends`, `@implements`, `@method`, `@property` (and mixin but dunno what it is), I merge the tags. For duplicates, the priority is for the stub.

For tag like `@final`, `@internal`, I considered this as defined as long as one of the two files (stub or original) has it. IMHO, if the original file is defining his class as final, we shouldn't be able to override this in the stub (same idea for others).