### PR TITLE
Implement identical/equal comparisons on EnumCaseObjectType

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -489,6 +489,11 @@ services:
 			- phpstan.parser.richParserNodeVisitor
 
 	-
+		class: PHPStan\Parser\LastConditionVisitor
+		tags:
+			- phpstan.parser.richParserNodeVisitor
+
+	-
 		class: PhpParser\NodeVisitor\NodeConnectingVisitor
 
 	-

--- a/src/Parser/LastConditionVisitor.php
+++ b/src/Parser/LastConditionVisitor.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parser;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use function count;
+
+class LastConditionVisitor extends NodeVisitorAbstract
+{
+
+	public const ATTRIBUTE_NAME = 'isLastCondition';
+
+	public function enterNode(Node $node): ?Node
+	{
+		if ($node instanceof Node\Stmt\If_ && $node->elseifs !== []) {
+			$lastElseIf = count($node->elseifs) - 1;
+
+			$node->elseifs[$lastElseIf]->cond->setAttribute(self::ATTRIBUTE_NAME, true);
+		}
+
+		if ($node instanceof Node\Expr\Match_ && $node->arms !== []) {
+			$lastArm = count($node->arms) - 1;
+
+			if ($node->arms[$lastArm]->conds !== null && $node->arms[$lastArm]->conds !== []) {
+				$node->arms[$lastArm]->conds[0]->setAttribute(self::ATTRIBUTE_NAME, true);
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1333,6 +1333,23 @@ class InitializerExprTypeResolver
 			return new ConstantBooleanType($leftType->equals($rightType));
 		}
 
+		if ($leftType instanceof TypeWithClassName && $rightType instanceof EnumCaseObjectType) {
+			$classReflection = $leftType->getClassReflection();
+			if ($classReflection !== null && $classReflection->isEnum() && $classReflection->getName() === $rightType->getClassName()) {
+				if (count($classReflection->getEnumCases()) === 1) {
+					return new ConstantBooleanType(true);
+				}
+			}
+		}
+		if ($rightType instanceof TypeWithClassName && $leftType instanceof EnumCaseObjectType) {
+			$classReflection = $rightType->getClassReflection();
+			if ($classReflection !== null && $classReflection->isEnum() && $classReflection->getName() === $leftType->getClassName()) {
+				if (count($classReflection->getEnumCases()) === 1) {
+					return new ConstantBooleanType(true);
+				}
+			}
+		}
+
 		$isSuperset = $leftType->isSuperTypeOf($rightType);
 		if ($isSuperset->no()) {
 			return new ConstantBooleanType(false);

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1329,6 +1329,10 @@ class InitializerExprTypeResolver
 			return new ConstantBooleanType($leftType->getValue() === $rightType->getValue());
 		}
 
+		if ($leftType instanceof EnumCaseObjectType && $rightType instanceof EnumCaseObjectType) {
+			return new ConstantBooleanType($leftType->equals($rightType));
+		}
+
 		$isSuperset = $leftType->isSuperTypeOf($rightType);
 		if ($isSuperset->no()) {
 			return new ConstantBooleanType(false);
@@ -1345,8 +1349,10 @@ class InitializerExprTypeResolver
 	{
 		$integerType = new IntegerType();
 		$floatType = new FloatType();
+
 		if (
-			($leftType->isString()->yes() && $rightType->isString()->yes())
+			($leftType instanceof EnumCaseObjectType && $rightType instanceof EnumCaseObjectType)
+			|| ($leftType->isString()->yes() && $rightType->isString()->yes())
 			|| ($integerType->isSuperTypeOf($leftType)->yes() && $integerType->isSuperTypeOf($rightType)->yes())
 			|| ($floatType->isSuperTypeOf($leftType)->yes() && $floatType->isSuperTypeOf($rightType)->yes())
 		) {

--- a/src/Rules/Classes/ImpossibleInstanceOfRule.php
+++ b/src/Rules/Classes/ImpossibleInstanceOfRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Classes;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -81,6 +82,10 @@ class ImpossibleInstanceOfRule implements Rule
 				)))->build(),
 			];
 		} elseif ($this->checkAlwaysTrueInstanceof) {
+			if ($node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+				return [];
+			}
+
 			return [
 				$addTip(RuleErrorBuilder::message(sprintf(
 					'Instanceof between %s and %s will always evaluate to true.',

--- a/src/Rules/Comparison/BooleanNotConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanNotConstantConditionRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -47,12 +48,14 @@ class BooleanNotConstantConditionRule implements Rule
 				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
 			};
 
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Negated boolean expression is always %s.',
-					$exprType->getValue() ? 'false' : 'true',
-				)))->line($node->expr->getLine())->build(),
-			];
+			if ($exprType->getValue() === true || $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) !== true) {
+				return [
+					$addTip(RuleErrorBuilder::message(sprintf(
+						'Negated boolean expression is always %s.',
+						$exprType->getValue() ? 'false' : 'true',
+					)))->line($node->expr->getLine())->build(),
+				];
+			}
 		}
 
 		return [];

--- a/src/Rules/Comparison/BooleanOrConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanOrConstantConditionRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\BooleanOrNode;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -53,11 +54,14 @@ class BooleanOrConstantConditionRule implements Rule
 
 				return $ruleErrorBuilder->tip($tipText);
 			};
-			$messages[] = $addTipLeft(RuleErrorBuilder::message(sprintf(
-				'Left side of %s is always %s.',
-				$nodeText,
-				$leftType->getValue() ? 'true' : 'false',
-			)))->line($originalNode->left->getLine())->build();
+
+			if ($leftType->getValue() === false || $originalNode->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) !== true) {
+				$messages[] = $addTipLeft(RuleErrorBuilder::message(sprintf(
+					'Left side of %s is always %s.',
+					$nodeText,
+					$leftType->getValue() ? 'true' : 'false',
+				)))->line($originalNode->left->getLine())->build();
+			}
 		}
 
 		$rightScope = $node->getRightScope();
@@ -65,7 +69,7 @@ class BooleanOrConstantConditionRule implements Rule
 			$rightScope,
 			$originalNode->right,
 		);
-		if ($rightType instanceof ConstantBooleanType) {
+		if ($rightType instanceof ConstantBooleanType && !$scope->isInFirstLevelStatement()) {
 			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($rightScope, $originalNode, $tipText): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
@@ -82,7 +86,7 @@ class BooleanOrConstantConditionRule implements Rule
 				return $ruleErrorBuilder->tip($tipText);
 			};
 
-			if (!$scope->isInFirstLevelStatement()) {
+			if ($rightType->getValue() === false || $originalNode->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) !== true) {
 				$messages[] = $addTipRight(RuleErrorBuilder::message(sprintf(
 					'Right side of %s is always %s.',
 					$nodeText,
@@ -91,7 +95,7 @@ class BooleanOrConstantConditionRule implements Rule
 			}
 		}
 
-		if (count($messages) === 0) {
+		if (count($messages) === 0 && !$scope->isInFirstLevelStatement()) {
 			$nodeType = $this->treatPhpDocTypesAsCertain ? $scope->getType($originalNode) : $scope->getNativeType($originalNode);
 			if ($nodeType instanceof ConstantBooleanType) {
 				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode, $tipText): RuleErrorBuilder {
@@ -107,7 +111,7 @@ class BooleanOrConstantConditionRule implements Rule
 					return $ruleErrorBuilder->tip($tipText);
 				};
 
-				if (!$scope->isInFirstLevelStatement()) {
+				if ($nodeType->getValue() === false || $originalNode->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) !== true) {
 					$messages[] = $addTip(RuleErrorBuilder::message(sprintf(
 						'Result of %s is always %s.',
 						$nodeText,

--- a/src/Rules/Comparison/ConstantConditionRuleHelper.php
+++ b/src/Rules/Comparison/ConstantConditionRuleHelper.php
@@ -21,10 +21,6 @@ class ConstantConditionRuleHelper
 
 	public function shouldReportAlwaysTrueByDefault(Expr $expr): bool
 	{
-		if ($expr->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
-			return false;
-		}
-
 		return $expr instanceof Expr\BooleanNot
 			|| $expr instanceof Expr\BinaryOp\BooleanOr
 			|| $expr instanceof Expr\BinaryOp\BooleanAnd
@@ -51,6 +47,11 @@ class ConstantConditionRuleHelper
 			|| $expr instanceof Expr\BinaryOp\SmallerOrEqual
 		) {
 			// already checked by different rules
+			return true;
+		}
+
+		if ($expr->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+			// always-true should not be reported because last condition
 			return true;
 		}
 

--- a/src/Rules/Comparison/ConstantConditionRuleHelper.php
+++ b/src/Rules/Comparison/ConstantConditionRuleHelper.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Type\BooleanType;
 
 class ConstantConditionRuleHelper

--- a/src/Rules/Comparison/ConstantConditionRuleHelper.php
+++ b/src/Rules/Comparison/ConstantConditionRuleHelper.php
@@ -21,6 +21,10 @@ class ConstantConditionRuleHelper
 
 	public function shouldReportAlwaysTrueByDefault(Expr $expr): bool
 	{
+		if ($expr->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+			return false;
+		}
+
 		return $expr instanceof Expr\BooleanNot
 			|| $expr instanceof Expr\BinaryOp\BooleanOr
 			|| $expr instanceof Expr\BinaryOp\BooleanAnd

--- a/src/Rules/Comparison/ConstantLooseComparisonRule.php
+++ b/src/Rules/Comparison/ConstantLooseComparisonRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -46,6 +47,10 @@ class ConstantLooseComparisonRule implements Rule
 				))->build(),
 			];
 		} elseif ($this->checkAlwaysTrueLooseComparison) {
+			if ($node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+				return [];
+			}
+
 			return [
 				RuleErrorBuilder::message(sprintf(
 					'Loose comparison using %s between %s and %s will always evaluate to true.',

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function sprintf;
@@ -65,6 +66,10 @@ class ImpossibleCheckTypeFunctionCallRule implements Rule
 				)))->build(),
 			];
 		} elseif ($this->checkAlwaysTrueCheckTypeFunctionCall) {
+			if ($node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+				return [];
+			}
+
 			return [
 				$addTip(RuleErrorBuilder::message(sprintf(
 					'Call to function %s()%s will always evaluate to true.',

--- a/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -65,6 +66,10 @@ class ImpossibleCheckTypeMethodCallRule implements Rule
 				)))->build(),
 			];
 		} elseif ($this->checkAlwaysTrueCheckTypeFunctionCall) {
+			if ($node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+				return [];
+			}
+
 			$method = $this->getMethod($node->var, $node->name->name, $scope);
 			return [
 				$addTip(RuleErrorBuilder::message(sprintf(

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -66,6 +67,10 @@ class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 				)))->build(),
 			];
 		} elseif ($this->checkAlwaysTrueCheckTypeFunctionCall) {
+			if ($node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+				return [];
+			}
+
 			$method = $this->getMethod($node->class, $node->name->name, $scope);
 
 			return [

--- a/src/Rules/Comparison/StrictComparisonOfDifferentTypesRule.php
+++ b/src/Rules/Comparison/StrictComparisonOfDifferentTypesRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -49,6 +50,10 @@ class StrictComparisonOfDifferentTypesRule implements Rule
 				))->build(),
 			];
 		} elseif ($this->checkAlwaysTrueStrictComparison) {
+			if ($node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true) {
+				return [];
+			}
+
 			return [
 				RuleErrorBuilder::message(sprintf(
 					'Strict comparison using %s between %s and %s will always evaluate to true.',

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1149,7 +1149,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8467b.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8442.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/PDOStatement.php');
-		if (PHP_VERSION_ID >= 80000) {
+		if (PHP_VERSION_ID >= 80100) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8485.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/discussion-8447.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1149,6 +1149,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8467b.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8442.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/PDOStatement.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8485.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/discussion-8447.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7805.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-82.php');

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -380,13 +380,24 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8042.php'], [
 			[
 				'Instanceof between Bug8042\B and Bug8042\B will always evaluate to true.',
-				18
+				18,
 			],
 			[
 				'Instanceof between Bug8042\B and Bug8042\B will always evaluate to true.',
-				26
+				26,
 			],
 		]);
+	}
+
+	public function testBug7721(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('This test needs PHP 8.1');
+		}
+
+		$this->checkAlwaysTrueInstanceOf = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-7721.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Classes;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ImpossibleInstanceOfRule>
@@ -364,6 +365,26 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between Bug5333\FinalRoute and Bug5333\FinalRoute will always evaluate to true.',
 				113,
+			],
+		]);
+	}
+
+	public function testBug8042(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('This test needs PHP 8.0');
+		}
+
+		$this->checkAlwaysTrueInstanceOf = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8042.php'], [
+			[
+				'Instanceof between Bug8042\B and Bug8042\B will always evaluate to true.',
+				18
+			],
+			[
+				'Instanceof between Bug8042\B and Bug8042\B will always evaluate to true.',
+				26
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/data/bug-7721.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-7721.php
@@ -1,0 +1,17 @@
+<?php // lint >= 8.1
+
+namespace Bug7721;
+
+final class A { }
+final class B { }
+final class C
+{
+	public function __construct(public readonly A|B $value) { }
+}
+
+$c = new C(value: new A());
+
+echo match (true) {
+	$c->value instanceof A => 'A',
+	$c->value instanceof B => 'B'
+};

--- a/tests/PHPStan/Rules/Classes/data/bug-8042.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-8042.php
@@ -1,0 +1,29 @@
+<?php // lint >= 8.0
+
+namespace Bug8042;
+
+class A {}
+class B {}
+
+function test(A|B $ab): string {
+	return match (true) {
+		$ab instanceof A => 'a',
+		$ab instanceof B => 'b',
+	};
+}
+
+function test2(A|B $ab): string {
+	return match (true) {
+		$ab instanceof A => 'a',
+		$ab instanceof B => 'b',
+		rand(0, 1) => 'never'
+	};
+}
+
+function test3(A|B $ab): string {
+	return match (true) {
+		$ab instanceof A => 'a',
+		$ab instanceof B => 'b',
+		default => 'never'
+	};
+}

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -118,6 +118,14 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 				'Right side of && is always true.',
 				147,
 			],
+			[
+				'Left side of && is always true.',
+				178,
+			],
+			[
+				'Right side of && is always true.',
+				178,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
@@ -64,6 +64,10 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 				'Negated boolean expression is always false.',
 				50,
 			],
+			[
+				'Negated boolean expression is always true.',
+				67,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -110,6 +110,14 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 				'Right side of || is always true.',
 				85,
 			],
+			[
+				'Left side of || is always true.',
+				101,
+			],
+			[
+				'Right side of || is always true.',
+				110,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ConstantLooseComparisonRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ConstantLooseComparisonRuleTest.php
@@ -26,6 +26,14 @@ class ConstantLooseComparisonRuleTest extends RuleTestCase
 				"Loose comparison using == between 0 and '1' will always evaluate to false.",
 				20,
 			],
+			[
+				"Loose comparison using == between 0 and '1' will always evaluate to false.",
+				27,
+			],
+			[
+				"Loose comparison using == between 0 and '1' will always evaluate to false.",
+				33,
+			],
 		]);
 	}
 
@@ -40,6 +48,18 @@ class ConstantLooseComparisonRuleTest extends RuleTestCase
 			[
 				"Loose comparison using == between 0 and '1' will always evaluate to false.",
 				20,
+			],
+			[
+				"Loose comparison using == between 0 and '1' will always evaluate to false.",
+				27,
+			],
+			[
+				"Loose comparison using == between 0 and '1' will always evaluate to false.",
+				33,
+			],
+			[
+				"Loose comparison using == between 0 and '0' will always evaluate to true.",
+				35,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -41,7 +41,7 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/elseif-condition.php'], [
 			[
 				'Elseif condition is always true.',
-				18,
+				56,
 			],
 		]);
 	}
@@ -52,7 +52,7 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/elseif-condition-not-phpdoc.php'], [
 			[
 				'Elseif condition is always true.',
-				18,
+				46,
 			],
 		]);
 	}
@@ -63,11 +63,11 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/elseif-condition-not-phpdoc.php'], [
 			[
 				'Elseif condition is always true.',
-				18,
+				46,
 			],
 			[
 				'Elseif condition is always true.',
-				24,
+				56,
 				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -140,15 +140,15 @@ class IfConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8485.php'], [
 			[
 				'If condition is always true.',
-				19,
+				21,
 			],
 			[
 				'If condition is always false.',
-				24,
+				26,
 			],
 			[
 				'If condition is always false.',
-				29,
+				31,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<IfConstantConditionRule>
@@ -127,6 +128,29 @@ class IfConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-6902.php'], []);
+	}
+
+	public function testBug8485(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8485.php'], [
+			[
+				'If condition is always true.',
+				19,
+			],
+			[
+				'If condition is always false.',
+				24,
+			],
+			[
+				'If condition is always false.',
+				29,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -238,6 +238,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					'Call to function testIsInt() with int will always evaluate to true.',
 					875,
 				],
+				[
+					'Call to function is_int() with int will always evaluate to true.',
+					889,
+				],
 			],
 		);
 	}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
@@ -117,6 +117,10 @@ class ImpossibleCheckTypeMethodCallRuleEqualsTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isNotSame() with 2 and 2 will always evaluate to false.',
 				194,
 			],
+			[
+				'Call to method ImpossibleMethodCall\ConditionalAlwaysTrue::isInt() with int will always evaluate to true.',
+				208,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -149,6 +149,10 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 				'Call to method ImpossibleMethodCall\Foo::isNotSame() with 2 and 2 will always evaluate to false.',
 				194,
 			],
+			[
+				'Call to method ImpossibleMethodCall\ConditionalAlwaysTrue::isInt() with int will always evaluate to true.',
+				208,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -61,6 +61,10 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 				'Call to static method PHPStan\Tests\AssertionClass::assertInt() with arguments 1, 2 and 3 will always evaluate to true.',
 				34,
 			],
+			[
+				'Call to static method ImpossibleStaticMethodCall\ConditionalAlwaysTrue::isInt() with int will always evaluate to true.',
+				66,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -246,4 +246,30 @@ class MatchExpressionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7746.php'], []);
 	}
 
+	public function testBug8240(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8240.php'], [
+			[
+				'Match arm comparison between Bug8240\Foo and Bug8240\Foo::BAR is always true.',
+				13,
+			],
+			[
+				'Match arm is unreachable because previous comparison is always true.',
+				14,
+			],
+			[
+				'Match arm comparison between Bug8240\Foo2::BAZ and Bug8240\Foo2::BAZ is always true.',
+				28,
+			],
+			[
+				'Match arm is unreachable because previous comparison is always true.',
+				29,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -153,7 +153,11 @@ class MatchExpressionRuleTest extends RuleTestCase
 				56,
 			],
 			[
-				'Match arm comparison between *NEVER* and MatchEnums\Foo is always false.',
+				'Match arm comparison between MatchEnums\Foo::THREE and MatchEnums\Foo::THREE is always true.',
+				76,
+			],
+			[
+				'Match arm is unreachable because previous comparison is always true.',
 				77,
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -653,7 +653,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->checkAlwaysTrueStrictComparison = true;
 		$this->analyse([__DIR__ . '/data/bug-8586.php'], []);
 	}
-	
+
 	public function testBug4242(): void
 	{
 		if (PHP_VERSION_ID < 80100) {

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -653,6 +653,16 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->checkAlwaysTrueStrictComparison = true;
 		$this->analyse([__DIR__ . '/data/bug-8586.php'], []);
 	}
+	
+	public function testBug4242(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-4242.php'], []);
+	}
 
 	public function testBug3633(): void
 	{

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -183,10 +183,6 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 					635,
 				],
 				[
-					'Strict comparison using === between \'foofoofoofoofoofoof…\' and \'foofoofoofoofoofoof…\' will always evaluate to true.',
-					654,
-				],
-				[
 					'Strict comparison using === between string|null and 1 will always evaluate to false.',
 					685,
 				],
@@ -249,6 +245,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 				[
 					'Strict comparison using !== between NAN and NAN will always evaluate to true.',
 					983,
+				],
+				[
+					'Strict comparison using === between \'foofoofoofoofoofoof…\' and \'foofoofoofoofoofoof…\' will always evaluate to true.',
+					996,
 				],
 			],
 		);
@@ -617,23 +617,27 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8485.php'], [
 			[
 				'Strict comparison using === between Bug8485\E::c and Bug8485\E::c will always evaluate to true.',
-				17,
+				19,
 			],
 			[
 				'Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.',
-				22,
+				24,
 			],
 			[
 				'Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.',
-				27,
+				29,
 			],
 			[
 				'Strict comparison using === between Bug8485\F and Bug8485\E will always evaluate to false.',
-				35,
+				36,
 			],
 			[
 				'Strict comparison using === between Bug8485\F and Bug8485\E::c will always evaluate to false.',
-				40,
+				41,
+			],
+			[
+				'Strict comparison using === between Bug8485\FooEnum::C and Bug8485\FooEnum::C will always evaluate to true.',
+				74,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -607,6 +607,37 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8158.php'], []);
 	}
 
+	public function testBug8485(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-8485.php'], [
+			[
+				'Strict comparison using === between Bug8485\E::c and Bug8485\E::c will always evaluate to true.',
+				17,
+			],
+			[
+				'Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.',
+				22,
+			],
+			[
+				'Strict comparison using === between Bug8485\F::c and Bug8485\E::c will always evaluate to false.',
+				27,
+			],
+			[
+				'Strict comparison using === between Bug8485\F and Bug8485\E will always evaluate to false.',
+				35,
+			],
+			[
+				'Strict comparison using === between Bug8485\F and Bug8485\E::c will always evaluate to false.',
+				40,
+			],
+		]);
+	}
+
 	public function testPhpUnitIntegration(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;

--- a/tests/PHPStan/Rules/Comparison/data/boolean-and.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-and.php
@@ -164,3 +164,19 @@ function bug1924() {
 	if (isset($arr['a']) && isset($arr['b'])) {
 	}
 }
+
+class ConditionalAlwaysTrue
+{
+	public function sayHello(int $i): void
+	{
+		$one = 1;
+		if ($i < 5) {
+		} elseif ($one && $i) { // always-true should not be reported because last condition
+		}
+
+		if ($i < 5) {
+		} elseif ($one && $i) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/boolean-not.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-not.php
@@ -52,3 +52,22 @@ class BooleanNot
 		}
 	}
 }
+
+class ConditionalAlwaysTrue
+{
+	public function doFoo(int $i)
+	{
+		$zero = 0;
+		if ($i < 0) {
+		} elseif (!$zero) { // always-true should not be reported because last condition
+		}
+
+		$zero = 0;
+		if ($i < 0) {
+		} elseif (!$zero) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+
+}
+

--- a/tests/PHPStan/Rules/Comparison/data/boolean-or.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-or.php
@@ -87,3 +87,29 @@ class OrInIfCondition
 		}
 	}
 }
+
+class ConditionalAlwaysTrue
+{
+	public function doFoo(int $i, $x)
+	{
+		$one = 1;
+		if ($x) {
+		} elseif ($one || $i) { // always-true should not be reported because last condition
+		}
+
+		if ($x) {
+		} elseif ($one || $i) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+
+		if ($x) {
+		} elseif ($i || $one) { // always-true should not be reported because last condition
+		}
+
+		if ($x) {
+		} elseif ($i || $one) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-4242.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4242.php
@@ -1,0 +1,101 @@
+<?php // lint >= 8.1
+
+namespace Bug4242;
+
+class Enum
+{
+	public const TYPE_A = 1;
+	public const TYPE_B = 2;
+	public const TYPE_C = 3;
+	public const TYPE_D = 4;
+}
+
+class Data
+{
+	private int $type;
+	private int $someLoad;
+	public function __construct(int $type)
+	{
+		$this->type=$type;
+	}
+	public function getType(): int
+	{
+		return $this->type;
+	}
+	public function someLoad(int $type): self
+	{
+		$this->someLoad=$type;
+		return $this;
+	}
+	public function getSomeLoad(): int
+	{
+		return $this->someLoad;
+	}
+}
+
+class HelloWorld
+{
+	public function case1(): void
+	{
+		$data=(new Data(Enum::TYPE_A));
+		if($data->getType()===Enum::TYPE_A){
+			$data->someLoad(4);
+		}elseif(\in_array($data->getType(), [7,8,9,100], true)){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_B){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_C){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_D){
+			$data->someLoad(6);
+		}else{
+			return;
+		}
+
+
+		if($data->getType()===Enum::TYPE_A){
+			$data->someLoad(4);
+		}elseif(\in_array($data->getType(), [7,8,9,100], true)){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_B){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_C){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_D){ // expected to work without an error
+			$data->someLoad(6);
+		}
+
+	}
+
+	public function case2(): void
+	{
+		$data=(new Data(Enum::TYPE_A));
+		if($data->getType()===Enum::TYPE_A){
+			$data->someLoad(4);
+		}elseif(\in_array($data->getType(), [7,8,9,100], true)){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_B){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_C){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_D){
+			$data->someLoad(6);
+		}else{
+			return;
+		}
+
+		// code above is the same as in case1. code bellow with sorted elseif's
+		if($data->getType()===Enum::TYPE_A){
+			$data->someLoad(4);
+		}elseif($data->getType()===Enum::TYPE_B){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_C){
+			$data->someLoad(6);
+		}elseif($data->getType()===Enum::TYPE_D){
+			$data->someLoad(6);
+		}elseif(\in_array($data->getType(), [7,8,9,100], true)){
+			$data->someLoad(6);
+		}
+
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-8240.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8240.php
@@ -1,0 +1,31 @@
+<?php // lint >= 8.1
+
+namespace Bug8240;
+
+enum Foo
+{
+	case BAR;
+}
+
+function doFoo(Foo $foo): int
+{
+	return match ($foo) {
+		Foo::BAR => 5,
+		default => throw new \Exception('This will not be executed')
+	};
+}
+
+enum Foo2
+{
+	case BAR;
+	case BAZ;
+}
+
+function doFoo2(Foo2 $foo): int
+{
+	return match ($foo) {
+		Foo2::BAR => 5,
+		Foo2::BAZ => 15,
+		default => throw new \Exception('This will not be executed')
+	};
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-8485.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8485.php
@@ -1,0 +1,45 @@
+<?php // lint >= 8.1
+
+namespace Bug8485;
+
+enum E {
+	case c;
+}
+
+enum F {
+	case c;
+}
+
+function shouldError():void {
+	$e = E::c;
+	$f = F::c;
+
+	if ($e === E::c) {
+	}
+	if ($e == E::c) {
+	}
+
+	if ($f === $e) {
+	}
+	if ($f == $e) {
+	}
+
+	if ($f === E::c) {
+	}
+	if ($f == E::c) {
+	}
+}
+
+
+function allGood(E $e, F $f):void {
+	if ($f === $e) {
+	}
+	if ($f == $e) {
+	}
+
+	if ($f === E::c) {
+	}
+	if ($f == E::c) {
+	}
+}
+

--- a/tests/PHPStan/Rules/Comparison/data/bug-8485.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8485.php
@@ -2,6 +2,8 @@
 
 namespace Bug8485;
 
+use function PHPStan\Testing\assertType;
+
 enum E {
 	case c;
 }
@@ -30,7 +32,6 @@ function shouldError():void {
 	}
 }
 
-
 function allGood(E $e, F $f):void {
 	if ($f === $e) {
 	}
@@ -43,3 +44,35 @@ function allGood(E $e, F $f):void {
 	}
 }
 
+enum FooEnum
+{
+	case A;
+	case B;
+	case C;
+}
+function dooFoo(FooEnum $s):void {
+	if ($s === FooEnum::A) {
+	} elseif ($s === FooEnum::B) {
+	} elseif ($s === FooEnum::C) {
+	}
+
+	if ($s === FooEnum::A) {
+	} elseif ($s === FooEnum::B) {
+	} else {
+		assertType('Bug8485\FooEnum::C', $s);
+	}
+
+	if ($s === FooEnum::A) {
+	} elseif ($s === FooEnum::B) {
+	} elseif ($s === FooEnum::C) {
+	} else {
+		assertType('*NEVER*', $s);
+	}
+
+	if ($s === FooEnum::A) {
+	} elseif ($s === FooEnum::B) {
+	} elseif ($s === FooEnum::C) {
+	} elseif (rand(0, 1)) {
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -876,3 +876,18 @@ function (int $int) {
 
 	}
 };
+
+class ConditionalAlwaysTrue
+{
+	public function sayHello(?int $date): void
+	{
+		if ($date === null) {
+		} elseif (is_int($date)) { // always-true should not be reported because last condition
+		}
+
+		if ($date === null) {
+		} elseif (is_int($date)) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/elseif-condition-not-phpdoc.php
+++ b/tests/PHPStan/Rules/Comparison/data/elseif-condition-not-phpdoc.php
@@ -27,3 +27,37 @@ class ElseIfCondition
 	}
 
 }
+
+class ConditionalAlwaysTrue
+{
+	/**
+	 * @param object $object
+	 */
+	public function doFoo(
+		self $self,
+			 $object
+	): void
+	{
+		if (rand(0, 1)) {
+		} elseif ($self) { // always-true should not be reported because last condition
+		}
+
+		if (rand(0, 1)) {
+		} elseif ($self) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+
+
+		if (rand(0, 1)) {
+		} elseif ($object) { // always-true should not be reported because last condition
+		}
+
+		if (rand(0, 1)) {
+		} elseif ($object) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+
+	}
+
+}
+

--- a/tests/PHPStan/Rules/Comparison/data/elseif-condition.php
+++ b/tests/PHPStan/Rules/Comparison/data/elseif-condition.php
@@ -39,3 +39,23 @@ class ElseIfCondition
 	}
 
 }
+
+class ConditionalAlwaysTrue
+{
+	/**
+	 * @param int $i
+	 * @param \stdClass $std
+	 */
+	public function doFoo(int $i, \stdClass $std)
+	{
+		if ($i) {
+		} elseif ($std) { // always-true should not be reported because last condition
+		}
+
+		if ($i) {
+		} elseif ($std) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call.php
@@ -195,3 +195,24 @@ class Foo
 	}
 
 }
+
+class ConditionalAlwaysTrue
+{
+	public function sayHello(?int $date): void
+	{
+		if ($date === null) {
+		} elseif ($this->isInt($date)) { // always-true should not be reported because last condition
+		}
+
+		if ($date === null) {
+		} elseif ($this->isInt($date)) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+
+	/**
+	 * @phpstan-assert-if-true int $value
+	 */
+	public function isInt($value): bool {
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/impossible-static-method-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-static-method-call.php
@@ -53,3 +53,24 @@ class Foo
 	}
 
 }
+
+class ConditionalAlwaysTrue
+{
+	public function sayHello(?int $date): void
+	{
+		if ($date === null) {
+		} elseif (self::isInt($date)) { // always-true should not be reported because last condition
+		}
+
+		if ($date === null) {
+		} elseif (self::isInt($date)) { // always-true should be reported, because another condition below
+		} elseif (rand(0,1)) {
+		}
+	}
+
+	/**
+	 * @phpstan-assert-if-true int $value
+	 */
+	static public function isInt($value): bool {
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/loose-comparison.php
+++ b/tests/PHPStan/Rules/Comparison/data/loose-comparison.php
@@ -22,4 +22,22 @@ class Foo
 		}
 	}
 
+	public function doFooBar(): void
+	{
+		if (0 == "1") {
+
+		} elseif (0 == "0") { // always-true should not be reported because last condition
+
+		}
+
+		if (0 == "1") {
+
+		} elseif (0 == "0") { // always-true should be reported, because another condition below
+
+		} elseif (rand (0, 1)) {
+
+		}
+
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/strict-comparison.php
+++ b/tests/PHPStan/Rules/Comparison/data/strict-comparison.php
@@ -982,3 +982,23 @@ function () {
 	INF !== INF;
 	NAN !== NAN;
 };
+
+class ArrayWithLongStrings
+{
+
+	public function doFoo()
+	{
+		$array = ['foofoofoofoofoofoofoo','foofoofoofoofoofoofob'];
+
+		foreach ($array as $value) {
+			if ('foofoofoofoofoofoofoo' === $value) {
+				echo 'nope';
+			} elseif ('foofoofoofoofoofoofob' === $value) {
+				echo 'nop nope';
+			} elseif (rand(0, 1) === 0) {
+				echo 'nope';
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
implements the idea of https://github.com/phpstan/phpstan-src/pull/2095#issuecomment-1347945023

closes https://github.com/phpstan/phpstan/issues/8042
closes https://github.com/phpstan/phpstan/issues/8485
closes https://github.com/phpstan/phpstan/issues/7721
closes https://github.com/phpstan/phpstan/issues/4242
closes https://github.com/phpstan/phpstan/issues/8240

re-implements https://github.com/phpstan/phpstan-src/pull/2095