### PR TITLE
added regression test

### DIFF
--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -145,4 +145,9 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6013.php'], []);
 	}
 
+	public function testBug2851(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-2851.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -140,4 +140,9 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6013(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6013.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -595,10 +595,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6181.php'], []);
 	}
 
-	public function testBug2851(): void
+	public function testBug2851b(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;
-		$this->analyse([__DIR__ . '/data/bug-2851.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-2851b.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -595,4 +595,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6181.php'], []);
 	}
 
+	public function testBug2851(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-2851.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-2851.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-2851.php
@@ -15,23 +15,3 @@ function doFoo() {
 
 	echo $words;
 }
-
-class HelloWorld
-{
-	public function sayHello(iterable $input): void
-	{
-		$expected = [
-			false,
-			1,
-			'x',
-			'y',
-		];
-
-		foreach ($input as $_) {
-			\assert(array_shift($expected) == $_);
-		}
-
-		\assert($expected === []);
-		\assert(\count($expected) === 0);
-	}
-}

--- a/tests/PHPStan/Rules/Comparison/data/bug-2851.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-2851.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Bug2851;
+
+function doFoo() {
+	$arguments = ['x', 'y'];
+
+	$words = '';
+	while (count($arguments) > 0) {
+		$words .= array_pop($arguments);
+		if (count($arguments) > 0) {
+			$words .= ' ';
+		}
+	}
+
+	echo $words;
+}
+
+class HelloWorld
+{
+	public function sayHello(iterable $input): void
+	{
+		$expected = [
+			false,
+			1,
+			'x',
+			'y',
+		];
+
+		foreach ($input as $_) {
+			\assert(array_shift($expected) == $_);
+		}
+
+		\assert($expected === []);
+		\assert(\count($expected) === 0);
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-2851b.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-2851b.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Bug2851b;
+
+class HelloWorld
+{
+	public function sayHello(iterable $input): void
+	{
+		$expected = [
+			false,
+			1,
+			'x',
+			'y',
+		];
+
+		foreach ($input as $_) {
+			\assert(array_shift($expected) == $_);
+		}
+
+		\assert($expected === []);
+		\assert(\count($expected) === 0);
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-6013.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6013.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Bug5999;
+namespace Bug6013;
 
 class Test
 {

--- a/tests/PHPStan/Rules/Comparison/data/bug-6013.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6013.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug5999;
+
+class Test
+{
+	public function run(): void
+	{
+		$data = [1, 2, 3];
+
+		while (count($data) > 0) {
+			array_shift($data);
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -425,4 +425,12 @@ class IssetRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-7776.php'], []);
 	}
 
+	public function testBug6008(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/data/bug-6008.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-6008.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-6008.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Bug6008;
+
+/**
+ * @phpstan-type Request array{url: string, options?: mixed[], copyTo?: ?string}
+ * @phpstan-type Job array{id: int, status: int, request: Request, sync: bool, origin: string, resolve?: callable, reject?: callable, curl_id?: int, response?: stdClass, exception?: stdClass}
+ */
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		/** @var Job */
+		$job = array();
+
+		if (isset($job['curl_id'])) {
+		}
+
+		$resolver = function () use (&$job) {
+			$job['resolve'] = 'strlen'; // static callable, works
+		};
+
+		if (isset($job['curl_id'])) {
+		}
+
+		$resolver = function ($resolve) use ($job) { // no use-by-reference, works
+			$job['resolve'] = $resolve;
+		};
+
+		if (isset($job['curl_id'])) {
+		}
+
+		// use-by-ref + variable callable assignment to a random key
+		// triggers $job['curl_id'] to become set somehow
+		$resolver = function ($resolve, $reject) use (&$job) {
+			$job['resolve'] = $resolve;
+		};
+
+		if (isset($job['curl_id'])) {
+		}
+	}
+}


### PR DESCRIPTION
was fixed in https://github.com/phpstan/phpstan-src/commit/617311022636af148ce910635adf85624fe59f8f

closes https://github.com/phpstan/phpstan/issues/6013
closes https://github.com/phpstan/phpstan/issues/2851
closes https://github.com/phpstan/phpstan/issues/6008

this PR without the latest fix commit:
```
1) PHPStan\Rules\Comparison\NumberComparisonOperatorsConstantConditionRuleTest::testBug6013
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'11: Comparison operation ">" between int<2, 3> and 0 is always true.
 '

/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:182
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php:145

2) PHPStan\Rules\Comparison\NumberComparisonOperatorsConstantConditionRuleTest::testBug2851
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'09: Comparison operation ">" between int<1, 2> and 0 is always true.
 '

/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:182
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php:150

3) PHPStan\Rules\Comparison\StrictComparisonOfDifferentTypesRuleTest::testBug2851b
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'20: Strict comparison using === between array{0: 1|(literal-string&non-falsy-string)|false, 1: 1|'x'|'y', 2?: 'x'|'y', 3?: 'y'} and array{} will always evaluate to false.
 '

/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:182
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php:601

4) PHPStan\Rules\Variables\IssetRuleTest::testBug6008
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'39: Offset 'curl_id' on array{curl_id: int, exception: Bug6008\stdClass, id: int, origin: string, reject: callable(): mixed, request: array{url: string, options?: array, copyTo?: string|null}, resolve: mixed, response: Bug6008\stdClass, ...} in isset() always exists and is not nullable.
 '

/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:182
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Variables/IssetRuleTest.php:433
 ```