### PR TITLE
Retain non-variable expression types in closure

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1116,6 +1116,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8225.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8242.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/composer-treatPhpDocTypesAsCertainBug.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-retain-expression-types.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/closure-retain-expression-types.php
+++ b/tests/PHPStan/Analyser/data/closure-retain-expression-types.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ClosureRetainExpressionTypes;
+
+use function class_exists;
+use function defined;
+use function function_exists;
+use function PHPStan\Testing\assertType;
+
+function () {
+	assertType('bool', function_exists('foo123'));
+	if (function_exists('foo123')) {
+		assertType('true', function_exists('foo123'));
+		function () {
+			assertType('true', function_exists('foo123'));
+		};
+	} else {
+		assertType('false', function_exists('foo123'));
+		function () {
+			assertType('bool', function_exists('foo123'));
+		};
+	}
+};

--- a/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToNonExistentFunctionRuleTest.php
@@ -186,4 +186,9 @@ class CallToNonExistentFunctionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8205(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8205.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-8205.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8205.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8205;
+
+interface  TakesCallable{
+	public function takes(callable $c): void;
+}
+
+function test(TakesCallable $tc): void
+{
+	if(function_exists('test123')) {
+		$tc->takes(function () {
+			test123();
+		});
+	}
+
+	$tc->takes(function () {
+		if(function_exists('test123')) {
+			test123();
+		}
+	});
+}


### PR DESCRIPTION
Fix phpstan/phpstan#8205