### PR TITLE
Infer constant array type from specifying count() on a list type

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1063,6 +1063,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-class-type.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5552.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extra-extra-int-types.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-count.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-4499.php
+++ b/tests/PHPStan/Analyser/data/bug-4499.php
@@ -11,7 +11,7 @@ class Foo
 	function thing(array $things) : void{
 		switch(count($things)){
 			case 1:
-				assertType('non-empty-list<int>', $things);
+				assertType('array{int}', $things);
 				assertType('int', array_shift($things));
 		}
 	}

--- a/tests/PHPStan/Analyser/data/list-count.php
+++ b/tests/PHPStan/Analyser/data/list-count.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ListCount;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param list<int> $items
+ */
+function foo(array $items) {
+	assertType('list<int>', $items);
+	if (count($items) === 3) {
+		assertType('array{int, int, int}', $items);
+		array_shift($items);
+		assertType('array{int, int}', $items);
+	} elseif (count($items) === 0) {
+		assertType('array{}', $items);
+	} elseif (count($items) === 5) {
+		assertType('array{int, int, int, int, int}', $items);
+	} else {
+		assertType('non-empty-list<int>', $items);
+	}
+	assertType('list<int>', $items);
+}

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -769,4 +769,10 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8071.php'], []);
 	}
 
+	public function testBug3499(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-3499.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-3499.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-3499.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3499;
+
+class JwtException extends \RuntimeException{}
+
+final class JwtUtils{
+
+	/**
+	 * @return string[]
+	 * @phpstan-return array{string, string, string}
+	 * @throws JwtException
+	 */
+	public static function split(string $jwt) : array{
+		$v = explode(".", $jwt);
+		if(count($v) !== 3){
+			throw new JwtException("Expected exactly 3 JWT parts, got " . count($v));
+		}
+		return $v;
+	}
+}


### PR DESCRIPTION
Fix phpstan/phpstan#3499