### PR TITLE
Abort loop processing if condition type gets never

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -879,7 +879,7 @@ class NodeScopeResolver
 				foreach ($bodyScopeResult->getExitPointsByType(Continue_::class) as $continueExitPoint) {
 					$bodyScope = $bodyScope->mergeWith($continueExitPoint->getScope());
 				}
-				if ($bodyScope->equals($prevScope)) {
+				if ($bodyScope->equals($prevScope) || $bodyScope->getType($stmt->cond) instanceof NeverType) {
 					break;
 				}
 
@@ -958,7 +958,7 @@ class NodeScopeResolver
 				}
 				$bodyScope = $this->processExprNode($stmt->cond, $bodyScope, static function (): void {
 				}, ExpressionContext::createDeep())->getTruthyScope();
-				if ($bodyScope->equals($prevScope)) {
+				if ($bodyScope->equals($prevScope) || $bodyScope->getType($stmt->cond) instanceof NeverType) {
 					break;
 				}
 
@@ -1062,6 +1062,12 @@ class NodeScopeResolver
 
 				if ($bodyScope->equals($prevScope)) {
 					break;
+				}
+
+				foreach ($stmt->cond as $condExpr) {
+					if ($bodyScope->getType($condExpr) instanceof NeverType) {
+						break 2;
+					}
 				}
 
 				if ($count >= self::GENERALIZE_AFTER_ITERATION) {


### PR DESCRIPTION
This is a weird one. In https://github.com/phpstan/phpstan-src/pull/1847 I noticed that the loop of https://github.com/phpstan/phpstan-src/blob/1.8.9/tests/PHPStan/Analyser/data/bug-3875.php is executed twice and in the second iteration `$queue` becomes `never`. The reason is that the condition evaluates to false after the first iteration and in the bodies truthy scope this makes it never. Basically, the loop should only be executed once.

I wonder -  is this so special or is there a better way to improve this? I also didn't understand yet how this condition is different to others and why e.g. normal counter variables don't make a problem?