### PR TITLE
Use "numeric-string" type for some `mysqli_stmt` properties

### DIFF
--- a/stubs/mysqli.stub
+++ b/stubs/mysqli.stub
@@ -4,7 +4,7 @@ class mysqli_stmt
 {
 
     /**
-     * @var int|string
+     * @var int<-1,max>|numeric-string
      */
     public $affected_rows;
 
@@ -34,7 +34,7 @@ class mysqli_stmt
     public $insert_id;
 
     /**
-     * @var 0|positive-int
+     * @var int<0,max>|numeric-string
      */
     public $num_rows;
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1198,6 +1198,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8775.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8752.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/trait-instance-of.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql-stmt.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/mysql-stmt.php
+++ b/tests/PHPStan/Analyser/data/mysql-stmt.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MySQLiStmt;
+
+use mysqli;
+use function PHPStan\Testing\assertType;
+
+final class Foo {
+	public function bar(): void
+	{
+		$mysqli = new mysqli();
+		$stmt = $mysqli->prepare('SELECT x FROM z;');
+		$stmt->execute();
+		assertType('int<0, max>|numeric-string', $stmt->num_rows);
+
+		$stmt = $mysqli->prepare('DELETE FROM z;');
+		$stmt->execute();
+		assertType('int<-1, max>|numeric-string', $stmt->affected_rows);
+	}
+}


### PR DESCRIPTION
Follow up of #2223.

#### To-Do:
- [x] Add test.