### PR TITLE
Improve Xdebug note

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -96,7 +96,7 @@ class CommandHelper
 		if ($allowXdebug && !XdebugHandler::isXdebugActive()) {
 			$errorOutput->getStyle()->note('You are running with "--xdebug" enabled, but the Xdebug PHP extension is not active. The process will not halt at breakpoints.');
 		} elseif (!$allowXdebug && XdebugHandler::isXdebugActive()) {
-			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. This may slow down performance and the process will not halt at breakpoints.');
+			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. Add it if you want to debug PHPStan itself (halt at breakpoints).');
 		}
 
 		if (!$allowXdebug) {


### PR DESCRIPTION
Coming from https://github.com/phpstan/phpstan-src/pull/1878#issuecomment-1337220986

I thought a lot about how to put all the "requirements" from https://github.com/phpstan/phpstan/discussions/8173 into a single warning message. In the end I found that there's a dilemma we cannot solve:
- on the one hand, we want a short and precise message
- on the other hand, we ideally want to convey multiple messages at the same time, namely the issue that breakpoints are ignored, and the performance impact that running Xdebug induces

In fact I think the actual (potential) problem we want to highlight here is the missed breakpoints issue. The Xdebug performance impact seems negligible to me because it is only equal to the time that it takes to restart PHPStan, which is "constant" compared to the overall time it takes to analyse any target source code (cf. [my simple benchmark for a medium-sized project](https://youtrack.jetbrains.com/issue/WI-69996/Quality-tools-phpstan-psalm-warning-if-interpreter-with-xdebug-extension-is-used#focus=Comments-27-6701051.0-0)).

You may want to "educate" people not to have Xdebug enabled in order to improve performance, but I really think this is not the way to go.

If you really, really want me to come up with a lengthy message that does include all of that, please let me know and I'll give it another shot.