### PR TITLE
Refined fpm_get_status function signature.

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -2998,7 +2998,7 @@ return [
 'forward_static_call' => ['mixed', 'function'=>'callable', '...parameters='=>'mixed'],
 'forward_static_call_array' => ['mixed', 'function'=>'callable', 'parameters'=>'array<int,mixed>'],
 'fpassthru' => ['0|positive-int|false', 'fp'=>'resource'],
-'fpm_get_status' => ['array|false'],
+'fpm_get_status' => ['array{pool: string, process-manager: \'dynamic\'|\'ondemand\'|\'static\', start-time: int<0, max>, start-since: int<0, max>, accepted-conn: int<0, max>, listen-queue: int<0, max>, max-listen-queue: int<0, max>, listen-queue-len: int<0, max>, idle-processes: int<0, max>, active-processes: int<1, max>, total-processes: int<1, max>, max-active-processes: int<1, max>, max-children-reached: 0|1, slow-requests: int<0, max>, procs: array<int, array{pid: int<2, max>, state: \'Idle\'|\'Running\', start-time: int<0, max>, start-since: int<0, max>, requests: int<0, max>, request-duration: int<0, max>, request-method: string, request-uri: string, query-string: string, request-length: int<0, max>, user: string, script: string, last-request-cpu: float, last-request-memory: int<0, max>}>}|false'],
 'fprintf' => ['int', 'stream'=>'resource', 'format'=>'string', '...values='=>'string|int|float'],
 'fputcsv' => ['0|positive-int|false', 'fp'=>'resource', 'fields'=>'array', 'delimiter='=>'string', 'enclosure='=>'string', 'escape_char='=>'string'],
 'fputs' => ['0|positive-int|false', 'fp'=>'resource', 'str'=>'string', 'length='=>'0|positive-int'],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1051,6 +1051,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/dnf.php');
 		}
 
+		if (PHP_VERSION_ID >= 70300) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/fpm-get-status.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-offset-unset.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8008.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5552.php');

--- a/tests/PHPStan/Analyser/data/fpm-get-status.php
+++ b/tests/PHPStan/Analyser/data/fpm-get-status.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace FpmGetStatus;
+
+use function fpm_get_status;
+use function PHPStan\Testing\assertType;
+
+$status = fpm_get_status();
+
+assertType('array{pool: string, process-manager: \'dynamic\'|\'ondemand\'|\'static\', start-time: int<0, max>, start-since: int<0, max>, accepted-conn: int<0, max>, listen-queue: int<0, max>, max-listen-queue: int<0, max>, listen-queue-len: int<0, max>, idle-processes: int<0, max>, active-processes: int<1, max>, total-processes: int<1, max>, max-active-processes: int<1, max>, max-children-reached: 0|1, slow-requests: int<0, max>, procs: array<int, array{pid: int<2, max>, state: \'Idle\'|\'Running\', start-time: int<0, max>, start-since: int<0, max>, requests: int<0, max>, request-duration: int<0, max>, request-method: string, request-uri: string, query-string: string, request-length: int<0, max>, user: string, script: string, last-request-cpu: float, last-request-memory: int<0, max>}>}|false', $status);
+
+if ($status !== false && isset($status['procs'][0])) {
+	assertType('array{pid: int<2, max>, state: \'Idle\'|\'Running\', start-time: int<0, max>, start-since: int<0, max>, requests: int<0, max>, request-duration: int<0, max>, request-method: string, request-uri: string, query-string: string, request-length: int<0, max>, user: string, script: string, last-request-cpu: float, last-request-memory: int<0, max>}', $status['procs'][0]);
+
+	assertType('int<2, max>', $status['procs'][0]['pid']);
+}


### PR DESCRIPTION
https://www.php.net/manual/en/function.fpm-get-status.php
https://www.php.net/manual/en/fpm.status.php#fpm.status.contents

An example from a local vagrant machine:
```
^ array:15 [▼
  "pool" => "admin"
  "process-manager" => "dynamic"
  "start-time" => 1664364711
  "start-since" => 3810
  "accepted-conn" => 7
  "listen-queue" => 0
  "max-listen-queue" => 0
  "listen-queue-len" => 0
  "idle-processes" => 1
  "active-processes" => 1
  "total-processes" => 2
  "max-active-processes" => 1
  "max-children-reached" => 0
  "slow-requests" => 0
  "procs" => array:2 [▼
    0 => array:14 [▼
      "pid" => 770
      "state" => "Running"
      "start-time" => 1664364711
      "start-since" => 3810
      "requests" => 4
      "request-duration" => 33595
      "request-method" => "GET"
      "request-uri" => "/admin/index.php"
      "query-string" => ""
      "request-length" => 0
      "user" => "-"
      "script" => "/vagrant/admin/public/index.php"
      "last-request-cpu" => 0.0
      "last-request-memory" => 0
    ]
    1 => array:14 [▼
      "pid" => 771
      "state" => "Idle"
      "start-time" => 1664364711
      "start-since" => 3810
      "requests" => 3
      "request-duration" => 73026
      "request-method" => "GET"
      "request-uri" => "/admin/index.php"
      "query-string" => ""
      "request-length" => 0
      "user" => "-"
      "script" => "/vagrant/admin/public/index.php"
      "last-request-cpu" => 54.775010415373
      "last-request-memory" => 4194304
    ]
  ]
]
```