### PR TITLE
Do not invalidate related expressions in ensureNonNullability

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3401,7 +3401,7 @@ class MutatingScope implements Scope
 		);
 	}
 
-	private function specifyExpressionType(Expr $expr, Type $type, Type $nativeType): self
+	public function specifyExpressionType(Expr $expr, Type $type, Type $nativeType): self
 	{
 		if ($expr instanceof Node\Scalar || $expr instanceof Array_) {
 			return $this;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1615,7 +1615,7 @@ class NodeScopeResolver
 		}
 
 		$nativeType = $scope->getNativeType($exprToSpecify);
-		$scope = $scope->assignExpression(
+		$scope = $scope->specifyExpressionType(
 			$exprToSpecify,
 			$exprTypeWithoutNull,
 			TypeCombinator::removeNull($nativeType),
@@ -1650,7 +1650,7 @@ class NodeScopeResolver
 	private function revertNonNullability(MutatingScope $scope, array $specifiedExpressions): MutatingScope
 	{
 		foreach ($specifiedExpressions as $specifiedExpressionResult) {
-			$scope = $scope->assignExpression(
+			$scope = $scope->specifyExpressionType(
 				$specifiedExpressionResult->getExpression(),
 				$specifiedExpressionResult->getOriginalType(),
 				$specifiedExpressionResult->getOriginalNativeType(),

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1128,6 +1128,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mixed-to-number.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-8113.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/phpunit-integration.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8361.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-8361.php
+++ b/tests/PHPStan/Analyser/data/bug-8361.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Bug8361;
+
+use function PHPStan\Testing\assertType;
+use DateTimeInterface;
+
+class HelloWorld
+{
+	public function sayHello(?DateTimeInterface $from = null, ?DateTimeInterface $to = null): void
+	{
+		if ($from || $to) {
+			$operator = $from ? 'notBefore' : 'notAfter';
+			assertType('true', $from || $to);
+			assertType('DateTimeInterface', $from ?? $to);
+			$date = ($from ?? $to)->format(DateTimeInterface::ATOM);
+			assertType('true', $from || $to);
+			assertType('DateTimeInterface', $from ?? $to);
+		}
+	}
+
+	public function sayHello2(?DateTimeInterface $from = null, ?DateTimeInterface $to = null): void
+	{
+		if ($from || $to) {
+			$operator = $from ? 'notBefore' : 'notAfter';
+			$date = ($from ?? $to)->format(DateTimeInterface::ATOM);
+			$date = ($from ?? $to)->format(DateTimeInterface::ATOM);
+			assertType('true', $from || $to);
+			assertType('DateTimeInterface', $from ?? $to);
+		}
+	}
+}


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/8361
As `specifyExpressionType`  and `assignExpression` is separated in 
https://github.com/phpstan/phpstan-src/pull/1950
I want to make it public to use them when appropriate.

In `ensureShallowNonNullability`, I think there are no reasons to invalidate related expressions