### PR TITLE
Fix array and iterable type action methods on `NeverType`

### DIFF
--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -12,10 +12,8 @@ use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
-use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
@@ -25,9 +23,7 @@ class NeverType implements CompoundType
 {
 
 	use UndecidedBooleanTypeTrait;
-	use NonArrayTypeTrait;
 	use NonGenericTypeTrait;
-	use NonIterableTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonRemoveableTypeTrait;
 	use NonGeneralizableTypeTrait;
@@ -46,6 +42,16 @@ class NeverType implements CompoundType
 	 * @return string[]
 	 */
 	public function getReferencedClasses(): array
+	{
+		return [];
+	}
+
+	public function getArrays(): array
+	{
+		return [];
+	}
+
+	public function getConstantArrays(): array
 	{
 		return [];
 	}
@@ -149,7 +155,22 @@ class NeverType implements CompoundType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function getArraySize(): Type
+	{
+		return new NeverType();
+	}
+
 	public function getIterableKeyType(): Type
+	{
+		return new NeverType();
+	}
+
+	public function getFirstIterableKeyType(): Type
+	{
+		return new NeverType();
+	}
+
+	public function getLastIterableKeyType(): Type
 	{
 		return new NeverType();
 	}
@@ -157,6 +178,36 @@ class NeverType implements CompoundType
 	public function getIterableValueType(): Type
 	{
 		return new NeverType();
+	}
+
+	public function getFirstIterableValueType(): Type
+	{
+		return new NeverType();
+	}
+
+	public function getLastIterableValueType(): Type
+	{
+		return new NeverType();
+	}
+
+	public function isArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+	public function isConstantArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+	public function isOversizedArray(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+	public function isList(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
@@ -180,6 +231,51 @@ class NeverType implements CompoundType
 	}
 
 	public function unsetOffset(Type $offsetType): Type
+	{
+		return new NeverType();
+	}
+
+	public function getKeysArray(): Type
+	{
+		return new NeverType();
+	}
+
+	public function getValuesArray(): Type
+	{
+		return new NeverType();
+	}
+
+	public function fillKeysArray(Type $valueType): Type
+	{
+		return new NeverType();
+	}
+
+	public function flipArray(): Type
+	{
+		return new NeverType();
+	}
+
+	public function intersectKeyArray(Type $otherArraysType): Type
+	{
+		return new NeverType();
+	}
+
+	public function popArray(): Type
+	{
+		return new NeverType();
+	}
+
+	public function searchArray(Type $needleType): Type
+	{
+		return new NeverType();
+	}
+
+	public function shiftArray(): Type
+	{
+		return new NeverType();
+	}
+
+	public function shuffleArray(): Type
 	{
 		return new NeverType();
 	}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1122,6 +1122,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7913.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-8280.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8272.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8277.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/strtr.php');
 	}
 

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -17,6 +17,11 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		return new NumberComparisonOperatorsConstantConditionRule();
 	}
 
+	public function testBug8277(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8277.php'], []);
+	}
+
 	public function testRule(): void
 	{
 		$this->analyse([__DIR__ . '/data/number-comparison-operators.php'], [

--- a/tests/PHPStan/Rules/Comparison/data/bug-8277.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8277.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8277;
+
+use Generator;
+use function PHPStan\Testing\assertType;
+
+/**
+ * {@see FunctionalStreamTest::testWindow()}
+ *
+ * @template K
+ * @template T
+ *
+ * @param iterable<K, T> $stream
+ * @param positive-int $width
+ *
+ * @return Generator<int, T[]>
+ */
+function swindow(iterable $stream, int $width): Generator
+{
+	$window = [];
+	foreach ($stream as $value) {
+		$window[] = $value;
+		$count = count($window);
+
+		assertType('int<1, max>', $count);
+
+		switch (true) {
+			case $count > $width:
+				array_shift($window);
+			// no break
+			case $count === $width:
+				yield $window;
+		}
+	}
+}


### PR DESCRIPTION
What does he mean with that cryptic title again?
Basically, methods that work on the type / modify it instead of only describing its characteristics should not magically turn `*NEVER*` into `mixed`. Things like `popArray()` or `shiftArray()` for example.

And to be on the safe side and avoid similar future failures here I removed usage of the two relevant traits completely.

Closes  https://github.com/phpstan/phpstan/issues/8277