### PR TITLE
Report invalid constructor property promotion for readonly props already defined in parent class constructor

### DIFF
--- a/src/Rules/Properties/OverridingPropertyRule.php
+++ b/src/Rules/Properties/OverridingPropertyRule.php
@@ -76,6 +76,14 @@ class OverridingPropertyRule implements Rule
 					$prototype->getDeclaringClass()->getDisplayName(),
 					$node->getName(),
 				))->nonIgnorable()->build();
+			} else {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'Readonly property %s::$%s overrides readonly property %s::$%s.',
+					$classReflection->getDisplayName(),
+					$node->getName(),
+					$prototype->getDeclaringClass()->getDisplayName(),
+					$node->getName(),
+				))->nonIgnorable()->build();
 			}
 		} elseif ($node->isReadOnly()) {
 			$errors[] = RuleErrorBuilder::message(sprintf(

--- a/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
@@ -167,10 +167,6 @@ class OverridingPropertyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/overriding-property-phpdoc.php'], $errors);
 	}
 
-	/**
-	 * @dataProvider dataRulePHPDocTypes
-	 * @param mixed[] $errors
-	 */
 	public function testBug8101(): void
 	{
 		$this->reportMaybes = false;

--- a/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
@@ -48,12 +48,20 @@ class OverridingPropertyRuleTest extends RuleTestCase
 				46,
 			],
 			[
+				'Readonly property OverridingProperty\ReadonlyChild::$readonly2 overrides readonly property OverridingProperty\ReadonlyParent::$readonly2.',
+				47,
+			],
+			[
 				'Readonly property OverridingProperty\ReadonlyChild2::$readWrite overrides readwrite property OverridingProperty\ReadonlyParent::$readWrite.',
 				55,
 			],
 			[
 				'Readwrite property OverridingProperty\ReadonlyChild2::$readOnly overrides readonly property OverridingProperty\ReadonlyParent::$readOnly.',
 				56,
+			],
+			[
+				'Readonly property OverridingProperty\ReadonlyChild2::$readonly2 overrides readonly property OverridingProperty\ReadonlyParent::$readonly2.',
+				57,
 			],
 			[
 				'Private property OverridingProperty\PrivateDolor::$protectedFoo overriding protected property OverridingProperty\Dolor::$protectedFoo should be protected or public.',
@@ -157,6 +165,21 @@ class OverridingPropertyRuleTest extends RuleTestCase
 	{
 		$this->reportMaybes = $reportMaybes;
 		$this->analyse([__DIR__ . '/data/overriding-property-phpdoc.php'], $errors);
+	}
+
+	/**
+	 * @dataProvider dataRulePHPDocTypes
+	 * @param mixed[] $errors
+	 */
+	public function testBug8101(): void
+	{
+		$this->reportMaybes = false;
+		$this->analyse([__DIR__ . '/data/bug-8101.php'], [
+			[
+				'Readonly property Bug8101\B::$myProp overrides readonly property Bug8101\A::$myProp.',
+				12,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-8101.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8101.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bug8101;
+
+class A {
+	public function __construct(public readonly int $myProp) {}
+}
+
+class B extends A
+{
+	// This should be reported as an error, as a readonly prop cannot be redeclared.
+	public function __construct(public readonly int $myProp) {
+		parent::__construct($myProp);
+	}
+}
+
+class C extends A
+{
+	public function __construct(public readonly int $anotherProp) {
+		parent::__construct($anotherProp);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-8101.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8101.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.1
 
 namespace Bug8101;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-8101.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8101.php
@@ -20,3 +20,14 @@ class C extends A
 		parent::__construct($anotherProp);
 	}
 }
+
+class ANonReadonly {
+	public function __construct(public int $myProp) {}
+}
+
+class BNonReadonly extends ANonReadonly
+{
+	public function __construct(public int $myProp) {
+		parent::__construct($myProp);
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/8101