### PR TITLE
Add `Type::isScalar()`

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -322,6 +322,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -236,6 +236,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		return $this;

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -236,6 +236,11 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		return $this;

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -236,6 +236,11 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		return $this;

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -239,6 +239,11 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		return $this;

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -239,6 +239,11 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function getKeysArray(): Type
 	{
 		return new NonEmptyArrayType();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -290,6 +290,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -307,6 +307,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -306,6 +306,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -327,6 +327,11 @@ class ArrayType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -113,6 +113,11 @@ class BooleanType implements Type
 		return TrinaryLogic::createYes();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function tryRemove(Type $typeToRemove): ?Type
 	{
 		if ($typeToRemove instanceof ConstantBooleanType) {

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -392,6 +392,11 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isCommonCallable(): bool
 	{
 		return $this->isCommonCallable;

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -394,7 +394,7 @@ class CallableType implements CompoundType, ParametersAcceptor
 
 	public function isScalar(): TrinaryLogic
 	{
-		return TrinaryLogic::createNo();
+		return TrinaryLogic::createMaybe();
 	}
 
 	public function isCommonCallable(): bool

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -461,6 +461,11 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 */

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -191,6 +191,11 @@ class FloatType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		return $this;

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -123,6 +123,11 @@ class IntegerType implements Type
 		return TrinaryLogic::createYes();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function tryRemove(Type $typeToRemove): ?Type
 	{
 		if ($typeToRemove instanceof IntegerRangeType || $typeToRemove instanceof ConstantIntegerType) {

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -534,6 +534,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isVoid());
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isScalar());
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessible());

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -330,6 +330,11 @@ class IterableType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function inferTemplateTypes(Type $receivedType): TemplateTypeMap
 	{
 		if ($receivedType instanceof UnionType || $receivedType instanceof IntersectionType) {

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -117,4 +117,9 @@ trait JustNullableTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 }

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -117,9 +117,4 @@ trait JustNullableTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
-	public function isScalar(): TrinaryLogic
-	{
-		return TrinaryLogic::createNo();
-	}
-
 }

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -776,6 +776,17 @@ class MixedType implements CompoundType, SubtractableType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		if ($this->subtractedType !== null) {
+			if ($this->subtractedType->isSuperTypeOf(new UnionType([new BooleanType(), new FloatType(), new IntegerType(), new StringType()]))->yes()) {
+				return TrinaryLogic::createNo();
+			}
+		}
+
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function tryRemove(Type $typeToRemove): ?Type
 	{
 		if ($this->isSuperTypeOf($typeToRemove)->yes()) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -403,6 +403,11 @@ class NeverType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 */

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -134,6 +134,11 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 */

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -247,6 +247,11 @@ class NullType implements ConstantScalarType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function getSmallerType(): Type
 	{
 		return new NeverType();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -909,6 +909,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	private function isExtraOffsetAccessibleClass(): TrinaryLogic
 	{
 		$classReflection = $this->getClassReflection();

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -80,6 +81,11 @@ class ResourceType implements Type
 	public function toArrayKey(): Type
 	{
 		return new ErrorType();
+	}
+
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
 	}
 
 	/**

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -496,6 +496,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->isVoid();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return $this->getStaticObjectType()->isScalar();
+	}
+
 	/**
 	 * @return ParametersAcceptor[]
 	 */

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -222,6 +222,11 @@ class StrictMixedType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -209,6 +209,11 @@ class StringType implements Type
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createYes();
+	}
+
 	public function hasMethod(string $methodName): TrinaryLogic
 	{
 		if ($this->isClassStringType()->yes()) {

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -380,6 +380,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->isVoid();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return $this->resolve()->isScalar();
+	}
+
 	public function getSmallerType(): Type
 	{
 		return $this->resolve()->getSmallerType();

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -171,6 +171,11 @@ trait ObjectTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function toNumber(): Type
 	{
 		return new ErrorType();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -171,6 +171,8 @@ interface Type
 
 	public function isVoid(): TrinaryLogic;
 
+	public function isScalar(): TrinaryLogic;
+
 	public function getSmallerType(): Type;
 
 	public function getSmallerOrEqualType(): Type;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -526,6 +526,11 @@ class UnionType implements CompoundType
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isVoid());
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isScalar());
+	}
+
 	public function isOffsetAccessible(): TrinaryLogic
 	{
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessible());

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -169,6 +169,11 @@ class VoidType implements Type
 		return TrinaryLogic::createYes();
 	}
 
+	public function isScalar(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
 	public function traverse(callable $cb): Type
 	{
 		return $this;

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -665,6 +665,35 @@ class MixedTypeTest extends PHPStanTestCase
 		];
 	}
 
+	/** @dataProvider dataSubtractedIsScalar */
+	public function testSubtractedIsScalar(MixedType $mixedType, Type $typeToSubtract, TrinaryLogic $expectedResult): void
+	{
+		$subtracted = $mixedType->subtract($typeToSubtract);
+		$actualResult = $subtracted->isScalar();
+
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isScalar()', $subtracted->describe(VerbosityLevel::precise())),
+		);
+	}
+
+	public function dataSubtractedIsScalar(): array
+	{
+		return [
+			[
+				new MixedType(),
+				new UnionType([new BooleanType(), new FloatType(), new IntegerType(), new StringType()]),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new MixedType(),
+				new StringType(),
+				TrinaryLogic::createMaybe(),
+			],
+		];
+	}
+
 	/**
 	 * @dataProvider dataSubstractedIsLiteralString
 	 */

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -643,6 +643,69 @@ class UnionTypeTest extends PHPStanTestCase
 		);
 	}
 
+	public function dataIsScalar(): array
+	{
+		return [
+			[
+				TypeCombinator::union(
+					new BooleanType(),
+					new IntegerType(),
+					new FloatType(),
+					new StringType(),
+				),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new UnionType([
+					new BooleanType(),
+					new ObjectType(DateTimeImmutable::class),
+				]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new UnionType([
+					new IntegerType(),
+					new NullType(),
+				]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new UnionType([
+					new FloatType(),
+					new MixedType(),
+				]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new UnionType([
+					new ArrayType(new IntegerType(), new StringType()),
+					new StringType(),
+				]),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new UnionType([
+					new ArrayType(new IntegerType(), new StringType()),
+					new NullType(),
+					new ObjectType(DateTimeImmutable::class),
+					new ResourceType(),
+				]),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	/** @dataProvider dataIsScalar */
+	public function testIsScalar(UnionType $type, TrinaryLogic $expectedResult): void
+	{
+		$actualResult = $type->isScalar();
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> isScalar()', $type->describe(VerbosityLevel::precise())),
+		);
+	}
+
 	public function dataDescribe(): array
 	{
 		return [


### PR DESCRIPTION
Returns `yes` for bool, float, int or string only. I found myself in need of something like that in the `filter_var()` extension. The alternative would be to combine `isBoolean()`, `isFloat()`, `isInteger()` and `isString()` of course, but that feels somehow wrong too.