### PR TITLE
Introduce oversized-array type to enforce max number of HasOffsetValueType accessory types

### DIFF
--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -133,6 +133,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -134,6 +134,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -133,6 +133,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new UnionType([

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -144,6 +144,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -163,6 +163,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -141,6 +141,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -207,6 +207,11 @@ class ArrayType implements Type
 		return TrinaryLogic::createYes();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -315,6 +315,11 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -395,6 +395,11 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -117,6 +117,11 @@ class FloatType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -234,6 +234,11 @@ class IterableType implements CompoundType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -57,6 +57,11 @@ trait JustNullableTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -21,6 +21,7 @@ use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Accessory\OversizedArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Generic\TemplateMixedType;
@@ -431,6 +432,22 @@ class MixedType implements CompoundType, SubtractableType
 	{
 		if ($this->subtractedType !== null) {
 			if ($this->subtractedType->isSuperTypeOf(new ArrayType(new MixedType(), new MixedType()))->yes()) {
+				return TrinaryLogic::createNo();
+			}
+		}
+
+		return TrinaryLogic::createMaybe();
+	}
+
+	public function isOversizedArray(): TrinaryLogic
+	{
+		if ($this->subtractedType !== null) {
+			$oversizedArray = TypeCombinator::intersect(
+				new ArrayType(new MixedType(), new MixedType()),
+				new OversizedArrayType(),
+			);
+
+			if ($this->subtractedType->isSuperTypeOf($oversizedArray)->yes()) {
 				return TrinaryLogic::createNo();
 			}
 		}

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -233,6 +233,11 @@ class NeverType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -175,6 +175,11 @@ class NullType implements ConstantScalarType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -797,6 +797,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -332,6 +332,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->isArray();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return $this->getStaticObjectType()->isOversizedArray();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isString();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -153,6 +153,11 @@ class StrictMixedType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -130,6 +130,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->isArray();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return $this->resolve()->isOversizedArray();
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		return $this->resolve()->isOffsetAccessible();

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -105,6 +105,11 @@ trait ObjectTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -63,6 +63,8 @@ interface Type
 
 	public function isArray(): TrinaryLogic;
 
+	public function isOversizedArray(): TrinaryLogic;
+
 	public function isOffsetAccessible(): TrinaryLogic;
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -424,6 +424,11 @@ class UnionType implements CompoundType
 		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isArray());
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isOversizedArray());
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isString());

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -102,6 +102,11 @@ class VoidType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isString(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/tests/PHPStan/Analyser/data/bug-5081.php
+++ b/tests/PHPStan/Analyser/data/bug-5081.php
@@ -2,6 +2,8 @@
 
 namespace Bug5081;
 
+use function PHPStan\Testing\assertType;
+
 global $_LANGADM;
 
 $_LANGADM = [];
@@ -501,3 +503,4 @@ $_LANGADM['AdminCustomerPreferences9f7a304fd501ed0e4d06b899fed739d0'] = 'Only ac
 $_LANGADM['AdminCustomerPreferencesf2c822352f0e0a62e2de6d716475911b'] = 'Standard (account creation and address creation)';
 $_LANGADM['AdminCustomerPreferences0db377921f4ce762c62526131097968f'] = 'General';
 $_LANGADM['AdminCustomerPreferencesbcb9adf1d2347258b5c65483e34cf86f'] = 'Registration process type';
+assertType('non-empty-array<literal-string&non-falsy-string, literal-string&non-falsy-string>&oversized-array', $_LANGADM);

--- a/tests/PHPStan/Rules/Api/ApiClassImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Api/ApiClassImplementsRuleTest.php
@@ -42,7 +42,7 @@ class ApiClassImplementsRuleTest extends RuleTestCase
 			],
 			[
 				'Implementing PHPStan\Reflection\ReflectionProvider is not covered by backward compatibility promise. The interface might change in a minor PHPStan version.',
-				312,
+				317,
 				$tip,
 			],
 		]);

--- a/tests/PHPStan/Rules/Api/data/class-implements-out-of-phpstan.php
+++ b/tests/PHPStan/Rules/Api/data/class-implements-out-of-phpstan.php
@@ -156,6 +156,11 @@ class Baz implements Type
 		// TODO: Implement isArray() method.
 	}
 
+	public function isOversizedArray(): \PHPStan\TrinaryLogic
+	{
+		// TODO: Implement isOversizedArray() method.
+	}
+
 	public function isOffsetAccessible(): \PHPStan\TrinaryLogic
 	{
 		// TODO: Implement isOffsetAccessible() method.


### PR DESCRIPTION
This is a generalization of e06f6f0705fc1895db5eab2ce1d42a04d047c1d8 that replaces "too many" `HasOffsetValueType`s with an "oversized array" type.