### PR TITLE
Add rule for casting objects to string

### DIFF
--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -10,7 +10,9 @@ use PHPStan\Reflection\Type\CallbackUnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\CompoundType;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
@@ -123,6 +125,15 @@ class HasMethodType implements AccessoryType, CompoundType
 		}
 
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function toString(): Type
+	{
+		if ($this->getCanonicalMethodName() === '__tostring') {
+			return new StringType();
+		}
+
+		return new ErrorType();
 	}
 
 	public function getCallableParametersAcceptors(ClassMemberAccessAnswerer $scope): array

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -133,7 +133,7 @@ trait ObjectTypeTrait
 
 	public function toString(): Type
 	{
-		return new StringType();
+		return new ErrorType();
 	}
 
 	public function toInteger(): Type

--- a/tests/PHPStan/Rules/Cast/InvalidCastRuleTest.php
+++ b/tests/PHPStan/Rules/Cast/InvalidCastRuleTest.php
@@ -35,6 +35,10 @@ class InvalidCastRuleTest extends RuleTestCase
 				24,
 			],
 			[
+				'Cannot cast object to string.',
+				35,
+			],
+			[
 				'Cannot cast Test\\Foo to string.',
 				41,
 			],
@@ -59,6 +63,20 @@ class InvalidCastRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/invalid-cast-nullsafe.php'], [
 			[
 				'Cannot cast stdClass|null to string.',
+				13,
+			],
+		]);
+	}
+
+	public function testCastObjectToString(): void
+	{
+		$this->analyse([__DIR__ . '/data/cast-object-to-string.php'], [
+			[
+				'Cannot cast object to string.',
+				12,
+			],
+			[
+				'Cannot cast object|string to string.',
 				13,
 			],
 		]);

--- a/tests/PHPStan/Rules/Cast/data/cast-object-to-string.php
+++ b/tests/PHPStan/Rules/Cast/data/cast-object-to-string.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace CastObjectToString;
+
+use function method_exists;
+
+/**
+ * @param object $object
+ * @param object|string $objectOrString
+ */
+function foo($object, $objectOrString) {
+	(string) $object;
+	(string) $objectOrString;
+
+	if (method_exists($object, '__toString')) {
+		(string) $object;
+	}
+
+	if (is_string($objectOrString) || method_exists($objectOrString, '__toString')) {
+		(string) $objectOrString;
+	}
+}


### PR DESCRIPTION
Rule extracted from #1905 because it's useful without explicit `stringable-object` support as well