### PR TITLE
Move iterable methods from array to iterable traits

### DIFF
--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -7,9 +7,11 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -20,7 +22,9 @@ class BooleanType implements Type
 {
 
 	use JustNullableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
+	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -10,7 +10,6 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -22,7 +21,6 @@ class BooleanType implements Type
 
 	use JustNullableTypeTrait;
 	use NonCallableTypeTrait;
-	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -25,6 +25,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -39,6 +40,7 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 
 	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
+	use NonIterableTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use NonRemoveableTypeTrait;
@@ -236,16 +238,6 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
-	}
-
-	public function getIterableKeyType(): Type
-	{
-		return new ErrorType();
-	}
-
-	public function getIterableValueType(): Type
-	{
-		return new ErrorType();
 	}
 
 	public function isCallable(): TrinaryLogic

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -5,9 +5,11 @@ namespace PHPStan\Type;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -18,7 +20,9 @@ class IntegerType implements Type
 {
 
 	use JustNullableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
+	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -8,7 +8,6 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
@@ -20,7 +19,6 @@ class IntegerType implements Type
 
 	use JustNullableTypeTrait;
 	use NonCallableTypeTrait;
-	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -226,7 +226,27 @@ class IterableType implements CompoundType
 		return $this->keyType;
 	}
 
+	public function getFirstIterableKeyType(): Type
+	{
+		return $this->keyType;
+	}
+
+	public function getLastIterableKeyType(): Type
+	{
+		return $this->keyType;
+	}
+
 	public function getIterableValueType(): Type
+	{
+		return $this->getItemType();
+	}
+
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->getItemType();
+	}
+
+	public function getLastIterableValueType(): Type
 	{
 		return $this->getItemType();
 	}

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -3,15 +3,10 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Traits\NonArrayTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use function get_class;
 
 trait JustNullableTypeTrait
 {
-
-	use NonArrayTypeTrait;
-	use NonIterableTypeTrait;
 
 	/**
 	 * @return string[]

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use function get_class;
 
 trait JustNullableTypeTrait
 {
 
 	use NonArrayTypeTrait;
+	use NonIterableTypeTrait;
 
 	/**
 	 * @return string[]

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -15,6 +15,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
@@ -26,6 +27,7 @@ class NeverType implements CompoundType
 	use UndecidedBooleanTypeTrait;
 	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
+	use NonIterableTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
 	use NonGeneralizableTypeTrait;

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -10,9 +10,11 @@ use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
@@ -22,7 +24,9 @@ class NonexistentParentClassType implements Type
 {
 
 	use JustNullableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
+	use NonIterableTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use TruthyBooleanTypeTrait;
 	use NonGenericTypeTrait;

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -13,7 +13,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
@@ -24,7 +23,6 @@ class NonexistentParentClassType implements Type
 
 	use JustNullableTypeTrait;
 	use NonCallableTypeTrait;
-	use NonIterableTypeTrait;
 	use NonOffsetAccessibleTypeTrait;
 	use TruthyBooleanTypeTrait;
 	use NonGenericTypeTrait;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -33,6 +33,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
@@ -53,6 +54,7 @@ use function strtolower;
 class ObjectType implements TypeWithClassName, SubtractableType
 {
 
+	use MaybeIterableTypeTrait;
 	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
@@ -753,6 +755,16 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new ErrorType();
 	}
 
+	public function getFirstIterableKeyType(): Type
+	{
+		return $this->getIterableKeyType();
+	}
+
+	public function getLastIterableKeyType(): Type
+	{
+		return $this->getIterableKeyType();
+	}
+
 	public function getIterableValueType(): Type
 	{
 		$isTraversable = false;
@@ -792,6 +804,16 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		return new ErrorType();
+	}
+
+	public function getFirstIterableValueType(): Type
+	{
+		return $this->getIterableValueType();
+	}
+
+	public function getLastIterableValueType(): Type
+	{
+		return $this->getIterableValueType();
 	}
 
 	public function isString(): TrinaryLogic

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -7,7 +7,6 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
@@ -20,7 +19,6 @@ class ResourceType implements Type
 
 	use JustNullableTypeTrait;
 	use NonCallableTypeTrait;
-	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use TruthyBooleanTypeTrait;
 	use NonGenericTypeTrait;

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -4,9 +4,11 @@ namespace PHPStan\Type;
 
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonOffsetAccessibleTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
@@ -18,7 +20,9 @@ class ResourceType implements Type
 {
 
 	use JustNullableTypeTrait;
+	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
+	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use TruthyBooleanTypeTrait;
 	use NonGenericTypeTrait;

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -15,6 +15,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 
@@ -23,6 +24,7 @@ class StrictMixedType implements CompoundType
 
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonArrayTypeTrait;
+	use NonIterableTypeTrait;
 	use NonRemoveableTypeTrait;
 	use NonGeneralizableTypeTrait;
 

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -9,8 +9,10 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
+use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -21,6 +23,8 @@ class StringType implements Type
 
 	use JustNullableTypeTrait;
 	use MaybeCallableTypeTrait;
+	use NonArrayTypeTrait;
+	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -11,7 +11,6 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -22,7 +21,6 @@ class StringType implements Type
 
 	use JustNullableTypeTrait;
 	use MaybeCallableTypeTrait;
-	use NonIterableTypeTrait;
 	use NonObjectTypeTrait;
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonTypeTrait;

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -3,8 +3,6 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\Type;
 
 trait MaybeArrayTypeTrait
 {
@@ -17,26 +15,6 @@ trait MaybeArrayTypeTrait
 	public function getConstantArrays(): array
 	{
 		return [];
-	}
-
-	public function getFirstIterableKeyType(): Type
-	{
-		return new MixedType();
-	}
-
-	public function getLastIterableKeyType(): Type
-	{
-		return new MixedType();
-	}
-
-	public function getFirstIterableValueType(): Type
-	{
-		return new MixedType();
-	}
-
-	public function getLastIterableValueType(): Type
-	{
-		return new MixedType();
 	}
 
 	public function isArray(): TrinaryLogic

--- a/src/Type/Traits/MaybeIterableTypeTrait.php
+++ b/src/Type/Traits/MaybeIterableTypeTrait.php
@@ -24,7 +24,27 @@ trait MaybeIterableTypeTrait
 		return new MixedType();
 	}
 
+	public function getFirstIterableKeyType(): Type
+	{
+		return new MixedType();
+	}
+
+	public function getLastIterableKeyType(): Type
+	{
+		return new MixedType();
+	}
+
 	public function getIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
+	public function getFirstIterableValueType(): Type
+	{
+		return new MixedType();
+	}
+
+	public function getLastIterableValueType(): Type
 	{
 		return new MixedType();
 	}

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -3,8 +3,6 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\Type;
 
 trait NonArrayTypeTrait
 {
@@ -17,26 +15,6 @@ trait NonArrayTypeTrait
 	public function getConstantArrays(): array
 	{
 		return [];
-	}
-
-	public function getFirstIterableKeyType(): Type
-	{
-		return new ErrorType();
-	}
-
-	public function getLastIterableKeyType(): Type
-	{
-		return new ErrorType();
-	}
-
-	public function getFirstIterableValueType(): Type
-	{
-		return new ErrorType();
-	}
-
-	public function getLastIterableValueType(): Type
-	{
-		return new ErrorType();
 	}
 
 	public function isArray(): TrinaryLogic

--- a/src/Type/Traits/NonIterableTypeTrait.php
+++ b/src/Type/Traits/NonIterableTypeTrait.php
@@ -24,7 +24,27 @@ trait NonIterableTypeTrait
 		return new ErrorType();
 	}
 
+	public function getFirstIterableKeyType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getLastIterableKeyType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function getIterableValueType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getFirstIterableValueType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getLastIterableValueType(): Type
 	{
 		return new ErrorType();
 	}


### PR DESCRIPTION
this makes more sense to me, having this in the array traits felt a bit weird already in https://github.com/phpstan/phpstan-src/pull/1811

Also fixes the new iterable methods via `IterableType` and `ObjectType`