### PR TITLE
Reduce calls to Scope->getType(). Cheap checks first.

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -208,9 +208,9 @@ class FunctionCallParametersCheck
 		}
 
 		if (
-			$scope->getType($funcCall)->isVoid()->yes()
+			!$funcCall instanceof Node\Expr\New_
 			&& !$scope->isInFirstLevelStatement()
-			&& !$funcCall instanceof Node\Expr\New_
+			&& $scope->getType($funcCall)->isVoid()->yes()
 		) {
 			$errors[] = RuleErrorBuilder::message($messages[7])->line($funcCall->getLine())->build();
 		}


### PR DESCRIPTION
```
 php -v
PHP 8.1.13 (cli) (built: Nov 24 2022 15:58:42) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.13, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.13, Copyright (c), by Zend Technologies
    with blackfire v1.81.0~mac-x64-non_zts81, https://blackfire.io, by Blackfire
```

`blackfire run php bin/phpstan -vvv --debug`


<img width="479" alt="grafik" src="https://user-images.githubusercontent.com/120441/206788067-d3e8378b-6cd2-434e-b6d1-e446159108db.png">
