### PR TITLE
Fix `ReflectionClass::newInstanceArgs()` - error on argument type

### DIFF
--- a/stubs/ReflectionClass.stub
+++ b/stubs/ReflectionClass.stub
@@ -31,7 +31,7 @@ class ReflectionClass
 	public function newInstance(...$args) {}
 
 	/**
-	 * @param array<int, mixed> $args
+	 * @param array<int|string, mixed> $args
 	 *
 	 * @return T
 	 */

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2710,4 +2710,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/imagick-pixel.php'], []);
 	}
 
+	public function testNewInstanceArgsIssue8679(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/reflection-class-issue-8679.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/reflection-class-issue-8679.php
+++ b/tests/PHPStan/Rules/Methods/data/reflection-class-issue-8679.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ReflectionClassIssue8679;
+
+class FooClass
+{
+    public function __construct(
+		private int $test1 = 0, 
+		private int $test2 = 0,
+		private int $test3 = 0
+	)
+	{}
+	
+	public function showTest(): string
+	{
+		return $this->test1.$this->test2.$this->test3."\n";
+	}
+}
+
+class FooClassSimpleFactory
+{
+	/**
+	 * @param array<int, mixed> $options Options for MyClass
+	 */
+	public static function getClassA(array $options = []): FooClass
+	{
+		return (new \ReflectionClass('FooClass'))->newInstanceArgs($options);
+	}
+
+	/**
+	 * @param array<string, mixed> $options Options for MyClass
+	 */
+	public static function getClassB(array $options = []): FooClass
+	{
+		return (new \ReflectionClass('FooClass'))->newInstanceArgs($options);
+	}
+
+	/**
+	 * @param array<int|string, mixed> $options Options for MyClass
+	 */
+	public static function getClassC(array $options = []): FooClass
+	{
+		return (new \ReflectionClass('FooClass'))->newInstanceArgs($options);
+	}
+}


### PR DESCRIPTION
Update ReflectionClass stub to solve phpstan/phpstan#8679.

Tests needed!