### PR TITLE
Cache resolved phpdoc in ClassReflection

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -106,6 +106,8 @@ class ClassReflection
 
 	private string|false|null $reflectionDocComment = false;
 
+	private false|ResolvedPhpDocBlock $resolvedPhpDocBlock = false;
+
 	/** @var ClassReflection[]|null */
 	private ?array $cachedInterfaces = null;
 
@@ -1319,7 +1321,11 @@ class ClassReflection
 			return null;
 		}
 
-		return $this->fileTypeMapper->getResolvedPhpDoc($fileName, $this->getName(), null, null, $this->reflectionDocComment);
+		if ($this->resolvedPhpDocBlock !== false) {
+			return $this->resolvedPhpDocBlock;
+		}
+
+		return $this->resolvedPhpDocBlock = $this->fileTypeMapper->getResolvedPhpDoc($fileName, $this->getName(), null, null, $this->reflectionDocComment);
 	}
 
 	private function getFirstExtendsTag(): ?ExtendsTag


### PR DESCRIPTION
running `blackfire run php bin/phpstan -vvv --debug` on my mac

```
php -v
PHP 8.1.13 (cli) (built: Nov 24 2022 15:58:42) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.13, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.13, Copyright (c), by Zend Technologies
    with blackfire v1.81.0~mac-x64-non_zts81, https://blackfire.io, by Blackfire
```

leads to 
<img width="485" alt="grafik" src="https://user-images.githubusercontent.com/120441/206842215-7cda24e7-52bc-4d64-ada8-09d6b9fed728.png">
