### PR TITLE
Implement php version dependent loose const comparison

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -216,4 +216,10 @@ class PhpVersion
 		return $this->versionId < 80000;
 	}
 
+	// see https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.string-number-comparision
+	public function castsNumbersToStringsOnLooseComparison(): bool
+	{
+		return $this->versionId >= 80000;
+	}
+
 }

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1358,16 +1358,37 @@ class InitializerExprTypeResolver
 
 	private function looseCompareConstantScalars(ConstantScalarType $leftType, ConstantScalarType $rightType): BooleanType
 	{
-		$isNumber = new UnionType([
-			new IntegerType(),
-			new FloatType(),
-		]);
+		if ($this->phpVersion->castsNumbersToStringsOnLooseComparison()) {
+			$isNumber = new UnionType([
+				new IntegerType(),
+				new FloatType(),
+			]);
 
-		if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $isNumber->isSuperTypeOf($rightType)->yes()) {
-			return new ConstantBooleanType(!$this->phpVersion->castsNumbersToStringsOnLooseComparison());
-		}
-		if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $isNumber->isSuperTypeOf($leftType)->yes()) {
-			return new ConstantBooleanType(!$this->phpVersion->castsNumbersToStringsOnLooseComparison());
+			if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $isNumber->isSuperTypeOf($rightType)->yes()) {
+				$stringValue = (string) $rightType->getValue();
+				return new ConstantBooleanType($stringValue === $leftType->getValue());
+			}
+			if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $isNumber->isSuperTypeOf($leftType)->yes()) {
+				$stringValue = (string) $leftType->getValue();
+				return new ConstantBooleanType($stringValue === $rightType->getValue());
+			}
+		} else {
+			if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $rightType->isFloat()->yes()) {
+				$numericPart = (float) $leftType->getValue();
+				return new ConstantBooleanType($numericPart === $rightType->getValue());
+			}
+			if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $leftType->isFloat()->yes()) {
+				$numericPart = (float) $rightType->getValue();
+				return new ConstantBooleanType($numericPart === $leftType->getValue());
+			}
+			if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $rightType->isInteger()->yes()) {
+				$numericPart = (int) $leftType->getValue();
+				return new ConstantBooleanType($numericPart === $rightType->getValue());
+			}
+			if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $leftType->isInteger()->yes()) {
+				$numericPart = (int) $rightType->getValue();
+				return new ConstantBooleanType($numericPart === $leftType->getValue());
+			}
 		}
 
 		// @phpstan-ignore-next-line

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -175,7 +175,7 @@ abstract class PHPStanTestCase extends TestCase
 					$container->getByType(PhpVersion::class),
 					$container->getByType(OperatorTypeSpecifyingExtensionRegistryProvider::class),
 					new OversizedArrayBuilder(),
-					$container->getParameter('usePathConstantsAsConstantString')
+					$container->getParameter('usePathConstantsAsConstantString'),
 				),
 				$container->getByType(DynamicReturnTypeExtensionRegistryProvider::class),
 				$container->getByType(ExprPrinter::class),

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -169,7 +169,14 @@ abstract class PHPStanTestCase extends TestCase
 			new DirectInternalScopeFactory(
 				MutatingScope::class,
 				$reflectionProvider,
-				new InitializerExprTypeResolver($constantResolver, $reflectionProviderProvider, new PhpVersion(PHP_VERSION_ID), $container->getByType(OperatorTypeSpecifyingExtensionRegistryProvider::class), new OversizedArrayBuilder(), $container->getParameter('usePathConstantsAsConstantString')),
+				new InitializerExprTypeResolver(
+					$constantResolver,
+					$reflectionProviderProvider,
+					$container->getByType(PhpVersion::class),
+					$container->getByType(OperatorTypeSpecifyingExtensionRegistryProvider::class),
+					new OversizedArrayBuilder(),
+					$container->getParameter('usePathConstantsAsConstantString')
+				),
 				$container->getByType(DynamicReturnTypeExtensionRegistryProvider::class),
 				$container->getByType(ExprPrinter::class),
 				$typeSpecifier,

--- a/tests/PHPStan/Analyser/LooseConstComparisonPhp7Test.php
+++ b/tests/PHPStan/Analyser/LooseConstComparisonPhp7Test.php
@@ -12,6 +12,8 @@ class LooseConstComparisonPhp7Test extends TypeInferenceTestCase
 	 */
 	public function dataFileAsserts(): iterable
 	{
+		// compares constants according to the php-version phpstan configuration,
+		// _NOT_ the current php runtime version
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-const-comparison-php7.php');
 	}
 

--- a/tests/PHPStan/Analyser/LooseConstComparisonPhp7Test.php
+++ b/tests/PHPStan/Analyser/LooseConstComparisonPhp7Test.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class LooseConstComparisonPhp7Test extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<array<string, mixed[]>>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-const-comparison-php7.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../conf/bleedingEdge.neon',
+			__DIR__ . '/looseConstComparisonPhp7.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/LooseConstComparisonPhp7Test.php
+++ b/tests/PHPStan/Analyser/LooseConstComparisonPhp7Test.php
@@ -31,7 +31,6 @@ class LooseConstComparisonPhp7Test extends TypeInferenceTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [
-			__DIR__ . '/../../../conf/bleedingEdge.neon',
 			__DIR__ . '/looseConstComparisonPhp7.neon',
 		];
 	}

--- a/tests/PHPStan/Analyser/LooseConstComparisonPhp8Test.php
+++ b/tests/PHPStan/Analyser/LooseConstComparisonPhp8Test.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class LooseConstComparisonPhp8Test extends TypeInferenceTestCase
+{
+
+	/**
+	 * @return iterable<array<string, mixed[]>>
+	 */
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-const-comparison-php8.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../conf/bleedingEdge.neon',
+			__DIR__ . '/looseConstComparisonPhp8.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/LooseConstComparisonPhp8Test.php
+++ b/tests/PHPStan/Analyser/LooseConstComparisonPhp8Test.php
@@ -31,7 +31,6 @@ class LooseConstComparisonPhp8Test extends TypeInferenceTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [
-			__DIR__ . '/../../../conf/bleedingEdge.neon',
 			__DIR__ . '/looseConstComparisonPhp8.neon',
 		];
 	}

--- a/tests/PHPStan/Analyser/LooseConstComparisonPhp8Test.php
+++ b/tests/PHPStan/Analyser/LooseConstComparisonPhp8Test.php
@@ -12,6 +12,8 @@ class LooseConstComparisonPhp8Test extends TypeInferenceTestCase
 	 */
 	public function dataFileAsserts(): iterable
 	{
+		// compares constants according to the php-version phpstan configuration,
+		// _NOT_ the current php runtime version
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/loose-const-comparison-php8.php');
 	}
 

--- a/tests/PHPStan/Analyser/data/loose-const-comparison-php7.php
+++ b/tests/PHPStan/Analyser/data/loose-const-comparison-php7.php
@@ -14,4 +14,7 @@ function doFoo() {
 
 	assertType('true', 0.0 == "");
 	assertType('true', 42.0 == "42foo");
+	assertType('true', 42 == "42.0foo");
+	assertType('false', 42.1 == "42.0foo");
+	assertType('true', 42.0 == "42.0foo");
 }

--- a/tests/PHPStan/Analyser/data/loose-const-comparison-php7.php
+++ b/tests/PHPStan/Analyser/data/loose-const-comparison-php7.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LooseConstComparisonPhp7;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	assertType('true', 0 == "0");
+	assertType('true', 0 == "0.0");
+	assertType('true', 0 == "foo");
+	assertType('true', 0 == "");
+	assertType('true', 42 == " 42");
+	assertType('true', 42 == "42foo");
+
+	assertType('true', 0.0 == "");
+}

--- a/tests/PHPStan/Analyser/data/loose-const-comparison-php7.php
+++ b/tests/PHPStan/Analyser/data/loose-const-comparison-php7.php
@@ -13,4 +13,5 @@ function doFoo() {
 	assertType('true', 42 == "42foo");
 
 	assertType('true', 0.0 == "");
+	assertType('true', 42.0 == "42foo");
 }

--- a/tests/PHPStan/Analyser/data/loose-const-comparison-php8.php
+++ b/tests/PHPStan/Analyser/data/loose-const-comparison-php8.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LooseConstComparisonPhp8;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	assertType('true', 0 == "0");
+	assertType('true', 0 == "0.0");
+	assertType('false', 0 == "foo");
+	assertType('false', 0 == "");
+	assertType('true', 42 == " 42");
+	assertType('false', 42 == "42foo");
+
+	assertType('false', 0.0 == "");
+}

--- a/tests/PHPStan/Analyser/data/loose-const-comparison-php8.php
+++ b/tests/PHPStan/Analyser/data/loose-const-comparison-php8.php
@@ -13,4 +13,5 @@ function doFoo() {
 	assertType('false', 42 == "42foo");
 
 	assertType('false', 0.0 == "");
+	assertType('false', 42.0 == "42foo");
 }

--- a/tests/PHPStan/Analyser/data/loose-const-comparison-php8.php
+++ b/tests/PHPStan/Analyser/data/loose-const-comparison-php8.php
@@ -14,4 +14,7 @@ function doFoo() {
 
 	assertType('false', 0.0 == "");
 	assertType('false', 42.0 == "42foo");
+	assertType('false', 42 == "42.0foo");
+	assertType('false', 42.1 == "42.0foo");
+	assertType('false', 42.0 == "42.0foo");
 }

--- a/tests/PHPStan/Analyser/looseConstComparisonPhp7.neon
+++ b/tests/PHPStan/Analyser/looseConstComparisonPhp7.neon
@@ -1,0 +1,2 @@
+parameters:
+	phpVersion: 70400 # PHP 7.4

--- a/tests/PHPStan/Analyser/looseConstComparisonPhp8.neon
+++ b/tests/PHPStan/Analyser/looseConstComparisonPhp8.neon
@@ -1,0 +1,2 @@
+parameters:
+	phpVersion: 80000 # PHP 8.0


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan-src/pull/2216#discussion_r1096637226

see https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.string-number-comparision

https://3v4l.org/pWAjV
https://3v4l.org/0VWtq

https://phpstan.org/r/b2748c38-b33e-4db7-a60f-4f5edd991270