### PR TITLE
Make array access on possible false tolerant with isset

### DIFF
--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
@@ -56,7 +56,11 @@ class NonexistentOffsetInArrayDimFetchRule implements Rule
 
 		$isOffsetAccessible = $isOffsetAccessibleType->isOffsetAccessible();
 
-		if (($scope->isInExpressionAssign($node) || $scope->isUndefinedExpressionAllowed($node)) && $isOffsetAccessible->yes()) {
+		if ($scope->isInExpressionAssign($node) && $isOffsetAccessible->yes()) {
+			return [];
+		}
+
+		if ($scope->isUndefinedExpressionAllowed($node) && !$isOffsetAccessible->no()) {
 			return [];
 		}
 

--- a/tests/PHPStan/Levels/data/arrayDimFetches-7.json
+++ b/tests/PHPStan/Levels/data/arrayDimFetches-7.json
@@ -28,10 +28,5 @@
         "message": "Cannot access offset 'foo' on iterable<int|string, object>.",
         "line": 58,
         "ignorable": true
-    },
-    {
-        "message": "Cannot access offset 'foo' on iterable<int|string, object>.",
-        "line": 66,
-        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -539,7 +539,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8068.php'], [
 			[
 				"Cannot access offset 'path' on Closure.",
-				14,
+				18,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -112,10 +112,6 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				253,
 			],
 			[
-				'Cannot access offset \'a\' on array{a: 1, b: 1}|(Closure(): void).',
-				258,
-			],
-			[
 				'Offset string does not exist on array<int, string>.',
 				308,
 			],
@@ -536,6 +532,16 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	public function testBug8097(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-8097.php'], []);
+	}
+
+	public function testBug8068(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8068.php'], [
+			[
+				"Cannot access offset 'path' on Closure.",
+				14,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-8068.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8068.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Bug8097;
+
+use Closure;
+
 class HelloWorld
 {
 	public function test(string $url): bool
@@ -9,7 +13,7 @@ class HelloWorld
 		return isset($urlParsed['path']);
 	}
 
-	public function test2(closure $closure): bool
+	public function test2(Closure $closure): bool
 	{
 		return isset($closure['path']);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/bug-8068.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8068.php
@@ -1,0 +1,24 @@
+<?php
+
+class HelloWorld
+{
+	public function test(string $url): bool
+	{
+		$urlParsed = parse_url($url);
+
+		return isset($urlParsed['path']);
+	}
+
+	public function test2(closure $closure): bool
+	{
+		return isset($closure['path']);
+	}
+
+	/**
+	 * @param iterable<int|string, object> $iterable
+	 */
+	public function test3($iterable): bool
+	{
+		unset($iterable['path']);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8068.

Hey Ondrej,

As discussed in the bug. PHP is tolerant with `isset`.  

The removed line `Cannot access offset \'a\' on array{a: 1, b: 1}|(Closure(): void).` from the other test is reasonable because closure key access in isset would always be reported.

appreciate your help on getting the fix for this one.
