### PR TITLE
Use TypeUtils::getOldConstantArrays in array_column extension

### DIFF
--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -46,7 +46,7 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		$columnType = $scope->getType($functionCall->getArgs()[1]->value);
 		$indexType = $numArgs >= 3 ? $scope->getType($functionCall->getArgs()[2]->value) : null;
 
-		$constantArrayTypes = TypeUtils::getConstantArrays($arrayType);
+		$constantArrayTypes = TypeUtils::getOldConstantArrays($arrayType);
 		if (count($constantArrayTypes) === 1) {
 			$type = $this->handleConstantArray($constantArrayTypes[0], $columnType, $indexType, $scope);
 			if ($type !== null) {
@@ -108,7 +108,7 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 	{
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 
-		foreach ($arrayType->getValueTypes() as $iterableValueType) {
+		foreach ($arrayType->getValueTypes() as $i => $iterableValueType) {
 			$valueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
 			if ($valueType === null) {
 				return null;
@@ -133,7 +133,7 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 			if ($keyType !== null) {
 				$keyType = $this->castToArrayKeyType($keyType);
 			}
-			$builder->setOffsetValueType($keyType, $valueType);
+			$builder->setOffsetValueType($keyType, $valueType, $arrayType->isOptionalKey($i));
 		}
 
 		return $builder->getArray();

--- a/tests/PHPStan/Analyser/data/array-column-php82.php
+++ b/tests/PHPStan/Analyser/data/array-column-php82.php
@@ -138,6 +138,13 @@ class ArrayColumnTest
 		assertType('array<\'\', string>', array_column($array, 'column', 'key'));
 	}
 
+	/** @param array{0?: array{column: 'foo', key: 'bar'}} $array */
+	public function testConstantArray12(array $array): void
+	{
+		assertType("array{0?: 'foo'}", array_column($array, 'column'));
+		assertType("array{bar?: 'foo'}", array_column($array, 'column', 'key'));
+	}
+
 	// These cases aren't handled precisely and will return non-constant arrays.
 
 	/** @param array{array{column?: 'foo', key: 'bar'}} $array */
@@ -160,13 +167,6 @@ class ArrayColumnTest
 	{
 		assertType('array<int, string>', array_column($array, 'column'));
 		assertType('array<int|string, string>', array_column($array, 'column', 'key'));
-	}
-
-	/** @param array{0?: array{column: 'foo', key: 'bar'}} $array */
-	public function testImprecise4(array $array): void
-	{
-		assertType("array<int, 'foo'>", array_column($array, 'column'));
-		assertType("array<'bar', 'foo'>", array_column($array, 'column', 'key'));
 	}
 
 	/** @param array<int, DOMElement> $array */

--- a/tests/PHPStan/Analyser/data/array-column.php
+++ b/tests/PHPStan/Analyser/data/array-column.php
@@ -138,6 +138,27 @@ class ArrayColumnTest
 		assertType('array<\'\', string>', array_column($array, 'column', 'key'));
 	}
 
+	/** @param array{0?: array{column: 'foo', key: 'bar'}} $array */
+	public function testConstantArray12(array $array): void
+	{
+		assertType("array{0?: 'foo'}", array_column($array, 'column'));
+		assertType("array{bar?: 'foo'}", array_column($array, 'column', 'key'));
+	}
+
+	/** @param array{0?: array{column: 'foo1', key: 'bar1'}, 1?: array{column: 'foo2', key: 'bar2'}} $array */
+	public function testConstantArray13(array $array): void
+	{
+		assertType("array{0?: 'foo1'|'foo2', 1?: 'foo2'}", array_column($array, 'column'));
+		assertType("array{bar1?: 'foo1', bar2?: 'foo2'}", array_column($array, 'column', 'key'));
+	}
+
+	/** @param array{0?: array{column: 'foo1', key: 'bar1'}, 1: array{column: 'foo2', key: 'bar2'}} $array */
+	public function testConstantArray14(array $array): void
+	{
+		assertType("array{0: 'foo1'|'foo2', 1?: 'foo2'}", array_column($array, 'column'));
+		assertType("array{bar1?: 'foo1', bar2: 'foo2'}", array_column($array, 'column', 'key'));
+	}
+
 	// These cases aren't handled precisely and will return non-constant arrays.
 
 	/** @param array{array{column?: 'foo', key: 'bar'}} $array */
@@ -160,13 +181,6 @@ class ArrayColumnTest
 	{
 		assertType('array<int, string>', array_column($array, 'column'));
 		assertType('array<int|string, string>', array_column($array, 'column', 'key'));
-	}
-
-	/** @param array{0?: array{column: 'foo', key: 'bar'}} $array */
-	public function testImprecise4(array $array): void
-	{
-		assertType("array<int, 'foo'>", array_column($array, 'column'));
-		assertType("array<'bar', 'foo'>", array_column($array, 'column', 'key'));
 	}
 
 	/** @param array<int, DOMElement> $array */


### PR DESCRIPTION
looks like it made it a tiny bit smarter. `testImprecise4` was converted to `testConstantArray12`
