### PR TITLE
Deprecate `ConstantArrayType::isEmpty()`

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -34,7 +34,6 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ConditionalTypeForParameter;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -378,7 +377,7 @@ class TypeSpecifier
 			if (
 				!$context->null()
 				&& $rightType->isArray()->yes()
-				&& $leftType instanceof ConstantArrayType && $leftType->isEmpty()
+				&& $leftType->isConstantArray()->yes() && $leftType->isIterableAtLeastOnce()->no()
 			) {
 				return $this->create($expr->right, new NonEmptyArrayType(), $context->negate(), false, $scope, $rootExpr);
 			}
@@ -386,7 +385,7 @@ class TypeSpecifier
 			if (
 				!$context->null()
 				&& $leftType->isArray()->yes()
-				&& $rightType instanceof ConstantArrayType && $rightType->isEmpty()
+				&& $rightType->isConstantArray()->yes() && $rightType->isIterableAtLeastOnce()->no()
 			) {
 				return $this->create($expr->left, new NonEmptyArrayType(), $context->negate(), false, $scope, $rootExpr);
 			}

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1300,11 +1300,11 @@ class InitializerExprTypeResolver
 			return $this->resolveIdenticalType($leftType, $rightType);
 		}
 
-		if ($leftType instanceof ConstantArrayType && $leftType->isEmpty() && $rightType instanceof ConstantScalarType) {
+		if ($leftType->isConstantArray()->yes() && $leftType->isIterableAtLeastOnce()->no() && $rightType instanceof ConstantScalarType) {
 			// @phpstan-ignore-next-line
 			return new ConstantBooleanType($rightType->getValue() == []); // phpcs:ignore
 		}
-		if ($rightType instanceof ConstantArrayType && $rightType->isEmpty() && $leftType instanceof ConstantScalarType) {
+		if ($rightType->isConstantArray()->yes() && $rightType->isIterableAtLeastOnce()->no() && $leftType instanceof ConstantScalarType) {
 			// @phpstan-ignore-next-line
 			return new ConstantBooleanType($leftType->getValue() == []); // phpcs:ignore
 		}

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -113,6 +113,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return [$this];
 	}
 
+	/** @deprecated Use isIterableAtLeastOnce()->no() instead */
 	public function isEmpty(): bool
 	{
 		return count($this->keyTypes) === 0;
@@ -1048,13 +1049,14 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function generalizeToArray(): Type
 	{
-		if ($this->isEmpty()) {
+		$isIterableAtLeastOnce = $this->isIterableAtLeastOnce();
+		if ($isIterableAtLeastOnce->no()) {
 			return $this;
 		}
 
 		$arrayType = new ArrayType($this->getKeyType(), $this->getItemType());
 
-		if ($this->isIterableAtLeastOnce()->yes()) {
+		if ($isIterableAtLeastOnce->yes()) {
 			$arrayType = TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
 		}
 		if ($this->isList) {

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Type;
 
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
@@ -63,7 +62,7 @@ class IterableType implements CompoundType
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
-		if ($type instanceof ConstantArrayType && $type->isEmpty()) {
+		if ($type->isConstantArray()->yes() && $type->isIterableAtLeastOnce()->no()) {
 			return TrinaryLogic::createYes();
 		}
 		if ($type->isIterable()->yes()) {
@@ -135,7 +134,7 @@ class IterableType implements CompoundType
 			$limit = TrinaryLogic::createMaybe();
 		}
 
-		if ($otherType instanceof ConstantArrayType && $otherType->isEmpty()) {
+		if ($otherType->isConstantArray()->yes() && $otherType->isIterableAtLeastOnce()->no()) {
 			return TrinaryLogic::createMaybe();
 		}
 

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -674,7 +674,7 @@ class TypeCombinator
 				continue;
 			}
 
-			if ($constantArray->isEmpty()) {
+			if ($constantArray->isIterableAtLeastOnce()->no()) {
 				$emptyArray = $constantArray;
 				continue;
 			}

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -140,14 +140,14 @@ class UnionTypeHelper
 				return self::compareStrings($a->getValue(), $b->getValue());
 			}
 
-			if ($a instanceof ConstantArrayType && $b instanceof ConstantArrayType) {
-				if ($a->isEmpty()) {
-					if ($b->isEmpty()) {
+			if ($a->isConstantArray()->yes() && $b->isConstantArray()->yes()) {
+				if ($a->isIterableAtLeastOnce()->no()) {
+					if ($b->isIterableAtLeastOnce()->no()) {
 						return 0;
 					}
 
 					return -1;
-				} elseif ($b->isEmpty()) {
+				} elseif ($b->isIterableAtLeastOnce()->no()) {
 					return 1;
 				}
 


### PR DESCRIPTION
I'm not done yet. slowly but steady :)