### PR TITLE
Fix non-working type assertions in `NodeScopeResolverTest` cases

### DIFF
--- a/tests/PHPStan/Analyser/data/DateTimeModifyReturnTypes.php
+++ b/tests/PHPStan/Analyser/data/DateTimeModifyReturnTypes.php
@@ -4,12 +4,13 @@ namespace DateTimeModifyReturnTypes;
 
 use DateTime;
 use DateTimeImmutable;
+use function PHPStan\Testing\assertType;
 
 class Foo
 {
 	public function modify(DateTime $datetime, DateTimeImmutable $dateTimeImmutable, string $modify): void {
-		assertType('DateTime|false', $datetime->modify($modify));
-		assertType('DateTimeImmutable|false', $dateTimeImmutable->modify($modify));
+		assertType('(DateTime|false)', $datetime->modify($modify));
+		assertType('(DateTimeImmutable|false)', $dateTimeImmutable->modify($modify));
 	}
 
 	/**
@@ -32,8 +33,8 @@ class Foo
 	 * @param '+1 day'|'koko' $modify
 	 */
 	public function modifyWithBothConstant(DateTime $datetime, DateTimeImmutable $dateTimeImmutable, string $modify): void {
-		assertType('DateTime|false', $datetime->modify($modify));
-		assertType('DateTimeImmutable|false', $dateTimeImmutable->modify($modify));
+		assertType('(DateTime|false)', $datetime->modify($modify));
+		assertType('(DateTimeImmutable|false)', $dateTimeImmutable->modify($modify));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-7031.php
+++ b/tests/PHPStan/Analyser/data/bug-7031.php
@@ -2,6 +2,8 @@
 
 namespace Bug7031;
 
+use function PHPStan\Testing\assertType;
+
 class SomeKey {}
 
 function () {


### PR DESCRIPTION
Discovered via https://github.com/phpstan/phpstan-src/pull/1991