### PR TITLE
Specify non-empty-string for callables via `is_string()`

### DIFF
--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -16,6 +16,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\CallableType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ConstantScalarType;
@@ -140,7 +141,7 @@ class ConstantStringType extends StringType implements ConstantScalarType
 			return $this->value === $type->value ? TrinaryLogic::createYes() : TrinaryLogic::createNo();
 		}
 
-		if ($type instanceof parent) {
+		if ($type instanceof parent || $type instanceof CallableType) {
 			return TrinaryLogic::createMaybe();
 		}
 

--- a/src/Type/Php/IsStringFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsStringFunctionTypeSpecifyingExtension.php
@@ -10,10 +10,8 @@ use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\StringType;
-use PHPStan\Type\TypeCombinator;
 use function strtolower;
 
 class IsStringFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
@@ -37,15 +35,7 @@ class IsStringFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingE
 			return new SpecifiedTypes();
 		}
 
-		$value = $node->getArgs()[0]->value;
-		$valueType = $scope->getType($value);
-
-		$resultType = new StringType();
-		if ($valueType->isCallable()->yes()) {
-			$resultType = TypeCombinator::intersect($resultType, new AccessoryNonEmptyStringType());
-		}
-
-		return $this->typeSpecifier->create($value, $resultType, $context, false, $scope);
+		return $this->typeSpecifier->create($node->getArgs()[0]->value, new StringType(), $context, false, $scope);
 	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1055,6 +1055,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8008.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5552.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Properties/data/bug-7839.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8153.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-8153.php
+++ b/tests/PHPStan/Analyser/data/bug-8153.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8153;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function sayHello(callable $foo): void
+	{
+		if (\is_string($foo) && strlen($foo) > 0) {
+			assertType('callable(): mixed&non-empty-string', $foo);
+			$this->nonEmptyStringParameter($foo);
+		}
+
+		if (\is_string($foo) && '' !== $foo) {
+			assertType('callable(): mixed&non-empty-string', $foo);
+			$this->nonEmptyStringParameter($foo);
+		}
+	}
+
+	/**
+	 * @param non-empty-string $foo
+	 */
+	private function nonEmptyStringParameter(string $foo): void
+	{
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -601,4 +601,15 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-2851b.php'], []);
 	}
 
+	public function testBug8153(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8153.php'], [
+			[
+				'Strict comparison using !== between \'\' and callable(): mixed&non-empty-string will always evaluate to true.',
+				16,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -604,12 +604,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 	public function testBug8153(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;
-		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8153.php'], [
-			[
-				'Strict comparison using !== between \'\' and callable(): mixed&non-empty-string will always evaluate to true.',
-				16,
-			],
-		]);
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8153.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2657,4 +2657,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8153(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->checkUnionTypes = false;
+		$this->checkExplicitMixed = false;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8153.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -4210,6 +4210,15 @@ class TypeCombinatorTest extends PHPStanTestCase
 				TemplateMixedType::class, // should be TemplateConstantBooleanType
 				'T (class Foo, parameter)', // should be T of true
 			],
+			[
+				new IntersectionType([
+					new CallableType(),
+					new StringType(),
+				]),
+				new ConstantStringType(''),
+				IntersectionType::class,
+				'callable(): mixed&non-empty-string',
+			],
 		];
 	}
 


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8153

See https://github.com/phpstan/phpstan/issues/8153#issuecomment-1275992641 and the next comment for how I came to this. I'm still not a 100% sure though if this really belongs here. It does make sense to me and https://phpstan.org/r/2d18e426-7943-41fd-af29-4e94d14225fd shows that phpstan ensures that `''` is not a callable.