### PR TITLE
Remove or test iterable check in `MissingTypehintCheck`

### DIFF
--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -6,7 +6,6 @@ use Closure;
 use Generator;
 use Iterator;
 use IteratorAggregate;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Accessory\AccessoryType;
 use PHPStan\Type\CallableType;
@@ -20,7 +19,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
-use PHPStan\Type\TypeWithClassName;
 use Traversable;
 use function array_keys;
 use function array_merge;
@@ -45,7 +43,6 @@ class MissingTypehintCheck
 	 * @param string[] $skipCheckGenericClasses
 	 */
 	public function __construct(
-		private ReflectionProvider $reflectionProvider,
 		private bool $disableCheckMissingIterableValueType,
 		private bool $checkMissingIterableValueType,
 		private bool $checkGenericClassInNonGenericObjectType,
@@ -86,16 +83,6 @@ class MissingTypehintCheck
 			if ($type->isIterable()->yes()) {
 				$iterableValue = $type->getIterableValueType();
 				if ($iterableValue instanceof MixedType && !$iterableValue->isExplicitMixed()) {
-					if (
-						$type instanceof TypeWithClassName
-						&& !in_array($type->getClassName(), self::ITERABLE_GENERIC_CLASS_NAMES, true)
-						&& $this->reflectionProvider->hasClass($type->getClassName())
-					) {
-						$classReflection = $this->reflectionProvider->getClass($type->getClassName());
-						if ($classReflection->isGeneric()) {
-							return $type;
-						}
-					}
 					$iterablesWithMissingValueTypehint[] = $type;
 				}
 				if (!$type instanceof IntersectionType) {

--- a/tests/PHPStan/Rules/Classes/MixinRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinRuleTest.php
@@ -24,7 +24,7 @@ class MixinRuleTest extends RuleTestCase
 			$reflectionProvider,
 			new ClassCaseSensitivityCheck($reflectionProvider, true),
 			new GenericObjectTypeCheck(),
-			new MissingTypehintCheck($reflectionProvider, true, true, true, true, []),
+			new MissingTypehintCheck(true, true, true, true, []),
 			new UnresolvableTypeHelper(),
 			true,
 		);

--- a/tests/PHPStan/Rules/Constants/MissingClassConstantTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/MissingClassConstantTypehintRuleTest.php
@@ -14,8 +14,7 @@ class MissingClassConstantTypehintRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$reflectionProvider = $this->createReflectionProvider();
-		return new MissingClassConstantTypehintRule(new MissingTypehintCheck($reflectionProvider, true, true, true, true, []));
+		return new MissingClassConstantTypehintRule(new MissingTypehintCheck(true, true, true, true, []));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionParameterTypehintRuleTest.php
@@ -14,8 +14,7 @@ class MissingFunctionParameterTypehintRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$broker = $this->createReflectionProvider();
-		return new MissingFunctionParameterTypehintRule(new MissingTypehintCheck($broker, true, true, true, true, []));
+		return new MissingFunctionParameterTypehintRule(new MissingTypehintCheck(true, true, true, true, []));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/MissingFunctionReturnTypehintRuleTest.php
@@ -14,8 +14,7 @@ class MissingFunctionReturnTypehintRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$broker = $this->createReflectionProvider();
-		return new MissingFunctionReturnTypehintRule(new MissingTypehintCheck($broker, true, true, true, true, []));
+		return new MissingFunctionReturnTypehintRule(new MissingTypehintCheck(true, true, true, true, []));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -14,8 +14,7 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$broker = $this->createReflectionProvider();
-		return new MissingMethodParameterTypehintRule(new MissingTypehintCheck($broker, true, true, true, true, []));
+		return new MissingMethodParameterTypehintRule(new MissingTypehintCheck(true, true, true, true, []));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -14,8 +14,7 @@ class MissingMethodReturnTypehintRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$broker = $this->createReflectionProvider();
-		return new MissingMethodReturnTypehintRule(new MissingTypehintCheck($broker, true, true, true, true, []));
+		return new MissingMethodReturnTypehintRule(new MissingTypehintCheck(true, true, true, true, []));
 	}
 
 	public function testRule(): void

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -24,7 +24,7 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 			$broker,
 			new ClassCaseSensitivityCheck($broker, true),
 			new GenericObjectTypeCheck(),
-			new MissingTypehintCheck($broker, true, true, true, true, []),
+			new MissingTypehintCheck(true, true, true, true, []),
 			new UnresolvableTypeHelper(),
 			true,
 			true,

--- a/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -14,8 +14,7 @@ class MissingPropertyTypehintRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		$broker = $this->createReflectionProvider();
-		return new MissingPropertyTypehintRule(new MissingTypehintCheck($broker, true, true, true, true, []));
+		return new MissingPropertyTypehintRule(new MissingTypehintCheck(true, true, true, true, []));
 	}
 
 	public function testRule(): void


### PR DESCRIPTION
This is not making any tests fail and I'd like to know why. It was apparently introduced in 41db2c908b1f57561e779d9cd81ea0022d78b28c