### PR TITLE
Get rid of closure ref-param generalization

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4432,7 +4432,6 @@ class MutatingScope implements Scope
 				$prevVariableType = $prevScope->getVariableType($variableName);
 				if (!$variableType->equals($prevVariableType)) {
 					$variableType = TypeCombinator::union($variableType, $prevVariableType);
-					$variableType = self::generalizeType($variableType, $prevVariableType);
 				}
 			}
 


### PR DESCRIPTION
I don't understand why this is generalized at the moment and the local test suite just works fine without it. Let's see 🤞