### PR TITLE
Implement identical/equal comparisons on EnumCaseObjectType

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1304,10 +1304,7 @@ class InitializerExprTypeResolver
 		}
 
 		if ($leftType instanceof EnumCaseObjectType && $rightType instanceof EnumCaseObjectType) {
-			return new ConstantBooleanType(
-				$leftType->getClassName() === $rightType->getClassName()
-				&& $leftType->getEnumCaseName() === $rightType->getEnumCaseName(),
-			);
+			return new ConstantBooleanType($leftType->equals($rightType));
 		}
 
 		$isSuperset = $leftType->isSuperTypeOf($rightType);

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1303,6 +1303,13 @@ class InitializerExprTypeResolver
 			return new ConstantBooleanType($leftType->getValue() === $rightType->getValue());
 		}
 
+		if ($leftType instanceof EnumCaseObjectType && $rightType instanceof EnumCaseObjectType) {
+			return new ConstantBooleanType(
+				$leftType->getClassName() === $rightType->getClassName()
+				&& $leftType->getEnumCaseName() === $rightType->getEnumCaseName(),
+			);
+		}
+
 		$isSuperset = $leftType->isSuperTypeOf($rightType);
 		if ($isSuperset->no()) {
 			return new ConstantBooleanType(false);
@@ -1319,8 +1326,10 @@ class InitializerExprTypeResolver
 	{
 		$integerType = new IntegerType();
 		$floatType = new FloatType();
+
 		if (
-			($leftType->isString()->yes() && $rightType->isString()->yes())
+			($leftType instanceof EnumCaseObjectType && $rightType instanceof EnumCaseObjectType)
+			|| ($leftType->isString()->yes() && $rightType->isString()->yes())
 			|| ($integerType->isSuperTypeOf($leftType)->yes() && $integerType->isSuperTypeOf($rightType)->yes())
 			|| ($floatType->isSuperTypeOf($leftType)->yes() && $floatType->isSuperTypeOf($rightType)->yes())
 		) {

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<IfConstantConditionRule>
@@ -127,6 +128,29 @@ class IfConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-6902.php'], []);
+	}
+
+	public function testBug8485(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8485.php'], [
+			[
+				'If condition is always true.',
+				19,
+			],
+			[
+				'If condition is always false.',
+				24,
+			],
+			[
+				'If condition is always false.',
+				29,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -153,7 +153,11 @@ class MatchExpressionRuleTest extends RuleTestCase
 				56,
 			],
 			[
-				'Match arm comparison between *NEVER* and MatchEnums\Foo is always false.',
+				'Match arm comparison between MatchEnums\Foo::THREE and MatchEnums\Foo::THREE is always true.',
+				76,
+			],
+			[
+				'Match arm is unreachable because previous comparison is always true.',
 				77,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -607,6 +607,37 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8158.php'], []);
 	}
 
+	public function testBug8485(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-8485.php'], [
+			[
+				'Strict comparison using === between Bug8485\E::c and Bug8485\E::c will always evaluate to true.',
+				17,
+			],
+			[
+				'Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.',
+				22,
+			],
+			[
+				'Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.',
+				27,
+			],
+			[
+				'Strict comparison using === between Bug8485\F and Bug8485\E will always evaluate to false.',
+				35,
+			],
+			[
+				'Strict comparison using === between Bug8485\F and Bug8485\E::c will always evaluate to false.',
+				40,
+			],
+		]);
+	}
+
 	public function testPhpUnitIntegration(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;

--- a/tests/PHPStan/Rules/Comparison/data/bug-8485.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8485.php
@@ -1,0 +1,45 @@
+<?php // lint >= 8.1
+
+namespace Bug8485;
+
+enum E {
+	case c;
+}
+
+enum F {
+	case c;
+}
+
+function shouldError():void {
+	$e = E::c;
+	$f = F::c;
+
+	if ($e === E::c) {
+	}
+	if ($e == E::c) {
+	}
+
+	if ($f === $e) {
+	}
+	if ($f == $e) {
+	}
+
+	if ($f === E::c) {
+	}
+	if ($f == E::c) {
+	}
+}
+
+
+function allGood(E $e, F $f):void {
+	if ($f === $e) {
+	}
+	if ($f == $e) {
+	}
+
+	if ($f === E::c) {
+	}
+	if ($f == E::c) {
+	}
+}
+


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/8485

for comparison see the handling of regular constants/class-constants: https://phpstan.org/r/a6a9d005-a9d5-4f7d-86ad-00a3a3422cec