### PR TITLE
simplify ArrayFilterArgVisitor

### DIFF
--- a/src/Parser/ArrayFilterArgVisitor.php
+++ b/src/Parser/ArrayFilterArgVisitor.php
@@ -15,7 +15,7 @@ class ArrayFilterArgVisitor extends NodeVisitorAbstract
 			if ($functionName === 'array_filter') {
 				$args = $node->getArgs();
 				if (isset($args[0])) {
-					$args[0]->setAttribute('isArrayFilterArg', $args);
+					$args[0]->setAttribute('isArrayFilterArg', true);
 				}
 			}
 		}


### PR DESCRIPTION
`isArrayFilterArg` is a bool attribute.. we don't need the attributes in there, and therefore don't need references on AST nodes, which can lead to leaking memory.

the only place we read this attribute is casted to a bool:
https://github.com/phpstan/phpstan-src/blob/f1fd385433480f87bdda1d7d8ff6887e25f003ba/src/Reflection/ParametersAcceptorSelector.php#L102