### PR TITLE
Fix various `filter_var()` range edge cases

### DIFF
--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -246,30 +246,42 @@ final class FilterFunctionReturnTypeHelper
 		$range = [];
 		if (isset($typeOptions['min_range'])) {
 			if ($typeOptions['min_range'] instanceof ConstantScalarType) {
-				$range['min'] = $typeOptions['min_range']->getValue();
+				$range['min'] = (int) $typeOptions['min_range']->getValue();
 			} elseif ($typeOptions['min_range'] instanceof IntegerRangeType) {
 				$range['min'] = $typeOptions['min_range']->getMin();
+			} else {
+				$range['min'] = null;
 			}
 		}
 		if (isset($typeOptions['max_range'])) {
 			if ($typeOptions['max_range'] instanceof ConstantScalarType) {
-				$range['max'] = $typeOptions['max_range']->getValue();
+				$range['max'] = (int) $typeOptions['max_range']->getValue();
 			} elseif ($typeOptions['max_range'] instanceof IntegerRangeType) {
 				$range['max'] = $typeOptions['max_range']->getMax();
+			} else {
+				$range['max'] = null;
 			}
 		}
 
-		if (isset($range['min']) || isset($range['max'])) {
-			$min = isset($range['min']) && is_int($range['min']) ? $range['min'] : null;
-			$max = isset($range['max']) && is_int($range['max']) ? $range['max'] : null;
+		if (array_key_exists('min', $range) || array_key_exists('max', $range)) {
+			$min = $range['min'] ?? null;
+			$max = $range['max'] ?? null;
 			$rangeType = IntegerRangeType::fromInterval($min, $max);
+			$rangeTypeIsSuperType = $rangeType->isSuperTypeOf($type);
 
-			if (!($type instanceof ConstantScalarType)) {
-				return $rangeType;
+			if ($rangeTypeIsSuperType->no()) {
+				// e.g. if 9 is filtered with a range of int<17, 19>
+				return $defaultType;
 			}
 
-			if ($rangeType->isSuperTypeOf($type)->no()) {
-				return $defaultType;
+			if (!($type instanceof ConstantScalarType)) {
+				if ($rangeTypeIsSuperType->yes() && !$rangeType->equals($type)) {
+					// e.g. if 18 or int<18, 19> are filtered with a range of int<17, 19>
+					return $type;
+				}
+
+				// Open ranges on either side means that the input is potentially not part of the range
+				return ($min === null || $max === null) ? TypeCombinator::union($rangeType, $defaultType) : $rangeType;
 			}
 		}
 

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -275,15 +275,13 @@ final class FilterFunctionReturnTypeHelper
 				return $defaultType;
 			}
 
-			if (!($type instanceof ConstantScalarType)) {
-				if ($rangeTypeIsSuperType->yes() && !$rangeType->equals($type)) {
-					// e.g. if 18 or int<18, 19> are filtered with a range of int<17, 19>
-					return $type;
-				}
-
-				// Open ranges on either side means that the input is potentially not part of the range
-				return $min === null || $max === null ? TypeCombinator::union($rangeType, $defaultType) : $rangeType;
+			if ($rangeTypeIsSuperType->yes() && !$rangeType->equals($type)) {
+				// e.g. if 18 or int<18, 19> are filtered with a range of int<17, 19>
+				return $type;
 			}
+
+			// Open ranges on either side means that the input is potentially not part of the range
+			return $min === null || $max === null ? TypeCombinator::union($rangeType, $defaultType) : $rangeType;
 		}
 
 		return $type;

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -22,6 +22,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use function array_key_exists;
 use function array_merge;
 use function hexdec;
 use function is_int;
@@ -281,7 +282,7 @@ final class FilterFunctionReturnTypeHelper
 				}
 
 				// Open ranges on either side means that the input is potentially not part of the range
-				return ($min === null || $max === null) ? TypeCombinator::union($rangeType, $defaultType) : $rangeType;
+				return $min === null || $max === null ? TypeCombinator::union($rangeType, $defaultType) : $rangeType;
 			}
 		}
 

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -19,6 +19,32 @@ class FilterVar
 		assertType('array<false>', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE));
 	}
 
+	/**
+	 * @param int<17, 19> $range1
+	 * @param int<1, 5> $range2
+	 * @param int<18, 19> $range3
+	 */
+	public function intRanges(int $int, int $min, int $max, int $range1, int $range2, int $range3): void
+	{
+		assertType('int<17, 19>|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => 19]]));
+		assertType('false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => 19, 'max_range' => 17]]));
+		assertType('0|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => null, 'max_range' => null]]));
+		assertType('int<17, 19>|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => '17', 'max_range' => '19']]));
+		assertType('int<min, 19>|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => $min, 'max_range' => 19]]));
+		assertType('int<17, max>|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => $max]]));
+		assertType('int<17, 19>', filter_var($range1, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => 19]]));
+		assertType('false', filter_var(9, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => 19]]));
+		assertType('18', filter_var(18, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => 19]]));
+		assertType('18', filter_var(18, FILTER_VALIDATE_INT, ['options' => ['min_range' => '17', 'max_range' => '19']]));
+		assertType('false', filter_var(-18, FILTER_VALIDATE_INT, ['options' => ['min_range' => null, 'max_range' => 19]]));
+		assertType('false', filter_var(18, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => null]]));
+		assertType('false', filter_var($range2, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => 19]]));
+		assertType('int<18, 19>', filter_var($range3, FILTER_VALIDATE_INT, ['options' => ['min_range' => 17, 'max_range' => 19]]));
+		assertType('int|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => $min, 'max_range' => $max]]));
+		assertType('int|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['min_range' => $min]]));
+		assertType('int|false', filter_var($int, FILTER_VALIDATE_INT, ['options' => ['max_range' => $max]]));
+	}
+
 	/** @param resource $resource */
 	public function invalidInput(array $arr, object $object, $resource): void
 	{

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -694,4 +694,11 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8736.php'], []);
 	}
 
+	public function testBug8776(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-8776-1.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-8776-2.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -694,10 +694,15 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8736.php'], []);
 	}
 
-	public function testBug8776(): void
+	public function testBug8776Part1(): void
 	{
 		$this->checkAlwaysTrueStrictComparison = true;
 		$this->analyse([__DIR__ . '/data/bug-8776-1.php'], []);
+	}
+
+	public function testBug8776Part2(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
 		$this->analyse([__DIR__ . '/data/bug-8776-2.php'], []);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/bug-8776-1.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8776-1.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Bug8776_1;
+namespace Bug8776Part1;
 
 use LogicException;
 

--- a/tests/PHPStan/Rules/Comparison/data/bug-8776-1.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8776-1.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8776_1;
+
+use LogicException;
+
+/**
+ * @param mixed $value
+ *
+ * @return array|bool
+ *
+ * @throws LogicException
+ */
+function validate($value, array $schema = null)
+{
+	if (is_int($value)) {
+		if (isset($schema['minimum'])) {
+			$minimum = $schema['minimum'];
+			if (filter_var($minimum, FILTER_VALIDATE_INT) === false) {
+				throw new LogicException('`minimum` must be `int`');
+			}
+			$options = ['options' => ['min_range' => $minimum]];
+			$filtered = filter_var($value, FILTER_VALIDATE_INT, $options);
+			if ($filtered === false) {
+				return compact('minimum', 'value');
+			}
+		}
+		if (isset($schema['maximum'])) {
+			$maximum = $schema['maximum'];
+			if (filter_var($maximum, FILTER_VALIDATE_INT) === false) {
+				throw new LogicException('`maximum` must be `int`');
+			}
+			$options = ['options' => ['max_range' => $maximum]];
+			/** @var int|false */
+			$filtered = filter_var($value, FILTER_VALIDATE_INT, $options);
+			if ($filtered === false) {
+				return compact('maximum', 'value');
+			}
+		}
+		// ...
+	}
+	if (is_string($value)) {
+		// ...
+	}
+	return true;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-8776-2.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8776-2.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Bug8776_2;
+namespace Bug8776Part2;
 
 class HelloWorld
 {

--- a/tests/PHPStan/Rules/Comparison/data/bug-8776-2.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8776-2.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8776_2;
+
+class HelloWorld
+{
+	public function sayHello(int $value, int $minimum): void
+	{
+		$options = ['options' => ['min_range' => $minimum]];
+		$filtered = filter_var($value, FILTER_VALIDATE_INT, $options);
+		if ($filtered === false) {
+			return;
+		}
+	}
+
+	public function sayWorld(int $value): void
+	{
+		$options = ['options' => ['min_range' => 17]];
+		$filtered = filter_var($value, FILTER_VALIDATE_INT, $options);
+		if ($filtered === false) {
+			return;
+		}
+	}
+}


### PR DESCRIPTION
I was hoping it would get simpler.. :D
but I couldn't figure out yet how to simplify it, so at least this are range specific changes

Closes https://github.com/phpstan/phpstan/issues/8776

reverting the changes makes the following tests fail
<details>
  <summary>phpunit output</summary>

```
There were 10 failures:

1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:30" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\NeverType Object (...), 30)
Expected type false, got type *NEVER* in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 30.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'false'
+'*NEVER*'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

2) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:31" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerType Object (), 31)
Expected type 0|false, got type int in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 31.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'0|false'
+'int'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

3) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:32" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerType Object (), 32)
Expected type int<17, 19>|false, got type int in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 32.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<17, 19>|false'
+'int'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

4) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:39" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\Constant\ConstantIntegerType Object (...), 39)
Expected type false, got type -18 in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 39.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'false'
+'-18'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

5) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:40" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\Constant\ConstantIntegerType Object (...), 40)
Expected type false, got type 18 in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 40.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'false'
+'18'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

6) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:41" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerRangeType Object (...), 41)
Expected type false, got type int<17, 19> in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 41.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'false'
+'int<17, 19>'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

7) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:42" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerRangeType Object (...), 42)
Expected type int<18, 19>, got type int<17, 19> in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 42.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<18, 19>'
+'int<17, 19>'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

8) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:43" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerType Object (), 43)
Expected type int|false, got type int in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 43.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int|false'
+'int'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

9) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:44" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerType Object (), 44)
Expected type int|false, got type int in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 44.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int|false'
+'int'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198

10) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php:45" ('type', '/Users/herndlm/Development/so...ar.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\IntegerType Object (), 45)
Expected type int|false, got type int in /Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/data/filter-var.php on line 45.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int|false'
+'int'

/Users/herndlm/Development/source/git-forks/phpstan-src/src/Testing/TypeInferenceTestCase.php:96
/Users/herndlm/Development/source/git-forks/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1198
```
</details>