### PR TITLE
NodeScopeResolver::earlyTerminatingMethodNames remove useless default

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -184,7 +184,7 @@ class NodeScopeResolver
 	private array $analysedFiles = [];
 
 	/** @var array<string, true> */
-	private array $earlyTerminatingMethodNames = [];
+	private array $earlyTerminatingMethodNames;
 
 	/**
 	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])


### PR DESCRIPTION
I just tried running https://github.com/shipmonk-rnd/phpstan-rules#uselessprivatepropertydefaultvalue, nothing else was found.