### PR TITLE
Improve JUnit error formatter

### DIFF
--- a/src/Command/ErrorFormatter/JunitErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JunitErrorFormatter.php
@@ -22,11 +22,14 @@ class JunitErrorFormatter implements ErrorFormatter
 		Output $output,
 	): int
 	{
+		$totalFailuresCount = $analysisResult->getTotalErrorsCount();
+		$totalTestsCount = $analysisResult->hasErrors() ? $totalFailuresCount : 1;
+
 		$result = '<?xml version="1.0" encoding="UTF-8"?>';
 		$result .= sprintf(
 			'<testsuite failures="%d" name="phpstan" tests="%d" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">',
-			$analysisResult->getTotalErrorsCount(),
-			$analysisResult->getTotalErrorsCount(),
+			$totalFailuresCount,
+			$totalTestsCount,
 		);
 
 		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {

--- a/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
@@ -29,7 +29,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			0,
 			'<?xml version="1.0" encoding="UTF-8"?>
-<testsuite failures="0" name="phpstan" tests="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+<testsuite failures="0" name="phpstan" tests="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
   <testcase name="phpstan"/>
 </testsuite>
 ',


### PR DESCRIPTION
Resolves phpstan/phpstan#6772

If `AnalysisResult` has no errors, mark `<testsuite>` as having 1 test in order to be considered as having passed.