### PR TITLE
Making `json_encode()` always produce a `non-empty-string`, when successful

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5698,7 +5698,7 @@ return [
 'join\'1' => ['string', 'pieces'=>'array'],
 'jpeg2wbmp' => ['bool', 'jpegname'=>'string', 'wbmpname'=>'string', 'dest_height'=>'int', 'dest_width'=>'int', 'threshold'=>'int'],
 'json_decode' => ['mixed', 'json'=>'string', 'assoc='=>'bool|null', 'depth='=>'positive-int', 'options='=>'int'],
-'json_encode' => ['string|false', 'data'=>'mixed', 'options='=>'int', 'depth='=>'positive-int'],
+'json_encode' => ['non-empty-string|false', 'data'=>'mixed', 'options='=>'int', 'depth='=>'positive-int'],
 'json_last_error' => ['int'],
 'json_last_error_msg' => ['string'],
 'JsonIncrementalParser::__construct' => ['void', 'depth'=>'', 'options'=>''],

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8705,19 +8705,19 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		return [
 			[
-				'string|false',
+				'non-empty-string|false',
 				'json_encode($mixed)',
 			],
 			[
-				'string',
+				'non-empty-string',
 				'json_encode($mixed,  JSON_THROW_ON_ERROR)',
 			],
 			[
-				'string',
+				'non-empty-string',
 				'json_encode($mixed,  JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[
-				'string',
+				'non-empty-string',
 				'json_encode($mixed,  $integer | JSON_THROW_ON_ERROR | JSON_NUMERIC_CHECK)',
 			],
 			[

--- a/tests/PHPStan/Analyser/data/bug-6654.php
+++ b/tests/PHPStan/Analyser/data/bug-6654.php
@@ -8,12 +8,12 @@ class Foo {
 	function doFoo() {
 		$data = '';
 		$flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR;
-		assertType('string',json_encode($data, $flags));
+		assertType('non-empty-string',json_encode($data, $flags));
 
 		if (rand(0, 1)) {
 			$flags |= JSON_FORCE_OBJECT;
 		}
 
-		assertType('string', json_encode($data, $flags));
+		assertType('non-empty-string', json_encode($data, $flags));
 	}
 }


### PR DESCRIPTION
See https://3v4l.org/E2P9K and https://github.com/vimeo/psalm/pull/8681