### PR TITLE
`headers_list()` returns a list of headers as strings

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3933,7 +3933,7 @@ return [
 'header' => ['void', 'header'=>'string', 'replace='=>'bool', 'http_response_code='=>'int'],
 'header_register_callback' => ['bool', 'callback'=>'callable'],
 'header_remove' => ['void', 'name='=>'string'],
-'headers_list' => ['list<string>'],
+'headers_list' => ['list<non-empty-string>'],
 'headers_sent' => ['bool', '&w_file='=>'string', '&w_line='=>'int'],
 'hebrev' => ['string', 'str'=>'string', 'max_chars_per_line='=>'int'],
 'hebrevc' => ['string', 'str'=>'string', 'max_chars_per_line='=>'int'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3933,7 +3933,7 @@ return [
 'header' => ['void', 'header'=>'string', 'replace='=>'bool', 'http_response_code='=>'int'],
 'header_register_callback' => ['bool', 'callback'=>'callable'],
 'header_remove' => ['void', 'name='=>'string'],
-'headers_list' => ['array'],
+'headers_list' => ['list<string>'],
 'headers_sent' => ['bool', '&w_file='=>'string', '&w_line='=>'int'],
 'hebrev' => ['string', 'str'=>'string', 'max_chars_per_line='=>'int'],
 'hebrevc' => ['string', 'str'=>'string', 'max_chars_per_line='=>'int'],


### PR DESCRIPTION
Example return value from `headers_list()`:

```
array(6) {
  [0]=>
  string(24) "X-Powered-By: PHP/8.0.19"
  [1]=>
  string(38) "Expires: Wed, 11 Jan 1984 05:00:00 GMT"
  [2]=>
  string(51) "Cache-Control: no-cache, must-revalidate, max-age=0"
  [3]=>
  string(48) "Referrer-Policy: strict-origin-when-cross-origin"
  [4]=>
  string(27) "X-Frame-Options: SAMEORIGIN"
  [5]=>
  string(38) "Content-Type: text/html; charset=UTF-8"
}
```

Ref: https://www.php.net/manual/en/function.headers-list.php