### PR TITLE
Use argument types as parameter types for inline closures (#7798)

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -418,6 +418,16 @@ services:
 			- phpstan.parser.richParserNodeVisitor
 
 	-
+		class: PHPStan\Parser\ClosureArgVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor
+
+	-
+		class: PHPStan\Parser\ArrowFunctionArgVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor
+
+	-
 		class: PHPStan\Parser\NewAssignedToPropertyVisitor
 		tags:
 			- phpstan.parser.richParserNodeVisitor

--- a/src/Parser/ArrowFunctionArgVisitor.php
+++ b/src/Parser/ArrowFunctionArgVisitor.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parser;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use function count;
+
+class ArrowFunctionArgVisitor extends NodeVisitorAbstract
+{
+
+	public function enterNode(Node $node): ?Node
+	{
+		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Expr\ArrowFunction) {
+			$args = $node->getArgs();
+
+			if (count($args) > 0) {
+				$node->name->setAttribute('arrowFunctionCallArgs', $args);
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/Parser/ClosureArgVisitor.php
+++ b/src/Parser/ClosureArgVisitor.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parser;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use function count;
+
+class ClosureArgVisitor extends NodeVisitorAbstract
+{
+
+	public function enterNode(Node $node): ?Node
+	{
+		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Expr\Closure) {
+			$args = $node->getArgs();
+
+			if (count($args) > 0) {
+				$node->name->setAttribute('closureCallArgs', $args);
+			}
+		}
+		return null;
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -971,6 +971,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7469.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-3391.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6901.php');
+
+		if (PHP_VERSION_ID >= 70400) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/arrow-function-argument-type.php');
+		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-argument-type.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/arrow-function-argument-type.php
+++ b/tests/PHPStan/Analyser/data/arrow-function-argument-type.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ArrowFunctionArgumentType;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param array{a: int} $array
+	 */
+	public function doFoo(int $integer, array $array, ?string $nullableString)
+	{
+		(fn($context) => assertType('int', $context))($integer);
+
+		(fn($context) => assertType('array{a: int}', $context))($array);
+
+		(fn($context) => assertType('string|null', $context))($nullableString);
+
+		(fn($a, $b, $c) => assertType('array{int, array{a: int}, string|null}', [$a, $b, $c]))($integer, $array, $nullableString);
+
+		(fn($a, $b, $c = null) => assertType('array{int, array{a: int}, mixed}', [$a, $b, $c]))($integer, $array);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/closure-argument-type.php
+++ b/tests/PHPStan/Analyser/data/closure-argument-type.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ClosureArgumentType;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param array{a: int} $array
+	 */
+	public function doFoo(int $integer, array $array, ?string $nullableString)
+	{
+		(function($context) {
+			assertType('int', $context);
+		})($integer);
+
+		(function($context) {
+			assertType('array{a: int}', $context);
+		})($array);
+
+		(function($context) {
+			assertType('string|null', $context);
+		})($nullableString);
+
+		(function($context1, $context2, $context3) {
+			assertType('int', $context1);
+			assertType('array{a: int}', $context2);
+			assertType('string|null', $context3);
+		})($integer, $array, $nullableString);
+
+		(function($context1, $context2, $context3 = null) {
+			assertType('int', $context1);
+			assertType('array{a: int}', $context2);
+			assertType('mixed', $context3);
+		})($integer, $array);
+	}
+
+}


### PR DESCRIPTION
Implements [#7798](https://github.com/phpstan/phpstan/issues/7798). Thank you for your advise, it was very helpful.

> The relevant code for this in NodeScopeResolver is this but you won't have to touch that for this feature request, it works in a general sense: https://github.com/phpstan/phpstan-src/blob/4b6d9647784966438c742b367066656cf269a8d4/src/Analyser/NodeScopeResolver.php#L2964-L2975

This unfortunately is not used for this case; `$passedToType` is only passed to `processClosureNode` when handling a closure as a function argument:
https://github.com/phpstan/phpstan-src/blob/4b6d9647784966438c742b367066656cf269a8d4/src/Analyser/NodeScopeResolver.php#L3223-L3226

https://github.com/phpstan/phpstan-src/blob/4b6d9647784966438c742b367066656cf269a8d4/src/Analyser/NodeScopeResolver.php#L2220-L2221

Because the closure is never the argument (it is the `name` of the `FuncCall`), this case is slightly different than for `array_map`, as the `Expr\Closure` is never handled by `ParametersAcceptorSelector::selectFromArgs` (only its `ClosureType` is).

Please let me know if I misunderstood.