### PR TITLE
handle ClassConstFetch in scope

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1663,6 +1663,9 @@ class MutatingScope implements Scope
 
 			return new ErrorType();
 		} elseif ($node instanceof Node\Expr\ClassConstFetch && $node->name instanceof Node\Identifier) {
+			if ($this->hasExpressionType($node)->yes()) {
+				return $this->expressionTypes[$this->getNodeKey($node)]->getType();
+			}
 			return $this->initializerExprTypeResolver->getClassConstFetchTypeByReflection(
 				$node->class,
 				$node->name->name,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3419,6 +3419,10 @@ class MutatingScope implements Scope
 				return $this;
 			}
 		}
+		if ($expr instanceof Expr\ClassConstFetch && $type instanceof NeverType) {
+			unset($this->expressionTypes[$exprString]);
+			return $this;
+		}
 
 		$scope = $this;
 		if ($expr instanceof Variable && is_string($expr->name)) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3414,10 +3414,6 @@ class MutatingScope implements Scope
 			if (in_array($loweredConstName, ['true', 'false', 'null'], true)) {
 				return $this;
 			}
-			if ($type instanceof NeverType) {
-				unset($this->expressionTypes[$exprString]);
-				return $this;
-			}
 		}
 
 		$scope = $this;

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3419,10 +3419,6 @@ class MutatingScope implements Scope
 				return $this;
 			}
 		}
-		if ($expr instanceof Expr\ClassConstFetch && $type instanceof NeverType) {
-			unset($this->expressionTypes[$exprString]);
-			return $this;
-		}
 
 		$scope = $this;
 		if ($expr instanceof Variable && is_string($expr->name)) {

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -160,7 +160,7 @@ class ClassConstantRule implements Rule
 			]);
 		}
 
-		if (strtolower($constantName) === 'class') {
+		if (strtolower($constantName) === 'class' || $scope->hasExpressionType($node)->yes()) {
 			return $messages;
 		}
 

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -15,7 +15,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -161,7 +160,7 @@ class ClassConstantRule implements Rule
 			]);
 		}
 
-		if (strtolower($constantName) === 'class' || $scope->hasExpressionType($node)->yes() && !$scope->getType($node) instanceof NeverType) {
+		if (strtolower($constantName) === 'class' || $scope->hasExpressionType($node)->yes()) {
 			return $messages;
 		}
 

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -15,6 +15,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -160,7 +161,7 @@ class ClassConstantRule implements Rule
 			]);
 		}
 
-		if (strtolower($constantName) === 'class' || $scope->hasExpressionType($node)->yes()) {
+		if (strtolower($constantName) === 'class' || $scope->hasExpressionType($node)->yes() && !$scope->getType($node) instanceof NeverType) {
 			return $messages;
 		}
 

--- a/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
+++ b/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
@@ -15,6 +15,7 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\MixedType;
 use function count;
 use function explode;
+use function ltrim;
 
 class DefinedConstantTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
@@ -54,8 +55,12 @@ class DefinedConstantTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 
 		$classConstParts = explode('::', $constantName->getValue());
 		if (count($classConstParts) >= 2) {
+			$classConstName = new Node\Name\FullyQualified(ltrim($classConstParts[0], '\\'));
+			if ($classConstName->isSpecialClassName()) {
+				$classConstName = new Node\Name($classConstName->toString());
+			}
 			$constNode = new Node\Expr\ClassConstFetch(
-				new Node\Name($classConstParts[0]),
+				$classConstName,
 				new Node\Identifier($classConstParts[1]),
 			);
 		} else {

--- a/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
+++ b/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\MixedType;
 use function count;
+use function explode;
 
 class DefinedConstantTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
@@ -51,10 +52,20 @@ class DefinedConstantTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 			return new SpecifiedTypes([], []);
 		}
 
-		return $this->typeSpecifier->create(
-			new Node\Expr\ConstFetch(
+		$classConstParts = explode('::', $constantName->getValue());
+		if (count($classConstParts) >= 2) {
+			$constNode = new Node\Expr\ClassConstFetch(
+				new Node\Name($classConstParts[0]),
+				new Node\Identifier($classConstParts[1]),
+			);
+		} else {
+			$constNode = new Node\Expr\ConstFetch(
 				new Node\Name\FullyQualified($constantName->getValue()),
-			),
+			);
+		}
+
+		return $this->typeSpecifier->create(
+			$constNode,
 			new MixedType(),
 			$context,
 			false,

--- a/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
+++ b/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
@@ -35,7 +35,7 @@ class DefinedConstantTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 	{
 		return $functionReflection->getName() === 'defined'
 			&& count($node->getArgs()) >= 1
-			&& !$context->null();
+			&& $context->truthy();
 	}
 
 	public function specifyTypes(

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -286,4 +286,10 @@ class ClassConstantRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7675.php'], []);
 	}
 
+	public function testBug8034(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/bug-8034.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -297,4 +297,83 @@ class ClassConstantRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testClassConstFetchDefined(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/class-const-fetch-defined.php'], [
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				12,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				14,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				16,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				17,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				18,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				22,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				24,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				26,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				27,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				28,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				33,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				36,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				37,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				38,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				43,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				46,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				47,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				48,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -289,7 +289,12 @@ class ClassConstantRuleTest extends RuleTestCase
 	public function testBug8034(): void
 	{
 		$this->phpVersion = PHP_VERSION_ID;
-		$this->analyse([__DIR__ . '/data/bug-8034.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-8034.php'], [
+			[
+				'Access to undefined constant static(Bug8034\HelloWorld)::FIELDS.',
+				19,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-8034.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-8034.php
@@ -16,6 +16,7 @@ abstract class HelloWorld
 
 			return $aOutput;
 		} else {
+			static::FIELDS;
 			return [];
 		}
 	}

--- a/tests/PHPStan/Rules/Classes/data/bug-8034.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-8034.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8034;
+
+abstract class HelloWorld
+{
+	/**
+	 * @return array
+	 */
+	private static function getFields() : array
+	{
+		if (isset(static::$fields)) {
+			return static::$fields;
+		} elseif (defined('static::FIELDS')) {
+			$aOutput = explode(',', static::FIELDS);
+
+			return $aOutput;
+		} else {
+			return [];
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/class-const-fetch-defined.php
+++ b/tests/PHPStan/Rules/Classes/data/class-const-fetch-defined.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace ClassConstFetchDefined;
+
+class Foo {}
+
+class HelloWorld
+{
+	public static function doFoo()
+	{
+		if (defined('Foo::TEST')) {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		} else {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		}
+
+		if (defined('\Foo::TEST')) {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		} else {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		}
+
+		if (defined('ClassConstFetchDefined\Foo::TEST')) {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		} else {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		}
+
+		if (defined('\ClassConstFetchDefined\Foo::TEST')) {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		} else {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Constants/ConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ConstantRuleTest.php
@@ -63,4 +63,21 @@ class ConstantRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/const-equals-no-namespace.php'], []);
 	}
 
+	public function testDefinedScopeMerge(): void
+	{
+		$this->analyse([__DIR__ . '/data/defined-scope-merge.php'], [
+			[
+				'Constant TEST not found.',
+				8,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+
+			[
+				'Constant TEST not found.',
+				11,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Constants/data/defined-scope-merge.php
+++ b/tests/PHPStan/Rules/Constants/data/defined-scope-merge.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DefinedScopeMerge;
+
+if (defined('TEST')) {
+	TEST;
+} else {
+	TEST;
+}
+
+TEST;


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/8034

blocking
https://github.com/phpstan/phpstan/issues/8191

regression from
https://github.com/phpstan/phpstan-src/pull/1938

Steps to fix

- [x] fix DefinedConstantTypeSpecifyingExtension to detect ClassConstFetch and specify them correctly
- [x]  fix ClassConst assigned as ConstFetch in NodeScopeResolver https://github.com/rajyan/phpstan-src/blob/69d7e8185af250ce7315a2000b88a3d31f84cf3a/src/Analyser/NodeScopeResolver.php#L1439  assign them as ClassConstFetch
- [x] skip ClassConstantRule if hasExpressionType->yes
- [x] add expressionTypes handling in resolveType of ClassConstFetch