### PR TITLE
Optimize complex constant array combinations

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -597,7 +597,7 @@ class TypeCombinator
 
 		$keyTypesForGeneralArray = [];
 		$valueTypesForGeneralArray = [];
-		$generalArrayOccurred = false;
+		$generalArrayOccurred = count($arrayTypes) > 64;
 		$constantKeyTypesNumbered = [];
 
 		/** @var int|float $nextConstantKeyTypeIndex */


### PR DESCRIPTION
Degrade to a general array sooner to prevent exponentially bad performance in `TypeCombinator::reduceArrays()`. The code generated by the [test script](https://github.com/phpstan/phpstan/issues/7581#issuecomment-1184745360) finish in reasonable time.