### PR TITLE
Relax `ConstantArrayType::isSuperTypeOf` in regard to optional keys

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -320,8 +320,11 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			if (count($this->keyTypes) === 0) {
 				if (count($type->keyTypes) > 0) {
 					if (count($type->optionalKeys) > 0) {
-						return TrinaryLogic::createMaybe();
+						return $this->isIterableAtLeastOnce()->no()
+							? TrinaryLogic::createYes()
+							: TrinaryLogic::createMaybe();
 					}
+
 					return TrinaryLogic::createNo();
 				}
 
@@ -336,10 +339,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 						return TrinaryLogic::createNo();
 					}
 
-					$results[] = TrinaryLogic::createMaybe();
+					$results[] = TrinaryLogic::createYes();
 					continue;
 				} elseif ($hasOffset->maybe() && !$this->isOptionalKey($i)) {
-					$results[] = TrinaryLogic::createMaybe();
+					$results[] = TrinaryLogic::createYes();
 				}
 				$results[] = $this->valueTypes[$i]->isSuperTypeOf($type->getOffsetValueType($keyType));
 			}

--- a/tests/PHPStan/Rules/PhpDoc/IncompatibleClassConstantPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatibleClassConstantPhpDocTypeRuleTest.php
@@ -54,4 +54,9 @@ class IncompatibleClassConstantPhpDocTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7352-with-sub-namespace.php'], []);
 	}
 
+	public function testBug7273(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7273.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-7273.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-7273.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7273;
+
+/**
+ * @template I
+ * @template O
+ */
+interface ConfigValueProcessorInterface
+{
+	/**
+	 * @param I $value
+	 *
+	 * @return O
+	 */
+	public function process(mixed $value, mixed $options): mixed;
+
+	/**
+	 * @param O $value
+	 *
+	 * @return I
+	 */
+	public function unprocess(mixed $value, mixed $options): mixed;
+}
+
+/**
+ * @implements ConfigValueProcessorInterface<string, int>
+ */
+abstract class SomeValueProcessor implements ConfigValueProcessorInterface {}
+
+interface ConfigKey
+{
+	public const ACTIVITY__EXPORT__TYPE = 'activity.export.type';
+	public const ACTIVITY__TAGS__MULTI = 'activity.tags.multi';
+	// ...
+}
+
+interface Module
+{
+	public const ABSENCEREQUEST = 'absencerequest';
+	public const ACTIVITY = 'activity';
+	// ...
+}
+
+interface ConfigRepositoryInterface
+{
+	/**
+	 * @var array<ConfigKey::*, array{
+	 *     type?: non-empty-string,
+	 *     default: mixed,
+	 *     acl: non-empty-string[],
+	 *     linked_module?: Module::*,
+	 *     value_processors?: array<class-string<ConfigValueProcessorInterface<mixed, mixed>>, mixed>,
+	 * }>
+	 */
+	public const CONFIGURATIONS = [
+		ConfigKey::ACTIVITY__EXPORT__TYPE => [
+			'type' => "'SomeExport'|'SomeOtherExport'|null",
+			'default' => null,
+			'acl' => ['superadmin'],
+			'linked_module' => Module::ACTIVITY,
+		],
+		ConfigKey::ACTIVITY__TAGS__MULTI => [
+			'default' => false,
+			'acl' => ['admin'],
+			'linked_module' => Module::ACTIVITY,
+			'value_processors' => [
+				SomeValueProcessor::class => ['someOption' => true],
+			],
+		],
+		// ...
+	];
+}

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -486,7 +486,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 				new IntegerType(),
 			], 2, [0, 1]),
 			new ConstantArrayType([], []),
-			TrinaryLogic::createMaybe(),
+			TrinaryLogic::createYes(),
 		];
 
 		yield [
@@ -498,7 +498,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 				new IntegerType(),
 				new IntegerType(),
 			], 2, [0, 1]),
-			TrinaryLogic::createMaybe(),
+			TrinaryLogic::createYes(),
 		];
 
 		yield [
@@ -526,7 +526,39 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 			], [
 				new IntegerType(),
 			], 1, [0]),
-			TrinaryLogic::createMaybe(),
+			TrinaryLogic::createYes(),
+		];
+
+		yield [
+			new ConstantArrayType([
+				new ConstantStringType('foo'),
+			], [
+				new IntegerType(),
+			]),
+			new ConstantArrayType([
+				new ConstantStringType('foo'),
+				new ConstantStringType('bar'),
+			], [
+				new IntegerType(),
+				new StringType(),
+			], 2, [1]),
+			TrinaryLogic::createYes(),
+		];
+
+		yield [
+			new ConstantArrayType([
+				new ConstantStringType('foo'),
+				new ConstantStringType('bar'),
+			], [
+				new IntegerType(),
+				new StringType(),
+			], 2, [1]),
+			new ConstantArrayType([
+				new ConstantStringType('foo'),
+			], [
+				new IntegerType(),
+			]),
+			TrinaryLogic::createYes(),
 		];
 	}
 


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7273

This is obviously still wrong, I merely want to show what currently breaks if https://github.com/phpstan/phpstan/issues/7273#issuecomment-1239571442 is implemented. Maybe parts can be fixed by sorting ConstantArrayTypes in TypeCombinator, but it feels still weird to me 🤔

I'm currently a bit stuck here.