### PR TITLE
Add namespace to bug-8573.php / fix `GenericsIntegrationTest`

### DIFF
--- a/tests/PHPStan/Rules/Methods/data/bug-8573.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-8573.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+namespace Bug8573;
+
 class A
 {
 	final public function __construct() { }


### PR DESCRIPTION
makes the build green again.

the missing namespace lead to `A` and `B` leaking into other tests and messing up templates in `GenericsIntegrationTest`  with the `functions` case.

the commit history on 1.9.x also shows that this was introduced with https://github.com/phpstan/phpstan-src/commit/630430fe810339da2a933903d2f3639ea3d0cbd5