### PR TITLE
Fix `pathinfo($s, PATHINFO_ALL)` return type

### DIFF
--- a/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
@@ -5,16 +5,24 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 use function count;
+use function sprintf;
 
 class PathinfoFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(private ReflectionProvider $reflectionProvider)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -25,24 +33,51 @@ class PathinfoFunctionDynamicReturnTypeExtension implements DynamicFunctionRetur
 		FunctionReflection $functionReflection,
 		Node\Expr\FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		$argsCount = count($functionCall->getArgs());
 		if ($argsCount === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
-		} elseif ($argsCount === 1) {
-			$pathType = $scope->getType($functionCall->getArgs()[0]->value);
-
-			$builder = ConstantArrayTypeBuilder::createEmpty();
-			$builder->setOffsetValueType(new ConstantStringType('dirname'), new StringType(), !$pathType->isNonEmptyString()->yes());
-			$builder->setOffsetValueType(new ConstantStringType('basename'), new StringType());
-			$builder->setOffsetValueType(new ConstantStringType('extension'), new StringType(), true);
-			$builder->setOffsetValueType(new ConstantStringType('filename'), new StringType());
-
-			return $builder->getArray();
+			return null;
 		}
 
-		return new StringType();
+		$pathType = $scope->getType($functionCall->getArgs()[0]->value);
+
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		$builder->setOffsetValueType(new ConstantStringType('dirname'), new StringType(), !$pathType->isNonEmptyString()->yes());
+		$builder->setOffsetValueType(new ConstantStringType('basename'), new StringType());
+		$builder->setOffsetValueType(new ConstantStringType('extension'), new StringType(), true);
+		$builder->setOffsetValueType(new ConstantStringType('filename'), new StringType());
+		$arrayType = $builder->getArray();
+
+		if ($argsCount === 1) {
+			return $arrayType;
+		} else {
+			$flagsType = $scope->getType($functionCall->getArgs()[1]->value);
+			if ($flagsType instanceof ConstantIntegerType) {
+				if ($flagsType->getValue() === $this->getConstant('PATHINFO_ALL')) {
+					return $arrayType;
+				}
+
+				return new StringType();
+			}
+		}
+
+		return TypeCombinator::union($arrayType, new StringType());
+	}
+
+	private function getConstant(string $constantName): ?int
+	{
+		if (!$this->reflectionProvider->hasConstant(new Node\Name($constantName), null)) {
+			return null;
+		}
+
+		$constant = $this->reflectionProvider->getConstant(new Node\Name($constantName), null);
+		$valueType = $constant->getValueType();
+		if (!$valueType instanceof ConstantIntegerType) {
+			throw new ShouldNotHappenException(sprintf('Constant %s does not have integer type.', $constantName));
+		}
+
+		return $valueType->getValue();
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1149,6 +1149,11 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8520.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var-dynamic-return-type-extension-regression.php');
+
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/pathinfo-php8.php');
+		}
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/pathinfo.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/pathinfo-php8.php
+++ b/tests/PHPStan/Analyser/data/pathinfo-php8.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace pathinfo;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo(string $s,  int $i) {
+	assertType('array{dirname?: string, basename: string, extension?: string, filename: string}', pathinfo($s, PATHINFO_ALL));
+}

--- a/tests/PHPStan/Analyser/data/pathinfo.php
+++ b/tests/PHPStan/Analyser/data/pathinfo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace pathinfo;
+namespace pathinfoInference;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/data/pathinfo.php
+++ b/tests/PHPStan/Analyser/data/pathinfo.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace pathinfo;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo(string $s,  int $i) {
+	assertType('array{dirname?: string, basename: string, extension?: string, filename: string}|string', pathinfo($s,  $i));
+	assertType('array{dirname?: string, basename: string, extension?: string, filename: string}', pathinfo($s));
+
+	assertType('string', pathinfo($s, PATHINFO_DIRNAME));
+	assertType('string', pathinfo($s, PATHINFO_BASENAME));
+	assertType('string', pathinfo($s, PATHINFO_EXTENSION));
+	assertType('string', pathinfo($s, PATHINFO_FILENAME));
+}


### PR DESCRIPTION
some tests fail with the current release: https://phpstan.org/r/adc64e75-4570-4aeb-acfd-bdcbf88ff872

`PATHINFO_ALL` is php8 only, see https://3v4l.org/4319K