### PR TITLE
Fix return type of array_search() with constant array type haystack

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1141,6 +1141,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7805.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-82.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4565.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3789.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-3789.php
+++ b/tests/PHPStan/Analyser/data/bug-3789.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bug3789;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array{string, string, string} $haystack
+ */
+function doFoo(string $needle, array $haystack): void {
+	assertType('0|1|2|false', array_search($needle, $haystack, true));
+	assertType('0|1|2|false', array_search('foo', $haystack, true));
+
+	assertType('0|1|2|false', array_search($needle, $haystack));
+	assertType('0|1|2|false', array_search('foo', $haystack));
+
+	$haystack[1] = 'foo';
+	assertType('0|1|2|false', array_search($needle, $haystack, true));
+	assertType('0|1|2', array_search('foo', $haystack, true));
+
+	assertType('0|1|2|false', array_search($needle, $haystack));
+	assertType('0|1|2|false', array_search('foo', $haystack));
+}


### PR DESCRIPTION
Return type of `array_search()` may be false unless we are sure that `$haystack` includes a value identical to `$needle`.

Closes phpstan/phpstan#3789