### PR TITLE
Fix invariance composition

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -24,3 +24,4 @@ parameters:
 		nullContextForVoidReturningFunctions: true
 		unescapeStrings: true
 		duplicateStubs: true
+		invarianceComposition: true

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -54,6 +54,7 @@ parameters:
 		nullContextForVoidReturningFunctions: false
 		unescapeStrings: false
 		duplicateStubs: false
+		invarianceComposition: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -271,6 +272,7 @@ parametersSchema:
 		nullContextForVoidReturningFunctions: bool()
 		unescapeStrings: bool()
 		duplicateStubs: bool()
+		invarianceComposition: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -21,6 +21,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\ReflectionProviderStaticAccessor;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use Symfony\Component\Finder\Finder;
 use function array_diff_key;
 use function array_map;
@@ -174,6 +175,7 @@ class ContainerFactory
 
 		BleedingEdgeToggle::setBleedingEdge($container->getParameter('featureToggles')['bleedingEdge']);
 		AccessoryArrayListType::setListTypeEnabled($container->getParameter('featureToggles')['listType']);
+		TemplateTypeVariance::setInvarianceCompositionEnabled($container->getParameter('featureToggles')['invarianceComposition']);
 	}
 
 	public function clearOldContainers(string $tempDirectory): void

--- a/src/Rules/Generics/GenericAncestorsCheck.php
+++ b/src/Rules/Generics/GenericAncestorsCheck.php
@@ -98,7 +98,7 @@ class GenericAncestorsCheck
 				$messages[] = RuleErrorBuilder::message(sprintf($invalidTypeMessage, $referencedClass))->build();
 			}
 
-			$variance = TemplateTypeVariance::createInvariant();
+			$variance = TemplateTypeVariance::createStatic();
 			$messageContext = sprintf(
 				$invalidVarianceMessage,
 				$ancestorType->describe(VerbosityLevel::typeOnly()),

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -21,6 +21,8 @@ class TemplateTypeVariance
 	/** @var self[] */
 	private static array $registry;
 
+	private static bool $invarianceCompositionEnabled = false;
+
 	private function __construct(private int $value)
 	{
 	}
@@ -93,7 +95,7 @@ class TemplateTypeVariance
 			return self::createInvariant();
 		}
 
-		if ($this->invariant()) {
+		if (self::$invarianceCompositionEnabled && $this->invariant()) {
 			return self::createInvariant();
 		}
 
@@ -175,6 +177,11 @@ class TemplateTypeVariance
 	public static function __set_state(array $properties): self
 	{
 		return new self($properties['value']);
+	}
+
+	public static function setInvarianceCompositionEnabled(bool $enabled): void
+	{
+		self::$invarianceCompositionEnabled = $enabled;
 	}
 
 }

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -93,6 +93,10 @@ class TemplateTypeVariance
 			return self::createInvariant();
 		}
 
+		if ($this->invariant()) {
+			return self::createInvariant();
+		}
+
 		return $other;
 	}
 

--- a/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
@@ -96,8 +96,16 @@ class ClassAncestorsRuleTest extends RuleTestCase
 				192,
 			],
 			[
+				'Template type T is declared as contravariant, but occurs in covariant position in extended type ClassAncestorsExtends\FooGeneric8<T, T> of class ClassAncestorsExtends\FooGeneric10.',
+				201,
+			],
+			[
+				'Template type T is declared as contravariant, but occurs in invariant position in extended type ClassAncestorsExtends\FooGeneric8<T, T> of class ClassAncestorsExtends\FooGeneric10.',
+				201,
+			],
+			[
 				'Class ClassAncestorsExtends\FilterIteratorChild extends generic class FilterIterator but does not specify its types: TKey, TValue, TIterator',
-				197,
+				215,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -63,7 +63,11 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 				35,
 			],
 			[
-				'Template type X is declared as covariant, but occurs in contravariant position in parameter k of method MethodSignatureVariance\Covariant\C::a().',
+				'Template type X is declared as covariant, but occurs in invariant position in parameter k of method MethodSignatureVariance\Covariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in parameter l of method MethodSignatureVariance\Covariant\C::a().',
 				35,
 			],
 			[
@@ -91,8 +95,12 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 				65,
 			],
 			[
-				'Template type X is declared as covariant, but occurs in contravariant position in return type of method MethodSignatureVariance\Covariant\C::l().',
+				'Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::l().',
 				68,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in return type of method MethodSignatureVariance\Covariant\C::m().',
+				71,
 			],
 		]);
 
@@ -122,7 +130,11 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 				35,
 			],
 			[
-				'Template type X is declared as contravariant, but occurs in covariant position in parameter l of method MethodSignatureVariance\Contravariant\C::a().',
+				'Template type X is declared as contravariant, but occurs in invariant position in parameter k of method MethodSignatureVariance\Contravariant\C::a().',
+				35,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in parameter l of method MethodSignatureVariance\Contravariant\C::a().',
 				35,
 			],
 			[
@@ -154,7 +166,11 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 				65,
 			],
 			[
-				'Template type X is declared as contravariant, but occurs in covariant position in return type of method MethodSignatureVariance\Contravariant\C::m().',
+				'Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::l().',
+				68,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in return type of method MethodSignatureVariance\Contravariant\C::m().',
 				71,
 			],
 		]);

--- a/tests/PHPStan/Rules/Generics/data/class-ancestors-extends.php
+++ b/tests/PHPStan/Rules/Generics/data/class-ancestors-extends.php
@@ -194,6 +194,24 @@ class FooGeneric9 extends FooGeneric8
 
 }
 
+/**
+ * @template-contravariant T
+ * @extends FooGeneric8<T, T>
+ */
+class FooGeneric10 extends FooGeneric8
+{
+
+}
+
+/**
+ * @template T
+ * @extends FooGeneric8<T, T>
+ */
+class FooGeneric11 extends FooGeneric8
+{
+
+}
+
 class FilterIteratorChild extends \FilterIterator
 {
 

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -355,7 +355,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 		);
 	}
 
-	/** @return array<array{TemplateTypeVariance,Type,array<TemplateTypeReference>}> */
+	/** @return array<array{TemplateTypeVariance,Type,bool,array<TemplateTypeReference>}> */
 	public function dataGetReferencedTypeArguments(): array
 	{
 		$templateType = static fn (string $name, ?Type $bound = null): TemplateType => TemplateTypeFactory::create(
@@ -371,6 +371,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(D\Invariant::class, [
 					$templateType('T'),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -383,6 +384,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(D\Out::class, [
 					$templateType('T'),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -397,6 +399,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -413,6 +416,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -425,6 +429,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(D\In::class, [
 					$templateType('T'),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -439,6 +444,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -455,6 +461,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -469,6 +476,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -483,6 +491,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -497,6 +506,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -511,6 +521,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -525,10 +536,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createCovariant(),
 					),
 				],
 			],
@@ -539,10 +551,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createContravariant(),
 					),
 				],
 			],
@@ -555,10 +568,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createCovariant(),
 					),
 				],
 			],
@@ -571,10 +585,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createContravariant(),
 					),
 				],
 			],
@@ -583,6 +598,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(D\Invariant::class, [
 					$templateType('T'),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -595,6 +611,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(D\Out::class, [
 					$templateType('T'),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -609,6 +626,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -625,6 +643,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -637,6 +656,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				new GenericObjectType(D\In::class, [
 					$templateType('T'),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -651,6 +671,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -667,6 +688,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -681,6 +703,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -695,6 +718,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -709,6 +733,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -723,6 +748,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -737,10 +763,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createCovariant(),
 					),
 				],
 			],
@@ -751,10 +778,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						$templateType('T'),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createContravariant(),
 					),
 				],
 			],
@@ -767,10 +795,11 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
+						TemplateTypeVariance::createCovariant(),
 					),
 				],
 			],
@@ -783,6 +812,195 @@ class GenericObjectTypeTest extends PHPStanTestCase
 						]),
 					]),
 				]),
+				false,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'param: Out<Invariant<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: In<Invariant<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Invariant<Out<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\Out::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Invariant<In<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: In<Invariant<Out<T>>> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\Out::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Out<Invariant<In<T>>> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\In::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Out<Invariant<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: In<Invariant<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Invariant<Out<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\Out::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Invariant<In<T>> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: In<Invariant<Out<T>>> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\Out::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Out<Invariant<In<T>>> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\In::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				true,
 				[
 					new TemplateTypeReference(
 						$templateType('T'),
@@ -798,8 +1016,10 @@ class GenericObjectTypeTest extends PHPStanTestCase
 	 *
 	 * @param array<TemplateTypeReference> $expectedReferences
 	 */
-	public function testGetReferencedTypeArguments(TemplateTypeVariance $positionVariance, Type $type, array $expectedReferences): void
+	public function testGetReferencedTypeArguments(TemplateTypeVariance $positionVariance, Type $type, bool $invarianceComposition, array $expectedReferences): void
 	{
+		TemplateTypeVariance::setInvarianceCompositionEnabled($invarianceComposition);
+
 		$result = [];
 		foreach ($type->getReferencedTemplateTypes($positionVariance) as $r) {
 			$result[] = $r;

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -490,6 +490,94 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					),
 				],
 			],
+			'param: Out<Invariant<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: In<Invariant<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Invariant<Out<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\Out::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Invariant<In<T>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: In<Invariant<Out<T>>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\Out::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Out<Invariant<In<T>>>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\In::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
 			'return: Invariant<T>' => [
 				TemplateTypeVariance::createCovariant(),
 				new GenericObjectType(D\Invariant::class, [
@@ -541,20 +629,6 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					new TemplateTypeReference(
 						$templateType('T'),
 						TemplateTypeVariance::createCovariant(),
-					),
-				],
-			],
-			'return: Out<Invariant<T>>' => [
-				TemplateTypeVariance::createCovariant(),
-				new GenericObjectType(D\Out::class, [
-					new GenericObjectType(D\Invariant::class, [
-						$templateType('T'),
-					]),
-				]),
-				[
-					new TemplateTypeReference(
-						$templateType('T'),
-						TemplateTypeVariance::createInvariant(),
 					),
 				],
 			],
@@ -625,6 +699,94 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					new TemplateTypeReference(
 						$templateType('T'),
 						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'return: Out<Invariant<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: In<Invariant<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Invariant<Out<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\Out::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Invariant<In<T>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					new GenericObjectType(D\In::class, [
+						$templateType('T'),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: In<Invariant<Out<T>>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\In::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\Out::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Out<Invariant<In<T>>>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Out::class, [
+					new GenericObjectType(D\Invariant::class, [
+						new GenericObjectType(D\In::class, [
+							$templateType('T'),
+						]),
+					]),
+				]),
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createInvariant(),
 					),
 				],
 			],


### PR DESCRIPTION
Now for the more complicated bit.

In my research for type projections, I've found [this paper](https://yanniss.github.io/variance-pldi11.pdf) very resourceful; in section 3.1 which discusses variance composition, it says that "invariance transforms everything into invariance".

So, as also argued in https://github.com/phpstan/phpstan-src/pull/1492#discussion_r912294565, this is indeed technically a bugfix. To make sure that the position variance is composed correctly, I've also replicated the test case from this PR in [Kotlin](https://pl.kotl.in/Yj8kr6jV3) whose type system I firmly trust.

Let's see what builds this breaks :)