### PR TITLE
Fix bug 8212

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -497,6 +497,9 @@ class MutatingScope implements Scope
 					new NonEmptyArrayType(),
 				));
 			}
+			if ($this->canAnyVariableExist()) {
+				return new MixedType();
+			}
 		}
 
 		if ($this->isGlobalVariable($variableName)) {
@@ -3877,25 +3880,6 @@ class MutatingScope implements Scope
 		$ourVariableTypes = array_filter($ourExpressionTypes, static fn ($expressionTypeHolder) => $expressionTypeHolder->getExpr() instanceof Variable);
 		$theirExpressionTypes = $otherScope->expressionTypes;
 		$theirVariableTypes = array_filter($theirExpressionTypes, static fn ($expressionTypeHolder) => $expressionTypeHolder->getExpr() instanceof Variable);
-		if ($this->canAnyVariableExist()) {
-			foreach ($theirVariableTypes as $exprString => $theirVariableTypeHolder) {
-				if (array_key_exists($exprString, $ourVariableTypes)) {
-					continue;
-				}
-
-				$ourExpressionTypes[$exprString] = ExpressionTypeHolder::createMaybe($theirVariableTypeHolder->getExpr(), new MixedType());
-				$ourVariableTypes[$exprString] = ExpressionTypeHolder::createMaybe($theirVariableTypeHolder->getExpr(), new MixedType());
-			}
-
-			foreach ($ourVariableTypes as $exprString => $ourVariableTypeHolder) {
-				if (array_key_exists($exprString, $theirVariableTypes)) {
-					continue;
-				}
-
-				$theirExpressionTypes[$exprString] = ExpressionTypeHolder::createMaybe($ourVariableTypeHolder->getExpr(), new MixedType());
-				$theirVariableTypes[$exprString] = ExpressionTypeHolder::createMaybe($ourVariableTypeHolder->getExpr(), new MixedType());
-			}
-		}
 
 		$mergedVariableTypes = $this->mergeVariableHolders($ourVariableTypes, $theirVariableTypes);
 		$mergedExpressionTypes = $this->mergeVariableHolders($ourExpressionTypes, $theirExpressionTypes);

--- a/tests/PHPStan/Rules/Variables/data/bug-8212.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-8212.php
@@ -2,17 +2,13 @@
 
 namespace Bug8212;
 
-function test(): void
-{
-
-	$foo = rand();
-	if ($foo) {
-		$var = rand();
-	}
+$foo = rand();
+if ($foo) {
+	$var = rand();
+}
 
 // 200 lines later:
 
-	if ($foo) {
-		echo $var; // Variable $var might not be defined.
-	}
+if ($foo) {
+	echo $var; // Variable $var might not be defined.
 }


### PR DESCRIPTION
Issue 8212 was closed in https://github.com/phpstan/phpstan-src/pull/1950 but the test added wasn't correct.
And, this revert commit https://github.com/phpstan/phpstan-src/pull/1950/commits/a1605df6c11b6c009e70bf8d6d000d6a9e3cadd9 made https://github.com/phpstan/phpstan/issues/8212 not work again.

ConditionalExpressions should work in global scope too, so fixed by handling `canAnyVariableExist` in `getVariableType`