### PR TITLE
Simplify default type handling in `FilterFunctionReturnTypeHelper`

### DIFF
--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -26,6 +26,7 @@ class FilterVar
 		assertType('false', filter_var($object));
 		assertType('false', filter_var($resource));
 		assertType('null', filter_var(new stdClass(), FILTER_DEFAULT, FILTER_NULL_ON_FAILURE));
+		assertType("'invalid'", filter_var(new stdClass(), FILTER_DEFAULT, ['options' => ['default' => 'invalid']]));
 	}
 
 	public function intToInt(int $int, array $options): void


### PR DESCRIPTION
This thing is still a complexity beast. My plan is to simplify it a bit, this is the first idea that came to mind. Without simplifications fixing things just makes it even more messy..

Basically this avoids unnecessary passing around, setting and unsetting of the default type.

It also fixes the following which was `false` before because it exited before knowing the correct default type.
```php
assertType("'invalid'", filter_var(new stdClass(), FILTER_DEFAULT, ['options' => ['default' => 'invalid']]));
```
https://3v4l.org/OCZ3J