### PR TITLE
Try to solve issue 5005

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1439,13 +1439,14 @@ class InitializerExprTypeResolver
 						$resultType = $this->resolveCommonMath($expr, $type, $rightType);
 					}
 
-					if ($resultType instanceof ErrorType) {
-						return new ErrorType();
-					}
 					$unionParts[] = $resultType;
 				}
 
 				$union = TypeCombinator::union(...$unionParts);
+				if ($union instanceof ErrorType) {
+					return new ErrorType();
+				}
+
 				if ($leftType instanceof BenevolentUnionType) {
 					return TypeUtils::toBenevolentUnion($union)->toNumber();
 				}

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1434,6 +1434,7 @@ class InitializerExprTypeResolver
 
 			return $union->toNumber();
 		}
+
 		if ($rightType instanceof UnionType) {
 			$unionParts = [];
 			foreach ($rightType->getTypes() as $type) {
@@ -1505,6 +1506,10 @@ class InitializerExprTypeResolver
 
 		$resultType = TypeCombinator::union($leftNumberType, $rightNumberType);
 		if ($expr instanceof Expr\BinaryOp\Div) {
+			if ($rightType->equals(new ConstantIntegerType(1))) {
+				return $leftType->toNumber();
+			}
+
 			if ($types instanceof MixedType || $resultType instanceof IntegerType) {
 				return new BenevolentUnionType([new IntegerType(), new FloatType()]);
 			}

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1434,10 +1434,15 @@ class InitializerExprTypeResolver
 
 				foreach ($leftType->getTypes() as $type) {
 					if ($type instanceof IntegerRangeType || $type instanceof ConstantIntegerType) {
-						$unionParts[] = $this->integerRangeMath($type, $expr, $rightType);
+						$resultType = $this->integerRangeMath($type, $expr, $rightType);
 					} else {
-						$unionParts[] = $type;
+						$resultType = $this->resolveCommonMath($expr, $type, $rightType);
 					}
+
+					if ($resultType instanceof ErrorType) {
+						return new ErrorType();
+					}
+					$unionParts[] = $resultType;
 				}
 
 				$union = TypeCombinator::union(...$unionParts);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -524,6 +524,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5584.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/math.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5005.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1870.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5562.php');

--- a/tests/PHPStan/Analyser/data/bug-5005.php
+++ b/tests/PHPStan/Analyser/data/bug-5005.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug5005;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function doFoo(
+		int|false $int1,
+		int|false $int2,
+		int|null $int3,
+		int|null $int4,
+		int $int5,
+		int $int6,
+	): void
+	{
+		assertType('(float|int)', $int1 / $int2);
+		assertType('(float|int)', $int3 / $int4);
+		assertType('(float|int)', $int5 / $int6);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/bug-5005.php
+++ b/tests/PHPStan/Analyser/data/bug-5005.php
@@ -14,11 +14,62 @@ class Foo
 		int|null $int4,
 		int $int5,
 		int $int6,
+		float|int|null $floatOrIntOrNull,
 	): void
 	{
 		assertType('(float|int)', $int1 / $int2);
 		assertType('(float|int)', $int3 / $int4);
 		assertType('(float|int)', $int5 / $int6);
+
+		assertType('(float|int)', $floatOrIntOrNull / $int6);
+	}
+
+	/**
+	 * @param float|int<1, 4> $floatOrIntRange
+	 * @param int<1, 4>       $intRange
+	 */
+	public function doBar(
+		float|int $floatOrInt,
+		float|int $floatOrIntRange,
+		float $float,
+		int $int,
+		int $intRange,
+		mixed $mixed
+	) {
+		assertType('float|int', $floatOrInt / 1);
+		assertType('float|int<1, 4>', $floatOrIntRange / 1);
+		assertType('float|int', $mixed / 1);
+		assertType('float', $float / 1);
+		assertType('int', $int / 1);
+		assertType('int<1, 4>', $intRange / 1);
+
+		assertType('(float|int)', $floatOrInt / 2);
+		assertType('float|int<0, 2>', $floatOrIntRange / 2);
+		assertType('(float|int)', $mixed / 2);
+		assertType('float', $float / 2);
+		assertType('(float|int)', $int / 2);
+		assertType('float|int<0, 2>', $intRange / 2);
+
+		assertType('(float|int)', $floatOrInt / $int);
+		assertType('(float|int)', $floatOrIntRange / $int);
+		assertType('(float|int)', $mixed / $int);
+		assertType('float', $float / $int);
+		assertType('(float|int)', $int / $int);
+		assertType('(float|int)', $intRange / $int);
+
+		assertType('float', $floatOrInt / $float);
+		assertType('float', $floatOrIntRange / $float);
+		assertType('float', $mixed / $float);
+		assertType('float', $float / $float);
+		assertType('float', $int / $float);
+		assertType('float', $intRange / $float);
+
+		assertType('(float|int)', $floatOrInt / $floatOrInt);
+		assertType('(float|int)', $floatOrIntRange / $floatOrInt);
+		assertType('(float|int)', $mixed / $floatOrInt);
+		assertType('float', $float / $floatOrInt);
+		assertType('(float|int)', $int / $floatOrInt);
+		assertType('(float|int)', $intRange / $floatOrInt);
 	}
 
 }


### PR DESCRIPTION
I'm trying to solve https://github.com/phpstan/phpstan/issues/5005
the most of the issue seems solve, the only remaining part can be resume to
https://phpstan.org/r/c5b1a21c-3365-4cf3-b9b6-dca415afdfff

Things are that `resolveCommonMath` has a special behavior for UnionType.
When we're doing something like `int|null / int`, there is
```
foreach ($leftType->getTypes() as $type) {
     if ($type instanceof IntegerRangeType || $type instanceof ConstantIntegerType) {
	$resultType = $this->integerRangeMath($type, $expr, $rightType);
     } else {
	$resultType = $type;
    }

    $unionParts[] = $resultType;
}
```
but even if the left part is an int, the computed type might be an int|float when div is used.

This misbehave can be reproduce with other operators:
https://phpstan.org/r/b65b3e08-8f55-4ac7-920d-46e52f1fae06

So, instead of `$resultType = $type;`, I believe that we should write
```
$resultType = $this->resolveCommonMath($expr, $type, $rightType);
```
The result of an operation on a union of type is the union of the result of the operation on the types.

I still have one legacy test failing and I'm not sure how to solve this:
```
$number / $int
```
should be float|int, but I currently get `(float|int)`.

This is because
- $number is an union type `int|float`
- I compute `int / int` it's a BenevolentUnion(float, int)
- I compute 'float / int' it's a Float
- Then I do an union Union(BenevolentUnion(float, int), Float), it's a BenevolentUnion(float, int).

I'm not sure how I should solve this...