### PR TITLE
Remove jean85/pretty-package-versions dependency

### DIFF
--- a/bin/phpstan
+++ b/bin/phpstan
@@ -152,16 +152,9 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 	$devOrPharLoader->register(true);
 
-	$version = 'Version unknown';
-	try {
-		$version = \Jean85\PrettyVersions::getVersion('phpstan/phpstan')->getPrettyVersion() ?: $version;
-	} catch (\OutOfBoundsException $e) {
-
-	}
-
 	$application = new \Symfony\Component\Console\Application(
 		'PHPStan - PHP Static Analysis Tool',
-		$version
+		ComposerHelper::getPhpStanVersion()
 	);
 	$application->setDefaultCommand('analyse');
 	ProgressBar::setFormatDefinition('file_download', ' [%bar%] %percent:3s%% %fileSize%');

--- a/compiler/build/scoper.inc.php
+++ b/compiler/build/scoper.inc.php
@@ -183,6 +183,13 @@ return [
 			return str_replace(sprintf('%s\\Composer\\Autoload\\ClassLoader', $prefix), 'Composer\\Autoload\\ClassLoader', $content);
 		},
 		function (string $filePath, string $prefix, string $content): string {
+			if ($filePath !== 'src/Internal/ComposerHelper.php') {
+				return $content;
+			}
+
+			return str_replace(sprintf('%s\\Composer\\InstalledVersions', $prefix), 'Composer\\InstalledVersions', $content);
+		},
+		function (string $filePath, string $prefix, string $content): string {
 			if ($filePath !== 'vendor/jetbrains/phpstorm-stubs/PhpStormStubsMap.php') {
 				return $content;
 			}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
 	],
 	"require": {
 		"php": "^8.0",
+		"composer-runtime-api": "^2.0",
 		"clue/block-react": "^1.4",
 		"clue/ndjson-react": "^1.0",
 		"composer/ca-bundle": "^1.2",
@@ -13,7 +14,6 @@
 		"hoa/compiler": "3.17.08.08",
 		"hoa/exception": "^1.0",
 		"hoa/regex": "1.17.01.13",
-		"jean85/pretty-package-versions": "^1.0.3",
 		"jetbrains/phpstorm-stubs": "dev-master#01006d9854679672fc8b85c6d5063ea6f25226ac",
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.0.11",
@@ -68,7 +68,6 @@
 		"platform-check": false,
 		"sort-packages": true,
 		"allow-plugins": {
-			"composer/package-versions-deprecated": true,
 			"vaimo/composer-patches": true
 		}
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "633a6fb459cf3d86a13825cb4ca97e20",
+    "content-hash": "719febe86baf354cbcf0298bef3c50e3",
     "packages": [
         {
             "name": "clue/block-react",
@@ -7293,7 +7293,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": "^8.0",
+        "composer-runtime-api": "^2.0"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -2,10 +2,8 @@
 
 namespace PHPStan\Analyser\ResultCache;
 
-use Jean85\PrettyVersions;
 use Nette\DI\Definitions\Statement;
 use Nette\Neon\Neon;
-use OutOfBoundsException;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Collectors\CollectedData;
@@ -731,7 +729,7 @@ php;
 
 		return [
 			'cacheVersion' => self::CACHE_VERSION,
-			'phpstanVersion' => $this->getPhpStanVersion(),
+			'phpstanVersion' => ComposerHelper::getPhpStanVersion(),
 			'phpVersion' => PHP_VERSION_ID,
 			'projectConfig' => $projectConfigArray,
 			'analysedPaths' => $this->analysedPaths,
@@ -803,15 +801,6 @@ php;
 		ksort($hashes);
 
 		return $hashes;
-	}
-
-	private function getPhpStanVersion(): string
-	{
-		try {
-			return PrettyVersions::getVersion('phpstan/phpstan')->getPrettyVersion();
-		} catch (OutOfBoundsException) {
-			return 'Version unknown';
-		}
 	}
 
 	/**

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -8,9 +8,7 @@ use Composer\CaBundle\CaBundle;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
-use Jean85\PrettyVersions;
 use Nette\Utils\Json;
-use OutOfBoundsException;
 use Phar;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
@@ -22,6 +20,7 @@ use PHPStan\File\FileMonitor;
 use PHPStan\File\FileMonitorResult;
 use PHPStan\File\FileReader;
 use PHPStan\File\FileWriter;
+use PHPStan\Internal\ComposerHelper;
 use PHPStan\Parallel\Scheduler;
 use PHPStan\Process\CpuCoreCounter;
 use PHPStan\Process\ProcessCanceledException;
@@ -146,7 +145,7 @@ class FixerApplication
 				'analysedPaths' => $this->analysedPaths,
 				'projectConfigFile' => $projectConfigFile,
 				'filesCount' => $filesCount,
-				'phpstanVersion' => $this->getPhpstanVersion(),
+				'phpstanVersion' => ComposerHelper::getPhpStanVersion(),
 			]]);
 			$decoder->on('data', function (array $data) use (
 				$loop,
@@ -555,15 +554,6 @@ class FixerApplication
 		$this->processInProgress = $process->run();
 
 		return $this->processInProgress->then(static fn (string $output): array => Json::decode($output, Json::FORCE_ARRAY));
-	}
-
-	private function getPhpstanVersion(): string
-	{
-		try {
-			return PrettyVersions::getVersion('phpstan/phpstan')->getPrettyVersion();
-		} catch (OutOfBoundsException) {
-			return 'Version unknown';
-		}
 	}
 
 	private function isDockerRunning(): bool

--- a/src/Internal/ComposerHelper.php
+++ b/src/Internal/ComposerHelper.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Internal;
 
+use Composer\InstalledVersions;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
 use PHPStan\File\CouldNotReadFileException;
@@ -10,6 +11,8 @@ use function basename;
 use function getenv;
 use function is_file;
 use function is_string;
+use function preg_match;
+use function substr;
 use function trim;
 
 final class ComposerHelper
@@ -50,6 +53,18 @@ final class ComposerHelper
 		$vendorDirectory = $composerConfig['config']['vendor-dir'] ?? 'vendor';
 
 		return $root . '/' . trim($vendorDirectory, '/');
+	}
+
+	public static function getPhpStanVersion(): string
+	{
+		$rootPackage = InstalledVersions::getRootPackage();
+
+		if (preg_match('/[^v\d.]/', $rootPackage['pretty_version']) === 0) {
+			// Handles tagged versions, see https://github.com/Jean85/pretty-package-versions/blob/2.0.5/src/Version.php#L31
+			return $rootPackage['pretty_version'];
+		}
+
+		return $rootPackage['pretty_version'] . '@' . substr((string) $rootPackage['reference'], 0, 7);
 	}
 
 }


### PR DESCRIPTION
in favor of direct usage of `composer/package-versions-deprecated` it was using internally already. See also https://github.com/Jean85/pretty-package-versions/blob/1.6.0/src/PrettyVersions.php#L13 and https://github.com/Jean85/pretty-package-versions/blob/1.6.0/src/Version.php#L25

the even nicer alternative would be to bump the composer API to v2 and use it's features as mentioned by @staabm https://github.com/phpstan/phpstan/issues/7768#issuecomment-1210431060

this is the precondition to update paratest without having to care about `jean85/pretty-package-versions` which is not compatible with PHP 7 in version 2.

I could somewhat test this by running e.g. `bin/phpstan --version` and `bin/phpstan analyse --fix` and partly dumping the version and modifying the package it looks for (because for local phpstan it will always be an empty string as it was before as well).