### PR TITLE
Add `Type::isConstantArray()`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -75,7 +75,6 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ClosureType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
@@ -4619,7 +4618,7 @@ class MutatingScope implements Scope
 					$constantStrings[$key][] = $type;
 					continue;
 				}
-				if ($type instanceof ConstantArrayType) {
+				if ($type->isConstantArray()->yes()) {
 					$constantArrays[$key][] = $type;
 					continue;
 				}
@@ -4713,9 +4712,9 @@ class MutatingScope implements Scope
 				$bArrays = $bValueType->getArrays();
 				if (
 					count($aArrays) === 1
-					&& !$aArrays[0] instanceof ConstantArrayType
+					&& $aArrays[0]->isConstantArray()->no()
 					&& count($bArrays) === 1
-					&& !$bArrays[0] instanceof ConstantArrayType
+					&& $bArrays[0]->isConstantArray()->no()
 				) {
 					$aDepth = self::getArrayDepth($aArrays[0]);
 					$bDepth = self::getArrayDepth($bArrays[0]);

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -35,7 +35,6 @@ use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
@@ -946,7 +945,7 @@ class PhpClassReflectionExtension
 			}
 
 			$propertyType = $propertyType->generalize(GeneralizePrecision::lessSpecific());
-			if ($propertyType instanceof ConstantArrayType) {
+			if ($propertyType->isConstantArray()->yes()) {
 				$propertyType = new ArrayType(new MixedType(true), new MixedType(true));
 			}
 

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -111,8 +111,8 @@ class RuleLevelHelper
 			$acceptedType->isArray()->yes()
 			&& $acceptingType->isArray()->yes()
 			&& !$acceptingType->isIterableAtLeastOnce()->yes()
-			&& count($acceptedType->getConstantArrays()) === 0
-			&& count($acceptingType->getConstantArrays()) === 0
+			&& $acceptedType->isConstantArray()->no()
+			&& $acceptingType->isConstantArray()->no()
 		) {
 			return self::accepts(
 				$acceptingType->getIterableKeyType(),

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -182,6 +182,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -171,6 +171,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -170,6 +170,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -736,6 +736,11 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return TypeCombinator::union(...$valueTypes);
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function isList(): TrinaryLogic
 	{
 		if ($this->isList) {

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -441,6 +441,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isArray());
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isConstantArray());
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isOversizedArray());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -472,7 +472,7 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function isConstantArray(): TrinaryLogic
 	{
-		return TrinaryLogic::createMaybe();
+		return $this->isArray();
 	}
 
 	public function isOversizedArray(): TrinaryLogic

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -470,6 +470,11 @@ class MixedType implements CompoundType, SubtractableType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/Php/IsCallableFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsCallableFunctionTypeSpecifyingExtension.php
@@ -14,7 +14,6 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\CallableType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use function count;
 use function strtolower;
@@ -49,7 +48,7 @@ class IsCallableFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyin
 		if (
 			$value instanceof Array_
 			&& count($value->items) === 2
-			&& $valueType instanceof ConstantArrayType
+			&& $valueType->isConstantArray()->yes()
 			&& !$valueType->isCallable()->no()
 		) {
 			if ($value->items[0] === null || $value->items[1] === null) {

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -161,7 +161,7 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 	): ?Type
 	{
 		if (
-			$firstType instanceof ConstantArrayType
+			$firstType->isConstantArray()->yes()
 			&& $secondType instanceof ConstantScalarType
 		) {
 			return $secondType;
@@ -169,7 +169,7 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 
 		if (
 			$firstType instanceof ConstantScalarType
-			&& $secondType instanceof ConstantArrayType
+			&& $secondType->isConstantArray()->yes()
 		) {
 			return $firstType;
 		}

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -362,6 +362,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->isArray();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return $this->getStaticObjectType()->isConstantArray();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isOversizedArray();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -160,6 +160,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->isArray();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return $this->resolve()->isConstantArray();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return $this->resolve()->isOversizedArray();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -44,6 +44,11 @@ trait MaybeArrayTypeTrait
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -44,6 +44,11 @@ trait NonArrayTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -78,6 +78,8 @@ interface Type
 
 	public function isArray(): TrinaryLogic;
 
+	public function isConstantArray(): TrinaryLogic;
+
 	public function isOversizedArray(): TrinaryLogic;
 
 	public function isList(): TrinaryLogic;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -455,6 +455,11 @@ class UnionType implements CompoundType
 		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isArray());
 	}
 
+	public function isConstantArray(): TrinaryLogic
+	{
+		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isConstantArray());
+	}
+
 	public function isOversizedArray(): TrinaryLogic
 	{
 		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isOversizedArray());

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -240,6 +240,80 @@ class MixedTypeTest extends PHPStanTestCase
 		);
 	}
 
+	public function dataSubstractedIsConstantArray(): array
+	{
+		return [
+			[
+				new MixedType(),
+				new ArrayType(new IntegerType(), new StringType()),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new ArrayType(new StringType(), new StringType()),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new ArrayType(new MixedType(), new MixedType()),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(),
+				new ConstantArrayType(
+					[new ConstantIntegerType(1)],
+					[new ConstantStringType('hello')],
+				),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new ConstantArrayType([], []),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new UnionType([new FloatType(), new ArrayType(new MixedType(), new MixedType())]),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(),
+				new UnionType([new FloatType(), new ArrayType(new StringType(), new MixedType())]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new UnionType([new FloatType(), new IntegerType()]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new FloatType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(true),
+				new FloatType(),
+				TrinaryLogic::createMaybe(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataSubstractedIsConstantArray
+	 */
+	public function testSubstractedIsConstantArray(MixedType $mixedType, Type $typeToSubtract, TrinaryLogic $expectedResult): void
+	{
+		$subtracted = $mixedType->subtract($typeToSubtract);
+		$actualResult = $subtracted->isConstantArray();
+
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isConstantArray()', $subtracted->describe(VerbosityLevel::precise())),
+		);
+	}
+
 	public function dataSubstractedIsString(): array
 	{
 		return [


### PR DESCRIPTION
Does not get rid of many `instanceof` type checks yet unfortunately though. in order to achieve that more methods on type are needed. I hope I can do a bit more soon, but there are definitely limits to what makes sense right now.