### PR TITLE
Make "required params following optional ones" ignorable

### DIFF
--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -373,7 +373,7 @@ class FunctionDefinitionCheck
 			}
 			$parameterName = $parameterNode->var->name;
 			if ($optionalParameter !== null && $parameterNode->default === null && !$parameterNode->variadic) {
-				$errors[] = RuleErrorBuilder::message(sprintf('Deprecated in PHP 8.0: Required parameter $%s follows optional parameter $%s.', $parameterName, $optionalParameter))->line($parameterNode->getStartLine())->nonIgnorable()->build();
+				$errors[] = RuleErrorBuilder::message(sprintf('Deprecated in PHP 8.0: Required parameter $%s follows optional parameter $%s.', $parameterName, $optionalParameter))->line($parameterNode->getStartLine())->build();
 				continue;
 			}
 			if ($parameterNode->default === null) {


### PR DESCRIPTION
Such code is working as expected and PHPStan should not enforce changes there.

[Slack discussion](https://symfony-devs.slack.com/archives/C8SFXTD2M/p1675439658867819), [playground example](https://phpstan.org/r/d397543b-22b7-4da0-8780-ca45f30620a9).