### PR TITLE
Update deprecated set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,7 +60,7 @@ jobs:
         id: rector-cache-key
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'
         run: |
-          echo "::set-output name=sha::$(php build/rector-cache-files-hash.php)"
+          echo "sha=$(php build/rector-cache-files-hash.php)" >> $GITHUB_OUTPUT
 
       - name: "Rector downgrade cache"
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -54,7 +54,7 @@ jobs:
       - name: "Rector downgrade cache key"
         id: rector-cache-key
         run: |
-          echo "::set-output name=sha::$(php build/rector-cache-files-hash.php)"
+          echo "sha=$(php build/rector-cache-files-hash.php)" >> $GITHUB_OUTPUT
 
       - name: "Rector downgrade cache"
         uses: actions/cache@v3
@@ -107,7 +107,7 @@ jobs:
 
       - name: "Save checksum"
         id: "checksum"
-        run: echo "::set-output name=md5::$(md5sum tmp/phpstan.phar | cut -d' ' -f1)"
+        run: echo "md5=$(md5sum tmp/phpstan.phar | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         with:
@@ -164,7 +164,7 @@ jobs:
       - name: "Get previous pushed dist commit"
         id: previous-commit
         working-directory: phpstan-dist
-        run: echo ::set-output name=sha::$(sed -n '2p' .phar-checksum)
+        run: echo "sha=$(sed -n '2p' .phar-checksum)" >> $GITHUB_OUTPUT
 
       - name: "Checkout phpstan-src"
         uses: actions/checkout@v3
@@ -175,7 +175,7 @@ jobs:
       - name: "Get Git log"
         id: git-log
         working-directory: phpstan-src
-        run: echo ::set-output name=log::$(git log ${{ steps.previous-commit.outputs.sha }}..${{ github.event.after }} --reverse --pretty='%H %s' | sed -e 's/^/https:\/\/github.com\/phpstan\/phpstan-src\/commit\//')
+        run: echo "log=$(git log ${{ steps.previous-commit.outputs.sha }}..${{ github.event.after }} --reverse --pretty='%H %s' | sed -e 's/^/https:\/\/github.com\/phpstan\/phpstan-src\/commit\//')" >> $GITHUB_OUTPUT
 
       - name: "Check PHAR checksum"
         id: checksum-difference
@@ -183,9 +183,9 @@ jobs:
         run: |
           checksum=${{needs.compiler-tests.outputs.checksum}}
           if [[ $(head -n 1 .phar-checksum) != "$checksum" ]]; then
-            echo "::set-output name=result::different
+            echo "result=different" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::same
+            echo "result=same" >> $GITHUB_OUTPUT
           fi
 
       - name: "Download phpstan.phar"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -67,7 +67,7 @@ jobs:
         id: rector-cache-key
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'
         run: |
-          echo "::set-output name=sha::$(php build/rector-cache-files-hash.php)"
+          echo "sha=$(php build/rector-cache-files-hash.php)" >> $GITHUB_OUTPUT
 
       - name: "Rector downgrade cache"
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         id: rector-cache-key
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'
         run: |
-          echo "::set-output name=sha::$(php build/rector-cache-files-hash.php)"
+          echo "sha=$(php build/rector-cache-files-hash.php)" >> $GITHUB_OUTPUT
 
       - name: "Rector downgrade cache"
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'
@@ -189,7 +189,7 @@ jobs:
         id: rector-cache-key
         if: matrix.php-version != '8.1' && matrix.php-version != '8.2'
         run: |
-          echo "::set-output name=sha::$(php build/rector-cache-files-hash.php)"
+          echo "sha=$(php build/rector-cache-files-hash.php)" >> $GITHUB_OUTPUT
 
       - name: "Rector downgrade cache"
         uses: actions/cache@v3


### PR DESCRIPTION
Ref https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/