### PR TITLE
Restrict some workflows to the main repository

### DIFF
--- a/.github/workflows/apiref.yml
+++ b/.github/workflows/apiref.yml
@@ -53,6 +53,7 @@ jobs:
     name: "Deploy"
     needs:
       - apigen
+    if: github.repository_owner == 'phpstan'
     runs-on: "ubuntu-latest"
     steps:
       - name: "Install Node"

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -141,9 +141,9 @@ jobs:
       phar-checksum: ${{needs.compiler-tests.outputs.checksum}}
 
   commit:
-    if: "github.ref == 'refs/heads/1.8.x' || startsWith(github.ref, 'refs/tags/')"
-    needs: compiler-tests
     name: "Commit PHAR"
+    if: "github.repository_owner == 'phpstan' && (github.ref == 'refs/heads/1.8.x' || startsWith(github.ref, 'refs/tags/'))"
+    needs: compiler-tests
     runs-on: "ubuntu-latest"
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Skip jobs that are deemed to fail on cloned repositories