### PR TITLE
Add `Type::getKeysArray()` and `Type::getValuesArray()`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -137,6 +137,16 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this;
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this;
+	}
+
 	public function flipArray(): Type
 	{
 		return new MixedType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -127,6 +127,16 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this;
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this;
+	}
+
 	public function flipArray(): Type
 	{
 		return $this;

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -126,6 +126,16 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return new ErrorType();
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this;
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this;
+	}
+
 	public function flipArray(): Type
 	{
 		return $this;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -177,7 +177,7 @@ class ArrayType implements Type
 
 	public function getKeysArray(): Type
 	{
-		return AccessoryArrayListType::intersectWith(new self(new IntegerType(), $this->keyType));
+		return AccessoryArrayListType::intersectWith(new self(new IntegerType(), $this->getIterableKeyType()));
 	}
 
 	public function getValuesArray(): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -511,6 +511,16 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->unsetOffset($offsetType));
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getKeysArray());
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getValuesArray());
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->flipArray());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -144,6 +144,16 @@ class MixedType implements CompoundType, SubtractableType
 		return $this;
 	}
 
+	public function getKeysArray(): Type
+	{
+		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new UnionType([new IntegerType(), new StringType()])));
+	}
+
+	public function getValuesArray(): Type
+	{
+		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new MixedType($this->isExplicitMixed)));
+	}
+
 	public function flipArray(): Type
 	{
 		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));

--- a/src/Type/Php/ArrayIsListFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayIsListFunctionTypeSpecifyingExtension.php
@@ -9,13 +9,7 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\Accessory\AccessoryArrayListType;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function strtolower;
 
 class ArrayIsListFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
@@ -45,21 +39,7 @@ class ArrayIsListFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyi
 			return new SpecifiedTypes();
 		}
 
-		$valueType = $scope->getType($arrayArg);
-		if ($valueType instanceof ConstantArrayType) {
-			return $this->typeSpecifier->create($arrayArg, $valueType->getValuesArray(), $context, false, $scope);
-		}
-
-		return $this->typeSpecifier->create(
-			$arrayArg,
-			AccessoryArrayListType::intersectWith(TypeCombinator::intersect(
-				new ArrayType(new IntegerType(), $valueType->getIterableValueType()),
-				...TypeUtils::getAccessoryTypes($valueType),
-			)),
-			$context,
-			false,
-			$scope,
-		);
+		return $this->typeSpecifier->create($arrayArg, $scope->getType($arrayArg)->getValuesArray(), $context, false, $scope);
 	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php
@@ -8,7 +8,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
@@ -31,12 +30,7 @@ class ArrayKeysFunctionDynamicReturnTypeExtension implements DynamicFunctionRetu
 		if ($arrayArg !== null) {
 			$valueType = $scope->getType($arrayArg);
 			if ($valueType->isArray()->yes()) {
-				if ($valueType instanceof ConstantArrayType) {
-					return $valueType->getKeysArray();
-				}
-
-				$keyType = $valueType->getIterableKeyType();
-				$array = AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), $keyType));
+				$array = $valueType->getKeysArray();
 				if ($valueType->isIterableAtLeastOnce()->yes()) {
 					$array = TypeCombinator::intersect($array, new NonEmptyArrayType());
 				}

--- a/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
@@ -8,7 +8,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
@@ -30,11 +29,7 @@ class ArrayValuesFunctionDynamicReturnTypeExtension implements DynamicFunctionRe
 		if ($arrayArg !== null) {
 			$valueType = $scope->getType($arrayArg);
 			if ($valueType->isArray()->yes()) {
-				if ($valueType instanceof ConstantArrayType) {
-					return $valueType->getValuesArray();
-				}
-
-				$array = AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), $valueType->getIterableValueType()));
+				$array = $valueType->getValuesArray();
 				if ($valueType->isIterableAtLeastOnce()->yes()) {
 					$array = TypeCombinator::intersect($array, new NonEmptyArrayType());
 				}

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -357,6 +357,16 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->unsetOffset($offsetType);
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this->getStaticObjectType()->getKeysArray();
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this->getStaticObjectType()->getValuesArray();
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->getStaticObjectType()->flipArray();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -205,6 +205,16 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->unsetOffset($offsetType);
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this->resolve()->getKeysArray();
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this->resolve()->getValuesArray();
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->resolve()->flipArray();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -39,6 +39,16 @@ trait MaybeArrayTypeTrait
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function getKeysArray(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getValuesArray(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function flipArray(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -39,6 +39,16 @@ trait NonArrayTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function getKeysArray(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getValuesArray(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function flipArray(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -96,6 +96,10 @@ interface Type
 
 	public function unsetOffset(Type $offsetType): Type;
 
+	public function getKeysArray(): Type;
+
+	public function getValuesArray(): Type;
+
 	public function flipArray(): Type;
 
 	public function isCallable(): TrinaryLogic;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -539,6 +539,16 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->unsetOffset($offsetType));
 	}
 
+	public function getKeysArray(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->getKeysArray());
+	}
+
+	public function getValuesArray(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->getValuesArray());
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->flipArray());

--- a/tests/PHPStan/Analyser/data/array-is-list-type-specifying.php
+++ b/tests/PHPStan/Analyser/data/array-is-list-type-specifying.php
@@ -12,6 +12,32 @@ function foo(array $foo) {
 	}
 }
 
+function foo2($foo) {
+	if (array_is_list($foo)) {
+		assertType('list<mixed>', $foo);
+	} else {
+		assertType('mixed~list<mixed>', $foo);
+	}
+}
+
+/** @param array{'foo', 'bar'}|array{'baz', 'foobar'} $foo */
+function foo3(array $foo) {
+	if (array_is_list($foo)) {
+		assertType("array{'baz', 'foobar'}|array{'foo', 'bar'}", $foo);
+	} else {
+		assertType('*NEVER*', $foo);
+	}
+}
+
+/** @param array{foo: 0, bar: 1}|array{baz: 3, foobar: 4} $foo */
+function foo4(array $foo) {
+	if (array_is_list($foo)) {
+		assertType('*NEVER*', $foo);
+	} else {
+		assertType('array{baz: 3, foobar: 4}|array{foo: 0, bar: 1}', $foo);
+	}
+}
+
 $bar = [1, 2, 3];
 
 if (array_is_list($bar)) {

--- a/tests/PHPStan/Analyser/data/shuffle.php
+++ b/tests/PHPStan/Analyser/data/shuffle.php
@@ -20,6 +20,14 @@ class Foo
 		assertType('non-empty-array<string, int>', $arr);
 		assertType('non-empty-list<string>', array_keys($arr));
 		assertType('non-empty-list<int>', array_values($arr));
+
+		/** @var array<mixed> $arr */
+		if (array_key_exists('foo', $arr)) {
+			shuffle($arr);
+			assertType("array&hasOffset('foo')", $arr);
+			assertType('non-empty-list<(int|string)>', array_keys($arr));
+			assertType('non-empty-list<mixed>', array_values($arr));
+		}
 	}
 
 	public function constantArrays(array $arr): void
@@ -53,6 +61,20 @@ class Foo
 		assertType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertType('non-empty-list<0|1|2>', array_keys($arr));
 		assertType('non-empty-list<1|2|3>', array_values($arr));
+
+		/** @var array{foo?: 1, bar: 2, }|array{baz: 3, foobar?: 4} $arr */
+		shuffle($arr); // no effect, constant array unions are not supported _yet_
+		assertType("array{baz: 3, foobar?: 4}|array{foo?: 1, bar: 2}", $arr);
+		assertType("array{0: 'baz', 1?: 'foobar'}|array{0?: 'foo', 1: 'bar'}", array_keys($arr));
+		assertType("array{0: 3, 1?: 4}|array{0?: 1, 1: 2}", array_values($arr));
+	}
+
+	public function mixed($arr): void
+	{
+		shuffle($arr);
+		assertType('mixed', $arr);
+		assertType('list<int|string>', array_keys($arr));
+		assertType('list<mixed>', array_values($arr));
 	}
 
 }


### PR DESCRIPTION
low-hanging fruit cleanup / improvement :)

- fixes `ArrayType::getKeysArray()` (by using `getIterableKeyType()` mixed keys are correctly transformed into benevolent unions)
- simplifies list type creation for `array_is_list`
- gives us support for constant array unions for free (`instanceof ConstantArrayType` be gone! one of the main reasons for all this refactoring)