### PR TITLE
Allow to know the node in the exceptionTypeResolver

### DIFF
--- a/src/Rules/Exceptions/MissingCheckedExceptionInThrowsCheck.php
+++ b/src/Rules/Exceptions/MissingCheckedExceptionInThrowsCheck.php
@@ -45,7 +45,11 @@ class MissingCheckedExceptionInThrowsCheck
 
 				if (
 					$throwPointType instanceof TypeWithClassName
-					&& !$this->exceptionTypeResolver->isCheckedException($throwPointType->getClassName(), $throwPoint->getScope())
+					&& !$this->exceptionTypeResolver->isCheckedException(
+						$throwPointType->getClassName(),
+						$throwPoint->getScope(),
+						$throwPoint->getNode()
+					)
 				) {
 					continue;
 				}

--- a/src/Rules/Exceptions/ThrowsVoidFunctionWithExplicitThrowPointRule.php
+++ b/src/Rules/Exceptions/ThrowsVoidFunctionWithExplicitThrowPointRule.php
@@ -54,7 +54,11 @@ class ThrowsVoidFunctionWithExplicitThrowPointRule implements Rule
 			foreach (TypeUtils::flattenTypes($throwPoint->getType()) as $throwPointType) {
 				if (
 					$throwPointType instanceof TypeWithClassName
-					&& $this->exceptionTypeResolver->isCheckedException($throwPointType->getClassName(), $throwPoint->getScope())
+					&& $this->exceptionTypeResolver->isCheckedException(
+						$throwPointType->getClassName(),
+						$throwPoint->getScope(),
+						$throwPoint->getNode()
+					)
 					&& $this->missingCheckedExceptionInThrows
 				) {
 					continue;

--- a/src/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRule.php
+++ b/src/Rules/Exceptions/ThrowsVoidMethodWithExplicitThrowPointRule.php
@@ -54,7 +54,11 @@ class ThrowsVoidMethodWithExplicitThrowPointRule implements Rule
 			foreach (TypeUtils::flattenTypes($throwPoint->getType()) as $throwPointType) {
 				if (
 					$throwPointType instanceof TypeWithClassName
-					&& $this->exceptionTypeResolver->isCheckedException($throwPointType->getClassName(), $throwPoint->getScope())
+					&& $this->exceptionTypeResolver->isCheckedException(
+						$throwPointType->getClassName(),
+						$throwPoint->getScope(),
+						$throwPoint->getNode()
+					)
 					&& $this->missingCheckedExceptionInThrows
 				) {
 					continue;


### PR DESCRIPTION
Currently we only know the class of the exception and the scope in the exceptionTypeResolver, but I don't think we know where come from the exception: 
- Is it from an expression `new Exception()`
- Is it from a constructor which can throw exception `new ThisConstructorMaybeFail()`
- Is it from a method call `$this->thisCanThrowException()`
- ...

This would allow to make more complex exceptionTypeResolver, but changing the interface
```
interface ExceptionTypeResolver
{
	public function isCheckedException(string $className, Scope $scope): bool;
}
```
Would be a BC break.

Should I do something like
```
interface ExceptionTypeResolver
{
	public function isCheckedException(string $className, Scope $scope, /** Node\Expr|Node\Stmt $node */): bool;
}
```
? Or is there a better way ?