### PR TITLE
Exit early in `TrinaryLogic::lazyAnd()` and `lazyOr()` if current instance allows it

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -94,6 +94,10 @@ class TrinaryLogic
 		callable $callback,
 	): self
 	{
+		if ($this->no()) {
+			return $this;
+		}
+
 		$results = [];
 		foreach ($objects as $object) {
 			$result = $callback($object);
@@ -124,6 +128,10 @@ class TrinaryLogic
 		callable $callback,
 	): self
 	{
+		if ($this->yes()) {
+			return $this;
+		}
+
 		$results = [];
 		foreach ($objects as $object) {
 			$result = $callback($object);


### PR DESCRIPTION
In the scope of the lazy methods this makes sense to me. But this change won't affect PHPStan at all at the moment, because all `lazyAnd()` and `lazyOr()` are called on valid `yes` or `no` already. It would lead to an early exit potentially if those methods would be used more dynamically like e.g. `TrinaryLogic::createFromBoolean($expression)->lazyAnd(...)`

this is covered by already existing tests at least so far that tests would break if the logic is inverted.