### PR TITLE
Add `Type::popArray()` and `Type::shiftArray()`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -142,6 +142,16 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function popArray(): Type
+	{
+		return $this;
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -132,6 +132,16 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function popArray(): Type
+	{
+		return new MixedType();
+	}
+
+	public function shiftArray(): Type
+	{
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -131,6 +131,16 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function popArray(): Type
+	{
+		return $this;
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -369,6 +369,16 @@ class ArrayType implements Type
 		return new self(self::castToArrayKeyType($this->getIterableValueType()), $this->getIterableKeyType());
 	}
 
+	public function popArray(): Type
+	{
+		return $this;
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this;
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe()->and($this->itemType->isString());

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -686,6 +686,16 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $builder->getArray();
 	}
 
+	public function popArray(): Type
+	{
+		return $this->removeLastElements(1);
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this->removeFirstElements(1);
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		$keysCount = count($this->keyTypes);
@@ -778,6 +788,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return parent::isList();
 	}
 
+	/** @deprecated Use popArray() instead */
 	public function removeLast(): self
 	{
 		return $this->removeLastElements(1);
@@ -837,6 +848,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		);
 	}
 
+	/** @deprecated Use shiftArray() instead */
 	public function removeFirst(): self
 	{
 		return $this->removeFirstElements(1);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -516,6 +516,16 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->flipArray());
 	}
 
+	public function popArray(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->popArray());
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->shiftArray());
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isCallable());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -149,6 +149,16 @@ class MixedType implements CompoundType, SubtractableType
 		return new self($this->isExplicitMixed);
 	}
 
+	public function popArray(): Type
+	{
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
+	}
+
+	public function shiftArray(): Type
+	{
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -362,6 +362,16 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->flipArray();
 	}
 
+	public function popArray(): Type
+	{
+		return $this->getStaticObjectType()->popArray();
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this->getStaticObjectType()->shiftArray();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -210,6 +210,16 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->flipArray();
 	}
 
+	public function popArray(): Type
+	{
+		return $this->resolve()->popArray();
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this->resolve()->shiftArray();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -44,4 +44,14 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function popArray(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function shiftArray(): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -44,4 +44,14 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function popArray(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function shiftArray(): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -98,6 +98,10 @@ interface Type
 
 	public function flipArray(): Type;
 
+	public function popArray(): Type;
+
+	public function shiftArray(): Type;
+
 	public function isCallable(): TrinaryLogic;
 
 	/**

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -544,6 +544,16 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->flipArray());
 	}
 
+	public function popArray(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->popArray());
+	}
+
+	public function shiftArray(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->shiftArray());
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isCallable());

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -58,4 +58,11 @@ class Foo
 		assertType('array{a?: 0, b?: 1}', $arr);
 	}
 
+	public function list(array $arr): void
+	{
+		/** @var list<string> $arr */
+		assertType('string|null', array_pop($arr));
+		assertType('list<string>', $arr);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -65,4 +65,10 @@ class Foo
 		assertType('list<string>', $arr);
 	}
 
+	public function mixed($mixed): void
+	{
+		assertType('mixed', array_pop($mixed));
+		assertType('array', $mixed);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -65,4 +65,10 @@ class Foo
 		assertType('list<string>', $arr);
 	}
 
+	public function mixed($mixed): void
+	{
+		assertType('mixed', array_shift($mixed));
+		assertType('array', $mixed);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -58,4 +58,11 @@ class Foo
 		assertType('array{b?: 1, c?: 2}', $arr);
 	}
 
+	public function list(array $arr): void
+	{
+		/** @var list<string> $arr */
+		assertType('string|null', array_shift($arr));
+		assertType('list<string>', $arr);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/bug-3993.php
+++ b/tests/PHPStan/Analyser/data/bug-3993.php
@@ -17,7 +17,7 @@ class Foo
 
 		array_shift($arguments);
 
-		assertType('mixed~null', $arguments);
+		assertType('array', $arguments);
 		assertType('int<0, max>', count($arguments));
 	}
 


### PR DESCRIPTION
This is a boring one, but at least I could get rid of the `TypeTraverser` usage. I should have never added that..

I wasn't sure at first, but indeed, `array_shift` re-indexes the array and preserves the list.