### PR TITLE
Fixed method_exists() on class-string&literal-string

### DIFF
--- a/src/Rules/Methods/MethodCallCheck.php
+++ b/src/Rules/Methods/MethodCallCheck.php
@@ -50,7 +50,7 @@ class MethodCallCheck
 		if ($type instanceof ErrorType) {
 			return [$typeResult->getUnknownClassErrors(), null];
 		}
-		if (!$type->canCallMethods()->yes()) {
+		if (!$type->canCallMethods()->yes() || $type->isClassStringType()->yes()) {
 			return [
 				[
 					RuleErrorBuilder::message(sprintf(

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -232,6 +232,11 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function hasMethod(string $methodName): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1176,9 +1176,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8621.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8084.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3019.php');
-
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/callsite-cast-narrowing.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8775.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8752.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-8752.php
+++ b/tests/PHPStan/Analyser/data/bug-8752.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bug8752;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param class-string&literal-string $s
+	 */
+	public function sayHello(string $s): void
+	{
+		if (method_exists($s, 'abc')) {
+			assertType('class-string&hasMethod(abc)&literal-string', $s);
+
+			$s::abc();
+			$s->abc();
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -677,4 +677,5 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
 	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -671,4 +671,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8474.php'], []);
 	}
 
+	public function testBug8752(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
+	}
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -678,4 +678,33 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
 	}
 
+	public function testImpossibleMethodExistOnGenericClassString(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/impossible-method-exists-on-generic-class-string.php'], [
+			[
+				"Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\S>&literal-string and 'staticAbc' will always evaluate to true.",
+				18,
+			],
+			[
+				"Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\S>&literal-string and 'nonStaticAbc' will always evaluate to true.",
+				23,
+			],
+			[
+				"Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>&literal-string and 'nonExistent' will always evaluate to false.",
+				34,
+			],
+			[
+				"Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>&literal-string and 'staticAbc' will always evaluate to true.",
+				39,
+			],
+			[
+				"Call to function method_exists() with class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>&literal-string and 'nonStaticAbc' will always evaluate to true.",
+				44,
+			],
+
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-exists-on-generic-class-string.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-exists-on-generic-class-string.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ImpossibleMethodExistsOnGenericClassString;
+
+class HelloWorld
+{
+	/**
+	 * @param class-string<S>&literal-string $s
+	 */
+	public function sayGenericHello(string $s): void
+	{
+		// no erros on non-final class
+		if (method_exists($s, 'nonExistent')) {
+			$s->nonExistent();
+			$s::nonExistent();
+		}
+
+		if (method_exists($s, 'staticAbc')) {
+			$s::staticAbc();
+			$s->staticAbc();
+		}
+
+		if (method_exists($s, 'nonStaticAbc')) {
+			$s::nonStaticAbc();
+			$s->nonStaticAbc();
+		}
+	}
+
+	/**
+	 * @param class-string<FinalS>&literal-string $s
+	 */
+	public function sayFinalGenericHello(string $s): void
+	{
+		if (method_exists($s, 'nonExistent')) {
+			$s->nonExistent();
+			$s::nonExistent();
+		}
+
+		if (method_exists($s, 'staticAbc')) {
+			$s::staticAbc();
+			$s->staticAbc();
+		}
+
+		if (method_exists($s, 'nonStaticAbc')) {
+			$s::nonStaticAbc();
+			$s->nonStaticAbc();
+		}
+	}
+}
+
+class S {
+	public static function staticAbc():void {}
+
+	public function nonStaticAbc():void {}
+}
+
+final class FinalS {
+	public static function staticAbc():void {}
+
+	public function nonStaticAbc():void {}
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2719,4 +2719,18 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/reflection-class-issue-8679.php'], []);
 	}
 
+	public function testBug8752(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], [
+			[
+				'Cannot call method abc() on class-string.',
+				18,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2733,4 +2733,39 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testCannotCallOnGenericClassString(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/../Comparison/data/impossible-method-exists-on-generic-class-string.php'], [
+			[
+				'Cannot call method nonExistent() on class-string<ImpossibleMethodExistsOnGenericClassString\S>.',
+				14,
+			],
+			[
+				'Cannot call method staticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\S>.',
+				20,
+			],
+			[
+				'Cannot call method nonStaticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\S>.',
+				25,
+			],
+			[
+				'Cannot call method nonExistent() on class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>.',
+				35,
+			],
+			[
+				'Cannot call method staticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>.',
+				41,
+			],
+			[
+				'Cannot call method nonStaticAbc() on class-string<ImpossibleMethodExistsOnGenericClassString\FinalS>.',
+				46,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -99,4 +99,9 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
 	}
 
+	public function testCallsOnGenericClassString(): void
+	{
+		$this->analyse([__DIR__ . '/../Comparison/data/impossible-method-exists-on-generic-class-string.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -94,4 +94,9 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8752(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
+	}
+
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/8752

test fails locally without the patch

```
There was 1 failure:

1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/data/bug-8752.php:13" ('type', '/Users/staabm/workspace/phpst...52.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\NeverType Object (...), 13)
Expected type class-string&hasMethod(abc)&literal-string, got type *NEVER* in /Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/data/bug-8752.php on line 13.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'class-string&hasMethod(abc)&literal-string'
+'*NEVER*'

/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1193
```