### PR TITLE
Add `Type::flip()`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -139,7 +139,7 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 
 	public function flipArray(): Type
 	{
-		return $this;
+		return new MixedType();
 	}
 
 	public function isIterable(): TrinaryLogic

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -137,6 +137,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function flipArray(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -127,6 +127,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function flipArray(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -126,6 +126,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function flipArray(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -364,6 +364,11 @@ class ArrayType implements Type
 		return $this;
 	}
 
+	public function flipArray(): Type
+	{
+		return new self(self::castToArrayKeyType($this->getIterableValueType()), $this->getIterableKeyType());
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe()->and($this->itemType->isString());

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -670,6 +670,22 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return new ArrayType($this->getKeyType(), $this->getItemType());
 	}
 
+	public function flipArray(): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		foreach ($this->keyTypes as $i => $keyType) {
+			$valueType = $this->valueTypes[$i];
+			$builder->setOffsetValueType(
+				ArrayType::castToArrayKeyType($valueType),
+				$keyType,
+				$this->isOptionalKey($i),
+			);
+		}
+
+		return $builder->getArray();
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		$keysCount = count($this->keyTypes);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -511,6 +511,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->unsetOffset($offsetType));
 	}
 
+	public function flipArray(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->flipArray());
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isCallable());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -144,6 +144,11 @@ class MixedType implements CompoundType, SubtractableType
 		return $this;
 	}
 
+	public function flipArray(): Type
+	{
+		return new self($this->isExplicitMixed);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
@@ -5,13 +5,8 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use function count;
 
 class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -22,53 +17,13 @@ class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 		return $functionReflection->getName() === 'array_flip';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (count($functionCall->getArgs()) !== 1) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
-		$array = $functionCall->getArgs()[0]->value;
-		$argType = $scope->getType($array);
-
-		$constantArrays = $argType->getConstantArrays();
-		if (count($constantArrays) > 0) {
-			$flipped = [];
-			foreach ($constantArrays as $constantArray) {
-				$builder = ConstantArrayTypeBuilder::createEmpty();
-				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-					$valueType = $constantArray->getValueTypes()[$i];
-					$builder->setOffsetValueType(
-						ArrayType::castToArrayKeyType($valueType),
-						$keyType,
-						$constantArray->isOptionalKey($i),
-					);
-				}
-				$flipped[] = $builder->getArray();
-			}
-
-			return TypeCombinator::union(...$flipped);
-		}
-
-		if ($argType->isArray()->yes()) {
-			$keyType = $argType->getIterableKeyType();
-			$itemType = $argType->getIterableValueType();
-
-			$itemType = ArrayType::castToArrayKeyType($itemType);
-
-			$flippedArrayType = new ArrayType(
-				$itemType,
-				$keyType,
-			);
-
-			if ($argType->isIterableAtLeastOnce()->yes()) {
-				$flippedArrayType = TypeCombinator::intersect($flippedArrayType, new NonEmptyArrayType());
-			}
-
-			return $flippedArrayType;
-		}
-
-		return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		return $scope->getType($functionCall->getArgs()[0]->value)->flipArray();
 	}
 
 }

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -357,6 +357,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->unsetOffset($offsetType);
 	}
 
+	public function flipArray(): Type
+	{
+		return $this->getStaticObjectType()->flipArray();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -205,6 +205,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->unsetOffset($offsetType);
 	}
 
+	public function flipArray(): Type
+	{
+		return $this->resolve()->flipArray();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
 
 trait MaybeArrayTypeTrait
 {
@@ -35,6 +37,11 @@ trait MaybeArrayTypeTrait
 	public function isList(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function flipArray(): Type
+	{
+		return new ErrorType();
 	}
 
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
 
 trait NonArrayTypeTrait
 {
@@ -35,6 +37,11 @@ trait NonArrayTypeTrait
 	public function isList(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
+	}
+
+	public function flipArray(): Type
+	{
+		return new ErrorType();
 	}
 
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -96,6 +96,8 @@ interface Type
 
 	public function unsetOffset(Type $offsetType): Type;
 
+	public function flipArray(): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -539,6 +539,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->unsetOffset($offsetType));
 	}
 
+	public function flipArray(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->flipArray());
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isCallable());

--- a/tests/PHPStan/Analyser/data/array-flip.php
+++ b/tests/PHPStan/Analyser/data/array-flip.php
@@ -50,3 +50,12 @@ function foo6($array)
 	$flip = array_flip($array);
 	assertType('non-empty-array<4|5|6, 1|2|3>', $flip);
 }
+
+/**
+ * @param list<1|2|3> $array
+ */
+function foo7($array)
+{
+	$flip = array_flip($array);
+	assertType('array<1|2|3, int<0, max>>', $flip);
+}

--- a/tests/PHPStan/Analyser/data/array-flip.php
+++ b/tests/PHPStan/Analyser/data/array-flip.php
@@ -41,3 +41,12 @@ function foo5($array)
 	$flip = array_flip($array);
 	assertType('array<string, 1|2|3>', $flip);
 }
+
+/**
+ * @param non-empty-array<1|2|3, 4|5|6> $array
+ */
+function foo6($array)
+{
+	$flip = array_flip($array);
+	assertType('non-empty-array<4|5|6, 1|2|3>', $flip);
+}


### PR DESCRIPTION
This would be the first new array modification function moved to Type. Most likely one of the simplest :)
As you can see and know anyways: it is a very specific thing, but it allows us to get rid of conditional code and `getConstantArrays()` calls, that I don't like much and are also messy with intersections/unions.

What about the name? There will be more to come, e.g. `pop`, `shift`, ... Does a common prefix like `array` for all of them make sense maybe? I'd definitely group them together everywhere, my worry is just that all of them are only meant for arrays and some could suggest that e.g. strings can be flipped or something like that.