### PR TITLE
Handle the expression `expr & number` for positive numbers

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -523,8 +523,18 @@ class InitializerExprTypeResolver
 			return $stringType;
 		}
 
-		if (TypeCombinator::union($leftType->toNumber(), $rightType->toNumber()) instanceof ErrorType) {
+		$leftNumberType = $leftType->toNumber();
+		$rightNumberType = $rightType->toNumber();
+
+		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
 			return new ErrorType();
+		}
+
+		if ($rightNumberType instanceof ConstantIntegerType && $rightNumberType->getValue() >= 0) {
+			return IntegerRangeType::fromInterval(0, $rightNumberType->getValue());
+		}
+		if ($leftNumberType instanceof ConstantIntegerType && $leftNumberType->getValue() >= 0) {
+			return IntegerRangeType::fromInterval(0, $leftNumberType->getValue());
 		}
 
 		return new IntegerType();

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -2744,8 +2744,16 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'5 & 3',
 			],
 			[
-				'int',
+				'int<0, 3>',
 				'$integer & 3',
+			],
+			[
+				'int<0, 7>',
+				'7 & $integer',
+			],
+			[
+				'int',
+				'$integer & $integer',
 			],
 			[
 				'\'x\'',
@@ -2812,7 +2820,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'"5" ^ 3',
 			],
 			[
-				'int',
+				'int<0, 3>',
 				'$integer &= 3',
 			],
 			[


### PR DESCRIPTION
This is a specific but very common use case, where the result a
bitwise-and with a positive number results in the range 0-number.