### PR TITLE
Introduce ArrayType traits

### DIFF
--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -15,6 +15,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -28,6 +29,7 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonObjectTypeTrait;
 	use NonIterableTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
@@ -121,21 +123,6 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 	public function unsetOffset(Type $offsetType): Type
 	{
 		return new ErrorType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function toNumber(): Type

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -14,6 +14,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -28,6 +29,7 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonObjectTypeTrait;
 	use NonIterableTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
@@ -126,21 +128,6 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 	public function unsetOffset(Type $offsetType): Type
 	{
 		return new ErrorType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function toNumber(): Type

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -14,6 +14,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
@@ -28,6 +29,7 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonObjectTypeTrait;
 	use NonIterableTypeTrait;
 	use TruthyBooleanTypeTrait;
@@ -127,21 +129,6 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 	public function unsetOffset(Type $offsetType): Type
 	{
 		return new ErrorType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function toNumber(): Type

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -13,6 +13,7 @@ use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
@@ -27,6 +28,7 @@ use PHPStan\Type\VerbosityLevel;
 class AccessoryNumericStringType implements CompoundType, AccessoryType
 {
 
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
 	use NonObjectTypeTrait;
 	use NonIterableTypeTrait;
@@ -126,21 +128,6 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 	public function unsetOffset(Type $offsetType): Type
 	{
 		return new ErrorType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function toNumber(): Type

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -10,6 +10,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
@@ -26,6 +27,7 @@ use function sprintf;
 class HasOffsetType implements CompoundType, AccessoryType
 {
 
+	use MaybeArrayTypeTrait;
 	use MaybeCallableTypeTrait;
 	use MaybeIterableTypeTrait;
 	use MaybeObjectTypeTrait;
@@ -137,16 +139,6 @@ class HasOffsetType implements CompoundType, AccessoryType
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
 	}
 
 	public function isList(): TrinaryLogic

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -11,6 +11,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
@@ -27,6 +28,7 @@ use function sprintf;
 class HasOffsetValueType implements CompoundType, AccessoryType
 {
 
+	use MaybeArrayTypeTrait;
 	use MaybeCallableTypeTrait;
 	use MaybeIterableTypeTrait;
 	use MaybeObjectTypeTrait;
@@ -156,16 +158,6 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
 	}
 
 	public function isList(): TrinaryLogic

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
@@ -29,6 +30,7 @@ use function sprintf;
 class CallableType implements CompoundType, ParametersAcceptor
 {
 
+	use MaybeArrayTypeTrait;
 	use MaybeIterableTypeTrait;
 	use MaybeObjectTypeTrait;
 	use MaybeOffsetAccessibleTypeTrait;
@@ -310,19 +312,9 @@ class CallableType implements CompoundType, ParametersAcceptor
 		);
 	}
 
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -22,6 +22,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
@@ -36,6 +37,7 @@ use function sprintf;
 class ClosureType implements TypeWithClassName, ParametersAcceptor
 {
 
+	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
@@ -388,21 +390,6 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 			$this->templateTypeMap,
 			$this->resolvedTemplateTypeMap,
 		);
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -6,6 +6,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
@@ -21,6 +22,7 @@ use function get_class;
 class FloatType implements Type
 {
 
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
@@ -110,21 +112,6 @@ class FloatType implements Type
 			[$this],
 			[1],
 		);
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeObjectTypeTrait;
 use PHPStan\Type\Traits\MaybeOffsetAccessibleTypeTrait;
@@ -23,6 +24,7 @@ use function sprintf;
 class IterableType implements CompoundType
 {
 
+	use MaybeArrayTypeTrait;
 	use MaybeCallableTypeTrait;
 	use MaybeObjectTypeTrait;
 	use MaybeOffsetAccessibleTypeTrait;
@@ -227,21 +229,6 @@ class IterableType implements CompoundType
 	public function getIterableValueType(): Type
 	{
 		return $this->getItemType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -3,10 +3,13 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use function get_class;
 
 trait JustNullableTypeTrait
 {
+
+	use NonArrayTypeTrait;
 
 	/**
 	 * @return string[]
@@ -50,21 +53,6 @@ trait JustNullableTypeTrait
 	public function traverse(callable $cb): Type
 	{
 		return $this;
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
@@ -23,6 +24,7 @@ class NeverType implements CompoundType
 {
 
 	use UndecidedBooleanTypeTrait;
+	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
@@ -226,21 +228,6 @@ class NeverType implements CompoundType
 	public function traverse(callable $cb): Type
 	{
 		return $this;
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
@@ -19,6 +20,7 @@ use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 class NullType implements ConstantScalarType
 {
 
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
@@ -168,21 +170,6 @@ class NullType implements ConstantScalarType
 	public function traverse(callable $cb): Type
 	{
 		return $this;
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -33,6 +33,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -52,6 +53,7 @@ use function strtolower;
 class ObjectType implements TypeWithClassName, SubtractableType
 {
 
+	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonGeneralizableTypeTrait;
@@ -790,21 +792,6 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		return new ErrorType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -13,6 +13,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
@@ -21,6 +22,7 @@ class StrictMixedType implements CompoundType
 {
 
 	use UndecidedComparisonCompoundTypeTrait;
+	use NonArrayTypeTrait;
 	use NonRemoveableTypeTrait;
 	use NonGeneralizableTypeTrait;
 
@@ -146,21 +148,6 @@ class StrictMixedType implements CompoundType
 	public function getIterableValueType(): Type
 	{
 		return $this;
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\TrinaryLogic;
+
+trait MaybeArrayTypeTrait
+{
+
+	public function isArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
+	public function isList(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
+}

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\TrinaryLogic;
+
+trait NonArrayTypeTrait
+{
+
+	public function isArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+	public function isList(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+}

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -26,6 +26,7 @@ trait ObjectTypeTrait
 	use MaybeCallableTypeTrait;
 	use MaybeIterableTypeTrait;
 	use MaybeOffsetAccessibleTypeTrait;
+	use NonArrayTypeTrait;
 	use TruthyBooleanTypeTrait;
 
 	public function canAccessProperties(): TrinaryLogic
@@ -98,21 +99,6 @@ trait ObjectTypeTrait
 	public function isCloneable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
@@ -17,6 +18,7 @@ use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 class VoidType implements Type
 {
 
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
 	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
@@ -95,21 +97,6 @@ class VoidType implements Type
 	public function toArray(): Type
 	{
 		return new ErrorType();
-	}
-
-	public function isArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isOversizedArray(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
-	public function isList(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
 	}
 
 	public function isString(): TrinaryLogic


### PR DESCRIPTION
After thinking a bit about more array type cleanups, I thought this might be a good idea and precondition for both https://github.com/phpstan/phpstan-src/pull/1684 and https://github.com/phpstan/phpstan-src/pull/1687

Next, I'd update those 2 PRs, which should make their diff way smaller. Maybe this is also useful for future array type cleanups.