### PR TITLE
Remove DateInterval stub

### DIFF
--- a/stubs/date.stub
+++ b/stubs/date.stub
@@ -1,15 +1,5 @@
 <?php
 
-class DateInterval
-{
-
-	/**
-	 * @var int|false
-	 */
-	public $days;
-
-}
-
 /**
  * @template TDate of DateTimeInterface
  * @template TEnd of ?DateTimeInterface


### PR DESCRIPTION
Am I wrong or can this stub be removed since your PR (https://github.com/JetBrains/phpstorm-stubs/pull/799) is merged @ondrejmirtes ?