### PR TITLE
Fix `filter_var()` narrowing with unknown options

### DIFF
--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -186,7 +186,7 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			}
 		}
 
-		if ($exactType !== null && !$hasOptions->maybe()) {
+		if ($exactType !== null && !$hasOptions->maybe() && ($inputType->equals($type) || !$inputType->isSuperTypeOf($type)->yes())) {
 			unset($otherTypes['default']);
 		}
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -248,6 +248,10 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		}
 
 		if ($filterValue === $this->getConstant('FILTER_DEFAULT')) {
+			if (!$this->canStringBeSanitized($filterValue, $flagsType) && $in->isString()->yes()) {
+				return $in;
+			}
+
 			if ($in->isBoolean()->yes() || $in->isFloat()->yes() || $in->isInteger()->yes() || $in->isNull()->yes()) {
 				return $in->toString();
 			}

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -157,6 +157,11 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		$defaultType = $this->hasFlag($this->getConstant('FILTER_NULL_ON_FAILURE'), $flagsType)
 			? new NullType()
 			: new ConstantBooleanType(false);
+
+		if ($inputType->isScalar()->no() && $inputType->isNull()->no()) {
+			return $defaultType;
+		}
+
 		$exactType = $this->determineExactType($inputType, $filterValue, $defaultType, $flagsType);
 		$type = $exactType ?? $this->getFilterTypeMap()[$filterValue] ?? $mixedType;
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -231,6 +231,14 @@ class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			return $in->toFloat();
 		}
 
+		if ($filterValue === $this->getConstant('FILTER_VALIDATE_INT') && $in->isFloat()->yes()) {
+			return $in->toInteger();
+		}
+
+		if ($filterValue === $this->getConstant('FILTER_DEFAULT') && ($in->isBoolean()->yes() || $in->isFloat()->yes() || $in->isInteger()->yes() || $in->isNull()->yes())) {
+			return $in->toString();
+		}
+
 		return null;
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -609,6 +609,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var.php');
 
 		if (PHP_VERSION_ID >= 80100) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums.php');

--- a/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
@@ -16,7 +16,7 @@ class Foo
 		assertType('non-empty-string', $str);
 
 		$return = filter_var($str, FILTER_DEFAULT);
-		assertType('non-empty-string|false', $return);
+		assertType('non-empty-string', $return);
 
 		$return = filter_var($str, FILTER_DEFAULT, FILTER_FLAG_STRIP_LOW);
 		assertType('string|false', $return);
@@ -98,7 +98,7 @@ class Foo
 
 		$str2 = '';
 		$return = filter_var($str2, FILTER_DEFAULT);
-		assertType('string|false', $return);
+		assertType("''", $return);
 
 		$return = filter_var($str2, FILTER_VALIDATE_URL);
 		assertType('string|false', $return);

--- a/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
+++ b/tests/PHPStan/Analyser/data/filter-var-returns-non-empty-string.php
@@ -82,7 +82,10 @@ class Foo
 		assertType('9', $return);
 
 		$return = filter_var(1.0, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 9]]);
-		assertType('int<1, 9>|false', $return);
+		assertType('1', $return);
+
+		$return = filter_var(11.0, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 9]]);
+		assertType('false', $return);
 
 		$return = filter_var($str, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => $positive_int]]);
 		assertType('int<1, max>|false', $return);

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -2,6 +2,7 @@
 
 namespace FilterVar;
 
+use stdClass;
 use function PHPStan\Testing\assertType;
 
 class FilterVar
@@ -16,6 +17,15 @@ class FilterVar
 		assertType('0|int<17, 19>', filter_var($mixed, FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));
 
 		assertType('array<false>', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE));
+	}
+
+	/** @param resource $resource */
+	public function invalidInput(array $arr, object $object, $resource): void
+	{
+		assertType('false', filter_var($arr));
+		assertType('false', filter_var($object));
+		assertType('false', filter_var($resource));
+		assertType('null', filter_var(new stdClass(), FILTER_DEFAULT, FILTER_NULL_ON_FAILURE));
 	}
 
 	public function intToInt(int $int, array $options): void

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -14,6 +14,8 @@ class FilterVar
 		assertType('array<int|false>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<int|null>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('0|int<17, 19>', filter_var($mixed, FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));
+
+		assertType('array<false>', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE));
 	}
 
 	public function intToInt(int $int, array $options): void
@@ -23,10 +25,63 @@ class FilterVar
 		assertType('int<0, max>|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]));
 	}
 
-	public function constants(): void
+	/**
+	 * @param int<0, 9> $intRange
+	 * @param non-empty-string $nonEmptyString
+	 */
+	public function scalars(bool $bool, float $float, int $int, string $string, int $intRange, string $nonEmptyString): void
 	{
-		assertType('array<false>', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE));
+		assertType('bool', filter_var($bool, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('true', filter_var(true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('false', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('bool|null', filter_var($float, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('bool|null', filter_var(17.0, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
+		assertType('bool|null', filter_var($int, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('bool|null', filter_var($intRange, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('bool|null', filter_var(17, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
+		assertType('bool|null', filter_var($string, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('bool|null', filter_var($nonEmptyString, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
+		assertType('bool|null', filter_var('17', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
+		assertType('bool|null', filter_var(null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
+
+		assertType('float|false', filter_var($bool, FILTER_VALIDATE_FLOAT));
+		assertType('float|false', filter_var(true, FILTER_VALIDATE_FLOAT)); // could be 1
+		assertType('float|false', filter_var(false, FILTER_VALIDATE_FLOAT)); // could be false
+		assertType('float', filter_var($float, FILTER_VALIDATE_FLOAT));
+		assertType('17.0', filter_var(17.0, FILTER_VALIDATE_FLOAT));
+		assertType('float', filter_var($int, FILTER_VALIDATE_FLOAT));
+		assertType('float', filter_var($intRange, FILTER_VALIDATE_FLOAT));
+		assertType('17.0', filter_var(17, FILTER_VALIDATE_FLOAT));
+		assertType('float|false', filter_var($string, FILTER_VALIDATE_FLOAT));
+		assertType('float|false', filter_var($nonEmptyString, FILTER_VALIDATE_FLOAT));
+		assertType('float|false', filter_var('17', FILTER_VALIDATE_FLOAT)); // could be 17.0
+		assertType('float|false', filter_var(null, FILTER_VALIDATE_FLOAT)); // could be false
+
+		assertType('int|false', filter_var($bool, FILTER_VALIDATE_INT));
+		assertType('int|false', filter_var(true, FILTER_VALIDATE_INT)); // could be 1
+		assertType('int|false', filter_var(false, FILTER_VALIDATE_INT)); // could be false
+		assertType('int', filter_var($float, FILTER_VALIDATE_INT));
+		assertType('17', filter_var(17.0, FILTER_VALIDATE_INT));
+		assertType('int', filter_var($int, FILTER_VALIDATE_INT));
+		assertType('int<0, 9>', filter_var($intRange, FILTER_VALIDATE_INT));
 		assertType('17', filter_var(17, FILTER_VALIDATE_INT));
+		assertType('int|false', filter_var($string, FILTER_VALIDATE_INT));
+		assertType('int|false', filter_var($nonEmptyString, FILTER_VALIDATE_INT));
+		assertType('17', filter_var('17', FILTER_VALIDATE_INT));
+		assertType('int|false', filter_var(null, FILTER_VALIDATE_INT)); // could be false
+
+		assertType("''|'1'", filter_var($bool));
+		assertType("'1'", filter_var(true));
+		assertType("''", filter_var(false));
+		assertType('numeric-string', filter_var($float));
+		assertType("'17'", filter_var(17.0));
+		assertType('numeric-string', filter_var($int));
+		assertType('numeric-string', filter_var($intRange));
+		assertType("'17'", filter_var(17));
+		assertType('string|false', filter_var($string));
+		assertType('non-empty-string|false', filter_var($nonEmptyString)); // could be non-empty-string
+		assertType('non-falsy-string|false', filter_var('17')); // could be '17'
+		assertType("''", filter_var(null));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace FilterVar;
+
+use function PHPStan\Testing\assertType;
+
+class FilterVar
+{
+
+	public function doFoo($mixed): void
+	{
+		assertType('int|false', filter_var($mixed, FILTER_VALIDATE_INT));
+		assertType('int|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_NULL_ON_FAILURE]));
+		assertType('array<int|false>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+		assertType('array<int|null>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('0|int<17, 19>', filter_var($mixed, FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));
+	}
+
+	public function intToInt(int $int, array $options): void
+	{
+		assertType('int', filter_var($int, FILTER_VALIDATE_INT));
+		assertType('int|false', filter_var($int, FILTER_VALIDATE_INT, $options));
+	}
+
+	public function constants(): void
+	{
+		assertType('array<false>', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE));
+		assertType('17', filter_var(17, FILTER_VALIDATE_INT));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -78,9 +78,9 @@ class FilterVar
 		assertType('numeric-string', filter_var($int));
 		assertType('numeric-string', filter_var($intRange));
 		assertType("'17'", filter_var(17));
-		assertType('string|false', filter_var($string));
-		assertType('non-empty-string|false', filter_var($nonEmptyString)); // could be non-empty-string
-		assertType('non-falsy-string|false', filter_var('17')); // could be '17'
+		assertType('string', filter_var($string));
+		assertType('non-empty-string', filter_var($nonEmptyString));
+		assertType("'17'", filter_var('17'));
 		assertType("''", filter_var(null));
 	}
 

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -20,6 +20,7 @@ class FilterVar
 	{
 		assertType('int', filter_var($int, FILTER_VALIDATE_INT));
 		assertType('int|false', filter_var($int, FILTER_VALIDATE_INT, $options));
+		assertType('int<0, max>|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]));
 	}
 
 	public function constants(): void

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -607,6 +607,16 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8158.php'], []);
 	}
 
+	public function testBug8516(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-8516.php'], []);
+	}
+
 	public function testPhpUnitIntegration(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;

--- a/tests/PHPStan/Rules/Comparison/data/bug-8516.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8516.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Bug8516;
+
+function validate($value, array $options = null): bool
+{
+	if (is_int($value)) {
+		$options ??= ['options' => ['min_range' => 0]];
+		if (filter_var($value, FILTER_VALIDATE_INT, $options) === false) {
+			return false;
+		}
+		// ...
+	}
+	if (is_string($value)) {
+		// ...
+	}
+	return true;
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8516

started the filter-var.php node scope resolver test file because I'd like to move some other filter-var tests over there

also: the fix is the first commit, the second one is still related, but the rest are unrelated fixes and improvements in additional commits.. thought I'll save you from 10 more PRs here :)