### PR TITLE
phpstorm.meta.php support for dynamic return types

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -219,6 +219,9 @@ parameters:
 	editorUrlTitle: null
 	errorFormat: null
 	__validate: true
+	phpStormMeta:
+		metaPaths:
+			- '.phpstorm.meta.php'
 
 extensions:
 	rules: PHPStan\DependencyInjection\RulesExtension
@@ -408,6 +411,9 @@ parametersSchema:
 	editorUrl: schema(string(), nullable())
 	editorUrlTitle: schema(string(), nullable())
 	errorFormat: schema(string(), nullable())
+	phpStormMeta: structure([
+		metaPaths: listOf(string())
+	])
 
 	# irrelevant Nette parameters
 	debugMode: bool()
@@ -2060,6 +2066,23 @@ services:
 			php8Parser: @php8Parser
 			singleReflectionFile: %singleReflectionFile%
 		autowired: false
+
+	# PhpStorm meta support
+	cachedParserForMeta:
+		class: PHPStan\Parser\CachedParser
+		arguments:
+			originalParser: @currentPhpVersionRichParser
+			cachedNodesByStringCountMax: %cache.nodesByStringCountMax%
+		autowired: false
+	-
+		class: PHPStan\PhpStormMeta\MetaFileParser
+		arguments:
+			parser: @cachedParserForMeta
+			metaPaths: %phpStormMeta.metaPaths%
+	-
+		class: PHPStan\PhpStormMeta\OverrideParser
+	-
+		class: PHPStan\PhpStormMeta\ReturnTypeExtensionGenerator
 
 	# Error formatters
 

--- a/src/DependencyInjection/Type/LazyDynamicReturnTypeExtensionRegistryProvider.php
+++ b/src/DependencyInjection/Type/LazyDynamicReturnTypeExtensionRegistryProvider.php
@@ -5,27 +5,40 @@ namespace PHPStan\DependencyInjection\Type;
 use PHPStan\Broker\Broker;
 use PHPStan\Broker\BrokerFactory;
 use PHPStan\DependencyInjection\Container;
+use PHPStan\PhpStormMeta\MetaFileParser;
+use PHPStan\PhpStormMeta\ReturnTypeExtensionGenerator;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\DynamicReturnTypeExtensionRegistry;
+use function array_push;
 
 class LazyDynamicReturnTypeExtensionRegistryProvider implements DynamicReturnTypeExtensionRegistryProvider
 {
 
 	private ?DynamicReturnTypeExtensionRegistry $registry = null;
 
-	public function __construct(private Container $container)
+	public function __construct(private Container $container, private MetaFileParser $phpStormMetaParser, private ReturnTypeExtensionGenerator $phpStormMetaExtensionGenerator)
 	{
 	}
 
 	public function getRegistry(): DynamicReturnTypeExtensionRegistry
 	{
 		if ($this->registry === null) {
+			$dynamicMethodReturnTypeExtensions = $this->container->getServicesByTag(BrokerFactory::DYNAMIC_METHOD_RETURN_TYPE_EXTENSION_TAG);
+			$dynamicStaticMethodReturnTypeExtensions = $this->container->getServicesByTag(BrokerFactory::DYNAMIC_STATIC_METHOD_RETURN_TYPE_EXTENSION_TAG);
+			$dynamicFunctionReturnTypeExtensions = $this->container->getServicesByTag(BrokerFactory::DYNAMIC_FUNCTION_RETURN_TYPE_EXTENSION_TAG);
+
+			$phpStormMetaExtensions = $this->phpStormMetaExtensionGenerator->generateExtensionsBasedOnMeta($this->phpStormMetaParser->getMeta());
+
+			array_push($dynamicMethodReturnTypeExtensions, ...$phpStormMetaExtensions->nonStaticMethodExtensions);
+			array_push($dynamicStaticMethodReturnTypeExtensions, ...$phpStormMetaExtensions->staticMethodExtensions);
+			array_push($dynamicFunctionReturnTypeExtensions, ...$phpStormMetaExtensions->functionExtensions);
+
 			$this->registry = new DynamicReturnTypeExtensionRegistry(
 				$this->container->getByType(Broker::class),
 				$this->container->getByType(ReflectionProvider::class),
-				$this->container->getServicesByTag(BrokerFactory::DYNAMIC_METHOD_RETURN_TYPE_EXTENSION_TAG),
-				$this->container->getServicesByTag(BrokerFactory::DYNAMIC_STATIC_METHOD_RETURN_TYPE_EXTENSION_TAG),
-				$this->container->getServicesByTag(BrokerFactory::DYNAMIC_FUNCTION_RETURN_TYPE_EXTENSION_TAG),
+				$dynamicMethodReturnTypeExtensions,
+				$dynamicStaticMethodReturnTypeExtensions,
+				$dynamicFunctionReturnTypeExtensions,
 			);
 		}
 

--- a/src/PhpStormMeta/FunctionReturnTypeResolver.php
+++ b/src/PhpStormMeta/FunctionReturnTypeResolver.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+use function array_map;
+use function count;
+use function in_array;
+use function strtolower;
+
+class FunctionReturnTypeResolver implements DynamicFunctionReturnTypeExtension
+{
+
+	/** @var list<string> */
+	private readonly array $functionNames;
+
+	/**
+	 * @param list<string> $functionNames
+	 */
+	public function __construct(
+		private readonly TypeFromMetaResolver $metaResolver,
+		array $functionNames,
+	)
+	{
+		$this->functionNames = array_map(strtolower(...), $functionNames);
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		$functionName = strtolower($functionReflection->getName());
+
+		return in_array($functionName, $this->functionNames, true);
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope,
+	): ?Type
+	{
+		$functionName = strtolower($functionReflection->getName());
+		$args = $functionCall->getArgs();
+
+		if (count($args) > 0) {
+			return $this->metaResolver->resolveReferencedType($functionName, ...$args);
+		}
+
+		return null;
+	}
+
+}

--- a/src/PhpStormMeta/MetaFileParser.php
+++ b/src/PhpStormMeta/MetaFileParser.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\File\FileHelper;
+use PHPStan\Parser\CachedParser;
+use PHPStan\PhpStormMeta\TypeMapping\CallReturnOverrideCollection;
+use PHPStan\PhpStormMeta\TypeMapping\FunctionCallTypeOverride;
+use PHPStan\PhpStormMeta\TypeMapping\MethodCallTypeOverride;
+use SplFileInfo;
+use Symfony\Component\Finder\Finder;
+use function array_key_exists;
+use function count;
+use function file_exists;
+use function is_dir;
+
+class MetaFileParser
+{
+
+	private readonly CallReturnOverrideCollection $parsedMeta;
+
+	/** @var array<string, string> */
+	private array $parsedMetaPaths = [];
+
+	private bool $metaParsed;
+
+	/**
+	 * @param list<string> $metaPaths
+	 */
+	public function __construct(
+		private readonly CachedParser $parser,
+		private readonly OverrideParser $overrideParser,
+		private readonly FileHelper $fileHelper,
+		private readonly array $metaPaths,
+	)
+	{
+		$this->parsedMeta = new CallReturnOverrideCollection();
+		$this->metaParsed = $this->metaPaths === [];
+	}
+
+	public function getMeta(): CallReturnOverrideCollection
+	{
+		if (!$this->metaParsed) {
+			$this->parseMeta($this->parsedMeta, ...$this->metaPaths);
+			$this->metaParsed = true;
+		}
+
+		return $this->parsedMeta;
+	}
+
+	private function parseMeta(
+		CallReturnOverrideCollection $resultCollector,
+		string ...$metaPaths,
+	): void
+	{
+		$metaFiles = [];
+
+		/** @var array<string, string> $newlyParsedMetaPaths */
+		$newlyParsedMetaPaths = [];
+		foreach ($metaPaths as $relativePath) {
+			if (array_key_exists($relativePath, $this->parsedMetaPaths)) {
+				continue;
+			}
+
+			$path = $this->fileHelper->absolutizePath($relativePath);
+
+			if (is_dir($path)) {
+				$finder = (new Finder())->in($path)->files()->ignoreDotFiles(false);
+				foreach ($finder as $fileInfo) {
+					$metaFiles [] = $fileInfo->getPathname();
+				}
+			} elseif (file_exists($path)) {
+				$singleFile = new SplFileInfo($path);
+				$metaFiles[] = $singleFile->getPathname();
+			}
+
+			$newlyParsedMetaPaths[$relativePath] = $path;
+		}
+
+		foreach ($metaFiles as $metaFile) {
+			$stmts = $this->parser->parseFile($metaFile);
+
+			foreach ($stmts as $topStmt) {
+				if (!($topStmt instanceof Stmt\Namespace_)) {
+					continue;
+				}
+
+				if ($topStmt->name === null || $topStmt->name->toString() !== 'PHPSTORM_META') {
+					continue;
+				}
+
+				foreach ($topStmt->stmts as $metaStmt) {
+					if (!($metaStmt instanceof Expression)
+						|| !($metaStmt->expr instanceof FuncCall)
+						|| !($metaStmt->expr->name instanceof Name)
+						|| $metaStmt->expr->name->toString() !== 'override'
+					) {
+						continue;
+					}
+
+					$args = $metaStmt->expr->getArgs();
+					if (count($args) < 2) {
+						continue;
+					}
+
+					[$callableArg, $overrideArg] = $args;
+					$parsedOverride = $this->overrideParser->parseOverride($callableArg, $overrideArg);
+
+					if ($parsedOverride instanceof MethodCallTypeOverride) {
+						$resultCollector->addMethodCallOverride($parsedOverride);
+					} elseif ($parsedOverride instanceof FunctionCallTypeOverride) {
+						$resultCollector->addFunctionCallOverride($parsedOverride);
+					}
+				}
+			}
+
+			foreach ($newlyParsedMetaPaths as $relativePath => $path) {
+				$this->parsedMetaPaths[$relativePath] = $path;
+			}
+		}
+	}
+
+}

--- a/src/PhpStormMeta/NonStaticMethodReturnTypeResolver.php
+++ b/src/PhpStormMeta/NonStaticMethodReturnTypeResolver.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use function array_map;
+use function count;
+use function in_array;
+use function sprintf;
+use function strtolower;
+
+class NonStaticMethodReturnTypeResolver implements DynamicMethodReturnTypeExtension
+{
+
+	/** @var list<string> */
+	private readonly array $methodNames;
+
+	/**
+	 * @param list<string> $methodNames
+	 */
+	public function __construct(
+		private readonly TypeFromMetaResolver $metaResolver,
+		private readonly string $className,
+		array $methodNames,
+	)
+	{
+		$this->methodNames = array_map(strtolower(...), $methodNames);
+	}
+
+	public function getClass(): string
+	{
+		return $this->className;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		$methodName = strtolower($methodReflection->getName());
+
+		return in_array($methodName, $this->methodNames, true);
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope,
+	): ?Type
+	{
+		$methodName = strtolower($methodReflection->getName());
+		$args = $methodCall->getArgs();
+
+		if (count($args) > 0) {
+			$fqn = sprintf('%s::%s', $this->className, $methodName);
+			return $this->metaResolver->resolveReferencedType($fqn, ...$args);
+		}
+
+		return null;
+	}
+
+}

--- a/src/PhpStormMeta/OverrideParser.php
+++ b/src/PhpStormMeta/OverrideParser.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PhpParser\Node as ParserNode;
+use PHPStan\PhpStormMeta\TypeMapping\FunctionCallTypeOverride;
+use PHPStan\PhpStormMeta\TypeMapping\MethodCallTypeOverride;
+use PHPStan\PhpStormMeta\TypeMapping\PassedArgumentType;
+use PHPStan\PhpStormMeta\TypeMapping\PassedArrayElementType;
+use PHPStan\PhpStormMeta\TypeMapping\ReturnTypeMap;
+use function count;
+use function strtolower;
+use function trim;
+
+class OverrideParser
+{
+
+	public function parseOverride(
+		ParserNode\Arg $callableArg,
+		ParserNode\Arg $overrideArg,
+	): MethodCallTypeOverride|FunctionCallTypeOverride|null
+	{
+		$identifier = $callableArg->value;
+
+		$override = $overrideArg->value;
+		if (!$override instanceof ParserNode\Expr\FuncCall
+			|| !$override->name instanceof ParserNode\Name
+		) {
+			return null;
+		}
+
+		$map = null;
+		$typeOffset = null;
+		$elementTypeOffset = null;
+
+		if (count($override->getArgs()) > 0) {
+			$overrideName = $override->name->toString();
+			$overrideArg0 = $override->getArgs()[0]->value;
+			if ($overrideName === 'map') {
+				if ($overrideArg0 instanceof ParserNode\Expr\Array_) {
+					$map = new ReturnTypeMap();
+					foreach ($overrideArg0->items as $arrayItem) {
+						if (!($arrayItem instanceof ParserNode\Expr\ArrayItem)
+							|| !($arrayItem->key instanceof ParserNode\Scalar\String_)
+						) {
+							continue;
+						}
+
+						$arrayKey = $arrayItem->key->value;
+						$arrayValue = $arrayItem->value;
+						if ($arrayValue instanceof ParserNode\Expr\ClassConstFetch
+							&& $arrayValue->class instanceof ParserNode\Name\FullyQualified
+							&& $arrayValue->name instanceof ParserNode\Identifier
+							&& strtolower(trim($arrayValue->name->name)) !== ''
+						) {
+							$map->addMapping($arrayKey, clone $arrayValue->class);
+						} elseif ($arrayValue instanceof ParserNode\Scalar\String_) {
+							$map->addMapping($arrayKey, $arrayValue->value);
+						}
+					}
+				}
+			} elseif ($overrideName === 'type') {
+				if ($overrideArg0 instanceof ParserNode\Scalar\LNumber) {
+					$typeOffset = new PassedArgumentType($overrideArg0->value);
+				}
+			} elseif ($overrideName === 'elementType') {
+				if ($overrideArg0 instanceof ParserNode\Scalar\LNumber) {
+					$elementTypeOffset = new PassedArrayElementType($overrideArg0->value);
+				}
+			}
+		}
+
+		$returnType = $map ?? $typeOffset ?? $elementTypeOffset;
+
+		if ($returnType === null) {
+			return null;
+		}
+
+		if ($identifier instanceof ParserNode\Expr\StaticCall) {
+			if ($identifier->class instanceof ParserNode\Name\FullyQualified &&
+				$identifier->name instanceof ParserNode\Identifier &&
+				count($identifier->getArgs()) > 0
+			) {
+				$identifierArg0 = $identifier->getArgs()[0]->value;
+				if ($identifierArg0 instanceof ParserNode\Scalar\LNumber) {
+					return new MethodCallTypeOverride(
+						$identifier->class->toString(),
+						$identifier->name->toString(),
+						$identifierArg0->value,
+						$returnType,
+					);
+				}
+			}
+		}
+
+		if ($identifier instanceof ParserNode\Expr\FuncCall) {
+			if ($identifier->name instanceof ParserNode\Name\FullyQualified &&
+				count($identifier->getArgs()) > 0
+			) {
+				$identifierArg0 = $identifier->getArgs()[0]->value;
+				if ($identifierArg0 instanceof ParserNode\Scalar\LNumber) {
+					return new FunctionCallTypeOverride(
+						$identifier->name->toString(),
+						$identifierArg0->value,
+						$returnType,
+					);
+				}
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/PhpStormMeta/ReturnTypeExtensionCollection.php
+++ b/src/PhpStormMeta/ReturnTypeExtensionCollection.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+
+final class ReturnTypeExtensionCollection
+{
+
+	/** @var list<DynamicMethodReturnTypeExtension> */
+	public array $nonStaticMethodExtensions = [];
+
+	/** @var list<DynamicStaticMethodReturnTypeExtension> */
+	public array $staticMethodExtensions = [];
+
+	/** @var list<DynamicFunctionReturnTypeExtension> */
+	public array $functionExtensions = [];
+
+}

--- a/src/PhpStormMeta/ReturnTypeExtensionGenerator.php
+++ b/src/PhpStormMeta/ReturnTypeExtensionGenerator.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PHPStan\PhpStormMeta\TypeMapping\CallReturnOverrideCollection;
+use PHPStan\PhpStormMeta\TypeMapping\FunctionCallTypeOverride;
+use PHPStan\PhpStormMeta\TypeMapping\MethodCallTypeOverride;
+use function array_key_exists;
+
+class ReturnTypeExtensionGenerator
+{
+
+	public function __construct()
+	{
+	}
+
+	public function generateExtensionsBasedOnMeta(CallReturnOverrideCollection $overrides): ReturnTypeExtensionCollection
+	{
+		$resolver = new TypeFromMetaResolver($overrides);
+
+		$result = new ReturnTypeExtensionCollection();
+
+		/** @var array<string, list<string>> $classMethodMap */
+		$classMethodMap = [];
+		/** @var list<string> $functionList */
+		$functionList = [];
+
+		foreach ($overrides->getAllOverrides() as $override) {
+			if ($override instanceof MethodCallTypeOverride) {
+				if (!array_key_exists($override->classlikeName, $classMethodMap)) {
+					$classMethodMap[$override->classlikeName] = [];
+				}
+				$classMethodMap[$override->classlikeName][] = $override->methodName;
+			} elseif ($override instanceof FunctionCallTypeOverride) {
+				$functionList [] = $override->functionName;
+			}
+		}
+
+		foreach ($classMethodMap as $className => $methodList) {
+			$result->nonStaticMethodExtensions [] = new NonStaticMethodReturnTypeResolver($resolver, $className, $methodList);
+			$result->staticMethodExtensions [] = new StaticMethodReturnTypeResolver($resolver, $className, $methodList);
+		}
+
+		$result->functionExtensions [] = new FunctionReturnTypeResolver($resolver, $functionList);
+
+		return $result;
+	}
+
+}

--- a/src/PhpStormMeta/StaticMethodReturnTypeResolver.php
+++ b/src/PhpStormMeta/StaticMethodReturnTypeResolver.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+use function array_map;
+use function count;
+use function in_array;
+use function sprintf;
+use function strtolower;
+
+class StaticMethodReturnTypeResolver implements DynamicStaticMethodReturnTypeExtension
+{
+
+	/** @var list<string> */
+	private readonly array $methodNames;
+
+	/**
+	 * @param list<string> $methodNames
+	 */
+	public function __construct(
+		private readonly TypeFromMetaResolver $metaResolver,
+		private readonly string $className,
+		array $methodNames,
+	)
+	{
+		$this->methodNames = array_map(strtolower(...), $methodNames);
+	}
+
+	public function getClass(): string
+	{
+		return $this->className;
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		$methodName = strtolower($methodReflection->getName());
+
+		return in_array($methodName, $this->methodNames, true);
+	}
+
+	public function getTypeFromStaticMethodCall(
+		MethodReflection $methodReflection,
+		StaticCall $methodCall,
+		Scope $scope,
+	): ?Type
+	{
+		$methodName = strtolower($methodReflection->getName());
+		$args = $methodCall->getArgs();
+
+		if (count($args) > 0) {
+			$fqn = sprintf('%s::%s', $this->className, $methodName);
+			return $this->metaResolver->resolveReferencedType($fqn, ...$args);
+		}
+
+		return null;
+	}
+
+}

--- a/src/PhpStormMeta/TypeFromMetaResolver.php
+++ b/src/PhpStormMeta/TypeFromMetaResolver.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta;
+
+use InvalidArgumentException;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\PhpStormMeta\TypeMapping\CallReturnOverrideCollection;
+use PHPStan\PhpStormMeta\TypeMapping\CallReturnTypeOverride;
+use PHPStan\PhpStormMeta\TypeMapping\PassedArgumentType;
+use PHPStan\PhpStormMeta\TypeMapping\PassedArrayElementType;
+use PHPStan\PhpStormMeta\TypeMapping\ReturnTypeMap;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
+use function explode;
+use function trim;
+
+class TypeFromMetaResolver
+{
+
+	public function __construct(
+		private readonly CallReturnOverrideCollection $overrides,
+	)
+	{
+	}
+
+	public function resolveReferencedType(
+		string $fqn,
+		Arg ...$args,
+	): ?Type
+	{
+		$override = $this->overrides->getOverrideForCall($fqn);
+
+		if ($override !== null) {
+			$arg = $args[$override->argumentOffset] ?? null;
+			if ($arg !== null) {
+				return $this->resolveTypeFromArgument($override->returnType, $arg);
+			}
+		}
+
+		return null;
+	}
+
+	private function resolveTypeFromArgument(CallReturnTypeOverride $overrideType, Arg $arg): ?Type
+	{
+		$argValue = $arg->value;
+		if ($overrideType instanceof ReturnTypeMap) {
+			if ($argValue instanceof String_) {
+				$resolvedType = $overrideType->getMappingForArgument($argValue->value);
+				return $this->parseResolvedType($resolvedType);
+			}
+			return null;
+		}
+
+		if ($overrideType instanceof PassedArgumentType) {
+			// TODO
+			return null;
+		}
+
+		if ($overrideType instanceof PassedArrayElementType) {
+			// TODO
+			return null;
+		}
+
+		throw new InvalidArgumentException();
+	}
+
+	private function parseResolvedType(FullyQualified|string|null $resolvedType): ?Type
+	{
+		if ($resolvedType === null) {
+			return null;
+		}
+
+		if ($resolvedType instanceof FullyQualified) {
+			return new ObjectType($resolvedType->toString());
+		}
+
+		$resolvedType = trim($resolvedType);
+		if ($resolvedType === '') {
+			return null;
+		}
+
+		$unionTypes = explode('|', $resolvedType);
+		if (count($unionTypes) === 1) {
+			return new ObjectType($resolvedType);
+		}
+
+		$resolvedSubtypes = [];
+		foreach ($unionTypes as $subtype) {
+			$resolvedSubtypes [] = new ObjectType($subtype);
+		}
+
+		return TypeCombinator::union(...$resolvedSubtypes);
+	}
+
+}

--- a/src/PhpStormMeta/TypeMapping/CallReturnOverrideCollection.php
+++ b/src/PhpStormMeta/TypeMapping/CallReturnOverrideCollection.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+use LogicException;
+use function array_key_exists;
+use function sprintf;
+use function strtolower;
+
+final class CallReturnOverrideCollection
+{
+
+	/** @var array<string, MethodCallTypeOverride|FunctionCallTypeOverride> */
+	private array $overridesByFqn = [];
+
+	public function addMethodCallOverride(MethodCallTypeOverride $override): void
+	{
+		$fqn = sprintf('%s::%s', $override->classlikeName, $override->methodName);
+
+		$key = strtolower($fqn);
+
+		if (array_key_exists($key, $this->overridesByFqn)) {
+			throw new LogicException(sprintf("An override for method '%s' has already been defined", $fqn));
+		}
+
+		$this->overridesByFqn[$key] = $override;
+	}
+
+	public function addFunctionCallOverride(FunctionCallTypeOverride $override): void
+	{
+		$fqn = $override->functionName;
+
+		$key = strtolower($fqn);
+
+		if (array_key_exists($key, $this->overridesByFqn)) {
+			throw new LogicException(sprintf("An override for function '%s' has already been defined", $fqn));
+		}
+
+		$this->overridesByFqn[$key] = $override;
+	}
+
+	/**
+	 * @return array<string, MethodCallTypeOverride|FunctionCallTypeOverride>
+	 */
+	public function getAllOverrides(): array
+	{
+		return $this->overridesByFqn;
+	}
+
+	public function getOverrideForCall(string $fqn): MethodCallTypeOverride|FunctionCallTypeOverride|null
+	{
+		$key = strtolower($fqn);
+
+		return $this->overridesByFqn[$key] ?? null;
+	}
+
+}

--- a/src/PhpStormMeta/TypeMapping/CallReturnTypeOverride.php
+++ b/src/PhpStormMeta/TypeMapping/CallReturnTypeOverride.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+interface CallReturnTypeOverride
+{
+
+}

--- a/src/PhpStormMeta/TypeMapping/FunctionCallTypeOverride.php
+++ b/src/PhpStormMeta/TypeMapping/FunctionCallTypeOverride.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+class FunctionCallTypeOverride
+{
+
+	public function __construct(
+		public readonly string $functionName,
+		public readonly int $argumentOffset,
+		public readonly CallReturnTypeOverride $returnType,
+	)
+	{
+	}
+
+}

--- a/src/PhpStormMeta/TypeMapping/MethodCallTypeOverride.php
+++ b/src/PhpStormMeta/TypeMapping/MethodCallTypeOverride.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+class MethodCallTypeOverride
+{
+
+	public function __construct(
+		public readonly string $classlikeName,
+		public readonly string $methodName,
+		public readonly int $argumentOffset,
+		public readonly CallReturnTypeOverride $returnType,
+	)
+	{
+	}
+
+}

--- a/src/PhpStormMeta/TypeMapping/PassedArgumentType.php
+++ b/src/PhpStormMeta/TypeMapping/PassedArgumentType.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+final class PassedArgumentType implements CallReturnTypeOverride
+{
+
+	public function __construct(
+		public readonly int $argumentOffset,
+	)
+	{
+	}
+
+}

--- a/src/PhpStormMeta/TypeMapping/PassedArrayElementType.php
+++ b/src/PhpStormMeta/TypeMapping/PassedArrayElementType.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+final class PassedArrayElementType implements CallReturnTypeOverride
+{
+
+	public function __construct(
+		public readonly int $argumentOffset,
+	)
+	{
+	}
+
+}

--- a/src/PhpStormMeta/TypeMapping/ReturnTypeMap.php
+++ b/src/PhpStormMeta/TypeMapping/ReturnTypeMap.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpStormMeta\TypeMapping;
+
+use LogicException;
+use PhpParser\Node as ParserNode;
+use function array_key_exists;
+use function sprintf;
+
+final class ReturnTypeMap implements CallReturnTypeOverride
+{
+
+	/** @var array<string, string|ParserNode\Name\FullyQualified> */
+	private array $map = [];
+
+	public function addMapping(string $argumentName, string|ParserNode\Name\FullyQualified $returnTypeMapping): void
+	{
+		if (array_key_exists($argumentName, $this->map)) {
+			throw new LogicException(sprintf("Return type for argument '%s' already specified", $argumentName));
+		}
+		$this->map[$argumentName] = $returnTypeMapping;
+	}
+
+	public function getMappingForArgument(string $argumentName): string|ParserNode\Name\FullyQualified|null
+	{
+		return $this->map[$argumentName] ?? null;
+	}
+
+	public static function merge(self ...$maps): self
+	{
+		$result = new self();
+
+		foreach ($maps as $map) {
+			foreach ($map->map as $argumentName => $returnTypeMapping) {
+				$result->map[$argumentName] = $returnTypeMapping;
+			}
+		}
+
+		return $result;
+	}
+
+}


### PR DESCRIPTION
This PR starts to add support for PHPStorm’s metadata files. It only supports a few basic directives for resolving method/function return types, but of course support for other directives can be added.

I do not think this is ready for a merge yet, I would like some feedback before I dig deeper into it. For example:
- which other meta directives need to be supported (`registerArgumentsSet`)?
- what tests are needed?
- PHPStorm scans the entire project looking for these meta files, including vendor directories. Should PHPStan also look for vendored meta files by default? I’m a bit concerned about parsing time for large projects.