### PR TITLE
ImagickPixel::getColor() normalized param accept int instead of bool

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -133,6 +133,7 @@ parameters:
 		- ../stubs/ArrayObject.stub
 		- ../stubs/WeakReference.stub
 		- ../stubs/ext-ds.stub
+		- ../stubs/ImagickPixel.stub
 		- ../stubs/PDOStatement.stub
 		- ../stubs/date.stub
 		- ../stubs/mysqli.stub

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5166,7 +5166,7 @@ return [
 'ImagickPixel::clear' => ['bool'],
 'ImagickPixel::clone' => ['void'],
 'ImagickPixel::destroy' => ['bool'],
-'ImagickPixel::getColor' => ['array', 'normalized='=>'int'],
+'ImagickPixel::getColor' => ['array', 'normalized='=>'0|1|2'],
 'ImagickPixel::getColorAsString' => ['string'],
 'ImagickPixel::getColorCount' => ['int'],
 'ImagickPixel::getColorQuantum' => ['mixed'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5166,7 +5166,7 @@ return [
 'ImagickPixel::clear' => ['bool'],
 'ImagickPixel::clone' => ['void'],
 'ImagickPixel::destroy' => ['bool'],
-'ImagickPixel::getColor' => ['array', 'normalized='=>'0|1|2'],
+'ImagickPixel::getColor' => ['array{r: int|float, g: int|float, b: int|float, a: int|float}', 'normalized='=>'0|1|2'],
 'ImagickPixel::getColorAsString' => ['string'],
 'ImagickPixel::getColorCount' => ['int'],
 'ImagickPixel::getColorQuantum' => ['mixed'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5166,7 +5166,7 @@ return [
 'ImagickPixel::clear' => ['bool'],
 'ImagickPixel::clone' => ['void'],
 'ImagickPixel::destroy' => ['bool'],
-'ImagickPixel::getColor' => ['array', 'normalized='=>'bool'],
+'ImagickPixel::getColor' => ['array', 'normalized='=>'int'],
 'ImagickPixel::getColorAsString' => ['string'],
 'ImagickPixel::getColorCount' => ['int'],
 'ImagickPixel::getColorQuantum' => ['mixed'],

--- a/stubs/ImagickPixel.stub
+++ b/stubs/ImagickPixel.stub
@@ -2,8 +2,8 @@
 
 class ImagickPixel
 {
-    /**
-     * @return ($normalized is 0 ? array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>} : ($normalized is 1 ? array{r: float, g: float, b: float, a: float} : ($normalized is 2 ? array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 255>} : array{})))
-     */
-    public function getColor(int $normalized = 0): array;
+	/**
+	 * @return ($normalized is 0 ? array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>} : ($normalized is 1 ? array{r: float, g: float, b: float, a: float} : ($normalized is 2 ? array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 255>} : array{})))
+	 */
+	public function getColor(int $normalized = 0): array;
 }

--- a/stubs/ImagickPixel.stub
+++ b/stubs/ImagickPixel.stub
@@ -1,0 +1,9 @@
+<?php
+
+class ImagickPixel
+{
+    /**
+     * @return ($normalized is 0 ? array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>} : ($normalized is 1 ? array{r: float, g: float, b: float, a: float} : ($normalized is 2 ? array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 255>} : array{})))
+     */
+    public function getColor(int $normalized = 0): array;
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1133,6 +1133,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8373.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-8389.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8421.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/imagick-pixel.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/imagick-pixel.php
+++ b/tests/PHPStan/Analyser/data/imagick-pixel.php
@@ -5,11 +5,11 @@ namespace ImagickPixelReturn;
 use function PHPStan\Testing\assertType;
 
 function (): void {
-    $imagickPixel = new \ImagickPixel('rgb(0, 0, 0)');
+	$imagickPixel = new \ImagickPixel('rgb(0, 0, 0)');
 
-    assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>}', $imagickPixel->getColor());
-    assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>}', $imagickPixel->getColor(0));
-    assertType('array{r: float, g: float, b: float, a: float}', $imagickPixel->getColor(1));
-    assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 255>}', $imagickPixel->getColor(2));
-    assertType('array{}', $imagickPixel->getColor(3));
+	assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>}', $imagickPixel->getColor());
+	assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>}', $imagickPixel->getColor(0));
+	assertType('array{r: float, g: float, b: float, a: float}', $imagickPixel->getColor(1));
+	assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 255>}', $imagickPixel->getColor(2));
+	assertType('array{}', $imagickPixel->getColor(3));
 };

--- a/tests/PHPStan/Analyser/data/imagick-pixel.php
+++ b/tests/PHPStan/Analyser/data/imagick-pixel.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ImagickPixelReturn;
+
+use function PHPStan\Testing\assertType;
+
+function (): void {
+    $imagickPixel = new \ImagickPixel('rgb(0, 0, 0)');
+
+    assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>}', $imagickPixel->getColor());
+    assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 1>}', $imagickPixel->getColor(0));
+    assertType('array{r: float, g: float, b: float, a: float}', $imagickPixel->getColor(1));
+    assertType('array{r: int<0, 255>, g: int<0, 255>, b: int<0, 255>, a: int<0, 255>}', $imagickPixel->getColor(2));
+    assertType('array{}', $imagickPixel->getColor(3));
+};

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2675,13 +2675,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5623.php'], []);
 	}
 
-    public function testImagickPixel(): void
-    {
-        $this->checkThisOnly = false;
-        $this->checkNullables = false;
-        $this->checkUnionTypes = true;
-        $this->checkExplicitMixed = false;
-        $this->analyse([__DIR__ . '/data/imagick-pixel.php'], []);
-    }
+	public function testImagickPixel(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = false;
+		$this->analyse([__DIR__ . '/data/imagick-pixel.php'], []);
+	}
 
 }

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2675,4 +2675,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5623.php'], []);
 	}
 
+    public function testImagickPixel(): void
+    {
+        $this->checkThisOnly = false;
+        $this->checkNullables = false;
+        $this->checkUnionTypes = true;
+        $this->checkExplicitMixed = false;
+        $this->analyse([__DIR__ . '/data/imagick-pixel.php'], []);
+    }
+
 }

--- a/tests/PHPStan/Rules/Methods/data/imagick-pixel.php
+++ b/tests/PHPStan/Rules/Methods/data/imagick-pixel.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace ImagickPixelParam;
+
+use ImagickPixel;
+
+class HelloWorld
+{
+    public function sayHello(ImagickPixel $pixel): void
+    {
+        $pixel->getColor();
+        $pixel->getColor(0);
+        $pixel->getColor(1);
+        $pixel->getColor(2);
+    }
+}

--- a/tests/PHPStan/Rules/Methods/data/imagick-pixel.php
+++ b/tests/PHPStan/Rules/Methods/data/imagick-pixel.php
@@ -6,11 +6,11 @@ use ImagickPixel;
 
 class HelloWorld
 {
-    public function sayHello(ImagickPixel $pixel): void
-    {
-        $pixel->getColor();
-        $pixel->getColor(0);
-        $pixel->getColor(1);
-        $pixel->getColor(2);
-    }
+	public function sayHello(ImagickPixel $pixel): void
+	{
+		$pixel->getColor();
+		$pixel->getColor(0);
+		$pixel->getColor(1);
+		$pixel->getColor(2);
+	}
 }


### PR DESCRIPTION
Should be fix https://phpstan.org/r/991c445c-3376-4892-947f-a1e5cd591d2d

See PHP doc:
https://www.php.net/manual/en/imagickpixel.getcolor.php