### PR TITLE
Use TypeUtils::getOldConstantArrays in RegularExpressionPatternRule

### DIFF
--- a/src/Rules/Regexp/RegularExpressionPatternRule.php
+++ b/src/Rules/Regexp/RegularExpressionPatternRule.php
@@ -83,7 +83,7 @@ class RegularExpressionPatternRule implements Rule
 			$patternStrings[] = $constantStringType->getValue();
 		}
 
-		foreach (TypeUtils::getConstantArrays($patternType) as $constantArrayType) {
+		foreach (TypeUtils::getOldConstantArrays($patternType) as $constantArrayType) {
 			if (
 				in_array($functionName, [
 					'preg_replace',


### PR DESCRIPTION
This is only getting all patterns here from the array and it should not matter if a key is optional or not, the pattern needs to be checked anyways