### PR TITLE
added bug 7692 regression test

### DIFF
--- a/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
@@ -165,4 +165,10 @@ class OverridingPropertyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7839.php'], []);
 	}
 
+	public function testBug7692(): void
+	{
+		$this->reportMaybes = true;
+		$this->analyse([__DIR__ . '/data/bug-7692.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-7692.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-7692.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace InheritingNamespace7692 {
+
+	use BaseNamespace7692\TheBaseService;
+	//use BaseNamespace\Entity\EntityBaseInterface;
+
+	class TheIntermediateService extends TheBaseService
+	{
+
+	}
+}
+
+namespace BaseNamespace7692 {
+
+	use BaseNamespace7692\Entity\EntityBaseInterface;
+
+	class TheBaseService
+	{
+		/**
+		 * @var class-string<EntityBaseInterface>
+		 */
+		protected static $entityClass;
+	}
+}
+
+namespace BaseNamespace7692\Entity {
+
+	interface EntityBaseInterface
+	{
+
+	}
+}
+
+namespace DeepInheritingNamespace7692 {
+
+	use InheritingNamespace7692\TheIntermediateService;
+	use DeepInheritingNamespace7692\Entity\TheEntity;
+
+	final class TheChildService extends TheIntermediateService
+	{
+		protected static $entityClass = TheEntity::class;
+	}
+}
+
+namespace DeepInheritingNamespace7692\Entity {
+
+	use BaseNamespace7692\Entity\EntityBaseInterface;
+
+	final class TheEntity implements EntityBaseInterface
+	{
+
+	}
+}


### PR DESCRIPTION
the main problem of the initial report was the error

> +'42: PHPDoc type class-string<InheritingNamespace7692\EntityBaseInterface> of property DeepInheritingNamespace7692\TheChildService::$entityClass is not the same as PHPDoc type class-string<BaseNamespace7692\Entity\EntityBaseInterface> of overridden property BaseNamespace7692\TheBaseService::$entityClass.

which is beeing coverd by this test.

closes https://github.com/phpstan/phpstan/issues/7692