### PR TITLE
Allow compare SimpleXMLElement to number

### DIFF
--- a/src/Rules/Operators/InvalidComparisonOperationRule.php
+++ b/src/Rules/Operators/InvalidComparisonOperationRule.php
@@ -48,6 +48,10 @@ class InvalidComparisonOperationRule implements Rule
 			return [];
 		}
 
+		if ($this->isNumberType($scope, $node->left) && $this->isNumberType($scope, $node->right)) {
+			return [];
+		}
+
 		if (
 			($this->isNumberType($scope, $node->left) && (
 				$this->isPossiblyNullableObjectType($scope, $node->right) || $this->isPossiblyNullableArrayType($scope, $node->right)
@@ -83,7 +87,8 @@ class InvalidComparisonOperationRule implements Rule
 			return false;
 		}
 
-		return !$acceptedType->isSuperTypeOf($type)->no();
+		// SimpleXMLElement can be cast to number union type
+		return !$acceptedType->isSuperTypeOf($type)->no() || $acceptedType->equals($type->toNumber());
 	}
 
 	private function isPossiblyNullableObjectType(Scope $scope, Node\Expr $expr): bool

--- a/tests/PHPStan/Rules/Operators/data/invalid-comparison.php
+++ b/tests/PHPStan/Rules/Operators/data/invalid-comparison.php
@@ -106,3 +106,7 @@ function (array $a, array $b) {
 	$a == $b;
 	$a < $b;
 };
+
+$xml = new SimpleXMLElement('<data><a><b>1</b></a><c></c></data>');
+$xml->a->b == 1;
+$xml->a->b > 1;


### PR DESCRIPTION
Fix https://github.com/phpstan/phpstan/issues/1795

SImpleXMLElement can be cast to int.
https://3v4l.org/sboWW

And, result toNumber of ObjectType (SimpleXMLElement) is UnionType(integer, float).
https://github.com/phpstan/phpstan-src/blob/81de3ebde89bea0e81ac0e28243e5022ad64e0af/src/Type/ObjectType.php#L474-L484

So, I think it can be allowed.