### PR TITLE
Fixed universal object crate classes not respecting @property annotations

### DIFF
--- a/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
+++ b/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection\Php;
 
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
@@ -16,7 +17,11 @@ class UniversalObjectCratesClassReflectionExtension
 	/**
 	 * @param string[] $classes
 	 */
-	public function __construct(private ReflectionProvider $reflectionProvider, private array $classes)
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+		private array $classes,
+		private AnnotationsPropertiesClassReflectionExtension $annotationClassReflection,
+	)
 	{
 	}
 
@@ -56,6 +61,10 @@ class UniversalObjectCratesClassReflectionExtension
 
 	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
 	{
+		if ($this->annotationClassReflection->hasProperty($classReflection, $propertyName)) {
+			return $this->annotationClassReflection->getProperty($classReflection, $propertyName);
+		}
+
 		if ($classReflection->hasNativeMethod('__get')) {
 			$readableType = ParametersAcceptorSelector::selectSingle($classReflection->getNativeMethod('__get')->getVariants())->getReturnType();
 		} else {

--- a/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection\Php;
 
+use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
@@ -13,10 +14,11 @@ class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 	public function testNonexistentClass(): void
 	{
 		$reflectionProvider = $this->createReflectionProvider();
-		$extension = new UniversalObjectCratesClassReflectionExtension($reflectionProvider, [
-			'NonexistentClass',
-			'stdClass',
-		]);
+		$extension = new UniversalObjectCratesClassReflectionExtension(
+			$reflectionProvider,
+			['NonexistentClass', 'stdClass'],
+			new AnnotationsPropertiesClassReflectionExtension(),
+		);
 		$this->assertTrue($extension->hasProperty($reflectionProvider->getClass(stdClass::class), 'foo'));
 	}
 
@@ -25,9 +27,11 @@ class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 		require_once __DIR__ . '/data/universal-object-crates.php';
 
 		$reflectionProvider = $this->createReflectionProvider();
-		$extension = new UniversalObjectCratesClassReflectionExtension($reflectionProvider, [
-			'UniversalObjectCreates\DifferentGetSetTypes',
-		]);
+		$extension = new UniversalObjectCratesClassReflectionExtension(
+			$reflectionProvider,
+			['UniversalObjectCreates\DifferentGetSetTypes'],
+			new AnnotationsPropertiesClassReflectionExtension(),
+		);
 
 		$this->assertEquals(
 			new ObjectType('UniversalObjectCreates\DifferentGetSetTypesValue'),
@@ -39,6 +43,32 @@ class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 			new StringType(),
 			$extension
 				->getProperty($reflectionProvider->getClass('UniversalObjectCreates\DifferentGetSetTypes'), 'foo')
+				->getWritableType(),
+		);
+	}
+
+	public function testAnnotationOverrides(): void
+	{
+		require_once __DIR__ . '/data/universal-object-crates-annotations.php';
+		$className = 'UniversalObjectCratesAnnotations\Model';
+
+		$reflectionProvider = $this->createReflectionProvider();
+		$extension = new UniversalObjectCratesClassReflectionExtension(
+			$reflectionProvider,
+			[$className],
+			new AnnotationsPropertiesClassReflectionExtension(),
+		);
+
+		$this->assertEquals(
+			new StringType(),
+			$extension
+				->getProperty($reflectionProvider->getClass($className), 'foo')
+				->getReadableType(),
+		);
+		$this->assertEquals(
+			new StringType(),
+			$extension
+				->getProperty($reflectionProvider->getClass($className), 'foo')
 				->getWritableType(),
 		);
 	}

--- a/tests/PHPStan/Reflection/Php/data/universal-object-crates-annotations.php
+++ b/tests/PHPStan/Reflection/Php/data/universal-object-crates-annotations.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace UniversalObjectCratesAnnotations;
+
+use StdClass;
+
+/**
+ * @property string $foo
+ */
+class Model extends StdClass
+{
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/7974

Doesn't resolve the [issue](https://github.com/phpstan/phpstan/issues/8102) that `PropertiesClassReflectionExtension` aren't called for classes that are universal object crates classes but it's a start. 