### PR TITLE
Declare FileReadTrapStreamWrapper::$context property

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
@@ -27,6 +27,7 @@ use const STREAM_URL_STAT_QUIET;
  */
 final class FileReadTrapStreamWrapper
 {
+
 	/** @var resource|null */
 	public $context;
 

--- a/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
@@ -27,6 +27,8 @@ use const STREAM_URL_STAT_QUIET;
  */
 final class FileReadTrapStreamWrapper
 {
+	/** @var resource */
+	public $context;
 
 	private const DEFAULT_STREAM_WRAPPER_PROTOCOLS = [
 		'file',

--- a/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
@@ -27,7 +27,7 @@ use const STREAM_URL_STAT_QUIET;
  */
 final class FileReadTrapStreamWrapper
 {
-	/** @var resource */
+	/** @var resource|null */
 	public $context;
 
 	private const DEFAULT_STREAM_WRAPPER_PROTOCOLS = [


### PR DESCRIPTION
should fix warnings like

```
 Deprecated: Creation of dynamic property                                   
     PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrapper::$context is deprecated in                                              
     /home/runner/work/redaxo/redaxo/redaxo/src/core/lib/autoload.php on line       256                                                                        
```

this property is defined in the [streamwrapper prototype ](https://www.php.net/manual/en/class.streamwrapper.php#streamwrapper.props.context) and when missing creates a runtime warning

----

the fix is related to https://github.com/phpstan/phpstan/issues/8610 but will not fix said issue