### PR TITLE
Do not consider mixed explicitness for parameter contravariance

### DIFF
--- a/src/Rules/Methods/MethodParameterComparisonHelper.php
+++ b/src/Rules/Methods/MethodParameterComparisonHelper.php
@@ -267,7 +267,7 @@ class MethodParameterComparisonHelper
 				continue;
 			}
 
-			if ($this->isTypeCompatible($methodParameterType, $prototypeParameterType, $this->phpVersion->supportsParameterContravariance())) {
+			if ($this->isParameterTypeCompatible($methodParameterType, $prototypeParameterType, $this->phpVersion->supportsParameterContravariance())) {
 				continue;
 			}
 
@@ -369,10 +369,20 @@ class MethodParameterComparisonHelper
 		return $messages;
 	}
 
-	public function isTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsContravariance): bool
+	public function isParameterTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsContravariance): bool
+	{
+		return $this->isTypeCompatible($methodParameterType, $prototypeParameterType, $supportsContravariance, false);
+	}
+
+	public function isReturnTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsCovariance): bool
+	{
+		return $this->isTypeCompatible($methodParameterType, $prototypeParameterType, $supportsCovariance, true);
+	}
+
+	private function isTypeCompatible(Type $methodParameterType, Type $prototypeParameterType, bool $supportsContravariance, bool $considerMixedExplicitness): bool
 	{
 		if ($methodParameterType instanceof MixedType) {
-			if ($prototypeParameterType instanceof MixedType) {
+			if ($considerMixedExplicitness && $prototypeParameterType instanceof MixedType) {
 				return !$methodParameterType->isExplicitMixed() || $prototypeParameterType->isExplicitMixed();
 			}
 

--- a/src/Rules/Methods/OverridingMethodRule.php
+++ b/src/Rules/Methods/OverridingMethodRule.php
@@ -142,7 +142,7 @@ class OverridingMethodRule implements Rule
 			&& !$this->hasReturnTypeWillChangeAttribute($node->getOriginalNode())
 		) {
 
-			if (!$this->methodParameterComparisonHelper->isTypeCompatible($prototype->getTentativeReturnType(), $methodVariant->getNativeReturnType(), true)) {
+			if (!$this->methodParameterComparisonHelper->isReturnTypeCompatible($prototype->getTentativeReturnType(), $methodVariant->getNativeReturnType(), true)) {
 				$messages[] = RuleErrorBuilder::message(sprintf(
 					'Return type %s of method %s::%s() is not covariant with tentative return type %s of method %s::%s().',
 					$methodReturnType->describe(VerbosityLevel::typeOnly()),
@@ -163,7 +163,7 @@ class OverridingMethodRule implements Rule
 
 		$prototypeReturnType = $prototypeVariant->getNativeReturnType();
 
-		if (!$this->methodParameterComparisonHelper->isTypeCompatible($prototypeReturnType, $methodReturnType, $this->phpVersion->supportsReturnCovariance())) {
+		if (!$this->methodParameterComparisonHelper->isReturnTypeCompatible($prototypeReturnType, $methodReturnType, $this->phpVersion->supportsReturnCovariance())) {
 			if ($this->phpVersion->supportsReturnCovariance()) {
 				$messages[] = RuleErrorBuilder::message(sprintf(
 					'Return type %s of method %s::%s() is not covariant with return type %s of method %s::%s().',

--- a/tests/PHPStan/Rules/Methods/data/parameter-contravariance.php
+++ b/tests/PHPStan/Rules/Methods/data/parameter-contravariance.php
@@ -61,3 +61,23 @@ class Ipsum extends Foo
 	}
 
 }
+
+class MixedExplicitnessFoo
+{
+
+	public function setValue($value): void
+	{
+
+	}
+
+}
+
+class MixedExplicitnessBar extends MixedExplicitnessFoo
+{
+
+	public function setValue(mixed $value): void
+	{
+
+	}
+
+}


### PR DESCRIPTION
Follow-up as mentioned in https://github.com/phpstan/phpstan-src/pull/1491#issuecomment-1225661916

That's the simplest I could come up with. Not sure if we should maybe refactor more here. Some names are a bit weird. But I'm also not very experienced with contravariance and covariance tbh.