### PR TITLE
revert conditionalExpression invalidation

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3477,25 +3477,22 @@ class MutatingScope implements Scope
 			$invalidated = true;
 		}
 
-		$newConditionalExpressions = [];
+		$exprString = $this->getNodeKey($expressionToInvalidate);
+		$newConditionalExpressions = $this->conditionalExpressions;
+		if (array_key_exists($exprString, $newConditionalExpressions)) {
+			unset($newConditionalExpressions[$exprString]);
+			$invalidated = true;
+		}
 		foreach ($this->conditionalExpressions as $conditionalExprString => $holders) {
-			if (count($holders) === 0) {
-				continue;
-			}
-			if ($this->shouldInvalidateExpression($expressionToInvalidate, $holders[array_key_first($holders)]->getTypeHolder()->getExpr())) {
-				$invalidated = true;
-				continue;
-			}
 			foreach ($holders as $holder) {
 				$conditionalTypeHolders = $holder->getConditionExpressionTypeHolders();
-				foreach ($conditionalTypeHolders as $conditionalTypeHolder) {
-					if ($this->shouldInvalidateExpression($expressionToInvalidate, $conditionalTypeHolder->getExpr())) {
-						$invalidated = true;
-						continue 3;
-					}
+				if (!array_key_exists($exprString, $conditionalTypeHolders)) {
+					continue;
 				}
+
+				unset($newConditionalExpressions[$conditionalExprString]);
+				$invalidated = true;
 			}
-			$newConditionalExpressions[$conditionalExprString] = $holders;
 		}
 
 		if (!$invalidated) {


### PR DESCRIPTION
from https://github.com/phpstan/phpstan/discussions/8397

I think my assumption was correct, this commit should be the cause.
https://github.com/phpstan/phpstan-src/commit/cb45b58b7ae3aff7a824f56e5b1aceb09eed347c

I knew that maybe this commit cause a performance regression, but it was needed to make conditional expression invalidation work with all expressions.

The problem is, before https://github.com/phpstan/phpstan-src/pull/2007 conditionalExpression was only used for variables, so this invalidation was enough.

If conditionalExpressions is used for all expressions, we have to invalidate like how expressionTypes are invalidated.
That is, we have to invalidate conditional expression that is related to `$a` like  `returnsBool($a)` when `$a` is invalidated.


The failing test can show what would not work without this

https://github.com/phpstan/phpstan-src/blob/e8707784f3d41605cdc4f619ee47d6cc60316e69/tests/PHPStan/Analyser/data/dependent-expression-certainty.php#L75
https://github.com/phpstan/phpstan-src/blob/e8707784f3d41605cdc4f619ee47d6cc60316e69/tests/PHPStan/Analyser/data/dependent-expression-certainty.php#L226