### PR TITLE
Improve non-array specification for recently cleaned-up array functions

### DIFF
--- a/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
@@ -4,13 +4,20 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 
 class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -23,7 +30,12 @@ class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 			return null;
 		}
 
-		return $scope->getType($functionCall->getArgs()[0]->value)->flipArray();
+		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		if ($arrayType->isArray()->no()) {
+			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
+		}
+
+		return $arrayType->flipArray();
 	}
 
 }

--- a/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php
@@ -4,14 +4,21 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 use function strtolower;
 
 class ArrayKeysFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -24,7 +31,12 @@ class ArrayKeysFunctionDynamicReturnTypeExtension implements DynamicFunctionRetu
 			return null;
 		}
 
-		return $scope->getType($functionCall->getArgs()[0]->value)->getKeysArray();
+		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		if ($arrayType->isArray()->no()) {
+			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
+		}
+
+		return $arrayType->getKeysArray();
 	}
 
 }

--- a/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
@@ -4,14 +4,21 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 use function strtolower;
 
 class ArrayValuesFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -24,7 +31,12 @@ class ArrayValuesFunctionDynamicReturnTypeExtension implements DynamicFunctionRe
 			return null;
 		}
 
-		return $scope->getType($functionCall->getArgs()[0]->value)->getValuesArray();
+		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		if ($arrayType->isArray()->no()) {
+			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
+		}
+
+		return $arrayType->getValuesArray();
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -287,7 +287,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-filter-arrow-functions.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-flip.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-map.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-map-closure.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-merge.php');
@@ -811,9 +810,15 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/weird-strlen-cases.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6439.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6748.php');
+
 		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-fill-keys.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-flip.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array_keys.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/array_values.php');
 		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-search-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-pop.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-push.php');
@@ -833,8 +838,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		} else {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-combine-php7.php');
 		}
-
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-fill-keys.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6917.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6936-limit.php');
@@ -1088,8 +1091,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/allowed-subtypes-datetime.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/allowed-subtypes-throwable.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_values.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_keys.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-8174.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8169.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7519.php');

--- a/tests/PHPStan/Analyser/data/array-fill-keys.php
+++ b/tests/PHPStan/Analyser/data/array-fill-keys.php
@@ -110,6 +110,6 @@ function mixedAndSubtractedArray($mixed): void
 	if (is_array($mixed)) {
 		assertType("array<'b'>", array_fill_keys($mixed, 'b'));
 	} else {
-		assertType("*ERROR*", array_fill_keys($mixed, 'b'));
+		assertType("*NEVER*", array_fill_keys($mixed, 'b'));
 	}
 }

--- a/tests/PHPStan/Analyser/data/array-flip.php
+++ b/tests/PHPStan/Analyser/data/array-flip.php
@@ -73,7 +73,7 @@ function foo9($mixed)
 		assertType('array<int|string, (int|string)>', array_flip($mixed));
 	} else {
 		assertType('mixed~array', $mixed);
-		assertType('*ERROR*', array_flip($mixed));
+		assertType('*NEVER*', array_flip($mixed));
 	}
 }
 

--- a/tests/PHPStan/Analyser/data/array_keys.php
+++ b/tests/PHPStan/Analyser/data/array_keys.php
@@ -12,7 +12,7 @@ class HelloWorld
 			assertType('list<(int|string)>', array_keys($mixed));
 		} else {
 			assertType('mixed~array', $mixed);
-			assertType('*ERROR*', array_keys($mixed));
+			assertType('*NEVER*', array_keys($mixed));
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/data/array_values.php
+++ b/tests/PHPStan/Analyser/data/array_values.php
@@ -12,7 +12,7 @@ class HelloWorld
 			assertType('list<mixed>', array_values($mixed));
 		} else {
 			assertType('mixed~array', $mixed);
-			assertType('*ERROR*', array_values($mixed));
+			assertType('*NEVER*', array_values($mixed));
 		}
 	}
 
@@ -25,7 +25,7 @@ class HelloWorld
 			assertType('list<string>', array_values($list));
 		} else {
 			assertType('*NEVER*', $list);
-			assertType('*ERROR*', array_values($list));
+			assertType('*NEVER*', array_values($list));
 		}
 	}
 }


### PR DESCRIPTION
array_fill_keys: https://3v4l.org/8ik8V
array_flip: https://3v4l.org/jBASO
array_keys: https://3v4l.org/TYWrU
array_values: https://3v4l.org/89UDN

I was lazy with the pre PHP 8 checks and just wrapped them in conditionals like I did it with array_search. should the test files be split maybe to assert this for PHP < 8 as well? or not worth the hassle? hmm. we could maybe also move them all out to 2 test files only. e.g. non-array-array-functions.php and non-array-array-functions-php8.php or so