### PR TITLE
ArrayFilterRule should care bout treatPhpDocTypesAsCertain

### DIFF
--- a/conf/config.level5.neon
+++ b/conf/config.level5.neon
@@ -23,3 +23,5 @@ services:
 
 	-
 		class: PHPStan\Rules\Functions\ArrayFilterRule
+		arguments:
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%

--- a/src/Rules/Functions/ArrayFilterRule.php
+++ b/src/Rules/Functions/ArrayFilterRule.php
@@ -20,7 +20,10 @@ use function strtolower;
 class ArrayFilterRule implements Rule
 {
 
-	public function __construct(private ReflectionProvider $reflectionProvider)
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+		private bool $treatPhpDocTypesAsCertain,
+	)
 	{
 	}
 
@@ -46,7 +49,11 @@ class ArrayFilterRule implements Rule
 			return [];
 		}
 
-		$arrayType = $scope->getType($args[0]->value);
+		if ($this->treatPhpDocTypesAsCertain) {
+			$arrayType = $scope->getType($args[0]->value);
+		} else {
+			$arrayType = $scope->getNativeType($args[0]->value);
+		}
 
 		if ($arrayType->isIterableAtLeastOnce()->no()) {
 			$message = 'Parameter #1 $array (%s) to function array_filter is empty, call has no effect.';

--- a/tests/PHPStan/Rules/Functions/ArrayFilterRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrayFilterRuleTest.php
@@ -11,9 +11,11 @@ use PHPStan\Testing\RuleTestCase;
 class ArrayFilterRuleTest extends RuleTestCase
 {
 
+	private bool $treatPhpDocTypesAsCertain = true;
+
 	protected function getRule(): Rule
 	{
-		return new ArrayFilterRule($this->createReflectionProvider());
+		return new ArrayFilterRule($this->createReflectionProvider(), $this->treatPhpDocTypesAsCertain);
 	}
 
 	public function testFile(): void
@@ -58,6 +60,52 @@ class ArrayFilterRuleTest extends RuleTestCase
 			[
 				'Parameter #1 $array (array<false|null>) to function array_filter contains falsy values only, the result will always be an empty array.',
 				27,
+			],
+			[
+				'Parameter #1 $array (array{}) to function array_filter is empty, call has no effect.',
+				28,
+			],
+		];
+
+		$this->analyse([__DIR__ . '/data/array_filter_empty.php'], $expectedErrors);
+	}
+
+	public function testFileWithoutPhpDocTypesAsCertain(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+
+		$expectedErrors = [
+			[
+				'Parameter #1 $array (array{1, 3}) to function array_filter does not contain falsy values, the array will always stay the same.',
+				11,
+			],
+			[
+				'Parameter #1 $array (array{\'test\'}) to function array_filter does not contain falsy values, the array will always stay the same.',
+				12,
+			],
+			[
+				'Parameter #1 $array (array{true, true}) to function array_filter does not contain falsy values, the array will always stay the same.',
+				17,
+			],
+			[
+				'Parameter #1 $array (array{stdClass}) to function array_filter does not contain falsy values, the array will always stay the same.',
+				18,
+			],
+			[
+				'Parameter #1 $array (array{0}) to function array_filter contains falsy values only, the result will always be an empty array.',
+				23,
+			],
+			[
+				'Parameter #1 $array (array{null}) to function array_filter contains falsy values only, the result will always be an empty array.',
+				24,
+			],
+			[
+				'Parameter #1 $array (array{null, null}) to function array_filter contains falsy values only, the result will always be an empty array.',
+				25,
+			],
+			[
+				'Parameter #1 $array (array{null, 0}) to function array_filter contains falsy values only, the result will always be an empty array.',
+				26,
 			],
 			[
 				'Parameter #1 $array (array{}) to function array_filter is empty, call has no effect.',

--- a/tests/PHPStan/Rules/Functions/ArrayFilterRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrayFilterRuleTest.php
@@ -70,50 +70,23 @@ class ArrayFilterRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/array_filter_empty.php'], $expectedErrors);
 	}
 
-	public function testFileWithoutPhpDocTypesAsCertain(): void
+	public function testBug2065WithPhpDocTypesAsCertain(): void
 	{
-		$this->treatPhpDocTypesAsCertain = false;
-
 		$expectedErrors = [
 			[
-				'Parameter #1 $array (array{1, 3}) to function array_filter does not contain falsy values, the array will always stay the same.',
-				11,
-			],
-			[
-				'Parameter #1 $array (array{\'test\'}) to function array_filter does not contain falsy values, the array will always stay the same.',
+				'Parameter #1 $array (array<class-string>) to function array_filter does not contain falsy values, the array will always stay the same.',
 				12,
-			],
-			[
-				'Parameter #1 $array (array{true, true}) to function array_filter does not contain falsy values, the array will always stay the same.',
-				17,
-			],
-			[
-				'Parameter #1 $array (array{stdClass}) to function array_filter does not contain falsy values, the array will always stay the same.',
-				18,
-			],
-			[
-				'Parameter #1 $array (array{0}) to function array_filter contains falsy values only, the result will always be an empty array.',
-				23,
-			],
-			[
-				'Parameter #1 $array (array{null}) to function array_filter contains falsy values only, the result will always be an empty array.',
-				24,
-			],
-			[
-				'Parameter #1 $array (array{null, null}) to function array_filter contains falsy values only, the result will always be an empty array.',
-				25,
-			],
-			[
-				'Parameter #1 $array (array{null, 0}) to function array_filter contains falsy values only, the result will always be an empty array.',
-				26,
-			],
-			[
-				'Parameter #1 $array (array{}) to function array_filter is empty, call has no effect.',
-				28,
 			],
 		];
 
-		$this->analyse([__DIR__ . '/data/array_filter_empty.php'], $expectedErrors);
+		$this->analyse([__DIR__ . '/data/bug-array-filter.php'], $expectedErrors);
+	}
+
+	public function testBug2065WithoutPhpDocTypesAsCertain(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+
+		$this->analyse([__DIR__ . '/data/bug-array-filter.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-array-filter.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-array-filter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug2065;
+
+class Test
+{
+	/**
+	 * @param class-string[] $array
+	 */
+	public function foo(array $array): array
+	{
+		return array_filter($array);
+	}
+}


### PR DESCRIPTION
Hi @ondrejmirtes, 

When using `treatPhpDocTypesAsCertain: false`, a call `array_filter` shouldn't be reported as useless if the type is coming from phpdoc.

So 
```
if ($this->treatPhpDocTypesAsCertain) {
     $arrayType = $scope->getType($args[0]->value);
} else {
     $arrayType = $scope->getNativeType($args[0]->value);
}
```
should be used instead of `$arrayType = $scope->getType($args[0]->value);`

But I don't know if there is something to do in order to not forgot this for others rules,
like changing `getType` to return the nativeType if treatPhpDocTypesAsCertain is false or exposing another method. 
Maybe you would have an idea @staabm, @herndlm or @rajyan ?