### PR TITLE
Fix native type on unset

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3352,8 +3352,8 @@ class MutatingScope implements Scope
 			$exprVarType = $scope->getType($expr->var);
 			$dimType = $scope->getType($expr->dim);
 			$unsetType = $exprVarType->unsetOffset($dimType);
-			$exprVarNativeType = $scope->getType($expr->var);
-			$dimNativeType = $scope->getType($expr->dim);
+			$exprVarNativeType = $scope->getNativeType($expr->var);
+			$dimNativeType = $scope->getNativeType($expr->dim);
 			$unsetNativeType = $exprVarNativeType->unsetOffset($dimNativeType);
 			$scope = $scope->assignExpression($expr->var, $unsetType, $unsetNativeType)->invalidateExpression(
 				new FuncCall(new FullyQualified('count'), [new Arg($expr->var)]),

--- a/tests/PHPStan/Analyser/data/native-expressions.php
+++ b/tests/PHPStan/Analyser/data/native-expressions.php
@@ -3,6 +3,7 @@
 namespace NativeExpressions;
 
 use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertNativeType;
 
 function doFoo(): string
 {
@@ -12,7 +13,7 @@ function (): void {
 	/** @var non-empty-string $a */
 	$a = doFoo();
 	assertType('non-empty-string', $a);
-	assertNativeType('string', $a);
+	assertNativeType('mixed', $a); // could be fixed
 };
 
 /**
@@ -34,7 +35,7 @@ class Foo{
 		private array $array
 	){
 		assertType('non-empty-array', $this->array);
-		assertNativeType('array', $this->array);
+		assertNativeType('non-empty-array', $this->array); // could be fixed issue https://github.com/phpstan/phpstan/issues/6260
 		if(count($array) === 0){
 			throw new \InvalidArgumentException();
 		}

--- a/tests/PHPStan/Analyser/data/native-expressions.php
+++ b/tests/PHPStan/Analyser/data/native-expressions.php
@@ -40,5 +40,17 @@ class Foo{
 			throw new \InvalidArgumentException();
 		}
 	}
+
+	/**
+	 * @param array{a: 'b'} $a
+	 * @return void
+	 */
+	public function doUnset(array $a){
+		assertType("array{a: 'b'}", $a);
+		assertNativeType('array', $a);
+		unset($a['a']);
+		assertType("array{}", $a);
+		assertNativeType('array', $a);
+	}
 }
 

--- a/tests/PHPStan/Analyser/data/native-expressions.php
+++ b/tests/PHPStan/Analyser/data/native-expressions.php
@@ -50,7 +50,7 @@ class Foo{
 		assertNativeType('array', $a);
 		unset($a['a']);
 		assertType("array{}", $a);
-		assertNativeType('array', $a);
+		assertNativeType("array<mixed~'a', mixed>", $a);
 	}
 }
 


### PR DESCRIPTION
Two fixes

1. Previously added native type test forgot to use assertNativeType and wasn't working correctly
2. getType was used for native type as mentioned in https://github.com/phpstan/phpstan-src/pull/2102

I'm sorry that I didn't add enough tests when adding these native type changes...

proof of wrong native type on unset
https://phpstan.org/r/85d3f157-6989-4e60-90f3-9aa7a90546ee