### PR TITLE
Fix issue 8467 ShowCommand regression

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3992,16 +3992,18 @@ class NodeScopeResolver
 			}
 		}
 
+		$constantArrays = $iterateeType->getConstantArrays();
 		if (
 			$stmt->getDocComment() === null
-			&& $iterateeType instanceof ConstantArrayType
+			&& $iterateeType->isConstantArray()->yes()
+			&& count($constantArrays) === 1
 			&& $stmt->valueVar instanceof Variable && is_string($stmt->valueVar->name)
 			&& $stmt->keyVar instanceof Variable && is_string($stmt->keyVar->name)
 		) {
 			$valueConditionalHolders = [];
 			$arrayDimFetchConditionalHolders = [];
-			foreach ($iterateeType->getKeyTypes() as $i => $keyType) {
-				$valueType = $iterateeType->getValueTypes()[$i];
+			foreach ($constantArrays[0]->getKeyTypes() as $i => $keyType) {
+				$valueType = $constantArrays[0]->getValueTypes()[$i];
 				$holder = new ConditionalExpressionHolder([
 					'$' . $stmt->keyVar->name => ExpressionTypeHolder::createYes(new Variable($stmt->keyVar->name), $keyType),
 				], new ExpressionTypeHolder($stmt->valueVar, $valueType, TrinaryLogic::createYes()));

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1134,6 +1134,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-8389.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8421.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/imagick-pixel.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-8467a.php');
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Arrays/data/bug-8467a.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8467a.php
@@ -2,6 +2,8 @@
 
 namespace Bug8467a;
 
+use function PHPStan\Testing\assertType;
+
 /**
  * @phpstan-type AutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
  */
@@ -25,9 +27,11 @@ class Test {
 		if (\count($package->getAutoload()) > 0) {
 			$autoloadConfig = $package->getAutoload();
 			foreach ($autoloadConfig as $type => $autoloads) {
+				assertType('array<int<0, max>|string, array<string>|string>', $autoloadConfig[$type]);
 				if ($type === 'psr-0' || $type === 'psr-4') {
 
 				} elseif ($type === 'classmap') {
+					assertType('list<string>', $autoloadConfig[$type]);
 					implode(', ', $autoloadConfig[$type]);
 				}
 			}

--- a/tests/PHPStan/Rules/Arrays/data/bug-8467a.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8467a.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8467a;
+
+/**
+ * @phpstan-type AutoloadRules array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
+ */
+interface CompletePackageInterface {
+	/**
+	 * Returns an associative array of autoloading rules
+	 *
+	 * {"<type>": {"<namespace": "<directory>"}}
+	 *
+	 * Type is either "psr-4", "psr-0", "classmap" or "files". Namespaces are mapped to
+	 * directories for autoloading using the type specified.
+	 *
+	 * @return array Mapping of autoloading rules
+	 * @phpstan-return AutoloadRules
+	 */
+	public function getAutoload(): array;
+}
+
+class Test {
+	public function foo (CompletePackageInterface $package): void {
+		if (\count($package->getAutoload()) > 0) {
+			$autoloadConfig = $package->getAutoload();
+			foreach ($autoloadConfig as $type => $autoloads) {
+				if ($type === 'psr-0' || $type === 'psr-4') {
+
+				} elseif ($type === 'classmap') {
+					implode(', ', $autoloadConfig[$type]);
+				}
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Functions/ImplodeFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ImplodeFunctionRuleTest.php
@@ -53,4 +53,9 @@ class ImplodeFunctionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../Arrays/data/bug-6000.php'], []);
 	}
 
+	public function testBug8467a(): void
+	{
+		$this->analyse([__DIR__ . '/../Arrays/data/bug-8467a.php'], []);
+	}
+
 }


### PR DESCRIPTION
In https://github.com/phpstan/phpstan-src/pull/1950

I replaced this specification
https://github.com/phpstan/phpstan-src/commit/46a8f32f5474b6f6127fb17a1638e7e11897be52#diff-dc817f2bab8672057a95375a542e68599164f6ab2380e4cccd1b50583e295d85R3514-R3544

with a conditional expression
https://github.com/phpstan/phpstan-src/blob/106cf1bc332242e94fce4bea25cea4cdc856e562/src/Analyser/NodeScopeResolver.php#L4021-L4024

which caused a regression for `non-empty-array` because of this line.
https://github.com/phpstan/phpstan-src/blob/024e98ecd612b3ca8a25cc1e612ed30d46d94202/src/Analyser/NodeScopeResolver.php#L3997

Thanks to `isConstantArray` and `getConstantArrays` we can handle this case correctly too.