### PR TITLE
Use TypeUtils::getOldConstantArrays in array_key_first and array_key_last extensions

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -212,6 +212,32 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $this->keyTypes;
 	}
 
+	public function getFirstKeyType(): Type
+	{
+		$keyTypes = [];
+		foreach ($this->keyTypes as $i => $keyType) {
+			$keyTypes[] = $keyType;
+			if (!$this->isOptionalKey($i)) {
+				break;
+			}
+		}
+
+		return TypeCombinator::union(...$keyTypes);
+	}
+
+	public function getLastKeyType(): Type
+	{
+		$keyTypes = [];
+		for ($i = count($this->keyTypes) - 1; $i >= 0; $i--) {
+			$keyTypes[] = $this->keyTypes[$i];
+			if (!$this->isOptionalKey($i)) {
+				break;
+			}
+		}
+
+		return TypeCombinator::union(...$keyTypes);
+	}
+
 	/**
 	 * @return array<int, Type>
 	 */
@@ -223,8 +249,8 @@ class ConstantArrayType extends ArrayType implements ConstantType
 	public function getFirstValueType(): Type
 	{
 		$valueTypes = [];
-		for ($i = 0, $keyTypesCount = count($this->keyTypes); $i < $keyTypesCount; $i++) {
-			$valueTypes[] = $this->valueTypes[$i];
+		foreach ($this->valueTypes as $i => $valueType) {
+			$valueTypes[] = $valueType;
 			if (!$this->isOptionalKey($i)) {
 				break;
 			}

--- a/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
@@ -33,17 +33,16 @@ class ArrayKeyFirstDynamicReturnTypeExtension implements DynamicFunctionReturnTy
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getConstantArrays($argType);
+		$constantArrays = TypeUtils::getOldConstantArrays($argType);
 		if (count($constantArrays) > 0) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {
-				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($constantArray->isEmpty()) {
 					$keyTypes[] = new NullType();
 					continue;
 				}
 
-				$keyTypes[] = $arrayKeyTypes[0];
+				$keyTypes[] = $constantArray->getFirstKeyType();
 			}
 
 			return TypeCombinator::union(...$keyTypes);

--- a/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
@@ -33,17 +33,16 @@ class ArrayKeyLastDynamicReturnTypeExtension implements DynamicFunctionReturnTyp
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getConstantArrays($argType);
+		$constantArrays = TypeUtils::getOldConstantArrays($argType);
 		if (count($constantArrays) > 0) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {
-				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				if ($constantArray->isEmpty()) {
 					$keyTypes[] = new NullType();
 					continue;
 				}
 
-				$keyTypes[] = $arrayKeyTypes[count($arrayKeyTypes) - 1];
+				$keyTypes[] = $constantArray->getLastKeyType();
 			}
 
 			return TypeCombinator::union(...$keyTypes);

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8773,6 +8773,30 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_key_last($anotherLiteralArray)',
 			],
 			[
+				"'a'|'b'",
+				'array_key_first($constantArrayOptionalKeys1)',
+			],
+			[
+				"'c'",
+				'array_key_last($constantArrayOptionalKeys1)',
+			],
+			[
+				"'a'",
+				'array_key_first($constantArrayOptionalKeys2)',
+			],
+			[
+				"'c'",
+				'array_key_last($constantArrayOptionalKeys2)',
+			],
+			[
+				"'a'",
+				'array_key_first($constantArrayOptionalKeys3)',
+			],
+			[
+				"'b'|'c'",
+				'array_key_last($constantArrayOptionalKeys3)',
+			],
+			[
 				'array{int, int}',
 				'$hrtime1',
 			],

--- a/tests/PHPStan/Analyser/data/php73_functions.php
+++ b/tests/PHPStan/Analyser/data/php73_functions.php
@@ -11,13 +11,19 @@ class Foo
 	 * @param array $mixedArray
 	 * @param array $nonEmptyArray
 	 * @param array<string, mixed> $arrayWithStringKeys
+	 * @param array{a?: 0, b: 1, c: 2} $constantArrayOptionalKeys1
+	 * @param array{a: 0, b?: 1, c: 2} $constantArrayOptionalKeys2
+	 * @param array{a: 0, b: 1, c?: 2} $constantArrayOptionalKeys3
 	 */
 	public function doFoo(
 		$mixed,
 		int $integer,
 		array $mixedArray,
 		array $nonEmptyArray,
-		array $arrayWithStringKeys
+		array $arrayWithStringKeys,
+		array $constantArrayOptionalKeys1,
+		array $constantArrayOptionalKeys2,
+		array $constantArrayOptionalKeys3
 	)
 	{
 		if (count($nonEmptyArray) === 0) {


### PR DESCRIPTION
Here we go again :) This also fixes the same optional key edge cases as https://github.com/phpstan/phpstan-src/pull/1668 did