### PR TITLE
Non-static method `DOMDocument::loadHTML()` can be called statically

### DIFF
--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Methods;
 
+use DOMDocument;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\NullsafeOperatorHelper;
@@ -224,6 +225,11 @@ class StaticMethodCallCheck
 					&& !$scope->getClassReflection()->isSubclassOf($classType->getClassName())
 				)
 			) {
+				// per php-src docs, this method can be called statically, even if declared non-static
+				if (strtolower($method->getName()) === 'loadhtml' && $method->getDeclaringClass()->getName() === DOMDocument::class) {
+					return [[], null];
+				}
+
 				return [
 					array_merge($errors, [
 						RuleErrorBuilder::message(sprintf(

--- a/tests/PHPStan/Rules/Methods/data/call-static-methods.php
+++ b/tests/PHPStan/Rules/Methods/data/call-static-methods.php
@@ -345,3 +345,11 @@ class CallWithStatic
 	}
 
 }
+
+class Bug2759 {
+	public function sayHello(string $html): void
+	{
+		$dom = \DOMDocument::loadHTML($html, LIBXML_NOWARNING | LIBXML_NONET | LIBXML_NOERROR);
+	}
+}
+


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/2759

expected test failure without the src/ change:

```diff
2) PHPStan\Rules\Methods\CallStaticMethodsRuleTest::testCallStaticMethods
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 328: Call to static method doFoo() on an unknown class CallStaticMethods\TraitWithStaticMethod.
     💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
 344: Call to an undefined static method static(CallStaticMethods\CallWithStatic)::nonexistent().
+352: Static call to instance method DOMDocument::loadHTML().
 '

/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:153
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php:40
```