### PR TITLE
Remove IssetCheck/MutatingScope::issetCheck deviations and remove too early exits

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1983,24 +1983,12 @@ class MutatingScope implements Scope
 			}
 
 			if ($hasOffsetValue->no()) {
-				if ($result !== null) {
-					return $result;
-				}
-
 				return false;
-			}
-
-			if ($hasOffsetValue->maybe()) {
-				return null;
 			}
 
 			// If offset is cannot be null, store this error message and see if one of the earlier offsets is.
 			// E.g. $array['a']['b']['c'] ?? null; is a valid coalesce if a OR b or C might be null.
-			if ($hasOffsetValue->yes()) {
-				if ($result !== null) {
-					return $result;
-				}
-
+			if ($hasOffsetValue->yes() || $this->isSpecified($expr)) {
 				$result = $typeCallback($type->getOffsetValueType($dimType));
 
 				if ($result !== null) {

--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -68,10 +68,6 @@ class IssetCheck
 			}
 
 			if ($hasOffsetValue->no()) {
-				if ($error !== null) {
-					return $error;
-				}
-
 				if (!$this->checkAdvancedIsset) {
 					return null;
 				}


### PR DESCRIPTION
While trying to check the deviations in the code that handles `ArrayDimFetch` I noticed the following things that I re-did in `MutatingScope::issetCheck()` because they were done at some point in `IssetCheck`
- the maybe block was removed 
- `Scope::isSpecified` was added additionally to the yes block
- the early exit in the yes block was removed (that also triggered errors when I used it via  https://github.com/phpstan/phpstan-src/pull/1781)

Additionally, I thought the early exit in the no block looked weird too and removed it as well since tests were green.

I hope this helps in removing duplications and I wanted to see if CI is also green.. 