### PR TITLE
Add missing scope merge in do-while

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -945,6 +945,7 @@ class NodeScopeResolver
 
 			do {
 				$prevScope = $bodyScope;
+				$bodyScope = $bodyScope->mergeWith($scope);
 				$bodyScopeResult = $this->processStmtNodes($stmt, $stmt->stmts, $bodyScope, static function (): void {
 				})->filterOutLoopExitPoints();
 				$alwaysTerminating = $bodyScopeResult->isAlwaysTerminating();


### PR DESCRIPTION
Adds the scope merge that all other loops have as well. Fixes the first failure mentioned in https://github.com/phpstan/phpstan-src/pull/1847#issuecomment-1279540898

I didn't understand it fully though tbh