### PR TITLE
Fix PreInc/PreDec of NeverType

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1474,6 +1474,8 @@ class MutatingScope implements Scope
 					$newTypes[] = $this->getTypeFromValue($varValue);
 				}
 				return TypeCombinator::union(...$newTypes);
+			} elseif ($varType instanceof NeverType) {
+				return $varType;
 			} elseif ($stringType->isSuperTypeOf($varType)->yes()) {
 				if ($varType->isLiteralString()->yes()) {
 					return new IntersectionType([$stringType, new AccessoryLiteralStringType()]);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1474,9 +1474,7 @@ class MutatingScope implements Scope
 					$newTypes[] = $this->getTypeFromValue($varValue);
 				}
 				return TypeCombinator::union(...$newTypes);
-			} elseif ($varType instanceof NeverType) {
-				return $varType;
-			} elseif ($stringType->isSuperTypeOf($varType)->yes()) {
+			} elseif ($varType->isString()->yes()) {
 				if ($varType->isLiteralString()->yes()) {
 					return new IntersectionType([$stringType, new AccessoryLiteralStringType()]);
 				}

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -46,6 +46,7 @@ use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -1370,6 +1371,9 @@ class InitializerExprTypeResolver
 		$rightNumberType = $rightType->toNumber();
 		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
 			return new ErrorType();
+		}
+		if ($leftNumberType instanceof NeverType || $rightNumberType instanceof NeverType) {
+			return new NeverType();
 		}
 
 		if (

--- a/tests/PHPStan/Analyser/data/for-loop-i-type.php
+++ b/tests/PHPStan/Analyser/data/for-loop-i-type.php
@@ -39,7 +39,7 @@ class Foo
 		$foo = null;
 		for($i = 1; $i < count([]); $i++) {
 			$foo = new \stdClass();
-			assertType('string', $i); // should be *NEVER*
+			assertType('*NEVER*', $i);
 		}
 
 		assertType('1', $i);

--- a/tests/PHPStan/Analyser/data/math.php
+++ b/tests/PHPStan/Analyser/data/math.php
@@ -139,4 +139,21 @@ class Foo
 
 	}
 
+	public function never(): void
+	{
+		for ($i = 1; $i < count([]); $i++) {
+			assertType('*NEVER*', $i);
+			assertType('*NEVER*', $i + 2);
+			assertType('*NEVER*', 2 + $i);
+			assertType('*NEVER*', $i - 2);
+			assertType('*NEVER*', 2 - $i);
+			assertType('*NEVER*', $i * 2);
+			assertType('*NEVER*', 2 * $i);
+			assertType('*NEVER*', $i ** 2);
+			assertType('*NEVER*', 2 ** $i);
+			assertType('*NEVER*', $i / 2);
+			assertType('*NEVER*', 2 / $i);
+		}
+	}
+
 }


### PR DESCRIPTION
Found this while working on something else. The problem is that with the NeverType being the bottom type the next if block `elseif ($stringType->isSuperTypeOf($varType)->yes())` would always evaluate to true leading to a string. That could still be improved by using `isString()` instead, but then the code afterwards would create Plus or Minus expressions leading to e.g. float.

While reading https://www.php.net/manual/en/language.operators.increment.php
> Note: The increment/decrement operators only affect numbers and strings. Arrays, objects, booleans and resources are not affected. Decrementing null values has no effect too, but incrementing them results in 1.

I thought those expressions should only be created for numbers or null but I also don't like to use `instanceof` for that. Therefore I decided to check explicitly if it is a NeverType. Maybe, but I'm really not sure, the Type interface should have a couple more primitive type methods like `isInteger`, `isFloat`, `isNull` or so to deal with this a bit different. Those would definitely be `no` for a NeverType then. 