### PR TITLE
#8086 Add colon as prefix of line number in table report, when running in VSCode terminal

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -11,6 +11,7 @@ use PHPStan\File\SimpleRelativePathHelper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use function array_map;
 use function count;
+use function getenv;
 use function is_string;
 use function sprintf;
 use function str_replace;
@@ -88,7 +89,7 @@ class TableErrorFormatter implements ErrorFormatter
 					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $this->relativePathHelper->getRelativePath($editorFile) . '</>';
 				}
 				$rows[] = [
-					(string) $error->getLine(),
+					$this->formatLineNumber($error->getLine()),
 					$message,
 				];
 			}
@@ -117,6 +118,20 @@ class TableErrorFormatter implements ErrorFormatter
 		}
 
 		return $analysisResult->getTotalErrorsCount() > 0 ? 1 : 0;
+	}
+
+	private function formatLineNumber(?int $lineNumber): string
+	{
+		if ($lineNumber === null) {
+			return '';
+		}
+
+		$isRunningInVSCodeTerminal = getenv('TERM_PROGRAM') === 'vscode';
+		if ($isRunningInVSCodeTerminal) {
+			return ':' . $lineNumber;
+		}
+
+		return (string) $lineNumber;
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -178,7 +178,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 	/**
 	 * @dataProvider dataFormatterOutputProvider
-	 *
+	 * @param array<string> $extraEnvVars
 	 */
 	public function testFormatErrors(
 		string $message,


### PR DESCRIPTION
This solves https://github.com/phpstan/phpstan/issues/8086

The diff of the test class is a bit bigger that required. I've added keys to the data provider arrays, so it's easier to understand, what the data values do, without having to scroll to the test method. I hope, it's okay, I did this in this PR, even if it's a bit out-of-scope.