### PR TITLE
When an array of replacements is passed to `strtr()` it should be an associative array of strings

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11804,7 +11804,7 @@ return [
 'strtotime' => ['int|false', 'time'=>'string', 'now='=>'int'],
 'strtoupper' => ['string', 'str'=>'string'],
 'strtr' => ['string', 'str'=>'string', 'from'=>'string', 'to'=>'string'],
-'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array'],
+'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array<string,string>'],
 'strval' => ['string', 'var'=>'mixed'],
 'substr' => ['__benevolent<string|false>', 'string'=>'string', 'start'=>'int', 'length='=>'int'],
 'substr_compare' => ['int<-1, 1>|false', 'main_str'=>'string', 'str'=>'string', 'offset'=>'int', 'length='=>'int', 'case_sensitivity='=>'bool'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -11804,7 +11804,7 @@ return [
 'strtotime' => ['int|false', 'time'=>'string', 'now='=>'int'],
 'strtoupper' => ['string', 'str'=>'string'],
 'strtr' => ['string', 'str'=>'string', 'from'=>'string', 'to'=>'string'],
-'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array<string,string>'],
+'strtr\'1' => ['string', 'str'=>'string', 'replace_pairs'=>'array<non-empty-string,string>'],
 'strval' => ['string', 'var'=>'mixed'],
 'substr' => ['__benevolent<string|false>', 'string'=>'string', 'start'=>'int', 'length='=>'int'],
 'substr_compare' => ['int<-1, 1>|false', 'main_str'=>'string', 'str'=>'string', 'offset'=>'int', 'length='=>'int', 'case_sensitivity='=>'bool'],


### PR DESCRIPTION
This specifies the type of the replacements array to prevent accidental mistakes with the format of the array.

Refs:

* https://phpstan.org/r/43f08118-c4d2-46aa-b05e-3a5c1c9bc4e3
* https://3v4l.org/XXcWD