### PR TITLE
Rename getIterableCount to getArraySize and move it to appropriate type trait

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -104,7 +104,7 @@ class FunctionCallParametersCheck
 				if (count($arrays) > 0) {
 					$minKeys = null;
 					foreach ($arrays as $array) {
-						$countType = $array->getIterableCount();
+						$countType = $array->getArraySize();
 						if ($countType instanceof ConstantIntegerType) {
 							$keysCount = $countType->getValue();
 						} elseif ($countType instanceof IntegerRangeType) {

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -147,7 +147,7 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		return IntegerRangeType::fromInterval(0, null);
 	}

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -137,7 +137,7 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		return IntegerRangeType::fromInterval(1, null);
 	}

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -136,7 +136,7 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		return IntegerRangeType::fromInterval(0, null);
 	}

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -195,7 +195,7 @@ class ArrayType implements Type
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		return IntegerRangeType::fromInterval(0, null);
 	}
@@ -412,10 +412,10 @@ class ArrayType implements Type
 		return $this;
 	}
 
-	/** @deprecated Use getIterableCount() instead */
+	/** @deprecated Use getArraySize() instead */
 	public function count(): Type
 	{
-		return $this->getIterableCount();
+		return $this->getArraySize();
 	}
 
 	public static function castToArrayKeyType(Type $offsetType): Type

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -685,7 +685,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		$optionalKeysCount = count($this->optionalKeys);
 		$totalKeysCount = count($this->getKeyTypes());
@@ -990,7 +990,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function toBoolean(): BooleanType
 	{
-		return $this->getIterableCount()->toBoolean();
+		return $this->getArraySize()->toBoolean();
 	}
 
 	public function toInteger(): Type
@@ -1127,10 +1127,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return new self($keyTypes, $valueTypes, $autoIndex, $optionalKeys, true);
 	}
 
-	/** @deprecated Use getIterableCount() instead */
+	/** @deprecated Use getArraySize() instead */
 	public function count(): Type
 	{
-		return $this->getIterableCount();
+		return $this->getArraySize();
 	}
 
 	public function describe(VerbosityLevel $level): string

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -406,9 +406,9 @@ class IntersectionType implements CompoundType
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isIterableAtLeastOnce());
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
-		return $this->intersectTypes(static fn (Type $type): Type => $type->getIterableCount());
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getArraySize());
 	}
 
 	public function getIterableKeyType(): Type

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -220,7 +220,7 @@ class IterableType implements CompoundType
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		return IntegerRangeType::fromInterval(0, null);
 	}

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -366,7 +366,7 @@ class MixedType implements CompoundType, SubtractableType
 		return $this->isIterable();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		if ($this->isIterable()->no()) {
 			return new ErrorType();

--- a/src/Type/Php/CountFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CountFunctionReturnTypeExtension.php
@@ -37,7 +37,7 @@ class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 			}
 		}
 
-		return $scope->getType($functionCall->getArgs()[0]->value)->getIterableCount();
+		return $scope->getType($functionCall->getArgs()[0]->value)->getArraySize();
 	}
 
 }

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -178,9 +178,9 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 			$firstType instanceof ConstantArrayType
 			&& $secondType instanceof ConstantArrayType
 		) {
-			if ($secondType->getIterableCount() < $firstType->getIterableCount()) {
+			if ($secondType->getArraySize() < $firstType->getArraySize()) {
 				return $secondType;
-			} elseif ($firstType->getIterableCount() < $secondType->getIterableCount()) {
+			} elseif ($firstType->getArraySize() < $secondType->getArraySize()) {
 				return $firstType;
 			}
 

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -297,9 +297,9 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->isIterableAtLeastOnce();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
-		return $this->getStaticObjectType()->getIterableCount();
+		return $this->getStaticObjectType()->getArraySize();
 	}
 
 	public function getIterableKeyType(): Type

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -125,9 +125,9 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->isIterableAtLeastOnce();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
-		return $this->resolve()->getIterableCount();
+		return $this->resolve()->getArraySize();
 	}
 
 	public function getIterableKeyType(): Type

--- a/src/Type/Traits/MaybeIterableTypeTrait.php
+++ b/src/Type/Traits/MaybeIterableTypeTrait.php
@@ -21,7 +21,7 @@ trait MaybeIterableTypeTrait
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		if ($this->isIterable()->no()) {
 			return new ErrorType();

--- a/src/Type/Traits/NonIterableTypeTrait.php
+++ b/src/Type/Traits/NonIterableTypeTrait.php
@@ -19,7 +19,7 @@ trait NonIterableTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
 		return new ErrorType();
 	}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -64,7 +64,7 @@ interface Type
 
 	public function isIterableAtLeastOnce(): TrinaryLogic;
 
-	public function getIterableCount(): Type;
+	public function getArraySize(): Type;
 
 	public function getIterableKeyType(): Type;
 

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -420,9 +420,9 @@ class UnionType implements CompoundType
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isIterableAtLeastOnce());
 	}
 
-	public function getIterableCount(): Type
+	public function getArraySize(): Type
 	{
-		return $this->unionTypes(static fn (Type $type): Type => $type->getIterableCount());
+		return $this->unionTypes(static fn (Type $type): Type => $type->getArraySize());
 	}
 
 	public function getIterableKeyType(): Type


### PR DESCRIPTION
ups, I undid the trait move, because `ObjectType` needs this logic, in fact it has to stay in the iterable traits because iterables are countable