### PR TITLE
Add `Type::fillKeysArray()`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -147,6 +147,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return new MixedType();
+	}
+
 	public function flipArray(): Type
 	{
 		return new MixedType();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -136,6 +136,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return new NonEmptyArrayType();
+	}
+
 	public function shuffleArray(): Type
 	{
 		return new NonEmptyArrayType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -165,6 +165,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new NonEmptyArrayType();
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return new NonEmptyArrayType();
+	}
+
 	public function flipArray(): Type
 	{
 		$valueType = $this->valueType->toArrayKey();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -137,6 +137,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return $this;
+	}
+
 	public function flipArray(): Type
 	{
 		return $this;

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -136,6 +136,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return $this;
+	}
+
 	public function flipArray(): Type
 	{
 		return $this;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -367,6 +367,17 @@ class ArrayType implements Type
 		return $this;
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		$itemType = $this->getIterableValueType();
+
+		if ((new IntegerType())->isSuperTypeOf($itemType)->no() && !$itemType->toString() instanceof ErrorType) {
+			return new ArrayType($itemType->toString(), $valueType);
+		}
+
+		return new ArrayType($itemType, $valueType);
+	}
+
 	public function flipArray(): Type
 	{
 		return new self($this->getIterableValueType()->toArrayKey(), $this->getIterableKeyType());

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -369,10 +369,14 @@ class ArrayType implements Type
 
 	public function fillKeysArray(Type $valueType): Type
 	{
-		$itemType = $this->getIterableValueType();
+		$itemType = $this->getItemType();
+		if ((new IntegerType())->isSuperTypeOf($itemType)->no()) {
+			$stringKeyType = $itemType->toString();
+			if ($stringKeyType instanceof ErrorType) {
+				return $stringKeyType;
+			}
 
-		if ((new IntegerType())->isSuperTypeOf($itemType)->no() && !$itemType->toString() instanceof ErrorType) {
-			return new ArrayType($itemType->toString(), $valueType);
+			return new ArrayType($stringKeyType, $valueType);
 		}
 
 		return new ArrayType($itemType, $valueType);

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -677,11 +677,12 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 		foreach ($this->valueTypes as $i => $keyType) {
 			if ((new IntegerType())->isSuperTypeOf($keyType)->no()) {
-				if ($keyType->toString() instanceof ErrorType) {
-					return new NeverType();
+				$stringKeyType = $keyType->toString();
+				if ($stringKeyType instanceof ErrorType) {
+					return $stringKeyType;
 				}
 
-				$builder->setOffsetValueType($keyType->toString(), $valueType, $this->isOptionalKey($i));
+				$builder->setOffsetValueType($stringKeyType, $valueType, $this->isOptionalKey($i));
 			} else {
 				$builder->setOffsetValueType($keyType, $valueType, $this->isOptionalKey($i));
 			}

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -521,6 +521,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->getValuesArray());
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->fillKeysArray($valueType));
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->flipArray());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -162,6 +162,15 @@ class MixedType implements CompoundType, SubtractableType
 		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new MixedType($this->isExplicitMixed)));
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType($this->getIterableValueType(), $valueType);
+	}
+
 	public function flipArray(): Type
 	{
 		if ($this->isArray()->no()) {

--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -5,15 +5,8 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use function count;
 
 class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -24,49 +17,13 @@ class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnT
 		return $functionReflection->getName() === 'array_fill_keys';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
-		$valueType = $scope->getType($functionCall->getArgs()[1]->value);
-		$keysType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = $keysType->getConstantArrays();
-		if (count($constantArrays) === 0) {
-			if ($keysType->isArray()->yes()) {
-				$itemType = $keysType->getIterableValueType();
-
-				if ((new IntegerType())->isSuperTypeOf($itemType)->no()) {
-					if ($itemType->toString() instanceof ErrorType) {
-						return new ArrayType($itemType, $valueType);
-					}
-
-					return new ArrayType($itemType->toString(), $valueType);
-				}
-			}
-
-			return new ArrayType($keysType->getIterableValueType(), $valueType);
-		}
-
-		$arrayTypes = [];
-		foreach ($constantArrays as $constantArray) {
-			$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-			foreach ($constantArray->getValueTypes() as $i => $keyType) {
-				if ((new IntegerType())->isSuperTypeOf($keyType)->no()) {
-					if ($keyType->toString() instanceof ErrorType) {
-						return new NeverType();
-					}
-
-					$arrayBuilder->setOffsetValueType($keyType->toString(), $valueType, $constantArray->isOptionalKey($i));
-				} else {
-					$arrayBuilder->setOffsetValueType($keyType, $valueType, $constantArray->isOptionalKey($i));
-				}
-			}
-			$arrayTypes[] = $arrayBuilder->getArray();
-		}
-
-		return TypeCombinator::union(...$arrayTypes);
+		return $scope->getType($functionCall->getArgs()[0]->value)->fillKeysArray($scope->getType($functionCall->getArgs()[1]->value));
 	}
 
 }

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -366,6 +366,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getValuesArray();
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return $this->getStaticObjectType()->fillKeysArray($valueType);
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->getStaticObjectType()->flipArray();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -215,6 +215,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->getValuesArray();
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return $this->resolve()->fillKeysArray($valueType);
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->resolve()->flipArray();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -49,6 +49,11 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function flipArray(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -49,6 +49,11 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function flipArray(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -100,6 +100,8 @@ interface Type
 
 	public function getValuesArray(): Type;
 
+	public function fillKeysArray(Type $valueType): Type;
+
 	public function flipArray(): Type;
 
 	public function popArray(): Type;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -549,6 +549,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->getValuesArray());
 	}
 
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->fillKeysArray($valueType));
+	}
+
 	public function flipArray(): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->flipArray());

--- a/tests/PHPStan/Analyser/data/array-fill-keys.php
+++ b/tests/PHPStan/Analyser/data/array-fill-keys.php
@@ -48,7 +48,7 @@ function withObjectKey() : array
 {
 	assertType("array{foo: 'b'}", array_fill_keys([new Foo()], 'b'));
 	assertType("non-empty-array<string, 'b'>", array_fill_keys([new Bar()], 'b'));
-	assertType("*NEVER*", array_fill_keys([new Baz()], 'b'));
+	assertType("*ERROR*", array_fill_keys([new Baz()], 'b'));
 }
 
 function withUnionKeys(): void
@@ -94,7 +94,7 @@ function withNotConstantArray(array $foo, array $bar, array $baz, array $floats,
 	assertType("array<numeric-string, null>", array_fill_keys($floats, null));
 	assertType("array<bool|int|string, null>", array_fill_keys($mixed, null));
 	assertType('array<string, null>', array_fill_keys($list, null));
-	assertType('array<ArrayFillKeys\Baz, null>', array_fill_keys($objectsWithoutToString, null)); // should be *NEVER* or *ERROR* according to https://3v4l.org/gGpic?
+	assertType('*ERROR*', array_fill_keys($objectsWithoutToString, null));
 
 	if (array_key_exists(17, $mixed)) {
 		assertType('non-empty-array<bool|int|string, null>', array_fill_keys($mixed, null));

--- a/tests/PHPStan/Analyser/data/array-fill-keys.php
+++ b/tests/PHPStan/Analyser/data/array-fill-keys.php
@@ -71,6 +71,10 @@ function withOptionalKeys(): void
 		$arr1[] = 'baz';
 	}
 	assertType("array{foo: 'b', bar: 'b', baz?: 'b'}", array_fill_keys($arr1, 'b'));
+
+	/** @var array{0?: 'foo', 1: 'bar', }|array{0: 'baz', 1?: 'foobar'} $arr2 */
+	$arr2 = [];
+	assertType("array{baz: 'b', foobar?: 'b'}|array{foo?: 'b', bar: 'b'}", array_fill_keys($arr2, 'b'));
 }
 
 /**
@@ -79,12 +83,33 @@ function withOptionalKeys(): void
  * @param Foo[] $baz
  * @param float[] $floats
  * @param array<int, int|string|bool> $mixed
+ * @param list<string> $list
+ * @param Baz[] $objectsWithoutToString
  */
-function withNotConstantArray(array $foo, array $bar, array $baz, array $floats, array $mixed): void
+function withNotConstantArray(array $foo, array $bar, array $baz, array $floats, array $mixed, array $list, array $objectsWithoutToString): void
 {
 	assertType("array<string, null>", array_fill_keys($foo, null));
 	assertType("array<int, null>", array_fill_keys($bar, null));
 	assertType("array<'foo', null>", array_fill_keys($baz, null));
 	assertType("array<numeric-string, null>", array_fill_keys($floats, null));
 	assertType("array<bool|int|string, null>", array_fill_keys($mixed, null));
+	assertType('array<string, null>', array_fill_keys($list, null));
+	assertType('array<ArrayFillKeys\Baz, null>', array_fill_keys($objectsWithoutToString, null)); // should be *NEVER* or *ERROR* according to https://3v4l.org/gGpic?
+
+	if (array_key_exists(17, $mixed)) {
+		assertType('non-empty-array<bool|int|string, null>', array_fill_keys($mixed, null));
+	}
+
+	if (array_key_exists(17, $mixed) && $mixed[17] === 'foo') {
+		assertType('non-empty-array<bool|int|string, null>', array_fill_keys($mixed, null));
+	}
+}
+
+function mixedAndSubtractedArray($mixed): void
+{
+	if (is_array($mixed)) {
+		assertType("array<'b'>", array_fill_keys($mixed, 'b'));
+	} else {
+		assertType("*ERROR*", array_fill_keys($mixed, 'b'));
+	}
 }


### PR DESCRIPTION
I did not change behaviour on purpose, but was wondering why the handling of `ArrayType` and `ConstantArrayType` is different for keys that cannot be casted to string. And also why we return a `NeverType` instead of a `ErrorType` 🤔
e.g. things that cannot be casted to a string will make it fail hard https://3v4l.org/gBHIk