### PR TITLE
Add `TypeCombinator::removeFalsey()`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -99,7 +99,6 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\ParserNodeTypeToPHPStanType;
 use PHPStan\Type\StaticType;
-use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -1681,7 +1680,7 @@ class MutatingScope implements Scope
 					return $this->filterByFalseyValue($node->cond)->getType($node->else);
 				}
 				return TypeCombinator::union(
-					TypeCombinator::remove($this->filterByTruthyValue($node->cond)->getType($node->cond), StaticTypeFactory::falsey()),
+					TypeCombinator::removeFalsey($this->filterByTruthyValue($node->cond)->getType($node->cond)),
 					$this->filterByFalseyValue($node->cond)->getType($node->else),
 				);
 			}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3417,7 +3417,7 @@ class NodeScopeResolver
 
 			$conditionalExpressions = [];
 
-			$truthyType = TypeCombinator::remove($type, StaticTypeFactory::falsey());
+			$truthyType = TypeCombinator::removeFalsey($type);
 			$falseyType = TypeCombinator::intersect($type, StaticTypeFactory::falsey());
 
 			$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -52,7 +52,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
-use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -165,7 +164,7 @@ class InitializerExprTypeResolver
 			$elseType = $this->getType($expr->else, $context);
 			if ($expr->if === null) {
 				return TypeCombinator::union(
-					TypeCombinator::remove($condType, StaticTypeFactory::falsey()),
+					TypeCombinator::removeFalsey($condType),
 					$elseType,
 				);
 			}
@@ -173,7 +172,7 @@ class InitializerExprTypeResolver
 			$ifType = $this->getType($expr->if, $context);
 
 			return TypeCombinator::union(
-				TypeCombinator::remove($ifType, StaticTypeFactory::falsey()),
+				TypeCombinator::removeFalsey($ifType),
 				$elseType,
 			);
 		}

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1072,4 +1072,9 @@ class TypeCombinator
 		return new IntersectionType($types);
 	}
 
+	public static function removeFalsey(Type $type): Type
+	{
+		return self::remove($type, StaticTypeFactory::falsey());
+	}
+
 }


### PR DESCRIPTION
This PR adds the ability for the type combinator to remove falsey types from a given type. I am in need of this functionality within an extension, but the static type factory is currently not part of the public API. Rather than changing that, this seemed like a better way to expose the functionality.

PHPStan also contains a few places where it removes falsey types, so I replaced those occurrences.