### PR TITLE
Preserve non-empty-array type when generalizing arrays with incompatible keys

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4680,10 +4680,14 @@ class MutatingScope implements Scope
 
 					$resultTypes[] = $resultArrayBuilder->getArray();
 				} else {
-					$resultTypes[] = new ArrayType(
+					$resultType = new ArrayType(
 						TypeCombinator::union(self::generalizeType($constantArraysA->getIterableKeyType(), $constantArraysB->getIterableKeyType())),
 						TypeCombinator::union(self::generalizeType($constantArraysA->getIterableValueType(), $constantArraysB->getIterableValueType())),
 					);
+					if ($constantArraysA->isIterableAtLeastOnce()->yes() && $constantArraysB->isIterableAtLeastOnce()->yes()) {
+						$resultType = TypeCombinator::intersect($resultType, new NonEmptyArrayType());
+					}
+					$resultTypes[] = $resultType;
 				}
 			}
 		} elseif (count($constantArrays['b']) > 0) {
@@ -4718,10 +4722,14 @@ class MutatingScope implements Scope
 					}
 				}
 
-				$resultTypes[] = new ArrayType(
+				$resultType = new ArrayType(
 					TypeCombinator::union(self::generalizeType($generalArraysA->getIterableKeyType(), $generalArraysB->getIterableKeyType())),
 					TypeCombinator::union(self::generalizeType($aValueType, $bValueType)),
 				);
+				if ($generalArraysA->isIterableAtLeastOnce()->yes() && $generalArraysB->isIterableAtLeastOnce()->yes()) {
+					$resultType = TypeCombinator::intersect($resultType, new NonEmptyArrayType());
+				}
+				$resultTypes[] = $resultType;
 			}
 		} elseif (count($generalArrays['b']) > 0) {
 			$resultTypes[] = TypeCombinator::union(...$generalArrays['b']);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1034,6 +1034,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7954.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7993.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7996.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7141.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/cli-globals.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8033.php');

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -139,7 +139,7 @@ class ScopeTest extends PHPStanTestCase
 					new ConstantIntegerType(1),
 					new ConstantIntegerType(1),
 				]),
-				'array<literal-string&non-falsy-string, 1>',
+				'non-empty-array<literal-string&non-falsy-string, 1>',
 			],
 			[
 				new ConstantArrayType([
@@ -154,7 +154,7 @@ class ScopeTest extends PHPStanTestCase
 					new ConstantIntegerType(1),
 					new ConstantIntegerType(2),
 				]),
-				'array<literal-string&non-falsy-string, int<1, max>>',
+				'non-empty-array<literal-string&non-falsy-string, int<1, max>>',
 			],
 			[
 				new UnionType([

--- a/tests/PHPStan/Analyser/data/bug-7996.php
+++ b/tests/PHPStan/Analyser/data/bug-7996.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7996;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param non-empty-array<\stdclass> $inputArray
+	 * @return non-empty-array<\stdclass>
+	 */
+	public function filter(array $inputArray): array
+	{
+		$currentItem = reset($inputArray);
+		$outputArray = [$currentItem]; // $outputArray is now non-empty-array
+		assertType('array{stdclass}', $outputArray);
+
+		while ($nextItem = next($inputArray)) {
+			if (rand(1, 2) === 1) {
+				assertType('non-empty-array<int, stdclass>', $outputArray);
+				// The fact that this is into an if, reverts type of $outputArray to array
+				$outputArray[] = $nextItem;
+			}
+			assertType('non-empty-array<int, stdclass>', $outputArray);
+		}
+
+		assertType('non-empty-array<int, stdclass>', $outputArray);
+		return $outputArray;
+	}
+}

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -746,4 +746,10 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7904.php'], []);
 	}
 
+	public function testBug7996(): void
+	{
+		$this->checkExplicitMixed = false;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-7996.php'], []);
+	}
+
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/7996

Extracted from https://github.com/phpstan/phpstan-src/pull/1732, there's no need for this dependency. Also @rvanvelzen is doing the same thing for the list in his new PR which is another reason for me to extract it :)

Update: changed the commit message. The incompatible key part is misleading