### PR TITLE
Add @phpstan-self-out support

### DIFF
--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -35,6 +35,7 @@ rules:
 	- PHPStan\Rules\PhpDoc\MethodConditionalReturnTypeRule
 	- PHPStan\Rules\PhpDoc\FunctionAssertRule
 	- PHPStan\Rules\PhpDoc\MethodAssertRule
+	- PHPStan\Rules\PhpDoc\IncompatibleSelfOutTypeRule
 	- PHPStan\Rules\PhpDoc\IncompatibleClassConstantPhpDocTypeRule
 	- PHPStan\Rules\PhpDoc\IncompatiblePhpDocTypeRule
 	- PHPStan\Rules\PhpDoc\IncompatiblePropertyPhpDocTypeRule

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -144,6 +144,11 @@ parameters:
 			path: src/PhpDoc/PhpDocBlock.php
 
 		-
+			message: "#^Call to function method_exists\\(\\) with PHPStan\\\\PhpDocParser\\\\Ast\\\\PhpDoc\\\\PhpDocNode and 'getSelfOutTypeTagVa…' will always evaluate to true\\.$#"
+			count: 1
+			path: src/PhpDoc/PhpDocNodeResolver.php
+
+		-
 			message: "#^Method PHPStan\\\\PhpDoc\\\\ResolvedPhpDocBlock\\:\\:getNameScope\\(\\) should return PHPStan\\\\Analyser\\\\NameScope but returns PHPStan\\\\Analyser\\\\NameScope\\|null\\.$#"
 			count: 1
 			path: src/PhpDoc/ResolvedPhpDocBlock.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -167,6 +167,11 @@ parameters:
 			path: src/PhpDoc/Tag/ReturnTag.php
 
 		-
+			message: "#^Return type \\(PHPStan\\\\PhpDoc\\\\Tag\\\\SelfOutTypeTag\\) of method PHPStan\\\\PhpDoc\\\\Tag\\\\SelfOutTypeTag\\:\\:withType\\(\\) should be covariant with return type \\(static\\(PHPStan\\\\PhpDoc\\\\Tag\\\\TypedTag\\)\\) of method PHPStan\\\\PhpDoc\\\\Tag\\\\TypedTag\\:\\:withType\\(\\)$#"
+			count: 1
+			path: src/PhpDoc/Tag/SelfOutTypeTag.php
+
+		-
 			message: "#^Return type \\(PHPStan\\\\PhpDoc\\\\Tag\\\\VarTag\\) of method PHPStan\\\\PhpDoc\\\\Tag\\\\VarTag\\:\\:withType\\(\\) should be covariant with return type \\(static\\(PHPStan\\\\PhpDoc\\\\Tag\\\\TypedTag\\)\\) of method PHPStan\\\\PhpDoc\\\\Tag\\\\TypedTag\\:\\:withType\\(\\)$#"
 			count: 1
 			path: src/PhpDoc/Tag/VarTag.php

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2532,6 +2532,7 @@ class MutatingScope implements Scope
 		?bool $isPure = null,
 		bool $acceptsNamedArguments = true,
 		?Assertions $asserts = null,
+		?Type $selfOutType = null,
 	): self
 	{
 		if (!$this->isInClass()) {
@@ -2557,6 +2558,7 @@ class MutatingScope implements Scope
 				$isPure,
 				$acceptsNamedArguments,
 				$asserts ?? Assertions::createEmpty(),
+				$selfOutType,
 			),
 			!$classMethod->isStatic(),
 		);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -468,7 +468,7 @@ class NodeScopeResolver
 			$hasYield = false;
 			$throwPoints = [];
 			$this->processAttributeGroups($stmt->attrGroups, $scope, $nodeCallback);
-			[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, , , $asserts] = $this->getPhpDocs($scope, $stmt);
+			[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, , , $asserts, $selfOutType] = $this->getPhpDocs($scope, $stmt);
 
 			foreach ($stmt->params as $param) {
 				$this->processParamNode($param, $scope, $nodeCallback);
@@ -491,6 +491,7 @@ class NodeScopeResolver
 				$isPure,
 				$acceptsNamedArguments,
 				$asserts,
+				$selfOutType,
 			);
 
 			if ($stmt->name->toLowerString() === '__construct') {
@@ -2061,6 +2062,13 @@ class NodeScopeResolver
 					$scope = $scope->invalidateExpression($expr->var, true);
 					foreach ($expr->getArgs() as $arg) {
 						$scope = $scope->invalidateExpression($arg->value, true);
+					}
+				}
+
+				if ($parametersAcceptor !== null) {
+					$selfOutType = $methodReflection->getSelfOutType();
+					if ($selfOutType !== null) {
+						$scope = $scope->assignExpression($expr->var, TemplateTypeHelper::resolveTemplateTypes($selfOutType, $parametersAcceptor->getResolvedTemplateTypeMap()));
 					}
 				}
 			} else {
@@ -3980,7 +3988,7 @@ class NodeScopeResolver
 	}
 
 	/**
-	 * @return array{TemplateTypeMap, Type[], ?Type, ?Type, ?string, bool, bool, bool, bool|null, bool, bool, string|null, Assertions}
+	 * @return array{TemplateTypeMap, Type[], ?Type, ?Type, ?string, bool, bool, bool, bool|null, bool, bool, string|null, Assertions, ?Type}
 	 */
 	public function getPhpDocs(Scope $scope, Node\FunctionLike|Node\Stmt\Property $node): array
 	{
@@ -3996,6 +4004,7 @@ class NodeScopeResolver
 		$acceptsNamedArguments = true;
 		$isReadOnly = $scope->isInClass() && $scope->getClassReflection()->isImmutable();
 		$asserts = Assertions::createEmpty();
+		$selfOutType = null;
 		$docComment = $node->getDocComment() !== null
 			? $node->getDocComment()->getText()
 			: null;
@@ -4105,9 +4114,10 @@ class NodeScopeResolver
 			$acceptsNamedArguments = $resolvedPhpDoc->acceptsNamedArguments();
 			$isReadOnly = $isReadOnly || $resolvedPhpDoc->isReadOnly();
 			$asserts = Assertions::createFromResolvedPhpDocBlock($resolvedPhpDoc);
+			$selfOutType = $resolvedPhpDoc->getThisOutTag() !== null ? $resolvedPhpDoc->getThisOutTag()->getType() : null;
 		}
 
-		return [$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $docComment, $asserts];
+		return [$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $docComment, $asserts, $selfOutType];
 	}
 
 	private function transformStaticType(ClassReflection $declaringClass, Type $type): Type

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -107,6 +107,7 @@ use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\Assertions;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\MethodReflection;
@@ -527,7 +528,7 @@ class NodeScopeResolver
 
 			if ($stmt->getAttribute('virtual', false) === false) {
 				$methodReflection = $methodScope->getFunction();
-				if (!$methodReflection instanceof MethodReflection) {
+				if (!$methodReflection instanceof ExtendedMethodReflection) {
 					throw new ShouldNotHappenException();
 				}
 				$nodeCallback(new InClassMethodNode($methodReflection, $stmt), $methodScope);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -4115,7 +4115,7 @@ class NodeScopeResolver
 			$acceptsNamedArguments = $resolvedPhpDoc->acceptsNamedArguments();
 			$isReadOnly = $isReadOnly || $resolvedPhpDoc->isReadOnly();
 			$asserts = Assertions::createFromResolvedPhpDocBlock($resolvedPhpDoc);
-			$selfOutType = $resolvedPhpDoc->getThisOutTag() !== null ? $resolvedPhpDoc->getThisOutTag()->getType() : null;
+			$selfOutType = $resolvedPhpDoc->getSelfOutTag() !== null ? $resolvedPhpDoc->getSelfOutTag()->getType() : null;
 		}
 
 		return [$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, $isReadOnly, $docComment, $asserts, $selfOutType];

--- a/src/Node/InClassMethodNode.php
+++ b/src/Node/InClassMethodNode.php
@@ -3,21 +3,21 @@
 namespace PHPStan\Node;
 
 use PhpParser\Node;
-use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
 
 /** @api */
 class InClassMethodNode extends Node\Stmt implements VirtualNode
 {
 
 	public function __construct(
-		private MethodReflection $methodReflection,
+		private ExtendedMethodReflection $methodReflection,
 		private Node\Stmt\ClassMethod $originalNode,
 	)
 	{
 		parent::__construct($originalNode->getAttributes());
 	}
 
-	public function getMethodReflection(): MethodReflection
+	public function getMethodReflection(): ExtendedMethodReflection
 	{
 		return $this->methodReflection;
 	}

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -36,6 +36,7 @@ use function array_merge;
 use function array_reverse;
 use function count;
 use function in_array;
+use function method_exists;
 use function strpos;
 use function substr;
 
@@ -454,6 +455,10 @@ class PhpDocNodeResolver
 
 	public function resolveSelfOutTypeTag(PhpDocNode $phpDocNode, NameScope $nameScope): ?SelfOutTypeTag
 	{
+		if (!method_exists($phpDocNode, 'getSelfOutTypeTagValues')) {
+			return null;
+		}
+
 		foreach (['@phpstan-this-out', '@phpstan-self-out', '@psalm-this-out', '@psalm-self-out'] as $tagName) {
 			foreach ($phpDocNode->getSelfOutTypeTagValues($tagName) as $selfOutTypeTagValue) {
 				$type = $this->typeNodeResolver->resolve($selfOutTypeTagValue->type, $nameScope);

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -14,6 +14,7 @@ use PHPStan\PhpDoc\Tag\MixinTag;
 use PHPStan\PhpDoc\Tag\ParamTag;
 use PHPStan\PhpDoc\Tag\PropertyTag;
 use PHPStan\PhpDoc\Tag\ReturnTag;
+use PHPStan\PhpDoc\Tag\SelfOutTypeTag;
 use PHPStan\PhpDoc\Tag\TemplateTag;
 use PHPStan\PhpDoc\Tag\ThrowsTag;
 use PHPStan\PhpDoc\Tag\TypeAliasImportTag;
@@ -449,6 +450,18 @@ class PhpDocNodeResolver
 		}
 
 		return $resolved;
+	}
+
+	public function resolveSelfOutTypeTag(PhpDocNode $phpDocNode, NameScope $nameScope): ?SelfOutTypeTag
+	{
+		foreach (['@phpstan-this-out', '@phpstan-self-out', '@psalm-this-out', '@psalm-self-out'] as $tagName) {
+			foreach ($phpDocNode->getSelfOutTypeTagValues($tagName) as $selfOutTypeTagValue) {
+				$type = $this->typeNodeResolver->resolve($selfOutTypeTagValue->type, $nameScope);
+				return new SelfOutTypeTag($type);
+			}
+		}
+
+		return null;
 	}
 
 	public function resolveDeprecatedTag(PhpDocNode $phpDocNode, NameScope $nameScope): ?DeprecatedTag

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -220,7 +220,7 @@ class ResolvedPhpDocBlock
 		$result->typeAliasTags = $this->getTypeAliasTags();
 		$result->typeAliasImportTags = $this->getTypeAliasImportTags();
 		$result->assertTags = self::mergeAssertTags($this->getAssertTags(), $parents, $parentPhpDocBlocks);
-		$result->selfOutTypeTag = $this->getThisOutTag();
+		$result->selfOutTypeTag = self::mergeSelfOutTypeTags($this->getSelfOutTag(), $parents);
 		$result->deprecatedTag = self::mergeDeprecatedTags($this->getDeprecatedTag(), $parents);
 		$result->isDeprecated = $result->deprecatedTag !== null;
 		$result->isInternal = $this->isInternal();
@@ -302,7 +302,7 @@ class ResolvedPhpDocBlock
 		$self->typeAliasTags = $this->typeAliasTags;
 		$self->typeAliasImportTags = $this->typeAliasImportTags;
 		$self->assertTags = $assertTags;
-		$self->selfOutTypeTag = $this->getThisOutTag();
+		$self->selfOutTypeTag = $this->selfOutTypeTag;
 		$self->deprecatedTag = $this->deprecatedTag;
 		$self->isDeprecated = $this->isDeprecated;
 		$self->isInternal = $this->isInternal;
@@ -528,7 +528,7 @@ class ResolvedPhpDocBlock
 		return $this->assertTags;
 	}
 
-	public function getThisOutTag(): ?SelfOutTypeTag
+	public function getSelfOutTag(): ?SelfOutTypeTag
 	{
 		if ($this->selfOutTypeTag === false) {
 			$this->selfOutTypeTag = $this->phpDocNodeResolver->resolveSelfOutTypeTag(
@@ -809,6 +809,25 @@ class ResolvedPhpDocBlock
 		}
 
 		return $assertTags;
+	}
+
+	/**
+	 * @param array<int, self> $parents
+	 */
+	private static function mergeSelfOutTypeTags(?SelfOutTypeTag $selfOutTypeTag, array $parents): ?SelfOutTypeTag
+	{
+		if ($selfOutTypeTag !== null) {
+			return $selfOutTypeTag;
+		}
+		foreach ($parents as $parent) {
+			$result = $parent->getSelfOutTag();
+			if ($result === null) {
+				continue;
+			}
+			return $result;
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/PhpDoc/ResolvedPhpDocBlock.php
+++ b/src/PhpDoc/ResolvedPhpDocBlock.php
@@ -12,6 +12,7 @@ use PHPStan\PhpDoc\Tag\MixinTag;
 use PHPStan\PhpDoc\Tag\ParamTag;
 use PHPStan\PhpDoc\Tag\PropertyTag;
 use PHPStan\PhpDoc\Tag\ReturnTag;
+use PHPStan\PhpDoc\Tag\SelfOutTypeTag;
 use PHPStan\PhpDoc\Tag\TemplateTag;
 use PHPStan\PhpDoc\Tag\ThrowsTag;
 use PHPStan\PhpDoc\Tag\TypeAliasImportTag;
@@ -90,6 +91,8 @@ class ResolvedPhpDocBlock
 	/** @var array<AssertTag>|false */
 	private array|false $assertTags = false;
 
+	private SelfOutTypeTag|false|null $selfOutTypeTag = false;
+
 	private DeprecatedTag|false|null $deprecatedTag = false;
 
 	private ?bool $isDeprecated = null;
@@ -164,6 +167,7 @@ class ResolvedPhpDocBlock
 		$self->typeAliasTags = [];
 		$self->typeAliasImportTags = [];
 		$self->assertTags = [];
+		$self->selfOutTypeTag = null;
 		$self->deprecatedTag = null;
 		$self->isDeprecated = false;
 		$self->isInternal = false;
@@ -216,6 +220,7 @@ class ResolvedPhpDocBlock
 		$result->typeAliasTags = $this->getTypeAliasTags();
 		$result->typeAliasImportTags = $this->getTypeAliasImportTags();
 		$result->assertTags = self::mergeAssertTags($this->getAssertTags(), $parents, $parentPhpDocBlocks);
+		$result->selfOutTypeTag = $this->getThisOutTag();
 		$result->deprecatedTag = self::mergeDeprecatedTags($this->getDeprecatedTag(), $parents);
 		$result->isDeprecated = $result->deprecatedTag !== null;
 		$result->isInternal = $this->isInternal();
@@ -297,6 +302,7 @@ class ResolvedPhpDocBlock
 		$self->typeAliasTags = $this->typeAliasTags;
 		$self->typeAliasImportTags = $this->typeAliasImportTags;
 		$self->assertTags = $assertTags;
+		$self->selfOutTypeTag = $this->getThisOutTag();
 		$self->deprecatedTag = $this->deprecatedTag;
 		$self->isDeprecated = $this->isDeprecated;
 		$self->isInternal = $this->isInternal;
@@ -520,6 +526,18 @@ class ResolvedPhpDocBlock
 		}
 
 		return $this->assertTags;
+	}
+
+	public function getThisOutTag(): ?SelfOutTypeTag
+	{
+		if ($this->selfOutTypeTag === false) {
+			$this->selfOutTypeTag = $this->phpDocNodeResolver->resolveSelfOutTypeTag(
+				$this->phpDocNode,
+				$this->getNameScope(),
+			);
+		}
+
+		return $this->selfOutTypeTag;
 	}
 
 	public function getDeprecatedTag(): ?DeprecatedTag

--- a/src/PhpDoc/Tag/SelfOutTypeTag.php
+++ b/src/PhpDoc/Tag/SelfOutTypeTag.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc\Tag;
+
+use PHPStan\Type\Type;
+
+class SelfOutTypeTag implements TypedTag
+{
+
+	public function __construct(private Type $type)
+	{
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
+	}
+
+	/**
+	 * @return self
+	 */
+	public function withType(Type $type): TypedTag
+	{
+		return new self($type);
+	}
+
+}

--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -121,4 +121,9 @@ class AnnotationMethodReflection implements ExtendedMethodReflection
 		return Assertions::createEmpty();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return null;
+	}
+
 }

--- a/src/Reflection/Dummy/ChangedTypeMethodReflection.php
+++ b/src/Reflection/Dummy/ChangedTypeMethodReflection.php
@@ -95,4 +95,9 @@ class ChangedTypeMethodReflection implements ExtendedMethodReflection
 		return $this->reflection->getAsserts();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return $this->reflection->getSelfOutType();
+	}
+
 }

--- a/src/Reflection/Dummy/DummyMethodReflection.php
+++ b/src/Reflection/Dummy/DummyMethodReflection.php
@@ -102,4 +102,9 @@ class DummyMethodReflection implements ExtendedMethodReflection
 		return Assertions::createEmpty();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return null;
+	}
+
 }

--- a/src/Reflection/ExtendedMethodReflection.php
+++ b/src/Reflection/ExtendedMethodReflection.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Reflection;
 
+use PHPStan\Type\Type;
+
 /**
  * The purpose of this interface is to be able to
  * answer more questions about methods
@@ -17,5 +19,7 @@ interface ExtendedMethodReflection extends MethodReflection
 {
 
 	public function getAsserts(): Assertions;
+
+	public function getSelfOutType(): ?Type;
 
 }

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -31,6 +31,7 @@ class NativeMethodReflection implements ExtendedMethodReflection
 		private TrinaryLogic $hasSideEffects,
 		private ?Type $throwType,
 		private Assertions $assertions,
+		private ?Type $selfOutType,
 	)
 	{
 	}
@@ -158,6 +159,11 @@ class NativeMethodReflection implements ExtendedMethodReflection
 	public function getAsserts(): Assertions
 	{
 		return $this->assertions;
+	}
+
+	public function getSelfOutType(): ?Type
+	{
+		return $this->selfOutType;
 	}
 
 }

--- a/src/Reflection/Php/ClosureCallMethodReflection.php
+++ b/src/Reflection/Php/ClosureCallMethodReflection.php
@@ -124,4 +124,9 @@ final class ClosureCallMethodReflection implements ExtendedMethodReflection
 		return $this->nativeMethodReflection->getAsserts();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return $this->nativeMethodReflection->getSelfOutType();
+	}
+
 }

--- a/src/Reflection/Php/EnumCasesMethodReflection.php
+++ b/src/Reflection/Php/EnumCasesMethodReflection.php
@@ -111,4 +111,9 @@ class EnumCasesMethodReflection implements ExtendedMethodReflection
 		return Assertions::createEmpty();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return null;
+	}
+
 }

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -502,6 +502,7 @@ class PhpClassReflectionExtension
 			$reflectionMethod = null;
 			$throwType = null;
 			$asserts = Assertions::createEmpty();
+			$selfOutType = null;
 			if ($classReflection->getNativeReflection()->hasMethod($methodReflection->getName())) {
 				$reflectionMethod = $classReflection->getNativeReflection()->getMethod($methodReflection->getName());
 			}
@@ -544,6 +545,11 @@ class PhpClassReflectionExtension
 						}
 
 						$asserts = Assertions::createFromResolvedPhpDocBlock($stubPhpDoc);
+
+						$selfOutTypeTag = $stubPhpDoc->getThisOutTag();
+						if ($selfOutTypeTag !== null) {
+							$selfOutType = $selfOutTypeTag->getType();
+						}
 					}
 				}
 				if ($stubPhpDocPair === null && $reflectionMethod !== null && $reflectionMethod->getDocComment() !== false) {
@@ -568,6 +574,11 @@ class PhpClassReflectionExtension
 							$phpDocParameterTypes[$name] = $paramTag->getType();
 						}
 						$asserts = Assertions::createFromResolvedPhpDocBlock($phpDocBlock);
+
+						$selfOutTypeTag = $phpDocBlock->getThisOutTag();
+						if ($selfOutTypeTag !== null) {
+							$selfOutType = $selfOutTypeTag->getType();
+						}
 
 						$signatureParameters = $methodSignature->getParameters();
 						foreach ($reflectionMethod->getParameters() as $paramI => $reflectionParameter) {
@@ -595,6 +606,7 @@ class PhpClassReflectionExtension
 				$hasSideEffects,
 				$throwType,
 				$asserts,
+				$selfOutType,
 			);
 		}
 
@@ -715,6 +727,7 @@ class PhpClassReflectionExtension
 		$isFinal = $resolvedPhpDoc->isFinal();
 		$isPure = $resolvedPhpDoc->isPure();
 		$asserts = Assertions::createFromResolvedPhpDocBlock($resolvedPhpDoc);
+		$selfOutType = $resolvedPhpDoc->getThisOutTag() !== null ? $resolvedPhpDoc->getThisOutTag()->getType() : null;
 
 		return $this->methodReflectionFactory->create(
 			$declaringClass,
@@ -730,6 +743,7 @@ class PhpClassReflectionExtension
 			$isFinal,
 			$isPure,
 			$asserts,
+			$selfOutType,
 		);
 	}
 
@@ -885,7 +899,7 @@ class PhpClassReflectionExtension
 			$constructor,
 			$namespace,
 		)->enterClass($declaringClass);
-		[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, , , $asserts] = $this->nodeScopeResolver->getPhpDocs($classScope, $methodNode);
+		[$templateTypeMap, $phpDocParameterTypes, $phpDocReturnType, $phpDocThrowType, $deprecatedDescription, $isDeprecated, $isInternal, $isFinal, $isPure, $acceptsNamedArguments, , , $asserts, $selfOutType] = $this->nodeScopeResolver->getPhpDocs($classScope, $methodNode);
 		$methodScope = $classScope->enterClassMethod(
 			$methodNode,
 			$templateTypeMap,
@@ -899,6 +913,7 @@ class PhpClassReflectionExtension
 			$isPure,
 			$acceptsNamedArguments,
 			$asserts,
+			$selfOutType,
 		);
 
 		$propertyTypes = [];

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -546,7 +546,7 @@ class PhpClassReflectionExtension
 
 						$asserts = Assertions::createFromResolvedPhpDocBlock($stubPhpDoc);
 
-						$selfOutTypeTag = $stubPhpDoc->getThisOutTag();
+						$selfOutTypeTag = $stubPhpDoc->getSelfOutTag();
 						if ($selfOutTypeTag !== null) {
 							$selfOutType = $selfOutTypeTag->getType();
 						}
@@ -575,7 +575,7 @@ class PhpClassReflectionExtension
 						}
 						$asserts = Assertions::createFromResolvedPhpDocBlock($phpDocBlock);
 
-						$selfOutTypeTag = $phpDocBlock->getThisOutTag();
+						$selfOutTypeTag = $phpDocBlock->getSelfOutTag();
 						if ($selfOutTypeTag !== null) {
 							$selfOutType = $selfOutTypeTag->getType();
 						}
@@ -727,7 +727,7 @@ class PhpClassReflectionExtension
 		$isFinal = $resolvedPhpDoc->isFinal();
 		$isPure = $resolvedPhpDoc->isPure();
 		$asserts = Assertions::createFromResolvedPhpDocBlock($resolvedPhpDoc);
-		$selfOutType = $resolvedPhpDoc->getThisOutTag() !== null ? $resolvedPhpDoc->getThisOutTag()->getType() : null;
+		$selfOutType = $resolvedPhpDoc->getSelfOutTag() !== null ? $resolvedPhpDoc->getSelfOutTag()->getType() : null;
 
 		return $this->methodReflectionFactory->create(
 			$declaringClass,

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -46,6 +46,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		?bool $isPure,
 		bool $acceptsNamedArguments,
 		Assertions $assertions,
+		private ?Type $selfOutType,
 	)
 	{
 		$name = strtolower($classMethod->name->name);
@@ -135,6 +136,11 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 	public function isBuiltin(): bool
 	{
 		return false;
+	}
+
+	public function getSelfOutType(): ?Type
+	{
+		return $this->selfOutType;
 	}
 
 }

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -80,6 +80,7 @@ class PhpMethodReflection implements ExtendedMethodReflection
 		private bool $isFinal,
 		private ?bool $isPure,
 		private Assertions $asserts,
+		private ?Type $selfOutType,
 	)
 	{
 	}
@@ -424,6 +425,11 @@ class PhpMethodReflection implements ExtendedMethodReflection
 	public function getAsserts(): Assertions
 	{
 		return $this->asserts;
+	}
+
+	public function getSelfOutType(): ?Type
+	{
+		return $this->selfOutType;
 	}
 
 }

--- a/src/Reflection/Php/PhpMethodReflectionFactory.php
+++ b/src/Reflection/Php/PhpMethodReflectionFactory.php
@@ -27,6 +27,7 @@ interface PhpMethodReflectionFactory
 		bool $isFinal,
 		?bool $isPure,
 		Assertions $asserts,
+		?Type $selfOutType,
 	): PhpMethodReflection;
 
 }

--- a/src/Reflection/ResolvedMethodReflection.php
+++ b/src/Reflection/ResolvedMethodReflection.php
@@ -16,6 +16,8 @@ class ResolvedMethodReflection implements ExtendedMethodReflection
 
 	private ?Assertions $asserts = null;
 
+	private Type|false|null $selfOutType = false;
+
 	public function __construct(private ExtendedMethodReflection $reflection, private TemplateTypeMap $resolvedTemplateTypeMap)
 	{
 	}
@@ -121,6 +123,20 @@ class ResolvedMethodReflection implements ExtendedMethodReflection
 	public function getAsserts(): Assertions
 	{
 		return $this->asserts ??= $this->reflection->getAsserts()->mapTypes(fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes($type, $this->resolvedTemplateTypeMap));
+	}
+
+	public function getSelfOutType(): ?Type
+	{
+		if ($this->selfOutType === false) {
+			$selfOutType = $this->reflection->getSelfOutType();
+			if ($selfOutType !== null) {
+				$selfOutType = TemplateTypeHelper::resolveTemplateTypes($selfOutType, $this->resolvedTemplateTypeMap);
+			}
+
+			$this->selfOutType = $selfOutType;
+		}
+
+		return $this->selfOutType;
 	}
 
 }

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -159,4 +159,9 @@ class IntersectionTypeMethodReflection implements ExtendedMethodReflection
 		return Assertions::createEmpty();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return null;
+	}
+
 }

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -153,4 +153,9 @@ class UnionTypeMethodReflection implements ExtendedMethodReflection
 		return Assertions::createEmpty();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return null;
+	}
+
 }

--- a/src/Reflection/WrappedExtendedMethodReflection.php
+++ b/src/Reflection/WrappedExtendedMethodReflection.php
@@ -87,4 +87,9 @@ class WrappedExtendedMethodReflection implements ExtendedMethodReflection
 		return Assertions::createEmpty();
 	}
 
+	public function getSelfOutType(): ?Type
+	{
+		return null;
+	}
+
 }

--- a/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
@@ -10,6 +10,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
+use function sprintf;
 
 /**
  * @implements Rule<InClassMethodNode>

--- a/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * @implements Rule<InClassMethodNode>
+ */
+class IncompatibleSelfOutTypeRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return InClassMethodNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$method = $scope->getFunction();
+		if ($method === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		$selfOutType = $method->getSelfOutType();
+		if ($selfOutType === null) {
+			return [];
+		}
+
+		$classReflection = $method->getDeclaringClass();
+		$classType = new ObjectType($classReflection->getName(), null, $classReflection);
+
+		if (!$classType->isSuperTypeOf($selfOutType)->no()) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Out type %s is not compatible with %s.',
+				$selfOutType->describe(VerbosityLevel::precise()),
+				$classType->describe(VerbosityLevel::precise()),
+			))->build(),
+		];
+	}
+
+}

--- a/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
@@ -25,11 +24,7 @@ class IncompatibleSelfOutTypeRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$method = $scope->getFunction();
-		if ($method === null) {
-			throw new ShouldNotHappenException();
-		}
-
+		$method = $node->getMethodReflection();
 		$selfOutType = $method->getSelfOutType();
 		if ($selfOutType === null) {
 			return [];

--- a/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatibleSelfOutTypeRule.php
@@ -26,6 +26,7 @@ class IncompatibleSelfOutTypeRule implements Rule
 	{
 		$method = $node->getMethodReflection();
 		$selfOutType = $method->getSelfOutType();
+
 		if ($selfOutType === null) {
 			return [];
 		}
@@ -33,14 +34,16 @@ class IncompatibleSelfOutTypeRule implements Rule
 		$classReflection = $method->getDeclaringClass();
 		$classType = new ObjectType($classReflection->getName(), null, $classReflection);
 
-		if (!$classType->isSuperTypeOf($selfOutType)->no()) {
+		if ($classType->isSuperTypeOf($selfOutType)->yes()) {
 			return [];
 		}
 
 		return [
 			RuleErrorBuilder::message(sprintf(
-				'Out type %s is not compatible with %s.',
+				'Self-out type %s of method %s::%s is not subtype of %s.',
 				$selfOutType->describe(VerbosityLevel::precise()),
+				$classReflection->getName(),
+				$method->getName(),
 				$classType->describe(VerbosityLevel::precise()),
 			))->build(),
 		];

--- a/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
+++ b/src/Rules/PhpDoc/InvalidPHPStanDocTagRule.php
@@ -44,6 +44,8 @@ class InvalidPHPStanDocTagRule implements Rule
 		'@phpstan-assert',
 		'@phpstan-assert-if-true',
 		'@phpstan-assert-if-false',
+		'@phpstan-self-out',
+		'@phpstan-this-out',
 	];
 
 	public function __construct(private Lexer $phpDocLexer, private PhpDocParser $phpDocParser)

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1065,6 +1065,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extra-extra-int-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-count.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Properties/data/bug-7839.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/self-out.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/self-out.php
+++ b/tests/PHPStan/Analyser/data/self-out.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SelfOut;
+
+use function PHPStan\dumpType;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ */
+class a {
+    /**
+     * @var list<T>
+     */
+    private array $data;
+    /**
+     * @param T $data
+     */
+    public function __construct($data) {
+        $this->data = [$data];
+    }
+    /**
+     * @template NewT
+     *
+     * @param NewT $data
+     *
+     * @phpstan-self-out self<T|NewT>
+     *
+     * @return void
+     */
+    public function addData($data) {
+        /** @var self<T|NewT> $this */
+        $this->data []= $data;
+    }
+    /**
+     * @template NewT
+     *
+     * @param NewT $data
+     *
+     * @phpstan-self-out self<NewT>
+     *
+     * @return void
+     */
+    public function setData($data) {
+        /** @var self<NewT> $this */
+        $this->data = [$data];
+    }
+    /**
+     * @return ($this is a<int> ? void : never)
+     */
+    public function test(): void {
+    }
+}
+
+function () {
+	$i = new a(123);
+	// OK - $i is a<123>
+	assertType('SelfOut\\a<int>', $i);
+	assertType('void', $i->test());
+
+	$i->addData(321);
+	// OK - $i is a<123|321>
+	assertType('SelfOut\\a<int>', $i);
+	assertType('void', $i->test());
+
+	$i->setData("test");
+	// IfThisIsMismatch - Class is not a<int> as required
+	assertType('SelfOut\\a<string>', $i);
+	assertType('*NEVER*', $i->test());
+};

--- a/tests/PHPStan/Analyser/data/self-out.php
+++ b/tests/PHPStan/Analyser/data/self-out.php
@@ -52,6 +52,19 @@ class a {
     }
 }
 
+/**
+ * @template T
+ * @extends a<T>
+ */
+class b extends a {
+	/**
+	 * @param T $data
+	 */
+	public function __construct($data) {
+		parent::__construct($data);
+	}
+}
+
 function () {
 	$i = new a(123);
 	// OK - $i is a<123>
@@ -67,4 +80,12 @@ function () {
 	// IfThisIsMismatch - Class is not a<int> as required
 	assertType('SelfOut\\a<string>', $i);
 	assertType('*NEVER*', $i->test());
+};
+
+function () {
+	$i = new b(123);
+	assertType('SelfOut\\b<int>', $i);
+
+	$i->addData(321);
+	assertType('SelfOut\\a<int>', $i);
 };

--- a/tests/PHPStan/Rules/PhpDoc/IncompatibleSelfOutTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatibleSelfOutTypeRuleTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<IncompatibleSelfOutTypeRule>
+ */
+class IncompatibleSelfOutTypeRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new IncompatibleSelfOutTypeRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/incompatible-self-out-type.php'], [
+			[
+				'Out type int is not compatible with IncompatibleSelfOutType\A.',
+				23,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/IncompatibleSelfOutTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatibleSelfOutTypeRuleTest.php
@@ -20,8 +20,12 @@ class IncompatibleSelfOutTypeRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/incompatible-self-out-type.php'], [
 			[
-				'Out type int is not compatible with IncompatibleSelfOutType\A.',
+				'Self-out type int of method IncompatibleSelfOutType\A::three is not subtype of IncompatibleSelfOutType\A.',
 				23,
+			],
+			[
+				'Self-out type IncompatibleSelfOutType\A|null of method IncompatibleSelfOutType\A::four is not subtype of IncompatibleSelfOutType\A.',
+				28,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-self-out-type.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-self-out-type.php
@@ -21,4 +21,9 @@ interface A
 	 * @phpstan-self-out int
 	 */
 	public function three();
+
+	/**
+	 * @phpstan-self-out self|null
+	 */
+	public function four();
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-self-out-type.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-self-out-type.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace IncompatibleSelfOutType;
+
+/**
+ * @template T
+ */
+interface A
+{
+	/** @phpstan-self-out self */
+	public function one();
+
+	/**
+	 * @template NewT
+	 * @param NewT $param
+	 * @phpstan-self-out self<NewT>
+	 */
+	public function two($param);
+
+	/**
+	 * @phpstan-self-out int
+	 */
+	public function three();
+}


### PR DESCRIPTION
This is a "missing" feature from the assert family which allows changing the `$this` type after a method call, which is particularly useful for setters.

See https://psalm.dev/docs/annotating_code/adding_assertions/#asserting-return-values-of-methods for the docs for psalm.

Syntax implementation in https://github.com/phpstan/phpdoc-parser/pull/149