### PR TITLE
Use TypeUtils::getOldConstantArrays in array_reduce extension

### DIFF
--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -45,12 +45,12 @@ class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 
 		$arraysType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = TypeUtils::getConstantArrays($arraysType);
+		$constantArrays = TypeUtils::getOldConstantArrays($arraysType);
 		if (count($constantArrays) > 0) {
 			$onlyEmpty = true;
 			$onlyNonEmpty = true;
 			foreach ($constantArrays as $constantArray) {
-				$isEmpty = count($constantArray->getValueTypes()) === 0;
+				$isEmpty = $constantArray->isEmpty();
 				$onlyEmpty = $onlyEmpty && $isEmpty;
 				$onlyNonEmpty = $onlyNonEmpty && !$isEmpty;
 			}


### PR DESCRIPTION
This is only doing emptyness checks and for that optional keys don't need to be considered AFAIK.