### PR TITLE
Fix sqliteCreateFunction signature

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -8466,7 +8466,7 @@ return [
 'PDO::setAttribute' => ['bool', 'attribute'=>'int', 'value'=>''],
 'PDO::sqliteCreateAggregate' => ['bool', 'function_name'=>'string', 'step_func'=>'callable', 'finalize_func'=>'callable', 'num_args='=>'int'],
 'PDO::sqliteCreateCollation' => ['bool', 'name'=>'string', 'callback'=>'callable'],
-'PDO::sqliteCreateFunction' => ['bool', 'function_name'=>'string', 'callback'=>'callable', 'num_args='=>'int'],
+'PDO::sqliteCreateFunction' => ['bool', 'function_name'=>'string', 'callback'=>'callable', 'num_args='=>'int', 'flags='=>'int'],
 'pdo_drivers' => ['array'],
 'PDOException::getCode' => [''],
 'PDOException::getFile' => [''],


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8802

cf https://www.php.net/manual/en/pdo.sqlitecreatefunction.php
According to https://www.php.net/manual/en/doc.changelog.php it was added in 7.1.4.