### PR TITLE
Reorder type conversion methods according to the interface

### DIFF
--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -128,6 +128,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function toBoolean(): BooleanType
+	{
+		return new BooleanType();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();
@@ -146,11 +151,6 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 	public function toString(): Type
 	{
 		return $this;
-	}
-
-	public function toBoolean(): BooleanType
-	{
-		return new BooleanType();
 	}
 
 	public function toArray(): Type

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -328,11 +328,6 @@ class ArrayType implements Type
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new ErrorType();
-	}
-
 	public function toInteger(): Type
 	{
 		return TypeCombinator::union(
@@ -347,6 +342,11 @@ class ArrayType implements Type
 			new ConstantFloatType(0.0),
 			new ConstantFloatType(1.0),
 		);
+	}
+
+	public function toString(): Type
+	{
+		return new ErrorType();
 	}
 
 	public function toArray(): Type

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -45,14 +45,6 @@ class BooleanType implements Type
 		return $this->toInteger();
 	}
 
-	public function toString(): Type
-	{
-		return TypeCombinator::union(
-			new ConstantStringType(''),
-			new ConstantStringType('1'),
-		);
-	}
-
 	public function toInteger(): Type
 	{
 		return TypeCombinator::union(
@@ -66,6 +58,14 @@ class BooleanType implements Type
 		return TypeCombinator::union(
 			new ConstantFloatType(0.0),
 			new ConstantFloatType(1.0),
+		);
+	}
+
+	public function toString(): Type
+	{
+		return TypeCombinator::union(
+			new ConstantStringType(''),
+			new ConstantStringType('1'),
 		);
 	}
 

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -172,17 +172,17 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new ErrorType();
-	}
-
 	public function toInteger(): Type
 	{
 		return new ErrorType();
 	}
 
 	public function toFloat(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function toString(): Type
 	{
 		return new ErrorType();
 	}

--- a/src/Type/Constant/ConstantBooleanType.php
+++ b/src/Type/Constant/ConstantBooleanType.php
@@ -75,11 +75,6 @@ class ConstantBooleanType extends BooleanType implements ConstantScalarType
 		return new ConstantIntegerType((int) $this->value);
 	}
 
-	public function toString(): Type
-	{
-		return new ConstantStringType((string) $this->value);
-	}
-
 	public function toInteger(): Type
 	{
 		return new ConstantIntegerType((int) $this->value);
@@ -88,6 +83,11 @@ class ConstantBooleanType extends BooleanType implements ConstantScalarType
 	public function toFloat(): Type
 	{
 		return new ConstantFloatType((float) $this->value);
+	}
+
+	public function toString(): Type
+	{
+		return new ConstantStringType((string) $this->value);
 	}
 
 	/**

--- a/src/Type/Constant/ConstantFloatType.php
+++ b/src/Type/Constant/ConstantFloatType.php
@@ -72,14 +72,14 @@ class ConstantFloatType extends FloatType implements ConstantScalarType
 		return TrinaryLogic::createNo();
 	}
 
-	public function toString(): Type
-	{
-		return new ConstantStringType((string) $this->value);
-	}
-
 	public function toInteger(): Type
 	{
 		return new ConstantIntegerType((int) $this->value);
+	}
+
+	public function toString(): Type
+	{
+		return new ConstantStringType((string) $this->value);
 	}
 
 	/**

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -85,14 +85,14 @@ class FloatType implements Type
 		return $this;
 	}
 
-	public function toFloat(): Type
-	{
-		return $this;
-	}
-
 	public function toInteger(): Type
 	{
 		return new IntegerType();
+	}
+
+	public function toFloat(): Type
+	{
+		return $this;
 	}
 
 	public function toString(): Type

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -51,14 +51,14 @@ class IntegerType implements Type
 		return $this;
 	}
 
-	public function toFloat(): Type
-	{
-		return new FloatType();
-	}
-
 	public function toInteger(): Type
 	{
 		return $this;
+	}
+
+	public function toFloat(): Type
+	{
+		return new FloatType();
 	}
 
 	public function toString(): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -565,13 +565,6 @@ class IntersectionType implements CompoundType
 		return $type;
 	}
 
-	public function toString(): Type
-	{
-		$type = $this->intersectTypes(static fn (Type $type): Type => $type->toString());
-
-		return $type;
-	}
-
 	public function toInteger(): Type
 	{
 		$type = $this->intersectTypes(static fn (Type $type): Type => $type->toInteger());
@@ -582,6 +575,13 @@ class IntersectionType implements CompoundType
 	public function toFloat(): Type
 	{
 		$type = $this->intersectTypes(static fn (Type $type): Type => $type->toFloat());
+
+		return $type;
+	}
+
+	public function toString(): Type
+	{
+		$type = $this->intersectTypes(static fn (Type $type): Type => $type->toString());
 
 		return $type;
 	}

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -189,17 +189,17 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new ErrorType();
-	}
-
 	public function toInteger(): Type
 	{
 		return new ErrorType();
 	}
 
 	public function toFloat(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function toString(): Type
 	{
 		return new ErrorType();
 	}

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -203,17 +203,17 @@ class NeverType implements CompoundType
 		return $this;
 	}
 
-	public function toString(): Type
-	{
-		return $this;
-	}
-
 	public function toInteger(): Type
 	{
 		return $this;
 	}
 
 	public function toFloat(): Type
+	{
+		return $this;
+	}
+
+	public function toString(): Type
 	{
 		return $this;
 	}

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -102,17 +102,17 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new ErrorType();
-	}
-
 	public function toInteger(): Type
 	{
 		return new ErrorType();
 	}
 
 	public function toFloat(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function toString(): Type
 	{
 		return new ErrorType();
 	}

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -119,11 +119,6 @@ class NullType implements ConstantScalarType
 		return new ConstantIntegerType(0);
 	}
 
-	public function toString(): Type
-	{
-		return new ConstantStringType('');
-	}
-
 	public function toInteger(): Type
 	{
 		return $this->toNumber();
@@ -132,6 +127,11 @@ class NullType implements ConstantScalarType
 	public function toFloat(): Type
 	{
 		return $this->toNumber()->toFloat();
+	}
+
+	public function toString(): Type
+	{
+		return new ConstantStringType('');
 	}
 
 	public function toArray(): Type

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -470,6 +470,15 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $description;
 	}
 
+	public function toBoolean(): BooleanType
+	{
+		if ($this->isInstanceOf('SimpleXMLElement')->yes()) {
+			return new BooleanType();
+		}
+
+		return new ConstantBooleanType(true);
+	}
+
 	public function toNumber(): Type
 	{
 		if ($this->isInstanceOf('SimpleXMLElement')->yes()) {
@@ -570,15 +579,6 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		} while ($classReflection !== null);
 
 		return new ConstantArrayType($arrayKeys, $arrayValues);
-	}
-
-	public function toBoolean(): BooleanType
-	{
-		if ($this->isInstanceOf('SimpleXMLElement')->yes()) {
-			return new BooleanType();
-		}
-
-		return new ConstantBooleanType(true);
 	}
 
 	public function canAccessProperties(): TrinaryLogic

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -44,11 +44,6 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new StringType();
-	}
-
 	public function toInteger(): Type
 	{
 		return new IntegerType();
@@ -57,6 +52,11 @@ class ResourceType implements Type
 	public function toFloat(): Type
 	{
 		return new ErrorType();
+	}
+
+	public function toString(): Type
+	{
+		return new StringType();
 	}
 
 	public function toArray(): Type

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -372,14 +372,14 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return TrinaryLogic::createYes();
 	}
 
+	public function toBoolean(): BooleanType
+	{
+		return $this->getStaticObjectType()->toBoolean();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();
-	}
-
-	public function toString(): Type
-	{
-		return $this->getStaticObjectType()->toString();
 	}
 
 	public function toInteger(): Type
@@ -392,14 +392,14 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function toString(): Type
+	{
+		return $this->getStaticObjectType()->toString();
+	}
+
 	public function toArray(): Type
 	{
 		return $this->getStaticObjectType()->toArray();
-	}
-
-	public function toBoolean(): BooleanType
-	{
-		return $this->getStaticObjectType()->toBoolean();
 	}
 
 	public function traverse(callable $cb): Type

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -135,11 +135,6 @@ trait ObjectTypeTrait
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new StringType();
-	}
-
 	public function toInteger(): Type
 	{
 		return new ErrorType();
@@ -148,6 +143,11 @@ trait ObjectTypeTrait
 	public function toFloat(): Type
 	{
 		return new ErrorType();
+	}
+
+	public function toString(): Type
+	{
+		return new StringType();
 	}
 
 	public function toArray(): Type

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -582,13 +582,6 @@ class UnionType implements CompoundType
 		return $type;
 	}
 
-	public function toString(): Type
-	{
-		$type = $this->unionTypes(static fn (Type $type): Type => $type->toString());
-
-		return $type;
-	}
-
 	public function toInteger(): Type
 	{
 		$type = $this->unionTypes(static fn (Type $type): Type => $type->toInteger());
@@ -599,6 +592,13 @@ class UnionType implements CompoundType
 	public function toFloat(): Type
 	{
 		$type = $this->unionTypes(static fn (Type $type): Type => $type->toFloat());
+
+		return $type;
+	}
+
+	public function toString(): Type
+	{
+		$type = $this->unionTypes(static fn (Type $type): Type => $type->toString());
 
 		return $type;
 	}

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -77,17 +77,17 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
-	public function toString(): Type
-	{
-		return new ErrorType();
-	}
-
 	public function toInteger(): Type
 	{
 		return new ErrorType();
 	}
 
 	public function toFloat(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function toString(): Type
 	{
 		return new ErrorType();
 	}


### PR DESCRIPTION
This is non-functional change. To improve general code readaibility, reorder type conversion methods according to the Type interface, which is the following:
 - toBoolean
 - toNumber
 - toInteger
 - toFloat
 - toString
 - toArray

Please let me know if this kind of code aesthetic changes are welcome, as I would have plenty more that I notice while doing walkthroughs.
