### PR TITLE
NeverType: accept nothing

### DIFF
--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -63,6 +63,10 @@ class NeverType implements CompoundType
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
 	{
+		if ($this->isExplicit()) {
+			return $this->isSuperTypeOf($type);
+		}
+
 		return TrinaryLogic::createYes();
 	}
 

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -262,4 +262,14 @@ class CallCallablesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/static-call-in-functions.php'], []);
 	}
 
+	public function testBug6485(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6485.php'], [
+			[
+				'Parameter #1 $ of closure expects *NEVER*, TBlockType of Bug6485\\Block given.',
+				28,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-6485.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-6485.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6485;
+
+interface Block {}
+
+final class BlockStateSerializer
+{
+
+	/**
+	 * @var array<string, \Closure(never): mixed>
+	 */
+	private array $serializers = [];
+
+	/**
+	 * @template TBlockType of Block
+	 * @param TBlockType $block
+	 */
+	public function serialize(Block $block): mixed
+	{
+		$class = get_class($block);
+		$serializer = $this->serializers[$class] ?? null;
+
+		if ($serializer === null){
+			throw new \InvalidArgumentException();
+		}
+
+		return $serializer($block);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2584,6 +2584,10 @@ class CallMethodsRuleTest extends RuleTestCase
 				'Parameter #2 $v of method UnresolvableParameter\HelloWorld::foo() contains unresolvable type.',
 				19,
 			],
+			[
+				'Parameter #2 $v of method UnresolvableParameter\HelloWorld::foo() expects *NEVER*, 0 given.',
+				20,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Type/NeverTypeTest.php
+++ b/tests/PHPStan/Type/NeverTypeTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\TrinaryLogic;
+use function sprintf;
+
+class NeverTypeTest extends PHPStanTestCase
+{
+
+	public function dataAccepts(): array
+	{
+		return [
+			0 => [
+				new NeverType(),
+				new NeverType(),
+				TrinaryLogic::createYes(),
+			],
+			1 => [
+				new NeverType(true),
+				new NeverType(),
+				TrinaryLogic::createYes(),
+			],
+			2 => [
+				new NeverType(),
+				new NeverType(true),
+				TrinaryLogic::createYes(),
+			],
+			3 => [
+				new NeverType(true),
+				new NeverType(true),
+				TrinaryLogic::createYes(),
+			],
+			4 => [
+				new NeverType(),
+				new MixedType(),
+				TrinaryLogic::createYes(),
+			],
+			5 => [
+				new NeverType(true),
+				new MixedType(),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataAccepts
+	 */
+	public function testAccepts(NeverType $type, Type $acceptedType, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $type->accepts($acceptedType, true);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),
+		);
+	}
+
+}


### PR DESCRIPTION
I was surprised to find out that `NeverType` accepts everything. Shouldn't it be the opposite? It's the bottom type, it's empty. No value can be of this type. Why accept _every_ value then?

Consider this PR me poking around and waiting to see what builds break.