### PR TITLE
OversizedArrayType contains at least 1 element

### DIFF
--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -188,7 +188,7 @@ class OversizedArrayType implements CompoundType, AccessoryType
 
 	public function getArraySize(): Type
 	{
-		return IntegerRangeType::fromInterval(0, null);
+		return IntegerRangeType::fromInterval(1, null);
 	}
 
 	public function getIterableKeyType(): Type


### PR DESCRIPTION
just stumbled over this small glitch while working on other Oversized-Array PRs