### PR TITLE
Fix Array_ expr type resolving with unpacked constant array items

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -452,9 +452,9 @@ class InitializerExprTypeResolver
 
 					foreach ($valueType->getValueTypes() as $i => $innerValueType) {
 						if ($hasStringKey && $this->phpVersion->supportsArrayUnpackingWithStringKeys()) {
-							$arrayBuilder->setOffsetValueType($valueType->getKeyTypes()[$i], $innerValueType);
+							$arrayBuilder->setOffsetValueType($valueType->getKeyTypes()[$i], $innerValueType, $valueType->isOptionalKey($i));
 						} else {
-							$arrayBuilder->setOffsetValueType(null, $innerValueType);
+							$arrayBuilder->setOffsetValueType(null, $innerValueType, $valueType->isOptionalKey($i));
 						}
 					}
 				} else {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -879,6 +879,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_VERSION_ID >= 80100) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7167.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6864.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7776.php');
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7068.php');
@@ -970,7 +971,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7469.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-3391.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6901.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7776.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -970,6 +970,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7469.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-3391.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6901.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7776.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7776.php
+++ b/tests/PHPStan/Analyser/data/bug-7776.php
@@ -13,3 +13,13 @@ function test(array $settings = []): bool {
 	assertType('array{page?: int, search?: string}', $settings);
 	return isset($copy['search']);
 }
+
+/**
+ * @param array{page?: int, search?: string} $settings
+ */
+function test2(array $settings = []): bool {
+	$copy = ['page' => 1, ...$settings];
+	assertType('array{page: int, search?: string}', $copy);
+	assertType('array{page?: int, search?: string}', $settings);
+	return isset($copy['search']);
+}

--- a/tests/PHPStan/Analyser/data/bug-7776.php
+++ b/tests/PHPStan/Analyser/data/bug-7776.php
@@ -13,5 +13,3 @@ function test(array $settings = []): bool {
 	assertType('array{page?: int, search?: string}', $settings);
 	return isset($copy['search']);
 }
-
-test();

--- a/tests/PHPStan/Analyser/data/bug-7776.php
+++ b/tests/PHPStan/Analyser/data/bug-7776.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7776;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array{page?: int, search?: string} $settings
+ */
+function test(array $settings = []): bool {
+	$copy = [...$settings];
+	assertType('array{page?: int, search?: string}', $copy);
+	assertType('array{page?: int, search?: string}', $settings);
+	return isset($copy['search']);
+}
+
+test();

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -415,8 +415,13 @@ class IssetRuleTest extends RuleTestCase
 
 	public function testBug7776(): void
 	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->strictUnnecessaryNullsafePropertyFetch = false;
+
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-7776.php'], []);
 	}
 

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -413,4 +413,11 @@ class IssetRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6997.php'], []);
 	}
 
+	public function testBug7776(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = false;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-7776.php'], []);
+	}
+
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7776

is basically the constant array counterpart to https://github.com/phpstan/phpstan-src/pull/1586