### PR TITLE
fixed TypeCombinator->containsNull() with late resolvable type

### DIFF
--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -4248,4 +4248,22 @@ class TypeCombinatorTest extends PHPStanTestCase
 		$this->assertSame('array{0: string, 1?: string, 2?: string, 3?: string, 4?: string, test?: string}', $resultType->describe(VerbosityLevel::precise()));
 	}
 
+	/**
+	 * @dataProvider dataContainsNull
+	 */
+	public function testContainsNull(
+		Type $type,
+		bool $expectedResult,
+	): void
+	{
+		$this->assertSame($expectedResult, TypeCombinator::containsNull($type));
+	}
+
+	public function dataContainsNull(): iterable
+	{
+		yield [new NullType(), true];
+		yield [new UnionType([new IntegerType(), new NullType()]), true];
+		yield [new MixedType(), false];
+	}
+
 }


### PR DESCRIPTION
given a conditional type like
`@return ($subject is array ? array<string>|null : string|null)`

`TypeCombinator->containsNull()` was not able to identify the containing `NullType`.

I targeted 1.8.x since I consider it a bugfix.