### PR TITLE
Do not set native type to `mixed` on annotation assignment

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3863,7 +3863,12 @@ class NodeScopeResolver
 					$certainty = TrinaryLogic::createYes();
 				}
 
-				$scope = $scope->assignVariable($name, $varTag->getType(), new MixedType(), $certainty);
+				$scope = $scope->assignVariable(
+					$name,
+					$varTag->getType(),
+					$scope->getNativeType(new Variable($name)),
+					$certainty,
+				);
 			}
 		}
 

--- a/tests/PHPStan/Analyser/data/native-types.php
+++ b/tests/PHPStan/Analyser/data/native-types.php
@@ -202,3 +202,15 @@ function fooFunction(
 	assertType('string', $nonNullableString);
 	assertNativeType('string', $nonNullableString);
 }
+
+function phpDocDoesNotInfluenceExistingNativeType(): void
+{
+	$array = [];
+
+	assertType('array{}', $array);
+	assertNativeType('array{}', $array);
+
+	/** @var array<string> $array */
+	assertType('array<string>', $array);
+	assertNativeType('array{}', $array);
+}

--- a/tests/PHPStan/Analyser/data/shuffle.php
+++ b/tests/PHPStan/Analyser/data/shuffle.php
@@ -8,7 +8,7 @@ use function PHPStan\Testing\assertType;
 class Foo
 {
 
-	public function normalArrays(array $arr): void
+	public function normalArrays1(array $arr): void
 	{
 		/** @var mixed[] $arr */
 		shuffle($arr);
@@ -16,14 +16,20 @@ class Foo
 		assertNativeType('list<mixed>', $arr);
 		assertType('list<int<0, max>>', array_keys($arr));
 		assertType('list<mixed>', array_values($arr));
+	}
 
+	public function normalArrays2(array $arr): void
+	{
 		/** @var non-empty-array<string, int> $arr */
 		shuffle($arr);
 		assertType('non-empty-list<int>', $arr);
 		assertNativeType('list<mixed>', $arr);
 		assertType('non-empty-list<int<0, max>>', array_keys($arr));
 		assertType('non-empty-list<int>', array_values($arr));
+	}
 
+	public function normalArrays3(array $arr): void
+	{
 		/** @var array<mixed> $arr */
 		if (array_key_exists('foo', $arr)) {
 			shuffle($arr);
@@ -32,7 +38,10 @@ class Foo
 			assertType('non-empty-list<int<0, max>>', array_keys($arr));
 			assertType('non-empty-list<mixed>', array_values($arr));
 		}
+	}
 
+	public function normalArrays4(array $arr): void
+	{
 		/** @var array<mixed> $arr */
 		if (array_key_exists('foo', $arr) && $arr['foo'] === 'bar') {
 			shuffle($arr);
@@ -43,7 +52,7 @@ class Foo
 		}
 	}
 
-	public function constantArrays(array $arr): void
+	public function constantArrays1(array $arr): void
 	{
 		$arr = [];
 		shuffle($arr);
@@ -51,35 +60,50 @@ class Foo
 		assertNativeType('array{}', $arr);
 		assertType('array{}', array_keys($arr));
 		assertType('array{}', array_values($arr));
+	}
 
+	public function constantArrays2(array $arr): void
+	{
 		/** @var array{0?: 1, 1?: 2, 2?: 3} $arr */
 		shuffle($arr);
 		assertType('array<0|1|2, 1|2|3>&list', $arr);
 		assertNativeType('list<mixed>', $arr);
 		assertType('list<0|1|2>', array_keys($arr));
 		assertType('list<1|2|3>', array_values($arr));
+	}
 
+	public function constantArrays3(array $arr): void
+	{
 		$arr = [1, 2, 3];
 		shuffle($arr);
 		assertType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertNativeType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertType('non-empty-list<0|1|2>', array_keys($arr));
 		assertType('non-empty-list<1|2|3>', array_values($arr));
+	}
 
+	public function constantArrays4(array $arr): void
+	{
 		$arr = ['a' => 1, 'b' => 2, 'c' => 3];
 		shuffle($arr);
 		assertType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertNativeType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertType('non-empty-list<0|1|2>', array_keys($arr));
 		assertType('non-empty-list<1|2|3>', array_values($arr));
+	}
 
+	public function constantArrays5(array $arr): void
+	{
 		$arr = [0 => 1, 3 => 2, 42 => 3];
 		shuffle($arr);
 		assertType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertNativeType('non-empty-array<0|1|2, 1|2|3>&list', $arr);
 		assertType('non-empty-list<0|1|2>', array_keys($arr));
 		assertType('non-empty-list<1|2|3>', array_values($arr));
+	}
 
+	public function constantArrays6(array $arr): void
+	{
 		/** @var array{foo?: 1, bar: 2, }|array{baz: 3, foobar?: 4} $arr */
 		shuffle($arr);
 		assertType('non-empty-array<0|1, 1|2|3|4>&list', $arr);


### PR DESCRIPTION
Not sure, but this looked weird to me. Or did I misunderstand it?

My shuffle tests started failing partly, but that makes sense to me because they were influencing each other and not cleanly separated. E.g. this should fix https://phpstan.org/r/20b7a14a-21e8-4e2e-aca7-c1119fc8528c

dang, this doesn't seem to fix any open issues, I was hoping it would, should have created one for my snippet 😅

CC @rajyan 