### PR TITLE
Fix CURLOPT_POSTFIELDS param type

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -646,7 +646,6 @@ class ParametersAcceptorSelector
 			'CURLOPT_KRB4LEVEL',
 			'CURLOPT_LOGIN_OPTIONS',
 			'CURLOPT_PINNEDPUBLICKEY',
-			'CURLOPT_POSTFIELDS',
 			'CURLOPT_PRIVATE',
 			'CURLOPT_PRE_PROXY',
 			'CURLOPT_PROXY',
@@ -721,6 +720,18 @@ class ParametersAcceptorSelector
 		foreach ($arrayConstants as $constName) {
 			if (defined($constName) && constant($constName) === $curlOpt) {
 				return new ArrayType(new MixedType(), new MixedType());
+			}
+		}
+
+		$arrayOrStringConstants = [
+			'CURLOPT_POSTFIELDS',
+		];
+		foreach ($arrayOrStringConstants as $constName) {
+			if (defined($constName) && constant($constName) === $curlOpt) {
+				return TypeCombinator::union(
+					new StringType(),
+					new ArrayType(new MixedType(), new MixedType()),
+				);
 			}
 		}
 

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -728,10 +728,10 @@ class ParametersAcceptorSelector
 		];
 		foreach ($arrayOrStringConstants as $constName) {
 			if (defined($constName) && constant($constName) === $curlOpt) {
-				return TypeCombinator::union(
+				return new UnionType([
 					new StringType(),
 					new ArrayType(new MixedType(), new MixedType()),
-				);
+				]);
 			}
 		}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1213,6 +1213,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #3 $value of function curl_setopt expects resource, string given.',
 				24,
 			],
+			[
+				'Parameter #3 $value of function curl_setopt expects array|string, int given.',
+				26,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -22,6 +22,8 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_CONNECT_TO, $s);
 		// expecting resource
 		curl_setopt($curl, CURLOPT_FILE, $s);
+		// expecting string or array
+		curl_setopt($curl, CURLOPT_POSTFIELDS, $i);
 	}
 
 	/**
@@ -45,5 +47,8 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_FILE, $fp);
 		curl_setopt($curl, CURLOPT_HEADER, false);
 		curl_setopt($curl, CURLOPT_HTTPHEADER, array('Content-type: text/plain', 'Content-length: 100'));
+		curl_setopt($curl, CURLOPT_POSTFIELDS, array('foo' => 'bar'));
+		curl_setopt($curl, CURLOPT_POSTFIELDS, '');
+		curl_setopt($curl, CURLOPT_POSTFIELDS, 'para1=val1&para2=val2');
 	}
 }


### PR DESCRIPTION
Hi Ondrej,

`CURLOPT_POSTFIELDS` accepts string or array but PHPStan reports a type error if the value is not a string
https://phpstan.org/r/db599e65-dfae-4e85-90bc-6bc96feadf96

I'm not sure about `TypeCombinator::union` but it's what I was able to find to achieve the fix. 

closes https://github.com/phpstan/phpstan/issues/8053.

Thanks.