### PR TITLE
Improve error messages for logical/boolean AND/OR (bleeding edge)

### DIFF
--- a/src/Rules/Comparison/BooleanAndConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanAndConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\BooleanAndNode;
 use PHPStan\Rules\Rule;
@@ -10,6 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use function count;
 use function sprintf;
+use function strtoupper;
 
 /**
  * @implements Rule<BooleanAndNode>
@@ -37,7 +40,7 @@ class BooleanAndConstantConditionRule implements Rule
 	{
 		$errors = [];
 		$originalNode = $node->getOriginalNode();
-		$nodeText = $this->bleedingEdge ? $originalNode->getOperatorSigil() : '&&';
+		$nodeText = $this->bleedingEdge ? $this->getOperatorDescription($originalNode) : '&&';
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		if ($leftType instanceof ConstantBooleanType) {
@@ -118,6 +121,15 @@ class BooleanAndConstantConditionRule implements Rule
 		}
 
 		return $errors;
+	}
+
+	private function getOperatorDescription(LogicalAnd|BooleanAnd $originalNode): string
+	{
+		return sprintf(
+			'%s %s',
+			$originalNode instanceof LogicalAnd ? 'logical' : 'boolean',
+			strtoupper($originalNode->getOperatorSigil()),
+		);
 	}
 
 }

--- a/src/Rules/Comparison/BooleanOrConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanOrConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\BooleanOrNode;
 use PHPStan\Rules\Rule;
@@ -10,6 +12,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use function count;
 use function sprintf;
+use function strtoupper;
 
 /**
  * @implements Rule<BooleanOrNode>
@@ -36,7 +39,7 @@ class BooleanOrConstantConditionRule implements Rule
 	): array
 	{
 		$originalNode = $node->getOriginalNode();
-		$nodeText = $this->bleedingEdge ? $originalNode->getOperatorSigil() : '||';
+		$nodeText = $this->bleedingEdge ? $this->getOperatorDescription($originalNode) : '||';
 		$messages = [];
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
@@ -118,6 +121,15 @@ class BooleanOrConstantConditionRule implements Rule
 		}
 
 		return $messages;
+	}
+
+	private function getOperatorDescription(LogicalOr|BooleanOr $originalNode): string
+	{
+		return sprintf(
+			'%s %s',
+			$originalNode instanceof LogicalOr ? 'logical' : 'boolean',
+			strtoupper($originalNode->getOperatorSigil()),
+		);
 	}
 
 }

--- a/tests/PHPStan/Levels/data/unreachable-4-alwaysTrue.json
+++ b/tests/PHPStan/Levels/data/unreachable-4-alwaysTrue.json
@@ -40,63 +40,88 @@
         "ignorable": true
     },
     {
-        "message": "Left side of && is always true.",
+        "message": "Left side of boolean && is always true.",
         "line": 59,
         "ignorable": true
     },
     {
-        "message": "Right side of && is always true.",
+        "message": "Right side of boolean && is always true.",
         "line": 59,
+        "ignorable": true
+    },
+    {
+        "message": "If condition is always true.",
+        "line": 71,
+        "ignorable": true
+    },
+    {
+        "message": "Left side of logical AND is always true.",
+        "line": 71,
+        "ignorable": true
+    },
+    {
+        "message": "Right side of logical AND is always true.",
+        "line": 71,
         "ignorable": true
     },
     {
         "message": "Else branch is unreachable because ternary operator condition is always true.",
-        "line": 74,
+        "line": 86,
         "ignorable": true
     },
     {
         "message": "Strict comparison using === between 5 and 5 will always evaluate to true.",
-        "line": 74,
+        "line": 86,
         "ignorable": true
     },
     {
         "message": "Else branch is unreachable because ternary operator condition is always true.",
-        "line": 79,
+        "line": 91,
         "ignorable": true
     },
     {
         "message": "Instanceof between $this(Levels\\Unreachable\\Bar) and Levels\\Unreachable\\Bar will always evaluate to true.",
-        "line": 79,
+        "line": 91,
         "ignorable": true
     },
     {
         "message": "Call to function is_string() with string will always evaluate to true.",
-        "line": 84,
+        "line": 96,
         "ignorable": true
     },
     {
         "message": "Else branch is unreachable because ternary operator condition is always true.",
-        "line": 84,
+        "line": 96,
         "ignorable": true
     },
     {
         "message": "Ternary operator condition is always true.",
-        "line": 89,
+        "line": 101,
         "ignorable": true
     },
     {
         "message": "Ternary operator condition is always true.",
-        "line": 94,
+        "line": 106,
         "ignorable": true
     },
     {
-        "message": "Left side of && is always true.",
-        "line": 102,
+        "message": "Left side of boolean && is always true.",
+        "line": 114,
         "ignorable": true
     },
     {
-        "message": "Right side of && is always true.",
-        "line": 102,
+        "message": "Right side of boolean && is always true.",
+        "line": 114,
+        "ignorable": true
+    },
+    {
+        "message": "Left side of logical AND is always true.",
+        "line": 122,
+        "ignorable": true
+    },
+    {
+        "message": "Ternary operator condition is always true.",
+        "line": 122,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/unreachable-4.json
+++ b/tests/PHPStan/Levels/data/unreachable-4.json
@@ -25,48 +25,68 @@
         "ignorable": true
     },
     {
-        "message": "Left side of && is always true.",
+        "message": "Left side of boolean && is always true.",
         "line": 59,
         "ignorable": true
     },
     {
-        "message": "Right side of && is always true.",
+        "message": "Right side of boolean && is always true.",
         "line": 59,
         "ignorable": true
     },
     {
-        "message": "Else branch is unreachable because ternary operator condition is always true.",
-        "line": 74,
+        "message": "Left side of logical AND is always true.",
+        "line": 71,
+        "ignorable": true
+    },
+    {
+        "message": "Right side of logical AND is always true.",
+        "line": 71,
         "ignorable": true
     },
     {
         "message": "Else branch is unreachable because ternary operator condition is always true.",
-        "line": 79,
+        "line": 86,
         "ignorable": true
     },
     {
         "message": "Else branch is unreachable because ternary operator condition is always true.",
-        "line": 84,
+        "line": 91,
+        "ignorable": true
+    },
+    {
+        "message": "Else branch is unreachable because ternary operator condition is always true.",
+        "line": 96,
         "ignorable": true
     },
     {
         "message": "Ternary operator condition is always true.",
-        "line": 89,
+        "line": 101,
         "ignorable": true
     },
     {
         "message": "Ternary operator condition is always true.",
-        "line": 94,
+        "line": 105,
         "ignorable": true
     },
     {
-        "message": "Left side of && is always true.",
-        "line": 102,
+        "message": "Left side of boolean && is always true.",
+        "line": 114,
         "ignorable": true
     },
     {
-        "message": "Right side of && is always true.",
-        "line": 102,
+        "message": "Right side of boolean && is always true.",
+        "line": 114,
+        "ignorable": true
+    },
+    {
+        "message": "Left side of logical AND is always true.",
+        "line": 114,
+        "ignorable": true
+    },
+    {
+        "message": "Right side of logical AND is always true.",
+        "line": 114,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/unreachable-6-alwaysTrue.json
+++ b/tests/PHPStan/Levels/data/unreachable-6-alwaysTrue.json
@@ -30,33 +30,43 @@
         "ignorable": true
     },
     {
+        "message": "Method Levels\\Unreachable\\Foo::doLogicalAnd() has no return type specified.",
+        "line": 66,
+        "ignorable": true
+    },
+    {
         "message": "Method Levels\\Unreachable\\Bar::doStrictComparison() has no return type specified.",
-        "line": 71,
+        "line": 83,
         "ignorable": true
     },
     {
         "message": "Method Levels\\Unreachable\\Bar::doInstanceOf() has no return type specified.",
-        "line": 77,
+        "line": 89,
         "ignorable": true
     },
     {
         "message": "Method Levels\\Unreachable\\Bar::doTypeSpecifyingFunction() has no return type specified.",
-        "line": 82,
+        "line": 94,
         "ignorable": true
     },
     {
         "message": "Method Levels\\Unreachable\\Bar::doOtherFunction() has no return type specified.",
-        "line": 87,
+        "line": 99,
         "ignorable": true
     },
     {
         "message": "Method Levels\\Unreachable\\Bar::doOtherValue() has no return type specified.",
-        "line": 92,
+        "line": 104,
         "ignorable": true
     },
     {
         "message": "Method Levels\\Unreachable\\Bar::doBooleanAnd() has no return type specified.",
-        "line": 97,
+        "line": 109,
+        "ignorable": true
+    },
+    {
+        "message": "Method Levels\\Unreachable\\Bar::doLogicalAnd() has no return type specified.",
+        "line": 117,
         "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/unreachable.php
+++ b/tests/PHPStan/Levels/data/unreachable.php
@@ -63,6 +63,18 @@ class Foo
 		}
 	}
 
+	public function doLogicalAnd()
+	{
+		$foo = 1;
+		$bar = 2;
+
+		if ($foo and $bar) {
+
+		} else {
+
+		}
+	}
+
 }
 
 class Bar
@@ -100,6 +112,14 @@ class Bar
 		$bar = 2;
 
 		$foo && $bar ? 'foo' : 'bar';
+	}
+
+	public function doLogicalAnd()
+	{
+		$foo = 1;
+		$bar = 2;
+
+		$foo and $bar ? 'foo' : 'bar';
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -121,6 +121,90 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRuleAndBleedingEdge(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->bleedingEdge = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/boolean-and.php'], [
+			[
+				'Left side of boolean && is always true.',
+				15,
+			],
+			[
+				'Right side of boolean && is always true.',
+				19,
+			],
+			[
+				'Left side of boolean && is always false.',
+				24,
+			],
+			[
+				'Right side of boolean && is always false.',
+				27,
+			],
+			[
+				'Result of boolean && is always false.',
+				30,
+			],
+			[
+				'Right side of boolean && is always true.',
+				33,
+			],
+			[
+				'Right side of boolean && is always true.',
+				36,
+			],
+			[
+				'Right side of boolean && is always true.',
+				39,
+			],
+			[
+				'Result of boolean && is always false.',
+				50,
+			],
+			[
+				'Result of boolean && is always true.',
+				54,
+				$tipText,
+			],
+			[
+				'Result of boolean && is always false.',
+				60,
+			],
+			[
+				'Result of boolean && is always true.',
+				64,
+				//$tipText,
+			],
+			[
+				'Result of boolean && is always false.',
+				66,
+				//$tipText,
+			],
+			[
+				'Result of boolean && is always false.',
+				125,
+			],
+			[
+				'Left side of boolean && is always false.',
+				139,
+			],
+			[
+				'Right side of boolean && is always false.',
+				141,
+			],
+			[
+				'Left side of boolean && is always true.',
+				145,
+			],
+			[
+				'Right side of boolean && is always true.',
+				147,
+			],
+		]);
+	}
+
 	public function testRuleLogicalAnd(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -211,78 +211,78 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		$this->analyse([__DIR__ . '/data/boolean-logical-and.php'], [
 			[
-				'Left side of and is always true.',
+				'Left side of logical AND is always true.',
 				15,
 			],
 			[
-				'Right side of and is always true.',
+				'Right side of logical AND is always true.',
 				19,
 			],
 			[
-				'Left side of and is always false.',
+				'Left side of logical AND is always false.',
 				24,
 			],
 			[
-				'Right side of and is always false.',
+				'Right side of logical AND is always false.',
 				27,
 			],
 			[
-				'Result of and is always false.',
+				'Result of logical AND is always false.',
 				30,
 			],
 			[
-				'Right side of and is always true.',
+				'Right side of logical AND is always true.',
 				33,
 			],
 			[
-				'Right side of and is always true.',
+				'Right side of logical AND is always true.',
 				36,
 			],
 			[
-				'Right side of and is always true.',
+				'Right side of logical AND is always true.',
 				39,
 			],
 			[
-				'Result of and is always false.',
+				'Result of logical AND is always false.',
 				50,
 			],
 			[
-				'Result of and is always true.',
+				'Result of logical AND is always true.',
 				54,
 				$tipText,
 			],
 			[
-				'Result of and is always false.',
+				'Result of logical AND is always false.',
 				60,
 			],
 			[
-				'Result of and is always true.',
+				'Result of logical AND is always true.',
 				64,
 				//$tipText,
 			],
 			[
-				'Result of and is always false.',
+				'Result of logical AND is always false.',
 				66,
 				//$tipText,
 			],
 			[
-				'Result of and is always false.',
+				'Result of logical AND is always false.',
 				125,
 			],
 			[
-				'Left side of and is always false.',
+				'Left side of logical AND is always false.',
 				139,
 			],
 			[
-				'Right side of and is always false.',
+				'Right side of logical AND is always false.',
 				141,
 			],
 			[
-				'Left side of and is always true.',
+				'Left side of logical AND is always true.',
 				145,
 			],
 			[
-				'Right side of and is always true.',
+				'Right side of logical AND is always true.',
 				147,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -194,69 +194,69 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		$this->analyse([__DIR__ . '/data/boolean-logical-or.php'], [
 			[
-				'Left side of or is always true.',
+				'Left side of logical OR is always true.',
 				15,
 			],
 			[
-				'Right side of or is always true.',
+				'Right side of logical OR is always true.',
 				19,
 			],
 			[
-				'Left side of or is always false.',
+				'Left side of logical OR is always false.',
 				24,
 			],
 			[
-				'Right side of or is always false.',
+				'Right side of logical OR is always false.',
 				27,
 			],
 			[
-				'Right side of or is always true.',
+				'Right side of logical OR is always true.',
 				30,
 			],
 			[
-				'Result of or is always true.',
+				'Result of logical OR is always true.',
 				33,
 			],
 			[
-				'Right side of or is always false.',
+				'Right side of logical OR is always false.',
 				36,
 			],
 			[
-				'Right side of or is always false.',
+				'Right side of logical OR is always false.',
 				39,
 			],
 			[
-				'Result of or is always true.',
+				'Result of logical OR is always true.',
 				50,
 				$tipText,
 			],
 			[
-				'Result of or is always true.',
+				'Result of logical OR is always true.',
 				54,
 				$tipText,
 			],
 			[
-				'Result of or is always true.',
+				'Result of logical OR is always true.',
 				61,
 			],
 			[
-				'Result of or is always true.',
+				'Result of logical OR is always true.',
 				65,
 			],
 			[
-				'Left side of or is always false.',
+				'Left side of logical OR is always false.',
 				77,
 			],
 			[
-				'Right side of or is always false.',
+				'Right side of logical OR is always false.',
 				79,
 			],
 			[
-				'Left side of or is always true.',
+				'Left side of logical OR is always true.',
 				83,
 			],
 			[
-				'Right side of or is always true.',
+				'Right side of logical OR is always true.',
 				85,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -113,6 +113,81 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRuleAndBleedingEdge(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->bleedingEdge = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/boolean-or.php'], [
+			[
+				'Left side of boolean || is always true.',
+				15,
+			],
+			[
+				'Right side of boolean || is always true.',
+				19,
+			],
+			[
+				'Left side of boolean || is always false.',
+				24,
+			],
+			[
+				'Right side of boolean || is always false.',
+				27,
+			],
+			[
+				'Right side of boolean || is always true.',
+				30,
+			],
+			[
+				'Result of boolean || is always true.',
+				33,
+			],
+			[
+				'Right side of boolean || is always false.',
+				36,
+			],
+			[
+				'Right side of boolean || is always false.',
+				39,
+			],
+			[
+				'Result of boolean || is always true.',
+				50,
+				$tipText,
+			],
+			[
+				'Result of boolean || is always true.',
+				54,
+				$tipText,
+			],
+			[
+				'Result of boolean || is always true.',
+				61,
+			],
+			[
+				'Result of boolean || is always true.',
+				65,
+			],
+			[
+				'Left side of boolean || is always false.',
+				77,
+			],
+			[
+				'Right side of boolean || is always false.',
+				79,
+			],
+			[
+				'Left side of boolean || is always true.',
+				83,
+			],
+			[
+				'Right side of boolean || is always true.',
+				85,
+			],
+		]);
+	}
+
 	public function testRuleLogicalOr(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;


### PR DESCRIPTION
As discussed [here](https://github.com/phpstan/phpstan/discussions/8385) I would like to improve error messages for logical/boolean AND/OR checks.

- include kind (`logical` vs `boolean`), taken from processed node
- uppercased sigil (`AND` instead of `and`, `OR` instead of `or`) for better readability