### PR TITLE
Deprecated `instanceof GenericClassStringType`, introduce `Type::getClassStringObjectType()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,11 +57,6 @@ parameters:
 			path: src/Analyser/NodeScopeResolver.php
 
 		-
-			message: "#^Parameter \\#11 \\$reflection of class PHPStan\\\\Reflection\\\\ClassReflection constructor expects PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionClass\\|PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum, object given\\.$#"
-			count: 1
-			path: src/Analyser/NodeScopeResolver.php
-
-		-
 			message: "#^Parameter \\#2 \\$node of method PHPStan\\\\BetterReflection\\\\SourceLocator\\\\Ast\\\\Strategy\\\\NodeToReflection\\:\\:__invoke\\(\\) expects PhpParser\\\\Node\\\\Expr\\\\ArrowFunction\\|PhpParser\\\\Node\\\\Expr\\\\Closure\\|PhpParser\\\\Node\\\\Expr\\\\FuncCall\\|PhpParser\\\\Node\\\\Stmt\\\\Class_\\|PhpParser\\\\Node\\\\Stmt\\\\Const_\\|PhpParser\\\\Node\\\\Stmt\\\\Enum_\\|PhpParser\\\\Node\\\\Stmt\\\\Function_\\|PhpParser\\\\Node\\\\Stmt\\\\Interface_\\|PhpParser\\\\Node\\\\Stmt\\\\Trait_, PhpParser\\\\Node\\\\Stmt\\\\ClassLike given\\.$#"
 			count: 1
 			path: src/Analyser/NodeScopeResolver.php
@@ -275,11 +270,6 @@ parameters:
 			path: src/Reflection/BetterReflection/BetterReflectionProvider.php
 
 		-
-			message: "#^Parameter \\#11 \\$reflection of class PHPStan\\\\Reflection\\\\ClassReflection constructor expects PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionClass\\|PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum, object given\\.$#"
-			count: 1
-			path: src/Reflection/BetterReflection/BetterReflectionProvider.php
-
-		-
 			message: """
 				#^Call to deprecated method getTypeFromValue\\(\\) of class PHPStan\\\\Type\\\\ConstantTypeHelper\\:
 				Use PHPStan\\\\Reflection\\\\InitializerExprTypeResolver$#
@@ -331,6 +321,11 @@ parameters:
 			message: "#^Creating new ReflectionClass is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine\\. Use objects retrieved from ReflectionProvider instead\\.$#"
 			count: 1
 			path: src/Reflection/BetterReflection/SourceLocator/SkipClassAliasSourceLocator.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
+			count: 3
+			path: src/Reflection/ClassReflection.php
 
 		-
 			message: "#^Method PHPStan\\\\Reflection\\\\ClassReflection\\:\\:getCacheKey\\(\\) should return string but returns string\\|null\\.$#"
@@ -534,11 +529,6 @@ parameters:
 			path: src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
 
 		-
-			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantArrayType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantArrays\\(\\) instead\\.$#"
-			count: 1
-			path: src/Rules/DeadCode/UnusedPrivateMethodRule.php
-
-		-
 			message: "#^Function class_implements\\(\\) is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine\\. Use objects retrieved from ReflectionProvider instead\\.$#"
 			count: 1
 			path: src/Rules/DirectRegistry.php
@@ -562,6 +552,11 @@ parameters:
 			message: "#^Property PHPStan\\\\Rules\\\\DirectRegistry\\:\\:\\$rules with generic interface PHPStan\\\\Rules\\\\Rule does not specify its types\\: TNodeType$#"
 			count: 1
 			path: src/Rules/DirectRegistry.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
+			count: 1
+			path: src/Rules/Generics/GenericAncestorsCheck.php
 
 		-
 			message: "#^Function class_implements\\(\\) is a runtime reflection concept that might not work in PHPStan because it uses fully static reflection engine\\. Use objects retrieved from ReflectionProvider instead\\.$#"
@@ -597,6 +592,16 @@ parameters:
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\IterableType is error\\-prone and deprecated\\. Use Type\\:\\:isIterable\\(\\) instead\\.$#"
 			count: 1
 			path: src/Rules/Methods/MethodParameterComparisonHelper.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
+			count: 1
+			path: src/Rules/Methods/StaticMethodCallCheck.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
+			count: 1
+			path: src/Rules/PhpDoc/VarTagTypeRuleHelper.php
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\NullType is error\\-prone and deprecated\\. Use Type\\:\\:isNull\\(\\) instead\\.$#"
@@ -690,7 +695,7 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantStringType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantStrings\\(\\) instead\\.$#"
-			count: 7
+			count: 4
 			path: src/Type/Constant/ConstantArrayType.php
 
 		-
@@ -744,6 +749,11 @@ parameters:
 			path: src/Type/Constant/ConstantStringType.php
 
 		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
+			count: 1
+			path: src/Type/Constant/ConstantStringType.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\StringType is error\\-prone and deprecated\\. Use Type\\:\\:isString\\(\\) instead\\.$#"
 			count: 1
 			path: src/Type/Constant/ConstantStringType.php
@@ -764,6 +774,11 @@ parameters:
 			path: src/Type/Enum/EnumCaseObjectType.php
 
 		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
+			count: 1
+			path: src/Type/FileTypeMapper.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\FloatType is error\\-prone and deprecated\\. Use Type\\:\\:isFloat\\(\\) instead\\.$#"
 			count: 2
 			path: src/Type/FloatType.php
@@ -779,9 +794,19 @@ parameters:
 			path: src/Type/Generic/GenericClassStringType.php
 
 		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
+			count: 4
+			path: src/Type/Generic/GenericClassStringType.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\StringType is error\\-prone and deprecated\\. Use Type\\:\\:isString\\(\\) instead\\.$#"
 			count: 2
 			path: src/Type/Generic/GenericClassStringType.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
+			count: 2
+			path: src/Type/Generic/GenericObjectType.php
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\ObjectType is error\\-prone and deprecated\\. Use Type\\:\\:isObject\\(\\) or Type\\:\\:getObjectClassNames\\(\\) instead\\.$#"
@@ -820,6 +845,11 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\FloatType is error\\-prone and deprecated\\. Use Type\\:\\:isFloat\\(\\) instead\\.$#"
+			count: 1
+			path: src/Type/Generic/TemplateTypeFactory.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
 			count: 1
 			path: src/Type/Generic/TemplateTypeFactory.php
 
@@ -901,6 +931,11 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Enum\\\\EnumCaseObjectType is error\\-prone and deprecated\\. Use Type\\:\\:getEnumCases\\(\\) instead\\.$#"
+			count: 1
+			path: src/Type/ObjectType.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericObjectType is error\\-prone and deprecated\\.$#"
 			count: 1
 			path: src/Type/ObjectType.php
 
@@ -1000,6 +1035,11 @@ parameters:
 			path: src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
 
 		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
+			count: 2
+			path: src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+
+		-
 			message: """
 				#^Call to deprecated method getTypeFromValue\\(\\) of class PHPStan\\\\Type\\\\ConstantTypeHelper\\:
 				Use PHPStan\\\\Reflection\\\\InitializerExprTypeResolver$#
@@ -1060,10 +1100,10 @@ parameters:
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantStringType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantStrings\\(\\) instead\\.$#"
 			count: 1
-			path: src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
+			path: src/Type/Php/ReflectionMethodConstructorThrowTypeExtension.php
 
 		-
-			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantStringType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantStrings\\(\\) instead\\.$#"
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
 			count: 1
 			path: src/Type/Php/ReflectionMethodConstructorThrowTypeExtension.php
 
@@ -1143,6 +1183,11 @@ parameters:
 			path: src/Type/TypeCombinator.php
 
 		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
+			count: 2
+			path: src/Type/TypeCombinator.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\IntegerType is error\\-prone and deprecated\\. Use Type\\:\\:isInteger\\(\\) instead\\.$#"
 			count: 1
 			path: src/Type/TypeCombinator.php
@@ -1194,6 +1239,11 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantBooleanType is error\\-prone and deprecated\\. Use Type\\:\\:isTrue\\(\\) or Type\\:\\:isFalse\\(\\) instead\\.$#"
+			count: 1
+			path: src/Type/UnionType.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\Generic\\\\GenericClassStringType is error\\-prone and deprecated\\. Use Type\\:\\:getClassStringObjectType\\(\\) instead\\.$#"
 			count: 1
 			path: src/Type/UnionType.php
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -135,7 +135,6 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\GeneralizePrecision;
-use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\IntegerType;
@@ -2217,20 +2216,9 @@ class NodeScopeResolver
 										$thisTypes[] = new ObjectType($directClassName);
 									}
 									$thisType = TypeCombinator::union(...$thisTypes);
-								} elseif (count($argValueType->getConstantStrings()) > 0) {
-									$thisTypes = [];
-									foreach ($argValueType->getConstantStrings() as $constantString) {
-										$scopeClasses[] = $constantString->getValue();
-										$thisTypes[] = new ObjectType($constantString->getValue());
-									}
-
-									$thisType = TypeCombinator::union(...$thisTypes);
-								} elseif ($argValueType instanceof GenericClassStringType) {
-									$genericClassNames = $argValueType->getGenericType()->getObjectClassNames();
-									if (count($genericClassNames) > 0) {
-										$scopeClasses = $genericClassNames;
-										$thisType = $argValueType->getGenericType();
-									}
+								} else {
+									$thisType = $argValueType->getClassStringObjectType();
+									$scopeClasses = $thisType->getObjectClassNames();
 								}
 							}
 							$closureBindScope = $scope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);

--- a/src/Rules/Api/ApiInstanceofTypeRule.php
+++ b/src/Rules/Api/ApiInstanceofTypeRule.php
@@ -29,6 +29,8 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\NullType;
@@ -65,6 +67,8 @@ class ApiInstanceofTypeRule implements Rule
 		IterableType::class => 'Type::isIterable()',
 		ObjectWithoutClassType::class => 'Type::isObject()',
 		ObjectType::class => 'Type::isObject() or Type::getObjectClassNames()',
+		GenericClassStringType::class => 'Type::getClassStringObjectType()',
+		GenericObjectType::class => null,
 
 		// accessory types
 		NonEmptyArrayType::class => 'Type::isIterableAtLeastOnce()',
@@ -127,14 +131,22 @@ class ApiInstanceofTypeRule implements Rule
 			}
 		}
 
+		$tip = 'Learn more: <fg=cyan>https://phpstan.org/blog/why-is-instanceof-type-wrong-and-getting-deprecated</>';
+		if ($lowerMap[$lowerClassName] === null) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'Doing instanceof %s is error-prone and deprecated.',
+					$className,
+				))->tip($tip)->build(),
+			];
+		}
+
 		return [
 			RuleErrorBuilder::message(sprintf(
 				'Doing instanceof %s is error-prone and deprecated. Use %s instead.',
 				$className,
 				$lowerMap[$lowerClassName],
-			))->tip(
-				'Learn more: <fg=cyan>https://phpstan.org/blog/why-is-instanceof-type-wrong-and-getting-deprecated</>',
-			)->build(),
+			))->tip($tip)->build(),
 		];
 	}
 

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -347,6 +347,16 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -16,6 +16,7 @@ use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -247,6 +248,16 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 	public function isClassStringType(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
 	}
 
 	public function hasMethod(string $methodName): TrinaryLogic

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -16,6 +16,7 @@ use PHPStan\Type\FloatType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -248,6 +249,16 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 	public function isClassStringType(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
 	}
 
 	public function isVoid(): TrinaryLogic

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -16,6 +16,7 @@ use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -248,6 +249,16 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 	public function isClassStringType(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
 	}
 
 	public function isVoid(): TrinaryLogic

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -253,6 +253,16 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -13,6 +13,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
@@ -249,6 +250,16 @@ class HasOffsetType implements CompoundType, AccessoryType
 	public function isClassStringType(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
 	}
 
 	public function isVoid(): TrinaryLogic

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -14,6 +14,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
@@ -304,6 +305,16 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 	public function isClassStringType(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
+	}
+
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
 	}
 
 	public function isVoid(): TrinaryLogic

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -332,6 +332,16 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -318,6 +318,16 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -336,6 +336,16 @@ class ArrayType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -403,6 +403,16 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/ClassStringType.php
+++ b/src/Type/ClassStringType.php
@@ -72,6 +72,16 @@ class ClassStringType extends StringType
 		return TrinaryLogic::createYes();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
 	/**
 	 * @param mixed[] $properties
 	 */

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -479,6 +479,16 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this;
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -75,12 +75,25 @@ class ConstantStringType extends StringType implements ConstantScalarType
 	{
 		if ($this->isClassString) {
 			return TrinaryLogic::createYes();
-
 		}
 
 		$reflectionProvider = ReflectionProviderStaticAccessor::getInstance();
 
 		return TrinaryLogic::createFromBoolean($reflectionProvider->hasClass($this->value));
+	}
+
+	public function getClassStringObjectType(): Type
+	{
+		if ($this->isClassStringType()->yes()) {
+			return new ObjectType($this->value);
+		}
+
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this->getClassStringObjectType();
 	}
 
 	/**

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -197,6 +197,16 @@ class FloatType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -42,6 +42,16 @@ class GenericClassStringType extends ClassStringType
 		return $this->type;
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return $this->getGenericType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this->getClassStringObjectType();
+	}
+
 	public function describe(VerbosityLevel $level): string
 	{
 		return sprintf('%s<%s>', parent::describe($level), $this->type->describe($level));

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -591,6 +591,16 @@ class IntersectionType implements CompoundType
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isClassStringType());
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getClassStringObjectType());
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->getObjectTypeOrClassStringObjectType());
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isVoid());

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -341,6 +341,16 @@ class IterableType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -122,6 +122,16 @@ trait JustNullableTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -801,6 +801,28 @@ class MixedType implements CompoundType, SubtractableType
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		if (!$this->isClassStringType()->no()) {
+			return new ObjectWithoutClassType();
+		}
+
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		$objectOrClass = new UnionType([
+			new ObjectWithoutClassType(),
+			new ClassStringType(),
+		]);
+		if (!$this->isSuperTypeOf($objectOrClass)->no()) {
+			return new ObjectWithoutClassType();
+		}
+
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -424,6 +424,16 @@ class NeverType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -253,6 +253,16 @@ class NullType implements ConstantScalarType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -993,6 +993,16 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this;
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
@@ -6,12 +6,9 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use ReflectionAttribute;
 use function count;
@@ -43,14 +40,7 @@ class ReflectionGetAttributesMethodReturnTypeExtension implements DynamicMethodR
 			return null;
 		}
 		$argType = $scope->getType($methodCall->getArgs()[0]->value);
-
-		if ($argType instanceof ConstantStringType) {
-			$classType = new ObjectType($argType->getValue());
-		} elseif ($argType instanceof GenericClassStringType) {
-			$classType = $argType->getGenericType();
-		} else {
-			return null;
-		}
+		$classType = $argType->getClassStringObjectType();
 
 		return new ArrayType(new MixedType(), new GenericObjectType(ReflectionAttribute::class, [$classType]));
 	}

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -517,6 +517,16 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->isClassStringType();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return $this->getStaticObjectType()->getClassStringObjectType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this;
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isVoid();

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -243,6 +243,16 @@ class StrictMixedType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -222,6 +222,16 @@ class StringType implements Type
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ObjectWithoutClassType();
+	}
+
 	public function isScalar(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -402,6 +402,16 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->isClassStringType();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return $this->resolve()->getClassStringObjectType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this->resolve()->getObjectTypeOrClassStringObjectType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return $this->resolve()->isVoid();

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -178,6 +178,16 @@ trait ObjectTypeTrait
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this;
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -30,6 +30,17 @@ interface Type
 	/** @return list<string> */
 	public function getObjectClassNames(): array;
 
+	/**
+	 * Returns object type Foo for class-string<Foo> and 'Foo' (if Foo is a valid class).
+	 */
+	public function getClassStringObjectType(): Type;
+
+	/**
+	 * Returns object type Foo for class-string<Foo>, 'Foo' (if Foo is a valid class),
+	 * and object type Foo.
+	 */
+	public function getObjectTypeOrClassStringObjectType(): Type;
+
 	public function isObject(): TrinaryLogic;
 
 	/** @return list<ArrayType> */

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -559,6 +559,16 @@ class UnionType implements CompoundType
 		return $this->notBenevolentUnionResults(static fn (Type $type): TrinaryLogic => $type->isClassStringType());
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->getClassStringObjectType());
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->getObjectTypeOrClassStringObjectType());
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isVoid());

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -175,6 +175,16 @@ class VoidType implements Type
 		return TrinaryLogic::createNo();
 	}
 
+	public function getClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
+	public function getObjectTypeOrClassStringObjectType(): Type
+	{
+		return new ErrorType();
+	}
+
 	public function isVoid(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/tests/PHPStan/Analyser/data/reflectionclass-issue-5511-php8.php
+++ b/tests/PHPStan/Analyser/data/reflectionclass-issue-5511-php8.php
@@ -40,7 +40,7 @@ function testGetAttributes(
 	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $classGCN);
 	assertType('array<ReflectionAttribute<object>>', $classCN);
 	assertType('array<ReflectionAttribute<object>>', $classStr);
-	assertType('array<ReflectionAttribute<some random string>>', $classNonsense);
+	assertType('array<ReflectionAttribute<*ERROR*>>', $classNonsense);
 
 	$methodAll = $reflectionMethod->getAttributes();
 	$methodAbc = $reflectionMethod->getAttributes(Abc::class);

--- a/tests/PHPStan/Rules/Api/ApiInstanceofTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Api/ApiInstanceofTypeRuleTest.php
@@ -22,17 +22,22 @@ class ApiInstanceofTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/instanceof-type.php'], [
 			[
 				'Doing instanceof PHPStan\Type\TypeWithClassName is error-prone and deprecated. Use Type::getObjectClassNames() instead.',
-				19,
+				20,
 				$tipText,
 			],
 			[
 				'Doing instanceof phpstan\type\typewithclassname is error-prone and deprecated. Use Type::getObjectClassNames() instead.',
-				23,
+				24,
 				$tipText,
 			],
 			[
 				'Doing instanceof PHPStan\Type\TypeWithClassName is error-prone and deprecated. Use Type::getObjectClassNames() instead.',
-				35,
+				36,
+				$tipText,
+			],
+			[
+				'Doing instanceof PHPStan\Type\Generic\GenericObjectType is error-prone and deprecated.',
+				40,
 				$tipText,
 			],
 		]);

--- a/tests/PHPStan/Rules/Api/data/instanceof-type.php
+++ b/tests/PHPStan/Rules/Api/data/instanceof-type.php
@@ -2,6 +2,7 @@
 
 namespace ApiInstanceofType;
 
+use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\TypeWithClassName;
@@ -33,6 +34,10 @@ class Foo
 		});
 
 		if ($a instanceof TypeWithClassName) {
+
+		}
+
+		if ($a instanceof GenericObjectType) {
 
 		}
 	}

--- a/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnusedPrivateMethodRuleTest.php
@@ -38,7 +38,7 @@ class UnusedPrivateMethodRuleTest extends RuleTestCase
 			],
 			[
 				'Method UnusedPrivateMethod\Lorem::doBaz() is unused.',
-				97,
+				99,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/DeadCode/data/unused-private-method.php
+++ b/tests/PHPStan/Rules/DeadCode/data/unused-private-method.php
@@ -80,8 +80,10 @@ class Baz
 
 	public function doBar(string $name)
 	{
-		$cb = [$this, $name];
-		$cb();
+		if ($name === 'doFoo') {
+			$cb = [$this, $name];
+			$cb();
+		}
 	}
 
 }


### PR DESCRIPTION
Part of https://github.com/phpstan/phpstan/issues/8311 but still needs some work