### PR TITLE
Consistently pass `$nativeExpressionTypes` in MutatingScope

### DIFF
--- a/tests/PHPStan/Analyser/data/native-types.php
+++ b/tests/PHPStan/Analyser/data/native-types.php
@@ -170,6 +170,70 @@ class Foo
 		}
 	}
 
+	public function declareStrictTypes(array $array): void
+	{
+		/** @var array<string> $array */
+		assertType('array<string>', $array);
+		assertNativeType('array', $array);
+
+		declare(strict_types=1);
+		assertType('array<string>', $array);
+		assertNativeType('array', $array);
+	}
+
+	public function arrowFunction(array $array): void
+	{
+		/** @var array<string> $array */
+		assertType('array<string>', $array);
+		assertNativeType('array', $array);
+
+		(fn () => assertNativeType('array', $array))();
+	}
+
+	public function closuresUsingCallMethod(array $array, object $object): void
+	{
+		/** @var \stdClass $object */
+		assertType('$this(NativeTypes\Foo)', $this);
+		assertNativeType('$this(NativeTypes\Foo)', $this);
+
+		/** @var array<string> $array */
+		assertType('array<string>', $array);
+		assertNativeType('array', $array);
+
+		(function () use ($array) {
+			assertType('stdClass', $this);
+			assertNativeType('object', $this);
+
+			assertType('array<string>', $array);
+			assertNativeType('array', $array);
+		})->call($object);
+
+		assertType('$this(NativeTypes\Foo)', $this);
+		assertNativeType('$this(NativeTypes\Foo)', $this);
+	}
+
+	public function closureBind(array $array, object $object): void
+	{
+		/** @var \stdClass $object */
+		assertType('$this(NativeTypes\Foo)', $this);
+		assertNativeType('$this(NativeTypes\Foo)', $this);
+
+		/** @var array<string> $array */
+		assertType('array<string>', $array);
+		assertNativeType('array', $array);
+
+		\Closure::bind(function () use ($array) {
+			assertType('stdClass', $this);
+			assertNativeType('object', $this);
+
+			assertType('array<string>', $array);
+			assertNativeType('array', $array);
+		}, $object);
+
+		assertType('$this(NativeTypes\Foo)', $this);
+		assertNativeType('$this(NativeTypes\Foo)', $this);
+	}
+
 }
 
 /**


### PR DESCRIPTION
because why not? no really, I have no clue and am asking myself exactly that.

I went through all ScopeFactory::create() calls and this makes the native expression types passing consistent with the expression types passing AFAIK.

This passes native types properly for
- enterDeclareStrictTypes
- enterClosureBind / restoreOriginalScopeAfterClosureBind
- enterClosureCall
- enterArrowFunction

CC @rajyan 