### PR TITLE
Fix type for CURLOPT_POSTFIELDS

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -515,6 +515,10 @@ class ParametersAcceptorSelector
 			return new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(2)]);
 		}
 
+		if (defined('CURLOPT_POSTFIELDS') && $curlOpt === CURLOPT_SSL_VERIFYHOST) {
+			return new UnionType([new StringType(), new ArrayType(new MixedType(), new MixedType())]);
+		}
+
 		$boolConstants = [
 			'CURLOPT_AUTOREFERER',
 			'CURLOPT_COOKIESESSION',
@@ -646,7 +650,6 @@ class ParametersAcceptorSelector
 			'CURLOPT_KRB4LEVEL',
 			'CURLOPT_LOGIN_OPTIONS',
 			'CURLOPT_PINNEDPUBLICKEY',
-			'CURLOPT_POSTFIELDS',
 			'CURLOPT_PRIVATE',
 			'CURLOPT_PRE_PROXY',
 			'CURLOPT_PROXY',

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -515,7 +515,7 @@ class ParametersAcceptorSelector
 			return new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(2)]);
 		}
 
-		if (defined('CURLOPT_POSTFIELDS') && $curlOpt === CURLOPT_SSL_VERIFYHOST) {
+		if (defined('CURLOPT_POSTFIELDS') && $curlOpt === CURLOPT_POSTFIELDS) {
 			return new UnionType([new StringType(), new ArrayType(new MixedType(), new MixedType())]);
 		}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1213,6 +1213,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #3 $value of function curl_setopt expects resource, string given.',
 				24,
 			],
+			[
+				'Parameter #3 $value of function curl_setopt expects array|string, int given.',
+				26,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -22,6 +22,8 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_CONNECT_TO, $s);
 		// expecting resource
 		curl_setopt($curl, CURLOPT_FILE, $s);
+		// expecting string or array
+		curl_setopt($curl, CURLOPT_POSTFIELDS, $i);
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -45,5 +45,8 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_FILE, $fp);
 		curl_setopt($curl, CURLOPT_HEADER, false);
 		curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: text/plain', 'Content-length: 100'));
+		curl_setopt($curl, CURLOPT_POSTFIELDS, array('foo' => 'bar'));
+		curl_setopt($curl, CURLOPT_POSTFIELDS, '');
+		curl_setopt($curl, CURLOPT_POSTFIELDS, 'para1=val1&para2=val2');
 	}
 }


### PR DESCRIPTION
Closes [#8065](https://github.com/phpstan/phpstan/issues/8065)

Should I target 1.8.x (bugfix) or 1.9.x (since it's maybe the next release ?)