### PR TITLE
Fix ConstantArrayType::isKeysSupersetOf for tagged unions

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1198,7 +1198,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 				$valueType = $this->valueTypes[$i];
 				$otherValueType = $otherArray->valueTypes[$j];
-				if ($valueType->isSuperTypeOf($otherValueType)->no()) {
+				if ($otherValueType->isSuperTypeOf($valueType)->no()) {
 					continue;
 				}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -237,6 +237,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testBug7898(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-7898.php'], []);
+	}
+
 	public function testImpossibleCheckTypeFunctionCallWithoutAlwaysTrue(): void
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = false;

--- a/tests/PHPStan/Rules/Comparison/data/bug-7898.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7898.php
@@ -1,0 +1,260 @@
+<?php // lint >= 8.0
+
+namespace Bug7898;
+
+class FooEnum
+{
+	public const FOO_TYPE = 'foo';
+	public const APPLICABLE_TAX_AND_FEES_BY_TYPE = [
+		'US' => [
+			'bar' => [
+				'sales_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'city_tax' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+				'resort_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+				'additional_tax_or_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+			],
+			'foo' => [
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'CA' => [
+			'bar' => [
+				'goods_and_services_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'provincial_sales_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'harmonized_sales_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'municipal_and_regional_district_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'additional_tax_or_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'SG' => [
+			'bar' => [
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'TH' => [
+			'bar' => [
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'city_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'AE' => [
+			'bar' => [
+				'vat' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'municipality_fee' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'tourism_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+				'destination_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'BH' => [
+			'bar' => [
+				'vat' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'city_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'HK' => [
+			'bar' => [
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'ES' => [
+			'bar' => [
+				'city_tax' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+	];
+}
+
+class Country
+{
+	public function __construct(private string $code)
+	{
+	}
+
+	public function getCode(): string
+	{
+		return $this->code;
+	}
+}
+
+class Foo
+{
+	public function __construct(private Country $country)
+	{
+	}
+
+	public const TAXES_AND_FEES_DAYCATION = 'daycation';
+	public const APPLICABLE_TAX_AND_FEES_BY_OFFER = [
+		'CA' => [
+			'dayuse' => [
+				'goods_and_services_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'provincial_sales_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'harmonized_sales_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'municipal_and_regional_district_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'additional_tax_or_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'SG' => [
+			'dayuse' => [
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'TH' => [
+			'dayuse' => [
+				'service_charge' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'city_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+		'US' => [
+			'daycation' => [
+				'tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+			],
+			'dayuse' => [
+				'sales_tax' => [
+					'type' => 'rate',
+					'unit' => 'per-room-per-night',
+				],
+				'city_tax' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+				'resort_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+				'additional_tax_or_fee' => [
+					'type' => 'both',
+					'unit' => 'per-room-per-night',
+				],
+			],
+		],
+	];
+
+	public function getCountryCode(): string
+	{
+		return $this->country->getCode();
+	}
+
+	public function getHasDaycationTaxesAndFees(): bool
+	{
+		return array_key_exists(FooEnum::FOO_TYPE, FooEnum::APPLICABLE_TAX_AND_FEES_BY_TYPE[$this->getCountryCode()]);
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7898

Looks like the type comparison was mixed up here, I'm surprised that this wasn't noticed so far and wonder if this has more implications  🤔 But I have to admit that this was more a lucky guess, I did not fully understand it yet tbh.

UPDATE: I _think_ I got it, basically it correctly skips the removal of the other arrays same key now, if it's value is a narrower type. before it would do it the other way around which could lead to a false-positive true return and therefore information loss, _if_ I'm right.