### PR TITLE
Fix intersecting array types with different mixed explicitness

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -112,6 +112,34 @@ class ArrayType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function isSuperTypeOfMixed(Type $type): TrinaryLogic
+	{
+		return $type->isArray()
+			->and($this->isNestedTypeSuperTypeOf($this->getIterableValueType(), $type->getIterableValueType()))
+			->and($this->isNestedTypeSuperTypeOf($this->getIterableKeyType(), $type->getIterableKeyType()));
+	}
+
+	private function isNestedTypeSuperTypeOf(Type $a, Type $b): TrinaryLogic
+	{
+		if (!$a instanceof MixedType || !$b instanceof MixedType) {
+			return $a->isSuperTypeOf($b);
+		}
+
+		if ($a instanceof TemplateMixedType || $b instanceof TemplateMixedType) {
+			return $a->isSuperTypeOf($b);
+		}
+
+		if ($a->isExplicitMixed()) {
+			if ($b->isExplicitMixed()) {
+				return TrinaryLogic::createYes();
+			}
+
+			return TrinaryLogic::createMaybe();
+		}
+
+		return TrinaryLogic::createYes();
+	}
+
 	public function equals(Type $type): bool
 	{
 		return $type instanceof self

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -366,6 +366,11 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isSuperTypeOfMixed(Type $type): TrinaryLogic
+	{
+		return $this->isSuperTypeOf($type);
+	}
+
 	public function equals(Type $type): bool
 	{
 		if (!$type instanceof self) {

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -302,7 +302,7 @@ class IterableType implements CompoundType
 
 	public function tryRemove(Type $typeToRemove): ?Type
 	{
-		$arrayType = new ArrayType(new MixedType(), new MixedType());
+		$arrayType = new ArrayType(new MixedType(true), new MixedType(true));
 		if ($typeToRemove->isSuperTypeOf($arrayType)->yes()) {
 			return new GenericObjectType(Traversable::class, [
 				$this->getIterableKeyType(),

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -886,7 +886,7 @@ class TypeCombinator
 					}
 				}
 
-				if ($types[$j] instanceof IterableType) {
+				if ($types[$j] instanceof ArrayType || $types[$j] instanceof IterableType) {
 					$isSuperTypeA = $types[$j]->isSuperTypeOfMixed($types[$i]);
 				} else {
 					$isSuperTypeA = $types[$j]->isSuperTypeOf($types[$i]);
@@ -898,7 +898,7 @@ class TypeCombinator
 					continue;
 				}
 
-				if ($types[$i] instanceof IterableType) {
+				if ($types[$i] instanceof ArrayType || $types[$i] instanceof IterableType) {
 					$isSuperTypeB = $types[$i]->isSuperTypeOfMixed($types[$j]);
 				} else {
 					$isSuperTypeB = $types[$i]->isSuperTypeOf($types[$j]);

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -531,4 +531,16 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7489.php'], []);
 	}
 
+	public function testBug7900(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-7900.php'], [
+			[
+				'Parameter #1 $requireInt of static method Bug7900\A::fromNumString() expects numeric-string, mixed given.',
+				21,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-7900.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-7900.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7900;
+
+abstract class A
+{
+	/**
+	 * @param numeric-string $requireInt
+	 */
+	public static function fromNumString(string $requireInt): void
+	{
+	}
+}
+
+final class B extends A {}
+
+/** @param mixed[] $vars */
+function x(array $vars): void {
+	$vars['b'] ?? '';
+
+	B::fromNumString($vars['a']);
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7900

Tbh I don't like the fix much, it is very similar to what `IterableType` and `MixedType` also do/have in regard to explicit mixed checks. The `isNestedTypeSuperTypeOf` is actually stolen from `IterableType`. But I couldn't figure out a simpler fix for now that doesn't lead to new problems.

As mentioned in the linked issue comment
> The problem is basically that `(new MixedType(true)->isSuperTypeOf(new MixedType())` returns `yes` which it shouldn't. This is handled correctly via `MixedType::isSuperTypeOfMixed` already, but my problem is that the checks are triggered via `ArrayType::isSuperTypeOf` which compares item and key super types. So it incorrectly assumes one array is a super type of the other because it ignores mixed explicitness and then one is dropped when intersecting both.