### PR TITLE
Fix node PHPDoc type hints

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -4064,7 +4064,7 @@ class NodeScopeResolver
 	}
 
 	/**
-	 * @param Node[]|Node|scalar $node
+	 * @param Node[]|Node|scalar|null $node
 	 * @param Node\Stmt\TraitUseAdaptation[] $adaptations
 	 * @param callable(Node $node, Scope $scope): void $nodeCallback
 	 */

--- a/src/Rules/UnusedFunctionParametersCheck.php
+++ b/src/Rules/UnusedFunctionParametersCheck.php
@@ -54,7 +54,7 @@ class UnusedFunctionParametersCheck
 	}
 
 	/**
-	 * @param Node[]|Node|scalar $node
+	 * @param Node[]|Node|scalar|null $node
 	 * @return string[]
 	 */
 	private function getUsedVariables(Scope $scope, $node): array

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -563,7 +563,7 @@ class FileTypeMapper
 	}
 
 	/**
-	 * @param Node[]|Node|scalar $node
+	 * @param Node[]|Node|scalar|null $node
 	 * @param Closure(Node $node): mixed $nodeCallback
 	 * @param Closure(Node $node, mixed $callbackResult): void $endNodeCallback
 	 */


### PR DESCRIPTION
Those 3 methods are also called with properties that are determined more dynamically like e.g.
```php
foreach ($node->getSubNodeNames() as $subNodeName) {
    $subNode = $node->{$subNodeName};
    $this->processNodes($subNode, $nodeCallback, $endNodeCallback);
}
```
and `$subNode` can be `null` here for e.g. `$node->stmts`.

noticed this when trying to enforce native union type hints for params return types via phpcs. btw what is the reason this is not done yet? BC for public methods I suppose?