### PR TITLE
extract `Parser\*Visitor::ATTRIBUTE_NAME` constants

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -37,6 +37,8 @@ use PHPStan\Node\Expr\OriginalPropertyTypeExpr;
 use PHPStan\Node\Expr\SetOffsetValueTypeExpr;
 use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Node\Printer\ExprPrinter;
+use PHPStan\Parser\ArrayMapArgVisitor;
+use PHPStan\Parser\NewAssignedToPropertyVisitor;
 use PHPStan\Parser\Parser;
 use PHPStan\Parser\ParserErrorsException;
 use PHPStan\Php\PhpVersion;
@@ -1257,7 +1259,7 @@ class MutatingScope implements Scope
 			}
 
 			$callableParameters = null;
-			$arrayMapArgs = $node->getAttribute('arrayMapArgs');
+			$arrayMapArgs = $node->getAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME);
 			if ($arrayMapArgs !== null) {
 				$callableParameters = [];
 				foreach ($arrayMapArgs as $funcCallArg) {
@@ -5083,7 +5085,7 @@ class MutatingScope implements Scope
 			return $objectType;
 		}
 
-		$assignedToProperty = $node->getAttribute('assignedToProperty');
+		$assignedToProperty = $node->getAttribute(NewAssignedToPropertyVisitor::ATTRIBUTE_NAME);
 		if ($assignedToProperty !== null) {
 			$constructorVariant = ParametersAcceptorSelector::selectSingle($constructorMethod->getVariants());
 			$classTemplateTypes = $classReflection->getTemplateTypeMap()->getTypes();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -98,6 +98,8 @@ use PHPStan\Node\PropertyAssignNode;
 use PHPStan\Node\ReturnStatement;
 use PHPStan\Node\StaticMethodCallableNode;
 use PHPStan\Node\UnreachableStatementNode;
+use PHPStan\Parser\ArrowFunctionArgVisitor;
+use PHPStan\Parser\ClosureArgVisitor;
 use PHPStan\Parser\Parser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
@@ -2960,7 +2962,7 @@ class NodeScopeResolver
 		$byRefUses = [];
 
 		$callableParameters = null;
-		$closureCallArgs = $expr->getAttribute('closureCallArgs');
+		$closureCallArgs = $expr->getAttribute(ClosureArgVisitor::ATTRIBUTE_NAME);
 
 		if ($closureCallArgs !== null) {
 			$acceptors = $scope->getType($expr)->getCallableParametersAcceptors($scope);
@@ -3122,7 +3124,7 @@ class NodeScopeResolver
 		}
 
 		$callableParameters = null;
-		$arrowFunctionCallArgs = $expr->getAttribute('arrowFunctionCallArgs');
+		$arrowFunctionCallArgs = $expr->getAttribute(ArrowFunctionArgVisitor::ATTRIBUTE_NAME);
 
 		if ($arrowFunctionCallArgs !== null) {
 			$acceptors = $scope->getType($expr)->getCallableParametersAcceptors($scope);

--- a/src/Parser/ArrayFilterArgVisitor.php
+++ b/src/Parser/ArrayFilterArgVisitor.php
@@ -8,6 +8,8 @@ use PhpParser\NodeVisitorAbstract;
 class ArrayFilterArgVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'isArrayFilterArg';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
@@ -15,7 +17,7 @@ class ArrayFilterArgVisitor extends NodeVisitorAbstract
 			if ($functionName === 'array_filter') {
 				$args = $node->getArgs();
 				if (isset($args[0])) {
-					$args[0]->setAttribute('isArrayFilterArg', true);
+					$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);
 				}
 			}
 		}

--- a/src/Parser/ArrayMapArgVisitor.php
+++ b/src/Parser/ArrayMapArgVisitor.php
@@ -10,6 +10,8 @@ use function count;
 class ArrayMapArgVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'arrayMapArgs';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
@@ -19,7 +21,7 @@ class ArrayMapArgVisitor extends NodeVisitorAbstract
 				if (isset($args[0])) {
 					$slicedArgs = array_slice($args, 1);
 					if (count($slicedArgs) > 0) {
-						$args[0]->value->setAttribute('arrayMapArgs', $slicedArgs);
+						$args[0]->value->setAttribute(self::ATTRIBUTE_NAME, $slicedArgs);
 					}
 				}
 			}

--- a/src/Parser/ArrayWalkArgVisitor.php
+++ b/src/Parser/ArrayWalkArgVisitor.php
@@ -8,6 +8,8 @@ use PhpParser\NodeVisitorAbstract;
 class ArrayWalkArgVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'isArrayWalkArg';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
@@ -15,7 +17,7 @@ class ArrayWalkArgVisitor extends NodeVisitorAbstract
 			if ($functionName === 'array_walk') {
 				$args = $node->getArgs();
 				if (isset($args[0])) {
-					$args[0]->setAttribute('isArrayWalkArg', true);
+					$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);
 				}
 			}
 		}

--- a/src/Parser/ArrowFunctionArgVisitor.php
+++ b/src/Parser/ArrowFunctionArgVisitor.php
@@ -9,13 +9,15 @@ use function count;
 class ArrowFunctionArgVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'arrowFunctionCallArgs';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Expr\ArrowFunction) {
 			$args = $node->getArgs();
 
 			if (count($args) > 0) {
-				$node->name->setAttribute('arrowFunctionCallArgs', $args);
+				$node->name->setAttribute(self::ATTRIBUTE_NAME, $args);
 			}
 		}
 		return null;

--- a/src/Parser/ClosureArgVisitor.php
+++ b/src/Parser/ClosureArgVisitor.php
@@ -9,13 +9,15 @@ use function count;
 class ClosureArgVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'closureCallArgs';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Expr\Closure) {
 			$args = $node->getArgs();
 
 			if (count($args) > 0) {
-				$node->name->setAttribute('closureCallArgs', $args);
+				$node->name->setAttribute(self::ATTRIBUTE_NAME, $args);
 			}
 		}
 		return null;

--- a/src/Parser/CurlSetOptArgVisitor.php
+++ b/src/Parser/CurlSetOptArgVisitor.php
@@ -8,6 +8,8 @@ use PhpParser\NodeVisitorAbstract;
 class CurlSetOptArgVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'isCurlSetOptArg';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
@@ -15,7 +17,7 @@ class CurlSetOptArgVisitor extends NodeVisitorAbstract
 			if ($functionName === 'curl_setopt') {
 				$args = $node->getArgs();
 				if (isset($args[0])) {
-					$args[0]->setAttribute('isCurlSetOptArg', true);
+					$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);
 				}
 			}
 		}

--- a/src/Parser/NewAssignedToPropertyVisitor.php
+++ b/src/Parser/NewAssignedToPropertyVisitor.php
@@ -8,11 +8,13 @@ use PhpParser\NodeVisitorAbstract;
 class NewAssignedToPropertyVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'assignedToProperty';
+
 	public function enterNode(Node $node): ?Node
 	{
 		if ($node instanceof Node\Expr\Assign || $node instanceof Node\Expr\AssignRef) {
 			if ($node->var instanceof Node\Expr\PropertyFetch && $node->expr instanceof Node\Expr\New_) {
-				$node->expr->setAttribute('assignedToProperty', $node->var);
+				$node->expr->setAttribute(self::ATTRIBUTE_NAME, $node->var);
 			}
 		}
 		return null;

--- a/src/Parser/ParentStmtTypesVisitor.php
+++ b/src/Parser/ParentStmtTypesVisitor.php
@@ -11,6 +11,8 @@ use function get_class;
 final class ParentStmtTypesVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'parentStmtTypes';
+
 	/** @var array<int, class-string<Node\Stmt|Node\Expr\Closure>> */
 	private array $typeStack = [];
 
@@ -27,7 +29,7 @@ final class ParentStmtTypesVisitor extends NodeVisitorAbstract
 		}
 
 		if (count($this->typeStack) > 0) {
-			$node->setAttribute('parentStmtTypes', $this->typeStack);
+			$node->setAttribute(self::ATTRIBUTE_NAME, $this->typeStack);
 		}
 		$this->typeStack[] = get_class($node);
 

--- a/src/Parser/TryCatchTypeVisitor.php
+++ b/src/Parser/TryCatchTypeVisitor.php
@@ -11,6 +11,8 @@ use function count;
 final class TryCatchTypeVisitor extends NodeVisitorAbstract
 {
 
+	public const ATTRIBUTE_NAME = 'tryCatchTypes';
+
 	/** @var array<int, array<int, string>|null> */
 	private array $typeStack = [];
 
@@ -24,7 +26,7 @@ final class TryCatchTypeVisitor extends NodeVisitorAbstract
 	{
 		if ($node instanceof Node\Stmt || $node instanceof Node\Expr\Match_) {
 			if (count($this->typeStack) > 0) {
-				$node->setAttribute('tryCatchTypes', $this->typeStack[count($this->typeStack) - 1]);
+				$node->setAttribute(self::ATTRIBUTE_NAME, $this->typeStack[count($this->typeStack) - 1]);
 			}
 		}
 

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -4,6 +4,10 @@ namespace PHPStan\Reflection;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\ArrayFilterArgVisitor;
+use PHPStan\Parser\ArrayMapArgVisitor;
+use PHPStan\Parser\ArrayWalkArgVisitor;
+use PHPStan\Parser\CurlSetOptArgVisitor;
 use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\ShouldNotHappenException;
@@ -78,7 +82,7 @@ class ParametersAcceptorSelector
 			count($args) > 0
 			&& count($parametersAcceptors) > 0
 		) {
-			$arrayMapArgs = $args[0]->value->getAttribute('arrayMapArgs');
+			$arrayMapArgs = $args[0]->value->getAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME);
 			if ($arrayMapArgs !== null) {
 				$acceptor = $parametersAcceptors[0];
 				$parameters = $acceptor->getParameters();
@@ -108,7 +112,7 @@ class ParametersAcceptorSelector
 				];
 			}
 
-			if (count($args) >= 3 && (bool) $args[0]->getAttribute('isCurlSetOptArg')) {
+			if (count($args) >= 3 && (bool) $args[0]->getAttribute(CurlSetOptArgVisitor::ATTRIBUTE_NAME)) {
 				$optType = $scope->getType($args[1]->value);
 				if ($optType instanceof ConstantIntegerType) {
 					$optValueType = self::getCurlOptValueType($optType->getValue());
@@ -139,7 +143,7 @@ class ParametersAcceptorSelector
 				}
 			}
 
-			if (isset($args[0]) && (bool) $args[0]->getAttribute('isArrayFilterArg')) {
+			if (isset($args[0]) && (bool) $args[0]->getAttribute(ArrayFilterArgVisitor::ATTRIBUTE_NAME)) {
 				if (isset($args[2])) {
 					$mode = $scope->getType($args[2]->value);
 					if ($mode instanceof ConstantIntegerType) {
@@ -183,7 +187,7 @@ class ParametersAcceptorSelector
 				];
 			}
 
-			if (isset($args[0]) && (bool) $args[0]->getAttribute('isArrayWalkArg')) {
+			if (isset($args[0]) && (bool) $args[0]->getAttribute(ArrayWalkArgVisitor::ATTRIBUTE_NAME)) {
 				$arrayWalkParameters = [
 					new DummyParameter('item', self::getIterableValueType($scope->getType($args[0]->value)), false, PassedByReference::createReadsArgument(), false, null),
 					new DummyParameter('key', self::getIterableKeyType($scope->getType($args[0]->value)), false, PassedByReference::createNo(), false, null),

--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\MatchExpressionNode;
+use PHPStan\Parser\TryCatchTypeVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -148,7 +149,7 @@ class MatchExpressionRule implements Rule
 
 	private function isUnhandledMatchErrorCaught(Node $node): bool
 	{
-		$tryCatchTypes = $node->getAttribute('tryCatchTypes');
+		$tryCatchTypes = $node->getAttribute(TryCatchTypeVisitor::ATTRIBUTE_NAME);
 		if ($tryCatchTypes === null) {
 			return false;
 		}

--- a/src/Rules/Keywords/ContinueBreakInLoopRule.php
+++ b/src/Rules/Keywords/ContinueBreakInLoopRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Keywords;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\ParentStmtTypesVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function array_reverse;
@@ -33,7 +34,7 @@ class ContinueBreakInLoopRule implements Rule
 			$value = $node->num->value;
 		}
 
-		$parentStmtTypes = array_reverse($node->getAttribute('parentStmtTypes'));
+		$parentStmtTypes = array_reverse($node->getAttribute(ParentStmtTypesVisitor::ATTRIBUTE_NAME));
 		foreach ($parentStmtTypes as $parentStmtType) {
 			if ($parentStmtType === Stmt\Case_::class) {
 				continue;


### PR DESCRIPTION
- extract magic strings into constants
- renders dependent components obvious
- allows to navigate between the dependent parts via IDE