### PR TITLE
Introduce Type::getConstantArrays as successor for TypeUtils::getOldContantArrays

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1893,7 +1893,7 @@ class NodeScopeResolver
 					}
 				};
 
-				$constantArrays = TypeUtils::getOldConstantArrays($arrayType);
+				$constantArrays = $arrayType->getConstantArrays();
 				if (count($constantArrays) > 0) {
 					$newArrayTypes = [];
 					$prepend = $functionReflection->getName() === 'array_unshift';

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -907,8 +907,8 @@ class InitializerExprTypeResolver
 			return TypeCombinator::union(...$resultTypes);
 		}
 
-		$leftConstantArrays = TypeUtils::getOldConstantArrays($leftType);
-		$rightConstantArrays = TypeUtils::getOldConstantArrays($rightType);
+		$leftConstantArrays = $leftType->getConstantArrays();
+		$rightConstantArrays = $rightType->getConstantArrays();
 
 		$leftCount = count($leftConstantArrays);
 		$rightCount = count($rightConstantArrays);

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
@@ -48,7 +48,7 @@ class NonexistentOffsetInArrayDimFetchCheck
 		$hasOffsetValueType = $type->hasOffsetValueType($dimType);
 		$report = $hasOffsetValueType->no();
 		if ($hasOffsetValueType->maybe()) {
-			$constantArrays = TypeUtils::getOldConstantArrays($type);
+			$constantArrays = $type->getConstantArrays();
 			if (count($constantArrays) > 0) {
 				foreach ($constantArrays as $constantArray) {
 					if ($constantArray->hasOffsetValueType($dimType)->no()) {

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -87,7 +87,7 @@ class ImpossibleCheckTypeHelper
 						return null;
 					}
 
-					$constantArrays = TypeUtils::getOldConstantArrays($haystackType);
+					$constantArrays = $haystackType->getConstantArrays();
 					$needleType = $scope->getType($node->getArgs()[0]->value);
 					$valueType = $haystackType->getIterableValueType();
 					$constantNeedleTypesCount = count(TypeUtils::getConstantScalars($needleType));

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -100,7 +100,7 @@ class FunctionCallParametersCheck
 				$argumentName = $arg->name->toString();
 			}
 			if ($arg->unpack) {
-				$arrays = TypeUtils::getOldConstantArrays($type);
+				$arrays = $type->getConstantArrays();
 				if (count($arrays) > 0) {
 					$minKeys = null;
 					foreach ($arrays as $array) {

--- a/src/Rules/Regexp/RegularExpressionPatternRule.php
+++ b/src/Rules/Regexp/RegularExpressionPatternRule.php
@@ -83,7 +83,7 @@ class RegularExpressionPatternRule implements Rule
 			$patternStrings[] = $constantStringType->getValue();
 		}
 
-		foreach (TypeUtils::getOldConstantArrays($patternType) as $constantArrayType) {
+		foreach ($patternType->getConstantArrays() as $constantArrayType) {
 			if (
 				in_array($functionName, [
 					'preg_replace',

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -111,8 +111,8 @@ class RuleLevelHelper
 			$acceptedType->isArray()->yes()
 			&& $acceptingType->isArray()->yes()
 			&& !$acceptingType->isIterableAtLeastOnce()->yes()
-			&& count(TypeUtils::getOldConstantArrays($acceptedType)) === 0
-			&& count(TypeUtils::getOldConstantArrays($acceptingType)) === 0
+			&& count($acceptedType->getConstantArrays()) === 0
+			&& count($acceptingType->getConstantArrays()) === 0
 		) {
 			return self::accepts(
 				$acceptingType->getIterableKeyType(),

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -44,6 +44,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -41,6 +41,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -40,6 +40,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -73,6 +73,11 @@ class ArrayType implements Type
 		);
 	}
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -108,6 +108,11 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		);
 	}
 
+	public function getConstantArrays(): array
+	{
+		return [$this];
+	}
+
 	public function isEmpty(): bool
 	{
 		return count($this->keyTypes) === 0;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -100,6 +100,11 @@ class IntersectionType implements CompoundType
 		return UnionTypeHelper::getReferencedClasses($this->types);
 	}
 
+	public function getConstantArrays(): array
+	{
+		return UnionTypeHelper::getConstantArrays($this->getTypes());
+	}
+
 	public function accepts(Type $otherType, bool $strictTypes): TrinaryLogic
 	{
 		foreach ($this->types as $type) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -63,6 +63,11 @@ class MixedType implements CompoundType, SubtractableType
 		return [];
 	}
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -47,7 +47,7 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		$columnType = $scope->getType($functionCall->getArgs()[1]->value);
 		$indexType = $numArgs >= 3 ? $scope->getType($functionCall->getArgs()[2]->value) : null;
 
-		$constantArrayTypes = TypeUtils::getOldConstantArrays($arrayType);
+		$constantArrayTypes = $arrayType->getConstantArrays();
 		if (count($constantArrayTypes) === 1) {
 			$type = $this->handleConstantArray($constantArrayTypes[0], $columnType, $indexType, $scope);
 			if ($type !== null) {

--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -14,7 +14,6 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -33,7 +32,7 @@ class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnT
 
 		$valueType = $scope->getType($functionCall->getArgs()[1]->value);
 		$keysType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = TypeUtils::getOldConstantArrays($keysType);
+		$constantArrays = $keysType->getConstantArrays();
 		if (count($constantArrays) === 0) {
 			if ($keysType->isArray()->yes()) {
 				$itemType = $keysType->getIterableValueType();

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -164,7 +164,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 			throw new ShouldNotHappenException();
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($arrayType);
+		$constantArrays = $arrayType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$results = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
@@ -12,7 +12,6 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -32,7 +31,7 @@ class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 		$array = $functionCall->getArgs()[0]->value;
 		$argType = $scope->getType($array);
 
-		$constantArrays = TypeUtils::getOldConstantArrays($argType);
+		$constantArrays = $argType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$flipped = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function array_slice;
 use function count;
 
@@ -47,7 +46,7 @@ class ArrayIntersectKeyFunctionReturnTypeExtension implements DynamicFunctionRet
 			return $firstArray;
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($firstArray);
+		$constantArrays = $firstArray->getConstantArrays();
 		if (count($constantArrays) === 0) {
 			return new ArrayType($firstArray->getIterableKeyType(), $firstArray->getIterableValueType());
 		}

--- a/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayKeyFirstDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -34,7 +33,7 @@ class ArrayKeyFirstDynamicReturnTypeExtension implements DynamicFunctionReturnTy
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($argType);
+		$constantArrays = $argType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
@@ -10,7 +10,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayKeyLastDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -33,7 +32,7 @@ class ArrayKeyLastDynamicReturnTypeExtension implements DynamicFunctionReturnTyp
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($argType);
+		$constantArrays = $argType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -63,7 +63,7 @@ class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			if ($callableIsNull) {
 				return $arrayType;
 			}
-			$constantArrays = TypeUtils::getOldConstantArrays($arrayType);
+			$constantArrays = $arrayType->getConstantArrays();
 			if (count($constantArrays) > 0) {
 				$arrayTypes = [];
 				foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
@@ -10,7 +10,6 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 use function in_array;
 
@@ -44,7 +43,7 @@ class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunction
 			return new ConstantBooleanType(false);
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($argType);
+		$constantArrays = $argType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$keyTypes = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -10,7 +10,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -33,7 +32,7 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($argType);
+		$constantArrays = $argType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -46,7 +45,7 @@ class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 
 		$arraysType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = TypeUtils::getOldConstantArrays($arraysType);
+		$constantArrays = $arraysType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$onlyEmpty = TrinaryLogic::createYes();
 			$onlyNonEmpty = TrinaryLogic::createYes();

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -10,7 +10,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -33,7 +32,7 @@ class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnType
 			return new NullType();
 		}
 
-		$constantArrays = TypeUtils::getOldConstantArrays($argType);
+		$constantArrays = $argType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/CountFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CountFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 use function in_array;
 use const COUNT_RECURSIVE;
@@ -42,7 +41,7 @@ class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = TypeUtils::getOldConstantArrays($scope->getType($functionCall->getArgs()[0]->value));
+		$constantArrays = $scope->getType($functionCall->getArgs()[0]->value)->getConstantArrays();
 		if (count($constantArrays) === 0) {
 			if ($argType->isIterableAtLeastOnce()->yes()) {
 				return IntegerRangeType::fromInterval(1, null);

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -104,6 +104,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getReferencedClasses();
 	}
 
+	public function getConstantArrays(): array
+	{
+		return $this->getStaticObjectType()->getConstantArrays();
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -21,6 +21,11 @@ trait LateResolvableTypeTrait
 
 	private ?Type $result = null;
 
+	public function getConstantArrays(): array
+	{
+		return $this->resolve()->getConstantArrays();
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return $this->resolve()->accepts($type, $strictTypes);

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -7,6 +7,11 @@ use PHPStan\TrinaryLogic;
 trait MaybeArrayTypeTrait
 {
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -7,6 +7,11 @@ use PHPStan\TrinaryLogic;
 trait NonArrayTypeTrait
 {
 
+	public function getConstantArrays(): array
+	{
+		return [];
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeReference;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -22,6 +23,9 @@ interface Type
 	 * @return string[]
 	 */
 	public function getReferencedClasses(): array;
+
+	/** @return list<ConstantArrayType> */
+	public function getConstantArrays(): array;
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic;
 

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -63,6 +63,8 @@ class TypeUtils
 
 	/**
 	 * @return ConstantArrayType[]
+	 *
+	 * @deprecated Use PHPStan\Type\Type::getConstantArrays() instead and handle optional keys if necessary.
 	 */
 	public static function getConstantArrays(Type $type): array
 	{
@@ -185,6 +187,8 @@ class TypeUtils
 	/**
 	 * @internal
 	 * @return ConstantArrayType[]
+	 *
+	 * @deprecated Use PHPStan\Type\Type::getConstantArrays().
 	 */
 	public static function getOldConstantArrays(Type $type): array
 	{

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -97,6 +97,11 @@ class UnionType implements CompoundType
 		return UnionTypeHelper::getReferencedClasses($this->getTypes());
 	}
 
+	public function getConstantArrays(): array
+	{
+		return UnionTypeHelper::getConstantArrays($this->getTypes());
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if (

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use function array_map;
 use function array_merge;
 use function count;
 use function strcasecmp;
@@ -23,12 +24,26 @@ class UnionTypeHelper
 	 */
 	public static function getReferencedClasses(array $types): array
 	{
-		$subTypeClasses = [];
-		foreach ($types as $type) {
-			$subTypeClasses[] = $type->getReferencedClasses();
-		}
+		return array_merge(
+			...array_map(
+				static fn (Type $type) => $type->getReferencedClasses(),
+				$types,
+			),
+		);
+	}
 
-		return array_merge(...$subTypeClasses);
+	/**
+	 * @param Type[] $types
+	 * @return list<ConstantArrayType>
+	 */
+	public static function getConstantArrays(array $types): array
+	{
+		return array_merge(
+			...array_map(
+				static fn (Type $type) => $type->getConstantArrays(),
+				$types,
+			),
+		);
 	}
 
 	/**

--- a/tests/PHPStan/Levels/data/arrayDimFetches-7-missing.json
+++ b/tests/PHPStan/Levels/data/arrayDimFetches-7-missing.json
@@ -1,10 +1,5 @@
 [
     {
-        "message": "Offset 'b' does not exist on array{a: 1}.",
-        "line": 21,
-        "ignorable": true
-    },
-    {
         "message": "Offset 'b' does not exist on array{a: 1}|stdClass.",
         "line": 28,
         "ignorable": true

--- a/tests/PHPStan/Levels/data/arrayDimFetches-8-missing.json
+++ b/tests/PHPStan/Levels/data/arrayDimFetches-8-missing.json
@@ -1,10 +1,5 @@
 [
     {
-        "message": "Offset 'b' does not exist on array{a: 1}.",
-        "line": 21,
-        "ignorable": true
-    },
-    {
         "message": "Offset 'b' does not exist on array{a: 1}|stdClass.",
         "line": 28,
         "ignorable": true

--- a/tests/PHPStan/Levels/data/arrayDimFetches-9-missing.json
+++ b/tests/PHPStan/Levels/data/arrayDimFetches-9-missing.json
@@ -1,10 +1,5 @@
 [
     {
-        "message": "Offset 'b' does not exist on array{a: 1}.",
-        "line": 21,
-        "ignorable": true
-    },
-    {
         "message": "Offset 'b' does not exist on array{a: 1}|stdClass.",
         "line": 28,
         "ignorable": true


### PR DESCRIPTION
and deprecate the now both unused `TypeUtils::getOldContantArrays()` and `TypeUtils::getConstantArrays()`