### PR TITLE
ignoreErrors fix reportUnmatched without path/paths

### DIFF
--- a/src/Analyser/IgnoredErrorHelper.php
+++ b/src/Analyser/IgnoredErrorHelper.php
@@ -69,13 +69,6 @@ class IgnoredErrorHelper
 						continue;
 					}
 					if (!isset($ignoreError['path'])) {
-						if (!isset($ignoreError['paths']) && !isset($ignoreError['reportUnmatched'])) {
-							$errors[] = sprintf(
-								'Ignored error %s is missing a path, paths or reportUnmatched.',
-								Json::encode($ignoreError),
-							);
-						}
-
 						$otherIgnoreErrors[] = $ignoreErrorEntry;
 					} elseif (@is_file($ignoreError['path'])) {
 						$normalizedPath = $this->fileHelper->normalizePath($ignoreError['path']);

--- a/src/Analyser/IgnoredErrorHelperResult.php
+++ b/src/Analyser/IgnoredErrorHelperResult.php
@@ -104,7 +104,10 @@ class IgnoredErrorHelperResult
 						break;
 					}
 				} else {
-					throw new ShouldNotHappenException();
+					$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'], null);
+					if ($shouldBeIgnored) {
+						unset($unmatchedIgnoredErrors[$i]);
+					}
 				}
 			}
 

--- a/tests/PHPStan/DependencyInjection/IgnoreErrorsTest.php
+++ b/tests/PHPStan/DependencyInjection/IgnoreErrorsTest.php
@@ -9,7 +9,7 @@ class IgnoreErrorsTest extends PHPStanTestCase
 
 	public function testIgnoreErrors(): void
 	{
-		$this->assertCount(10, self::getContainer()->getParameter('ignoreErrors'));
+		$this->assertCount(12, self::getContainer()->getParameter('ignoreErrors'));
 	}
 
 	/**

--- a/tests/PHPStan/DependencyInjection/ignoreErrors.neon
+++ b/tests/PHPStan/DependencyInjection/ignoreErrors.neon
@@ -3,6 +3,8 @@ parameters:
 		- "#error#"
 		-
 			message: '#error#'
+		-
+			message: '#error#'
 			reportUnmatched: false
 		-
 			message: '#error#'
@@ -11,6 +13,9 @@ parameters:
 			message: '#error#'
 			path: '/dir/*'
 			reportUnmatched: false
+		-
+			messages:
+				- '#error#'
 		-
 			messages:
 				- '#error#'


### PR DESCRIPTION
Another fix of extended ignoreErrors - when reportUnmatched is used for message without path/paths it lead to ShouldNotHappen exception. Now this branch is valid and covered. 

I also added few more tests for this feature.