### PR TITLE
Get rid of of `Type::getArrays()` usage in `InvalidKeyInArrayDimFetchRule`

### DIFF
--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
@@ -37,6 +38,10 @@ class InvalidKeyInArrayDimFetchRule implements Rule
 		}
 
 		$dimensionType = $scope->getType($node->dim);
+		if ($dimensionType instanceof MixedType) {
+			return [];
+		}
+
 		$varType = $this->ruleLevelHelper->findTypeToCheck(
 			$scope,
 			$node->var,

--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -8,7 +8,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\VerbosityLevel;
-use function count;
 use function sprintf;
 
 /**
@@ -33,7 +32,7 @@ class InvalidKeyInArrayDimFetchRule implements Rule
 		}
 
 		$varType = $scope->getType($node->var);
-		if (count($varType->getArrays()) === 0) {
+		if ($varType->isArray()->no() || $varType instanceof MixedType) {
 			return [];
 		}
 

--- a/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/InvalidKeyInArrayDimFetchRule.php
@@ -8,7 +8,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
@@ -50,21 +49,15 @@ class InvalidKeyInArrayDimFetchRule implements Rule
 		}
 
 		$isSuperType = AllowedArrayKeysTypes::getType()->isSuperTypeOf($dimensionType);
-		if ($isSuperType->no()) {
-			return [
-				RuleErrorBuilder::message(
-					sprintf('Invalid array key type %s.', $dimensionType->describe(VerbosityLevel::typeOnly())),
-				)->build(),
-			];
-		} elseif ($this->reportMaybes && $isSuperType->maybe() && !$dimensionType instanceof MixedType) {
-			return [
-				RuleErrorBuilder::message(
-					sprintf('Possibly invalid array key type %s.', $dimensionType->describe(VerbosityLevel::typeOnly())),
-				)->build(),
-			];
+		if ($isSuperType->yes() || ($isSuperType->maybe() && !$this->reportMaybes)) {
+			return [];
 		}
 
-		return [];
+		return [
+			RuleErrorBuilder::message(
+				sprintf('%s array key type %s.', $isSuperType->no() ? 'Invalid' : 'Possibly invalid', $dimensionType->describe(VerbosityLevel::typeOnly())),
+			)->build(),
+		];
 	}
 
 }

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
@@ -8,5 +8,10 @@
         "message": "Offset 12.34 does not exist on 'foo'.",
         "line": 16,
         "ignorable": true
+    },
+    {
+        "message": "Invalid array key type stdClass.",
+        "line": 59,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
@@ -13,5 +13,10 @@
         "message": "Possibly invalid array key type int|object.",
         "line": 35,
         "ignorable": true
+    },
+    {
+        "message": "Possibly invalid array key type int|object.",
+        "line": 55,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/stringOffsetAccess.php
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess.php
@@ -49,4 +49,12 @@ function () {
 	/** @var mixed $mixed */
 	$mixed = null;
 	echo $mixed[$maybeInt];
+
+	/** @var array{foo: 17, bar: 19}|array{baz: 21} $arrayUnion */
+	$arrayUnion = [];
+	echo $arrayUnion[$maybeInt];
+
+	/** @var array{foo: 17, bar: 19}|array{baz: 21} $arrayUnion */
+	$arrayUnion = [];
+	echo $arrayUnion[new \stdClass()];
 };

--- a/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
@@ -35,6 +35,10 @@ class InvalidKeyInArrayDimFetchRuleTest extends RuleTestCase
 				'Invalid array key type DateTimeImmutable.',
 				31,
 			],
+			[
+				'Possibly invalid array key type int|object.',
+				44,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Arrays;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
 
 /**
@@ -13,7 +14,8 @@ class InvalidKeyInArrayDimFetchRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new InvalidKeyInArrayDimFetchRule(true);
+		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, false, false);
+		return new InvalidKeyInArrayDimFetchRule($ruleLevelHelper, true);
 	}
 
 	public function testInvalidKey(): void
@@ -34,10 +36,6 @@ class InvalidKeyInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Invalid array key type DateTimeImmutable.',
 				31,
-			],
-			[
-				'Possibly invalid array key type int|object.',
-				44,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayDimFetchRuleTest.php
@@ -14,7 +14,7 @@ class InvalidKeyInArrayDimFetchRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, false, false);
+		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, false, false, true);
 		return new InvalidKeyInArrayDimFetchRule($ruleLevelHelper, true);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
+++ b/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
@@ -35,3 +35,14 @@ $array = doFoo();
 foreach ($array as $i => $val) {
 	echo $array[$i];
 }
+
+/** @var int|object $maybeInt */
+$maybeInt = null;
+
+/** @var string|array $maybeString */
+$maybeString = [];
+echo $maybeString[$maybeInt];
+
+/** @var mixed $mixed */
+$mixed = null;
+echo $mixed[$maybeInt];

--- a/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
+++ b/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
@@ -35,3 +35,7 @@ $array = doFoo();
 foreach ($array as $i => $val) {
 	echo $array[$i];
 }
+
+/** @var mixed $mixed */
+$mixed = null;
+$a[$mixed];

--- a/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
+++ b/tests/PHPStan/Rules/Arrays/data/invalid-key-array-dim-fetch.php
@@ -35,14 +35,3 @@ $array = doFoo();
 foreach ($array as $i => $val) {
 	echo $array[$i];
 }
-
-/** @var int|object $maybeInt */
-$maybeInt = null;
-
-/** @var string|array $maybeString */
-$maybeString = [];
-echo $maybeString[$maybeInt];
-
-/** @var mixed $mixed */
-$mixed = null;
-echo $mixed[$maybeInt];


### PR DESCRIPTION
this thing just keeps annoying me and I want to do something about it. of course I dislike the `instanceof MixedType`, but maybe someone has a better idea?