### PR TITLE
Make IntegerRangeType constructor private

### DIFF
--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -20,9 +20,8 @@ use const PHP_INT_MIN;
 class IntegerRangeType extends IntegerType implements CompoundType
 {
 
-	public function __construct(private ?int $min, private ?int $max)
+	private function __construct(private ?int $min, private ?int $max)
 	{
-		// this constructor can be made private when PHP 7.2 is the minimum
 		parent::__construct();
 		assert($min === null || $max === null || $min <= $max);
 		assert($min !== null || $max !== null);

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2101,8 +2101,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 		];
 		yield [
 			[
-				new MixedType(false, new IntegerRangeType(17, null)),
-				new IntegerRangeType(19, null),
+				new MixedType(false, IntegerRangeType::fromInterval(17, null)),
+				IntegerRangeType::fromInterval(19, null),
 			],
 			MixedType::class,
 			'mixed~int<17, 18>=implicit',
@@ -3603,7 +3603,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		];
 		yield [
 			[
-				new MixedType(false, new IntegerRangeType(17, null)),
+				new MixedType(false, IntegerRangeType::fromInterval(17, null)),
 				new MixedType(),
 			],
 			MixedType::class,


### PR DESCRIPTION
I was blindly following that comment (see diff), but tbh I did not fully understand it. Is it fine to do this or should it be rather deprecated via phpdoc?

Something should be done I think to avoid people using it instead of the static create function.