### PR TITLE
emit warnings when xdebug is not used according to cli-flags

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -91,13 +91,6 @@ class CommandHelper
 		bool $cleanupContainerCache = true,
 	): InceptionResult
 	{
-		if (!$allowXdebug) {
-			$xdebug = new XdebugHandler('phpstan');
-			$xdebug->setPersistent();
-			$xdebug->check();
-			unset($xdebug);
-		}
-
 		$stdOutput = new SymfonyOutput($output, new SymfonyStyle(new ErrorsConsoleStyle($input, $output)));
 
 		/** @var Output $errorOutput */
@@ -105,6 +98,20 @@ class CommandHelper
 			$symfonyErrorOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 			return new SymfonyOutput($symfonyErrorOutput, new SymfonyStyle(new ErrorsConsoleStyle($input, $symfonyErrorOutput)));
 		})();
+
+		if ($allowXdebug && !XdebugHandler::isXdebugActive()) {
+			$errorOutput->getStyle()->note('You are running with "--xdebug" enabled, but the Xdebug PHP extension is not active. The process will not halt at breakpoints.');
+		} elseif (!$allowXdebug && XdebugHandler::isXdebugActive()) {
+			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. This may slow down performance and the process will not halt at breakpoints.');
+		}
+
+		if (!$allowXdebug) {
+			$xdebug = new XdebugHandler('phpstan');
+			$xdebug->setPersistent();
+			$xdebug->check();
+			unset($xdebug);
+		}
+
 		if ($memoryLimit !== null) {
 			if (Strings::match($memoryLimit, '#^-?\d+[kMG]?$#i') === null) {
 				$errorOutput->writeLineFormatted(sprintf('Invalid memory limit format "%s".', $memoryLimit));


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan/discussions/8173

we don't have tests with/without xdebug. does this PR require tests?

I tested it manually
```
$ php bin/phpstan analyze test.php --debug  --level 9
Note: The xdebug php-extension is active, but "--xdebug" is not used.
      This may slow down performance and the process will not halt at breakpoints.
Note: Using configuration file C:\dvl\Workspace\phpstan-src-staabm\phpstan.neon.dist.
C:\dvl\Workspace\phpstan-src-staabm\test.php


$ php bin/phpstan analyze test.php --debug  --level 9   --xdebug
Note: You are running with "--xdebug" enabled, but the xdebug php-extension is not active.
      The process will not halt at breakpoints.
Note: Using configuration file C:\dvl\Workspace\phpstan-src-staabm\phpstan.neon.dist.
C:\dvl\Workspace\phpstan-src-staabm\test.php
```