### PR TITLE
Fix checking empty constant arrays in array_pop and array_shift extensions

### DIFF
--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -37,9 +37,11 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		if (count($constantArrays) > 0) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {
-				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				$iterableAtLeastOnce = $constantArray->isIterableAtLeastOnce();
+				if (!$iterableAtLeastOnce->yes()) {
 					$valueTypes[] = new NullType();
+				}
+				if ($iterableAtLeastOnce->no()) {
 					continue;
 				}
 				$valueTypes[] = $constantArray->getLastValueType();

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -37,9 +37,11 @@ class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnType
 		if (count($constantArrays) > 0) {
 			$valueTypes = [];
 			foreach ($constantArrays as $constantArray) {
-				$arrayKeyTypes = $constantArray->getKeyTypes();
-				if (count($arrayKeyTypes) === 0) {
+				$iterableAtLeastOnce = $constantArray->isIterableAtLeastOnce();
+				if (!$iterableAtLeastOnce->yes()) {
 					$valueTypes[] = new NullType();
+				}
+				if ($iterableAtLeastOnce->no()) {
 					continue;
 				}
 

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -48,6 +48,10 @@ class Foo
 		/** @var array{a: 0, b: 1, c?: 2} $arr */
 		assertType('1|2', array_pop($arr));
 		assertType('array{a: 0, b?: 1}', $arr);
+
+		/** @var array{a?: 0, b?: 1, c?: 2} $arr */
+		assertType('0|1|2|null', array_pop($arr));
+		assertType('array{a?: 0, b?: 1}', $arr);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -48,6 +48,10 @@ class Foo
 		/** @var array{a: 0, b: 1, c?: 2} $arr */
 		assertType('0', array_shift($arr));
 		assertType('array{b: 1, c?: 2}', $arr);
+
+		/** @var array{a?: 0, b?: 1, c?: 2} $arr */
+		assertType('0|1|2|null', array_shift($arr));
+		assertType('array{b?: 1, c?: 2}', $arr);
 	}
 
 }

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -352,4 +352,12 @@ class NullCoalesceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7968(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/data/bug-7968.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-7968.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-7968.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7968;
+
+class HelloWorld
+{
+	/**
+	 * @param array{name: string, age: int} $a
+	 * @param array{name: string, age: int} $b
+	 */
+	public function compare(array $a, array $b): int
+	{
+		$sort = [
+			$a['name'] <=> $b['name'],
+			$a['age'] <=> $b['age'],
+		];
+
+		$sort = array_filter($sort, function (int $value): bool {
+			return $value !== 0;
+		});
+
+		return array_shift($sort) ?? 0;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7968