### PR TITLE
Faster ConstantArrayType->isSuperTypeOf()

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -330,7 +330,12 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				} elseif ($hasOffset->maybe() && !$this->isOptionalKey($i)) {
 					$results[] = TrinaryLogic::createMaybe();
 				}
-				$results[] = $this->valueTypes[$i]->isSuperTypeOf($type->getOffsetValueType($keyType));
+
+				$isValueSuperType = $this->valueTypes[$i]->isSuperTypeOf($type->getOffsetValueType($keyType));
+				if ($isValueSuperType->no()) {
+					return TrinaryLogic::createNo();
+				}
+				$results[] = $isValueSuperType;
 			}
 
 			return TrinaryLogic::createYes()->and(...$results);


### PR DESCRIPTION
23% speedup of https://github.com/phpstan/phpstan/issues/8504

> This file [mmarton/phpstan-issue8146@master/src/DataFixtures/LocationFixtures.php](https://github.com/mmarton/phpstan-issue8146/blob/master/src/DataFixtures/LocationFixtures.php?rgh-link-date=2022-12-11T08%3A29%3A10Z) from https://github.com/phpstan/phpstan/issues/8146 really slows PHPStan down, because it contains a lot of literal arrays.

----

<img width="666" alt="grafik" src="https://user-images.githubusercontent.com/120441/206927935-8eeefb78-0f8a-4a60-b74c-764bce54000d.png">
