### PR TITLE
Result cache should not be invalidated by changes to editorUrl, editorUrlTitle and errorFormat parameters

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -734,6 +734,9 @@ return [
 		sort($extensions);
 
 		if ($projectConfigArray !== null) {
+			unset($projectConfigArray['parameters']['editorUrl']);
+			unset($projectConfigArray['parameters']['editorUrlTitle']);
+			unset($projectConfigArray['parameters']['errorFormat']);
 			unset($projectConfigArray['parameters']['ignoreErrors']);
 			unset($projectConfigArray['parameters']['tipsOfTheDay']);
 			unset($projectConfigArray['parameters']['parallel']);


### PR DESCRIPTION
- Result cache should not be invalidated by changes to editorUrl and editorUrlTitle parameters