### PR TITLE
Error in TypeInferenceTestCase when missing namespace

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -120,7 +120,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			if ($node instanceof Node\Stmt\Namespace_) {
 				$isNamespaced = true;
 			}
-			if ($node instanceof Node\Stmt\Class_ && $node->name !== null || $node instanceof Node\Stmt\Function_) {
+			if ($node instanceof Node\Stmt\Class_ && $node->name !== null || $node instanceof Node\Stmt\Function_ || $node instanceof Node\Stmt\Trait_) {
 				$requiresNamespace = true;
 			}
 

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -120,7 +120,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			if ($node instanceof Node\Stmt\Namespace_) {
 				$isNamespaced = true;
 			}
-			if ($node instanceof Node\Stmt\Class_ && $node->name !== null || $node instanceof Node\Stmt\Function_ || $node instanceof Node\Stmt\Trait_) {
+			if ($node instanceof Node\Stmt\Class_ && $node->getAttribute('anonymousClass', false) === false || $node instanceof Node\Stmt\Function_ || $node instanceof Node\Stmt\Trait_) {
 				$requiresNamespace = true;
 			}
 

--- a/tests/PHPStan/Analyser/data/bug-1014.php
+++ b/tests/PHPStan/Analyser/data/bug-1014.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace bug1014;
+
 use function PHPStan\Testing\assertType;
 
 function bug1014(): void {

--- a/tests/PHPStan/Analyser/data/bug-3351.php
+++ b/tests/PHPStan/Analyser/data/bug-3351.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+namespace Bug3351;
+
 use function PHPStan\Testing\assertType;
 
 class HelloWorld

--- a/tests/PHPStan/Analyser/data/isset-coalesce-empty-type-post-81.php
+++ b/tests/PHPStan/Analyser/data/isset-coalesce-empty-type-post-81.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace IssetCoalesceEmptyTypePost81;
+
 use function PHPStan\Testing\assertType;
 
 function baz(\ReflectionClass $ref): void {

--- a/tests/PHPStan/Analyser/data/isset-coalesce-empty-type-pre-81.php
+++ b/tests/PHPStan/Analyser/data/isset-coalesce-empty-type-pre-81.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace IssetCoalesceEmptyTypePre81;
+
 use function PHPStan\Testing\assertType;
 
 function baz(\ReflectionClass $ref): void {

--- a/tests/PHPStan/Analyser/data/mb-strlen-php72.php
+++ b/tests/PHPStan/Analyser/data/mb-strlen-php72.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+namespace MbStrlenPhp72;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/data/mb-strlen-php73.php
+++ b/tests/PHPStan/Analyser/data/mb-strlen-php73.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+namespace MbStrlenPhp73;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/data/mb-strlen-php8.php
+++ b/tests/PHPStan/Analyser/data/mb-strlen-php8.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+namespace MbStrlenPhp8;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/data/mb-strlen-php82.php
+++ b/tests/PHPStan/Analyser/data/mb-strlen-php82.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+namespace MbStrlenPhp82;
 
 use function PHPStan\Testing\assertType;
 
-class MbStrlenPhp8
+class MbStrlenPhp82
 {
 
 	/**

--- a/tests/PHPStan/Analyser/data/preg_split.php
+++ b/tests/PHPStan/Analyser/data/preg_split.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace PregSplit;
+
 use function PHPStan\Testing\assertType;
 
 class HelloWorld

--- a/tests/PHPStan/Analyser/data/splfixedarray-iterator-types.php
+++ b/tests/PHPStan/Analyser/data/splfixedarray-iterator-types.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SplFixedArrayIteratorTypes;
+
 class HelloWorld
 {
 	/**


### PR DESCRIPTION
inspired by https://github.com/phpstan/phpstan-src/pull/2147 added a error condition when test files contain named classes or functions but do not declare a namespace

catched the following error on first run (and even more on subsequent runs):

```
There was 1 error:

1) Error
The data provider specified for PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts is invalid.
PHPUnit\Framework\AssertionFailedError: File C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser/data/preg_split.php does not contain a namespace declaration
C:\dvl\Workspace\phpstan-src-staabm\src\Testing\TypeInferenceTestCase.php:195
C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\NodeScopeResolverTest.php:142

2) Error
The data provider specified for PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts is invalid.
PHPUnit\Framework\AssertionFailedError: File C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser/data/bug-1014.php does not contain a namespace declaration
C:\dvl\Workspace\phpstan-src-staabm\src\Testing\TypeInferenceTestCase.php:195
C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\NodeScopeResolverTest.php:154

```

