### PR TITLE
Remove `Type::getConstantArrays()`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1905,7 +1905,7 @@ class NodeScopeResolver
 					}
 				};
 
-				$constantArrays = $arrayType->getConstantArrays();
+				$constantArrays = TypeUtils::getOldConstantArrays($arrayType);
 				if (count($constantArrays) > 0) {
 					$newArrayTypes = [];
 					$prepend = $functionReflection->getName() === 'array_unshift';

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -907,8 +907,8 @@ class InitializerExprTypeResolver
 			return TypeCombinator::union(...$resultTypes);
 		}
 
-		$leftConstantArrays = $leftType->getConstantArrays();
-		$rightConstantArrays = $rightType->getConstantArrays();
+		$leftConstantArrays = TypeUtils::getOldConstantArrays($leftType);
+		$rightConstantArrays = TypeUtils::getOldConstantArrays($rightType);
 
 		$leftCount = count($leftConstantArrays);
 		$rightCount = count($rightConstantArrays);

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -100,7 +100,7 @@ class FunctionCallParametersCheck
 				$argumentName = $arg->name->toString();
 			}
 			if ($arg->unpack) {
-				$arrays = $type->getConstantArrays();
+				$arrays = TypeUtils::getOldConstantArrays($type);
 				if (count($arrays) > 0) {
 					$minKeys = null;
 					foreach ($arrays as $array) {

--- a/src/Rules/Regexp/RegularExpressionPatternRule.php
+++ b/src/Rules/Regexp/RegularExpressionPatternRule.php
@@ -83,7 +83,7 @@ class RegularExpressionPatternRule implements Rule
 			$patternStrings[] = $constantStringType->getValue();
 		}
 
-		foreach ($patternType->getConstantArrays() as $constantArrayType) {
+		foreach (TypeUtils::getOldConstantArrays($patternType) as $constantArrayType) {
 			if (
 				in_array($functionName, [
 					'preg_replace',

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -49,11 +49,6 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return [];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -47,11 +47,6 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -46,11 +46,6 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -76,11 +76,6 @@ class ArrayType implements Type
 		return [$this];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -110,11 +110,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		);
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [$this];
-	}
-
 	/** @deprecated Use isIterableAtLeastOnce()->no() instead */
 	public function isEmpty(): bool
 	{

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -106,11 +106,6 @@ class IntersectionType implements CompoundType
 		return UnionTypeHelper::getArrays($this->getTypes());
 	}
 
-	public function getConstantArrays(): array
-	{
-		return UnionTypeHelper::getConstantArrays($this->getTypes());
-	}
-
 	public function accepts(Type $otherType, bool $strictTypes): TrinaryLogic
 	{
 		foreach ($this->types as $type) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -68,11 +68,6 @@ class MixedType implements CompoundType, SubtractableType
 		return [];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -47,7 +47,7 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		$columnType = $scope->getType($functionCall->getArgs()[1]->value);
 		$indexType = $numArgs >= 3 ? $scope->getType($functionCall->getArgs()[2]->value) : null;
 
-		$constantArrayTypes = $arrayType->getConstantArrays();
+		$constantArrayTypes = TypeUtils::getOldConstantArrays($arrayType);
 		if (count($constantArrayTypes) === 1) {
 			$type = $this->handleConstantArray($constantArrayTypes[0], $columnType, $indexType, $scope);
 			if ($type !== null) {

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -29,6 +29,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use function array_map;
 use function count;
 use function is_string;
@@ -163,7 +164,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 			throw new ShouldNotHappenException();
 		}
 
-		$constantArrays = $arrayType->getConstantArrays();
+		$constantArrays = TypeUtils::getOldConstantArrays($arrayType);
 		if (count($constantArrays) > 0) {
 			$results = [];
 			foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use function array_slice;
 use function count;
 
@@ -46,7 +47,7 @@ class ArrayIntersectKeyFunctionReturnTypeExtension implements DynamicFunctionRet
 			return $firstArray;
 		}
 
-		$constantArrays = $firstArray->getConstantArrays();
+		$constantArrays = TypeUtils::getOldConstantArrays($firstArray);
 		if (count($constantArrays) === 0) {
 			return new ArrayType($firstArray->getIterableKeyType(), $firstArray->getIterableValueType());
 		}

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -63,7 +63,7 @@ class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			if ($callableIsNull) {
 				return $arrayType;
 			}
-			$constantArrays = $arrayType->getConstantArrays();
+			$constantArrays = TypeUtils::getOldConstantArrays($arrayType);
 			if (count($constantArrays) > 0) {
 				$arrayTypes = [];
 				foreach ($constantArrays as $constantArray) {

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use function count;
 
 class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -45,7 +46,7 @@ class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 
 		$arraysType = $scope->getType($functionCall->getArgs()[0]->value);
-		$constantArrays = $arraysType->getConstantArrays();
+		$constantArrays = TypeUtils::getOldConstantArrays($arraysType);
 		if (count($constantArrays) > 0) {
 			$onlyEmpty = TrinaryLogic::createYes();
 			$onlyNonEmpty = TrinaryLogic::createYes();

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -16,6 +16,7 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function count;
 
@@ -102,7 +103,7 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 
 	private function processArrayType(string $functionName, Type $argType): Type
 	{
-		$constArrayTypes = $argType->getConstantArrays();
+		$constArrayTypes = TypeUtils::getOldConstantArrays($argType);
 		if (count($constArrayTypes) > 0) {
 			$resultTypes = [];
 			foreach ($constArrayTypes as $constArrayType) {

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -108,11 +108,6 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getArrays();
 	}
 
-	public function getConstantArrays(): array
-	{
-		return $this->getStaticObjectType()->getConstantArrays();
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -26,11 +26,6 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->getArrays();
 	}
 
-	public function getConstantArrays(): array
-	{
-		return $this->resolve()->getConstantArrays();
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return $this->resolve()->accepts($type, $strictTypes);

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -14,11 +14,6 @@ trait MaybeArrayTypeTrait
 		return [];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -14,11 +14,6 @@ trait NonArrayTypeTrait
 		return [];
 	}
 
-	public function getConstantArrays(): array
-	{
-		return [];
-	}
-
 	public function isArray(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -10,7 +10,6 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeReference;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -26,9 +25,6 @@ interface Type
 
 	/** @return list<ArrayType> */
 	public function getArrays(): array;
-
-	/** @return list<ConstantArrayType> */
-	public function getConstantArrays(): array;
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic;
 

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -65,8 +65,6 @@ class TypeUtils
 
 	/**
 	 * @return ConstantArrayType[]
-	 *
-	 * @deprecated Use PHPStan\Type\Type::getConstantArrays() instead and handle optional keys if necessary.
 	 */
 	public static function getConstantArrays(Type $type): array
 	{
@@ -191,8 +189,6 @@ class TypeUtils
 	/**
 	 * @internal
 	 * @return ConstantArrayType[]
-	 *
-	 * @deprecated Use PHPStan\Type\Type::getConstantArrays().
 	 */
 	public static function getOldConstantArrays(Type $type): array
 	{

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -102,11 +102,6 @@ class UnionType implements CompoundType
 		return UnionTypeHelper::getArrays($this->getTypes());
 	}
 
-	public function getConstantArrays(): array
-	{
-		return UnionTypeHelper::getConstantArrays($this->getTypes());
-	}
-
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if (

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Type;
 
 use PHPStan\Type\Accessory\AccessoryType;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -41,20 +40,6 @@ class UnionTypeHelper
 		return array_merge(
 			...array_map(
 				static fn (Type $type) => $type->getArrays(),
-				$types,
-			),
-		);
-	}
-
-	/**
-	 * @param Type[] $types
-	 * @return list<ConstantArrayType>
-	 */
-	public static function getConstantArrays(array $types): array
-	{
-		return array_merge(
-			...array_map(
-				static fn (Type $type) => $type->getConstantArrays(),
 				$types,
 			),
 		);


### PR DESCRIPTION
As preparation for the 1.9.0 release :) 
See https://github.com/phpstan/phpstan-src/pull/1687#issuecomment-1282840241 where I mentioned that I think this was not the correct solution

This also reverts the deprecation of `TypeUtils::getOldConstantArrays()` and `TypeUtils::getConstantArrays()`. The latter is unused in PHPStan and I don't like it, but I'm not sure if we can just deprecate it. Or if we do if we should point people to getOldConstantArrays() or something else..