### PR TITLE
Improve constant string support in DateTime return type extensions

### DIFF
--- a/tests/PHPStan/Analyser/data/DateTimeCreateDynamicReturnTypes.php
+++ b/tests/PHPStan/Analyser/data/DateTimeCreateDynamicReturnTypes.php
@@ -29,4 +29,20 @@ class Foo
 		assertType('DateTimeImmutable', date_create_immutable($datetime));
 	}
 
+	/**
+	 * @param '2020-04-09'|'2022-02-01' $datetimes
+	 * @param '1990-04-11'|'foo' $maybeDatetimes
+	 * @param 'foo'|'bar' $noDatetimes
+	 */
+	public function unions(string $datetimes, string $maybeDatetimes, string $noDatetimes): void {
+		assertType('DateTime', date_create($datetimes));
+		assertType('DateTimeImmutable', date_create_immutable($datetimes));
+
+		assertType('DateTime|false', date_create($maybeDatetimes));
+		assertType('DateTimeImmutable|false', date_create_immutable($maybeDatetimes));
+
+		assertType('false', date_create($noDatetimes));
+		assertType('false', date_create_immutable($noDatetimes));
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
+++ b/tests/PHPStan/Analyser/data/DateTimeDynamicReturnTypes.php
@@ -38,4 +38,20 @@ class Foo
 		assertType('DateTimeImmutable', date_create_immutable_from_format($format, $datetime));
 	}
 
+	/**
+	 * @param '2020-04-09'|'2022-02-01' $datetimes
+	 * @param '1990-04-11'|'foo' $maybeDatetimes
+	 * @param 'foo'|'bar' $noDatetimes
+	 */
+	public function unions(string $datetimes, string $maybeDatetimes, string $noDatetimes): void {
+		assertType('DateTime', date_create_from_format('Y-m-d', $datetimes));
+		assertType('DateTimeImmutable', date_create_immutable_from_format('Y-m-d', $datetimes));
+
+		assertType('DateTime|false', date_create_from_format('Y-m-d', $maybeDatetimes));
+		assertType('DateTimeImmutable|false', date_create_immutable_from_format('Y-m-d', $maybeDatetimes));
+
+		assertType('false', date_create_from_format('Y-m-d', $noDatetimes));
+		assertType('false', date_create_immutable_from_format('Y-m-d', $noDatetimes));
+	}
+
 }


### PR DESCRIPTION
the other DateTime* extensions seem to be using `Type::getConstantStrings()` already

There are many more extensions that need this and I'll open more PRs after this one most likely :)