### PR TITLE
Do not check variance validity in private methods

### DIFF
--- a/src/Rules/Generics/FunctionSignatureVarianceRule.php
+++ b/src/Rules/Generics/FunctionSignatureVarianceRule.php
@@ -40,6 +40,7 @@ class FunctionSignatureVarianceRule implements Rule
 			sprintf('in return type of function %s()', $functionName),
 			sprintf('in function %s()', $functionName),
 			false,
+			false,
 		);
 	}
 

--- a/src/Rules/Generics/MethodSignatureVarianceRule.php
+++ b/src/Rules/Generics/MethodSignatureVarianceRule.php
@@ -39,6 +39,7 @@ class MethodSignatureVarianceRule implements Rule
 			sprintf('in return type of method %s::%s()', $method->getDeclaringClass()->getDisplayName(), $method->getName()),
 			sprintf('in method %s::%s()', $method->getDeclaringClass()->getDisplayName(), $method->getName()),
 			$method->getName() === '__construct' || $method->isStatic(),
+			$method->isPrivate(),
 		);
 	}
 

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -20,20 +20,10 @@ class VarianceCheck
 		string $returnTypeMessage,
 		string $generalMessage,
 		bool $isStatic,
+		bool $isPrivate,
 	): array
 	{
 		$errors = [];
-
-		foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
-			$variance = $isStatic
-				? TemplateTypeVariance::createStatic()
-				: TemplateTypeVariance::createContravariant();
-			$type = $parameterReflection->getType();
-			$message = sprintf($parameterTypeMessage, $parameterReflection->getName());
-			foreach ($this->check($variance, $type, $message) as $error) {
-				$errors[] = $error;
-			}
-		}
 
 		foreach ($parametersAcceptor->getTemplateTypeMap()->getTypes() as $templateType) {
 			if (!$templateType instanceof TemplateType
@@ -48,6 +38,21 @@ class VarianceCheck
 				$templateType->getName(),
 				$generalMessage,
 			))->build();
+		}
+
+		if ($isPrivate) {
+			return $errors;
+		}
+
+		foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
+			$variance = $isStatic
+				? TemplateTypeVariance::createStatic()
+				: TemplateTypeVariance::createContravariant();
+			$type = $parameterReflection->getType();
+			$message = sprintf($parameterTypeMessage, $parameterReflection->getName());
+			foreach ($this->check($variance, $type, $message) as $error) {
+				$errors[] = $error;
+			}
 		}
 
 		$variance = TemplateTypeVariance::createCovariant();

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-contravariant.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-contravariant.php
@@ -69,4 +69,7 @@ class C {
 
 	/** @return Invariant<Out<X>> */
 	function m() {}
+
+	/** @return X */
+	private function n() {}
 }

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-covariant.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-covariant.php
@@ -69,4 +69,7 @@ class C {
 
 	/** @return Invariant<Out<X>> */
 	function m() {}
+
+	/** @param X $n */
+	private function n($n) {}
 }


### PR DESCRIPTION
As part of my ongoing work on generics (and type projections, eventually 🤞), I'm investigating an idea to add an (optional) variance check for properties, and I thought it would be a nightmare – you couldn't even have a `class Collection` with a covariant template for the item type because you couldn't use the template type in the inherently invariant `private array $items`.

That's when it occurred to me that perhaps the variance check should ignore private members altogether – variance is all about subtyping, and private members do not really come into play in that context. PHP doesn't enforce variance rules for private members in normal subtyping, and I think neither should PHPStan in generic subtyping.

(Kotlin [approves](https://pl.kotl.in/PYd1h3CG3) 😉)