### PR TITLE
ErrorConsoleStyle: use nomax format when needed

### DIFF
--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -119,7 +119,7 @@ class ErrorsConsoleStyle extends SymfonyStyle
 	{
 		$this->progressBar = parent::createProgressBar($max);
 
-		$format = $this->getProgressBarFormat();
+		$format = $this->getProgressBarFormat($max);
 		if ($format !== null) {
 			$this->progressBar->setFormat($format);
 		}
@@ -141,7 +141,7 @@ class ErrorsConsoleStyle extends SymfonyStyle
 		return $this->progressBar;
 	}
 
-	private function getProgressBarFormat(): ?string
+	private function getProgressBarFormat(int $max): ?string
 	{
 		switch ($this->getVerbosity()) {
 			case OutputInterface::VERBOSITY_NORMAL:
@@ -161,6 +161,10 @@ class ErrorsConsoleStyle extends SymfonyStyle
 
 		if ($formatName === null) {
 			return null;
+		}
+
+		if ($max === 0) {
+			$formatName .= '_nomax';
 		}
 
 		return ProgressBar::getFormatDefinition($formatName);


### PR DESCRIPTION
Fixes hard failure when trying to do partial analysis of only excluded files. Testable in this repo by:
```bash
php bin/phpstan analyse -vvv tests/e2e/data/*.php
```

causing

```
In ProgressBar.php line 538:
                                                                                   
  [Symfony\Component\Console\Exception\LogicException]                             
  Unable to display the estimated time if the maximum number of steps is not set.  
                                                                                   

Exception trace:
  at /usr/src/myapp/vendor/symfony/console/Helper/ProgressBar.php:538
 Symfony\Component\Console\Helper\ProgressBar::Symfony\Component\Console\Helper\{closure}() at /usr/src/myapp/vendor/symfony/console/Helper/ProgressBar.php:580
 Symfony\Component\Console\Helper\ProgressBar->Symfony\Component\Console\Helper\{closure}() at n/a:n/a
 preg_replace_callback() at /usr/src/myapp/vendor/symfony/console/Helper/ProgressBar.php:593
 Symfony\Component\Console\Helper\ProgressBar->buildLine() at /usr/src/myapp/vendor/symfony/console/Helper/ProgressBar.php:416
 Symfony\Component\Console\Helper\ProgressBar->display() at /usr/src/myapp/vendor/symfony/console/Helper/ProgressBar.php:325
 Symfony\Component\Console\Helper\ProgressBar->start() at /usr/src/myapp/vendor/symfony/console/Style/SymfonyStyle.php:301
 Symfony\Component\Console\Style\SymfonyStyle->progressStart() at /usr/src/myapp/src/Command/ErrorsConsoleStyle.php:174
 PHPStan\Command\ErrorsConsoleStyle->progressStart() at /usr/src/myapp/src/Command/Symfony/SymfonyStyle.php:75
 PHPStan\Command\Symfony\SymfonyStyle->progressStart() at /usr/src/myapp/src/Command/AnalyseApplication.php:200
 PHPStan\Command\AnalyseApplication->runAnalyser() at /usr/src/myapp/src/Command/AnalyseApplication.php:81
 PHPStan\Command\AnalyseApplication->analyse() at /usr/src/myapp/src/Command/AnalyseCommand.php:230
 PHPStan\Command\AnalyseCommand->execute() at /usr/src/myapp/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at /usr/src/myapp/vendor/symfony/console/Application.php:1028
 Symfony\Component\Console\Application->doRunCommand() at /usr/src/myapp/vendor/symfony/console/Application.php:299
 Symfony\Component\Console\Application->doRun() at /usr/src/myapp/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at /usr/src/myapp/bin/phpstan:169
 {closure}() at /usr/src/myapp/bin/phpstan:170

```

Broken since 1.9.6