### PR TITLE
Improve expression resolving of superglobals

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -605,6 +605,8 @@ services:
 
 	-
 		class: PHPStan\Analyser\ScopeFactory
+		arguments:
+			explicitMixedForGlobalVariables: %featureToggles.explicitMixedForGlobalVariables%
 
 	-
 		class: PHPStan\Analyser\NodeScopeResolver

--- a/src/Analyser/DirectInternalScopeFactory.php
+++ b/src/Analyser/DirectInternalScopeFactory.php
@@ -34,7 +34,6 @@ class DirectInternalScopeFactory implements InternalScopeFactory
 		private bool $treatPhpDocTypesAsCertain,
 		private PhpVersion $phpVersion,
 		private bool $explicitMixedInUnknownGenericNew,
-		private bool $explicitMixedForGlobalVariables,
 		private ConstantResolver $constantResolver,
 	)
 	{
@@ -102,7 +101,6 @@ class DirectInternalScopeFactory implements InternalScopeFactory
 			$parentScope,
 			$nativeTypesPromoted,
 			$this->explicitMixedInUnknownGenericNew,
-			$this->explicitMixedForGlobalVariables,
 		);
 	}
 

--- a/src/Analyser/DirectInternalScopeFactory.php
+++ b/src/Analyser/DirectInternalScopeFactory.php
@@ -39,14 +39,6 @@ class DirectInternalScopeFactory implements InternalScopeFactory
 	{
 	}
 
-	/**
-	 * @param array<string, ExpressionTypeHolder> $expressionTypes
-	 * @param array<string, ExpressionTypeHolder> $nativeExpressionTypes
-	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
-	 * @param array<(FunctionReflection|MethodReflection)> $inFunctionCallsStack
-	 * @param array<string, true> $currentlyAssignedExpressions
-	 * @param array<string, true> $currentlyAllowedUndefinedExpressions
-	 */
 	public function create(
 		ScopeContext $context,
 		bool $declareStrictTypes = false,

--- a/src/Analyser/InternalScopeFactory.php
+++ b/src/Analyser/InternalScopeFactory.php
@@ -15,7 +15,7 @@ interface InternalScopeFactory
 	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
 	 * @param array<string, true> $currentlyAssignedExpressions
 	 * @param array<string, true> $currentlyAllowedUndefinedExpressions
-	 * @param array<MethodReflection|FunctionReflection> $inFunctionCallsStack
+	 * @param array<FunctionReflection|MethodReflection> $inFunctionCallsStack
 	 */
 	public function create(
 		ScopeContext $context,

--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -41,7 +41,6 @@ class LazyInternalScopeFactory implements InternalScopeFactory
 	 * @param array<string, true> $currentlyAssignedExpressions
 	 * @param array<string, true> $currentlyAllowedUndefinedExpressions
 	 * @param array<(FunctionReflection|MethodReflection)> $inFunctionCallsStack
-	 *
 	 */
 	public function create(
 		ScopeContext $context,

--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -34,14 +34,6 @@ class LazyInternalScopeFactory implements InternalScopeFactory
 		$this->explicitMixedInUnknownGenericNew = $this->container->getParameter('featureToggles')['explicitMixedInUnknownGenericNew'];
 	}
 
-	/**
-	 * @param array<string, ExpressionTypeHolder> $expressionTypes
-	 * @param array<string, ExpressionTypeHolder> $nativeExpressionTypes
-	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
-	 * @param array<string, true> $currentlyAssignedExpressions
-	 * @param array<string, true> $currentlyAllowedUndefinedExpressions
-	 * @param array<(FunctionReflection|MethodReflection)> $inFunctionCallsStack
-	 */
 	public function create(
 		ScopeContext $context,
 		bool $declareStrictTypes = false,

--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -22,8 +22,6 @@ class LazyInternalScopeFactory implements InternalScopeFactory
 
 	private bool $explicitMixedInUnknownGenericNew;
 
-	private bool $explicitMixedForGlobalVariables;
-
 	/**
 	 * @param class-string $scopeClass
 	 */
@@ -34,7 +32,6 @@ class LazyInternalScopeFactory implements InternalScopeFactory
 	{
 		$this->treatPhpDocTypesAsCertain = $container->getParameter('treatPhpDocTypesAsCertain');
 		$this->explicitMixedInUnknownGenericNew = $this->container->getParameter('featureToggles')['explicitMixedInUnknownGenericNew'];
-		$this->explicitMixedForGlobalVariables = $this->container->getParameter('featureToggles')['explicitMixedForGlobalVariables'];
 	}
 
 	/**
@@ -100,7 +97,6 @@ class LazyInternalScopeFactory implements InternalScopeFactory
 			$parentScope,
 			$nativeTypesPromoted,
 			$this->explicitMixedInUnknownGenericNew,
-			$this->explicitMixedForGlobalVariables,
 		);
 	}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -190,7 +190,6 @@ class MutatingScope implements Scope
 		private ?Scope $parentScope = null,
 		private bool $nativeTypesPromoted = false,
 		private bool $explicitMixedInUnknownGenericNew = false,
-		private bool $explicitMixedForGlobalVariables = false,
 	)
 	{
 		if ($namespace === '') {
@@ -2150,7 +2149,6 @@ class MutatingScope implements Scope
 			$this->parentScope,
 			false,
 			$this->explicitMixedInUnknownGenericNew,
-			$this->explicitMixedForGlobalVariables,
 		);
 	}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2445,8 +2445,8 @@ class MutatingScope implements Scope
 			$this->isDeclareStrictTypes(),
 			null,
 			$this->getNamespace(),
-			array_merge($this->getSuperglobalExpressionTypes(), $this->getConstantTypes(), ['$this' => $thisHolder]),
-			array_merge($this->getSuperglobalExpressionTypes(), $this->getNativeConstantTypes(), ['$this' => $thisHolder]),
+			array_merge($this->getSuperglobalTypes(), $this->getConstantTypes(), ['$this' => $thisHolder]),
+			array_merge($this->getNativeSuperglobalTypes(), $this->getNativeConstantTypes(), ['$this' => $thisHolder]),
 			[],
 			null,
 			null,
@@ -2682,8 +2682,8 @@ class MutatingScope implements Scope
 			$this->isDeclareStrictTypes(),
 			$functionReflection,
 			$this->getNamespace(),
-			array_merge($this->getSuperglobalExpressionTypes(), $this->getConstantTypes(), $expressionTypes),
-			array_merge($this->getSuperglobalExpressionTypes(), $this->getNativeConstantTypes(), $nativeExpressionTypes),
+			array_merge($this->getSuperglobalTypes(), $this->getConstantTypes(), $expressionTypes),
+			array_merge($this->getNativeSuperglobalTypes(), $this->getNativeConstantTypes(), $nativeExpressionTypes),
 		);
 	}
 
@@ -2695,8 +2695,8 @@ class MutatingScope implements Scope
 			$this->isDeclareStrictTypes(),
 			null,
 			$namespaceName,
-			$this->getSuperglobalExpressionTypes(),
-			$this->getSuperglobalExpressionTypes(),
+			$this->getSuperglobalTypes(),
+			$this->getNativeSuperglobalTypes(),
 		);
 	}
 
@@ -2920,8 +2920,8 @@ class MutatingScope implements Scope
 			$this->isDeclareStrictTypes(),
 			$this->getFunction(),
 			$this->getNamespace(),
-			array_merge($this->getSuperglobalExpressionTypes(), $this->getConstantTypes(), $expressionTypes),
-			array_merge($this->getSuperglobalExpressionTypes(), $this->getNativeConstantTypes(), $nativeTypes),
+			array_merge($this->getSuperglobalTypes(), $this->getConstantTypes(), $expressionTypes),
+			array_merge($this->getNativeSuperglobalTypes(), $this->getNativeConstantTypes(), $nativeTypes),
 			[],
 			$this->inClosureBindScopeClass,
 			new TrivialParametersAcceptor(),
@@ -4995,18 +4995,33 @@ class MutatingScope implements Scope
 	}
 
 	/** @return array<string, ExpressionTypeHolder> */
-	private function getSuperglobalExpressionTypes(): array
+	private function getSuperglobalTypes(): array
 	{
-		$superglobalExpressionTypes = [];
+		$superglobalTypes = [];
 		$exprStrings = ['$GLOBALS', '$_SERVER', '$_GET', '$_POST', '$_FILES', '$_COOKIE', '$_SESSION', '$_REQUEST', '$_ENV'];
 		foreach ($this->expressionTypes as $exprString => $typeHolder) {
 			if (!in_array($exprString, $exprStrings, true)) {
 				continue;
 			}
 
-			$superglobalExpressionTypes[$exprString] = $typeHolder;
+			$superglobalTypes[$exprString] = $typeHolder;
 		}
-		return $superglobalExpressionTypes;
+		return $superglobalTypes;
+	}
+
+	/** @return array<string, ExpressionTypeHolder> */
+	private function getNativeSuperglobalTypes(): array
+	{
+		$superglobalTypes = [];
+		$exprStrings = ['$GLOBALS', '$_SERVER', '$_GET', '$_POST', '$_FILES', '$_COOKIE', '$_SESSION', '$_REQUEST', '$_ENV'];
+		foreach ($this->nativeExpressionTypes as $exprString => $typeHolder) {
+			if (!in_array($exprString, $exprStrings, true)) {
+				continue;
+			}
+
+			$superglobalTypes[$exprString] = $typeHolder;
+		}
+		return $superglobalTypes;
 	}
 
 }

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -502,16 +502,16 @@ class MutatingScope implements Scope
 			}
 		}
 
-		if ($this->isGlobalVariable($variableName)) {
-			return new ArrayType(new StringType(), new MixedType($this->explicitMixedForGlobalVariables));
-		}
-
 		if ($this->hasVariableType($variableName)->no()) {
 			throw new UndefinedVariableException($this, $variableName);
 		}
 
 		$varExprString = '$' . $variableName;
 		if (!array_key_exists($varExprString, $this->expressionTypes)) {
+			if ($this->isGlobalVariable($variableName)) {
+				return new ArrayType(new StringType(), new MixedType($this->explicitMixedForGlobalVariables));
+			}
+
 			return new MixedType();
 		}
 

--- a/src/Analyser/ScopeFactory.php
+++ b/src/Analyser/ScopeFactory.php
@@ -2,17 +2,45 @@
 
 namespace PHPStan\Analyser;
 
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+
 /** @api */
 class ScopeFactory
 {
 
-	public function __construct(private InternalScopeFactory $internalScopeFactory)
+	public function __construct(
+		private InternalScopeFactory $internalScopeFactory,
+		private bool $explicitMixedForGlobalVariables,
+	)
 	{
 	}
 
 	public function create(ScopeContext $context): MutatingScope
 	{
-		return $this->internalScopeFactory->create($context);
+		$superglobalType = new ArrayType(new StringType(), new MixedType($this->explicitMixedForGlobalVariables));
+		$expressionTypes = [
+			'$GLOBALS' => ExpressionTypeHolder::createYes(new Variable('GLOBALS'), $superglobalType),
+			'$_SERVER' => ExpressionTypeHolder::createYes(new Variable('_SERVER'), $superglobalType),
+			'$_GET' => ExpressionTypeHolder::createYes(new Variable('_GET'), $superglobalType),
+			'$_POST' => ExpressionTypeHolder::createYes(new Variable('_POST'), $superglobalType),
+			'$_FILES' => ExpressionTypeHolder::createYes(new Variable('_FILES'), $superglobalType),
+			'$_COOKIE' => ExpressionTypeHolder::createYes(new Variable('_COOKIE'), $superglobalType),
+			'$_SESSION' => ExpressionTypeHolder::createYes(new Variable('_SESSION'), $superglobalType),
+			'$_REQUEST' => ExpressionTypeHolder::createYes(new Variable('_REQUEST'), $superglobalType),
+			'$_ENV' => ExpressionTypeHolder::createYes(new Variable('_ENV'), $superglobalType),
+		];
+
+		return $this->internalScopeFactory->create(
+			$context,
+			false,
+			null,
+			null,
+			$expressionTypes,
+			$expressionTypes,
+		);
 	}
 
 }

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -181,6 +181,7 @@ abstract class PHPStanTestCase extends TestCase
 				$container->getParameter('featureToggles')['explicitMixedForGlobalVariables'],
 				$constantResolver,
 			),
+			$container->getParameter('featureToggles')['explicitMixedForGlobalVariables'],
 		);
 	}
 

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -178,7 +178,6 @@ abstract class PHPStanTestCase extends TestCase
 				$this->shouldTreatPhpDocTypesAsCertain(),
 				$container->getByType(PhpVersion::class),
 				$container->getParameter('featureToggles')['explicitMixedInUnknownGenericNew'],
-				$container->getParameter('featureToggles')['explicitMixedForGlobalVariables'],
 				$constantResolver,
 			),
 			$container->getParameter('featureToggles')['explicitMixedForGlobalVariables'],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -457,6 +457,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-types.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5219.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/strval.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/superglobals.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-next.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string.php');

--- a/tests/PHPStan/Analyser/data/superglobals.php
+++ b/tests/PHPStan/Analyser/data/superglobals.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Superglobals;
+
+use function PHPStan\Testing\assertType;
+
+class Superglobals
+{
+
+	public function originalTypes(): void
+	{
+		assertType('array<string, mixed>', $GLOBALS);
+		assertType('array<string, mixed>', $_SERVER);
+		assertType('array<string, mixed>', $_GET);
+		assertType('array<string, mixed>', $_POST);
+		assertType('array<string, mixed>', $_FILES);
+		assertType('array<string, mixed>', $_COOKIE);
+		assertType('array<string, mixed>', $_SESSION);
+		assertType('array<string, mixed>', $_REQUEST);
+		assertType('array<string, mixed>', $_ENV);
+	}
+
+	public function canBeOverwritten(): void
+	{
+		$_SESSION = [];
+		assertType('array{}', $_SESSION);
+	}
+
+	public function canBePartlyOverwritten(): void
+	{
+		$_SESSION['foo'] = 'foo';
+		assertType("non-empty-array<string, mixed>&hasOffsetValue('foo', 'foo')", $_SESSION);
+	}
+
+}


### PR DESCRIPTION
Handles superglobals as any other expressions, which fixes narrowing them.

~~Closes https://github.com/phpstan/phpstan/issues/5805 (which I was totally not expecting, most likely unlocked also by recent changes from @rajyan)~~ nope, not anymore, this was fixed in https://github.com/phpstan/phpstan-src/pull/2030, I do understand that this change then is only improving things if people use superglobal expressions to narrow types, which might not be the case often in modern apps. Therefore I also get it if this is not wanted in the scope :)

The superglobals creation is most likely also a good integration point for https://github.com/phpstan/phpstan/issues/8037