### PR TITLE
RuleTestCase: enable gathering analyser errors without assert

### DIFF
--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -124,6 +124,41 @@ abstract class RuleTestCase extends PHPStanTestCase
 	 */
 	public function analyse(array $files, array $expectedErrors): void
 	{
+		$actualErrors = $this->gatherAnalyserErrors($files);
+		$strictlyTypedSprintf = static function (int $line, string $message, ?string $tip): string {
+			$message = sprintf('%02d: %s', $line, $message);
+			if ($tip !== null) {
+				$message .= "\n    💡 " . $tip;
+			}
+
+			return $message;
+		};
+
+		$expectedErrors = array_map(
+			static fn (array $error): string => $strictlyTypedSprintf($error[1], $error[0], $error[2] ?? null),
+			$expectedErrors,
+		);
+
+		$actualErrors = array_map(
+			static function (Error $error) use ($strictlyTypedSprintf): string {
+				$line = $error->getLine();
+				if ($line === null) {
+					return $strictlyTypedSprintf(-1, $error->getMessage(), $error->getTip());
+				}
+				return $strictlyTypedSprintf($line, $error->getMessage(), $error->getTip());
+			},
+			$actualErrors,
+		);
+
+		$this->assertSame(implode("\n", $expectedErrors) . "\n", implode("\n", $actualErrors) . "\n");
+	}
+
+	/**
+	 * @param string[] $files
+	 * @return list<Error>
+	 */
+	public function gatherAnalyserErrors(array $files): array
+	{
 		$files = array_map([$this->getFileHelper(), 'normalizePath'], $files);
 		$analyserResult = $this->getAnalyser()->analyse(
 			$files,
@@ -154,32 +189,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			}
 		}
 
-		$strictlyTypedSprintf = static function (int $line, string $message, ?string $tip): string {
-			$message = sprintf('%02d: %s', $line, $message);
-			if ($tip !== null) {
-				$message .= "\n    💡 " . $tip;
-			}
-
-			return $message;
-		};
-
-		$expectedErrors = array_map(
-			static fn (array $error): string => $strictlyTypedSprintf($error[1], $error[0], $error[2] ?? null),
-			$expectedErrors,
-		);
-
-		$actualErrors = array_map(
-			static function (Error $error) use ($strictlyTypedSprintf): string {
-				$line = $error->getLine();
-				if ($line === null) {
-					return $strictlyTypedSprintf(-1, $error->getMessage(), $error->getTip());
-				}
-				return $strictlyTypedSprintf($line, $error->getMessage(), $error->getTip());
-			},
-			$actualErrors,
-		);
-
-		$this->assertSame(implode("\n", $expectedErrors) . "\n", implode("\n", $actualErrors) . "\n");
+		return $actualErrors;
 	}
 
 	protected function shouldPolluteScopeWithLoopInitialAssignments(): bool


### PR DESCRIPTION
I want to propose extracting the part of `RuleTestCase::analyse` that gathers the actual errors into its own public method so that the child test can do the comparison in a different way when necessary.

The use-case I have for this is that I want to use golden tests (i.e. gather the errors once, save them into a file, check them manually and then test against this saved sample in the future) instead of writing down the expected errors manually. This should make it possible to change the error messages easily, as well as edit the analysed file without having to worry about line numbers etc.

Unfortunately, the current interface of the `RuleTestCase` does not allow me to do this easily. For now, I'm using [this workaround](https://github.com/schlndh/maria-stan/blob/5fed52f1df98dcddee5707489df4c288acf7cb50/tests/PHPStan/Rules/MariaStanRuleTestCase.php#L23) but as I'm relying on things not covered by BC promise, it could break easily in the future.