### PR TITLE
Fix issue 8467 intersect resolved conditional types

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1135,6 +1135,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8421.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/imagick-pixel.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-8467a.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8467b.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-8467b.php
+++ b/tests/PHPStan/Analyser/data/bug-8467b.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8467b;
+
+use function PHPStan\Testing\assertType;
+
+class Test {
+	public function foo (?string $cwd, bool $initialClone = false): void {
+		if ($initialClone) {
+			$origCwd = $cwd;
+			$cwd = null;
+		}
+
+		if ($initialClone && isset($origCwd)) {
+			assertType('string', $origCwd);
+			assertType('null', $cwd);
+		}
+	}
+
+	/**
+	 * @param mixed[]|null $mirrors
+	 *
+	 * @return list<non-empty-string>
+	 *
+	 * @phpstan-param list<array{url: non-empty-string, preferred: bool}>|null $mirrors
+	 */
+	protected function getUrls(?string $url, ?array $mirrors, ?string $ref, ?string $type, string $urlType): array
+	{
+		if (!$url) {
+			return [];
+		}
+
+		if ($urlType === 'dist' && false !== strpos($url, '%')) {
+			assertType('string|null', $type);
+			$url = 'test';
+		}
+		assertType('non-falsy-string', $url);
+
+		$urls = [$url];
+		if ($mirrors) {
+			foreach ($mirrors as $mirror) {
+				if ($urlType === 'dist') {
+					assertType('string|null', $type);
+				} elseif ($urlType === 'source' && $type === 'git') {
+					assertType("'git'", $type);
+				} elseif ($urlType === 'source' && $type === 'hg') {
+					assertType("'hg'", $type);
+				} else {
+					continue;
+				}
+			}
+		}
+
+		return $urls;
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-8467b.php
+++ b/tests/PHPStan/Analyser/data/bug-8467b.php
@@ -13,7 +13,7 @@ class Test {
 
 		if ($initialClone && isset($origCwd)) {
 			assertType('string', $origCwd);
-			assertType('null', $cwd);
+			assertType('string|null', $cwd); // could be null
 		}
 	}
 


### PR DESCRIPTION
I thought about this once in https://github.com/phpstan/phpstan-src/pull/2030/commits/42bddf0262d38dccb34aa9670335956ed6047a15 but wasn't sure when this is needed.

The composer integration test failure was a very good example.
The conditional type knows `$initialClone=true => $origCwd=string|null`, but `isset($originCwd)` has already specified `$originCwd=>'string'` in the `if ($initialClone && isset($origCwd))` truthy scope. Conditional type can be resolved in the scope too, so it overwrites the `$originCwd`'s type as `$origCwd=string|null`.

Before my changes (in 1.9.2) resolving conditional types for specified types were skipped, but I think it is better to intersect, because the conditional type can be narrower than the specified type.