### PR TITLE
Add regression test for https://github.com/phpstan/phpstan/issues/7805

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1138,6 +1138,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8467b.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/PDOStatement.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/discussion-8447.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7805.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7805.php
+++ b/tests/PHPStan/Analyser/data/bug-7805.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+namespace Bug7805;
+
 use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/data/bug-7805.php
+++ b/tests/PHPStan/Analyser/data/bug-7805.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @phpstan-param array{help?: null} $params
+ */
+function foo(array $params)
+{
+	assertType('array{help?: null}', $params);
+	assertNativeType('array', $params);
+	if (array_key_exists('help', $params)) {
+		assertType('array{help: null}', $params);
+		assertNativeType("array&hasOffset('help')", $params);
+		unset($params['help']);
+
+		assertType('array{}', $params);
+		assertNativeType("array<mixed~'help', mixed>", $params);
+		$params = $params === [] ? ['list'] : $params;
+		assertType("array{'list'}", $params);
+		assertNativeType("array{'list'}", $params);
+		// assertNativeType("array<mixed~'help', mixed>", $params); // not working yet
+		array_unshift($params, 'help');
+		assertType("array{'help', 'list'}", $params);
+		assertNativeType("array{'list'}", $params);
+		// assertNativeType("array<mixed~'help', mixed>", $params); // not working yet
+	}
+	assertType("array{}|array{'help', 'list'}", $params);
+	assertNativeType('array', $params);
+
+	return $params;
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/7805

fixed in
https://github.com/phpstan/phpstan-src/pull/2107

I intentionally left the commented out test, `filterByTruthy/FalsyType` for native type is not working yet.