### PR TITLE
Fix class-const resolving will always evaluate to true/false in traits

### DIFF
--- a/build/enum-adapter-errors.neon
+++ b/build/enum-adapter-errors.neon
@@ -347,7 +347,7 @@ parameters:
 
 		-
 			message: "#^Call to method getProperty\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
+			count: 2
 			path: ../tests/PHPStan/Analyser/AnalyserIntegrationTest.php
 
 		-

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1621,11 +1621,13 @@ class MutatingScope implements Scope
 			if ($this->hasExpressionType($node)->yes()) {
 				return $this->expressionTypes[$exprString]->getType();
 			}
+
 			return $this->initializerExprTypeResolver->getClassConstFetchTypeByReflection(
 				$node->class,
 				$node->name->name,
 				$this->isInClass() ? $this->getClassReflection() : null,
 				fn (Expr $expr): Type => $this->getType($expr),
+				InitializerExprContext::fromScope($this),
 			);
 		}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -2,9 +2,6 @@
 
 namespace PHPStan\Analyser;
 
-use Bug4288\MyClass;
-use Bug4713\Service;
-use ExtendingKnownClassWithCheck\Foo;
 use PHPStan\File\FileHelper;
 use PHPStan\Reflection\InitializerExprContext;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -13,6 +10,7 @@ use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\MixedType;
 use function extension_loaded;
 use function restore_error_handler;
 use function sprintf;
@@ -84,7 +82,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 
 		$reflectionProvider = $this->createReflectionProvider();
-		$this->assertTrue($reflectionProvider->hasClass(Foo::class));
+		$this->assertTrue($reflectionProvider->hasClass(\ExtendingKnownClassWithCheck\Foo::class)); // phpcs:ignore
 	}
 
 	public function testInfiniteRecursionWithCallable(): void
@@ -354,11 +352,11 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame('Method Bug4713\Service::createInstance() should return Bug4713\Service but returns object.', $errors[0]->getMessage());
 
 		$reflectionProvider = $this->createReflectionProvider();
-		$class = $reflectionProvider->getClass(Service::class);
+		$class = $reflectionProvider->getClass(\Bug4713\Service::class); // phpcs:ignore
 		$parameter = ParametersAcceptorSelector::selectSingle($class->getNativeMethod('createInstance')->getVariants())->getParameters()[0];
 		$defaultValue = $parameter->getDefaultValue();
 		$this->assertInstanceOf(ConstantStringType::class, $defaultValue);
-		$this->assertSame(Service::class, $defaultValue->getValue());
+		$this->assertSame(\Bug4713\Service::class, $defaultValue->getValue()); // phpcs:ignore
 	}
 
 	public function testBug4288(): void
@@ -367,7 +365,28 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 
 		$reflectionProvider = $this->createReflectionProvider();
-		$class = $reflectionProvider->getClass(MyClass::class);
+		$class = $reflectionProvider->getClass(\Bug4288\MyClass::class); // phpcs:ignore
+		$parameter = ParametersAcceptorSelector::selectSingle($class->getNativeMethod('paginate')->getVariants())->getParameters()[0];
+		$defaultValue = $parameter->getDefaultValue();
+		$this->assertInstanceOf(MixedType::class, $defaultValue);
+
+		$nativeProperty = $class->getNativeReflection()->getProperty('test');
+		$initializerExprTypeResolver = self::getContainer()->getByType(InitializerExprTypeResolver::class);
+		$defaultValueType = $initializerExprTypeResolver->getType(
+			$nativeProperty->getDefaultValueExpression(),
+			InitializerExprContext::fromClassReflection($class->getNativeProperty('test')->getDeclaringClass()),
+		);
+		$this->assertInstanceOf(ConstantIntegerType::class, $defaultValueType);
+		$this->assertSame(10, $defaultValueType->getValue());
+	}
+
+	public function testBug4288b(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4288b.php');
+		$this->assertNoErrors($errors);
+
+		$reflectionProvider = $this->createReflectionProvider();
+		$class = $reflectionProvider->getClass(\Bug4288b\MyClass::class); // phpcs:ignore
 		$parameter = ParametersAcceptorSelector::selectSingle($class->getNativeMethod('paginate')->getVariants())->getParameters()[0];
 		$defaultValue = $parameter->getDefaultValue();
 		$this->assertInstanceOf(ConstantIntegerType::class, $defaultValue);

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1181,6 +1181,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8752.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-shapes.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7607.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/trait-generalized-consts.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-4288b.php
+++ b/tests/PHPStan/Analyser/data/bug-4288b.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug4288b;
+
+trait PaginationTrait
+{
+
+	/** @var int */
+	private $test = MyClass::DEFAULT_SIZE;
+
+	private function paginate(int $size = MyClass::DEFAULT_SIZE): void
+	{
+		echo $size;
+	}
+}
+
+class MyClass
+{
+	use PaginationTrait;
+
+	const DEFAULT_SIZE = 10;
+
+	public function test(): void
+	{
+		$this->paginate();
+	}
+}
+

--- a/tests/PHPStan/Analyser/data/trait-generalized-consts.php
+++ b/tests/PHPStan/Analyser/data/trait-generalized-consts.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace TraitGeneralizedConsts;
+
+use function PHPStan\Testing\assertType;
+
+trait MyLogic
+{
+	public function fetchValue() : string
+	{
+		assertType('mixed', self::MY_CONST);
+		assertType('mixed', static::MY_CONST);
+
+		if (self::MY_CONST === 'hallo') {
+			assertType("'hallo'", self::MY_CONST);
+			return 'foo';
+		}
+		assertType("mixed~'hallo'", self::MY_CONST);
+		if (self::MY_CONST === 1) {
+			assertType('1', self::MY_CONST);
+			return 'foo1';
+		}
+		assertType("mixed~1|'hallo'", self::MY_CONST);
+
+		assertType('class-string&literal-string', self::class);
+		assertType('class-string&literal-string', static::class);
+
+		assertType('1', FirstConsumer::MY_CONST);
+	}
+
+	public function fetchValue2() : string {
+		assertType('mixed', self::MY_CONST_ARRAY);
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			assertType("array&hasOffset('valueToFetch')", self::MY_CONST_ARRAY);
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+		assertType("mixed~hasOffset('valueToFetch')", self::MY_CONST_ARRAY);
+
+		assertType("array{someValue: 'abc', valueToFetch: '123'}", FirstConsumer::MY_CONST_ARRAY);
+
+		return 'defaultValue';
+	}
+}
+
+final class FirstConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST = 1;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'    => 'abc',
+		'valueToFetch' => '123',
+	];
+
+	public function fetchOwnValue() : string
+	{
+		assertType('1', self::MY_CONST);
+		if (self::MY_CONST === 'hallo') {
+			assertType('*NEVER*', self::MY_CONST);
+			return 'foo';
+		}
+		assertType('1', self::MY_CONST);
+		if (self::MY_CONST === 1) {
+			assertType('1', self::MY_CONST);
+			return 'foo1';
+		}
+		assertType('*NEVER*', self::MY_CONST);
+	}
+
+	public function fetchOwnValue2() : string {
+		assertType("array{someValue: 'abc', valueToFetch: '123'}", self::MY_CONST_ARRAY);
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			assertType("array{someValue: 'abc', valueToFetch: '123'}", self::MY_CONST_ARRAY);
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+		assertType("array{someValue: 'abc', valueToFetch: '123'}", self::MY_CONST_ARRAY);
+
+		return 'defaultValue';
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -186,18 +186,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					640,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'method\' will always evaluate to true.',
-					643,
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'someAnother\' will always evaluate to true.',
-					646,
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
-					649,
-				],
-				[
 					'Call to function is_string() with string will always evaluate to true.',
 					678,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
@@ -328,10 +316,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				[
 					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
 					640,
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
-					649,
 				],
 				[
 					'Call to function assert() with false will always evaluate to false.',
@@ -705,6 +689,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 			],
 
 		]);
+	}
+
+	public function testBug4570(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-4570.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-4570.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4570.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4570;
+
+trait MyLogic
+{
+	public function fetchValue() : string {
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+
+		return 'defaultValue';
+	}
+}
+
+final class FirstConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'    => 'abc',
+		'valueToFetch' => '123',
+	];
+}
+
+final class SecondConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'      => 'abc',
+		'someOtherValue' => '123',
+	];
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/4570

test fails without the src changes like
```diff
1) PHPStan\Rules\Comparison\ImpossibleCheckTypeFunctionCallRuleTest::testBug4570
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'08: Call to function array_key_exists() with 'valueToFetch' and array{someValue: 'abc', valueToFetch: '123'} will always evaluate to true.
+08: Call to function array_key_exists() with 'valueToFetch' and array{someValue: 'abc', someOtherValue: '123'} will always evaluate to false.
 '
```