### PR TITLE
Specify return type for `filter_input()`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1457,6 +1457,11 @@ services:
 		class: PHPStan\Type\Php\FilterFunctionReturnTypeHelper
 
 	-
+		class: PHPStan\Type\Php\FilterInputDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\FilterVarDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -51,20 +51,20 @@ final class FilterFunctionReturnTypeHelper
 		$this->flagsString = new ConstantStringType('flags');
 	}
 
-	public function getArrayOffsetValueType(ArrayType $arrayType, Type $offsetType, ?Type $filterType, ?Type $flagsType): ?Type
+	public function getOffsetValueType(Type $inputType, Type $offsetType, ?Type $filterType, ?Type $flagsType): ?Type
 	{
 		$inexistentOffsetType = $this->hasFlag($this->getConstant('FILTER_NULL_ON_FAILURE'), $flagsType)
 			? new ConstantBooleanType(false)
 			: new NullType();
 
-		$arrayTypeHasOffsetValueType = $arrayType->hasOffsetValueType($offsetType);
-		if ($arrayTypeHasOffsetValueType->no()) {
+		$hasOffsetValueType = $inputType->hasOffsetValueType($offsetType);
+		if ($hasOffsetValueType->no()) {
 			return $inexistentOffsetType;
 		}
 
-		$filteredType = $this->getType($arrayType->getOffsetValueType($offsetType), $filterType, $flagsType);
+		$filteredType = $this->getType($inputType->getOffsetValueType($offsetType), $filterType, $flagsType);
 
-		return $arrayTypeHasOffsetValueType->maybe()
+		return $hasOffsetValueType->maybe()
 			? TypeCombinator::union($filteredType, $inexistentOffsetType)
 			: $filteredType;
 	}

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -51,7 +51,7 @@ final class FilterFunctionReturnTypeHelper
 		$this->flagsString = new ConstantStringType('flags');
 	}
 
-	public function getArrayOffsetValueType(Type $arrayType, Type $offsetType, ?Type $filterType, ?Type $flagsType): ?Type
+	public function getArrayOffsetValueType(ArrayType $arrayType, Type $offsetType, ?Type $filterType, ?Type $flagsType): ?Type
 	{
 		$inexistentOffsetType = $this->hasFlag($this->getConstant('FILTER_NULL_ON_FAILURE'), $flagsType)
 			? new ConstantBooleanType(false)

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -122,6 +122,11 @@ final class FilterFunctionReturnTypeHelper
 		return $type;
 	}
 
+	public function hasConstantFlag(string $constant, ?Type $flagsType): bool
+	{
+		return $this->hasFlag($this->getConstant($constant), $flagsType);
+	}
+
 	/**
 	 * @return array<int, Type>
 	 */

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -14,7 +14,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
-use function strtolower;
 
 class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -44,7 +44,7 @@ class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnType
 		// See https://github.com/phpstan/phpstan-src/pull/2012 for details
 		$inputType = new ArrayType(new StringType(), new MixedType());
 
-		return $this->filterFunctionReturnTypeHelper->getArrayOffsetValueType(
+		return $this->filterFunctionReturnTypeHelper->getOffsetValueType(
 			$inputType,
 			$scope->getType($functionCall->getArgs()[1]->value),
 			isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null,

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
+use function strtolower;
+
+class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	private const INPUT_TYPE_VARIABLE_NAME_MAP = [
+		'INPUT_GET' => '_GET',
+		'INPUT_POST' => '_POST',
+		'INPUT_COOKIE' => '_COOKIE',
+		'INPUT_SERVER' => '_SERVER',
+		'INPUT_ENV' => '_ENV',
+	];
+
+	public function __construct(private FilterFunctionReturnTypeHelper $filterFunctionReturnTypeHelper)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return strtolower($functionReflection->getName()) === 'filter_input';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+	{
+		if (count($functionCall->getArgs()) < 2) {
+			return null;
+		}
+
+		$inputVariable = $this->determineInputVariable($functionCall->getArgs()[0]);
+		$varNameType = $scope->getType($functionCall->getArgs()[1]->value);
+		if ($inputVariable === null || !$varNameType->isString()->yes()) {
+			return null;
+		}
+
+		$inputVariableType = $scope->getType($inputVariable);
+		$inputHasOffsetValue = $inputVariableType->hasOffsetValueType($varNameType);
+		$flagsType = isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null;
+		if ($inputHasOffsetValue->no()) {
+			return $this->determineNonExistentOffsetReturnType($flagsType);
+		}
+
+		$filterType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
+		$filteredType = $this->filterFunctionReturnTypeHelper->getTypeFromFunctionCall(
+			$inputVariableType->getOffsetValueType($varNameType),
+			$filterType,
+			$flagsType,
+		);
+
+		return !$inputVariableType->hasOffsetValueType($varNameType)->yes()
+			? TypeCombinator::union($filteredType, $this->determineNonExistentOffsetReturnType($flagsType))
+			: $filteredType;
+	}
+
+	private function determineInputVariable(Arg $type): ?Variable
+	{
+		if (!$type->value instanceof ConstFetch) {
+			return null;
+		}
+
+		$variableName = self::INPUT_TYPE_VARIABLE_NAME_MAP[(string) $type->value->name] ?? null;
+		return $variableName === null ? null : new Variable($variableName);
+	}
+
+	private function determineNonExistentOffsetReturnType(?Type $flagsType): Type
+	{
+		return $flagsType === null || !$this->filterFunctionReturnTypeHelper->hasConstantFlag('FILTER_NULL_ON_FAILURE', $flagsType)
+			? new NullType()
+			: new ConstantBooleanType(false);
+	}
+
+}

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
@@ -33,18 +32,11 @@ class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnType
 			return null;
 		}
 
-		$typeArgExpr = $functionCall->getArgs()[0]->value;
-		$varNameType = $scope->getType($functionCall->getArgs()[1]->value);
-		$varNameTypeIsString = $varNameType->isString();
+		$typeExpr = $functionCall->getArgs()[0]->value;
 		if (
-			$varNameTypeIsString->no()
-			|| !($typeArgExpr instanceof ConstFetch)
-			|| !in_array((string) $typeArgExpr->name, ['INPUT_GET', 'INPUT_POST', 'INPUT_COOKIE', 'INPUT_SERVER', 'INPUT_ENV'], true)
+			!($typeExpr instanceof ConstFetch)
+			|| !in_array((string) $typeExpr->name, ['INPUT_GET', 'INPUT_POST', 'INPUT_COOKIE', 'INPUT_SERVER', 'INPUT_ENV'], true)
 		) {
-			return new NeverType();
-		}
-
-		if ($varNameTypeIsString->maybe()) {
 			return null;
 		}
 
@@ -54,7 +46,7 @@ class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnType
 
 		return $this->filterFunctionReturnTypeHelper->getArrayOffsetValueType(
 			$inputType,
-			$varNameType,
+			$scope->getType($functionCall->getArgs()[1]->value),
 			isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null,
 			isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null,
 		);

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -32,7 +32,7 @@ class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnType
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
-		return strtolower($functionReflection->getName()) === 'filter_input';
+		return $functionReflection->getName() === 'filter_input';
 	}
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -32,7 +32,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		$filterType = isset($functionCall->getArgs()[1]) ? $scope->getType($functionCall->getArgs()[1]->value) : null;
 		$flagsType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
 
-		return $this->filterFunctionReturnTypeHelper->getTypeFromFunctionCall($inputType, $filterType, $flagsType);
+		return $this->filterFunctionReturnTypeHelper->getType($inputType, $filterType, $flagsType);
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -623,6 +623,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var.php');
 
 		if (PHP_VERSION_ID >= 80100) {

--- a/tests/PHPStan/Analyser/data/filter-input.php
+++ b/tests/PHPStan/Analyser/data/filter-input.php
@@ -7,11 +7,11 @@ use function PHPStan\Testing\assertType;
 class FilterInput
 {
 
-	public function invalidTypesOrVarNamesAreIgnored($mixed): void
+	public function invalidTypesOrVarNames($mixed): void
 	{
 		assertType('mixed', filter_input(INPUT_GET, $mixed, FILTER_VALIDATE_INT));
-		assertType('mixed', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT));
-		assertType('mixed', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
+		assertType('*NEVER*', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT));
+		assertType('*NEVER*', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
 	}
 
 	public function supportedSuperGlobals(): void
@@ -28,6 +28,7 @@ class FilterInput
 		assertType('int|false|null', filter_input(INPUT_GET, $foo, FILTER_VALIDATE_INT));
 		assertType('int|false|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT));
 		assertType('int|false|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['flags' => FILTER_NULL_ON_FAILURE]));
+		assertType("'invalid'|int|null", filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['options' => ['default' => 'invalid']]));
 		assertType('array<int|false>|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<int|null>|false', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('0|int<17, 19>|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));

--- a/tests/PHPStan/Analyser/data/filter-input.php
+++ b/tests/PHPStan/Analyser/data/filter-input.php
@@ -9,9 +9,10 @@ class FilterInput
 
 	public function invalidTypesOrVarNames($mixed): void
 	{
-		assertType('mixed', filter_input(INPUT_GET, $mixed, FILTER_VALIDATE_INT));
-		assertType('*NEVER*', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT));
-		assertType('*NEVER*', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_GET, $mixed, FILTER_VALIDATE_INT));
+		assertType('mixed', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
+		assertType('null', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT));
+		assertType('false', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE));
 	}
 
 	public function supportedSuperGlobals(): void

--- a/tests/PHPStan/Analyser/data/filter-input.php
+++ b/tests/PHPStan/Analyser/data/filter-input.php
@@ -24,6 +24,11 @@ class FilterInput
 		assertType('int|false|null', filter_input(INPUT_ENV, 'foo', FILTER_VALIDATE_INT));
 	}
 
+	public function inputTypeUnion(): void
+	{
+		assertType('int|false|null', filter_input(rand(0, 1) ? INPUT_GET : INPUT_POST, 'foo', FILTER_VALIDATE_INT));
+	}
+
 	public function doFoo(string $foo): void
 	{
 		assertType('int|false|null', filter_input(INPUT_GET, $foo, FILTER_VALIDATE_INT));

--- a/tests/PHPStan/Analyser/data/filter-input.php
+++ b/tests/PHPStan/Analyser/data/filter-input.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace FilterInput;
+
+use function PHPStan\Testing\assertType;
+
+class FilterInput
+{
+
+	public function invalidTypesOrVarNamesAreIgnored($mixed): void
+	{
+		assertType('mixed', filter_input(INPUT_GET, $mixed, FILTER_VALIDATE_INT));
+		assertType('mixed', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT));
+		assertType('mixed', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
+	}
+
+	public function supportedSuperGlobals(): void
+	{
+		assertType('int|false|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_POST, 'foo', FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_COOKIE, 'foo', FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_SERVER, 'foo', FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_ENV, 'foo', FILTER_VALIDATE_INT));
+	}
+
+	public function doFoo(string $foo): void
+	{
+		assertType('int|false|null', filter_input(INPUT_GET, $foo, FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT));
+		assertType('int|false|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['flags' => FILTER_NULL_ON_FAILURE]));
+		assertType('array<int|false>|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+		assertType('array<int|null>|false', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('0|int<17, 19>|null', filter_input(INPUT_GET, 'foo', FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1130,6 +1130,12 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug6261(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-6261.php'], []);
+	}
+
 	public function testBug6781(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-6781.php'], []);

--- a/tests/PHPStan/Rules/Functions/data/bug-6261.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-6261.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6261;
+
+function needs_int(int $x) : void {}
+
+function () {
+	$x = filter_input(INPUT_POST, 'row_id', FILTER_VALIDATE_INT);
+
+	if($x === false || $x === null) {
+		die("I expected a numeric string!\n");
+	}
+
+	needs_int($x);
+};


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6261

See https://www.php.net/manual/en/function.filter-input.php, the important difference to `filter_var` is the handling of the non-set variables in the superglobal arrays
> Return Values
> Value of the requested variable on success, false if the filter fails, or null if the var_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used, it returns false if the variable is not set and null if the filter fails. 