### PR TITLE
A bundle of generic variance enhancements

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -25,3 +25,4 @@ parameters:
 		unescapeStrings: true
 		duplicateStubs: true
 		invarianceComposition: true
+		checkPropertyVariance: true

--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -50,6 +50,8 @@ conditionalTags:
 		phpstan.rules.rule: %featureToggles.illegalConstructorMethodCall%
 	PHPStan\Rules\Methods\IllegalConstructorStaticCallRule:
 		phpstan.rules.rule: %featureToggles.illegalConstructorMethodCall%
+	PHPStan\Rules\Generics\PropertyVarianceRule:
+		phpstan.rules.rule: %featureToggles.checkPropertyVariance%
 
 services:
 	-
@@ -75,3 +77,5 @@ services:
 			checkMissingVarTagTypehint: %checkMissingVarTagTypehint%
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPStan\Rules\Generics\PropertyVarianceRule

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -55,6 +55,7 @@ parameters:
 		unescapeStrings: false
 		duplicateStubs: false
 		invarianceComposition: false
+		checkPropertyVariance: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -274,6 +275,7 @@ parametersSchema:
 		unescapeStrings: bool()
 		duplicateStubs: bool()
 		invarianceComposition: bool()
+		checkPropertyVariance: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/Rules/Generics/FunctionSignatureVarianceRule.php
+++ b/src/Rules/Generics/FunctionSignatureVarianceRule.php
@@ -41,6 +41,7 @@ class FunctionSignatureVarianceRule implements Rule
 			sprintf('in function %s()', $functionName),
 			false,
 			false,
+			false,
 		);
 	}
 

--- a/src/Rules/Generics/GenericAncestorsCheck.php
+++ b/src/Rules/Generics/GenericAncestorsCheck.php
@@ -103,7 +103,7 @@ class GenericAncestorsCheck
 				$invalidVarianceMessage,
 				$ancestorType->describe(VerbosityLevel::typeOnly()),
 			);
-			foreach ($this->varianceCheck->check($variance, $ancestorType, $messageContext) as $message) {
+			foreach ($this->varianceCheck->check($variance, $ancestorType, $messageContext, false, false) as $message) {
 				$messages[] = $message;
 			}
 		}

--- a/src/Rules/Generics/MethodSignatureVarianceRule.php
+++ b/src/Rules/Generics/MethodSignatureVarianceRule.php
@@ -38,7 +38,8 @@ class MethodSignatureVarianceRule implements Rule
 			sprintf('in parameter %%s of method %s::%s()', SprintfHelper::escapeFormatString($method->getDeclaringClass()->getDisplayName()), SprintfHelper::escapeFormatString($method->getName())),
 			sprintf('in return type of method %s::%s()', $method->getDeclaringClass()->getDisplayName(), $method->getName()),
 			sprintf('in method %s::%s()', $method->getDeclaringClass()->getDisplayName(), $method->getName()),
-			$method->getName() === '__construct' || $method->isStatic(),
+			$method->getName() === '__construct',
+			$method->isStatic(),
 			$method->isPrivate(),
 		);
 	}

--- a/src/Rules/Generics/PropertyVarianceRule.php
+++ b/src/Rules/Generics/PropertyVarianceRule.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Internal\SprintfHelper;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use function sprintf;
+
+/**
+ * @implements Rule<ClassPropertyNode>
+ */
+class PropertyVarianceRule implements Rule
+{
+
+	public function __construct(private VarianceCheck $varianceCheck)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return ClassPropertyNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$classReflection = $scope->getClassReflection();
+		if (!$classReflection instanceof ClassReflection) {
+			return [];
+		}
+
+		if (!$classReflection->hasNativeProperty($node->getName())) {
+			return [];
+		}
+
+		$propertyReflection = $classReflection->getNativeProperty($node->getName());
+
+		return $this->varianceCheck->checkProperty(
+			$propertyReflection,
+			sprintf('in property %s::$%s', SprintfHelper::escapeFormatString($classReflection->getDisplayName()), SprintfHelper::escapeFormatString($node->getName())),
+			$propertyReflection->isStatic(),
+			$propertyReflection->isPrivate(),
+			$propertyReflection->isReadOnly(),
+		);
+	}
+
+}

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -27,8 +27,22 @@ class VarianceCheck
 		$errors = [];
 
 		foreach ($parametersAcceptor->getTemplateTypeMap()->getTypes() as $templateType) {
-			if (!$templateType instanceof TemplateType
-				|| $templateType->getScope()->getFunctionName() === null
+			if (!$templateType instanceof TemplateType) {
+				continue;
+			}
+
+			if ($templateType->getScope()->getClassName() !== null
+				&& $templateType->getScope()->getFunctionName() === '__construct'
+			) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'Constructor is not allowed to define type parameters, but template type %s is defined %s.',
+					$templateType->getName(),
+					$generalMessage,
+				))->build();
+				continue;
+			}
+
+			if ($templateType->getScope()->getFunctionName() === null
 				|| $templateType->getVariance()->invariant()
 			) {
 				continue;

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -34,7 +34,7 @@ class VarianceCheck
 			}
 
 			$errors[] = RuleErrorBuilder::message(sprintf(
-				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type %s in %s.',
+				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type %s %s.',
 				$templateType->getName(),
 				$generalMessage,
 			))->build();

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -41,10 +41,12 @@ class VarianceCheck
 			))->build();
 		}
 
+		if ($isConstructor) {
+			return $errors;
+		}
+
 		foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
-			$variance = $isConstructor || $isStatic
-				? TemplateTypeVariance::createStatic()
-				: TemplateTypeVariance::createContravariant();
+			$variance = TemplateTypeVariance::createContravariant();
 			$type = $parameterReflection->getType();
 			$message = sprintf($parameterTypeMessage, $parameterReflection->getName());
 			foreach ($this->check($variance, $type, $message, $isStatic, $isPrivate) as $error) {

--- a/tests/PHPStan/Rules/Generics/FunctionSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionSignatureVarianceRuleTest.php
@@ -22,7 +22,7 @@ class FunctionSignatureVarianceRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/function-signature-variance.php'], [
 			[
-				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type T in in function FunctionSignatureVariance\f().',
+				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type T in function FunctionSignatureVariance\f().',
 				20,
 			],
 		]);

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -22,11 +22,11 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/method-signature-variance.php'], [
 			[
-				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in in method MethodSignatureVariance\C::b().',
+				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in method MethodSignatureVariance\C::b().',
 				16,
 			],
 			[
-				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in in method MethodSignatureVariance\C::c().',
+				'Variance annotation is only allowed for type parameters of classes and interfaces, but occurs in template type U in method MethodSignatureVariance\C::c().',
 				22,
 			],
 		]);

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -185,6 +185,8 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 				23,
 			],
 		]);
+
+		$this->analyse([__DIR__ . '/data/method-signature-variance-constructor.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -186,7 +186,12 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 			],
 		]);
 
-		$this->analyse([__DIR__ . '/data/method-signature-variance-constructor.php'], []);
+		$this->analyse([__DIR__ . '/data/method-signature-variance-constructor.php'], [
+			[
+				'Constructor is not allowed to define type parameters, but template type Y is defined in method MethodSignatureVariance\Constructor\D::__construct().',
+				79,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -174,6 +174,17 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 				71,
 			],
 		]);
+
+		$this->analyse([__DIR__ . '/data/method-signature-variance-static.php'], [
+			[
+				'Class template type X cannot be referenced in a static member in return type of method MethodSignatureVariance\Static\C::b().',
+				18,
+			],
+			[
+				'Class template type X cannot be referenced in a static member in return type of method MethodSignatureVariance\Static\C::c().',
+				23,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Generics/PropertyVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/PropertyVarianceRuleTest.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<PropertyVarianceRule>
+ */
+class PropertyVarianceRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new PropertyVarianceRule(
+			self::getContainer()->getByType(VarianceCheck::class),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/property-variance.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$a.',
+				51,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$b.',
+				54,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$c.',
+				57,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$d.',
+				60,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$a.',
+				80,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$b.',
+				83,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$c.',
+				86,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$d.',
+				89,
+			],
+		]);
+
+		$this->analyse([__DIR__ . '/data/property-variance-static.php'], [
+			[
+				'Class template type X cannot be referenced in a static member in property PropertyVariance\Static\A::$a.',
+				10,
+			],
+			[
+				'Class template type X cannot be referenced in a static member in property PropertyVariance\Static\A::$b.',
+				13,
+			],
+		]);
+	}
+
+	public function testPromoted(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$this->analyse([__DIR__ . '/data/property-variance-promoted.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$a.',
+				58,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$b.',
+				59,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$c.',
+				60,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$d.',
+				61,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$a.',
+				84,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$b.',
+				85,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$c.',
+				86,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$d.',
+				87,
+			],
+		]);
+	}
+
+	public function testReadOnly(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/property-variance-readonly.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in property PropertyVariance\ReadOnly\B::$b.',
+				45,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\ReadOnly\B::$d.',
+				51,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\C::$a.',
+				62,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\C::$c.',
+				68,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\ReadOnly\C::$d.',
+				71,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\D::$a.',
+				86,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-constructor.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-constructor.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MethodSignatureVariance\Constructor;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/** @template X */
+class A {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param In<In<X>> $c
+	 * @param In<Out<X>> $d
+	 * @param In<Invariant<X>> $e
+	 * @param Out<X> $f
+	 * @param Out<In<X>> $g
+	 * @param Out<Out<X>> $h
+	 * @param Out<Invariant<X>> $i
+	 * @param Invariant<X> $j
+	 * @param Invariant<In<X>> $k
+	 * @param Invariant<Out<X>> $l
+	 */
+	function __construct($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
+}
+
+/** @template-covariant X */
+class B {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param In<In<X>> $c
+	 * @param In<Out<X>> $d
+	 * @param In<Invariant<X>> $e
+	 * @param Out<X> $f
+	 * @param Out<In<X>> $g
+	 * @param Out<Out<X>> $h
+	 * @param Out<Invariant<X>> $i
+	 * @param Invariant<X> $j
+	 * @param Invariant<In<X>> $k
+	 * @param Invariant<Out<X>> $l
+	 */
+	function __construct($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
+}
+
+/** @template-contravariant X */
+class C {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param In<In<X>> $c
+	 * @param In<Out<X>> $d
+	 * @param In<Invariant<X>> $e
+	 * @param Out<X> $f
+	 * @param Out<In<X>> $g
+	 * @param Out<Out<X>> $h
+	 * @param Out<Invariant<X>> $i
+	 * @param Invariant<X> $j
+	 * @param Invariant<In<X>> $k
+	 * @param Invariant<Out<X>> $l
+	 */
+	function __construct($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-constructor.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-constructor.php
@@ -70,3 +70,11 @@ class C {
 	 */
 	function __construct($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l) {}
 }
+
+/** @template X */
+class D {
+	/**
+	 * @template Y of X
+	 */
+	function __construct() {}
+}

--- a/tests/PHPStan/Rules/Generics/data/method-signature-variance-static.php
+++ b/tests/PHPStan/Rules/Generics/data/method-signature-variance-static.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace MethodSignatureVariance\Static;
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/**
+	 * @template Y of X
+	 * @return Y
+	 */
+	static function a() {}
+
+	/**
+	 * @return X
+	 */
+	static function b() {}
+
+	/**
+	 * @return X
+	 */
+	private static function c() {}
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance-promoted.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance-promoted.php
@@ -1,0 +1,93 @@
+<?php // lint >= 8.0
+
+namespace PropertyVariance\Promoted;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class A {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param Out<X> $c
+	 * @param Invariant<X> $d
+	 * @param X $e
+	 * @param In<X> $f
+	 * @param Out<X> $g
+	 * @param Invariant<X> $h
+	 */
+	public function __construct(
+		public $a,
+		public $b,
+		public $c,
+		public $d,
+		private $e,
+		private $f,
+		private $g,
+		private $h,
+	) {}
+}
+
+/**
+ * @template-covariant X
+ */
+class B {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param Out<X> $c
+	 * @param Invariant<X> $d
+	 * @param X $e
+	 * @param In<X> $f
+	 * @param Out<X> $g
+	 * @param Invariant<X> $h
+	 */
+	public function __construct(
+		public $a,
+		public $b,
+		public $c,
+		public $d,
+		private $e,
+		private $f,
+		private $g,
+		private $h,
+	) {}
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param Out<X> $c
+	 * @param Invariant<X> $d
+	 * @param X $e
+	 * @param In<X> $f
+	 * @param Out<X> $g
+	 * @param Invariant<X> $h
+	 */
+	public function __construct(
+		public $a,
+		public $b,
+		public $c,
+		public $d,
+		private $e,
+		private $f,
+		private $g,
+		private $h,
+	) {}
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance-readonly.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance-readonly.php
@@ -1,0 +1,89 @@
+<?php // lint >= 8.1
+
+namespace PropertyVariance\ReadOnly;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class A {
+	/** @var X */
+	public readonly mixed $a;
+
+	/** @var In<X> */
+	public readonly mixed $b;
+
+	/** @var Out<X> */
+	public readonly mixed $c;
+
+	/** @var Invariant<X> */
+	public readonly mixed $d;
+
+	/** @var Invariant<X> */
+	private readonly mixed $e;
+}
+
+/**
+ * @template-covariant X
+ */
+class B {
+	/** @var X */
+	public readonly mixed $a;
+
+	/** @var In<X> */
+	public readonly mixed $b;
+
+	/** @var Out<X> */
+	public readonly mixed $c;
+
+	/** @var Invariant<X> */
+	public readonly mixed $d;
+
+	/** @var Invariant<X> */
+	private readonly mixed $e;
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/** @var X */
+	public readonly mixed $a;
+
+	/** @var In<X> */
+	public readonly mixed $b;
+
+	/** @var Out<X> */
+	public readonly mixed $c;
+
+	/** @var Invariant<X> */
+	public readonly mixed $d;
+
+	/** @var Invariant<X> */
+	private readonly mixed $e;
+}
+
+/**
+ * @template-contravariant X
+ */
+class D {
+	/**
+	 * @param X $a
+	 * @param X $b
+	 */
+	public function __construct(
+		public readonly mixed $a,
+		private readonly mixed $b,
+	) {}
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance-static.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance-static.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PropertyVariance\Static;
+
+/**
+ * @template-contravariant X
+ */
+class A {
+	/** @var X */
+	static $a;
+
+	/** @var X */
+	private static $b;
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PropertyVariance;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class A {
+	/** @var X */
+	public $a;
+
+	/** @var In<X> */
+	public $b;
+
+	/** @var Out<X> */
+	public $c;
+
+	/** @var Invariant<X> */
+	public $d;
+
+	/** @var X */
+	private $e;
+
+	/** @var In<X> */
+	private $f;
+
+	/** @var Out<X> */
+	private $g;
+
+	/** @var Invariant<X> */
+	private $h;
+}
+
+/**
+ * @template-covariant X
+ */
+class B {
+	/** @var X */
+	public $a;
+
+	/** @var In<X> */
+	public $b;
+
+	/** @var Out<X> */
+	public $c;
+
+	/** @var Invariant<X> */
+	public $d;
+
+	/** @var X */
+	private $e;
+
+	/** @var In<X> */
+	private $f;
+
+	/** @var Out<X> */
+	private $g;
+
+	/** @var Invariant<X> */
+	private $h;
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/** @var X */
+	public $a;
+
+	/** @var In<X> */
+	public $b;
+
+	/** @var Out<X> */
+	public $c;
+
+	/** @var Invariant<X> */
+	public $d;
+
+	/** @var X */
+	private $e;
+
+	/** @var In<X> */
+	private $f;
+
+	/** @var Out<X> */
+	private $g;
+
+	/** @var Invariant<X> */
+	private $h;
+}


### PR DESCRIPTION
After #2064, I've had a few more eureka moments about generic variance. Honestly, I'm starting to feel like I'm fighting a hydra: I cut off one head and two more grow back 😅 as a result, I'm proposing several changes.

Sorry for not opening separate pull requests, but all these changes sort of build upon one another, and I believe they make the most sense as a whole package. I'm opening a draft PR so that you can take a look at the changes in their interconnectedness, and then I can split this commit by commit. It's 100% ready for review.

## Disallow class template types in static methods

Other languages with generics such as Java, Kotlin, or TypeScript do not allow template type references in static members (with the obvious exception of a static method referencing its own template types). I think PHPStan should follow suit.

After all, static members are shared, even between various instances of the type constructor, while the type parameter is bound to its instances. In terms of (pseudo)code, you can't just call `Collection<Dog>::create()`. You make the factory itself generic and call `Collection::create<Dog>()` instead.

I hope this change should be relatively safe; I seriously doubt people are using class template types in static methods because the semantics of that are just so unclear. But if necessary, I believe it wouldn't be that difficult to add a feature toggle for this, even in the context of all the surrounding changes.

## Do not check variance in constructor

Turns out [you were _almost_ right](https://github.com/phpstan/phpstan-src/pull/2064#issuecomment-1342510951): there really should be a similar exception for constructor, except there isn't :) the check has so far behaved in the way I described in reply to your comment, but that way is indeed incorrect. I've changed the code so that the constructor is ignored as well.

This potentially relaxes the whole check: I imagine it might have previously discovered variance issues with promoted properties. But I consider it to be just a fortunate side effect rather than a feature. PHPStan should distinguish between the constructor _parameter_ which should be omitted from the variance check, and the promoted _property_ which should be included in the variance check just as any other property (more on that below).

## Explicitly disallow defining type parameters in constructor

While methods are allowed to define their own type parameters and become generic, the constructor is a special case and should be exempt from this. I expect nobody is doing this, anyway, but I think it can't hurt to forbid it explicitly.

## Check generic variance rules for properties

All these changes gradually build up towards the final one: generic variance check for properties.

Properties are treated as invariant, therefore this new rule will be most useful with `invarianceComposition` enabled (#2054). The only exception is native readonly properties: I believe we can safely consider them covariant because PHPStan already makes sure that they are initialized in the constructor and only read ever since.

Similarly to methods, private properties are ignored and static properties are prevented from referencing template types altogether.

I've hidden this new rule behind a bleeding-edge feature toggle because I expect it might break a build or two for projects (although hopefully not that many since private properties are ignored).