### PR TITLE
Add `Type::getLastIterableValueType()`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -157,6 +157,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return new MixedType();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -157,6 +157,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -146,6 +146,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -146,6 +146,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return new MixedType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -145,6 +145,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -145,6 +145,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return new MixedType();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -213,6 +213,11 @@ class ArrayType implements Type
 		return $this->getItemType();
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->getItemType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return $this->getItemType();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -213,6 +213,11 @@ class ArrayType implements Type
 		return $this->getItemType();
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return $this->getItemType();
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -274,17 +274,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return TypeCombinator::union(...$valueTypes);
 	}
 
+	/** @deprecated Use getLastIterableValueType() instead */
 	public function getLastValueType(): Type
 	{
-		$valueTypes = [];
-		for ($i = count($this->keyTypes) - 1; $i >= 0; $i--) {
-			$valueTypes[] = $this->valueTypes[$i];
-			if (!$this->isOptionalKey($i)) {
-				break;
-			}
-		}
-
-		return TypeCombinator::union(...$valueTypes);
+		return $this->getLastIterableValueType();
 	}
 
 	public function isOptionalKey(int $i): bool
@@ -710,6 +703,19 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getLastIterableValueType(): Type
+	{
+		$valueTypes = [];
+		for ($i = count($this->keyTypes) - 1; $i >= 0; $i--) {
+			$valueTypes[] = $this->valueTypes[$i];
+			if (!$this->isOptionalKey($i)) {
+				break;
+			}
+		}
+
+		return TypeCombinator::union(...$valueTypes);
 	}
 
 	public function isList(): TrinaryLogic

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -261,17 +261,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $this->valueTypes;
 	}
 
+	/** @deprecated Use getFirstIterableValueType() instead */
 	public function getFirstValueType(): Type
 	{
-		$valueTypes = [];
-		foreach ($this->valueTypes as $i => $valueType) {
-			$valueTypes[] = $valueType;
-			if (!$this->isOptionalKey($i)) {
-				break;
-			}
-		}
-
-		return TypeCombinator::union(...$valueTypes);
+		return $this->getFirstIterableValueType();
 	}
 
 	/** @deprecated Use getLastIterableValueType() instead */
@@ -703,6 +696,19 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getFirstIterableValueType(): Type
+	{
+		$valueTypes = [];
+		foreach ($this->valueTypes as $i => $valueType) {
+			$valueTypes[] = $valueType;
+			if (!$this->isOptionalKey($i)) {
+				break;
+			}
+		}
+
+		return TypeCombinator::union(...$valueTypes);
 	}
 
 	public function getLastIterableValueType(): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -416,6 +416,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->getIterableValueType());
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getFirstIterableValueType());
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->getLastIterableValueType());

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -416,6 +416,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->getIterableValueType());
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getLastIterableValueType());
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isArray());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -376,6 +376,11 @@ class MixedType implements CompoundType, SubtractableType
 		return new self($this->isExplicitMixed);
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return new self($this->isExplicitMixed);
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -376,6 +376,11 @@ class MixedType implements CompoundType, SubtractableType
 		return new self($this->isExplicitMixed);
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return new self($this->isExplicitMixed);
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return new self($this->isExplicitMixed);

--- a/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
@@ -57,7 +57,7 @@ class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunction
 
 				$keyTypes[] = $functionReflection->getName() === 'reset'
 					? $constantArray->getFirstValueType()
-					: $constantArray->getLastValueType();
+					: $constantArray->getLastIterableValueType();
 			}
 
 			return TypeCombinator::union(...$keyTypes);

--- a/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
@@ -56,7 +56,7 @@ class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunction
 				}
 
 				$keyTypes[] = $functionReflection->getName() === 'reset'
-					? $constantArray->getFirstValueType()
+					? $constantArray->getFirstIterableValueType()
 					: $constantArray->getLastIterableValueType();
 			}
 

--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -5,12 +5,10 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use function count;
 
 class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -20,10 +18,10 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return $functionReflection->getName() === 'array_pop';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
@@ -32,24 +30,7 @@ class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			return new NullType();
 		}
 
-		$constantArrays = $argType->getConstantArrays();
-		if (count($constantArrays) > 0) {
-			$valueTypes = [];
-			foreach ($constantArrays as $constantArray) {
-				$iterableAtLeastOnce = $constantArray->isIterableAtLeastOnce();
-				if (!$iterableAtLeastOnce->yes()) {
-					$valueTypes[] = new NullType();
-				}
-				if ($iterableAtLeastOnce->no()) {
-					continue;
-				}
-				$valueTypes[] = $constantArray->getLastValueType();
-			}
-
-			return TypeCombinator::union(...$valueTypes);
-		}
-
-		$itemType = $argType->getIterableValueType();
+		$itemType = $argType->getLastIterableValueType();
 		if ($iterableAtLeastOnce->yes()) {
 			return $itemType;
 		}

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -307,6 +307,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getIterableValueType();
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return $this->getStaticObjectType()->getLastIterableValueType();
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isOffsetAccessible();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -307,6 +307,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getIterableValueType();
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->getStaticObjectType()->getFirstIterableValueType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return $this->getStaticObjectType()->getLastIterableValueType();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -135,6 +135,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->getIterableValueType();
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return $this->resolve()->getLastIterableValueType();
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return $this->resolve()->isArray();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -135,6 +135,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->getIterableValueType();
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->resolve()->getFirstIterableValueType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return $this->resolve()->getLastIterableValueType();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
 
 trait MaybeArrayTypeTrait
 {
@@ -15,6 +17,11 @@ trait MaybeArrayTypeTrait
 	public function getConstantArrays(): array
 	{
 		return [];
+	}
+
+	public function getLastIterableValueType(): Type
+	{
+		return new MixedType();
 	}
 
 	public function isArray(): TrinaryLogic

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -19,6 +19,11 @@ trait MaybeArrayTypeTrait
 		return [];
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return new MixedType();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -19,6 +19,11 @@ trait NonArrayTypeTrait
 		return [];
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
 
 trait NonArrayTypeTrait
 {
@@ -15,6 +17,11 @@ trait NonArrayTypeTrait
 	public function getConstantArrays(): array
 	{
 		return [];
+	}
+
+	public function getLastIterableValueType(): Type
+	{
+		return new ErrorType();
 	}
 
 	public function isArray(): TrinaryLogic

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -68,6 +68,8 @@ interface Type
 
 	public function getIterableValueType(): Type;
 
+	public function getFirstIterableValueType(): Type;
+
 	public function getLastIterableValueType(): Type;
 
 	public function isArray(): TrinaryLogic;

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -68,6 +68,8 @@ interface Type
 
 	public function getIterableValueType(): Type;
 
+	public function getLastIterableValueType(): Type;
+
 	public function isArray(): TrinaryLogic;
 
 	public function isOversizedArray(): TrinaryLogic;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -430,6 +430,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->getIterableValueType());
 	}
 
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->getFirstIterableValueType());
+	}
+
 	public function getLastIterableValueType(): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->getLastIterableValueType());

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -430,6 +430,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->getIterableValueType());
 	}
 
+	public function getLastIterableValueType(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->getLastIterableValueType());
+	}
+
 	public function isArray(): TrinaryLogic
 	{
 		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isArray());

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -33,6 +33,10 @@ class Foo
 		/** @var array{a: 0, b: 1, c: 2} $arr */
 		assertType('2', array_pop($arr));
 		assertType('array{a: 0, b: 1}', $arr);
+
+		/** @var array{} $arr */
+		assertType('null', array_pop($arr));
+		assertType('array{}', $arr);
 	}
 
 	public function constantArraysWithOptionalKeys(array $arr): void

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -33,6 +33,10 @@ class Foo
 		/** @var array{a: 0, b: 1, c: 2} $arr */
 		assertType('0', array_shift($arr));
 		assertType('array{b: 1, c: 2}', $arr);
+
+		/** @var array{} $arr */
+		assertType('null', array_shift($arr));
+		assertType('array{}', $arr);
 	}
 
 	public function constantArraysWithOptionalKeys(array $arr): void


### PR DESCRIPTION
just playing around, kind of POC for moving more array-related methods to `Type` which I mentioned in https://github.com/phpstan/phpstan-src/pull/1801#issuecomment-1272401520. I'm not sure about this or if this should be the direction to move forward for other array return type extensions too.. 

What I like
- no special constant array handling and union type building anymore in `ArrayPopFunctionReturnTypeExtension`. I actually **love** that

What I dislike
- it's basically just for constant array and `array_pop` in particular
- boiler plate code in some type classes, but this is already minimized thanks to the new array traits
- naming-wise it's maybe hard to understand in some cases, e.g. how would `flip()` be called on Type and what do people expect it to do ..
- not much related to this PR, but there's also `MaybeIterableTypeTrait` and `NonIterableTypeTrait` which are kind of related to the new array type traits IMO

Most likely this is the best-case example and others will be more complicated to move over.

This PR is really mostly just for discussing this to not do this in other PRs that are not related :)