### PR TITLE
Improve conditional type resolving performance

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3856,52 +3856,44 @@ class MutatingScope implements Scope
 		return $this->inFirstLevelStatement;
 	}
 
-	public function mergeWith(?self $theirScope): self
+	public function mergeWith(?self $otherScope): self
 	{
-		$ourScope = $this;
-		foreach ($ourScope->conditionalExpressions as $conditionalExpression) {
-			$ourScope = $ourScope->resolveConditionalType($conditionalExpression[array_key_first($conditionalExpression)]->getTypeHolder()->getExpr());
+		if ($otherScope === null) {
+			return $this;
 		}
-		if ($theirScope === null) {
-			return $ourScope;
-		}
+		$ourExpressionTypes = $this->expressionTypes;
+		$theirExpressionTypes = $otherScope->expressionTypes;
 
-		foreach ($theirScope->conditionalExpressions as $conditionalExpression) {
-			$theirScope = $theirScope->resolveConditionalType($conditionalExpression[array_key_first($conditionalExpression)]->getTypeHolder()->getExpr());
-		}
-		$ourExpressionTypes = $ourScope->expressionTypes;
-		$theirExpressionTypes = $theirScope->expressionTypes;
-
-		$mergedExpressionTypes = $ourScope->mergeVariableHolders($ourExpressionTypes, $theirExpressionTypes);
-		$conditionalExpressions = $ourScope->intersectConditionalExpressions($theirScope->conditionalExpressions);
-		$conditionalExpressions = $ourScope->createConditionalExpressions(
+		$mergedExpressionTypes = $this->mergeVariableHolders($ourExpressionTypes, $theirExpressionTypes);
+		$conditionalExpressions = $this->intersectConditionalExpressions($otherScope->conditionalExpressions);
+		$conditionalExpressions = $this->createConditionalExpressions(
 			$conditionalExpressions,
 			$ourExpressionTypes,
 			$theirExpressionTypes,
 			$mergedExpressionTypes,
 		);
-		$conditionalExpressions = $ourScope->createConditionalExpressions(
+		$conditionalExpressions = $this->createConditionalExpressions(
 			$conditionalExpressions,
 			$theirExpressionTypes,
 			$ourExpressionTypes,
 			$mergedExpressionTypes,
 		);
-		return $ourScope->scopeFactory->create(
-			$ourScope->context,
-			$ourScope->isDeclareStrictTypes(),
-			$ourScope->getFunction(),
-			$ourScope->getNamespace(),
+		return $this->scopeFactory->create(
+			$this->context,
+			$this->isDeclareStrictTypes(),
+			$this->getFunction(),
+			$this->getNamespace(),
 			$mergedExpressionTypes,
-			$ourScope->mergeVariableHolders($ourScope->nativeExpressionTypes, $theirScope->nativeExpressionTypes),
+			$this->mergeVariableHolders($this->nativeExpressionTypes, $otherScope->nativeExpressionTypes),
 			$conditionalExpressions,
-			$ourScope->inClosureBindScopeClass,
-			$ourScope->anonymousFunctionReflection,
-			$ourScope->inFirstLevelStatement,
+			$this->inClosureBindScopeClass,
+			$this->anonymousFunctionReflection,
+			$this->inFirstLevelStatement,
 			[],
 			[],
 			[],
-			$ourScope->afterExtractCall && $theirScope->afterExtractCall,
-			$ourScope->parentScope,
+			$this->afterExtractCall && $otherScope->afterExtractCall,
+			$this->parentScope,
 		);
 	}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3483,14 +3483,16 @@ class MutatingScope implements Scope
 					}
 					$newConditionExpressionTypeHolders[$holderExprString] = $conditionalTypeHolder;
 				}
-				if ($newConditionExpressionTypeHolders === []) {
-					if ($conditionalExpression->getTypeHolder()->getCertainty()->no()) {
-						unset($expressionTypes[$conditionalExprString]);
-					} else {
-						$expressionTypes[$conditionalExprString] = $conditionalExpression->getTypeHolder();
-					}
-					continue 2;
+				if ($newConditionExpressionTypeHolders !== []) {
+					continue;
 				}
+
+				if ($conditionalExpression->getTypeHolder()->getCertainty()->no()) {
+					unset($expressionTypes[$conditionalExprString]);
+				} else {
+					$expressionTypes[$conditionalExprString] = $conditionalExpression->getTypeHolder();
+				}
+				continue 2;
 			}
 		}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3474,9 +3474,7 @@ class MutatingScope implements Scope
 		$nativeTypes = $scope->nativeExpressionTypes;
 		$nativeTypes[$exprString] = ExpressionTypeHolder::createYes($expr, $nativeType);
 
-		$newConditionalExpressions = [];
 		foreach ($scope->conditionalExpressions as $conditionalExprString => $conditionalExpressions) {
-			$newConditionalExpression = [];
 			foreach (array_reverse($conditionalExpressions) as $conditionalExpression) {
 				$newConditionExpressionTypeHolders = [];
 				foreach ($conditionalExpression->getConditionExpressionTypeHolders() as $holderExprString => $conditionalTypeHolder) {
@@ -3489,10 +3487,7 @@ class MutatingScope implements Scope
 					$expressionTypes[$conditionalExprString] = $conditionalExpression->getTypeHolder();
 					continue 2;
 				}
-				$newHolder = new ConditionalExpressionHolder($newConditionExpressionTypeHolders, $conditionalExpression->getTypeHolder());
-				$newConditionalExpression[$newHolder->getKey()] = $newHolder;
 			}
-			$newConditionalExpressions[$conditionalExprString] = $newConditionalExpression;
 		}
 
 		return $this->scopeFactory->create(
@@ -3502,7 +3497,7 @@ class MutatingScope implements Scope
 			$this->getNamespace(),
 			$expressionTypes,
 			$nativeTypes,
-			$newConditionalExpressions,
+			$this->conditionalExpressions,
 			$this->inClosureBindScopeClass,
 			$this->anonymousFunctionReflection,
 			$this->inFirstLevelStatement,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3751,6 +3751,7 @@ class MutatingScope implements Scope
 					unset($scope->expressionTypes[$conditionalExprString]);
 				} else {
 					$scope->expressionTypes[$conditionalExprString] = $conditionalExpression->getTypeHolder();
+					$specifiedExpressions[$conditionalExprString] = $conditionalExpression->getTypeHolder()->getType();
 				}
 				continue 2;
 			}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3484,7 +3484,11 @@ class MutatingScope implements Scope
 					$newConditionExpressionTypeHolders[$holderExprString] = $conditionalTypeHolder;
 				}
 				if ($newConditionExpressionTypeHolders === []) {
-					$expressionTypes[$conditionalExprString] = $conditionalExpression->getTypeHolder();
+					if ($conditionalExpression->getTypeHolder()->getCertainty()->no()) {
+						unset($expressionTypes[$conditionalExprString]);
+					} else {
+						$expressionTypes[$conditionalExprString] = $conditionalExpression->getTypeHolder();
+					}
 					continue 2;
 				}
 			}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3736,15 +3736,10 @@ class MutatingScope implements Scope
 
 		foreach ($scope->conditionalExpressions as $conditionalExprString => $conditionalExpressions) {
 			foreach (array_reverse($conditionalExpressions) as $conditionalExpression) {
-				$newConditionExpressionTypeHolders = [];
 				foreach ($conditionalExpression->getConditionExpressionTypeHolders() as $holderExprString => $conditionalTypeHolder) {
-					if (array_key_exists($holderExprString, $specifiedExpressions) && $specifiedExpressions[$holderExprString]->equals($conditionalTypeHolder->getType())) {
-						continue;
+					if (!array_key_exists($holderExprString, $specifiedExpressions) || !$specifiedExpressions[$holderExprString]->equals($conditionalTypeHolder->getType())) {
+						continue 2;
 					}
-					$newConditionExpressionTypeHolders[$holderExprString] = $conditionalTypeHolder;
-				}
-				if ($newConditionExpressionTypeHolders !== []) {
-					continue;
 				}
 
 				if ($conditionalExpression->getTypeHolder()->getCertainty()->no()) {

--- a/tests/PHPStan/Rules/SlowdownRuleTest.php
+++ b/tests/PHPStan/Rules/SlowdownRuleTest.php
@@ -31,6 +31,7 @@ class SlowdownRuleTest extends RuleTestCase
 			{
 				return [];
 			}
+
 		};
 	}
 

--- a/tests/PHPStan/Rules/SlowdownRuleTest.php
+++ b/tests/PHPStan/Rules/SlowdownRuleTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<Rule>
+ */
+class SlowdownRuleTest extends RuleTestCase
+{
+
+	/**
+	 * @return Rule<Node>
+	 */
+	protected function getRule(): Rule
+	{
+		return new class implements Rule {
+
+			public function getNodeType(): string
+			{
+				return Node::class;
+			}
+
+			/**
+			 * @return string[]
+			 */
+			public function processNode(Node $node, Scope $scope): array
+			{
+				return [];
+			}
+		};
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/1.9.x-slowdown.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -918,4 +918,13 @@ class DefinedVariableRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug5803(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = false;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/bug-5803.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-5803.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-5803.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug5803;
+
+function () {
+	if (!($_GET['foo'])) { // if 'foo' is falsy, SET $var
+		$var = "set";
+	}
+
+	if ($_GET['foo']) {
+
+	} else {
+		echo $var;
+	}
+};

--- a/tests/PHPStan/Rules/data/1.9.x-slowdown.php
+++ b/tests/PHPStan/Rules/data/1.9.x-slowdown.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Foo;
+
+use function trim;
+
+class Foo
+{
+
+	public const FIELD_TITLE = 'title';
+	public const FIELD_SOURCE = 'source';
+	public const FIELD_BODY = 'body';
+	public const EMPTY_NOTE_BODY = '-';
+
+	public const FIELD_NOTES = 'notes';
+	public const SUBFIELD_NOTE = 'note';
+
+	/**
+	 * @param array<mixed> $data
+	 * @return array<mixed>
+	 */
+	private function someMethod(array $data): array
+	{
+		foreach ($data[self::FIELD_NOTES][self::SUBFIELD_NOTE] ?? [] as $index => $noteData) {
+			$noteTitle = $noteData[self::FIELD_TITLE] ?? null;
+			$noteSource = $noteData[self::FIELD_SOURCE] ?? null;
+			$noteBody = $noteData[self::FIELD_BODY] ?? null;
+
+			if ($noteBody === null || trim($noteBody) === '') {
+				$data[self::FIELD_NOTES] = self::EMPTY_NOTE_BODY;
+			}
+		}
+
+		if (isset($data[self::FIELD_NOTES][self::SUBFIELD_NOTE])) {}
+
+		return $data;
+	}
+
+}


### PR DESCRIPTION
resolves https://github.com/phpstan/phpstan/discussions/8397
resolves https://github.com/phpstan/phpstan-src/pull/2033
closes https://github.com/phpstan/phpstan/issues/5805

~~I've improved the logic of `conditionalExpressions` to only resolve conditional types when needed, instead of resolving all `conditionalExpressions` every time `filterBySpecifiedTypes` is called.
I'm quite confident that this change can improve the performance :)~~
Now, all I have to do is to pass all the tests!

Update:

Instead of calling `getType` each time to check if conditional types's conditions are resolvable, I changed to only check if the conditions are specified and the specified type is same as the condition type.
This became possible, because previous refactoring made `assignExpression` and `specifyExpressionType` separated correctly, and `$scope->getType` can be used to get the specified types:+1: