### PR TITLE
Use TypeUtils::getOldConstantArrays in array_pop and array_shift extensions

### DIFF
--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -42,9 +42,7 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 					$valueTypes[] = new NullType();
 					continue;
 				}
-
-				$constantArray->removeLast($removedValueType);
-				$valueTypes[] = $removedValueType;
+				$valueTypes[] = $constantArray->getLastValueType();
 			}
 
 			return TypeCombinator::union(...$valueTypes);

--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -33,7 +33,7 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getConstantArrays($argType);
+		$constantArrays = TypeUtils::getOldConstantArrays($argType);
 		if (count($constantArrays) > 0) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {
@@ -43,7 +43,8 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 					continue;
 				}
 
-				$valueTypes[] = $constantArray->getOffsetValueType($arrayKeyTypes[count($arrayKeyTypes) - 1]);
+				$constantArray->removeLast($removedValueType);
+				$valueTypes[] = $removedValueType;
 			}
 
 			return TypeCombinator::union(...$valueTypes);

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -43,8 +43,7 @@ class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnType
 					continue;
 				}
 
-				$constantArray->removeFirst($removedValueType);
-				$valueTypes[] = $removedValueType;
+				$valueTypes[] = $constantArray->getFirstValueType();
 			}
 
 			return TypeCombinator::union(...$valueTypes);

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -33,7 +33,7 @@ class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnType
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getConstantArrays($argType);
+		$constantArrays = TypeUtils::getOldConstantArrays($argType);
 		if (count($constantArrays) > 0) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {
@@ -43,7 +43,8 @@ class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnType
 					continue;
 				}
 
-				$valueTypes[] = $constantArray->getOffsetValueType($arrayKeyTypes[0]);
+				$constantArray->removeFirst($removedValueType);
+				$valueTypes[] = $removedValueType;
 			}
 
 			return TypeCombinator::union(...$valueTypes);

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -38,11 +38,11 @@ class Foo
 	public function constantArraysWithOptionalKeys(array $arr): void
 	{
 		/** @var array{a?: 0, b: 1, c: 2} $arr */
-		assertType('0|2', array_pop($arr)); // should be 2
+		assertType('2', array_pop($arr));
 		assertType('array{a?: 0, b: 1}', $arr);
 
 		/** @var array{a: 0, b?: 1, c: 2} $arr */
-		assertType('1|2', array_pop($arr)); // should be 2
+		assertType('2', array_pop($arr));
 		assertType('array{a: 0, b?: 1}', $arr);
 
 		/** @var array{a: 0, b: 1, c?: 2} $arr */

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -38,7 +38,7 @@ class Foo
 	public function constantArraysWithOptionalKeys(array $arr): void
 	{
 		/** @var array{a?: 0, b: 1, c: 2} $arr */
-		assertType('1', array_shift($arr)); // should be 0|1
+		assertType('0|1', array_shift($arr));
 		assertType('array{b?: 1, c: 2}', $arr);
 
 		/** @var array{a: 0, b?: 1, c: 2} $arr */


### PR DESCRIPTION
~~Since the logic for removing first and last elements was already there I wanted to re-use it. I'm not the biggest fan of passing this info by reference, but did not come up with something better yet.~~

I'd like to get rid of `TypeUtils::getConstantArrays` for performance reasons where possible.