### PR TITLE
Preserve subtracted type on `MixedType::flipArray()`

### DIFF
--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -146,7 +146,7 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function flipArray(): Type
 	{
-		return new ArrayType(new MixedType(), new MixedType());
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
 	}
 
 	public function isCallable(): TrinaryLogic

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -146,7 +146,7 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function flipArray(): Type
 	{
-		return new self($this->isExplicitMixed);
+		return new self($this->isExplicitMixed, $this->subtractedType);
 	}
 
 	public function isCallable(): TrinaryLogic

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -146,7 +146,7 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function flipArray(): Type
 	{
-		return new self($this->isExplicitMixed, $this->subtractedType);
+		return new ArrayType(new MixedType(), new MixedType());
 	}
 
 	public function isCallable(): TrinaryLogic

--- a/tests/PHPStan/Analyser/data/array-flip.php
+++ b/tests/PHPStan/Analyser/data/array-flip.php
@@ -62,11 +62,7 @@ function foo7($array)
 
 function foo8($mixed)
 {
-	if ($mixed === null) {
-		return;
-	}
-
-	assertType('mixed~null', $mixed);
+	assertType('mixed', $mixed);
 	$mixed = array_flip($mixed);
-	assertType('mixed~null', $mixed);
+	assertType('array', $mixed);
 }

--- a/tests/PHPStan/Analyser/data/array-flip.php
+++ b/tests/PHPStan/Analyser/data/array-flip.php
@@ -59,3 +59,14 @@ function foo7($array)
 	$flip = array_flip($array);
 	assertType('array<1|2|3, int<0, max>>', $flip);
 }
+
+function foo8($mixed)
+{
+	if ($mixed === null) {
+		return;
+	}
+
+	assertType('mixed~null', $mixed);
+	$mixed = array_flip($mixed);
+	assertType('mixed~null', $mixed);
+}


### PR DESCRIPTION
does that make sense? I'm still not good with subtracts, but it felt weird that that info is lost on flip, shouldn't hurt to preserve it I guess 