### PR TITLE
Make http_response_header a non-empty-list<non-falsy-string>

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -123,6 +123,8 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClosureType;
@@ -1994,7 +1996,31 @@ class NodeScopeResolver
 				isset($functionReflection)
 				&& in_array($functionReflection->getName(), ['fopen', 'file_get_contents'], true)
 			) {
-				$scope = $scope->assignVariable('http_response_header', new ArrayType(new IntegerType(), new StringType()), new ArrayType(new IntegerType(), new StringType()));
+				$scope = $scope->assignVariable(
+					'http_response_header',
+					TypeCombinator::intersect(
+						new ArrayType(
+							new IntegerType(),
+							TypeCombinator::intersect(
+								new StringType(),
+								new AccessoryNonFalsyStringType(),
+							)
+						),
+						new AccessoryArrayListType(),
+						new NonEmptyArrayType()
+					),
+					TypeCombinator::intersect(
+						new ArrayType(
+							new IntegerType(),
+							TypeCombinator::intersect(
+								new StringType(),
+								new AccessoryNonFalsyStringType(),
+							)
+						),
+						new AccessoryArrayListType(),
+						new NonEmptyArrayType()
+					),
+				);
 			}
 
 			if (isset($functionReflection) && $functionReflection->getName() === 'shuffle') {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1153,6 +1153,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/pathinfo-php8.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pathinfo.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/http-response-header.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/http-response-header.php
+++ b/tests/PHPStan/Analyser/data/http-response-header.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace HttpResponseHeader;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	public function foo(): void
+	{
+		file_get_contents('https://example.com');
+		assertType('non-empty-list<non-falsy-string>', $http_response_header);
+	}
+
+}


### PR DESCRIPTION
This list always contains at least one element: http status code. So I think it's safe to assume it's a non-empty-list of non-falsy-strings.
https://www.php.net/manual/en/reserved.variables.httpresponseheader.php