### PR TITLE
Remove unnecessary regex matching

### DIFF
--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -107,11 +107,7 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	private function export(string $value): string
 	{
-		if (Strings::match($value, '([\000-\037])') !== null) {
-			return '"' . addcslashes($value, "\0..\37\\\"") . '"';
-		}
-
-		return "'" . addcslashes($value, '\\\'') . "'";
+		return '"' . addcslashes($value, "\0..\37\\\"") . '"';
 	}
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic


### PR DESCRIPTION
~~.. testing this small change while my laptop is busy running blackfire profiles~~

seems the change is not useful, since I missed single vs. double quotes.
leaving open for now, as it serves as a example for https://github.com/phpstan/phpstan/discussions/8482