### PR TITLE
Show combined memory usage in parallel mode

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -10,6 +10,7 @@ use Throwable;
 use function array_fill_keys;
 use function array_merge;
 use function count;
+use function memory_get_peak_usage;
 use function sprintf;
 
 class Analyser
@@ -110,6 +111,7 @@ class Analyser
 			$internalErrorsCount === 0 ? $dependencies : null,
 			$exportedNodes,
 			$reachedInternalErrorsCountLimit,
+			memory_get_peak_usage(true),
 		);
 	}
 

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -26,6 +26,7 @@ class AnalyserResult
 		private ?array $dependencies,
 		private array $exportedNodes,
 		private bool $reachedInternalErrorsCountLimit,
+		private int $estimatedPeakMemoryUsage,
 	)
 	{
 		$this->unorderedErrors = $errors;
@@ -95,6 +96,11 @@ class AnalyserResult
 	public function hasReachedInternalErrorsCountLimit(): bool
 	{
 		return $this->reachedInternalErrorsCountLimit;
+	}
+
+	public function getEstimatedPeakMemoryUsage(): int
+	{
+		return $this->estimatedPeakMemoryUsage;
 	}
 
 }

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -26,7 +26,7 @@ class AnalyserResult
 		private ?array $dependencies,
 		private array $exportedNodes,
 		private bool $reachedInternalErrorsCountLimit,
-		private int $estimatedPeakMemoryUsage,
+		private int $peakMemoryUsageBytes,
 	)
 	{
 		$this->unorderedErrors = $errors;
@@ -98,9 +98,9 @@ class AnalyserResult
 		return $this->reachedInternalErrorsCountLimit;
 	}
 
-	public function getEstimatedPeakMemoryUsage(): int
+	public function getPeakMemoryUsageBytes(): int
 	{
-		return $this->estimatedPeakMemoryUsage;
+		return $this->peakMemoryUsageBytes;
 	}
 
 }

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -424,7 +424,7 @@ class ResultCacheManager
 			$dependencies,
 			$exportedNodes,
 			$analyserResult->hasReachedInternalErrorsCountLimit(),
-			$analyserResult->getEstimatedPeakMemoryUsage(),
+			$analyserResult->getPeakMemoryUsageBytes(),
 		), $saved);
 	}
 

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -424,6 +424,7 @@ class ResultCacheManager
 			$dependencies,
 			$exportedNodes,
 			$analyserResult->hasReachedInternalErrorsCountLimit(),
+			$analyserResult->getEstimatedPeakMemoryUsage(),
 		), $saved);
 	}
 

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -71,7 +71,7 @@ class AnalyseApplication
 			$internalErrors = [];
 			$collectedData = [];
 			$savedResultCache = false;
-			$estimatedMemoryUsage = 0;
+			$memoryUsageBytes = memory_get_peak_usage(true);
 			if ($errorOutput->isDebug()) {
 				$errorOutput->writeLineFormatted('Result cache was not saved because of ignoredErrorHelperResult errors.');
 			}
@@ -98,7 +98,7 @@ class AnalyseApplication
 					$intermediateAnalyserResult->getDependencies(),
 					$intermediateAnalyserResult->getExportedNodes(),
 					$intermediateAnalyserResult->hasReachedInternalErrorsCountLimit(),
-					$intermediateAnalyserResult->getEstimatedPeakMemoryUsage(),
+					$intermediateAnalyserResult->getPeakMemoryUsageBytes(),
 				);
 			}
 
@@ -107,7 +107,7 @@ class AnalyseApplication
 			$internalErrors = $analyserResult->getInternalErrors();
 			$errors = $analyserResult->getErrors();
 			$hasInternalErrors = count($internalErrors) > 0 || $analyserResult->hasReachedInternalErrorsCountLimit();
-			$estimatedMemoryUsage = $analyserResult->getEstimatedPeakMemoryUsage();
+			$memoryUsageBytes = $analyserResult->getPeakMemoryUsageBytes();
 
 			if (!$hasInternalErrors) {
 				foreach ($this->getCollectedDataErrors($analyserResult->getCollectedData()) as $error) {
@@ -143,7 +143,7 @@ class AnalyseApplication
 			$defaultLevelUsed,
 			$projectConfigFile,
 			$savedResultCache,
-			$estimatedMemoryUsage,
+			$memoryUsageBytes,
 		);
 	}
 

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -71,6 +71,7 @@ class AnalyseApplication
 			$internalErrors = [];
 			$collectedData = [];
 			$savedResultCache = false;
+			$estimatedMemoryUsage = 0;
 			if ($errorOutput->isDebug()) {
 				$errorOutput->writeLineFormatted('Result cache was not saved because of ignoredErrorHelperResult errors.');
 			}
@@ -97,6 +98,7 @@ class AnalyseApplication
 					$intermediateAnalyserResult->getDependencies(),
 					$intermediateAnalyserResult->getExportedNodes(),
 					$intermediateAnalyserResult->hasReachedInternalErrorsCountLimit(),
+					$intermediateAnalyserResult->getEstimatedPeakMemoryUsage(),
 				);
 			}
 
@@ -105,6 +107,8 @@ class AnalyseApplication
 			$internalErrors = $analyserResult->getInternalErrors();
 			$errors = $analyserResult->getErrors();
 			$hasInternalErrors = count($internalErrors) > 0 || $analyserResult->hasReachedInternalErrorsCountLimit();
+			$estimatedMemoryUsage = $analyserResult->getEstimatedPeakMemoryUsage();
+
 			if (!$hasInternalErrors) {
 				foreach ($this->getCollectedDataErrors($analyserResult->getCollectedData()) as $error) {
 					$errors[] = $error;
@@ -139,6 +143,7 @@ class AnalyseApplication
 			$defaultLevelUsed,
 			$projectConfigFile,
 			$savedResultCache,
+			$estimatedMemoryUsage,
 		);
 	}
 
@@ -195,7 +200,7 @@ class AnalyseApplication
 			$errorOutput->getStyle()->progressStart($allAnalysedFilesCount);
 			$errorOutput->getStyle()->progressAdvance($allAnalysedFilesCount);
 			$errorOutput->getStyle()->progressFinish();
-			return new AnalyserResult([], [], [], [], [], false);
+			return new AnalyserResult([], [], [], [], [], false, memory_get_peak_usage(true));
 		}
 
 		if (!$debug) {

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -379,6 +379,7 @@ class AnalyseCommand extends Command
 					$analysisResult->isDefaultLevelUsed(),
 					$analysisResult->getProjectConfigFile(),
 					$analysisResult->isResultCacheSaved(),
+					$analysisResult->getEstimatedPeakMemoryUsage(),
 				);
 
 				$stdOutput = $inceptionResult->getStdOutput();

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -14,6 +14,7 @@ use function array_values;
 use function count;
 use function function_exists;
 use function is_file;
+use function memory_get_peak_usage;
 
 class AnalyserRunner
 {
@@ -48,7 +49,7 @@ class AnalyserRunner
 	{
 		$filesCount = count($files);
 		if ($filesCount === 0) {
-			return new AnalyserResult([], [], [], [], [], false);
+			return new AnalyserResult([], [], [], [], [], false, memory_get_peak_usage(true));
 		}
 
 		$schedule = $this->scheduler->scheduleWork($this->cpuCoreCounter->getNumberOfCpuCores(), $files);

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -30,7 +30,7 @@ class AnalysisResult
 		private bool $defaultLevelUsed,
 		private ?string $projectConfigFile,
 		private bool $savedResultCache,
-		private int $estimatedPeakMemoryUsage,
+		private int $peakMemoryUsageBytes,
 	)
 	{
 		usort(
@@ -124,9 +124,9 @@ class AnalysisResult
 		return $this->savedResultCache;
 	}
 
-	public function getEstimatedPeakMemoryUsage(): int
+	public function getPeakMemoryUsageBytes(): int
 	{
-		return $this->estimatedPeakMemoryUsage;
+		return $this->peakMemoryUsageBytes;
 	}
 
 }

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -30,6 +30,7 @@ class AnalysisResult
 		private bool $defaultLevelUsed,
 		private ?string $projectConfigFile,
 		private bool $savedResultCache,
+		private int $estimatedPeakMemoryUsage,
 	)
 	{
 		usort(
@@ -121,6 +122,11 @@ class AnalysisResult
 	public function isResultCacheSaved(): bool
 	{
 		return $this->savedResultCache;
+	}
+
+	public function getEstimatedPeakMemoryUsage(): int
+	{
+		return $this->estimatedPeakMemoryUsage;
 	}
 
 }

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -8,6 +8,7 @@ use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
+use PHPStan\Internal\BytesHelper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use function array_map;
 use function count;
@@ -46,6 +47,11 @@ class TableErrorFormatter implements ErrorFormatter
 
 		if (!$analysisResult->hasErrors() && !$analysisResult->hasWarnings()) {
 			$style->success('No errors');
+
+			if ($output->isVerbose()) {
+				$output->writeLineFormatted(sprintf('Took about %s memory', BytesHelper::bytes($analysisResult->getEstimatedPeakMemoryUsage())));
+			}
+
 			if ($this->showTipsOfTheDay) {
 				if ($analysisResult->isDefaultLevelUsed()) {
 					$output->writeLineFormatted('💡 Tip of the Day:');
@@ -127,6 +133,10 @@ class TableErrorFormatter implements ErrorFormatter
 			$style->error($finalMessage);
 		} else {
 			$style->warning($finalMessage);
+		}
+
+		if ($output->isVerbose()) {
+			$output->writeLineFormatted(sprintf('Took about %s memory', BytesHelper::bytes($analysisResult->getEstimatedPeakMemoryUsage())));
 		}
 
 		return $analysisResult->getTotalErrorsCount() > 0 ? 1 : 0;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -8,7 +8,6 @@ use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
-use PHPStan\Internal\BytesHelper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use function array_map;
 use function count;
@@ -47,10 +46,6 @@ class TableErrorFormatter implements ErrorFormatter
 
 		if (!$analysisResult->hasErrors() && !$analysisResult->hasWarnings()) {
 			$style->success('No errors');
-
-			if ($output->isVerbose()) {
-				$output->writeLineFormatted(sprintf('Took about %s memory', BytesHelper::bytes($analysisResult->getEstimatedPeakMemoryUsage())));
-			}
 
 			if ($this->showTipsOfTheDay) {
 				if ($analysisResult->isDefaultLevelUsed()) {
@@ -133,10 +128,6 @@ class TableErrorFormatter implements ErrorFormatter
 			$style->error($finalMessage);
 		} else {
 			$style->warning($finalMessage);
-		}
-
-		if ($output->isVerbose()) {
-			$output->writeLineFormatted(sprintf('Took about %s memory', BytesHelper::bytes($analysisResult->getEstimatedPeakMemoryUsage())));
 		}
 
 		return $analysisResult->getTotalErrorsCount() > 0 ? 1 : 0;

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -143,13 +143,22 @@ class ErrorsConsoleStyle extends SymfonyStyle
 
 	private function getProgressBarFormat(): ?string
 	{
-		$formatName = match ($this->getVerbosity()) {
-			OutputInterface::VERBOSITY_NORMAL => ProgressBar::FORMAT_NORMAL,
-			OutputInterface::VERBOSITY_VERBOSE => ProgressBar::FORMAT_VERBOSE,
-			OutputInterface::VERBOSITY_VERY_VERBOSE,
-			OutputInterface::VERBOSITY_DEBUG => ProgressBar::FORMAT_VERY_VERBOSE, // FORMAT_DEBUG shows invalid memory, avoid that
-			default => null,
-		};
+		switch ($this->getVerbosity()) {
+			case OutputInterface::VERBOSITY_NORMAL:
+				$formatName = ProgressBar::FORMAT_NORMAL;
+				break;
+			case OutputInterface::VERBOSITY_VERBOSE:
+				$formatName = ProgressBar::FORMAT_VERBOSE;
+				break;
+			case OutputInterface::VERBOSITY_VERY_VERBOSE:
+			case OutputInterface::VERBOSITY_DEBUG:
+				$formatName = ProgressBar::FORMAT_VERY_VERBOSE;
+				break;
+			default:
+				$formatName = null;
+				break;
+		}
+
 		if ($formatName === null) {
 			return null;
 		}

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -118,7 +118,11 @@ class ErrorsConsoleStyle extends SymfonyStyle
 	public function createProgressBar(int $max = 0): ProgressBar
 	{
 		$this->progressBar = parent::createProgressBar($max);
-		$this->progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%');
+
+		$format = $this->getProgressBarFormat();
+		if ($format !== null) {
+			$this->progressBar->setFormat($format);
+		}
 
 		$ci = $this->isCiDetected();
 		$this->progressBar->setOverwrite(!$ci);
@@ -135,6 +139,22 @@ class ErrorsConsoleStyle extends SymfonyStyle
 		}
 
 		return $this->progressBar;
+	}
+
+	private function getProgressBarFormat(): ?string
+	{
+		$formatName = match ($this->getVerbosity()) {
+			OutputInterface::VERBOSITY_NORMAL => ProgressBar::FORMAT_NORMAL,
+			OutputInterface::VERBOSITY_VERBOSE => ProgressBar::FORMAT_VERBOSE,
+			OutputInterface::VERBOSITY_VERY_VERBOSE,
+			OutputInterface::VERBOSITY_DEBUG => ProgressBar::FORMAT_VERY_VERBOSE, // FORMAT_DEBUG shows invalid memory, avoid that
+			default => null,
+		};
+		if ($formatName === null) {
+			return null;
+		}
+
+		return ProgressBar::getFormatDefinition($formatName);
 	}
 
 	public function progressStart(int $max = 0): void

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -118,6 +118,7 @@ class ErrorsConsoleStyle extends SymfonyStyle
 	public function createProgressBar(int $max = 0): ProgressBar
 	{
 		$this->progressBar = parent::createProgressBar($max);
+		$this->progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%');
 
 		$ci = $this->isCiDetected();
 		$this->progressBar->setOverwrite(!$ci);

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -60,6 +60,7 @@ use function ini_get;
 use function is_dir;
 use function is_file;
 use function is_string;
+use function memory_get_peak_usage;
 use function min;
 use function mkdir;
 use function parse_url;
@@ -507,7 +508,7 @@ class FixerApplication
 		$resultCache = $resultCacheManager->restore($inceptionFiles, false, false, $projectConfigArray, $inceptionResult->getErrorOutput(), $fixerSuggestionId);
 		if (count($resultCache->getFilesToAnalyse()) === 0) {
 			$result = $resultCacheManager->process(
-				new AnalyserResult([], [], [], [], [], false),
+				new AnalyserResult([], [], [], [], [], false, memory_get_peak_usage(true)),
 				$resultCache,
 				$inceptionResult->getErrorOutput(),
 				false,

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -268,7 +268,7 @@ class FixerWorkerCommand extends Command
 			$dependencies,
 			$exportedNodes,
 			$analyserResult->hasReachedInternalErrorsCountLimit(),
-			$analyserResult->getEstimatedPeakMemoryUsage(),
+			$analyserResult->getPeakMemoryUsageBytes(),
 		);
 	}
 

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -268,6 +268,7 @@ class FixerWorkerCommand extends Command
 			$dependencies,
 			$exportedNodes,
 			$analyserResult->hasReachedInternalErrorsCountLimit(),
+			$analyserResult->getEstimatedPeakMemoryUsage(),
 		);
 	}
 

--- a/src/Command/InceptionResult.php
+++ b/src/Command/InceptionResult.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Command;
 
 use PHPStan\DependencyInjection\Container;
+use PHPStan\Internal\BytesHelper;
+use function sprintf;
 
 class InceptionResult
 {
@@ -76,8 +78,12 @@ class InceptionResult
 		return $this->generateBaselineFile;
 	}
 
-	public function handleReturn(int $exitCode): int
+	public function handleReturn(int $exitCode, ?int $peakMemoryUsageBytes): int
 	{
+		if ($peakMemoryUsageBytes !== null && $this->getErrorOutput()->isVerbose()) {
+			$this->getErrorOutput()->writeLineFormatted(sprintf('Used memory: %s', BytesHelper::bytes($peakMemoryUsageBytes)));
+		}
+
 		return $exitCode;
 	}
 

--- a/src/Command/InceptionResult.php
+++ b/src/Command/InceptionResult.php
@@ -3,9 +3,6 @@
 namespace PHPStan\Command;
 
 use PHPStan\DependencyInjection\Container;
-use PHPStan\Internal\BytesHelper;
-use function memory_get_peak_usage;
-use function sprintf;
 
 class InceptionResult
 {
@@ -81,10 +78,6 @@ class InceptionResult
 
 	public function handleReturn(int $exitCode): int
 	{
-		if ($this->getErrorOutput()->isVerbose()) {
-			$this->getErrorOutput()->writeLineFormatted(sprintf('Used memory: %s', BytesHelper::bytes(memory_get_peak_usage(true))));
-		}
-
 		return $exitCode;
 	}
 

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -30,6 +30,7 @@ use function defined;
 use function is_array;
 use function is_bool;
 use function is_string;
+use function memory_get_peak_usage;
 use function sprintf;
 
 class WorkerCommand extends Command
@@ -242,6 +243,7 @@ class WorkerCommand extends Command
 				'result' => [
 					'errors' => $errors,
 					'collectedData' => $collectedData,
+					'memoryUsage' => memory_get_peak_usage(true),
 					'dependencies' => $dependencies,
 					'exportedNodes' => $exportedNodes,
 					'filesCount' => count($files),

--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -100,6 +100,7 @@ abstract class ErrorFormatterTestCase extends PHPStanTestCase
 			false,
 			null,
 			true,
+			0,
 		);
 	}
 

--- a/tests/PHPStan/Command/AnalysisResultTest.php
+++ b/tests/PHPStan/Command/AnalysisResultTest.php
@@ -43,6 +43,7 @@ final class AnalysisResultTest extends PHPStanTestCase
 				false,
 				null,
 				true,
+				0,
 			))->getFileSpecificErrors(),
 		);
 	}

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -148,6 +148,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			false,
 			null,
 			true,
+			0,
 		);
 		$formatter->formatErrors(
 			$result,
@@ -185,6 +186,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			false,
 			null,
 			true,
+			0,
 		);
 
 		$formatter->formatErrors(
@@ -249,6 +251,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			false,
 			null,
 			true,
+			0,
 		);
 
 		$formatter->formatErrors(
@@ -406,6 +409,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			false,
 			null,
 			true,
+			0,
 		);
 
 		$resource = fopen('php://memory', 'w', false);

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -154,6 +154,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 			false,
 			null,
 			true,
+			0,
 		), $this->getOutput());
 		$this->assertXmlStringEqualsXmlString('<checkstyle>
 	<file name="FooTrait.php">

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -228,7 +228,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = $this->createErrorFormatter('editor://any', '%relFile%:%line%');
 		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
-		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true), $this->getOutput(true));
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput(true));
 
 		$this->assertStringContainsString('rel/Foo.php:12', $this->getOutputContent(true));
 	}

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -210,7 +210,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = $this->createErrorFormatter('editor://%file%/%line%');
 		$error = new Error('Test', 'Foo.php (in context of trait)', 12, true, 'Foo.php', 'Bar.php');
-		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true), $this->getOutput());
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput());
 
 		$this->assertStringContainsString('Bar.php', $this->getOutputContent());
 	}
@@ -219,7 +219,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = $this->createErrorFormatter('editor://custom/path/%relFile%/%line%');
 		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
-		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true), $this->getOutput(true));
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput(true));
 
 		$this->assertStringContainsString('editor://custom/path/rel/Foo.php', $this->getOutputContent(true));
 	}
@@ -253,6 +253,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 				false,
 				null,
 				true,
+				0,
 			),
 			$this->getOutput(),
 		);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/4683

Looks like this:
```
$ php bin/phpstan clear-result-cache -q && php bin/phpstan -v
Note: Using configuration file /usr/src/myapp/phpstan.neon.
 1486/1486 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 56 secs/56 secs

 [OK] No errors                                                                 

Took about 1.35 GB memory
```