### PR TITLE
Improve isset specification in falsy scope

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1948,7 +1948,7 @@ class MutatingScope implements Scope
 	/**
 	 * @param callable(Type): ?bool $typeCallback
 	 */
-	private function issetCheck(Expr $expr, callable $typeCallback, ?bool $result = null): ?bool
+	public function issetCheck(Expr $expr, callable $typeCallback, ?bool $result = null): ?bool
 	{
 		// mirrored in PHPStan\Rules\IssetCheck
 		if ($expr instanceof Node\Expr\Variable && is_string($expr->name)) {
@@ -1988,7 +1988,7 @@ class MutatingScope implements Scope
 
 			// If offset is cannot be null, store this error message and see if one of the earlier offsets is.
 			// E.g. $array['a']['b']['c'] ?? null; is a valid coalesce if a OR b or C might be null.
-			if ($hasOffsetValue->yes() || $this->isSpecified($expr)) {
+			if ($hasOffsetValue->yes()) {
 				$result = $typeCallback($type->getOffsetValueType($dimType));
 
 				if ($result !== null) {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -538,7 +538,8 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$barOrNull' => '~null',
 				],
 				[
-					'isset($stringOrNull, $barOrNull)' => self::SURE_NOT_TRUTHY,
+					'$stringOrNull' => self::SURE_NOT_TRUTHY,
+					'$barOrNull' => self::SURE_NOT_TRUTHY,
 				],
 			],
 			[
@@ -546,7 +547,9 @@ class TypeSpecifierTest extends PHPStanTestCase
 				[
 					'$stringOrNull' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
 				],
-				[],
+				[
+					'$stringOrNull' => '\'\'|\'0\'|null',
+				],
 			],
 			[
 				new Expr\BinaryOp\Identical(
@@ -560,7 +563,9 @@ class TypeSpecifierTest extends PHPStanTestCase
 			],
 			[
 				new Expr\Empty_(new Variable('array')),
-				[],
+				[
+					'$array' => 'array{}',
+				],
 				[
 					'$array' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
 				],
@@ -570,7 +575,9 @@ class TypeSpecifierTest extends PHPStanTestCase
 				[
 					'$array' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
 				],
-				[],
+				[
+					'$array' => 'array{}',
+				],
 			],
 			[
 				new FuncCall(new Name('count'), [
@@ -668,9 +675,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$foo' => 'object&hasProperty(bar) & ~null',
 					'$foo->bar' => '~null',
 				],
-				[
-					'isset($foo->bar)' => self::SURE_NOT_TRUTHY,
-				],
+				[],
 			],
 			[
 				new Expr\Isset_(
@@ -681,9 +686,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 				[
 					'Foo::$bar' => '~null',
 				],
-				[
-					'isset(Foo::$bar)' => self::SURE_NOT_TRUTHY,
-				],
+				[],
 			],
 			[
 				new Identical(

--- a/tests/PHPStan/Analyser/data/bug-3991.php
+++ b/tests/PHPStan/Analyser/data/bug-3991.php
@@ -18,8 +18,12 @@ class Foo
 		assertType('array|stdClass|null', $config);
 		if (empty($config))
 		{
-			assertNativeType('mixed', $config);
-			assertType('array|stdClass|null', $config);
+			// the native type should be `0|0.0|''|'0'|array{}|false|null`
+			// the problem is that `empty($config)` translates to `!isset($config) || !$config`
+			// and before specified types of the left and right side are intersected they are "normalized"
+			// by removing the sureNotType from $scope->getType() which is `stdClass|array|null` here
+			assertNativeType('array{}|null', $config);
+			assertType('array{}|null', $config);
 			$config = new \stdClass();
 		} elseif (! (is_array($config) || $config instanceof \stdClass)) {
 			assertNativeType('mixed~0|0.0|\'\'|\'0\'|array{}|stdClass|false|null', $config);


### PR DESCRIPTION
Continues specifying the type for a variable in a falsy `isset` if it exists in the scope.

This affectively leads to a more refined variable type and "fixes" type narrowing with `empty()` in a **truthy** scope too (see `TypeSpecifierTest` changes). The reason for that is that e.g. `empty($foo)` translates to `!isset($foo) || !$foo` and without types for `$foo` on the left side of the `BooleanOr` `SpecifiedTypes::intersectWith()` would simply drop the type info for the right side.