### PR TITLE
TableErrorFormatter: allow editor url title configuration

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -205,6 +205,7 @@ parameters:
 		- ZEND_THREAD_SAFE
 	customRulesetUsed: null
 	editorUrl: null
+	editorUrlTitle: null
 	errorFormat: null
 	__validate: true
 
@@ -384,6 +385,7 @@ parametersSchema:
 	scanDirectories: listOf(string())
 	fixerTmpDir: string()
 	editorUrl: schema(string(), nullable())
+	editorUrlTitle: schema(string(), nullable())
 	errorFormat: schema(string(), nullable())
 
 	# irrelevant Nette parameters
@@ -2012,6 +2014,7 @@ services:
 			simpleRelativePathHelper: @simpleRelativePathHelper
 			showTipsOfTheDay: %tipsOfTheDay%
 			editorUrl: %editorUrl%
+			editorUrlTitle: %editorUrlTitle%
 
 	errorFormatter.checkstyle:
 		class: PHPStan\Command\ErrorFormatter\CheckstyleErrorFormatter

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -25,6 +25,7 @@ class TableErrorFormatter implements ErrorFormatter
 		private CiDetectedErrorFormatter $ciDetectedErrorFormatter,
 		private bool $showTipsOfTheDay,
 		private ?string $editorUrl,
+		private ?string $editorUrlTitle,
 	)
 	{
 	}
@@ -86,7 +87,18 @@ class TableErrorFormatter implements ErrorFormatter
 						[$editorFile, $this->simpleRelativePathHelper->getRelativePath($editorFile), (string) $error->getLine()],
 						$this->editorUrl,
 					);
-					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $this->relativePathHelper->getRelativePath($editorFile) . '</>';
+
+					if (is_string($this->editorUrlTitle)) {
+						$title = str_replace(
+							['%file%', '%relFile%', '%line%'],
+							[$editorFile, $this->simpleRelativePathHelper->getRelativePath($editorFile), (string) $error->getLine()],
+							$this->editorUrlTitle,
+						);
+					} else {
+						$title = $this->relativePathHelper->getRelativePath($editorFile);
+					}
+
+					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
 				}
 				$rows[] = [
 					$this->formatLineNumber($error->getLine()),

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -77,6 +77,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 			),
 			false,
 			null,
+			null,
 		);
 		$analysisResult = $analyserApplication->analyse(
 			[$path],

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -224,6 +224,15 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		$this->assertStringContainsString('editor://custom/path/rel/Foo.php', $this->getOutputContent(true));
 	}
 
+	public function testEditorUrlWithCustomTitle(): void
+	{
+		$formatter = $this->createErrorFormatter('editor://any', '%relFile%:%line%');
+		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true), $this->getOutput(true));
+
+		$this->assertStringContainsString('rel/Foo.php:12', $this->getOutputContent(true));
+	}
+
 	public function testBug6727(): void
 	{
 		putenv('COLUMNS=30');
@@ -250,7 +259,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		self::expectNotToPerformAssertions();
 	}
 
-	private function createErrorFormatter(?string $editorUrl): TableErrorFormatter
+	private function createErrorFormatter(?string $editorUrl, ?string $editorUrlTitle = null): TableErrorFormatter
 	{
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
 
@@ -263,6 +272,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			),
 			false,
 			$editorUrl,
+			$editorUrlTitle,
 		);
 	}
 


### PR DESCRIPTION
This allows me to have easily-copyable file+line even in GitLab CI even in docker and clickable locally.
```
parameters:
    editorUrl: 'phpstorm://open?file=%%relFile%%&line=%%line%%'
    editorUrlTitle: '%%file%%:%%line%%'
```

```
$ php bin/phpstan analyse --debug src/Parallel/ParallelAnalyser.php
Using php 8.1 from dockerhub
Note: Using configuration file /usr/src/myapp/phpstan.neon.
/usr/src/myapp/src/Parallel/ParallelAnalyser.php
 ------ ------------------------------------------------------------ 
  Line   ParallelAnalyser.php                                        
 ------ ------------------------------------------------------------ 
  195    Anonymous function has an unused use $internalErrorsCount.  
         ✏️  src/Parallel/ParallelAnalyser.php:195                   
 ------ ------------------------------------------------------------
```

Related: https://github.com/phpstan/phpstan/issues/7796
