### PR TITLE
Optimize path related utils on windows

### DIFF
--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -59,7 +59,7 @@ class FileHelper
 		if ($originalPath !== '') {
 			if ($originalPath[0] === '/') {
 				$isLocalPath = true;
-			} elseif (strlen($originalPath) >= 3 && in_array($originalPath[0], range('A', 'Z'), true) && $originalPath[1] === ':' && $originalPath[2] === '\\') {
+			} elseif (strlen($originalPath) >= 3 && $originalPath[1] === ':' && $originalPath[2] === '\\') { // e.g. C:\\
 				$isLocalPath = true;
 			}
 		}

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -10,6 +10,7 @@ use function ltrim;
 use function rtrim;
 use function str_replace;
 use function str_starts_with;
+use function strlen;
 use function strpos;
 use function substr;
 use function trim;
@@ -52,7 +53,14 @@ class FileHelper
 	/** @api */
 	public function normalizePath(string $originalPath, string $directorySeparator = DIRECTORY_SEPARATOR): string
 	{
-		$isLocalPath = $originalPath !== '' && $originalPath[0] === '/';
+		$isLocalPath = false;
+		if ($originalPath !== '') {
+			if ($originalPath[0] === '/') {
+				$isLocalPath = true;
+			} elseif (strlen($originalPath) >= 3 && $originalPath[0] === 'C' && $originalPath[1] === ':' && $originalPath[2] === '\\') {
+				$isLocalPath = true;
+			}
+		}
 
 		$matches = null;
 		if (!$isLocalPath) {

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -6,8 +6,9 @@ use Nette\Utils\Strings;
 use function array_pop;
 use function explode;
 use function implode;
+use function in_array;
 use function ltrim;
-use function ord;
+use function range;
 use function rtrim;
 use function str_replace;
 use function str_starts_with;
@@ -19,9 +20,6 @@ use const DIRECTORY_SEPARATOR;
 
 class FileHelper
 {
-
-	private const LETTER_A = 65;
-	private const LETTER_Z = 90;
 
 	private string $workingDirectory;
 
@@ -61,7 +59,7 @@ class FileHelper
 		if ($originalPath !== '') {
 			if ($originalPath[0] === '/') {
 				$isLocalPath = true;
-			} elseif (strlen($originalPath) >= 3 && ord($originalPath[0]) >= self::LETTER_A && ord($originalPath[0]) <= self::LETTER_Z && $originalPath[1] === ':' && $originalPath[2] === '\\') {
+			} elseif (strlen($originalPath) >= 3 && in_array($originalPath[0], range('A', 'Z'), true) && $originalPath[1] === ':' && $originalPath[2] === '\\') {
 				$isLocalPath = true;
 			}
 		}

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -7,6 +7,7 @@ use function array_pop;
 use function explode;
 use function implode;
 use function ltrim;
+use function ord;
 use function rtrim;
 use function str_replace;
 use function str_starts_with;
@@ -18,6 +19,9 @@ use const DIRECTORY_SEPARATOR;
 
 class FileHelper
 {
+
+	private const LETTER_A = 65;
+	private const LETTER_Z = 90;
 
 	private string $workingDirectory;
 
@@ -57,7 +61,7 @@ class FileHelper
 		if ($originalPath !== '') {
 			if ($originalPath[0] === '/') {
 				$isLocalPath = true;
-			} elseif (strlen($originalPath) >= 3 && $originalPath[0] >= 'A' && $originalPath[0] <= 'Z' && $originalPath[1] === ':' && $originalPath[2] === '\\') {
+			} elseif (strlen($originalPath) >= 3 && ord($originalPath[0]) >= self::LETTER_A && ord($originalPath[0]) <= self::LETTER_Z && $originalPath[1] === ':' && $originalPath[2] === '\\') {
 				$isLocalPath = true;
 			}
 		}

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -57,7 +57,7 @@ class FileHelper
 		if ($originalPath !== '') {
 			if ($originalPath[0] === '/') {
 				$isLocalPath = true;
-			} elseif (strlen($originalPath) >= 3 && $originalPath[0] === 'C' && $originalPath[1] === ':' && $originalPath[2] === '\\') {
+			} elseif (strlen($originalPath) >= 3 && $originalPath[0] >= 'A' && $originalPath[0] <= 'Z' && $originalPath[1] === ':' && $originalPath[2] === '\\') {
 				$isLocalPath = true;
 			}
 		}

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -6,9 +6,7 @@ use Nette\Utils\Strings;
 use function array_pop;
 use function explode;
 use function implode;
-use function in_array;
 use function ltrim;
-use function range;
 use function rtrim;
 use function str_replace;
 use function str_starts_with;
@@ -59,7 +57,7 @@ class FileHelper
 		if ($originalPath !== '') {
 			if ($originalPath[0] === '/') {
 				$isLocalPath = true;
-			} elseif (strlen($originalPath) >= 3 && $originalPath[1] === ':' && $originalPath[2] === '\\') { // e.g. C:\\
+			} elseif (strlen($originalPath) >= 3 && $originalPath[1] === ':' && $originalPath[2] === '\\') { // e.g. C:\
 				$isLocalPath = true;
 			}
 		}

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -76,16 +76,16 @@ class FileTypeMapper
 		string $docComment,
 	): ResolvedPhpDocBlock
 	{
-		if ($fileName !== null) {
-			$fileName = $this->fileHelper->normalizePath($fileName);
-		}
-
 		if ($className === null && $traitName !== null) {
 			throw new ShouldNotHappenException();
 		}
 
 		if ($docComment === '') {
 			return ResolvedPhpDocBlock::createEmpty();
+		}
+
+		if ($fileName !== null) {
+			$fileName = $this->fileHelper->normalizePath($fileName);
 		}
 
 		$nameScopeKey = $this->getNameScopeKey($fileName, $className, $traitName, $functionName);


### PR DESCRIPTION
the changes mainly prevent excessive use of PCRE on windows. this leads to a small performance improvement of ~3%. 

more suprising is blackfire reporting a 56% improvement on memory usage (830 MB instead of 1.9 GB).

![grafik](https://user-images.githubusercontent.com/120441/206733270-19a8b1f2-b713-4da7-89a3-2a4e248eb029.png)


tested on windows 11
```
php -v
PHP 8.1.2 (cli) (built: Jan 19 2022 10:13:52) (NTS Visual C++ 2019 x64)
Copyright (c) The PHP Group
Zend Engine v4.1.2, Copyright (c) Zend Technologies
    with blackfire v1.76.0~win-x64-non_zts81, https://blackfire.io, by Blackfire
```