### PR TITLE
More specific type for 'port' component of 'parse_url()'

### DIFF
--- a/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -122,17 +122,17 @@ final class ParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		}
 
 		$string = new StringType();
-		$integer = new IntegerType();
+		$port = IntegerRangeType::fromInterval(0, 65535);
 		$false = new ConstantBooleanType(false);
 		$null = new NullType();
 
 		$stringOrFalseOrNull = TypeCombinator::union($string, $false, $null);
-		$integerOrFalseOrNull = TypeCombinator::union($integer, $false, $null);
+		$portOrFalseOrNull = TypeCombinator::union($port, $false, $null);
 
 		$this->componentTypesPairedConstants = [
 			PHP_URL_SCHEME => $stringOrFalseOrNull,
 			PHP_URL_HOST => $stringOrFalseOrNull,
-			PHP_URL_PORT => $integerOrFalseOrNull,
+			PHP_URL_PORT => $portOrFalseOrNull,
 			PHP_URL_USER => $stringOrFalseOrNull,
 			PHP_URL_PASS => $stringOrFalseOrNull,
 			PHP_URL_PATH => $stringOrFalseOrNull,
@@ -143,7 +143,7 @@ final class ParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		$this->componentTypesPairedStrings = [
 			'scheme' => $string,
 			'host' => $string,
-			'port' => $integer,
+			'port' => $port,
 			'user' => $string,
 			'pass' => $string,
 			'path' => $string,

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5385,7 +5385,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$parseUrlConstantUrlWithoutComponent2',
 			],
 			[
-				'array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false',
+				'array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false',
 				'$parseUrlConstantUrlUnknownComponent',
 			],
 			[
@@ -5405,11 +5405,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$parseUrlStringUrlWithComponentInvalid',
 			],
 			[
-				'int|false|null',
+				'int<0, 65535>|false|null',
 				'$parseUrlStringUrlWithComponentPort',
 			],
 			[
-				'array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false',
+				'array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false',
 				'$parseUrlStringUrlWithoutComponent',
 			],
 			[

--- a/tests/PHPStan/Analyser/data/bug-2001.php
+++ b/tests/PHPStan/Analyser/data/bug-2001.php
@@ -9,28 +9,28 @@ class HelloWorld
 	public function parseUrl(string $url): string
 	{
 		$parsedUrl = parse_url(urldecode($url));
-		assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedUrl);
+		assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedUrl);
 
 		if (array_key_exists('host', $parsedUrl)) {
-			assertType('array{scheme?: string, host: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $parsedUrl);
+			assertType('array{scheme?: string, host: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $parsedUrl);
 			throw new \RuntimeException('Absolute URLs are prohibited for the redirectTo parameter.');
 		}
 
-		assertType('array{scheme?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedUrl);
+		assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedUrl);
 
 		$redirectUrl = $parsedUrl['path'];
 
 		if (array_key_exists('query', $parsedUrl)) {
-			assertType('array{scheme?: string, port?: int, user?: string, pass?: string, path?: string, query: string, fragment?: string}', $parsedUrl);
+			assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query: string, fragment?: string}', $parsedUrl);
 			$redirectUrl .= '?' . $parsedUrl['query'];
 		}
 
 		if (array_key_exists('fragment', $parsedUrl)) {
-			assertType('array{scheme?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment: string}', $parsedUrl);
+			assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment: string}', $parsedUrl);
 			$redirectUrl .= '#' . $parsedUrl['query'];
 		}
 
-		assertType('array{scheme?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedUrl);
+		assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedUrl);
 
 		return $redirectUrl;
 	}

--- a/tests/PHPStan/Analyser/data/bug-3009.php
+++ b/tests/PHPStan/Analyser/data/bug-3009.php
@@ -11,18 +11,18 @@ class HelloWorld
 	{
 		$redirectUrlParts = parse_url($redirectUri);
 		if (false === is_array($redirectUrlParts) || true === array_key_exists('host', $redirectUrlParts)) {
-			assertType('array{scheme?: string, host: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $redirectUrlParts);
+			assertType('array{scheme?: string, host: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $redirectUrlParts);
 			return null;
 		}
 
-		assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
+		assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
 
 		if (true === array_key_exists('query', $redirectUrlParts)) {
-			assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query: string, fragment?: string}', $redirectUrlParts);
+			assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query: string, fragment?: string}', $redirectUrlParts);
 			$redirectServer['QUERY_STRING'] = $redirectUrlParts['query'];
 		}
 
-		assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
+		assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
 
 		return 'foo';
 	}


### PR DESCRIPTION
The `port` component can only be in the range 0-65535:

```php
<?php
var_dump(parse_url("http://localhost:-1/"));    // false
var_dump(parse_url("http://localhost:0/"));     // [ ... ]
var_dump(parse_url("http://localhost:65535/")); // [ ... ]
var_dump(parse_url("http://localhost:65536/")); // false
```