### PR TITLE
Improve wording of the NonexistentOffset, BooleanAndConstantConditionRule and BooleanOrConstantConditionRule

### DIFF
--- a/conf/config.level4.neon
+++ b/conf/config.level4.neon
@@ -45,6 +45,7 @@ services:
 		class: PHPStan\Rules\Comparison\BooleanAndConstantConditionRule
 		arguments:
 			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+			bleedingEdge: %featureToggles.bleedingEdge%
 		tags:
 			- phpstan.rules.rule
 
@@ -52,6 +53,7 @@ services:
 		class: PHPStan\Rules\Comparison\BooleanOrConstantConditionRule
 		arguments:
 			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+			bleedingEdge: %featureToggles.bleedingEdge%
 		tags:
 			- phpstan.rules.rule
 

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -903,6 +903,7 @@ services:
 		class: PHPStan\Rules\Arrays\NonexistentOffsetInArrayDimFetchCheck
 		arguments:
 			reportMaybes: %reportMaybes%
+			bleedingEdge: %featureToggles.bleedingEdge%
 
 	-
 		class: PHPStan\Rules\ClassCaseSensitivityCheck

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
@@ -44,9 +44,19 @@ class NonexistentOffsetInArrayDimFetchCheck
 			return $typeResult->getUnknownClassErrors();
 		}
 
-		$report = $type->hasOffsetValueType($dimType)->no();
+		if ($scope->isInExpressionAssign($var) || $scope->isUndefinedExpressionAllowed($var)) {
+			return [];
+		}
 
-		if (!$report && $this->reportMaybes) {
+		if ($type->hasOffsetValueType($dimType)->no()) {
+			return [
+				RuleErrorBuilder::message(sprintf('Offset %s does not exist on %s.', $dimType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())))->build(),
+			];
+		}
+
+		if ($this->reportMaybes) {
+			$report = false;
+
 			if ($type instanceof BenevolentUnionType) {
 				$flattenedTypes = [$type];
 			} else {
@@ -67,16 +77,12 @@ class NonexistentOffsetInArrayDimFetchCheck
 					}
 				}
 			}
-		}
 
-		if ($report) {
-			if ($scope->isInExpressionAssign($var) || $scope->isUndefinedExpressionAllowed($var)) {
-				return [];
+			if ($report) {
+				return [
+					RuleErrorBuilder::message(sprintf('Offset %s might not exist on %s.', $dimType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())))->build(),
+				];
 			}
-
-			return [
-				RuleErrorBuilder::message(sprintf('Offset %s does not exist on %s.', $dimType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())))->build(),
-			];
 		}
 
 		return [];

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchCheck.php
@@ -19,7 +19,11 @@ use function sprintf;
 class NonexistentOffsetInArrayDimFetchCheck
 {
 
-	public function __construct(private RuleLevelHelper $ruleLevelHelper, private bool $reportMaybes)
+	public function __construct(
+		private RuleLevelHelper $ruleLevelHelper,
+		private bool $reportMaybes,
+		private bool $bleedingEdge,
+	)
 	{
 	}
 
@@ -79,8 +83,13 @@ class NonexistentOffsetInArrayDimFetchCheck
 			}
 
 			if ($report) {
+				if ($this->bleedingEdge) {
+					return [
+						RuleErrorBuilder::message(sprintf('Offset %s might not exist on %s.', $dimType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())))->build(),
+					];
+				}
 				return [
-					RuleErrorBuilder::message(sprintf('Offset %s might not exist on %s.', $dimType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())))->build(),
+					RuleErrorBuilder::message(sprintf('Offset %s does not exist on %s.', $dimType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())))->build(),
 				];
 			}
 		}

--- a/src/Rules/Comparison/BooleanAndConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanAndConstantConditionRule.php
@@ -20,6 +20,7 @@ class BooleanAndConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private bool $treatPhpDocTypesAsCertain,
+		private bool $bleedingEdge,
 	)
 	{
 	}
@@ -36,6 +37,7 @@ class BooleanAndConstantConditionRule implements Rule
 	{
 		$errors = [];
 		$originalNode = $node->getOriginalNode();
+		$nodeText = $this->bleedingEdge ? $originalNode->getOperatorSigil() : '&&';
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		if ($leftType instanceof ConstantBooleanType) {
@@ -52,7 +54,8 @@ class BooleanAndConstantConditionRule implements Rule
 				return $ruleErrorBuilder->tip($tipText);
 			};
 			$errors[] = $addTipLeft(RuleErrorBuilder::message(sprintf(
-				'Left side of && is always %s.',
+				'Left side of %s is always %s.',
+				$nodeText,
 				$leftType->getValue() ? 'true' : 'false',
 			)))->line($originalNode->left->getLine())->build();
 		}
@@ -81,7 +84,8 @@ class BooleanAndConstantConditionRule implements Rule
 
 			if (!$scope->isInFirstLevelStatement()) {
 				$errors[] = $addTipRight(RuleErrorBuilder::message(sprintf(
-					'Right side of && is always %s.',
+					'Right side of %s is always %s.',
+					$nodeText,
 					$rightType->getValue() ? 'true' : 'false',
 				)))->line($originalNode->right->getLine())->build();
 			}
@@ -105,7 +109,8 @@ class BooleanAndConstantConditionRule implements Rule
 
 				if (!$scope->isInFirstLevelStatement()) {
 					$errors[] = $addTip(RuleErrorBuilder::message(sprintf(
-						'Result of && is always %s.',
+						'Result of %s is always %s.',
+						$nodeText,
 						$nodeType->getValue() ? 'true' : 'false',
 					)))->build();
 				}

--- a/src/Rules/Comparison/BooleanOrConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanOrConstantConditionRule.php
@@ -20,6 +20,7 @@ class BooleanOrConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private bool $treatPhpDocTypesAsCertain,
+		private bool $bleedingEdge,
 	)
 	{
 	}
@@ -35,6 +36,7 @@ class BooleanOrConstantConditionRule implements Rule
 	): array
 	{
 		$originalNode = $node->getOriginalNode();
+		$nodeText = $this->bleedingEdge ? $originalNode->getOperatorSigil() : '||';
 		$messages = [];
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
@@ -52,7 +54,8 @@ class BooleanOrConstantConditionRule implements Rule
 				return $ruleErrorBuilder->tip($tipText);
 			};
 			$messages[] = $addTipLeft(RuleErrorBuilder::message(sprintf(
-				'Left side of || is always %s.',
+				'Left side of %s is always %s.',
+				$nodeText,
 				$leftType->getValue() ? 'true' : 'false',
 			)))->line($originalNode->left->getLine())->build();
 		}
@@ -81,7 +84,8 @@ class BooleanOrConstantConditionRule implements Rule
 
 			if (!$scope->isInFirstLevelStatement()) {
 				$messages[] = $addTipRight(RuleErrorBuilder::message(sprintf(
-					'Right side of || is always %s.',
+					'Right side of %s is always %s.',
+					$nodeText,
 					$rightType->getValue() ? 'true' : 'false',
 				)))->line($originalNode->right->getLine())->build();
 			}
@@ -105,7 +109,8 @@ class BooleanOrConstantConditionRule implements Rule
 
 				if (!$scope->isInFirstLevelStatement()) {
 					$messages[] = $addTip(RuleErrorBuilder::message(sprintf(
-						'Result of || is always %s.',
+						'Result of %s is always %s.',
+						$nodeText,
 						$nodeType->getValue() ? 'true' : 'false',
 					)))->build();
 				}

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
@@ -1,11 +1,11 @@
 [
     {
-        "message": "Offset 'foo' does not exist on array|string.",
+        "message": "Offset 'foo' might not exist on array|string.",
         "line": 27,
         "ignorable": true
     },
     {
-        "message": "Offset 12.34 does not exist on array|string.",
+        "message": "Offset 12.34 might not exist on array|string.",
         "line": 31,
         "ignorable": true
     },

--- a/tests/PHPStan/Rules/Arrays/ArrayDestructuringRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/ArrayDestructuringRuleTest.php
@@ -13,13 +13,15 @@ use const PHP_VERSION_ID;
 class ArrayDestructuringRuleTest extends RuleTestCase
 {
 
+	private bool $bleedingEdge = false;
+
 	protected function getRule(): Rule
 	{
 		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, false, false);
 
 		return new ArrayDestructuringRule(
 			$ruleLevelHelper,
-			new NonexistentOffsetInArrayDimFetchCheck($ruleLevelHelper, true),
+			new NonexistentOffsetInArrayDimFetchCheck($ruleLevelHelper, true, $this->bleedingEdge),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -15,19 +15,166 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	private bool $checkExplicitMixed = false;
 
+	private bool $bleedingEdge = false;
+
 	protected function getRule(): Rule
 	{
 		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, $this->checkExplicitMixed, false);
 
 		return new NonexistentOffsetInArrayDimFetchRule(
 			$ruleLevelHelper,
-			new NonexistentOffsetInArrayDimFetchCheck($ruleLevelHelper, true),
+			new NonexistentOffsetInArrayDimFetchCheck($ruleLevelHelper, true, $this->bleedingEdge),
 			true,
 		);
 	}
 
 	public function testRule(): void
 	{
+		$this->analyse([__DIR__ . '/data/nonexistent-offset.php'], [
+			[
+				'Offset \'b\' does not exist on array{a: stdClass, 0: 2}.',
+				17,
+			],
+			[
+				'Offset 1 does not exist on array{a: stdClass, 0: 2}.',
+				18,
+			],
+			[
+				'Offset \'a\' does not exist on array{b: 1}.',
+				55,
+			],
+			[
+				'Access to offset \'bar\' on an unknown class NonexistentOffset\Bar.',
+				101,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+			[
+				'Access to an offset on an unknown class NonexistentOffset\Bar.',
+				102,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+			[
+				'Offset 0 does not exist on array<string, string>.',
+				111,
+			],
+			[
+				'Offset \'0\' does not exist on array<string, string>.',
+				112,
+			],
+			[
+				'Offset int does not exist on array<string, string>.',
+				114,
+			],
+			[
+				'Offset \'test\' does not exist on null.',
+				126,
+			],
+			[
+				'Cannot access offset 42 on int.',
+				142,
+			],
+			[
+				'Cannot access offset 42 on float.',
+				143,
+			],
+			[
+				'Cannot access offset 42 on bool.',
+				144,
+			],
+			[
+				'Cannot access offset 42 on resource.',
+				145,
+			],
+			[
+				'Offset \'c\' does not exist on array{c: false}|array{c: true}|array{e: true}.',
+				171,
+			],
+			[
+				'Offset int does not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.',
+				190,
+			],
+			[
+				'Offset int does not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.',
+				193,
+			],
+			[
+				'Offset \'b\' does not exist on array{a: \'blabla\'}.',
+				225,
+			],
+			[
+				'Offset \'b\' does not exist on array{a: \'blabla\'}.',
+				228,
+			],
+			[
+				'Offset string does not exist on array<int, mixed>.',
+				240,
+			],
+			[
+				'Cannot access offset \'a\' on Closure(): void.',
+				253,
+			],
+			[
+				'Offset string does not exist on array<int, string>.',
+				308,
+			],
+			[
+				'Offset null does not exist on array<int, string>.',
+				310,
+			],
+			[
+				'Offset int does not exist on array<string, string>.',
+				312,
+			],
+			[
+				'Offset \'baz\' does not exist on array{bar: 1, baz?: 2}.',
+				344,
+			],
+			[
+				'Offset \'foo\' does not exist on ArrayAccess<int, stdClass>.',
+				411,
+			],
+			[
+				'Cannot access offset \'foo\' on stdClass.',
+				423,
+			],
+			[
+				'Cannot access offset \'foo\' on true.',
+				426,
+			],
+			[
+				'Cannot access offset \'foo\' on false.',
+				429,
+			],
+			[
+				'Cannot access offset \'foo\' on resource.',
+				433,
+			],
+			[
+				'Cannot access offset \'foo\' on 42.',
+				436,
+			],
+			[
+				'Cannot access offset \'foo\' on 4.141.',
+				439,
+			],
+			[
+				'Cannot access offset \'foo\' on array|int.',
+				443,
+			],
+			[
+				'Offset \'feature_pretty…\' does not exist on array{version: non-falsy-string, commit: string|null, pretty_version: string|null, feature_version: non-falsy-string, feature_pretty_version?: string|null}.',
+				504,
+			],
+			[
+				"Cannot access offset 'foo' on bool.",
+				517,
+			],
+		]);
+	}
+
+	public function testRuleBleedingEdge(): void
+	{
+		$this->bleedingEdge = true;
 		$this->analyse([__DIR__ . '/data/nonexistent-offset.php'], [
 			[
 				'Offset \'b\' does not exist on array{a: stdClass, 0: 2}.',
@@ -182,11 +329,11 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				13,
 			],
 			[
-				'Offset \'foo\' might not exist on array|string.',
+				'Offset \'foo\' does not exist on array|string.',
 				24,
 			],
 			[
-				'Offset 12.34 might not exist on array|string.',
+				'Offset 12.34 does not exist on array|string.',
 				28,
 			],
 		]);
@@ -386,7 +533,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-7000.php'], [
 			[
-				"Offset 'require'|'require-dev' might not exist on array{require?: array<string, string>, require-dev?: array<string, string>}.",
+				"Offset 'require'|'require-dev' does not exist on array{require?: array<string, string>, require-dev?: array<string, string>}.",
 				16,
 			],
 		]);

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -84,15 +84,15 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				145,
 			],
 			[
-				'Offset \'c\' does not exist on array{c: false}|array{c: true}|array{e: true}.',
+				'Offset \'c\' might not exist on array{c: false}|array{c: true}|array{e: true}.',
 				171,
 			],
 			[
-				'Offset int does not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.',
+				'Offset int might not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.',
 				190,
 			],
 			[
-				'Offset int does not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.',
+				'Offset int might not exist on array{}|array{1: 1, 2: 2}|array{3: 3, 4: 4}.',
 				193,
 			],
 			[
@@ -124,7 +124,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				312,
 			],
 			[
-				'Offset \'baz\' does not exist on array{bar: 1, baz?: 2}.',
+				'Offset \'baz\' might not exist on array{bar: 1, baz?: 2}.',
 				344,
 			],
 			[
@@ -160,7 +160,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				443,
 			],
 			[
-				'Offset \'feature_pretty…\' does not exist on array{version: non-falsy-string, commit: string|null, pretty_version: string|null, feature_version: non-falsy-string, feature_pretty_version?: string|null}.',
+				'Offset \'feature_pretty…\' might not exist on array{version: non-falsy-string, commit: string|null, pretty_version: string|null, feature_version: non-falsy-string, feature_pretty_version?: string|null}.',
 				504,
 			],
 			[
@@ -182,11 +182,11 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				13,
 			],
 			[
-				'Offset \'foo\' does not exist on array|string.',
+				'Offset \'foo\' might not exist on array|string.',
 				24,
 			],
 			[
-				'Offset 12.34 does not exist on array|string.',
+				'Offset 12.34 might not exist on array|string.',
 				28,
 			],
 		]);
@@ -386,7 +386,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-7000.php'], [
 			[
-				"Offset 'require'|'require-dev' does not exist on array{require?: array<string, string>, require-dev?: array<string, string>}.",
+				"Offset 'require'|'require-dev' might not exist on array{require?: array<string, string>, require-dev?: array<string, string>}.",
 				16,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -13,6 +13,8 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 
 	private bool $treatPhpDocTypesAsCertain;
 
+	private bool $bleedingEdge = false;
+
 	protected function getRule(): Rule
 	{
 		return new BooleanAndConstantConditionRule(
@@ -27,6 +29,7 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 				$this->treatPhpDocTypesAsCertain,
 			),
 			$this->treatPhpDocTypesAsCertain,
+			$this->bleedingEdge,
 		);
 	}
 
@@ -113,6 +116,173 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 			],
 			[
 				'Right side of && is always true.',
+				147,
+			],
+		]);
+	}
+
+	public function testRuleLogicalAnd(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/boolean-logical-and.php'], [
+			[
+				'Left side of && is always true.',
+				15,
+			],
+			[
+				'Right side of && is always true.',
+				19,
+			],
+			[
+				'Left side of && is always false.',
+				24,
+			],
+			[
+				'Right side of && is always false.',
+				27,
+			],
+			[
+				'Result of && is always false.',
+				30,
+			],
+			[
+				'Right side of && is always true.',
+				33,
+			],
+			[
+				'Right side of && is always true.',
+				36,
+			],
+			[
+				'Right side of && is always true.',
+				39,
+			],
+			[
+				'Result of && is always false.',
+				50,
+			],
+			[
+				'Result of && is always true.',
+				54,
+				$tipText,
+			],
+			[
+				'Result of && is always false.',
+				60,
+			],
+			[
+				'Result of && is always true.',
+				64,
+				//$tipText,
+			],
+			[
+				'Result of && is always false.',
+				66,
+				//$tipText,
+			],
+			[
+				'Result of && is always false.',
+				125,
+			],
+			[
+				'Left side of && is always false.',
+				139,
+			],
+			[
+				'Right side of && is always false.',
+				141,
+			],
+			[
+				'Left side of && is always true.',
+				145,
+			],
+			[
+				'Right side of && is always true.',
+				147,
+			],
+		]);
+	}
+
+	public function testRuleLogicalAndBleedingEdge(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->bleedingEdge = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/boolean-logical-and.php'], [
+			[
+				'Left side of and is always true.',
+				15,
+			],
+			[
+				'Right side of and is always true.',
+				19,
+			],
+			[
+				'Left side of and is always false.',
+				24,
+			],
+			[
+				'Right side of and is always false.',
+				27,
+			],
+			[
+				'Result of and is always false.',
+				30,
+			],
+			[
+				'Right side of and is always true.',
+				33,
+			],
+			[
+				'Right side of and is always true.',
+				36,
+			],
+			[
+				'Right side of and is always true.',
+				39,
+			],
+			[
+				'Result of and is always false.',
+				50,
+			],
+			[
+				'Result of and is always true.',
+				54,
+				$tipText,
+			],
+			[
+				'Result of and is always false.',
+				60,
+			],
+			[
+				'Result of and is always true.',
+				64,
+				//$tipText,
+			],
+			[
+				'Result of and is always false.',
+				66,
+				//$tipText,
+			],
+			[
+				'Result of and is always false.',
+				125,
+			],
+			[
+				'Left side of and is always false.',
+				139,
+			],
+			[
+				'Right side of and is always false.',
+				141,
+			],
+			[
+				'Left side of and is always true.',
+				145,
+			],
+			[
+				'Right side of and is always true.',
 				147,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -14,6 +14,8 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 
 	private bool $treatPhpDocTypesAsCertain;
 
+	private bool $bleedingEdge = false;
+
 	protected function getRule(): Rule
 	{
 		return new BooleanOrConstantConditionRule(
@@ -28,6 +30,7 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 				$this->treatPhpDocTypesAsCertain,
 			),
 			$this->treatPhpDocTypesAsCertain,
+			$this->bleedingEdge,
 		);
 	}
 
@@ -105,6 +108,155 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 			],
 			[
 				'Right side of || is always true.',
+				85,
+			],
+		]);
+	}
+
+	public function testRuleLogicalOr(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/boolean-logical-or.php'], [
+			[
+				'Left side of || is always true.',
+				15,
+			],
+			[
+				'Right side of || is always true.',
+				19,
+			],
+			[
+				'Left side of || is always false.',
+				24,
+			],
+			[
+				'Right side of || is always false.',
+				27,
+			],
+			[
+				'Right side of || is always true.',
+				30,
+			],
+			[
+				'Result of || is always true.',
+				33,
+			],
+			[
+				'Right side of || is always false.',
+				36,
+			],
+			[
+				'Right side of || is always false.',
+				39,
+			],
+			[
+				'Result of || is always true.',
+				50,
+				$tipText,
+			],
+			[
+				'Result of || is always true.',
+				54,
+				$tipText,
+			],
+			[
+				'Result of || is always true.',
+				61,
+			],
+			[
+				'Result of || is always true.',
+				65,
+			],
+			[
+				'Left side of || is always false.',
+				77,
+			],
+			[
+				'Right side of || is always false.',
+				79,
+			],
+			[
+				'Left side of || is always true.',
+				83,
+			],
+			[
+				'Right side of || is always true.',
+				85,
+			],
+		]);
+	}
+
+	public function testRuleLogicalOrBleedingEdge(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->bleedingEdge = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/boolean-logical-or.php'], [
+			[
+				'Left side of or is always true.',
+				15,
+			],
+			[
+				'Right side of or is always true.',
+				19,
+			],
+			[
+				'Left side of or is always false.',
+				24,
+			],
+			[
+				'Right side of or is always false.',
+				27,
+			],
+			[
+				'Right side of or is always true.',
+				30,
+			],
+			[
+				'Result of or is always true.',
+				33,
+			],
+			[
+				'Right side of or is always false.',
+				36,
+			],
+			[
+				'Right side of or is always false.',
+				39,
+			],
+			[
+				'Result of or is always true.',
+				50,
+				$tipText,
+			],
+			[
+				'Result of or is always true.',
+				54,
+				$tipText,
+			],
+			[
+				'Result of or is always true.',
+				61,
+			],
+			[
+				'Result of or is always true.',
+				65,
+			],
+			[
+				'Left side of or is always false.',
+				77,
+			],
+			[
+				'Right side of or is always false.',
+				79,
+			],
+			[
+				'Left side of or is always true.',
+				83,
+			],
+			[
+				'Right side of or is always true.',
 				85,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/data/boolean-logical-and.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-logical-and.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace ConstantCondition;
+
+class BooleanAnd
+{
+
+	public function doFoo(int $i, bool $j, \stdClass $std, ?\stdClass $nullableStd)
+	{
+		if ($i and $j) {
+
+		}
+
+		$one = 1;
+		if ($one and $i) {
+
+		}
+
+		if ($i and $std) {
+
+		}
+
+		$zero = 0;
+		if ($zero and $i) {
+
+		}
+		if ($i and $zero) {
+
+		}
+		if ($one === 0 and $one) {
+
+		}
+		if ($one === 1 and $one) {
+
+		}
+		if ($nullableStd and $nullableStd) {
+
+		}
+		if ($nullableStd !== null and $nullableStd) {
+
+		}
+	}
+
+	/**
+	 * @param Foo|Bar $union
+	 * @param Lorem&Ipsum $intersection
+	 */
+	public function checkUnionAndIntersection($union, $intersection)
+	{
+		if ($union instanceof Foo and $union instanceof Bar) {
+
+		}
+
+		if ($intersection instanceof Lorem and $intersection instanceof Ipsum) {
+
+		}
+
+		if ($union instanceof Foo || $union instanceof Bar) {
+
+		} elseif ($union instanceof Foo and doFoo()) {
+
+		}
+
+		if ($intersection instanceof Lorem and $intersection instanceof Ipsum) {
+
+		} elseif ($intersection instanceof Lorem and doFoo()) {
+
+		}
+	}
+
+}
+
+class NonNullablePropertiesShouldNotReportError
+{
+
+	/** @var self */
+	private $foo;
+
+	/** @var self */
+	private $bar;
+
+	public function doFoo()
+	{
+		if ($this->foo !== null and $this->bar !== null) {
+
+		}
+	}
+
+}
+
+class StringInIsset
+{
+
+	public function doFoo(string $s, string $t)
+	{
+		if (isset($s[1]) and isset($t[1])) {
+
+		}
+	}
+
+}
+
+class IssetBug
+{
+
+	public function doFoo(string $alias, array $options = [])
+	{
+		list($name, $p) = explode('.', $alias);
+		if (isset($options['c']) and !\strpos($options['c'], '\\')) {
+			// ...
+		}
+
+		if (!isset($options['c']) and \strpos($p, 'X') === 0) {
+			// ?
+		}
+	}
+
+}
+
+class IntegerRangeType
+{
+
+	public function doFoo(int $i, float $f)
+	{
+		if ($i < 3 and $i > 5) { // can never happen
+		}
+
+		if ($f > 0 and $f < 1) {
+		}
+	}
+
+}
+
+class AndInIfCondition
+{
+	public function andInIfCondition($mixed, int $i): void
+	{
+		if (!$mixed) {
+			if ($mixed and $i) {
+			}
+			if ($i and $mixed) {
+			}
+		}
+		if ($mixed) {
+			if ($mixed and $i) {
+			}
+			if ($i and $mixed) {
+			}
+		}
+	}
+}
+
+function getMaybeArray() : ?array {
+	if (rand(0, 1)) { return [1, 2, 3]; }
+	return null;
+}
+
+function bug1924() {
+	$arr = [
+		'a' => getMaybeArray(),
+		'b' => getMaybeArray(),
+	];
+
+	if (isset($arr['a']) and isset($arr['b'])) {
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/boolean-logical-or.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-logical-or.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace ConstantCondition;
+
+class BooleanOr
+{
+
+	public function doFoo(int $i, bool $j, \stdClass $std, ?\stdClass $nullableStd)
+	{
+		if ($i or $j) {
+
+		}
+
+		$one = 1;
+		if ($one or $i) {
+
+		}
+
+		if ($i or $std) {
+
+		}
+
+		$zero = 0;
+		if ($zero or $i) {
+
+		}
+		if ($i or $zero) {
+
+		}
+		if ($one === 0 or $one) {
+
+		}
+		if ($one === 1 or $one) {
+
+		}
+		if ($nullableStd or $nullableStd) {
+
+		}
+		if ($nullableStd !== null or $nullableStd) {
+
+		}
+	}
+
+	/**
+	 * @param Foo|Bar $union
+	 * @param Lorem&Ipsum $intersection
+	 */
+	public function checkUnionAndIntersection($union, $intersection)
+	{
+		if ($union instanceof Foo or $union instanceof Bar) {
+
+		}
+
+		if ($intersection instanceof Lorem or $intersection instanceof Ipsum) {
+
+		}
+	}
+
+	public function directorySeparator()
+	{
+		if (DIRECTORY_SEPARATOR === '/' or DIRECTORY_SEPARATOR === '\\') {
+
+		}
+
+		if ('/' === DIRECTORY_SEPARATOR or '\\' === DIRECTORY_SEPARATOR) {
+
+		}
+	}
+
+}
+
+class OrInIfCondition
+{
+	public function orInIfCondition($mixed, int $i): void
+	{
+		if (!$mixed) {
+			if ($mixed or $i) {
+			}
+			if ($i or $mixed) {
+			}
+		}
+		if ($mixed) {
+			if ($mixed or $i) {
+			}
+			if ($i or $mixed) {
+			}
+		}
+	}
+}


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan/issues/8187#issuecomment-1286169876

I feel like 
```
Offset 'c' does not exist on array{c?: int}.
```
is confusing and 
```
Offset 'c' might not exist on array{c?: int}.
```
is better.