### PR TITLE
Example test of huge slowdown in 1.9.x

### DIFF
--- a/tests/PHPStan/Rules/SlowdownRuleTest.php
+++ b/tests/PHPStan/Rules/SlowdownRuleTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<Rule>
+ */
+class SlowdownRuleTest extends RuleTestCase
+{
+
+	/**
+	 * @return Rule<Node>
+	 */
+	protected function getRule(): Rule
+	{
+		return new class implements Rule {
+
+			public function getNodeType(): string
+			{
+				return Node::class;
+			}
+
+			/**
+			 * @return string[]
+			 */
+			public function processNode(Node $node, Scope $scope): array
+			{
+				return [];
+			}
+		};
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/1.9.x-slowdown.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Rules/data/1.9.x-slowdown.php
+++ b/tests/PHPStan/Rules/data/1.9.x-slowdown.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Foo;
+
+use function trim;
+
+class Foo
+{
+
+	public const FIELD_TITLE = 'title';
+	public const FIELD_SOURCE = 'source';
+	public const FIELD_BODY = 'body';
+	public const EMPTY_NOTE_BODY = '-';
+
+	public const FIELD_NOTES = 'notes';
+	public const SUBFIELD_NOTE = 'note';
+
+	/**
+	 * @param array<mixed> $data
+	 * @return array<mixed>
+	 */
+	private function someMethod(array $data): array
+	{
+		foreach ($data[self::FIELD_NOTES][self::SUBFIELD_NOTE] ?? [] as $index => $noteData) {
+			$noteTitle = $noteData[self::FIELD_TITLE] ?? null;
+			$noteSource = $noteData[self::FIELD_SOURCE] ?? null;
+			$noteBody = $noteData[self::FIELD_BODY] ?? null;
+
+			if ($noteBody === null || trim($noteBody) === '') {
+				$data[self::FIELD_NOTES] = self::EMPTY_NOTE_BODY;
+			}
+		}
+
+		if (isset($data[self::FIELD_NOTES][self::SUBFIELD_NOTE])) {}
+
+		return $data;
+	}
+
+}


### PR DESCRIPTION
Hi, I'm meeting huge slowdown (feels like infinite loop, but probably is some exponential time degradation) in 1.9.x, here is a separated (minimal) example.

- takes **minutes** on 1.9.x
- takes **4 secs** on 1.9.2 (which still feels a lot)

Possibly related to https://github.com/phpstan/phpstan-src/pull/2030