### PR TITLE
Do not drop original specified expression in TypeSpecifier

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1363,8 +1363,16 @@ class TypeSpecifier
 		$exprString = $this->exprPrinter->printExpr($expr);
 		if ($context->false()) {
 			$sureNotTypes[$exprString] = [$expr, $type];
+			if ($expr !== $originalExpr) {
+				$originalExprString = $this->exprPrinter->printExpr($originalExpr);
+				$sureNotTypes[$originalExprString] = [$originalExpr, $type];
+			}
 		} elseif ($context->true()) {
 			$sureTypes[$exprString] = [$expr, $type];
+			if ($expr !== $originalExpr) {
+				$originalExprString = $this->exprPrinter->printExpr($originalExpr);
+				$sureTypes[$originalExprString] = [$originalExpr, $type];
+			}
 		}
 
 		$types = new SpecifiedTypes($sureTypes, $sureNotTypes, $overwrite, [], $rootExpr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1361,16 +1361,15 @@ class TypeSpecifier
 		$sureTypes = [];
 		$sureNotTypes = [];
 		$exprString = $this->exprPrinter->printExpr($expr);
+		$originalExprString = $this->exprPrinter->printExpr($originalExpr);
 		if ($context->false()) {
 			$sureNotTypes[$exprString] = [$expr, $type];
-			if ($expr !== $originalExpr) {
-				$originalExprString = $this->exprPrinter->printExpr($originalExpr);
+			if ($exprString !== $originalExprString) {
 				$sureNotTypes[$originalExprString] = [$originalExpr, $type];
 			}
 		} elseif ($context->true()) {
 			$sureTypes[$exprString] = [$expr, $type];
-			if ($expr !== $originalExpr) {
-				$originalExprString = $this->exprPrinter->printExpr($originalExpr);
+			if ($exprString !== $originalExprString) {
 				$sureTypes[$originalExprString] = [$originalExpr, $type];
 			}
 		}

--- a/tests/PHPStan/Rules/Comparison/UnreachableIfBranchesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/UnreachableIfBranchesRuleTest.php
@@ -115,4 +115,10 @@ class UnreachableIfBranchesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8076(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8076.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-8076.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8076.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8076;
+
+class HelloWorld
+{
+	/**
+	 * @param array{maybe?: string} $in
+	 */
+	public static function doThing(array $in): void
+	{
+		if(is_string($in['maybe'] ?? null)) {
+		} else {
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8076

Overwriting `$expr` and dropping the type specification for the original expression would otherwise lead to false-positives via `ImpossibleCheckTypeHelper`