### PR TITLE
Fix assigning generic object without a constructor (like SplObjectStorage) to a nullable property

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5090,7 +5090,7 @@ class MutatingScope implements Scope
 			}
 
 			if (count($classTemplateTypes) === count($originalClassTemplateTypes)) {
-				$propertyType = $this->getType($assignedToProperty);
+				$propertyType = TypeCombinator::removeNull($this->getType($assignedToProperty));
 				if ($objectType->isSuperTypeOf($propertyType)->yes()) {
 					return $propertyType;
 				}

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -427,4 +427,10 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6757.php'], []);
 	}
 
+	public function testBug4526(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-4526.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-4526.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-4526.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4526;
+
+use DateTime;
+use DateTimeImmutable;
+use SplObjectStorage;
+
+class HelloWorld
+{
+	/**
+	 * @var SplObjectStorage<DateTime, DateTimeImmutable>|null
+	 */
+	private $map;
+
+	public function __construct(){
+		$this->map = new SplObjectStorage;
+	}
+}


### PR DESCRIPTION
Fix phpstan/phpstan#4526