### PR TITLE
Fix numeric-string negated intersection

### DIFF
--- a/src/Type/Php/IsNumericFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsNumericFunctionTypeSpecifyingExtension.php
@@ -41,14 +41,11 @@ class IsNumericFunctionTypeSpecifyingExtension implements FunctionTypeSpecifying
 		$numericTypes = [
 			new IntegerType(),
 			new FloatType(),
-		];
-
-		if ($context->truthy()) {
-			$numericTypes[] = new IntersectionType([
+			new IntersectionType([
 				new StringType(),
 				new AccessoryNumericStringType(),
-			]);
-		}
+			])
+		];
 
 		return $this->typeSpecifier->create($node->getArgs()[0]->value, new UnionType($numericTypes), $context, false, $scope);
 	}

--- a/src/Type/Php/IsNumericFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsNumericFunctionTypeSpecifyingExtension.php
@@ -44,7 +44,7 @@ class IsNumericFunctionTypeSpecifyingExtension implements FunctionTypeSpecifying
 			new IntersectionType([
 				new StringType(),
 				new AccessoryNumericStringType(),
-			])
+			]),
 		];
 
 		return $this->typeSpecifier->create($node->getArgs()[0]->value, new UnionType($numericTypes), $context, false, $scope);

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -105,14 +105,6 @@ class TypeSpecifierTest extends PHPStanTestCase
 				['$foo' => '~float|int|numeric-string'],
 			],
 			[
-				new Expr\BinaryOp\BooleanAnd(
-					$this->createFunctionCall('is_string'),
-					$this->createFunctionCall('is_numeric'),
-				),
-				['$foo' => 'numeric-string'],
-				['$foo' => '~numeric-string'],
-			],
-			[
 				$this->createFunctionCall('is_scalar'),
 				['$foo' => 'bool|float|int|string'],
 				['$foo' => '~bool|float|int|string'],

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -102,7 +102,15 @@ class TypeSpecifierTest extends PHPStanTestCase
 			[
 				$this->createFunctionCall('is_numeric'),
 				['$foo' => 'float|int|numeric-string'],
-				['$foo' => '~float|int'],
+				['$foo' => '~float|int|numeric-string'],
+			],
+			[
+				new Expr\BinaryOp\BooleanAnd(
+					$this->createFunctionCall('is_string'),
+					$this->createFunctionCall('is_numeric'),
+				),
+				['$foo' => 'numeric-string'],
+				['$foo' => '~numeric-string'],
 			],
 			[
 				$this->createFunctionCall('is_scalar'),


### PR DESCRIPTION
Fixes phpstan/phpstan#7814
As the docs says:
> numeric-string is a string that would pass an [is_numeric()](https://www.php.net/manual/en/function.is-numeric.php) check.

https://phpstan.org/writing-php-code/phpdoc-types#other-advanced-string-types
So, `numeric-string` should be also subtracted from any type not passed `is_numeric`, because `is_numeric` is the `numeric-string` determiner itself.

But I've added a test that shows there's a bug with `numeric-string` subtraction from `mixed`. It's still `mixed`. I would be glad if someone give me an advice how to fix it :)