### PR TITLE
Fix fatal error when autoloader open directories

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FileReadTrapStreamWrapper.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 
 use PHPStan\ShouldNotHappenException;
+use function is_dir;
 use function is_file;
 use function stat;
 use function stream_resolve_include_path;
@@ -257,6 +258,16 @@ final class FileReadTrapStreamWrapper
 	public function stream_set_option($option, $arg1, $arg2): bool
 	{
 		return false;
+	}
+
+	public function dir_opendir(string $path, int $options): bool
+	{
+		return is_dir($path);
+	}
+
+	public function dir_readdir(): string
+	{
+		return '';
 	}
 
 }


### PR DESCRIPTION
before this fix running the reproducer in https://github.com/phpstan/phpstan/pull/8611 resulted in

refs https://github.com/phpstan/phpstan/issues/8610

```
$ php bin/phpstan analyze ../phpstan/e2e/bug8610/ -c ../phpstan/e2e/bug8610/phpstan.neon 
 3/3 [============================] 100%

 -- -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
     Error
 -- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     Internal error: Internal error: RecursiveDirectoryIterator::__construct(C:\dvl\Workspace\phpstan\e2e\bug8610/classes): Failed to open directory:
     "PHPStan\Reflection\BetterReflection\SourceLocator\FileReadTrapStreamWrapper::dir_opendir" call failed in file C:\dvl\Workspace\phpstan\e2e\bug8610\trigger-autoload.php
     Run PHPStan with -v option and post the stack trace to:
     https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md
     Child process error (exit code 1):
 -- --------------------------------------------------------------------------------------------------------------------------------------------------------------------------


                                                                                                                        
 [ERROR] Found 2 errors                                                                                                                                                                                                                      

```

after this fix I get

```
$ php bin/phpstan analyze ../phpstan/e2e/bug8610/ -c ../phpstan/e2e/bug8610/phpstan.neon 
 3/3 [============================] 100%

 ------ --------------------------------------------------------------------- 
  Line   phpstan\e2e\bug8610\trigger-autoload.php                             
 ------ --------------------------------------------------------------------- 
  5      Instantiated class DoesNotExist not found.                           
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols  
 ------ --------------------------------------------------------------------- 


                                                                                                                        
 [ERROR] Found 1 error                                                                                                                                                                                                                         

```

since I am not able to reproduce the actual reported issue locally, thats more of a educated guess then a properly tested fix.

wdyt? or is it required to actually read the dir etc.?