### PR TITLE
Bump fidry/cpu-core-counter version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"clue/ndjson-react": "^1.0",
 		"composer/ca-bundle": "^1.2",
 		"composer/xdebug-handler": "^3.0.3",
-		"fidry/cpu-core-counter": "^0.4.0",
+		"fidry/cpu-core-counter": "^0.5.0",
 		"hoa/compiler": "3.17.08.08",
 		"hoa/exception": "^1.0",
 		"hoa/regex": "1.17.01.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eed7115ba5b8fba969c30a7d11808e93",
+    "content-hash": "b3e47003b51b19163de0cef237ada90a",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -332,16 +332,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64"
+                "reference": "040127eef12ad4b05a412e767d0d294ea96f6e48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/666cb04a02f2801f3b19955fc23c824f9018bf64",
-                "reference": "666cb04a02f2801f3b19955fc23c824f9018bf64",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/040127eef12ad4b05a412e767d0d294ea96f6e48",
+                "reference": "040127eef12ad4b05a412e767d0d294ea96f6e48",
                 "shasum": ""
             },
             "require": {
@@ -381,7 +381,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.0"
             },
             "funding": [
                 {
@@ -389,7 +389,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-10T21:26:31+00:00"
+            "time": "2022-12-17T09:26:59+00:00"
         },
         {
             "name": "fig/http-message-util",


### PR DESCRIPTION
Version `0.5.0` is out with some fixes and improvements.