### PR TITLE
Remove unnecessary file IO

### DIFF
--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -52,10 +52,6 @@ class FileCacheStorage implements CacheStorage
 		[,, $filePath] = $this->getFilePaths($key);
 
 		return (static function () use ($variableKey, $filePath) {
-			if (!is_file($filePath)) {
-				return null;
-			}
-
 			$cacheItem = @include $filePath;
 			if (!$cacheItem instanceof CacheItem) {
 				return null;

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -38,7 +38,6 @@ use function array_map;
 use function explode;
 use function filemtime;
 use function is_bool;
-use function is_file;
 use function sprintf;
 use function strtolower;
 use function time;
@@ -223,8 +222,8 @@ class PhpMethodReflection implements ExtendedMethodReflection
 			$filename = $this->declaringTrait->getFileName();
 		}
 
-		if (!$isNativelyVariadic && $filename !== null && is_file($filename)) {
-			$modifiedTime = filemtime($filename);
+		if (!$isNativelyVariadic && $filename !== null) {
+			$modifiedTime = @filemtime($filename);
 			if ($modifiedTime === false) {
 				$modifiedTime = time();
 			}


### PR DESCRIPTION
remove file IO when not necessary. the IO subsystem can be super slow or at least performance can vary a lot dependent on when/where you read data from

![grafik](https://user-images.githubusercontent.com/120441/206740861-02e6c2ab-1d9a-41fb-9f1f-118ebee052f8.png)
