### PR TITLE
Validate usages of assert*-methods in TypeInferenceTestCase

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -22,8 +22,10 @@ use PHPStan\Type\VerbosityLevel;
 use function array_map;
 use function array_merge;
 use function count;
+use function in_array;
 use function is_string;
 use function sprintf;
+use function stripos;
 
 /** @api */
 abstract class TypeInferenceTestCase extends PHPStanTestCase
@@ -124,7 +126,13 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			}
 
 			$functionName = $nameNode->toString();
-			if ($functionName === 'PHPStan\\Testing\\assertType') {
+			if (in_array($functionName, ['assertType', 'assertNativeType', 'assertVariableCertainty'], true)) {
+				$this->fail(sprintf(
+					'ERROR: Missing import for %s() on line %d.',
+					$functionName,
+					$node->getLine(),
+				));
+			} elseif ($functionName === 'PHPStan\\Testing\\assertType') {
 				$expectedType = $scope->getType($node->getArgs()[0]->value);
 				$actualType = $scope->getType($node->getArgs()[1]->value);
 				$assert = ['type', $file, $expectedType, $actualType, $node->getLine()];
@@ -163,7 +171,24 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				$actualCertaintyValue = $scope->hasVariableType($variable->name);
 				$assert = ['variableCertainty', $file, $expectedertaintyValue, $actualCertaintyValue, $variable->name, $node->getLine()];
 			} else {
-				return;
+				$isAssertFn = false;
+				foreach (['assertType', 'assertNativeType', 'assertVariableCertainty'] as $assertFn) {
+					if (stripos($functionName, $assertFn) === false) {
+						continue;
+					}
+
+					$isAssertFn = true;
+				}
+
+				if ($isAssertFn !== true) {
+					return;
+				}
+
+				$this->fail(sprintf(
+					'ERROR: Assert-Method %s imported with wrong namespace called from line %d.',
+					$functionName,
+					$node->getLine(),
+				));
 			}
 
 			if (count($node->getArgs()) !== 2) {


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan-src/pull/2107/files#r1048450984

tested using

```diff
diff --git a/tests/PHPStan/Analyser/data/implode.php b/tests/PHPStan/Analyser/data/implode.php
index b2e2b9aa7..86a03a838 100644
--- a/tests/PHPStan/Analyser/data/implode.php
+++ b/tests/PHPStan/Analyser/data/implode.php
@@ -2,7 +2,8 @@

 namespace ImplodeFunctionReturn;

-use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\wrong\assertType;

 class Foo
 {
@@ -10,6 +11,8 @@ class Foo
        const ONE = 1;

        public function constants() {
+               assertNativeType('string', implode(',', [self::X, '345']));
+
                assertType("'12345'", implode(['12', '345']));

                assertType("'12345'", implode('', ['12', '345']));
```

```
➜  phpstan-src git:(pr/2118) ✗ vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php
Xdebug: [Step Debug] Could not connect to debugging client. Tried: 127.0.0.1:9003 (through xdebug.client_host/xdebug.client_port) :-(
PHPUnit 9.5.23 #StandWithUkraine

Warning:       XDEBUG_MODE=coverage or xdebug.mode=coverage has to be set

E                                                                   1 / 1 (100%)

Time: 00:00.017, Memory: 54.00 MB

There was 1 error:

1) Error
The data provider specified for PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts is invalid.
PHPUnit\Framework\AssertionFailedError: ERROR: Assert-Method PHPStan\wrong\assertType imported with wrong namespace called from line 16.
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:182
/Users/staabm/workspace/phpstan-src/src/Node/ClassStatementsGatherer.php:115
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:553
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:3037
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:1751
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:618
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:294
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:569
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:294
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:668
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:294
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:638
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:249
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:71
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:197
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:19

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

----


```diff
diff --git a/tests/PHPStan/Analyser/data/implode.php b/tests/PHPStan/Analyser/data/implode.php
index b2e2b9aa7..8e80ecead 100644
--- a/tests/PHPStan/Analyser/data/implode.php
+++ b/tests/PHPStan/Analyser/data/implode.php
@@ -2,7 +2,7 @@

 namespace ImplodeFunctionReturn;

-use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertNativeType;

 class Foo
 {
@@ -10,6 +10,8 @@ class Foo
        const ONE = 1;

        public function constants() {
+               assertNativeType('string', implode(',', [self::X, '345']));
+
                assertType("'12345'", implode(['12', '345']));

                assertType("'12345'", implode('', ['12', '345']));
```

```
➜  phpstan-src git:(asserts) ✗ vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php
PHPUnit 9.5.23 #StandWithUkraine

Warning:       No code coverage driver available

E                                                                   1 / 1 (100%)

Time: 00:00.011, Memory: 52.00 MB

There was 1 error:

1) Error
The data provider specified for PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts is invalid.
PHPUnit\Framework\AssertionFailedError: ERROR: Missing import for assertType() on line 15.
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:131
/Users/staabm/workspace/phpstan-src/src/Node/ClassStatementsGatherer.php:115
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:553
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:3037
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:1751
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:618
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:294
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:569
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:294
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:668
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:294
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:638
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:249
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:71
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:197
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:19

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```