### PR TITLE
refactor pow() return type extension to re-use BinaryOp\Pow

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1122,6 +1122,25 @@ class InitializerExprTypeResolver
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
 
+		if ($leftType instanceof MixedType || $rightType instanceof MixedType) {
+			return new BenevolentUnionType([
+				new FloatType(),
+				new IntegerType(),
+			]);
+		}
+
+		$object = new ObjectWithoutClassType();
+		if (
+			!$leftType instanceof NeverType &&
+			!$rightType instanceof NeverType &&
+			(
+				!$object->isSuperTypeOf($leftType)->no()
+				|| !$object->isSuperTypeOf($rightType)->no()
+			)
+		) {
+			return TypeCombinator::union($leftType, $rightType);
+		}
+
 		$leftTypes = TypeUtils::getConstantScalars($leftType);
 		$rightTypes = TypeUtils::getConstantScalars($rightType);
 		$leftTypesCount = count($leftTypes);

--- a/src/Type/Php/PowFunctionReturnTypeExtension.php
+++ b/src/Type/Php/PowFunctionReturnTypeExtension.php
@@ -2,17 +2,12 @@
 
 namespace PHPStan\Type\Php;
 
+use PhpParser\Node\Expr\BinaryOp\Pow;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\FloatType;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use function count;
 
 class PowFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -23,31 +18,13 @@ class PowFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtensi
 		return $functionReflection->getName() === 'pow';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		$defaultReturnType = new BenevolentUnionType([
-			new FloatType(),
-			new IntegerType(),
-		]);
 		if (count($functionCall->getArgs()) < 2) {
-			return $defaultReturnType;
+			return null;
 		}
 
-		$firstArgType = $scope->getType($functionCall->getArgs()[0]->value);
-		$secondArgType = $scope->getType($functionCall->getArgs()[1]->value);
-		if ($firstArgType instanceof MixedType || $secondArgType instanceof MixedType) {
-			return $defaultReturnType;
-		}
-
-		$object = new ObjectWithoutClassType();
-		if (
-			!$object->isSuperTypeOf($firstArgType)->no()
-			|| !$object->isSuperTypeOf($secondArgType)->no()
-		) {
-			return TypeCombinator::union($firstArgType, $secondArgType);
-		}
-
-		return $defaultReturnType;
+		return $scope->getType(new Pow($functionCall->getArgs()[0]->value, $functionCall->getArgs()[1]->value));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/pow.php
+++ b/tests/PHPStan/Analyser/data/pow.php
@@ -6,16 +6,20 @@ use function PHPStan\Testing\assertType;
 
 function ($a, $b): void {
 	assertType('(float|int)', pow($a, $b));
+	assertType('(float|int)', $a ** $b);
 };
 
 function (int $a, int $b): void {
 	assertType('(float|int)', pow($a, $b));
+	assertType('(float|int)', $a ** $b);
 };
 
 function (\GMP $a, \GMP $b): void {
 	assertType('GMP', pow($a, $b));
+	assertType('GMP', $a ** $b);
 };
 
 function (\stdClass $a, \GMP $b): void {
 	assertType('GMP|stdClass', pow($a, $b));
+	assertType('GMP|stdClass', $a ** $b);
 };


### PR DESCRIPTION
to bring both implementations in sync, and therefore on feature parity.

next step, in a followup PR, will be to add IntegerRangeType support to `pow`