### PR TITLE
Infinite loop regression test

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3730,7 +3730,7 @@ class MutatingScope implements Scope
 			foreach ($conditionalExpressions as $conditionalExpression) {
 				$targetTypeHolder = $conditionalExpression->getTypeHolder();
 				foreach ($conditionalExpression->getConditionExpressionTypeHolders() as $conditionalTypeHolder) {
-					if (!$scope->unsetExpression($targetTypeHolder->getExpr())->getType($conditionalTypeHolder->getExpr())->equals($conditionalTypeHolder->getType())) {
+					if (!$scope->invalidateExpression($targetTypeHolder->getExpr())->getType($conditionalTypeHolder->getExpr())->equals($conditionalTypeHolder->getType())) {
 						continue 2;
 					}
 				}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1045,6 +1045,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testConditionalExpressionInfiniteLoop(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/conditional-expression-infinite-loop.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/conditional-expression-infinite-loop.php
+++ b/tests/PHPStan/Analyser/data/conditional-expression-infinite-loop.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace ConditionalExpressionInfiniteLoop;
+class test
+{
+	public function test2(bool $isFoo, bool $isBar): void
+	{
+		match (true) {
+			$isFoo && $isBar => $foo = 1,
+			$isFoo || $isBar => $foo = 2,
+			default => $foo = null,
+		};
+	}
+}


### PR DESCRIPTION
small follow up fixes for https://github.com/phpstan/phpstan-src/pull/2007

I miss used `unsetExpression` while fixing https://github.com/phpstan/phpstan-src/pull/2007/files#diff-8ebf997b275a1b4e9be07f399f4b71c00617f43cfb16c3f9e4d088aabd522fa2R226 test.

Confirmed that the test causes an infinite loop without invalidateExpression.