### PR TITLE
Fix min max call on array of union types

### DIFF
--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -119,7 +119,6 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 				}
 
 				if ($iterableValueType instanceof UnionType) {
-					$argumentTypes = [];
 					foreach ($iterableValueType->getTypes() as $innerType) {
 						$argumentTypes[] = $innerType;
 					}

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -16,7 +16,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function count;
 

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -51,7 +51,7 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 				if (!$isIterable->yes()) {
 					$argumentTypes[] = new ConstantBooleanType(false);
 				}
-				if ($iterableValueType instanceof UnionType) {
+				if ($iterableValueType instanceof UnionType && $argType instanceof ConstantArrayType) {
 					foreach ($iterableValueType->getTypes() as $innerType) {
 						$argumentTypes[] = $innerType;
 					}

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -103,7 +103,7 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 
 	private function processArrayType(string $functionName, Type $argType): Type
 	{
-		$constArrayTypes = TypeUtils::getOldConstantArrays($argType);
+		$constArrayTypes = $argType->getConstantArrays();
 		if (count($constArrayTypes) > 0) {
 			$resultTypes = [];
 			foreach ($constArrayTypes as $constArrayType) {

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -111,18 +111,13 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 					$resultTypes[] = new ConstantBooleanType(false);
 					continue;
 				}
-				$iterableValueType = $constArrayType->getIterableValueType();
 				$argumentTypes = [];
 				if (!$isIterable->yes()) {
 					$argumentTypes[] = new ConstantBooleanType(false);
 				}
 
-				if ($iterableValueType instanceof UnionType) {
-					foreach ($iterableValueType->getTypes() as $innerType) {
-						$argumentTypes[] = $innerType;
-					}
-				} else {
-					$argumentTypes[] = $iterableValueType;
+				foreach ($constArrayType->getValueTypes() as $innerType) {
+					$argumentTypes[] = $innerType;
 				}
 
 				$resultTypes[] = $this->processType($functionName, $argumentTypes);

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -149,4 +149,18 @@ class HelloWorld
 		assertType('int<1, 4>', min($range, 4));
 		assertType('int<4, 6>', max(4, $range));
 	}
+
+	public function unionType(): void
+	{
+		/**
+		 * @var array<0|1|2|3|4|5|6|7|8|9>
+		 */
+		$numbers = getFoo();
+
+		assertType('0|1|2|3|4|5|6|7|8|9|false', min($numbers));
+		assertType('0', min([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+
+		assertType('0|1|2|3|4|5|6|7|8|9|false', max($numbers));
+		assertType('9', max([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+	}
 }

--- a/tests/PHPStan/Analyser/data/minmax-arrays.php
+++ b/tests/PHPStan/Analyser/data/minmax-arrays.php
@@ -162,5 +162,13 @@ class HelloWorld
 
 		assertType('0|1|2|3|4|5|6|7|8|9|false', max($numbers));
 		assertType('9', max([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+
+		/**
+		 * @var array{0, 1, 2}|array{4, 5, 6} $numbers2
+		 */
+		$numbers2 = getFoo();
+
+		assertType('0|4', min($numbers2));
+		assertType('2|6', max($numbers2));
 	}
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8088

The dynamic extensions was considering
```
array<0|1|2|3|4|5|6|7|8|9>
```
and
```
array{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
```
as the same