### PR TITLE
test param-out in constructors

### DIFF
--- a/tests/PHPStan/Analyser/data/param-out.php
+++ b/tests/PHPStan/Analyser/data/param-out.php
@@ -345,3 +345,31 @@ function fooPassthru() {
 
 	assertType('int', $exitCode);
 }
+
+class X {
+	/**
+	 * @param-out array $ref
+	 */
+	public function __construct(string &$ref) {
+		$ref = [];
+	}
+}
+
+class SubX extends X {
+	/**
+	 * @param-out float $ref
+	 */
+	public function __construct(string $a, string &$ref) {
+		parent::__construct($ref);
+	}
+}
+
+function fooConstruct(string $s) {
+	$x = new X($s);
+	assertType('array', $s);
+}
+
+function fooSubConstruct(string $s) {
+	$x = new SubX('', $s);
+	assertType('float', $s);
+}


### PR DESCRIPTION
since `__construct` is handeld on a different code path