### PR TITLE
Use TypeUtils::getOldConstantArrays in array_fill_keys extension

### DIFF
--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -33,7 +33,7 @@ class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnT
 
 		$valueType = $scope->getType($functionCall->getArgs()[1]->value);
 		$keysType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = TypeUtils::getConstantArrays($keysType);
+		$constantArrays = TypeUtils::getOldConstantArrays($keysType);
 		if (count($constantArrays) === 0) {
 			if ($keysType->isArray()->yes()) {
 				$itemType = $keysType->getIterableValueType();
@@ -53,15 +53,15 @@ class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnT
 		$arrayTypes = [];
 		foreach ($constantArrays as $constantArray) {
 			$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-			foreach ($constantArray->getValueTypes() as $keyType) {
+			foreach ($constantArray->getValueTypes() as $i => $keyType) {
 				if ((new IntegerType())->isSuperTypeOf($keyType)->no()) {
 					if ($keyType->toString() instanceof ErrorType) {
 						return new NeverType();
 					}
 
-					$arrayBuilder->setOffsetValueType($keyType->toString(), $valueType);
+					$arrayBuilder->setOffsetValueType($keyType->toString(), $valueType, $constantArray->isOptionalKey($i));
 				} else {
-					$arrayBuilder->setOffsetValueType($keyType, $valueType);
+					$arrayBuilder->setOffsetValueType($keyType, $valueType, $constantArray->isOptionalKey($i));
 				}
 			}
 			$arrayTypes[] = $arrayBuilder->getArray();

--- a/tests/PHPStan/Analyser/data/array-fill-keys.php
+++ b/tests/PHPStan/Analyser/data/array-fill-keys.php
@@ -51,6 +51,28 @@ function withObjectKey() : array
 	assertType("*NEVER*", array_fill_keys([new Baz()], 'b'));
 }
 
+function withUnionKeys(): void
+{
+	$arr1 = ['foo', rand(0, 1) ? 'bar1' : 'bar2', 'baz'];
+	assertType("non-empty-array<'bar1'|'bar2'|'baz'|'foo', 'b'>", array_fill_keys($arr1, 'b'));
+
+	$arr2 = ['foo'];
+	if (rand(0, 1)) {
+		$arr2[] = 'bar';
+	}
+	$arr2[] = 'baz';
+	assertType("non-empty-array<'bar'|'baz'|'foo', 'b'>", array_fill_keys($arr2, 'b'));
+}
+
+function withOptionalKeys(): void
+{
+	$arr1 = ['foo', 'bar'];
+	if (rand(0, 1)) {
+		$arr1[] = 'baz';
+	}
+	assertType("array{foo: 'b', bar: 'b', baz?: 'b'}", array_fill_keys($arr1, 'b'));
+}
+
 /**
  * @param Bar[] $foo
  * @param int[] $bar


### PR DESCRIPTION
jfyi: an optional key that is not at the end of the array will lead to a union key which will lead to generalization to a generic array via the ConstantArrayBuilder, which makes sense since a union cannot be used as key. this is not changed behaviour but surprised me for a second when I added optional key tests :)