### PR TITLE
fix IntlDateFormatter::create return signature

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5517,7 +5517,7 @@ return [
 'IntlChar::toupper' => ['mixed', 'codepoint'=>'mixed'],
 'IntlCodePointBreakIterator::getLastCodePoint' => ['int'],
 'IntlDateFormatter::__construct' => ['void', 'locale'=>'?string', 'datetype'=>'?int', 'timetype'=>'?int', 'timezone='=>'null|string|IntlTimeZone|DateTimeZone', 'calendar='=>'null|int|IntlCalendar', 'pattern='=>'string'],
-'IntlDateFormatter::create' => ['IntlDateFormatter|false', 'locale'=>'?string', 'datetype'=>'?int', 'timetype'=>'?int', 'timezone='=>'null|string|IntlTimeZone|DateTimeZone', 'calendar='=>'int|IntlCalendar', 'pattern='=>'string'],
+'IntlDateFormatter::create' => ['IntlDateFormatter|null', 'locale'=>'?string', 'datetype'=>'?int', 'timetype'=>'?int', 'timezone='=>'null|string|IntlTimeZone|DateTimeZone', 'calendar='=>'int|IntlCalendar', 'pattern='=>'string'],
 'IntlDateFormatter::format' => ['string|false', 'args'=>''],
 'IntlDateFormatter::formatObject' => ['string', 'object'=>'object', 'format='=>'mixed', 'locale='=>'string'],
 'IntlDateFormatter::getCalendar' => ['int'],


### PR DESCRIPTION
Conf php doc => https://www.php.net/manual/en/intldateformatter.create.php

I didn't manage to install and run test for this phpstan-src project.
When I do:
```
composer install
make tests
```
I get 
```
php vendor/bin/paratest --runner WrapperRunner --no-coverage
You need to set up the project dependencies using the following commands:
curl -s http://getcomposer.org/installer | php
php composer.phar install
```
autoload.php is not created
and if I do:
`composer update `
it endup with
```
- Applying patches for jetbrains/phpstorm-stubs (2)
    ~ phpstan/phpstan-src: patches/PDO.patch [NEW]
      Failed to apply the patch. Halting execution!
```

Did I miss something to make it work ?

Thx for your time