### PR TITLE
Explicitly specify native type for `array_pop`/`array_shift` arg

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1838,12 +1838,15 @@ class NodeScopeResolver
 				&& count($expr->getArgs()) >= 1
 			) {
 				$arrayArg = $expr->getArgs()[0]->value;
-				$arrayArgType = $scope->getType($arrayArg);
 
+				$arrayArgType = $scope->getType($arrayArg);
+				$arrayArgNativeType = $scope->getNativeType($arrayArg);
+
+				$isArrayPop = $functionReflection->getName() === 'array_pop';
 				$scope = $scope->invalidateExpression($arrayArg)->assignExpression(
 					$arrayArg,
-					$functionReflection->getName() === 'array_pop' ? $arrayArgType->popArray() : $arrayArgType->shiftArray(),
-					$scope->getNativeType($arrayArg),
+					$isArrayPop ? $arrayArgType->popArray() : $arrayArgType->shiftArray(),
+					$isArrayPop ? $arrayArgNativeType->popArray() : $arrayArgNativeType->shiftArray(),
 				);
 			}
 

--- a/tests/PHPStan/Analyser/data/array-pop.php
+++ b/tests/PHPStan/Analyser/data/array-pop.php
@@ -2,6 +2,7 @@
 
 namespace ArrayPop;
 
+use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;
 
 class Foo
@@ -80,6 +81,16 @@ class Foo
 			assertType('mixed', array_pop($mixed));
 			assertType('*ERROR*', $mixed);
 		}
+	}
+
+	/** @param non-empty-array<string> $arr1 */
+	public function nativeTypes(array $arr1, array $arr2): void
+	{
+		assertType('string', array_pop($arr1));
+		assertType('array<string>', $arr1);
+
+		assertNativeType('mixed', array_pop($arr2));
+		assertNativeType('array', $arr2);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/array-shift.php
+++ b/tests/PHPStan/Analyser/data/array-shift.php
@@ -2,6 +2,7 @@
 
 namespace ArrayShift;
 
+use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;
 
 class Foo
@@ -80,5 +81,15 @@ class Foo
 			assertType('mixed', array_shift($mixed));
 			assertType('*ERROR*', $mixed);
 		}
+	}
+
+	/** @param non-empty-array<string> $arr1 */
+	public function nativeTypes(array $arr1, array $arr2): void
+	{
+		assertType('string', array_shift($arr1));
+		assertType('array<string>', $arr1);
+
+		assertNativeType('mixed', array_shift($arr2));
+		assertNativeType('array', $arr2);
 	}
 }


### PR DESCRIPTION
As it was felt in https://github.com/phpstan/phpstan-src/pull/1847#discussion_r996431484 :) and we also did it in https://github.com/phpstan/phpstan-src/pull/1853 in the mean time