### PR TITLE
Add `Type::getUnionedTypes()`, deprecate `TypeUtils::flattenTypes()`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4613,8 +4613,8 @@ class MutatingScope implements Scope
 		$otherTypes = [];
 
 		foreach ([
-			'a' => TypeUtils::flattenTypes($a),
-			'b' => TypeUtils::flattenTypes($b),
+			'a' => $a->getUnionedTypes(),
+			'b' => $b->getUnionedTypes(),
 		] as $key => $types) {
 			foreach ($types as $type) {
 				if ($type instanceof ConstantIntegerType) {
@@ -4684,7 +4684,7 @@ class MutatingScope implements Scope
 				$constantArraysB = TypeCombinator::union(...$constantArrays['b']);
 				if ($constantArraysA->getIterableKeyType()->equals($constantArraysB->getIterableKeyType())) {
 					$resultArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-					foreach (TypeUtils::flattenTypes($constantArraysA->getIterableKeyType()) as $keyType) {
+					foreach ($constantArraysA->getIterableKeyType()->getUnionedTypes() as $keyType) {
 						$resultArrayBuilder->setOffsetValueType(
 							$keyType,
 							self::generalizeType(

--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -14,7 +14,6 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\SubtractableType;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -102,9 +101,8 @@ class MatchExpressionRule implements Rule
 							$cases[$name] = new EnumCaseObjectType($classReflection->getName(), $name);
 						}
 
-						$subtractedTypes = TypeUtils::flattenTypes($subtractedType);
 						$set = true;
-						foreach ($subtractedTypes as $subType) {
+						foreach ($subtractedType->getUnionedTypes() as $subType) {
 							if (!$subType instanceof EnumCaseObjectType) {
 								$set = false;
 								break;

--- a/src/Rules/Exceptions/MissingCheckedExceptionInThrowsCheck.php
+++ b/src/Rules/Exceptions/MissingCheckedExceptionInThrowsCheck.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\ThrowPoint;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\VerbosityLevel;
 use Throwable;
@@ -35,7 +34,7 @@ class MissingCheckedExceptionInThrowsCheck
 				continue;
 			}
 
-			foreach (TypeUtils::flattenTypes($throwPoint->getType()) as $throwPointType) {
+			foreach ($throwPoint->getType()->getUnionedTypes() as $throwPointType) {
 				if ($throwPointType->isSuperTypeOf(new ObjectType(Throwable::class))->yes()) {
 					continue;
 				}

--- a/src/Rules/Exceptions/ThrowsVoidFunctionWithExplicitThrowPointRule.php
+++ b/src/Rules/Exceptions/ThrowsVoidFunctionWithExplicitThrowPointRule.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
@@ -51,7 +50,7 @@ class ThrowsVoidFunctionWithExplicitThrowPointRule implements Rule
 				continue;
 			}
 
-			foreach (TypeUtils::flattenTypes($throwPoint->getType()) as $throwPointType) {
+			foreach ($throwPoint->getType()->getUnionedTypes() as $throwPointType) {
 				if (
 					$throwPointType instanceof TypeWithClassName
 					&& $this->exceptionTypeResolver->isCheckedException($throwPointType->getClassName(), $throwPoint->getScope())

--- a/src/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRule.php
+++ b/src/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRule.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
@@ -51,7 +50,7 @@ class ThrowsVoidMethodWithExplicitThrowPointRule implements Rule
 				continue;
 			}
 
-			foreach (TypeUtils::flattenTypes($throwPoint->getType()) as $throwPointType) {
+			foreach ($throwPoint->getType()->getUnionedTypes() as $throwPointType) {
 				if (
 					$throwPointType instanceof TypeWithClassName
 					&& $this->exceptionTypeResolver->isCheckedException($throwPointType->getClassName(), $throwPoint->getScope())

--- a/src/Rules/Exceptions/TooWideThrowTypeCheck.php
+++ b/src/Rules/Exceptions/TooWideThrowTypeCheck.php
@@ -6,7 +6,6 @@ use PHPStan\Analyser\ThrowPoint;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 use function array_map;
@@ -33,7 +32,7 @@ class TooWideThrowTypeCheck
 		}, $throwPoints));
 
 		$throwClasses = [];
-		foreach (TypeUtils::flattenTypes($throwType) as $type) {
+		foreach ($throwType->getUnionedTypes() as $type) {
 			if (!$throwPointType instanceof NeverType && !$type->isSuperTypeOf($throwPointType)->no()) {
 				continue;
 			}

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -54,6 +54,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -46,6 +46,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof MixedType) {

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -46,6 +46,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -47,6 +47,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -46,6 +46,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -41,6 +41,11 @@ class HasMethodType implements AccessoryType, CompoundType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	private function getCanonicalMethodName(): string
 	{
 		return strtolower($this->methodName);

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -58,6 +58,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -57,6 +57,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -39,6 +39,11 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function getPropertyName(): string
 	{
 		return $this->propertyName;

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -52,6 +52,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -51,6 +51,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -81,6 +81,11 @@ class ArrayType implements Type
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -74,6 +74,11 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return array_merge($classes, $this->returnType->getReferencedClasses());
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType && !$type instanceof self) {

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -97,6 +97,11 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return array_merge($classes, $this->returnType->getReferencedClasses());
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/ConditionalType.php
+++ b/src/Type/ConditionalType.php
@@ -71,6 +71,11 @@ final class ConditionalType implements CompoundType, LateResolvableType
 		);
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
 		return array_merge(

--- a/src/Type/ConditionalTypeForParameter.php
+++ b/src/Type/ConditionalTypeForParameter.php
@@ -92,6 +92,11 @@ final class ConditionalTypeForParameter implements CompoundType, LateResolvableT
 		);
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
 		return array_merge(

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -491,8 +491,8 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		[$classOrObjects, $methods] = $this->valueTypes;
-		$classOrObjects = TypeUtils::flattenTypes($classOrObjects);
-		$methods = TypeUtils::flattenTypes($methods);
+		$classOrObjects = $classOrObjects->getUnionedTypes();
+		$methods = $methods->getUnionedTypes();
 
 		$typeAndMethods = [];
 		foreach ($classOrObjects as $classOrObject) {

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -46,6 +46,11 @@ class FloatType implements Type
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof self || $type instanceof IntegerType) {

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -101,6 +101,11 @@ class IntersectionType implements CompoundType
 		return UnionTypeHelper::getReferencedClasses($this->types);
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function getArrays(): array
 	{
 		return UnionTypeHelper::getArrays($this->getTypes());

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -60,6 +60,11 @@ class IterableType implements CompoundType
 		);
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type->isConstantArray()->yes() && $type->isIterableAtLeastOnce()->no()) {

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -16,6 +16,11 @@ trait JustNullableTypeTrait
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof static) {

--- a/src/Type/KeyOfType.php
+++ b/src/Type/KeyOfType.php
@@ -28,6 +28,11 @@ class KeyOfType implements CompoundType, LateResolvableType
 		return $this->type->getReferencedClasses();
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return $this->type->getUnionedTypes();
+	}
+
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
 		return $this->type->getReferencedTemplateTypes($positionVariance);

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -73,6 +73,11 @@ class MixedType implements CompoundType, SubtractableType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -50,6 +50,11 @@ class NeverType implements CompoundType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -41,6 +41,11 @@ class NullType implements ConstantScalarType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	/**
 	 * @return null
 	 */

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -223,6 +223,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return [$this->className];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof StaticType) {
@@ -1099,9 +1104,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 				$originalAllowedSubTypes = $allowedSubTypes;
 				$subtractedSubTypes = [];
 
-				$subtractedTypesList = TypeUtils::flattenTypes($subtractedType);
+				$subtractedTypesList = $subtractedType->getUnionedTypes();
 				if ($this->subtractedType !== null) {
-					$subtractedTypesList = array_merge($subtractedTypesList, TypeUtils::flattenTypes($this->subtractedType));
+					$subtractedTypesList = array_merge($subtractedTypesList, $this->subtractedType->getUnionedTypes());
 				}
 
 				$subtractedTypes = [];

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -40,6 +40,11 @@ class ObjectWithoutClassType implements SubtractableType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/src/Type/OffsetAccessType.php
+++ b/src/Type/OffsetAccessType.php
@@ -30,6 +30,11 @@ final class OffsetAccessType implements CompoundType, LateResolvableType
 		);
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
 		return array_merge(

--- a/src/Type/Php/ReflectionClassConstructorThrowTypeExtension.php
+++ b/src/Type/Php/ReflectionClassConstructorThrowTypeExtension.php
@@ -12,7 +12,6 @@ use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeUtils;
 use ReflectionClass;
 use function count;
 
@@ -35,7 +34,7 @@ class ReflectionClassConstructorThrowTypeExtension implements DynamicStaticMetho
 		}
 
 		$valueType = $scope->getType($methodCall->getArgs()[0]->value);
-		foreach (TypeUtils::flattenTypes($valueType) as $type) {
+		foreach ($valueType->getUnionedTypes() as $type) {
 			if ($type instanceof ClassStringType || $type instanceof ObjectWithoutClassType || $type instanceof ObjectType) {
 				continue;
 			}

--- a/src/Type/Php/ReflectionMethodConstructorThrowTypeExtension.php
+++ b/src/Type/Php/ReflectionMethodConstructorThrowTypeExtension.php
@@ -36,7 +36,7 @@ class ReflectionMethodConstructorThrowTypeExtension implements DynamicStaticMeth
 
 		$valueType = $scope->getType($methodCall->getArgs()[0]->value);
 		$propertyType = $scope->getType($methodCall->getArgs()[1]->value);
-		foreach (TypeUtils::flattenTypes($valueType) as $type) {
+		foreach ($valueType->getUnionedTypes() as $type) {
 			if ($type instanceof GenericClassStringType) {
 				$classes = $type->getReferencedClasses();
 			} elseif (

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -103,6 +103,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->getReferencedClasses();
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return $this->getStaticObjectType()->getUnionedTypes();
+	}
+
 	public function getArrays(): array
 	{
 		return $this->getStaticObjectType()->getArrays();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -33,6 +33,11 @@ class StrictMixedType implements CompoundType
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -30,6 +30,9 @@ interface Type
 	/** @return list<ConstantArrayType> */
 	public function getConstantArrays(): array;
 
+	/** @return list<Type> */
+	public function getUnionedTypes(): array;
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic;
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic;

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -265,6 +265,8 @@ class TypeUtils
 
 	/**
 	 * @return Type[]
+	 *
+	 * @deprecated Use PHPStan\Type\Type::getUnionedTypes() instead and handle optional ConstantArrayType keys if necessary.
 	 */
 	public static function flattenTypes(Type $type): array
 	{

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -25,6 +25,7 @@ use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateUnionType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use function array_map;
+use function array_values;
 use function count;
 use function implode;
 use function sprintf;
@@ -105,6 +106,11 @@ class UnionType implements CompoundType
 	public function getConstantArrays(): array
 	{
 		return UnionTypeHelper::getConstantArrays($this->getTypes());
+	}
+
+	public function getUnionedTypes(): array
+	{
+		return array_values($this->types);
 	}
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic

--- a/src/Type/ValueOfType.php
+++ b/src/Type/ValueOfType.php
@@ -23,6 +23,11 @@ final class ValueOfType implements CompoundType, LateResolvableType
 		return $this->type->getReferencedClasses();
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return $this->type->getUnionedTypes();
+	}
+
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
 		return $this->type->getReferencedTemplateTypes($positionVariance);

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -42,6 +42,11 @@ class VoidType implements Type
 		return [];
 	}
 
+	public function getUnionedTypes(): array
+	{
+		return [$this];
+	}
+
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
 		if ($type instanceof CompoundType) {

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
@@ -15,6 +15,11 @@
         "ignorable": true
     },
     {
+        "message": "Offset int|object might not exist on array{baz: 21}|array{foo: 17, bar: 19}.",
+        "line": 55,
+        "ignorable": true
+    },
+    {
         "message": "Possibly invalid array key type int|object.",
         "line": 55,
         "ignorable": true


### PR DESCRIPTION
Just an idea I had already a while ago and wanted to discuss. The essence of flattenTypes() is to get the inner types of a union or pass-through the current type in case it's not a union, which is how I came to that name.

I dislike a bit that it's another very specific thing again. But I didn't come up with something smarter / more generic.

And there is still a problem with the regression test for https://github.com/phpstan/phpstan/issues/6379 in `NonexistentOffsetInArrayDimFetchCheck` which I couldn't figure out yet. But I also don't really understand the narrowed types, see https://phpstan.org/r/788351dc-d1f1-4a17-a6a5-f0120a32222e. The error that is reported is `16: Offset 'c' does not exist on array{cr?: string, c?: string}&non-empty-array.`.