### PR TITLE
Fixed comparison of empty array with a scalar type

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1253,6 +1253,15 @@ class InitializerExprTypeResolver
 			return $this->resolveIdenticalType($leftType, $rightType);
 		}
 
+		if ($leftType instanceof ConstantArrayType && $leftType->isEmpty() && $rightType instanceof ConstantScalarType) {
+			// @phpstan-ignore-next-line
+			return new ConstantBooleanType($rightType->getValue() == []); // phpcs:ignore
+		}
+		if ($rightType instanceof ConstantArrayType && $rightType->isEmpty() && $leftType instanceof ConstantScalarType) {
+			// @phpstan-ignore-next-line
+			return new ConstantBooleanType($leftType->getValue() == []); // phpcs:ignore
+		}
+
 		if ($leftType instanceof ConstantScalarType && $rightType instanceof ConstantScalarType) {
 			// @phpstan-ignore-next-line
 			return new ConstantBooleanType($leftType->getValue() == $rightType->getValue()); // phpcs:ignore

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -983,6 +983,14 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/composer-non-empty-array-after-unset.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-6000.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/prestashop-breakdowns-empty-array.php');
+
+		if (PHP_VERSION_ID < 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-comparisons-php7.php');
+		}
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-comparisons-php8.php');
+		}
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-comparisons.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/loose-comparisons-php7.php
+++ b/tests/PHPStan/Analyser/data/loose-comparisons-php7.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LooseSemanticsPhp7;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param 0 $zero
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayZero(
+		$zero,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $zero == $phpStr);
+		assertType('true', $zero == $emptyStr);
+	}
+
+	/**
+	 * @param 0 $zero
+	 * @param 'php' $phpStr
+	 */
+	public function sayPhpStr(
+		$zero,
+		$phpStr,
+	): void
+	{
+		assertType('true', $phpStr == $zero);
+	}
+
+	/**
+	 * @param 0 $zero
+	 * @param '' $emptyStr
+	 */
+	public function sayEmptyStr(
+		$zero,
+		$emptyStr
+	): void
+	{
+		assertType('true', $emptyStr == $zero);
+	}
+}

--- a/tests/PHPStan/Analyser/data/loose-comparisons-php8.php
+++ b/tests/PHPStan/Analyser/data/loose-comparisons-php8.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LooseSemanticsPhp8;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param 0 $zero
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayZero(
+		$zero,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $zero == $phpStr); // PHP8+ only
+		assertType('false', $zero == $emptyStr); // PHP8+ only
+	}
+
+	/**
+	 * @param 0 $zero
+	 * @param 'php' $phpStr
+	 */
+	public function sayPhpStr(
+		$zero,
+		$phpStr,
+	): void
+	{
+		assertType('false', $phpStr == $zero); // PHP8+ only
+	}
+
+	/**
+	 * @param 0 $zero
+	 * @param '' $emptyStr
+	 */
+	public function sayEmptyStr(
+		$zero,
+		$emptyStr
+	): void
+	{
+		assertType('false', $emptyStr == $zero); // PHP8+ only
+	}
+}

--- a/tests/PHPStan/Analyser/data/loose-comparisons.php
+++ b/tests/PHPStan/Analyser/data/loose-comparisons.php
@@ -1,0 +1,522 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LooseSemantics;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayTrue(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $true == $true);
+		assertType('false', $true == $false);
+		assertType('true', $true == $one);
+		assertType('false', $true == $zero);
+		assertType('true', $true == $minusOne);
+		assertType('true', $true == $oneStr);
+		assertType('false', $true == $zeroStr);
+		assertType('true', $true == $minusOneStr);
+		assertType('false', $true == $null);
+		assertType('false', $true == $emptyArr);
+		assertType('true', $true == $phpStr);
+		assertType('false', $true == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayFalse(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $false == $true);
+		assertType('true', $false == $false);
+		assertType('false', $false == $one);
+		assertType('true', $false == $zero);
+		assertType('false', $false == $minusOne);
+		assertType('false', $false == $oneStr);
+		assertType('true', $false == $zeroStr);
+		assertType('false', $false == $minusOneStr);
+		assertType('true', $false == $null);
+		assertType('true', $false == $emptyArr);
+		assertType('false', $false == $phpStr);
+		assertType('true', $false == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayOne(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $one == $true);
+		assertType('false', $one == $false);
+		assertType('true', $one == $one);
+		assertType('false', $one == $zero);
+		assertType('false', $one == $minusOne);
+		assertType('true', $one == $oneStr);
+		assertType('false', $one == $zeroStr);
+		assertType('false', $one == $minusOneStr);
+		assertType('false', $one == $null);
+		assertType('false', $one == $emptyArr);
+		assertType('false', $one == $phpStr);
+		assertType('false', $one == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayZero(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $zero == $true);
+		assertType('true', $zero == $false);
+		assertType('false', $zero == $one);
+		assertType('true', $zero == $zero);
+		assertType('false', $zero == $minusOne);
+		assertType('false', $zero == $oneStr);
+		assertType('true', $zero == $zeroStr);
+		assertType('false', $zero == $minusOneStr);
+		assertType('true', $zero == $null);
+		assertType('false', $zero == $emptyArr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayMinusOne(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $minusOne == $true);
+		assertType('false', $minusOne == $false);
+		assertType('false', $minusOne == $one);
+		assertType('false', $minusOne == $zero);
+		assertType('true', $minusOne == $minusOne);
+		assertType('false', $minusOne == $oneStr);
+		assertType('false', $minusOne == $zeroStr);
+		assertType('true', $minusOne == $minusOneStr);
+		assertType('false', $minusOne == $null);
+		assertType('false', $minusOne == $emptyArr);
+		assertType('false', $minusOne == $phpStr);
+		assertType('false', $minusOne == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayOneStr(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $oneStr == $true);
+		assertType('false', $oneStr == $false);
+		assertType('true', $oneStr == $one);
+		assertType('false', $oneStr == $zero);
+		assertType('false', $oneStr == $minusOne);
+		assertType('true', $oneStr == $oneStr);
+		assertType('false', $oneStr == $zeroStr);
+		assertType('false', $oneStr == $minusOneStr);
+		assertType('false', $oneStr == $null);
+		assertType('false', $oneStr == $emptyArr);
+		assertType('false', $oneStr == $phpStr);
+		assertType('false', $oneStr == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayZeroStr(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $zeroStr == $true);
+		assertType('true', $zeroStr == $false);
+		assertType('false', $zeroStr == $one);
+		assertType('true', $zeroStr == $zero);
+		assertType('false', $zeroStr == $minusOne);
+		assertType('false', $zeroStr == $oneStr);
+		assertType('true', $zeroStr == $zeroStr);
+		assertType('false', $zeroStr == $minusOneStr);
+		assertType('false', $zeroStr == $null);
+		assertType('false', $zeroStr == $emptyArr);
+		assertType('false', $zeroStr == $phpStr);
+		assertType('false', $zeroStr == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayMinusOneStr(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $minusOneStr == $true);
+		assertType('false', $minusOneStr == $false);
+		assertType('false', $minusOneStr == $one);
+		assertType('false', $minusOneStr == $zero);
+		assertType('true', $minusOneStr == $minusOne);
+		assertType('false', $minusOneStr == $oneStr);
+		assertType('false', $minusOneStr == $zeroStr);
+		assertType('true', $minusOneStr == $minusOneStr);
+		assertType('false', $minusOneStr == $null);
+		assertType('false', $minusOneStr == $emptyArr);
+		assertType('false', $minusOneStr == $phpStr);
+		assertType('false', $minusOneStr == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayNull(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $null == $true);
+		assertType('true', $null == $false);
+		assertType('false', $null == $one);
+		assertType('true', $null == $zero);
+		assertType('false', $null == $minusOne);
+		assertType('false', $null == $oneStr);
+		assertType('false', $null == $zeroStr);
+		assertType('false', $null == $minusOneStr);
+		assertType('true', $null == $null);
+		assertType('true', $null == $emptyArr);
+		assertType('false', $null == $phpStr);
+		assertType('true', $null == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayEmptyArray(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $emptyArr == $true);
+		assertType('true', $emptyArr == $false);
+		assertType('false', $emptyArr == $one);
+		assertType('false', $emptyArr == $zero);
+		assertType('false', $emptyArr == $minusOne);
+		assertType('false', $emptyArr == $oneStr);
+		assertType('false', $emptyArr == $zeroStr);
+		assertType('false', $emptyArr == $minusOneStr);
+		assertType('true', $emptyArr == $null);
+		assertType('true', $emptyArr == $emptyArr);
+		assertType('false', $emptyArr == $phpStr);
+		assertType('false', $emptyArr == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayNonFalsyStr(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('true', $phpStr == $true);
+		assertType('false', $phpStr == $false);
+		assertType('false', $phpStr == $one);
+		assertType('false', $phpStr == $minusOne);
+		assertType('false', $phpStr == $oneStr);
+		assertType('false', $phpStr == $zeroStr);
+		assertType('false', $phpStr == $minusOneStr);
+		assertType('false', $phpStr == $null);
+		assertType('false', $phpStr == $emptyArr);
+		assertType('true', $phpStr == $phpStr);
+		assertType('false', $phpStr == $emptyStr);
+	}
+
+	/**
+	 * @param true $true
+	 * @param false $false
+	 * @param 1 $one
+	 * @param 0 $zero
+	 * @param -1 $minusOne
+	 * @param '1' $oneStr
+	 * @param '0' $zeroStr
+	 * @param '-1' $minusOneStr
+	 * @param null $null
+	 * @param array{} $emptyArr
+	 * @param 'php' $phpStr
+	 * @param '' $emptyStr
+	 */
+	public function sayEmptyStr(
+		$true,
+		$false,
+		$one,
+		$zero,
+		$minusOne,
+		$oneStr,
+		$zeroStr,
+		$minusOneStr,
+		$null,
+		$emptyArr,
+		$phpStr,
+		$emptyStr
+	): void
+	{
+		assertType('false', $emptyStr == $true);
+		assertType('true', $emptyStr == $false);
+		assertType('false', $emptyStr == $one);
+		assertType('false', $emptyStr == $minusOne);
+		assertType('false', $emptyStr == $oneStr);
+		assertType('false', $emptyStr == $zeroStr);
+		assertType('false', $emptyStr == $minusOneStr);
+		assertType('true', $emptyStr == $null);
+		assertType('false', $emptyStr == $emptyArr);
+		assertType('false', $emptyStr == $phpStr);
+		assertType('true', $emptyStr == $emptyStr);
+	}
+}


### PR DESCRIPTION
extracted the first commit of https://github.com/phpstan/phpstan-src/pull/1640 into a separate PR, as it is not coupled to `looseCompare` and fixes a bug/type on its own.

the tests added with his PR represent the comparison table from https://www.php.net/manual/en/types.comparisons.php based on constant type comparisons