### PR TITLE
Add support for maths with constant numeric string

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -65,8 +65,6 @@ use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\TypeWithClassName;
 use PHPStan\Type\UnionType;
-use PHPStan\Type\VerbosityLevel;
-
 use function array_keys;
 use function array_merge;
 use function assert;
@@ -1451,11 +1449,8 @@ class InitializerExprTypeResolver
 		$leftNumberType = $leftType->toNumber();
 		$rightNumberType = $rightType->toNumber();
 
-		if (($leftNumberType instanceof IntegerRangeType || $leftNumberType instanceof ConstantIntegerType || $leftType instanceof UnionType) &&
-			($rightNumberType instanceof IntegerRangeType || $rightNumberType instanceof ConstantIntegerType || $rightType instanceof UnionType)
-		) {
-
-			if ($leftNumberType instanceof ConstantIntegerType) {
+		if ($rightNumberType instanceof IntegerRangeType || $rightNumberType instanceof ConstantIntegerType || $rightType instanceof UnionType) {
+			if ($leftNumberType instanceof IntegerRangeType || $leftNumberType instanceof ConstantIntegerType) {
 				return $this->integerRangeMath(
 					$leftNumberType,
 					$expr,
@@ -1480,8 +1475,6 @@ class InitializerExprTypeResolver
 
 				return $union->toNumber();
 			}
-
-			return $this->integerRangeMath($leftNumberType, $expr, $rightNumberType);
 		}
 
 		$specifiedTypes = $this->callOperatorTypeSpecifyingExtensions($expr, $leftType, $rightType);
@@ -1567,16 +1560,14 @@ class InitializerExprTypeResolver
 		}
 
 		$operand = $operand->toNumber();
-		if (!$operand instanceof IntegerRangeType && !$operand instanceof ConstantIntegerType) {
-			return $operand;
-		}
-
 		if ($operand instanceof IntegerRangeType) {
 			$operandMin = $operand->getMin();
 			$operandMax = $operand->getMax();
-		} else {
+		} elseif ($operand instanceof ConstantIntegerType) {
 			$operandMin = $operand->getValue();
 			$operandMax = $operand->getValue();
+		} else {
+			return $operand;
 		}
 
 		if ($node instanceof BinaryOp\Plus) {

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1446,23 +1446,26 @@ class InitializerExprTypeResolver
 	 */
 	private function resolveCommonMath(Expr\BinaryOp $expr, Type $leftType, Type $rightType): Type
 	{
-		if (($leftType instanceof IntegerRangeType || $leftType instanceof ConstantIntegerType || $leftType instanceof UnionType) &&
-			($rightType instanceof IntegerRangeType || $rightType instanceof ConstantIntegerType || $rightType instanceof UnionType)
+		$leftNumberType = $leftType->toNumber();
+		$rightNumberType = $rightType->toNumber();
+
+		if (($leftNumberType instanceof IntegerRangeType || $leftNumberType instanceof ConstantIntegerType || $leftType instanceof UnionType) &&
+			($rightNumberType instanceof IntegerRangeType || $rightNumberType instanceof ConstantIntegerType || $rightType instanceof UnionType)
 		) {
 
-			if ($leftType instanceof ConstantIntegerType) {
+			if ($leftNumberType instanceof ConstantIntegerType) {
 				return $this->integerRangeMath(
-					$leftType,
+					$leftNumberType,
 					$expr,
-					$rightType,
+					$rightNumberType,
 				);
 			} elseif ($leftType instanceof UnionType) {
-
 				$unionParts = [];
 
 				foreach ($leftType->getTypes() as $type) {
-					if ($type instanceof IntegerRangeType || $type instanceof ConstantIntegerType) {
-						$unionParts[] = $this->integerRangeMath($type, $expr, $rightType);
+					$numberType = $type->toNumber();
+					if ($numberType instanceof IntegerRangeType || $numberType instanceof ConstantIntegerType) {
+						$unionParts[] = $this->integerRangeMath($numberType, $expr, $rightNumberType);
 					} else {
 						$unionParts[] = $type;
 					}
@@ -1493,8 +1496,6 @@ class InitializerExprTypeResolver
 			return new ErrorType();
 		}
 
-		$leftNumberType = $leftType->toNumber();
-		$rightNumberType = $rightType->toNumber();
 		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
 			return new ErrorType();
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1249,6 +1249,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8956.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8917.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ds-copy.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8803.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/trait-type-alias.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8609.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-8609-function.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1250,6 +1250,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8917.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ds-copy.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8803.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8827.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/trait-type-alias.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8609.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-8609-function.php');

--- a/tests/PHPStan/Analyser/data/bug-8803.php
+++ b/tests/PHPStan/Analyser/data/bug-8803.php
@@ -17,4 +17,11 @@ class HelloWorld
 			assertType('int<2, 21>', $value);
 		}
 	}
+
+	public function testWithMixed(mixed $a, mixed $b): void
+	{
+		assertType('(array|float|int)', $a + $b);
+		assertType('(float|int)', 3 + $b);
+		assertType('(float|int)', $a + 3);
+	}
 }

--- a/tests/PHPStan/Analyser/data/bug-8803.php
+++ b/tests/PHPStan/Analyser/data/bug-8803.php
@@ -11,6 +11,9 @@ class HelloWorld
 		$from = new \DateTimeImmutable('2023-01-30');
 		for ($offset = 1; $offset <= 14; $offset++) {
 			$value = $from->format('N') + $offset;
+			if ($value > 7) {
+			}
+
 			$value2 = $offset + $from->format('N');
 			$value3 = '1e3' + $offset;
 			$value4 = $offset + '1e3';

--- a/tests/PHPStan/Analyser/data/bug-8803.php
+++ b/tests/PHPStan/Analyser/data/bug-8803.php
@@ -12,11 +12,15 @@ class HelloWorld
 		for ($offset = 1; $offset <= 14; $offset++) {
 			$value = $from->format('N') + $offset;
 			$value2 = $offset + $from->format('N');
+			$value3 = '1e3' + $offset;
+			$value4 = $offset + '1e3';
 
 			assertType("'1'|'2'|'3'|'4'|'5'|'6'|'7'", $from->format('N'));
 			assertType('int<1, 14>', $offset);
 			assertType('int<2, 21>', $value);
 			assertType('int<2, 21>', $value2);
+			assertType('float', $value3);
+			assertType('float', $value4);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-8803.php
+++ b/tests/PHPStan/Analyser/data/bug-8803.php
@@ -11,10 +11,12 @@ class HelloWorld
 		$from = new \DateTimeImmutable('2023-01-30');
 		for ($offset = 1; $offset <= 14; $offset++) {
 			$value = $from->format('N') + $offset;
+			$value2 = $offset + $from->format('N');
 
 			assertType("'1'|'2'|'3'|'4'|'5'|'6'|'7'", $from->format('N'));
 			assertType('int<1, 14>', $offset);
 			assertType('int<2, 21>', $value);
+			assertType('int<2, 21>', $value2);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-8803.php
+++ b/tests/PHPStan/Analyser/data/bug-8803.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug8803;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		$from = new \DateTimeImmutable('2023-01-30');
+		for ($offset = 1; $offset <= 14; $offset++) {
+			$value = $from->format('N') + $offset;
+
+			assertType("'1'|'2'|'3'|'4'|'5'|'6'|'7'", $from->format('N'));
+			assertType('int<1, 14>', $offset);
+			assertType('int<2, 21>', $value);
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-8827.php
+++ b/tests/PHPStan/Analyser/data/bug-8827.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8827;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function test(): void
+	{
+		$efferent = $afferent = 0;
+		$nbElements = random_int(0, 30);
+
+		$elements = array_fill(0, $nbElements, random_int(0, 2));
+
+		foreach ($elements as $element)
+		{
+			$efferent += ($element === 1);
+			$afferent += ($element === 2);
+		}
+
+		assertType('int<0, max>', $efferent); // Expected: int<0, $nbElements> | Actual: 0|1
+		assertType('int<0, max>', $afferent); // Expected: int<0, $nbElements> | Actual: 0|1
+
+		$instability = ($efferent + $afferent > 0) ? $efferent / ($afferent + $efferent) : 0;
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -207,6 +207,12 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7075.php'], []);
 	}
 
+	public function testBug8803(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8803.php'], []);
+	}
+
 	public function testBug8938(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -259,6 +259,11 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3515.php'], []);
 	}
 
+	public function testBug8827(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8827.php'], []);
+	}
+
 	public function testRuleWithNullsafeVariant(): void
 	{
 		if (PHP_VERSION_ID < 80000) {


### PR DESCRIPTION
When doing math, constantString can be casted to ConstantInt by Phpstan to compute the result.
Closes https://github.com/phpstan/phpstan/issues/8803

In the same way boolean can be casted to `0|1`, I added a commit 
Closes https://github.com/phpstan/phpstan/issues/8827