### PR TITLE
Fix return type of Ds\Sequence#copy()

### DIFF
--- a/stubs/ext-ds.stub
+++ b/stubs/ext-ds.stub
@@ -18,7 +18,7 @@ use UnderflowException;
 interface Collection extends IteratorAggregate, Countable, JsonSerializable
 {
 	/**
-	 * @return Collection<TKey, TValue>
+	 * @return static
 	 */
 	public function copy();
 
@@ -391,11 +391,6 @@ interface Sequence extends Collection, ArrayAccess
 	 * @return void
 	 */
 	public function apply(callable $callback);
-
-	/**
-	 * @return Sequence<TValue>
-	 */
-	public function copy();
 
 	/**
 	 * @param TValue ...$values

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1213,6 +1213,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8956.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8917.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/ds-copy.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/ds-copy.php
+++ b/tests/PHPStan/Analyser/data/ds-copy.php
@@ -17,7 +17,7 @@ use function PHPStan\Testing\assertType;
 final class DsCopy
 {
 	/**
-	 * @param Collection<int> $col
+	 * @param Collection<string, int> $col
 	 * @param Sequence<int> $seq
 	 * @param Vector<int> $vec
 	 * @param Deque<int> $deque
@@ -52,7 +52,7 @@ final class DsCopy
 		$pq = $this->pq->copy();
 		$set = $this->set->copy();
 
-		assertType('Ds\Collection<int>', $col);
+		assertType('Ds\Collection<string, int>', $col);
 		assertType('Ds\Sequence<int>', $seq);
 		assertType('Ds\Vector<int>', $vec);
 		assertType('Ds\Deque<int>', $deque);

--- a/tests/PHPStan/Analyser/data/ds-copy.php
+++ b/tests/PHPStan/Analyser/data/ds-copy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DsCopy;
+
+use Ds\Collection;
+use Ds\Deque;
+use Ds\Map;
+use Ds\PriorityQueue;
+use Ds\Queue;
+use Ds\Sequence;
+use Ds\Set;
+use Ds\Stack;
+use Ds\Vector;
+
+use function PHPStan\Testing\assertType;
+
+final class DsCopy
+{
+	/**
+	 * @param Collection<int> $col
+	 * @param Sequence<int> $seq
+	 * @param Vector<int> $vec
+	 * @param Deque<int> $deque
+	 * @param Map<string, int> $map
+	 * @param Queue<int> $queue
+	 * @param Stack<int> $stack
+	 * @param PriorityQueue<int> $pq
+	 * @param Set<int> $set
+	 */
+	public function __construct(
+		private readonly Collection $col,
+		private readonly Sequence $seq,
+		private readonly Vector $vec,
+		private readonly Deque $deque,
+		private readonly Map $map,
+		private readonly Queue $queue,
+		private readonly Stack $stack,
+		private readonly PriorityQueue $pq,
+		private readonly Set $set,
+	) {
+	}
+
+	public function copy(): void
+	{
+		$col = $this->col->copy();
+		$seq = $this->seq->copy();
+		$vec = $this->vec->copy();
+		$deque = $this->deque->copy();
+		$map = $this->map->copy();
+		$queue = $this->queue->copy();
+		$stack = $this->stack->copy();
+		$pq = $this->pq->copy();
+		$set = $this->set->copy();
+
+		assertType('Ds\Collection<int>', $col);
+		assertType('Ds\Sequence<int>', $seq);
+		assertType('Ds\Vector<int>', $vec);
+		assertType('Ds\Deque<int>', $deque);
+		assertType('Ds\Map<string, int>', $map);
+		assertType('Ds\Queue<int>', $queue);
+		assertType('Ds\Stack<int>', $stack);
+		assertType('Ds\PriorityQueue<int>', $pq);
+		assertType('Ds\Set<int>', $set);
+	}
+}


### PR DESCRIPTION
I don't know why the return type isn't correctly inferred. [It seems fine to me.](https://github.com/phpstan/phpstan-src/blob/1.9.x/stubs/ext-ds.stub#L398) Any ideas?

[Playground link](https://phpstan.org/r/c7881107-0ded-4599-8225-78cdb089b0c6)