### PR TITLE
Deprecate TypeUtils::getArrays

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4701,8 +4701,8 @@ class MutatingScope implements Scope
 
 				$aValueType = $generalArraysA->getIterableValueType();
 				$bValueType = $generalArraysB->getIterableValueType();
-				$aArrays = TypeUtils::getAnyArrays($aValueType);
-				$bArrays = TypeUtils::getAnyArrays($bValueType);
+				$aArrays = $aValueType->getArrays();
+				$bArrays = $bValueType->getArrays();
 				if (
 					count($aArrays) === 1
 					&& !$aArrays[0] instanceof ConstantArrayType
@@ -4883,7 +4883,7 @@ class MutatingScope implements Scope
 		$depth = 0;
 		while ($type instanceof ArrayType) {
 			$temp = $type->getIterableValueType();
-			$arrays = TypeUtils::getAnyArrays($temp);
+			$arrays = $temp->getArrays();
 			if (count($arrays) === 1) {
 				$type = $arrays[0];
 			} else {

--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use function count;
 use function sprintf;
@@ -34,7 +33,7 @@ class InvalidKeyInArrayDimFetchRule implements Rule
 		}
 
 		$varType = $scope->getType($node->var);
-		if (count(TypeUtils::getAnyArrays($varType)) === 0) {
+		if (count($varType->getArrays()) === 0) {
 			return [];
 		}
 

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -108,16 +108,30 @@ class ImpossibleCheckTypeHelper
 					}
 
 					if (!$haystackType instanceof ConstantArrayType || count($haystackType->getValueTypes()) > 0) {
-						$haystackArrayTypes = TypeUtils::getArrays($haystackType);
+						$haystackArrayTypes = $haystackType->getArrays();
 						if (count($haystackArrayTypes) === 1 && $haystackArrayTypes[0]->getIterableValueType() instanceof NeverType) {
 							return null;
 						}
 
 						if ($isNeedleSupertype->maybe() || $isNeedleSupertype->yes()) {
 							foreach ($haystackArrayTypes as $haystackArrayType) {
-								foreach (TypeUtils::getConstantScalars($haystackArrayType->getIterableValueType()) as $constantScalarType) {
-									if ($constantScalarType->isSuperTypeOf($needleType)->yes()) {
-										continue 2;
+								if ($haystackArrayType instanceof ConstantArrayType) {
+									foreach ($haystackArrayType->getValueTypes() as $i => $haystackArrayValueType) {
+										if ($haystackArrayType->isOptionalKey($i)) {
+											continue;
+										}
+
+										foreach (TypeUtils::getConstantScalars($haystackArrayValueType) as $constantScalarType) {
+											if ($constantScalarType->isSuperTypeOf($needleType)->yes()) {
+												continue 3;
+											}
+										}
+									}
+								} else {
+									foreach (TypeUtils::getConstantScalars($haystackArrayType->getIterableValueType()) as $constantScalarType) {
+										if ($constantScalarType->isSuperTypeOf($needleType)->yes()) {
+											continue 2;
+										}
 									}
 								}
 

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -44,6 +44,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getArrays(): array
+	{
+		return [];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -41,6 +41,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getArrays(): array
+	{
+		return [];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -40,6 +40,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getArrays(): array
+	{
+		return [];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -73,6 +73,11 @@ class ArrayType implements Type
 		);
 	}
 
+	public function getArrays(): array
+	{
+		return [$this];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -100,6 +100,11 @@ class IntersectionType implements CompoundType
 		return UnionTypeHelper::getReferencedClasses($this->types);
 	}
 
+	public function getArrays(): array
+	{
+		return UnionTypeHelper::getArrays($this->getTypes());
+	}
+
 	public function getConstantArrays(): array
 	{
 		return UnionTypeHelper::getConstantArrays($this->getTypes());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -63,6 +63,11 @@ class MixedType implements CompoundType, SubtractableType
 		return [];
 	}
 
+	public function getArrays(): array
+	{
+		return [];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -29,7 +29,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function array_map;
 use function count;
 use function is_string;
@@ -70,7 +69,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 
 		if ($callbackArg === null || ($callbackArg instanceof ConstFetch && strtolower($callbackArg->name->parts[0]) === 'null')) {
 			return TypeCombinator::union(
-				...array_map([$this, 'removeFalsey'], TypeUtils::getArrays($arrayArgType)),
+				...array_map([$this, 'removeFalsey'], $arrayArgType->getArrays()),
 			);
 		}
 
@@ -139,7 +138,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 				if ($isFalsey->maybe()) {
 					$builder->setOffsetValueType($keys[$offset], TypeCombinator::remove($value, $falseyTypes), true);
 				} elseif ($isFalsey->no()) {
-					$builder->setOffsetValueType($keys[$offset], $value);
+					$builder->setOffsetValueType($keys[$offset], $value, $type->isOptionalKey($offset));
 				}
 			}
 

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -14,7 +14,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 
 final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -57,7 +56,7 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 			$typesFromConstantArrays[] = new NullType();
 		}
 
-		$haystackArrays = TypeUtils::getAnyArrays($haystackArgType);
+		$haystackArrays = $haystackArgType->getArrays();
 		if (count($haystackArrays) === 0) {
 			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -104,6 +104,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getReferencedClasses();
 	}
 
+	public function getArrays(): array
+	{
+		return $this->getStaticObjectType()->getArrays();
+	}
+
 	public function getConstantArrays(): array
 	{
 		return $this->getStaticObjectType()->getConstantArrays();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -21,6 +21,11 @@ trait LateResolvableTypeTrait
 
 	private ?Type $result = null;
 
+	public function getArrays(): array
+	{
+		return $this->resolve()->getArrays();
+	}
+
 	public function getConstantArrays(): array
 	{
 		return $this->resolve()->getConstantArrays();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -7,6 +7,11 @@ use PHPStan\TrinaryLogic;
 trait MaybeArrayTypeTrait
 {
 
+	public function getArrays(): array
+	{
+		return [];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -7,6 +7,11 @@ use PHPStan\TrinaryLogic;
 trait NonArrayTypeTrait
 {
 
+	public function getArrays(): array
+	{
+		return [];
+	}
+
 	public function getConstantArrays(): array
 	{
 		return [];

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -24,6 +24,9 @@ interface Type
 	 */
 	public function getReferencedClasses(): array;
 
+	/** @return list<ArrayType> */
+	public function getArrays(): array;
+
 	/** @return list<ConstantArrayType> */
 	public function getConstantArrays(): array;
 

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -19,6 +19,8 @@ class TypeUtils
 
 	/**
 	 * @return ArrayType[]
+	 *
+	 * @deprecated Use PHPStan\Type\Type::getArrays() instead and handle optional ConstantArrayType keys if necessary.
 	 */
 	public static function getArrays(Type $type): array
 	{
@@ -123,6 +125,8 @@ class TypeUtils
 
 	/**
 	 * @return ArrayType[]
+	 *
+	 * @deprecated Use PHPStan\Type\Type::getArrays() instead.
 	 */
 	public static function getAnyArrays(Type $type): array
 	{

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -97,6 +97,11 @@ class UnionType implements CompoundType
 		return UnionTypeHelper::getReferencedClasses($this->getTypes());
 	}
 
+	public function getArrays(): array
+	{
+		return UnionTypeHelper::getArrays($this->getTypes());
+	}
+
 	public function getConstantArrays(): array
 	{
 		return UnionTypeHelper::getConstantArrays($this->getTypes());

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -34,6 +34,20 @@ class UnionTypeHelper
 
 	/**
 	 * @param Type[] $types
+	 * @return list<ArrayType>
+	 */
+	public static function getArrays(array $types): array
+	{
+		return array_merge(
+			...array_map(
+				static fn (Type $type) => $type->getArrays(),
+				$types,
+			),
+		);
+	}
+
+	/**
+	 * @param Type[] $types
 	 * @return list<ConstantArrayType>
 	 */
 	public static function getConstantArrays(array $types): array


### PR DESCRIPTION
Deprecates `TypeUtils::getArrays()` and `TypeUtils::getAnyArrays()` in favor of `Type::getArrays()`

I might be getting a bit greedy now, but this is the first step towards reducing usage of `ConstantArrayType::getAllArrays()`