### PR TITLE
Skip `testEditorUrlWithRelativePath()` test on PHPStorm console

### DIFF
--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -217,6 +217,10 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 	public function testEditorUrlWithRelativePath(): void
 	{
+		if ('JetBrains-JediTerm' === getenv('TERMINAL_EMULATOR')) {
+			$this->markTestSkipped('PHPStorm console does not support links in console.');
+		}
+
 		$formatter = $this->createErrorFormatter('editor://custom/path/%relFile%/%line%');
 		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput(true));

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -217,8 +217,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 	public function testEditorUrlWithRelativePath(): void
 	{
-		if ('JetBrains-JediTerm' === getenv('TERMINAL_EMULATOR')) {
-			$this->markTestSkipped('PHPStorm console does not support links in console.');
+		if (getenv('TERMINAL_EMULATOR') === 'JetBrains-JediTerm') {
+			$this->markTestSkipped('PhpStorm console does not support links in console.');
 		}
 
 		$formatter = $this->createErrorFormatter('editor://custom/path/%relFile%/%line%');

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -8,6 +8,7 @@ use PHPStan\File\FuzzyRelativePathHelper;
 use PHPStan\File\NullRelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\Testing\ErrorFormatterTestCase;
+use function getenv;
 use function putenv;
 use function sprintf;
 use const PHP_VERSION_ID;


### PR DESCRIPTION
Skip the only test which does not run successfully in the PHPStorm console.

see https://github.com/phpstan/phpstan/discussions/8854
I am not the only one with this problem, see https://github.com/phpstan/phpstan-src/pull/1927#discussion_r1009129184