### PR TITLE
Fix composer integration

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2193,7 +2193,7 @@ class MutatingScope implements Scope
 		$expressionTypes = $this->expressionTypes;
 		foreach ($this->nativeExpressionTypes as $exprString => $type) {
 			$has = $this->hasVariableType(substr($exprString, 1));
-			if ($has->no()) {
+			if (!$has->yes()) {
 				continue;
 			}
 


### PR DESCRIPTION
solve composer integration test errors caused by
https://github.com/phpstan/phpstan-src/pull/1919

Finally found the cause by deep debugging!

When promoting native types, variable with certainty "maybe" was promoted which led to wrong specification in `$treatPhpDocTypesAsCertain: false`.
We can promote "maybe" native types again after
https://github.com/phpstan/phpstan-src/pull/1919#issuecomment-1292596647
> Change $nativeExpressionTypes into array<string, ExpressionTypeHolder>

and native type is handled correctly in all places.