### PR TITLE
Fix infinite loop when fully qualified callback is supplied

### DIFF
--- a/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeReturnTypeExtension.php
@@ -33,6 +33,7 @@ use function array_map;
 use function count;
 use function is_string;
 use function strtolower;
+use function substr;
 
 class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -83,7 +84,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 				return $this->filterByTruthyValue($scope, $callbackArg->params[0]->var, $arrayArgType, null, $callbackArg->expr);
 			} elseif ($callbackArg instanceof String_) {
 				$itemVar = new Variable('item');
-				$expr = new FuncCall(new Name($callbackArg->value), [new Arg($itemVar)]);
+				$expr = new FuncCall(self::createFunctionName($callbackArg->value), [new Arg($itemVar)]);
 				return $this->filterByTruthyValue($scope, $itemVar, $arrayArgType, null, $expr);
 			}
 		}
@@ -98,7 +99,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 				return $this->filterByTruthyValue($scope, null, $arrayArgType, $callbackArg->params[0]->var, $callbackArg->expr);
 			} elseif ($callbackArg instanceof String_) {
 				$keyVar = new Variable('key');
-				$expr = new FuncCall(new Name($callbackArg->value), [new Arg($keyVar)]);
+				$expr = new FuncCall(self::createFunctionName($callbackArg->value), [new Arg($keyVar)]);
 				return $this->filterByTruthyValue($scope, null, $arrayArgType, $keyVar, $expr);
 			}
 		}
@@ -114,7 +115,7 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 			} elseif ($callbackArg instanceof String_) {
 				$itemVar = new Variable('item');
 				$keyVar = new Variable('key');
-				$expr = new FuncCall(new Name($callbackArg->value), [new Arg($itemVar), new Arg($keyVar)]);
+				$expr = new FuncCall(self::createFunctionName($callbackArg->value), [new Arg($itemVar), new Arg($keyVar)]);
 				return $this->filterByTruthyValue($scope, $itemVar, $arrayArgType, $keyVar, $expr);
 			}
 		}
@@ -232,6 +233,15 @@ class ArrayFilterFunctionReturnTypeReturnTypeExtension implements DynamicFunctio
 			$itemVarName !== null ? $scope->getVariableType($itemVarName) : $itemType,
 			!$booleanResult instanceof ConstantBooleanType,
 		];
+	}
+
+	private static function createFunctionName(string $funcName): Name
+	{
+		if ($funcName[0] === '\\') {
+			return new Name\FullyQualified(substr($funcName, 1));
+		}
+
+		return new Name($funcName);
 	}
 
 }

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1025,6 +1025,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame(30, $errors[0]->getLine());
 	}
 
+	public function testBug8376(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8376.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testAssertDocblock(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/assert-docblock.php');

--- a/tests/PHPStan/Analyser/data/bug-8376.php
+++ b/tests/PHPStan/Analyser/data/bug-8376.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Bug8376;
+
+function (array $arr): array {
+    return array_filter($arr, '\\is_int');
+};
+
+function ($var): void {
+    \assert(\is_int($var));
+};


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/8376

This seemed to only cause a problem when running the code on PHP 7 and where the same file contained a native call to the same callback function.

Example:

```php
<?php
\array_filter([1], '\\is_int');
\is_int(1);
```

You can replicate the problem by running Rector over the code and then trying to analyse a file containing the above example using PHP 7.4.