### PR TITLE
ConditionalTagsExtension: Multiple conditions support

### DIFF
--- a/tests/PHPStan/DependencyInjection/ConditionalTagsExtensionTest.php
+++ b/tests/PHPStan/DependencyInjection/ConditionalTagsExtensionTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+use PHPStan\Rules\RegistryFactory as RuleRegistryFactory;
+use PHPStan\Testing\PHPStanTestCase;
+use function array_map;
+use function get_class;
+
+class ConditionalTagsExtensionTest extends PHPStanTestCase
+{
+
+	public function testConditionalTags(): void
+	{
+		$enabledServices = self::getContainer()->getServicesByTag(RuleRegistryFactory::RULE_TAG);
+		$enabledServices = array_map(static fn ($service) => get_class($service), $enabledServices);
+		$this->assertNotContains(TestedConditionalServiceDisabled::class, $enabledServices);
+		$this->assertContains(TestedConditionalServiceEnabled::class, $enabledServices);
+		$this->assertNotContains(TestedConditionalServiceDisabledDisabled::class, $enabledServices);
+		$this->assertNotContains(TestedConditionalServiceDisabledEnabled::class, $enabledServices);
+		$this->assertNotContains(TestedConditionalServiceEnabledDisabled::class, $enabledServices);
+		$this->assertContains(TestedConditionalServiceEnabledEnabled::class, $enabledServices);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/conditionalTags.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/DependencyInjection/TestedConditionalServiceDisabled.php
+++ b/tests/PHPStan/DependencyInjection/TestedConditionalServiceDisabled.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+class TestedConditionalServiceDisabled
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/TestedConditionalServiceDisabledDisabled.php
+++ b/tests/PHPStan/DependencyInjection/TestedConditionalServiceDisabledDisabled.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+class TestedConditionalServiceDisabledDisabled
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/TestedConditionalServiceDisabledEnabled.php
+++ b/tests/PHPStan/DependencyInjection/TestedConditionalServiceDisabledEnabled.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+class TestedConditionalServiceDisabledEnabled
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/TestedConditionalServiceEnabled.php
+++ b/tests/PHPStan/DependencyInjection/TestedConditionalServiceEnabled.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+class TestedConditionalServiceEnabled
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/TestedConditionalServiceEnabledDisabled.php
+++ b/tests/PHPStan/DependencyInjection/TestedConditionalServiceEnabledDisabled.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+class TestedConditionalServiceEnabledDisabled
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/TestedConditionalServiceEnabledEnabled.php
+++ b/tests/PHPStan/DependencyInjection/TestedConditionalServiceEnabledEnabled.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+class TestedConditionalServiceEnabledEnabled
+{
+
+}

--- a/tests/PHPStan/DependencyInjection/conditionalTags.neon
+++ b/tests/PHPStan/DependencyInjection/conditionalTags.neon
@@ -1,0 +1,29 @@
+parameters:
+	enabled: true
+	disabled: false
+
+parametersSchema:
+	enabled: bool()
+	disabled: bool()
+
+conditionalTags:
+	PHPStan\DependencyInjection\TestedConditionalServiceDisabled:
+		phpstan.rules.rule: %disabled%
+	PHPStan\DependencyInjection\TestedConditionalServiceEnabled:
+		phpstan.rules.rule: %enabled%
+	PHPStan\DependencyInjection\TestedConditionalServiceDisabledDisabled:
+		phpstan.rules.rule: [%disabled%, %disabled%]
+	PHPStan\DependencyInjection\TestedConditionalServiceDisabledEnabled:
+		phpstan.rules.rule: [%disabled%, %enabled%]
+	PHPStan\DependencyInjection\TestedConditionalServiceEnabledDisabled:
+		phpstan.rules.rule: [%enabled%, %disabled%]
+	PHPStan\DependencyInjection\TestedConditionalServiceEnabledEnabled:
+		phpstan.rules.rule: [%enabled%, %enabled%]
+
+services:
+	- PHPStan\DependencyInjection\TestedConditionalServiceDisabled
+	- PHPStan\DependencyInjection\TestedConditionalServiceEnabled
+	- PHPStan\DependencyInjection\TestedConditionalServiceDisabledDisabled
+	- PHPStan\DependencyInjection\TestedConditionalServiceDisabledEnabled
+	- PHPStan\DependencyInjection\TestedConditionalServiceEnabledDisabled
+	- PHPStan\DependencyInjection\TestedConditionalServiceEnabledEnabled


### PR DESCRIPTION
```neon
parameters:
  strictRules:
    allRules: true
    disallowedLooseComparsion: [%strictRules.allRules%, %featureToggles.bleedingEdge%]
    # ...

parametersSchema:
  strictRules: structure([
    allRules: bool(),
    disallowedLooseComparsion: anyOf(bool(), arrayOf(bool()))
    # ...
  ])

conditionalTags:
  PHPStan\Rules\DisallowedConstructs\DisallowedLooseComparisonRule:
    phpstan.rules.rule: %strictRules.disallowedLooseComparsion%
```

it accepts not only bool but also array of bools that all have to be true for tag to be added (AND).