### PR TITLE
Faster Scope->shouldInvalidateExpression()

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3500,6 +3500,11 @@ class MutatingScope implements Scope
 			return false;
 		}
 
+		// Variables will not contain traversable expressions. skip the NodeFinder overhead
+		if ($expr instanceof Variable && is_string($expr->name)) {
+			return $exprStringToInvalidate === $this->getNodeKey($expr);
+		}
+
 		$nodeFinder = new NodeFinder();
 		$expressionToInvalidateClass = get_class($exprToInvalidate);
 		$found = $nodeFinder->findFirst([$expr], function (Node $node) use ($expressionToInvalidateClass, $exprStringToInvalidate): bool {


### PR DESCRIPTION
when analyzing [tcpdf.php](https://github.com/tecnickcom/TCPDF/blob/2fb1c01bc37487d1f94fe1297f8d8ad1b5c290bb/tcpdf.php) most of the time is spend in FindFirst

`blackfire run --ignore-exit-status php ../phpstan-src/bin/phpstan --debug -vvv analyze tcpdf.php`

<img width="612" alt="grafik" src="https://user-images.githubusercontent.com/120441/209003405-8a6fc31e-fac9-4444-9263-be24fbc6ba90.png">

speedup:

<img width="666" alt="grafik" src="https://user-images.githubusercontent.com/120441/209003297-2dc89f98-c79e-4291-81b4-602480e5fe7b.png">
