### PR TITLE
Use TypeUtils::getOldConstantArrays in array pointer functions extension

### DIFF
--- a/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
@@ -44,21 +44,18 @@ class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunction
 			return new ConstantBooleanType(false);
 		}
 
-		$constantArrays = TypeUtils::getConstantArrays($argType);
+		$constantArrays = TypeUtils::getOldConstantArrays($argType);
 		if (count($constantArrays) > 0) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {
-				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($constantArray->isEmpty()) {
 					$keyTypes[] = new ConstantBooleanType(false);
 					continue;
 				}
 
-				$valueOffset = $functionReflection->getName() === 'reset'
-					? $arrayKeyTypes[0]
-					: $arrayKeyTypes[count($arrayKeyTypes) - 1];
-
-				$keyTypes[] = $constantArray->getOffsetValueType($valueOffset);
+				$keyTypes[] = $functionReflection->getName() === 'reset'
+					? $constantArray->getFirstValueType()
+					: $constantArray->getLastValueType();
 			}
 
 			return TypeCombinator::union(...$keyTypes);

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -7299,6 +7299,18 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'reset($conditionalArray)',
 			],
 			[
+				'0|1',
+				'reset($constantArrayOptionalKeys1)',
+			],
+			[
+				'0',
+				'reset($constantArrayOptionalKeys2)',
+			],
+			[
+				'0',
+				'reset($constantArrayOptionalKeys3)',
+			],
+			[
 				'mixed',
 				'end()',
 			],
@@ -7321,6 +7333,18 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			[
 				'\'bar\'|\'baz\'',
 				'end($secondConditionalArray)',
+			],
+			[
+				'2',
+				'end($constantArrayOptionalKeys1)',
+			],
+			[
+				'2',
+				'end($constantArrayOptionalKeys2)',
+			],
+			[
+				'1|2',
+				'end($constantArrayOptionalKeys3)',
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/data/array-pointer-functions.php
+++ b/tests/PHPStan/Analyser/data/array-pointer-functions.php
@@ -2,6 +2,8 @@
 
 namespace ResetDynamicReturnTypeExtension;
 
+use function PHPStan\Testing\assertType;
+
 class Foo
 {
 
@@ -16,6 +18,12 @@ class Foo
 			'a' => 1,
 			'b' => 2,
 		];
+		/** @var array{a?: 0, b: 1, c: 2} $constantArrayOptionalKeys1 */
+		$constantArrayOptionalKeys1 = [];
+		/** @var array{a: 0, b?: 1, c: 2} $constantArrayOptionalKeys2 */
+		$constantArrayOptionalKeys2 = [];
+		/** @var array{a: 0, b: 1, c?: 2} $constantArrayOptionalKeys3 */
+		$constantArrayOptionalKeys3 = [];
 
 		$conditionalArray = ['foo', 'bar'];
 		if (doFoo()) {


### PR DESCRIPTION
I noticed that this is fixing the same optional key edge cases as https://github.com/phpstan/phpstan-src/pull/1668 did, but for `reset` and `end`