### PR TITLE
Add `Type::searchArray()`

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -206,4 +206,9 @@ class PhpVersion
 		return $this->versionId >= 80100;
 	}
 
+	public function arrayFunctionsReturnNullWithNonArray(): bool
+	{
+		return $this->versionId < 80000;
+	}
+
 }

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -162,6 +162,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return new MixedType();
+	}
+
 	public function shiftArray(): Type
 	{
 		return $this;

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -180,6 +180,18 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		if (
+			$needleType instanceof ConstantScalarType && $this->valueType instanceof ConstantScalarType
+			&& $needleType->getValue() === $this->valueType->getValue()
+		) {
+			return $this->offsetType;
+		}
+
+		return new MixedType();
+	}
+
 	public function shuffleArray(): Type
 	{
 		return new NonEmptyArrayType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -152,6 +152,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return new MixedType();
+	}
+
 	public function shiftArray(): Type
 	{
 		return new MixedType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -151,6 +151,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return new MixedType();
+	}
+
 	public function shiftArray(): Type
 	{
 		return $this;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Accessory\HasOffsetValueType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -390,6 +391,11 @@ class ArrayType implements Type
 	public function popArray(): Type
 	{
 		return $this;
+	}
+
+	public function searchArray(Type $needleType): Type
+	{
+		return TypeCombinator::union($this->getIterableKeyType(), new ConstantBooleanType(false));
 	}
 
 	public function shiftArray(): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -536,6 +536,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->popArray());
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->searchArray($needleType));
+	}
+
 	public function shiftArray(): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->shiftArray());

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -189,6 +189,15 @@ class MixedType implements CompoundType, SubtractableType
 		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return TypeCombinator::union(new IntegerType(), new StringType(), new ConstantBooleanType(false));
+	}
+
 	public function shiftArray(): Type
 	{
 		if ($this->isArray()->no()) {

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -5,13 +5,9 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\NullType;
-use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -24,17 +20,16 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 		return $functionReflection->getName() === 'array_search';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$argsCount = count($functionCall->getArgs());
 		if ($argsCount < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$haystackArgType = $scope->getType($functionCall->getArgs()[1]->value);
-		$haystackIsArray = $haystackArgType->isArray();
-		if ($haystackIsArray->no()) {
-			return new NullType();
+		if ($haystackArgType->isArray()->no()) {
+			return new ErrorType();
 		}
 
 		if ($argsCount < 3) {
@@ -51,81 +46,7 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 			return new ConstantBooleanType(false);
 		}
 
-		$typesFromConstantArrays = [];
-		if ($haystackIsArray->maybe()) {
-			$typesFromConstantArrays[] = new NullType();
-		}
-
-		$haystackArrays = $haystackArgType->getArrays();
-		if (count($haystackArrays) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
-		}
-
-		$arrays = [];
-		$typesFromConstantArraysCount = 0;
-		foreach ($haystackArrays as $haystackArray) {
-			if (!$haystackArray instanceof ConstantArrayType) {
-				$arrays[] = $haystackArray;
-				continue;
-			}
-
-			$typesFromConstantArrays[] = $this->resolveTypeFromConstantHaystackAndNeedle($needleArgType, $haystackArray);
-			$typesFromConstantArraysCount++;
-		}
-
-		if (
-			$typesFromConstantArraysCount > 0
-			&& count($haystackArrays) === $typesFromConstantArraysCount
-		) {
-			return TypeCombinator::union(...$typesFromConstantArrays);
-		}
-
-		$iterableKeyType = TypeCombinator::union(...$arrays)->getIterableKeyType();
-
-		return TypeCombinator::union(
-			$iterableKeyType,
-			new ConstantBooleanType(false),
-			...$typesFromConstantArrays,
-		);
-	}
-
-	private function resolveTypeFromConstantHaystackAndNeedle(Type $needle, ConstantArrayType $haystack): Type
-	{
-		$matchesByType = [];
-
-		foreach ($haystack->getValueTypes() as $index => $valueType) {
-			$isNeedleSuperType = $valueType->isSuperTypeOf($needle);
-			if ($isNeedleSuperType->no()) {
-				$matchesByType[] = new ConstantBooleanType(false);
-				continue;
-			}
-
-			if ($needle instanceof ConstantScalarType && $valueType instanceof ConstantScalarType
-				&& $needle->getValue() === $valueType->getValue()
-			) {
-				return $haystack->getKeyTypes()[$index];
-			}
-
-			$matchesByType[] = $haystack->getKeyTypes()[$index];
-			if (!$isNeedleSuperType->maybe()) {
-				continue;
-			}
-
-			$matchesByType[] = new ConstantBooleanType(false);
-		}
-
-		if (count($matchesByType) > 0) {
-			if (
-				$haystack->getIterableValueType()->accepts($needle, true)->yes()
-				&& $needle->isSuperTypeOf(new ObjectWithoutClassType())->no()
-			) {
-				return TypeCombinator::union(...$matchesByType);
-			}
-
-			return TypeCombinator::union(new ConstantBooleanType(false), ...$matchesByType);
-		}
-
-		return new ConstantBooleanType(false);
+		return $haystackArgType->searchArray($needleArgType);
 	}
 
 }

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -4,16 +4,22 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
 final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -29,7 +35,7 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 
 		$haystackArgType = $scope->getType($functionCall->getArgs()[1]->value);
 		if ($haystackArgType->isArray()->no()) {
-			return new ErrorType();
+			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}
 
 		if ($argsCount < 3) {

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -381,6 +381,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->popArray();
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return $this->getStaticObjectType()->searchArray($needleType);
+	}
+
 	public function shiftArray(): Type
 	{
 		return $this->getStaticObjectType()->shiftArray();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -230,6 +230,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->popArray();
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return $this->resolve()->searchArray($needleType);
+	}
+
 	public function shiftArray(): Type
 	{
 		return $this->resolve()->shiftArray();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -64,6 +64,11 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftArray(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -64,6 +64,11 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return new ErrorType();
+	}
+
 	public function shiftArray(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -106,6 +106,8 @@ interface Type
 
 	public function popArray(): Type;
 
+	public function searchArray(Type $needleType): Type;
+
 	public function shiftArray(): Type;
 
 	public function shuffleArray(): Type;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -564,6 +564,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->popArray());
 	}
 
+	public function searchArray(Type $needleType): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->searchArray($needleType));
+	}
+
 	public function shiftArray(): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->shiftArray());

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4892,7 +4892,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_search(9, $generalStringKeys)',
 			],
 			[
-				'null',
+				'*ERROR*',
 				'array_search(999, $integer, true)',
 			],
 			[
@@ -4940,19 +4940,19 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_search(\'id\', $generalIntegerOrStringKeysMixedValues, true)',
 			],
 			[
-				'int|string|false|null',
+				'*ERROR*',
 				'array_search(\'id\', doFoo() ? $generalIntegerOrStringKeys : false, true)',
 			],
 			[
-				'false|null',
+				'*ERROR*',
 				'array_search(\'id\', doFoo() ? [] : false, true)',
 			],
 			[
-				'null',
+				'*ERROR*',
 				'array_search(\'id\', false, true)',
 			],
 			[
-				'null',
+				'*ERROR*',
 				'array_search(\'id\', false)',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4892,7 +4892,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_search(9, $generalStringKeys)',
 			],
 			[
-				'*ERROR*',
+				PHP_VERSION_ID < 80000 ? 'null' : '*NEVER*',
 				'array_search(999, $integer, true)',
 			],
 			[
@@ -4948,11 +4948,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_search(\'id\', doFoo() ? [] : false, true)',
 			],
 			[
-				'*ERROR*',
+				PHP_VERSION_ID < 80000 ? 'null' : '*NEVER*',
 				'array_search(\'id\', false, true)',
 			],
 			[
-				'*ERROR*',
+				PHP_VERSION_ID < 80000 ? 'null' : '*NEVER*',
 				'array_search(\'id\', false)',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -811,7 +811,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/weird-strlen-cases.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-pop.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-push.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -811,6 +811,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/weird-strlen-cases.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-pop.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-push.php');

--- a/tests/PHPStan/Analyser/data/array-search.php
+++ b/tests/PHPStan/Analyser/data/array-search.php
@@ -77,9 +77,9 @@ class Foo
 			assertType('int|string|false', array_search($string, $mixed, true));
 		} else {
 			assertType('mixed~array', $mixed);
-			assertType('*ERROR*', array_search('foo', $mixed, true));
-			assertType('*ERROR*', array_search('foo', $mixed));
-			assertType('*ERROR*', array_search($string, $mixed, true));
+			assertType('*NEVER*', array_search('foo', $mixed, true));
+			assertType('*NEVER*', array_search('foo', $mixed));
+			assertType('*NEVER*', array_search($string, $mixed, true));
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/data/array-search.php
+++ b/tests/PHPStan/Analyser/data/array-search.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types = 1);
+
+namespace ArraySearch;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function nonEmpty(array $arr, string $string): void
+	{
+		/** @var non-empty-array<string> $arr */
+		assertType('int|string|false', array_search('foo', $arr, true));
+		assertType('int|string|false', array_search('foo', $arr));
+		assertType('int|string|false', array_search($string, $arr, true));
+	}
+
+	public function normalArrays(array $arr, string $string): void
+	{
+		/** @var array<int, string> $arr */
+		assertType('int|false', array_search('foo', $arr, true));
+		assertType('int|false', array_search('foo', $arr));
+		assertType('int|false', array_search($string, $arr, true));
+
+		if (array_key_exists(17, $arr)) {
+			assertType('int|false', array_search('foo', $arr, true));
+			assertType('int|false', array_search('foo', $arr));
+			assertType('int|false', array_search($string, $arr, true));
+		}
+
+		if (array_key_exists(17, $arr) && $arr[17] === 'foo') {
+			assertType('17', array_search('foo', $arr, true));
+			assertType('int|false', array_search('foo', $arr));
+			assertType('int|false', array_search($string, $arr, true));
+		}
+	}
+
+	public function constantArrays(array $arr, string $string): void
+	{
+		/** @var array{'a', 'b', 'c'} $arr */
+		assertType('1', array_search('b', $arr, true));
+		assertType('0|1|2|false', array_search('b', $arr));
+		assertType('0|1|2|false', array_search($string, $arr, true));
+
+		/** @var array{} $arr */
+		assertType('false', array_search('b', $arr, true));
+		assertType('false', array_search('b', $arr));
+		assertType('false', array_search($string, $arr, true));
+	}
+
+	public function constantArraysWithOptionalKeys(array $arr, string $string): void
+	{
+		/** @var array{0: 'a', 1?: 'b', 2: 'c'} $arr */
+		assertType('1|false', array_search('b', $arr, true));
+		assertType('0|1|2|false', array_search('b', $arr));
+		assertType('0|1|2|false', array_search($string, $arr, true));
+
+		/** @var array{0: 'a', 1?: 'b', 2: 'b'} $arr */
+		assertType('1|2', array_search('b', $arr, true));
+		assertType('0|1|2|false', array_search('b', $arr));
+		assertType('0|1|2|false', array_search($string, $arr, true));
+	}
+
+	public function list(array $arr, string $string): void
+	{
+		/** @var list<string> $arr */
+		assertType('int<0, max>|false', array_search('foo', $arr, true));
+		assertType('int<0, max>|false', array_search('foo', $arr));
+		assertType('int<0, max>|false', array_search($string, $arr, true));
+	}
+
+	public function mixedAndSubtractedArray($mixed, string $string): void
+	{
+		if (is_array($mixed)) {
+			assertType('int|string|false', array_search('foo', $mixed, true));
+			assertType('int|string|false', array_search('foo', $mixed));
+			assertType('int|string|false', array_search($string, $mixed, true));
+		} else {
+			assertType('mixed~array', $mixed);
+			assertType('*ERROR*', array_search('foo', $mixed, true));
+			assertType('*ERROR*', array_search('foo', $mixed));
+			assertType('*ERROR*', array_search($string, $mixed, true));
+		}
+	}
+}


### PR DESCRIPTION
Split out of the extension, but with a couple of small differences
- instead of returning `null` (happened on PHP < 8 with a warning, see https://3v4l.org/lNrqs) it returns `*ERROR*`. not sure if that's OK?
- support for `HasOffsetValueType` which wasn't understood before, see https://phpstan.org/r/e20727f4-7809-42fc-825e-85df0f5ef635
- support for optional array keys, this was incorrect before, see https://phpstan.org/r/96b559ec-55a2-4feb-b3a9-a1e4dff2a84b

not sure if `$strictType` should be moved into the method signature as well or not 🤔