### PR TITLE
Fix issue 8292

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3058,7 +3058,7 @@ class MutatingScope implements Scope
 			$this->isDeclareStrictTypes(),
 			$arrowFunctionScope->getFunction(),
 			$arrowFunctionScope->getNamespace(),
-			$arrowFunctionScope->expressionTypes,
+			$this->invalidateStaticExpressions($arrowFunctionScope->expressionTypes),
 			$arrowFunctionScope->conditionalExpressions,
 			$arrowFunctionScope->inClosureBindScopeClass,
 			null,

--- a/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
@@ -35,4 +35,9 @@ class DeadForeachRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7913.php'], []);
 	}
 
+	public function testBug8292(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8292.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-8292.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8292.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types = 1); // lint >= 7.4
 
 namespace Bug8292;
 

--- a/tests/PHPStan/Rules/Arrays/data/bug-8292.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8292.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8292;
+
+class World{
+	public function addOnUnloadCallback(\Closure $c) : void{}
+}
+
+interface Compressor{}
+
+class ChunkCache
+{
+	/** @var self[][] */
+	private static array $instances = [];
+
+	/**
+	 * Fetches the ChunkCache instance for the given world. This lazily creates cache systems as needed.
+	 */
+	public static function getInstance(World $world, Compressor $compressor) : void{
+		$worldId = spl_object_id($world);
+		$compressorId = spl_object_id($compressor);
+		if(!isset(self::$instances[$worldId])){
+			self::$instances[$worldId] = [];
+			$world->addOnUnloadCallback(static function() use ($worldId) : void{
+				foreach(self::$instances[$worldId] as $cache){
+					$cache->caches = [];
+				}
+				unset(self::$instances[$worldId]);
+			});
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -257,4 +257,9 @@ class CallCallablesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testStaticCallInFunctions(): void
+	{
+		$this->analyse([__DIR__ . '/data/static-call-in-functions.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/static-call-in-functions.php
+++ b/tests/PHPStan/Rules/Functions/data/static-call-in-functions.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace StaticCallsInFunctions;
+
+class HelloWorld
+{
+	/** @var \Closure[] */
+	private static $resolvers;
+
+	/** @return \Closure[] */
+	public static function getResolvers(): array
+	{
+		if (self::$resolvers === null) {
+			self::$resolvers = [
+				'a' => static function ($one, $two) {
+					return $one ?? $two;
+				},
+				'b' => static function ($one, $two, $three) {
+					return $one ?? $two ?? $three;
+				},
+			];
+
+			foreach (['c', 'd', 'e'] as $name) {
+				self::$resolvers[$name] = static function ($one, $two) {
+					return self::$resolvers['a']($one, $two);
+				};
+
+				self::$resolvers[$name] = static fn ($one, $two) => self::$resolvers['a']($one, $two);
+			}
+		}
+
+		return self::$resolvers;
+	}
+}


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/8292

All static expression types should be invalidated in anonymous/arrow functions, because the type is not reliable in delayed calls (skipped ClassConstFetch because I think it cannot change).
Also, this fixes the inconsistency between anonymous and arrow functions, which rvanvelzen mentioned in
https://github.com/phpstan/phpstan-src/pull/1929#issuecomment-1294553610
static expressions should be invalidate for arrows as well.

https://github.com/phpstan/phpstan-src/pull/1929#issuecomment-1295885526

I have a feeling that maybe we can get rid of `expressionTypeIsUnchangeable` if example like
https://github.com/phpstan/phpstan-src/pull/1934#issuecomment-1295766300
is not possible without using static expressions, but not sure enough.
