### PR TITLE
Fix `MixedType::hasOffsetValueType()` for subtracted types

### DIFF
--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -514,6 +514,10 @@ class MixedType implements CompoundType, SubtractableType
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
+		if ($this->isOffsetAccessible()->no()) {
+			return TrinaryLogic::createNo();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -1030,4 +1030,62 @@ class MixedTypeTest extends PHPStanTestCase
 		);
 	}
 
+	public function dataSubtractedHasOffsetValueType(): array
+	{
+		return [
+			[
+				new MixedType(),
+				new ArrayType(new MixedType(), new MixedType()),
+				new StringType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new StringType(),
+				new StringType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new ObjectType(ArrayAccess::class),
+				new StringType(),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new MixedType(),
+				new UnionType([
+					new ArrayType(new MixedType(), new MixedType()),
+					new StringType(),
+					new ObjectType(ArrayAccess::class),
+				]),
+				new StringType(),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(),
+				new UnionType([
+					new ArrayType(new MixedType(), new MixedType()),
+					new StringType(),
+					new ObjectType(ArrayAccess::class),
+					new FloatType(),
+				]),
+				new StringType(),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/** @dataProvider dataSubtractedHasOffsetValueType */
+	public function testSubtractedHasOffsetValueType(MixedType $mixedType, Type $typeToSubtract, Type $offsetType, TrinaryLogic $expectedResult): void
+	{
+		$subtracted = $mixedType->subtract($typeToSubtract);
+		$actualResult = $subtracted->hasOffsetValueType($offsetType);
+
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> hasOffsetValueType()', $subtracted->describe(VerbosityLevel::precise())),
+		);
+	}
+
 }


### PR DESCRIPTION
just stumbled over this by luck. I don't expect it to have much of an influence because most of the code using `hasOffsetValueType()` does a `isOffsetAccessible()` before already. which kind of made me thinking - maybe we should look into how much of a performance impact it has that e.g. `hasOffsetValueType()` is not cached for big constant arrays, but maybe it doesn't matter any more now..