### PR TITLE
min() and max() do not return false on php8

### DIFF
--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\BinaryOp\Smaller;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -27,6 +28,12 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		'min' => '',
 		'max' => '',
 	];
+
+	public function __construct(
+		private PhpVersion $phpVersion,
+	)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -107,12 +114,12 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 			$resultTypes = [];
 			foreach ($constArrayTypes as $constArrayType) {
 				$isIterable = $constArrayType->isIterableAtLeastOnce();
-				if ($isIterable->no()) {
+				if ($isIterable->no() && !$this->phpVersion->throwsValueErrorForInternalFunctions()) {
 					$resultTypes[] = new ConstantBooleanType(false);
 					continue;
 				}
 				$argumentTypes = [];
-				if (!$isIterable->yes()) {
+				if (!$isIterable->yes() && !$this->phpVersion->throwsValueErrorForInternalFunctions()) {
 					$argumentTypes[] = new ConstantBooleanType(false);
 				}
 
@@ -127,12 +134,12 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		}
 
 		$isIterable = $argType->isIterableAtLeastOnce();
-		if ($isIterable->no()) {
+		if ($isIterable->no() && !$this->phpVersion->throwsValueErrorForInternalFunctions()) {
 			return new ConstantBooleanType(false);
 		}
 		$iterableValueType = $argType->getIterableValueType();
 		$argumentTypes = [];
-		if (!$isIterable->yes()) {
+		if (!$isIterable->yes() && !$this->phpVersion->throwsValueErrorForInternalFunctions()) {
 			$argumentTypes[] = new ConstantBooleanType(false);
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -133,7 +133,13 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/staticReturnType.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/minmax-arrays.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/minmax.php');
+		if (PHP_VERSION_ID < 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/minmax-arrays.php');
+		}
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/minmax-php8.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/classPhpDocs.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-array-key-type.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3133.php');
@@ -509,7 +515,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5529.php');
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/sizeof.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/sizeof-php8.php');
+		}
+		if (PHP_VERSION_ID < 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/sizeof.php');
+		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/div-by-zero.php');
 

--- a/tests/PHPStan/Analyser/data/minmax-php8.php
+++ b/tests/PHPStan/Analyser/data/minmax-php8.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace MinMaxArrays;
+namespace MinMaxArraysPhp8;
 
 use function PHPStan\Testing\assertType;
 
 function dummy(): void
 {
 	assertType('1', min([1]));
-	assertType('false', min([]));
+	assertType('*ERROR*', min([]));
 	assertType('1', max([1]));
-	assertType('false', max([]));
+	assertType('*ERROR*', max([]));
 }
 
 /**
@@ -18,8 +18,8 @@ function dummy(): void
 function dummy2(array $ints): void
 {
 	if (count($ints) === 0) {
-		assertType('false', min($ints));
-		assertType('false', max($ints));
+		assertType('*ERROR*', min($ints));
+		assertType('*ERROR*', max($ints));
 	} else {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
@@ -28,19 +28,19 @@ function dummy2(array $ints): void
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	} else {
-		assertType('int|false', min($ints));
-		assertType('int|false', max($ints));
+		assertType('int', min($ints));
+		assertType('int', max($ints));
 	}
 	if (count($ints) !== 0) {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	} else {
-		assertType('false', min($ints));
-		assertType('false', max($ints));
+		assertType('*ERROR*', min($ints));
+		assertType('*ERROR*', max($ints));
 	}
 	if (count($ints) !== 1) {
-		assertType('int|false', min($ints));
-		assertType('int|false', max($ints));
+		assertType('int', min($ints));
+		assertType('int', max($ints));
 	} else {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
@@ -49,40 +49,40 @@ function dummy2(array $ints): void
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	} else {
-		assertType('false', min($ints));
-		assertType('false', max($ints));
+		assertType('*ERROR*', min($ints));
+		assertType('*ERROR*', max($ints));
 	}
 	if (count($ints) >= 1) {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	} else {
-		assertType('false', min($ints));
-		assertType('false', max($ints));
+		assertType('*ERROR*', min($ints));
+		assertType('*ERROR*', max($ints));
 	}
 	if (count($ints) >= 2) {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	} else {
-		assertType('int|false', min($ints));
-		assertType('int|false', max($ints));
+		assertType('int', min($ints));
+		assertType('int', max($ints));
 	}
 	if (count($ints) <= 0) {
-		assertType('false', min($ints));
-		assertType('false', max($ints));
+		assertType('*ERROR*', min($ints));
+		assertType('*ERROR*', max($ints));
 	} else {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	}
 	if (count($ints) < 1) {
-		assertType('false', min($ints));
-		assertType('false', max($ints));
+		assertType('*ERROR*', min($ints));
+		assertType('*ERROR*', max($ints));
 	} else {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
 	}
 	if (count($ints) < 2) {
-		assertType('int|false', min($ints));
-		assertType('int|false', max($ints));
+		assertType('int', min($ints));
+		assertType('int', max($ints));
 	} else {
 		assertType('int', min($ints));
 		assertType('int', max($ints));
@@ -94,8 +94,8 @@ function dummy2(array $ints): void
  */
 function dummy3(array $ints): void
 {
-	assertType('int|false', min($ints));
-	assertType('int|false', max($ints));
+	assertType('int', min($ints));
+	assertType('int', max($ints));
 }
 
 
@@ -105,9 +105,10 @@ function dummy4(\DateTimeInterface $dateA, ?\DateTimeInterface $dateB): void
 	assertType('DateTimeInterface', min(array_filter([$dateA, $dateB])));
 	assertType('DateTimeInterface', max(array_filter([$dateA, $dateB])));
 	assertType('array{0?: DateTimeInterface}', array_filter([$dateB]));
-	assertType('DateTimeInterface|false', min(array_filter([$dateB])));
-	assertType('DateTimeInterface|false', max(array_filter([$dateB])));
+	assertType('DateTimeInterface', min(array_filter([$dateB])));
+	assertType('DateTimeInterface', max(array_filter([$dateB])));
 }
+
 
 class HelloWorld
 {
@@ -118,10 +119,10 @@ class HelloWorld
 		 */
 		$numbers = getFoo();
 
-		assertType('0|1|2|3|4|5|6|7|8|9|false', min($numbers));
+		assertType('0|1|2|3|4|5|6|7|8|9', min($numbers));
 		assertType('0', min([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 
-		assertType('0|1|2|3|4|5|6|7|8|9|false', max($numbers));
+		assertType('0|1|2|3|4|5|6|7|8|9', max($numbers));
 		assertType('9', max([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
 	}
 }

--- a/tests/PHPStan/Analyser/data/minmax.php
+++ b/tests/PHPStan/Analyser/data/minmax.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace MinMax;
+
+use function PHPStan\Testing\assertType;
+
+function dummy4(\DateTimeInterface $dateA, ?\DateTimeInterface $dateB): void
+{
+	assertType('array{0: DateTimeInterface, 1?: DateTimeInterface}', array_filter([$dateA, $dateB]));
+	assertType('DateTimeInterface', min(array_filter([$dateA, $dateB])));
+	assertType('DateTimeInterface', max(array_filter([$dateA, $dateB])));
+	assertType('array{0?: DateTimeInterface}', array_filter([$dateB]));
+}
+
+function dummy5(int $i, int $j): void
+{
+	assertType('array{0?: int<min, -1>|int<1, max>, 1?: int<min, -1>|int<1, max>}', array_filter([$i, $j]));
+	assertType('array{1: true}', array_filter([false, true]));
+}
+
+function dummy6(string $s, string $t): void {
+	assertType('array{0?: non-falsy-string, 1?: non-falsy-string}', array_filter([$s, $t]));
+}
+
+class HelloWorld
+{
+	public function setRange(int $range): void
+	{
+		if ($range < 0) {
+			return;
+		}
+		assertType('int<0, 100>', min($range, 100));
+		assertType('int<0, 100>', min(100, $range));
+	}
+
+	public function setRange2(int $range): void
+	{
+		if ($range > 100) {
+			return;
+		}
+		assertType('int<0, 100>', max($range, 0));
+		assertType('int<0, 100>', max(0, $range));
+	}
+
+	public function boundRange(): void
+	{
+		/**
+		 * @var int<1, 6> $range
+		 */
+		$range = getFoo();
+
+		assertType('int<1, 4>', min($range, 4));
+		assertType('int<4, 6>', max(4, $range));
+	}
+
+	public function unionType(): void
+	{
+		/**
+		 * @var array{0, 1, 2}|array{4, 5, 6} $numbers2
+		 */
+		$numbers2 = getFoo();
+
+		assertType('0|4', min($numbers2));
+		assertType('2|6', max($numbers2));
+	}
+}

--- a/tests/PHPStan/Analyser/data/sizeof-php8.php
+++ b/tests/PHPStan/Analyser/data/sizeof-php8.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace sizeof_php8;
+
+use function PHPStan\Testing\assertType;
+
+
+class Sizeof
+{
+	/**
+	 * @param int[] $ints
+	 */
+	function doFoo1(array $ints): string
+	{
+		if (count($ints) <= 0) {
+			assertType('*ERROR*', min($ints));
+			assertType('*ERROR*', max($ints));
+		}
+	}
+
+	/**
+	 * @param int[] $ints
+	 */
+	function doFoo2(array $ints): string
+	{
+		if (sizeof($ints) <= 0) {
+			assertType('*ERROR*', min($ints));
+			assertType('*ERROR*', max($ints));
+		}
+	}
+
+	function doFoo3(array $arr): string
+	{
+		if (0 != count($arr)) {
+			assertType('non-empty-array', $arr);
+		}
+		return "";
+	}
+
+	function doFoo4(array $arr): string
+	{
+		if (0 != sizeof($arr)) {
+			assertType('non-empty-array', $arr);
+		}
+		return "";
+	}
+
+	function doFoo5(array $arr): void
+	{
+		if ([] != $arr) {
+			assertType('non-empty-array', $arr);
+		}
+		assertType('array', $arr);
+	}
+
+	function doFoo6(array $arr): void
+	{
+		if ($arr != []) {
+			assertType('non-empty-array', $arr);
+		}
+		assertType('array', $arr);
+	}
+}


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/7239#issuecomment-1368407228

bottom line: in php8 `min()` and `max()` do no longer return false
https://www.php.net/manual/en/function.max.php