### PR TITLE
Faster ConstantStringType->toArrayKey()

### DIFF
--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -53,6 +53,8 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	private ?ObjectType $objectType = null;
 
+	private ?Type $arrayKeyType = null;
+
 	/** @api */
 	public function __construct(private string $value, private bool $isClassString = false)
 	{
@@ -263,9 +265,13 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	public function toArrayKey(): Type
 	{
+		if ($this->arrayKeyType !== null) {
+			return $this->arrayKeyType;
+		}
+
 		/** @var int|string $offsetValue */
 		$offsetValue = key([$this->value => null]);
-		return is_int($offsetValue) ? new ConstantIntegerType($offsetValue) : new ConstantStringType($offsetValue);
+		return $this->arrayKeyType = is_int($offsetValue) ? new ConstantIntegerType($offsetValue) : new ConstantStringType($offsetValue);
 	}
 
 	public function isString(): TrinaryLogic


### PR DESCRIPTION
11% speedup of https://github.com/phpstan/phpstan/issues/8504

> This file [mmarton/phpstan-issue8146@master/src/DataFixtures/LocationFixtures.php](https://github.com/mmarton/phpstan-issue8146/blob/master/src/DataFixtures/LocationFixtures.php?rgh-link-date=2022-12-11T08%3A29%3A10Z) from https://github.com/phpstan/phpstan/issues/8146 really slows PHPStan down, because it contains a lot of literal arrays.

-----


<img width="667" alt="grafik" src="https://user-images.githubusercontent.com/120441/206903750-43aa1f04-575e-4664-baaf-1adcad86e911.png">
