### PR TITLE
Add support for mb_convert_case() and mb_convert_kana()

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -6310,7 +6310,7 @@ return [
 'maxdb_thread_safe' => ['bool'],
 'maxdb_use_result' => ['resource', 'link'=>''],
 'maxdb_warning_count' => ['int', 'link'=>'resource'],
-'mb_check_encoding' => ['bool', 'var='=>'string', 'encoding='=>'string'],
+'mb_check_encoding' => ['bool', 'var='=>'string|array<string>', 'encoding='=>'string'],
 'mb_chr' => ['string|false', 'cp'=>'int', 'encoding='=>'string'],
 'mb_convert_case' => ['string', 'sourcestring'=>'string', 'mode'=>'int', 'encoding='=>'string'],
 'mb_convert_encoding' => ['string|array<int, string>|false', 'val'=>'string|array<int, string>', 'to_encoding'=>'string', 'from_encoding='=>'mixed'],

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1015,7 +1015,7 @@ class TypeSpecifier
 			$context->truthy()
 			&& $exprNode instanceof FuncCall
 			&& $exprNode->name instanceof Name
-			&& in_array(strtolower($exprNode->name->toString()), ['substr', 'strstr', 'stristr', 'strchr', 'strrchr', 'strtolower', 'strtoupper', 'mb_strtolower', 'mb_strtoupper', 'ucfirst', 'lcfirst', 'ucwords'], true)
+			&& in_array(strtolower($exprNode->name->toString()), ['substr', 'strstr', 'stristr', 'strchr', 'strrchr', 'strtolower', 'strtoupper', 'mb_strtolower', 'mb_strtoupper', 'ucfirst', 'lcfirst', 'ucwords', 'mb_convert_case', 'mb_convert_kana'], true)
 			&& isset($exprNode->getArgs()[0])
 			&& $constantType->getValue() !== ''
 		) {

--- a/tests/PHPStan/Analyser/data/str-casing.php
+++ b/tests/PHPStan/Analyser/data/str-casing.php
@@ -12,8 +12,9 @@ class Foo {
 	 * @param 'foo'|'Foo' $edgeUnion
 	 * @param MB_CASE_UPPER|MB_CASE_LOWER|MB_CASE_TITLE|MB_CASE_FOLD|MB_CASE_UPPER_SIMPLE|MB_CASE_LOWER_SIMPLE|MB_CASE_TITLE_SIMPLE|MB_CASE_FOLD_SIMPLE $caseMode
 	 * @param 'aKV'|'hA'|'AH'|'K'|'KV'|'RNKV' $kanaMode
+	 * @param mixed $mixed
 	 */
-	public function bar($numericS, $nonE, $literal, $edgeUnion, $caseMode, $kanaMode) {
+	public function bar($numericS, $nonE, $literal, $edgeUnion, $caseMode, $kanaMode, $mixed) {
 		assertType("'abc'", strtolower('ABC'));
 		assertType("'ABC'", strtoupper('abc'));
 		assertType("'abc'", mb_strtolower('ABC'));
@@ -28,11 +29,13 @@ class Foo {
 		assertType("'Hello|World'", ucwords('hello|world', "|"));
 		assertType("'ČESKÁ REPUBLIKA'", mb_convert_case('Česká republika', MB_CASE_UPPER));
 		assertType("'česká republika'", mb_convert_case('Česká republika', MB_CASE_LOWER));
+		assertType("non-falsy-string", mb_convert_case('Česká republika', $mixed));
 		assertType("'ČESKÁ REPUBLIKA'|'Česká Republika'|'česká republika'", mb_convert_case('Česká republika', $caseMode));
 		assertType("'Ａｂｃ１２３アイウガギグばびぶ漢字'", mb_convert_kana('Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞばびぶ漢字'));
 		assertType("'Abc123アイウガギグばびぶ漢字'", mb_convert_kana('Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞばびぶ漢字', 'aKV'));
 		assertType("'Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞﾊﾞﾋﾞﾌﾞ漢字'", mb_convert_kana('Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞばびぶ漢字', 'hA'));
 		assertType("'Abc123アガば漢'|'Ａｂｃ１２３あか゛ば漢'|'Ａｂｃ１２３アカ゛ば漢'|'Ａｂｃ１２３アガば漢'|'Ａｂｃ１２３ｱｶﾞﾊﾞ漢'", mb_convert_kana('Ａｂｃ１２３ｱｶﾞば漢', $kanaMode));
+		assertType("non-falsy-string", mb_convert_kana('Ａｂｃ１２３ｱｶﾞば漢', $mixed));
 
 		assertType("numeric-string", strtolower($numericS));
 		assertType("numeric-string", strtoupper($numericS));
@@ -43,7 +46,9 @@ class Foo {
 		assertType("numeric-string", ucwords($numericS));
 		assertType("numeric-string", mb_convert_case($numericS, MB_CASE_UPPER));
 		assertType("numeric-string", mb_convert_case($numericS, MB_CASE_LOWER));
+		assertType("numeric-string", mb_convert_case($numericS, $mixed));
 		assertType("numeric-string", mb_convert_kana($numericS));
+		assertType("numeric-string", mb_convert_kana($numericS, $mixed));
 
 		assertType("non-empty-string", strtolower($nonE));
 		assertType("non-empty-string", strtoupper($nonE));
@@ -54,7 +59,9 @@ class Foo {
 		assertType("non-empty-string", ucwords($nonE));
 		assertType("non-empty-string", mb_convert_case($nonE, MB_CASE_UPPER));
 		assertType("non-empty-string", mb_convert_case($nonE, MB_CASE_LOWER));
+		assertType("non-empty-string", mb_convert_case($nonE, $mixed));
 		assertType("non-empty-string", mb_convert_kana($nonE));
+		assertType("non-empty-string", mb_convert_kana($nonE, $mixed));
 
 		assertType("string", strtolower($literal));
 		assertType("string", strtoupper($literal));
@@ -65,7 +72,9 @@ class Foo {
 		assertType("string", ucwords($literal));
 		assertType("string", mb_convert_case($literal, MB_CASE_UPPER));
 		assertType("string", mb_convert_case($literal, MB_CASE_LOWER));
+		assertType("string", mb_convert_case($literal, $mixed));
 		assertType("string", mb_convert_kana($literal));
+		assertType("string", mb_convert_kana($literal, $mixed));
 
 		assertType("'foo'", lcfirst($edgeUnion));
 	}
@@ -75,6 +84,7 @@ class Foo {
 		assertType("non-falsy-string", mb_strtolower("\xfe\xff\x65\xe5\x67\x2c\x8a\x9e", 'CP1252'));
 		// valid char sequence, but not support non ASCII / UTF-8 encodings
 		assertType("non-falsy-string", mb_convert_kana("\x95\x5c\x8c\xbb", 'SJIS-win'));
-
+		// invalid UTF-8 sequence
+		assertType("non-falsy-string", mb_convert_kana("\x95\x5c\x8c\xbb", 'UTF-8'));
 	}
 }

--- a/tests/PHPStan/Analyser/data/str-casing.php
+++ b/tests/PHPStan/Analyser/data/str-casing.php
@@ -10,15 +10,29 @@ class Foo {
 	 * @param non-empty-string $nonE
 	 * @param literal-string $literal
 	 * @param 'foo'|'Foo' $edgeUnion
+	 * @param MB_CASE_UPPER|MB_CASE_LOWER|MB_CASE_TITLE|MB_CASE_FOLD|MB_CASE_UPPER_SIMPLE|MB_CASE_LOWER_SIMPLE|MB_CASE_TITLE_SIMPLE|MB_CASE_FOLD_SIMPLE $caseMode
+	 * @param 'aKV'|'hA'|'AH'|'K'|'KV'|'RNKV' $kanaMode
 	 */
-	public function bar($numericS, $nonE, $literal, $edgeUnion) {
+	public function bar($numericS, $nonE, $literal, $edgeUnion, $caseMode, $kanaMode) {
 		assertType("'abc'", strtolower('ABC'));
 		assertType("'ABC'", strtoupper('abc'));
 		assertType("'abc'", mb_strtolower('ABC'));
 		assertType("'ABC'", mb_strtoupper('abc'));
+		assertType("'abc'", mb_strtolower('ABC', 'UTF-8'));
+		assertType("'ABC'", mb_strtoupper('abc', 'UTF-8'));
+		assertType("'ａｂｃ'", mb_strtolower('Ａｂｃ'));
+		assertType("'ＡＢＣ'", mb_strtoupper('Ａｂｃ'));
 		assertType("'aBC'", lcfirst('ABC'));
 		assertType("'Abc'", ucfirst('abc'));
 		assertType("'Hello World'", ucwords('hello world'));
+		assertType("'Hello|World'", ucwords('hello|world', "|"));
+		assertType("'ČESKÁ REPUBLIKA'", mb_convert_case('Česká republika', MB_CASE_UPPER));
+		assertType("'česká republika'", mb_convert_case('Česká republika', MB_CASE_LOWER));
+		assertType("'ČESKÁ REPUBLIKA'|'Česká Republika'|'česká republika'", mb_convert_case('Česká republika', $caseMode));
+		assertType("'Ａｂｃ１２３アイウガギグばびぶ漢字'", mb_convert_kana('Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞばびぶ漢字'));
+		assertType("'Abc123アイウガギグばびぶ漢字'", mb_convert_kana('Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞばびぶ漢字', 'aKV'));
+		assertType("'Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞﾊﾞﾋﾞﾌﾞ漢字'", mb_convert_kana('Ａｂｃ１２３ｱｲｳｶﾞｷﾞｸﾞばびぶ漢字', 'hA'));
+		assertType("'Abc123アガば漢'|'Ａｂｃ１２３あか゛ば漢'|'Ａｂｃ１２３アカ゛ば漢'|'Ａｂｃ１２３アガば漢'|'Ａｂｃ１２３ｱｶﾞﾊﾞ漢'", mb_convert_kana('Ａｂｃ１２３ｱｶﾞば漢', $kanaMode));
 
 		assertType("numeric-string", strtolower($numericS));
 		assertType("numeric-string", strtoupper($numericS));
@@ -27,6 +41,9 @@ class Foo {
 		assertType("numeric-string", lcfirst($numericS));
 		assertType("numeric-string", ucfirst($numericS));
 		assertType("numeric-string", ucwords($numericS));
+		assertType("numeric-string", mb_convert_case($numericS, MB_CASE_UPPER));
+		assertType("numeric-string", mb_convert_case($numericS, MB_CASE_LOWER));
+		assertType("numeric-string", mb_convert_kana($numericS));
 
 		assertType("non-empty-string", strtolower($nonE));
 		assertType("non-empty-string", strtoupper($nonE));
@@ -35,6 +52,9 @@ class Foo {
 		assertType("non-empty-string", lcfirst($nonE));
 		assertType("non-empty-string", ucfirst($nonE));
 		assertType("non-empty-string", ucwords($nonE));
+		assertType("non-empty-string", mb_convert_case($nonE, MB_CASE_UPPER));
+		assertType("non-empty-string", mb_convert_case($nonE, MB_CASE_LOWER));
+		assertType("non-empty-string", mb_convert_kana($nonE));
 
 		assertType("string", strtolower($literal));
 		assertType("string", strtoupper($literal));
@@ -43,18 +63,18 @@ class Foo {
 		assertType("string", lcfirst($literal));
 		assertType("string", ucfirst($literal));
 		assertType("string", ucwords($literal));
+		assertType("string", mb_convert_case($literal, MB_CASE_UPPER));
+		assertType("string", mb_convert_case($literal, MB_CASE_LOWER));
+		assertType("string", mb_convert_kana($literal));
 
 		assertType("'foo'", lcfirst($edgeUnion));
 	}
 
 	public function foo() {
-		// calls with a 2nd arg could be more precise, but there was no use-case yet to support it
-		assertType("non-falsy-string", mb_strtolower('ABC', 'UTF-8'));
-		assertType("non-falsy-string", mb_strtoupper('abc', 'UTF-8'));
-		assertType("non-falsy-string", ucwords('hello|world!', "|"));
-
 		// invalid char conversions still lead to non-falsy-string
 		assertType("non-falsy-string", mb_strtolower("\xfe\xff\x65\xe5\x67\x2c\x8a\x9e", 'CP1252'));
+		// valid char sequence, but not support non ASCII / UTF-8 encodings
+		assertType("non-falsy-string", mb_convert_kana("\x95\x5c\x8c\xbb", 'SJIS-win'));
 
 	}
 }


### PR DESCRIPTION
Type [`mb_convert_case()`](https://php.net/mb_convert_case) and [`mb_convert_kana()`](https://php.net/mb_convert_case) with `StrCaseFunctionsReturnTypeExtension`.

Strictly speaking, Japanese [kana characters](https://en.wikipedia.org/wiki/Kana) are not casing, but many of the treatments are common.