### PR TITLE
Fix usage of context->truthy

### DIFF
--- a/src/Type/Php/ArrayKeyExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayKeyExistsFunctionTypeSpecifyingExtension.php
@@ -61,7 +61,7 @@ class ArrayKeyExistsFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		if (!$keyType instanceof ConstantIntegerType
 			&& !$keyType instanceof ConstantStringType
 			&& !$arrayType->isIterableAtLeastOnce()->no()) {
-			if ($context->truthy()) {
+			if ($context->true()) {
 				$arrayKeyType = $arrayType->getIterableKeyType();
 				if ($keyType->isString()->yes()) {
 					$arrayKeyType = $arrayKeyType->toString();
@@ -95,7 +95,7 @@ class ArrayKeyExistsFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 			return new SpecifiedTypes();
 		}
 
-		if ($context->truthy()) {
+		if ($context->true()) {
 			$type = TypeCombinator::intersect(
 				new ArrayType(new MixedType(), new MixedType()),
 				new HasOffsetType($keyType),

--- a/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
@@ -35,7 +35,7 @@ class ClassExistsFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyi
 			'interface_exists',
 			'trait_exists',
 			'enum_exists',
-		], true) && isset($node->getArgs()[0]) && $context->truthy();
+		], true) && isset($node->getArgs()[0]) && $context->true();
 	}
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
+++ b/src/Type/Php/DefinedConstantTypeSpecifyingExtension.php
@@ -35,7 +35,7 @@ class DefinedConstantTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 	{
 		return $functionReflection->getName() === 'defined'
 			&& count($node->getArgs()) >= 1
-			&& $context->truthy();
+			&& $context->true();
 	}
 
 	public function specifyTypes(

--- a/src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
@@ -29,7 +29,7 @@ class FunctionExistsFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		TypeSpecifierContext $context,
 	): bool
 	{
-		return $functionReflection->getName() === 'function_exists' && isset($node->getArgs()[0]) && $context->truthy();
+		return $functionReflection->getName() === 'function_exists' && isset($node->getArgs()[0]) && $context->true();
 	}
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -53,11 +53,13 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 
 		if (
 			$context->true()
-			|| $context->false()
+			|| (
+				$context->false()
 				&& (
 					count(TypeUtils::getConstantScalars($arrayValueType)) > 0
 					|| count(TypeUtils::getEnumCaseObjects($arrayValueType)) > 0
 				)
+			)
 		) {
 			$specifiedTypes = $this->typeSpecifier->create(
 				$node->getArgs()[0]->value,
@@ -70,11 +72,13 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 
 		if (
 			$context->true()
-			|| $context->false()
+			|| (
+				$context->false()
 				&& (
 					count(TypeUtils::getConstantScalars($needleType)) > 0
 					|| count(TypeUtils::getEnumCaseObjects($arrayValueType)) > 0
 				)
+			)
 		) {
 			if ($context->true()) {
 				$arrayValueType = TypeCombinator::union($arrayValueType, $needleType);

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -52,9 +52,12 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 		$specifiedTypes = new SpecifiedTypes();
 
 		if (
-			$context->truthy()
-			|| count(TypeUtils::getConstantScalars($arrayValueType)) > 0
-			|| count(TypeUtils::getEnumCaseObjects($arrayValueType)) > 0
+			$context->true()
+			|| $context->false()
+				&& (
+					count(TypeUtils::getConstantScalars($arrayValueType)) > 0
+					|| count(TypeUtils::getEnumCaseObjects($arrayValueType)) > 0
+				)
 		) {
 			$specifiedTypes = $this->typeSpecifier->create(
 				$node->getArgs()[0]->value,
@@ -66,11 +69,14 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 		}
 
 		if (
-			$context->truthy()
-			|| count(TypeUtils::getConstantScalars($needleType)) > 0
-			|| count(TypeUtils::getEnumCaseObjects($needleType)) > 0
+			$context->true()
+			|| $context->false()
+				&& (
+					count(TypeUtils::getConstantScalars($needleType)) > 0
+					|| count(TypeUtils::getEnumCaseObjects($arrayValueType)) > 0
+				)
 		) {
-			if ($context->truthy()) {
+			if ($context->true()) {
 				$arrayValueType = TypeCombinator::union($arrayValueType, $needleType);
 			} else {
 				$arrayValueType = TypeCombinator::remove($arrayValueType, $needleType);
@@ -85,7 +91,7 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 			));
 		}
 
-		if ($context->truthy() && $arrayType->isArray()->yes()) {
+		if ($context->true() && $arrayType->isArray()->yes()) {
 			$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
 				$node->getArgs()[1]->value,
 				TypeCombinator::intersect($arrayType, new NonEmptyArrayType()),

--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -39,7 +39,7 @@ class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtens
 		}
 		$classType = $scope->getType($node->getArgs()[1]->value);
 
-		if (!$classType instanceof ConstantStringType && !$context->truthy()) {
+		if (!$classType instanceof ConstantStringType && !$context->true()) {
 			return new SpecifiedTypes([], []);
 		}
 

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -34,7 +34,7 @@ class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeSpecify
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		if (!$context->truthy() || count($node->getArgs()) < 2) {
+		if (!$context->true() || count($node->getArgs()) < 2) {
 			return new SpecifiedTypes();
 		}
 

--- a/src/Type/Php/MethodExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/MethodExistsTypeSpecifyingExtension.php
@@ -35,7 +35,7 @@ class MethodExistsTypeSpecifyingExtension implements FunctionTypeSpecifyingExten
 	): bool
 	{
 		return $functionReflection->getName() === 'method_exists'
-			&& $context->truthy()
+			&& $context->true()
 			&& count($node->getArgs()) >= 2;
 	}
 

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -40,7 +40,7 @@ class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecifyingExt
 	): bool
 	{
 		return $functionReflection->getName() === 'property_exists'
-			&& $context->truthy()
+			&& $context->true()
 			&& count($node->getArgs()) >= 2;
 	}
 

--- a/src/Type/Php/StrContainingTypeSpecifyingExtension.php
+++ b/src/Type/Php/StrContainingTypeSpecifyingExtension.php
@@ -51,7 +51,7 @@ final class StrContainingTypeSpecifyingExtension implements FunctionTypeSpecifyi
 	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
 	{
 		return array_key_exists(strtolower($functionReflection->getName()), $this->strContainingFunctions)
-			&& $context->truthy();
+			&& $context->true();
 	}
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1199,6 +1199,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8752.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql-stmt.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-shapes.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-3013.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7607.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ibm_db2.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/benevolent-union-math.php');

--- a/tests/PHPStan/Analyser/data/bug-3009.php
+++ b/tests/PHPStan/Analyser/data/bug-3009.php
@@ -15,14 +15,14 @@ class HelloWorld
 			return null;
 		}
 
-		assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
+		assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
 
 		if (true === array_key_exists('query', $redirectUrlParts)) {
-			assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query: string, fragment?: string}', $redirectUrlParts);
+			assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query: string, fragment?: string}', $redirectUrlParts);
 			$redirectServer['QUERY_STRING'] = $redirectUrlParts['query'];
 		}
 
-		assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
+		assertType('array{scheme?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}', $redirectUrlParts);
 
 		return 'foo';
 	}

--- a/tests/PHPStan/Analyser/data/bug-3013.php
+++ b/tests/PHPStan/Analyser/data/bug-3013.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3013;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function test()
+	{
+		// Foo can be empty array, or list of ints
+		$foo =  array_map('intval', $_GET['foobar']);
+		assertType('array<int>', $foo);
+
+		$bar = $this->intOrNull();
+		assertType('int|null', $bar);
+
+		if (in_array($bar, $foo, true)) {
+			assertType('non-empty-array<int>', $foo);
+			assertType('int', $bar);
+			return;
+		}
+		assertType('array<int>', $foo);
+		assertType('int|null', $bar);
+
+		if (in_array($bar, $foo, true) === true) {
+			assertType('int', $bar);
+			return;
+		}
+		assertType('array<int>', $foo);
+		assertType('int|null', $bar);
+	}
+
+
+	public function intOrNull(): ?int
+	{
+		return rand() === 2 ? null : rand();
+	}
+
+	/**
+	 * @param array{0: 1, 1?: 2} $foo
+	 */
+	public function testArrayKeyExists($foo): void
+	{
+		assertType("array{0: 1, 1?: 2}", $foo);
+
+		$bar = 1;
+		assertType("1", $bar);
+
+		if (array_key_exists($bar, $foo) === true) {
+			assertType("array{1, 2}", $foo);
+			assertType("1", $bar);
+			return;
+		}
+
+		assertType("array{1}", $foo);
+		assertType("1", $bar);
+	}
+}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -373,6 +373,26 @@ class ClassConstantRuleTest extends RuleTestCase
 				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
 				48,
 			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				52,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				54,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				56,
+			],
+			[
+				'Access to undefined constant Foo::TEST.',
+				57,
+			],
+			[
+				'Access to undefined constant ClassConstFetchDefined\Foo::TEST.',
+				58,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Classes/data/class-const-fetch-defined.php
+++ b/tests/PHPStan/Rules/Classes/data/class-const-fetch-defined.php
@@ -47,5 +47,15 @@ class HelloWorld
 			\Foo::TEST;
 			\ClassConstFetchDefined\Foo::TEST;
 		}
+
+		if (defined('Foo::TEST') === true) {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		} else {
+			Foo::TEST;
+			\Foo::TEST;
+			\ClassConstFetchDefined\Foo::TEST;
+		}
 	}
 }

--- a/tests/PHPStan/Rules/Comparison/UnreachableTernaryElseBranchRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/UnreachableTernaryElseBranchRuleTest.php
@@ -99,4 +99,10 @@ class UnreachableTernaryElseBranchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-3019.php'], []);
 	}
 
+	public function testBug7686(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-7686.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-7686.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7686.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7686;
+
+class Foo
+{
+	/**
+	 * @param array<array{name: string, type: string}> $input
+	 * @return array<'return'|int, string>
+	 */
+	public static function test(array $input): array
+	{
+		$output = [];
+		foreach($input as $match) {
+			if (array_key_exists($match['name'], $output) == false) {
+				$output[$match['name']] = '';
+			}
+			if (($match['type'] === '') || (in_array($match['type'], explode('|', $output[$match['name']]), true) === true)) {
+				continue;
+			}
+			$output[$match['name']] = ($output[$match['name']] === '' ? $match['type'] : $output[$match['name']] . '|' . $match['type']);
+		}
+		return $output;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/3013
Closes https://github.com/phpstan/phpstan/issues/7686

I tried to work on this issue to understand more `TypeSpecifyingExtension`,
I discovered like explained in https://github.com/phpstan/phpstan/issues/3013#issuecomment-1423390743 that we don't get the same behavior with 
```
if (in_array($bar, $foo, true) === true)
```
than with
```
if (in_array($bar, $foo, true))
```

I started a PR to solve this, it seems like replacing `$context->truthy()` by `$context->true()` solve the issue.
It's because we get
```
if (in_array($bar, $foo, true)) (
     $context->true();
     $context->truthy();
} else {
     $context->false();
     $context->falsey();
}
```
but
```
if (in_array($bar, $foo, true) === true) (
     $context->true();
     $context->truthy();
} else {
     $context->truthy();
     $context->false();
     $context->falsey();
}
```

Then I started to look at another type specifying extensions I worked on, the array_key_exists one, and I was able to reproduce the same issue by using `array_key_exists($foo, $bar) === true)`. And again I solved it by changing `$context->truthy()` by `$context->true()`.

There is 8 others TypeSpecifyingExtensions with `$context->truthy()` about method which can only return false or true:
- ClassExistsFunctionTypeSpecifyingExtension
- DefinedConstantTypeSpecifyingExtension
- FunctionExistsFunctionTypeSpecifyingExtension
- IsAFunctionTypeSpecifyingExtension
- IsSubclassOfFunctionTypeSpecifyingExtension
- MethodExistsTypeSpecifyingExtension
- PropertyExistsTypeSpecifyingExtension
- StrContainingTypeSpecifyingExtension

And I wonder if there is not the same issue for them.
(Also there is 7 truthy calls (and 3 falsey calls) in the TypeSpecifier and I don't know if similar issues can occur in it.)

Since I don't really know if I'm going in the right direction, I'd like your opinion @ondrejmirtes
(cc @staabm if you can help me) 