### PR TITLE
AccessoryArrayListType::intersectWith() compatibility promise

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -22,6 +22,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
+/** @api */
 class AccessoryArrayListType implements CompoundType, AccessoryType
 {
 
@@ -332,6 +333,7 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return self::$enabled;
 	}
 
+	/** @api */
 	public static function intersectWith(Type $type): Type
 	{
 		if (self::$enabled) {


### PR DESCRIPTION
See https://github.com/phpstan/phpstan-symfony/pull/309

I didn't do similar PR before... is it correct to add the `@api` annotation to both the class and the method?

Also do I need to update some test?