### PR TITLE
WIP/RFC - Extend support for `treatPhpDocTypesAsCertain` to more expressions (initial attempt)

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -663,19 +663,19 @@ class MutatingScope implements Scope
 		}
 
 		if ($node instanceof Expr\BinaryOp\Smaller) {
-			return $this->getType($node->left)->isSmallerThan($this->getType($node->right))->toBooleanType();
+			return $this->getTypeOrNative($node->left)->isSmallerThan($this->getTypeOrNative($node->right))->toBooleanType();
 		}
 
 		if ($node instanceof Expr\BinaryOp\SmallerOrEqual) {
-			return $this->getType($node->left)->isSmallerThanOrEqual($this->getType($node->right))->toBooleanType();
+			return $this->getTypeOrNative($node->left)->isSmallerThanOrEqual($this->getTypeOrNative($node->right))->toBooleanType();
 		}
 
 		if ($node instanceof Expr\BinaryOp\Greater) {
-			return $this->getType($node->right)->isSmallerThan($this->getType($node->left))->toBooleanType();
+			return $this->getTypeOrNative($node->right)->isSmallerThan($this->getTypeOrNative($node->left))->toBooleanType();
 		}
 
 		if ($node instanceof Expr\BinaryOp\GreaterOrEqual) {
-			return $this->getType($node->right)->isSmallerThanOrEqual($this->getType($node->left))->toBooleanType();
+			return $this->getTypeOrNative($node->right)->isSmallerThanOrEqual($this->getTypeOrNative($node->left))->toBooleanType();
 		}
 
 		if ($node instanceof Expr\BinaryOp\Equal) {
@@ -2139,6 +2139,15 @@ class MutatingScope implements Scope
 		}
 
 		return $this->getType($expr);
+	}
+
+	public function getTypeOrNative(Expr $expr): Type
+	{
+		if ($this->treatPhpDocTypesAsCertain) {
+			return $this->getType($expr);
+		} else {
+			return $this->getNativeType($expr);
+		}
 	}
 
 	/** @api */


### PR DESCRIPTION
**WIP/RFC - do not merge!**

I took a crack at the issue phpstan/phpstan#7075 (also as phpstan/phpstan#7795) but I have a lot of doubts
about this patch, so I'm posting the PR to get some initial feedback in particular
on the following points:

**1)** What's the difference between `promoteNativeTypes()`, and the
conditional use of `getType()` vs `getNativeType()` based on the setting
`treatPhpDocTypesAsCertain`?

**2)** Should we unify all of this for all expressions? It sounds like there
are more cases where we should honor `treatPhpDocTypesAsCertain`, that why I
introduced the new `getTypeOrNative()` function. So if this is the way to go,
I would first refactor all existing cases to use this newly introduced method

**3)** What do you think about the name `getTypeOrNative()`? I don't like it but
I still would like something short as it's going to be used a lot. Also, should
it be private, protected, or public?

**4)** This change broke zero tests, that means new tests should be introduced
before making this change. Any recommended strategy? Where should they go?
How should they look like? They clearly need to be ran twice with the different
configuration.
