### PR TITLE
Support contravariant template types

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -264,6 +264,8 @@ class PhpDocNodeResolver
 				$variance = TemplateTypeVariance::createInvariant();
 			} elseif (in_array($tagName, ['@template-covariant', '@psalm-template-covariant', '@phpstan-template-covariant'], true)) {
 				$variance = TemplateTypeVariance::createCovariant();
+			} elseif (in_array($tagName, ['@template-contravariant', '@psalm-template-contravariant', '@phpstan-template-contravariant'], true)) {
+				$variance = TemplateTypeVariance::createContravariant();
 			} else {
 				continue;
 			}

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -85,7 +85,7 @@ class TemplateTypeVariance
 
 		if ($this->covariant()) {
 			if ($other->contravariant()) {
-				return self::createCovariant();
+				return self::createContravariant();
 			}
 			if ($other->covariant()) {
 				return self::createCovariant();

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -22,24 +22,140 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/method-signature-variance.php'], [
 			[
-				'Template type T is declared as covariant, but occurs in contravariant position in parameter a of method MethodSignatureVariance\C::a().',
-				25,
-			],
-			[
-				'Template type T is declared as covariant, but occurs in invariant position in parameter b of method MethodSignatureVariance\C::a().',
-				25,
-			],
-			[
-				'Template type T is declared as covariant, but occurs in contravariant position in parameter c of method MethodSignatureVariance\C::a().',
-				25,
-			],
-			[
-				'Template type W is declared as covariant, but occurs in contravariant position in parameter d of method MethodSignatureVariance\C::a().',
-				25,
-			],
-			[
 				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in in method MethodSignatureVariance\C::b().',
+				16,
+			],
+			[
+				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in in method MethodSignatureVariance\C::c().',
+				22,
+			],
+		]);
+
+		$this->analyse([__DIR__ . '/data/method-signature-variance-invariant.php'], []);
+
+		$this->analyse([__DIR__ . '/data/method-signature-variance-covariant.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in parameter a of method MethodSignatureVariance\Covariant\C::a().',
 				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in parameter c of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in parameter e of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in parameter f of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in parameter h of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in parameter i of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in parameter j of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in parameter k of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::c().',
+				41,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::e().',
+				47,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::f().',
+				50,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::h().',
+				56,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::j().',
+				62,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::k().',
+				65,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::l().',
+				68,
+			],
+		]);
+
+		$this->analyse([__DIR__ . '/data/method-signature-variance-contravariant.php'], [
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in parameter b of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in parameter d of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in parameter e of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in parameter g of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in parameter i of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in parameter j of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in parameter l of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::b().',
+				38,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::d().',
+				44,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::f().',
+				50,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::g().',
+				53,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::i().',
+				59,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::j().',
+				62,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::k().',
+				65,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::m().',
+				71,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-contravariant.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-contravariant.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MethodSignatureVariance\Contravariant;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param In<In<X>> $c
+	 * @param In<Out<X>> $d
+	 * @param In<Invariant<X>> $e
+	 * @param Out<X> $f
+	 * @param Out<In<X>> $g
+	 * @param Out<Out<X>> $h
+	 * @param Out<Invariant<X>> $i
+	 * @param Invariant<X> $j
+	 * @param Invariant<In<X>> $k
+	 * @param Invariant<Out<X>> $l
+	 */
+	function a($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
+
+	/** @return X */
+	function b() {}
+
+	/** @return In<X> */
+	function c() {}
+
+	/** @return In<In<X>> */
+	function d() {}
+
+	/** @return In<Out<X>> */
+	function e() {}
+
+	/** @return In<Invariant<X>> */
+	function f() {}
+
+	/** @return Out<X> */
+	function g() {}
+
+	/** @return Out<In<X>> */
+	function h() {}
+
+	/** @return Out<Out<X>> */
+	function i() {}
+
+	/** @return Out<Invariant<X>> */
+	function j() {}
+
+	/** @return Invariant<X> */
+	function k() {}
+
+	/** @return Invariant<In<X>> */
+	function l() {}
+
+	/** @return Invariant<Out<X>> */
+	function m() {}
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-covariant.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-covariant.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MethodSignatureVariance\Covariant;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template-covariant X
+ */
+class C {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param In<In<X>> $c
+	 * @param In<Out<X>> $d
+	 * @param In<Invariant<X>> $e
+	 * @param Out<X> $f
+	 * @param Out<In<X>> $g
+	 * @param Out<Out<X>> $h
+	 * @param Out<Invariant<X>> $i
+	 * @param Invariant<X> $j
+	 * @param Invariant<In<X>> $k
+	 * @param Invariant<Out<X>> $l
+	 */
+	function a($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
+
+	/** @return X */
+	function b() {}
+
+	/** @return In<X> */
+	function c() {}
+
+	/** @return In<In<X>> */
+	function d() {}
+
+	/** @return In<Out<X>> */
+	function e() {}
+
+	/** @return In<Invariant<X>> */
+	function f() {}
+
+	/** @return Out<X> */
+	function g() {}
+
+	/** @return Out<In<X>> */
+	function h() {}
+
+	/** @return Out<Out<X>> */
+	function i() {}
+
+	/** @return Out<Invariant<X>> */
+	function j() {}
+
+	/** @return Invariant<X> */
+	function k() {}
+
+	/** @return Invariant<In<X>> */
+	function l() {}
+
+	/** @return Invariant<Out<X>> */
+	function m() {}
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-invariant.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-invariant.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MethodSignatureVariance\Invariant;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class C {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param In<In<X>> $c
+	 * @param In<Out<X>> $d
+	 * @param In<Invariant<X> $e
+	 * @param Out<X> $f
+	 * @param Out<In<X>> $g
+	 * @param Out<Out<X>> $h
+	 * @param Out<Invariant<X> $i
+	 * @param Invariant<X> $j
+	 * @param Invariant<In<X>> $k
+	 * @param Invariant<Out<X>> $l
+	 * @return X
+	 */
+	function a($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
+
+	/** @return In<X> */
+	function b() {}
+
+	/** @return In<In<X>>*/
+	function c() {}
+
+	/** @return In<Out<X>>*/
+	function d() {}
+
+	/** @return In<Invariant<X> */
+	function e() {}
+
+	/** @return Out<X> */
+	function f() {}
+
+	/** @return Out<In<X>>*/
+	function g() {}
+
+	/** @return Out<Out<X>>*/
+	function h() {}
+
+	/** @return Out<Invariant<X> */
+	function i() {}
+
+	/** @return Invariant<X> */
+	function j() {}
+
+	/** @return Invariant<In<X>>*/
+	function k() {}
+
+	/** @return Invariant<Out<X>>*/
+	function l() {}
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance.php
@@ -2,37 +2,22 @@
 
 namespace MethodSignatureVariance;
 
-/** @template-covariant T */
-interface Out {
-}
-
-/** @template T */
-interface Invariant {
-}
-
-/**
- * @template-covariant T
- * @template-covariant W of \DateTimeInterface
- */
 class C {
 	/**
-	 * @param Out<T> $a
-	 * @param Invariant<T> $b
-	 * @param T $c
-	 * @param W $d
-	 * @return T
+	 * @template U
+	 * @return void
 	 */
-	function a($a, $b, $c, $d) {
-		return $c;
-	}
+	function a() {}
+
 	/**
 	 * @template-covariant U
-	 * @param Out<U> $a
-	 * @param Invariant<U> $b
-	 * @param U $c
-	 * @return U
+	 * @return void
 	 */
-	function b($a, $b, $c) {
-		return $c;
-	}
+	function b() {}
+
+	/**
+	 * @template-contravariant U
+	 * @return void
+	 */
+	function c() {}
 }

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2512,6 +2512,32 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testGenericVariance(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = false;
+		$this->analyse([__DIR__ . '/data/generic-variance.php'], [
+			[
+				'Parameter #1 $param of method GenericVarianceCall\Foo::invariant() expects GenericVarianceCall\Invariant<GenericVarianceCall\B>, GenericVarianceCall\Invariant<GenericVarianceCall\A> given.',
+				45,
+			],
+			[
+				'Parameter #1 $param of method GenericVarianceCall\Foo::invariant() expects GenericVarianceCall\Invariant<GenericVarianceCall\B>, GenericVarianceCall\Invariant<GenericVarianceCall\C> given.',
+				53,
+			],
+			[
+				'Parameter #1 $param of method GenericVarianceCall\Foo::covariant() expects GenericVarianceCall\Covariant<GenericVarianceCall\B>, GenericVarianceCall\Covariant<GenericVarianceCall\A> given.',
+				60,
+			],
+			[
+				'Parameter #1 $param of method GenericVarianceCall\Foo::contravariant() expects GenericVarianceCall\Contravariant<GenericVarianceCall\B>, GenericVarianceCall\Contravariant<GenericVarianceCall\C> given.',
+				83,
+			],
+		]);
+	}
+
 	public function testBug6904(): void
 	{
 		if (PHP_VERSION_ID < 80100) {

--- a/tests/PHPStan/Rules/Methods/data/generic-variance.php
+++ b/tests/PHPStan/Rules/Methods/data/generic-variance.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace GenericVarianceCall;
+
+class A {}
+class B extends A {}
+class C extends B {}
+
+/** @template T */
+class Invariant {}
+
+/** @template-covariant T */
+class Covariant {}
+
+/** @template-contravariant T */
+class Contravariant {}
+
+class Foo
+{
+	/**
+	 * @param Invariant<B> $param
+	 */
+	public function invariant(Invariant $param): void
+	{
+	}
+
+	/**
+	 * @param Covariant<B> $param
+	 */
+	public function covariant(Covariant $param): void
+	{
+	}
+
+	/**
+	 * @param Contravariant<B> $param
+	 */
+	public function contravariant(Contravariant $param): void
+	{
+	}
+
+	public function testInvariant(): void
+	{
+		/** @var Invariant<A> $invariantA */
+		$invariantA = new Invariant();
+		$this->invariant($invariantA);
+
+		/** @var Invariant<B> $invariantB */
+		$invariantB = new Invariant();
+		$this->invariant($invariantB);
+
+		/** @var Invariant<C> $invariantC */
+		$invariantC = new Invariant();
+		$this->invariant($invariantC);
+	}
+
+	public function testCovariant(): void
+	{
+		/** @var Covariant<A> $covariantA */
+		$covariantA = new Covariant();
+		$this->covariant($covariantA);
+
+		/** @var Covariant<B> $covariantB */
+		$covariantB = new Covariant();
+		$this->covariant($covariantB);
+
+		/** @var Covariant<C> $covariantC */
+		$covariantC = new Covariant();
+		$this->covariant($covariantC);
+	}
+
+	public function testContravariant(): void
+	{
+		/** @var Contravariant<A> $contravariantA */
+		$contravariantA = new Contravariant();
+		$this->contravariant($contravariantA);
+
+		/** @var Contravariant<B> $contravariantB */
+		$contravariantB = new Contravariant();
+		$this->contravariant($contravariantB);
+
+		/** @var Contravariant<C> $contravariantC */
+		$contravariantC = new Contravariant();
+		$this->contravariant($contravariantC);
+	}
+}

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -405,6 +405,76 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					),
 				],
 			],
+			'param: In<T>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					$templateType('T'),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
+			'param: In<In<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'param: In<In<In<T>>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\In::class, [
+						new GenericObjectType(D\In::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
+			'param: In<Out<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Out::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
+			'param: Out<In<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
 			'return: Invariant<T>' => [
 				TemplateTypeVariance::createCovariant(),
 				new GenericObjectType(D\Invariant::class, [
@@ -470,6 +540,76 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					new TemplateTypeReference(
 						$templateType('T'),
 						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: In<T>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					$templateType('T'),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'return: In<In<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
+			'return: In<In<In<T>>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\In::class, [
+						new GenericObjectType(D\In::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'return: In<Out<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Out::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'return: Out<In<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
 					),
 				],
 			],

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -97,6 +97,21 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(C\Covariant::class, [new ObjectType('DateTimeInterface')]),
 				TrinaryLogic::createMaybe(),
 			],
+			'contravariant with equal types' => [
+				new GenericObjectType(C\Contravariant::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(C\Contravariant::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createYes(),
+			],
+			'contravariant with sub type' => [
+				new GenericObjectType(C\Contravariant::class, [new ObjectType('DateTimeInterface')]),
+				new GenericObjectType(C\Contravariant::class, [new ObjectType('DateTime')]),
+				TrinaryLogic::createMaybe(),
+			],
+			'contravariant with super type' => [
+				new GenericObjectType(C\Contravariant::class, [new ObjectType('DateTime')]),
+				new GenericObjectType(C\Contravariant::class, [new ObjectType('DateTimeInterface')]),
+				TrinaryLogic::createYes(),
+			],
 			[
 				new ObjectType(ReflectionClass::class),
 				new GenericObjectType(ReflectionClass::class, [

--- a/tests/PHPStan/Type/Generic/data/generic-classes-c.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-c.php
@@ -9,3 +9,7 @@ interface Invariant {
 /** @template-covariant T */
 interface Covariant {
 }
+
+/** @template-contravariant T */
+interface Contravariant {
+}

--- a/tests/PHPStan/Type/Generic/data/generic-classes-d.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-d.php
@@ -13,3 +13,9 @@ interface Out {
 	/** @return T */
 	public function get();
 }
+
+/** @template-contravariant T */
+interface In {
+	/** @return T */
+	public function get();
+}


### PR DESCRIPTION
Closes phpstan/phpstan#3960.

Basically, I'm picking up where #1492 left off, with a couple more tests.

Once this lands, I'd like to follow up with a fix to the bug mentioned in the original PR (https://github.com/phpstan/phpstan-src/pull/1492#discussion_r912294565). The logs are no longer available for the relevant builds, but I understand it caused some turmoil, and should therefore be discussed separately.