### PR TITLE
CodeLocationMissing: getStartLine failing test

### DIFF
--- a/tests/PHPStan/Rules/EnumCases/EnumMethodReflectionTest.php
+++ b/tests/PHPStan/Rules/EnumCases/EnumMethodReflectionTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\EnumCases;
+
+use Nette\Utils\Strings;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<Rule>
+ */
+class EnumMethodReflectionTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new class implements Rule {
+
+			public function getNodeType(): string
+			{
+				return InClassNode::class;
+			}
+
+			public function processNode(Node $node, Scope $scope): array
+			{
+				foreach ($node->getClassReflection()->getNativeReflection()->getMethods() as $method) {
+					$method->getStartLine();
+				}
+
+				return [];
+			}
+		};
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/enum-reflection.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Rules/EnumCases/data/enum-reflection.php
+++ b/tests/PHPStan/Rules/EnumCases/data/enum-reflection.php
@@ -1,0 +1,8 @@
+<?php // lint >= 8.1
+
+namespace EnumReflection;
+
+enum MyEnum
+{
+
+}


### PR DESCRIPTION
When `BackedEnum::cases` is analysed, method `getStartLine` throws `CodeLocationMissing` exception although real PHP reflection returns false: https://3v4l.org/EgqRf