### PR TITLE
Fix comparison with get_class() in traits always evaluate to true

### DIFF
--- a/src/Type/Php/GetClassDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetClassDynamicReturnTypeExtension.php
@@ -17,6 +17,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeWithClassName;
@@ -34,12 +35,17 @@ class GetClassDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExt
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
 		$args = $functionCall->getArgs();
+
 		if (count($args) === 0) {
 			if ($scope->isInClass()) {
 				return new ConstantStringType($scope->getClassReflection()->getName(), true);
 			}
 
 			return new ConstantBooleanType(false);
+		}
+
+		if ($scope->isInTrait()) {
+			return new StringType();
 		}
 
 		$argType = $scope->getType($args[0]->value);

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -625,23 +625,55 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3633.php'], [
 			[
 				'Strict comparison using === between class-string<Bug3633\HelloWorld> and \'Bug3633\\\OtherClass\' will always evaluate to false.',
-				23,
+				37,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\HelloWorld\' and \'Bug3633\\\HelloWorld\' will always evaluate to true.',
+				41,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\HelloWorld\' and \'Bug3633\\\OtherClass\' will always evaluate to false.',
+				44,
 			],
 			[
 				'Strict comparison using === between class-string<Bug3633\OtherClass> and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
-				35,
+				64,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\OtherClass\' and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
+				71,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\OtherClass\' and \'Bug3633\\\OtherClass\' will always evaluate to true.',
+				74,
 			],
 			[
 				'Strict comparison using === between class-string<Bug3633\FinalClass> and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
-				50,
+				93,
 			],
 			[
 				'Strict comparison using === between class-string<Bug3633\FinalClass> and \'Bug3633\\\OtherClass\' will always evaluate to false.',
-				53,
+				96,
 			],
 			[
 				'Strict comparison using === between \'Bug3633\\\FinalClass\' and \'Bug3633\\\FinalClass\' will always evaluate to true.',
-				59,
+				102,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\FinalClass\' and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
+				106,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\FinalClass\' and \'Bug3633\\\OtherClass\' will always evaluate to false.',
+				109,
+			],
+			[
+				'Strict comparison using !== between \'Bug3633\\\FinalClass\' and \'Bug3633\\\FinalClass\' will always evaluate to false.',
+				112,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\FinalClass\' and \'Bug3633\\\FinalClass\' will always evaluate to true.',
+				115,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -619,4 +619,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8586.php'], []);
 	}
 
+	public function testBug3633(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-3633.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -622,7 +622,28 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 	public function testBug3633(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;
-		$this->analyse([__DIR__ . '/data/bug-3633.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-3633.php'], [
+			[
+				'Strict comparison using === between class-string<Bug3633\HelloWorld> and \'Bug3633\\\OtherClass\' will always evaluate to false.',
+				23,
+			],
+			[
+				'Strict comparison using === between class-string<Bug3633\OtherClass> and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
+				35,
+			],
+			[
+				'Strict comparison using === between class-string<Bug3633\FinalClass> and \'Bug3633\\\HelloWorld\' will always evaluate to false.',
+				50,
+			],
+			[
+				'Strict comparison using === between class-string<Bug3633\FinalClass> and \'Bug3633\\\OtherClass\' will always evaluate to false.',
+				53,
+			],
+			[
+				'Strict comparison using === between \'Bug3633\\\FinalClass\' and \'Bug3633\\\FinalClass\' will always evaluate to true.',
+				59,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-3633.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3633.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3633;
+
+trait Foo {
+	public function test(): void {
+		if (get_class($this) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($this) === OtherClass::class) {
+			echo "OK";
+		}
+	}
+}
+
+class HelloWorld {
+	use Foo;
+
+	public function bar(): void {
+		$this->test();
+	}
+}
+
+class OtherClass {
+	use Foo;
+
+	public function bar(): void {
+		$this->test();
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-3633.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3633.php
@@ -17,6 +17,13 @@ class HelloWorld {
 	use Foo;
 
 	public function bar(): void {
+		if (get_class($this) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($this) === OtherClass::class) {
+			echo "OK";
+		}
+
 		$this->test();
 	}
 }
@@ -25,6 +32,34 @@ class OtherClass {
 	use Foo;
 
 	public function bar(): void {
+		if (get_class($this) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($this) === OtherClass::class) {
+			echo "OK";
+		}
+
+		$this->test();
+	}
+}
+
+final class FinalClass {
+	use Foo;
+
+	public function bar(): void {
+		if (get_class($this) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($this) === OtherClass::class) {
+			echo "OK";
+		}
+		if (get_class($this) !== FinalClass::class) {
+			echo "OK";
+		}
+		if (get_class($this) === FinalClass::class) {
+			echo "OK";
+		}
+
 		$this->test();
 	}
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-3633.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3633.php
@@ -3,11 +3,25 @@
 namespace Bug3633;
 
 trait Foo {
-	public function test(): void {
+	public function test($obj): void {
 		if (get_class($this) === HelloWorld::class) {
 			echo "OK";
 		}
 		if (get_class($this) === OtherClass::class) {
+			echo "OK";
+		}
+
+		if (get_class() === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class() === OtherClass::class) {
+			echo "OK";
+		}
+
+		if (get_class($obj) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($obj) === OtherClass::class) {
 			echo "OK";
 		}
 	}
@@ -16,13 +30,28 @@ trait Foo {
 class HelloWorld {
 	use Foo;
 
-	public function bar(): void {
+	public function bar($obj): void {
 		if (get_class($this) === HelloWorld::class) {
 			echo "OK";
 		}
 		if (get_class($this) === OtherClass::class) {
 			echo "OK";
 		}
+
+		if (get_class() === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class() === OtherClass::class) {
+			echo "OK";
+		}
+
+		if (get_class($obj) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($obj) === OtherClass::class) {
+			echo "OK";
+		}
+
 
 		$this->test();
 	}
@@ -31,11 +60,25 @@ class HelloWorld {
 class OtherClass {
 	use Foo;
 
-	public function bar(): void {
+	public function bar($obj): void {
 		if (get_class($this) === HelloWorld::class) {
 			echo "OK";
 		}
 		if (get_class($this) === OtherClass::class) {
+			echo "OK";
+		}
+
+		if (get_class() === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class() === OtherClass::class) {
+			echo "OK";
+		}
+
+		if (get_class($obj) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($obj) === OtherClass::class) {
 			echo "OK";
 		}
 
@@ -46,7 +89,7 @@ class OtherClass {
 final class FinalClass {
 	use Foo;
 
-	public function bar(): void {
+	public function bar($obj): void {
 		if (get_class($this) === HelloWorld::class) {
 			echo "OK";
 		}
@@ -57,6 +100,26 @@ final class FinalClass {
 			echo "OK";
 		}
 		if (get_class($this) === FinalClass::class) {
+			echo "OK";
+		}
+
+		if (get_class() === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class() === OtherClass::class) {
+			echo "OK";
+		}
+		if (get_class() !== FinalClass::class) {
+			echo "OK";
+		}
+		if (get_class() === FinalClass::class) {
+			echo "OK";
+		}
+
+		if (get_class($obj) === HelloWorld::class) {
+			echo "OK";
+		}
+		if (get_class($obj) === OtherClass::class) {
 			echo "OK";
 		}
 


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/3633

see https://3v4l.org/LalXd

test fails without the src change:

```diff
1) PHPStan\Rules\Comparison\StrictComparisonOfDifferentTypesRuleTest::testBug3633
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'23: Strict comparison using === between class-string<Bug3633\HelloWorld> and 'Bug3633\\OtherClass' will always evaluate to false.
+'10: Strict comparison using === between class-string<Bug3633\HelloWorld> and 'Bug3633\\OtherClass' will always evaluate to false.
+23: Strict comparison using === between class-string<Bug3633\HelloWorld> and 'Bug3633\\OtherClass' will always evaluate to false.
+07: Strict comparison using === between class-string<Bug3633\OtherClass> and 'Bug3633\\HelloWorld' will always evaluate to false.
 35: Strict comparison using === between class-string<Bug3633\OtherClass> and 'Bug3633\\HelloWorld' will always evaluate to false.
+07: Strict comparison using === between class-string<Bug3633\FinalClass> and 'Bug3633\\HelloWorld' will always evaluate to false.
+10: Strict comparison using === between class-string<Bug3633\FinalClass> and 'Bug3633\\OtherClass' will always evaluate to false.
 50: Strict comparison using === between class-string<Bug3633\FinalClass> and 'Bug3633\\HelloWorld' will always evaluate to false.
 53: Strict comparison using === between class-string<Bug3633\FinalClass> and 'Bug3633\\OtherClass' will always evaluate to false.
 59: Strict comparison using === between 'Bug3633\\FinalClass' and 'Bug3633\\FinalClass' will always evaluate to true.
 '
```