### PR TITLE
Add more support for benevolentUnion config

### DIFF
--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -226,8 +226,14 @@ class RuleLevelHelper
 		}
 
 		if (
-			!$this->checkUnionTypes && $type instanceof UnionType && !$type instanceof BenevolentUnionType
-			|| !$this->checkBenevolentUnionTypes && $type instanceof BenevolentUnionType
+			(
+				!$this->checkUnionTypes
+				&& $type instanceof UnionType
+				&& !$type instanceof BenevolentUnionType
+			) || (
+				!$this->checkBenevolentUnionTypes
+				&& $type instanceof BenevolentUnionType
+			)
 		) {
 			$newTypes = [];
 

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -221,23 +221,26 @@ class RuleLevelHelper
 			return new FoundTypeResult(new ErrorType(), [], $errors, null);
 		}
 
-		if (!$this->checkUnionTypes) {
-			if ($type instanceof ObjectWithoutClassType) {
-				return new FoundTypeResult(new ErrorType(), [], [], null);
+		if (!$this->checkUnionTypes && $type instanceof ObjectWithoutClassType) {
+			return new FoundTypeResult(new ErrorType(), [], [], null);
+		}
+
+		if (
+			!$this->checkUnionTypes && $type instanceof UnionType && !$type instanceof BenevolentUnionType
+			|| !$this->checkBenevolentUnionTypes && $type instanceof BenevolentUnionType
+		) {
+			$newTypes = [];
+
+			foreach ($type->getTypes() as $innerType) {
+				if (!$unionTypeCriteriaCallback($innerType)) {
+					continue;
+				}
+
+				$newTypes[] = $innerType;
 			}
-			if ($type instanceof UnionType) {
-				$newTypes = [];
-				foreach ($type->getTypes() as $innerType) {
-					if (!$unionTypeCriteriaCallback($innerType)) {
-						continue;
-					}
 
-					$newTypes[] = $innerType;
-				}
-
-				if (count($newTypes) > 0) {
-					return new FoundTypeResult(TypeCombinator::union(...$newTypes), $directClassNames, [], null);
-				}
+			if (count($newTypes) > 0) {
+				return new FoundTypeResult(TypeCombinator::union(...$newTypes), $directClassNames, [], null);
 			}
 		}
 

--- a/tests/PHPStan/Rules/Arrays/ArrayUnpackingRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/ArrayUnpackingRuleTest.php
@@ -16,15 +16,61 @@ class ArrayUnpackingRuleTest extends RuleTestCase
 
 	private bool $checkUnions;
 
+	private bool $checkBenevolentUnions = false;
+
 	protected function getRule(): Rule
 	{
 		return new ArrayUnpackingRule(
 			self::getContainer()->getByType(PhpVersion::class),
-			new RuleLevelHelper($this->createReflectionProvider(), true, false, $this->checkUnions, false, false, true, false),
+			new RuleLevelHelper($this->createReflectionProvider(), true, false, $this->checkUnions, false, false, true, $this->checkBenevolentUnions),
 		);
 	}
 
 	public function testRule(): void
+	{
+		if (PHP_VERSION_ID >= 80100) {
+			$this->markTestSkipped('Test requires PHP version <= 8.0');
+		}
+
+		$this->checkUnions = true;
+		$this->checkBenevolentUnions = true;
+		$this->analyse([__DIR__ . '/data/array-unpacking.php'], [
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array{foo: \'bar\', 0: 1, 1: 2, 2: 3}',
+				7,
+			],
+			[
+				'Array unpacking cannot be used on an array with string keys: array<string, string>',
+				18,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				24,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array<string>',
+				30,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array',
+				35,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				46,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				58,
+			],
+			[
+				'Array unpacking cannot be used on an array with string keys: array{foo: string, bar: int}',
+				69,
+			],
+		]);
+	}
+
+	public function testRuleDoNotCheckBenevolentUnion(): void
 	{
 		if (PHP_VERSION_ID >= 80100) {
 			$this->markTestSkipped('Test requires PHP version <= 8.0');
@@ -41,24 +87,20 @@ class ArrayUnpackingRuleTest extends RuleTestCase
 				18,
 			],
 			[
-				'Array unpacking cannot be used on an array with potential string keys: array<string>',
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
 				24,
 			],
 			[
-				'Array unpacking cannot be used on an array with potential string keys: array',
-				29,
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				46,
 			],
 			[
 				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				40,
-			],
-			[
-				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				52,
+				58,
 			],
 			[
 				'Array unpacking cannot be used on an array with string keys: array{foo: string, bar: int}',
-				63,
+				69,
 			],
 		]);
 	}
@@ -77,7 +119,7 @@ class ArrayUnpackingRuleTest extends RuleTestCase
 			],
 			[
 				'Array unpacking cannot be used on an array with string keys: array{foo: string, bar: int}',
-				63,
+				69,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/ArrayUnpackingRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/ArrayUnpackingRuleTest.php
@@ -44,28 +44,28 @@ class ArrayUnpackingRuleTest extends RuleTestCase
 				18,
 			],
 			[
-				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				'Array unpacking cannot be used on an array with potential string keys: array<string>',
 				24,
 			],
 			[
-				'Array unpacking cannot be used on an array with potential string keys: array<string>',
-				30,
-			],
-			[
 				'Array unpacking cannot be used on an array with potential string keys: array',
-				35,
+				29,
 			],
 			[
 				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				46,
+				40,
 			],
 			[
 				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				58,
+				52,
 			],
 			[
 				'Array unpacking cannot be used on an array with string keys: array{foo: string, bar: int}',
-				69,
+				63,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				71,
 			],
 		]);
 	}
@@ -88,19 +88,19 @@ class ArrayUnpackingRuleTest extends RuleTestCase
 			],
 			[
 				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				24,
+				40,
 			],
 			[
 				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				46,
-			],
-			[
-				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
-				58,
+				52,
 			],
 			[
 				'Array unpacking cannot be used on an array with string keys: array{foo: string, bar: int}',
-				69,
+				63,
+			],
+			[
+				'Array unpacking cannot be used on an array with potential string keys: array<int|string, string>',
+				71,
 			],
 		]);
 	}
@@ -119,7 +119,7 @@ class ArrayUnpackingRuleTest extends RuleTestCase
 			],
 			[
 				'Array unpacking cannot be used on an array with string keys: array{foo: string, bar: int}',
-				69,
+				63,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/array-unpacking.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-unpacking.php
@@ -18,12 +18,6 @@ function stringKeyedArray(array $bar)
 	$baz = [...$bar];
 }
 
-/** @param array<int|string, string> $bar */
-function unionKeyedArray(array $bar)
-{
-	$baz = [...$bar];
-}
-
 /** @param array<array-key, string> $bar */
 function benevolentUnionKeyedArray(array $bar)
 {
@@ -69,4 +63,10 @@ function unpackingArrayShapes(array $foo, array $bar)
 		...$foo,
 		...$bar,
 	];
+}
+
+/** @param array<int|string, string> $bar */
+function unionKeyedArray(array $bar)
+{
+	$baz = [...$bar];
 }

--- a/tests/PHPStan/Rules/Arrays/data/array-unpacking.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-unpacking.php
@@ -18,8 +18,14 @@ function stringKeyedArray(array $bar)
 	$baz = [...$bar];
 }
 
-/** @param array<array-key, string> $bar */
+/** @param array<int|string, string> $bar */
 function unionKeyedArray(array $bar)
+{
+	$baz = [...$bar];
+}
+
+/** @param array<array-key, string> $bar */
+function benevolentUnionKeyedArray(array $bar)
 {
 	$baz = [...$bar];
 }


### PR DESCRIPTION
While working on https://github.com/phpstan/phpstan-src/pull/1939, I discovered that `findTypeToCheck` were also checking BenevolentUnion when the option `checkUnionType` were used.

This would report error like 
```
Binary operation "+" between (int|string) and 1 results in an error
```
only if `checkBenevolentUnion` is enabled and solve most of the error of the #1939 pr.

The only issue I have is that I had to modify the `ArrayUnpackingRule` since it was the only rule which was already checking benevolent union (array-key). I dunno if we should make a special behavior, and how.

The integration tests failure doesn't seem related to the PR.