### PR TITLE
Faster ConstantFloatType->isSuperTypeOf(ConstantFloatType)

### DIFF
--- a/src/Type/Constant/ConstantFloatType.php
+++ b/src/Type/Constant/ConstantFloatType.php
@@ -11,8 +11,10 @@ use PHPStan\Type\Traits\ConstantNumericComparisonTypeTrait;
 use PHPStan\Type\Traits\ConstantScalarTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use function abs;
 use function is_finite;
 use function strpos;
+use const PHP_FLOAT_EPSILON;
 
 /** @api */
 class ConstantFloatType extends FloatType implements ConstantScalarType
@@ -52,7 +54,7 @@ class ConstantFloatType extends FloatType implements ConstantScalarType
 	{
 		if ($type instanceof self) {
 			if (!$this->equals($type)) {
-				if ($this->describe(VerbosityLevel::value()) === $type->describe(VerbosityLevel::value())) {
+				if (abs($this->value - $type->value) < PHP_FLOAT_EPSILON) {
 					return TrinaryLogic::createMaybe();
 				}
 


### PR DESCRIPTION
40% speedup of https://github.com/phpstan/phpstan/issues/8504

> This file [mmarton/phpstan-issue8146@master/src/DataFixtures/LocationFixtures.php](https://github.com/mmarton/phpstan-issue8146/blob/master/src/DataFixtures/LocationFixtures.php?rgh-link-date=2022-12-11T08%3A29%3A10Z) from https://github.com/phpstan/phpstan/issues/8146 really slows PHPStan down, because it contains a lot of literal arrays.

-----

<img width="693" alt="grafik" src="https://user-images.githubusercontent.com/120441/206902343-23583bc1-aaa2-4d87-8c8e-e1936761f65a.png">
