### PR TITLE
Cover expr ExprPrinter by bc promise

### DIFF
--- a/src/Node/Printer/ExprPrinter.php
+++ b/src/Node/Printer/ExprPrinter.php
@@ -4,6 +4,7 @@ namespace PHPStan\Node\Printer;
 
 use PhpParser\Node\Expr;
 
+/** @api */
 class ExprPrinter
 {
 


### PR DESCRIPTION
to allow building of more precise error messages, I would love to use `ExprPrinter` in my custom rules

my use case:
https://github.com/FriendsOfREDAXO/rexstan/pull/155/files#diff-70bebcfad16bb92660e1c41bfd8448c4ab6cbe69a9d174bffa0f9f5b31168a83R84-R92