### PR TITLE
Fix array_search extension incorrectly returning null

### DIFF
--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -43,9 +43,7 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 		}
 
 		$strictArgType = $scope->getType($functionCall->getArgs()[2]->value);
-		if (!($strictArgType instanceof ConstantBooleanType)) {
-			return TypeCombinator::union($haystackArgType->getIterableKeyType(), new ConstantBooleanType(false), new NullType());
-		} elseif ($strictArgType->getValue() === false) {
+		if (!$strictArgType instanceof ConstantBooleanType || $strictArgType->getValue() === false) {
 			return TypeCombinator::union($haystackArgType->getIterableKeyType(), new ConstantBooleanType(false));
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -978,6 +978,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-argument-type.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7788.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7809.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7809.php
+++ b/tests/PHPStan/Analyser/data/bug-7809.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Bug7809;
+
+use function array_search;
+use function PHPStan\Testing\assertType;
+
+function foo(bool $strict = false): void {
+	assertType('0|1|2|false', array_search('c', ['a', 'b', 'c'], $strict));
+}
+
+function bar(): void{
+	assertType('2', array_search('c', ['a', 'b', 'c'], true));
+}
+
+function baz(): void{
+	assertType('0|1|2|false', array_search('c', ['a', 'b', 'c'], false));
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7809

I think this was already wrongfully introduced in 5ecdd079318dbf93d9963221a689a4fca529dc71 and partly fixed in c74dca665399176dfcd736b8e553bed672bc4ac4. But maybe I'm also missing something..