### PR TITLE
Draft: hide class-level template types from static members

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -31,3 +31,4 @@ parameters:
 		closureDefaultParameterTypeRule: true
 		newRuleLevelHelper: true
 		instanceofType: true
+		disallowClassLevelTemplatesInStatic: true

--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -31,4 +31,4 @@ parameters:
 		closureDefaultParameterTypeRule: true
 		newRuleLevelHelper: true
 		instanceofType: true
-		disallowClassLevelTemplatesInStatic: true
+		disallowClassLevelTemplatesInStaticMethods: true

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -61,7 +61,7 @@ parameters:
 		closureDefaultParameterTypeRule: false
 		newRuleLevelHelper: false
 		instanceofType: false
-		disallowClassLevelTemplatesInStatic: false
+		disallowClassLevelTemplatesInStaticMethods: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -289,7 +289,7 @@ parametersSchema:
 		closureDefaultParameterTypeRule: bool()
 		newRuleLevelHelper: bool()
 		instanceofType: bool()
-		disallowClassLevelTemplatesInStatic: bool()
+		disallowClassLevelTemplatesInStaticMethods: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()
@@ -1127,7 +1127,7 @@ services:
 		class: PHPStan\Type\FileTypeMapper
 		arguments:
 			phpParser: @defaultAnalysisParser
-			disallowClassLevelTemplatesInStatic: %featureToggles.disallowClassLevelTemplatesInStatic%
+			disallowClassLevelTemplatesInStaticMethods: %featureToggles.disallowClassLevelTemplatesInStaticMethods%
 
 	-
 		class: PHPStan\Type\TypeAliasResolver

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -61,6 +61,7 @@ parameters:
 		closureDefaultParameterTypeRule: false
 		newRuleLevelHelper: false
 		instanceofType: false
+		disallowClassLevelTemplatesInStatic: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -288,6 +289,7 @@ parametersSchema:
 		closureDefaultParameterTypeRule: bool()
 		newRuleLevelHelper: bool()
 		instanceofType: bool()
+		disallowClassLevelTemplatesInStatic: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()
@@ -1125,6 +1127,7 @@ services:
 		class: PHPStan\Type\FileTypeMapper
 		arguments:
 			phpParser: @defaultAnalysisParser
+			disallowClassLevelTemplatesInStatic: %featureToggles.disallowClassLevelTemplatesInStatic%
 
 	-
 		class: PHPStan\Type\TypeAliasResolver

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -63,6 +63,7 @@ class FileTypeMapper
 		private PhpDocNodeResolver $phpDocNodeResolver,
 		private AnonymousClassNameHelper $anonymousClassNameHelper,
 		private FileHelper $fileHelper,
+		private bool $disallowClassLevelTemplatesInStatic,
 	)
 	{
 	}
@@ -309,7 +310,11 @@ class FileTypeMapper
 							$typeMapCb = $typeMapStack[count($typeMapStack) - 1] ?? null;
 
 							// static methods exist in their own scope
-							if ($node instanceof Node\Stmt\ClassMethod && $node->isStatic()) {
+							if (
+								$this->disallowClassLevelTemplatesInStatic
+								&& $node instanceof Node\Stmt\ClassMethod
+								&& $node->isStatic()
+							) {
 								$typeMapCb = null;
 							}
 

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -63,7 +63,7 @@ class FileTypeMapper
 		private PhpDocNodeResolver $phpDocNodeResolver,
 		private AnonymousClassNameHelper $anonymousClassNameHelper,
 		private FileHelper $fileHelper,
-		private bool $disallowClassLevelTemplatesInStatic,
+		private bool $disallowClassLevelTemplatesInStaticMethods,
 	)
 	{
 	}
@@ -311,7 +311,7 @@ class FileTypeMapper
 
 							// static methods exist in their own scope
 							if (
-								$this->disallowClassLevelTemplatesInStatic
+								$this->disallowClassLevelTemplatesInStaticMethods
 								&& $node instanceof Node\Stmt\ClassMethod
 								&& $node->isStatic()
 							) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1200,6 +1200,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/trait-instance-of.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql-stmt.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-shapes.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/static-methods-template-types.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -1395,7 +1395,7 @@ class CarFactoryProcessor {
 	 */
 	public function process($class): void {
 		$car = $class::create();
-		assertType(Car::class, $car);
+		assertType(T::class, $car); // @template T is unknown in static method
 	}
 }
 

--- a/tests/PHPStan/Analyser/data/static-methods-template-types.php
+++ b/tests/PHPStan/Analyser/data/static-methods-template-types.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace StaticMethodsTemplateTypes;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ */
+class Foo
+{
+
+	/**
+	 * @template U
+	 * @param T $t
+	 * @return T
+	 */
+	public static function bar($t)
+	{
+	}
+
+	/**
+	 * @template U
+	 * @param U $u
+	 * @return U
+	 */
+	public static function baz($u)
+	{
+	}
+
+	/**
+	 * @return T
+	 */
+	public static function qux()
+	{
+	}
+
+	public static function doFoo()
+	{
+		assertType('StaticMethodsTemplateTypes\T', self::bar(42));
+		assertType('int', self::baz(42));
+		assertType('StaticMethodsTemplateTypes\T', self::qux());
+	}
+
+}
+
+assertType('StaticMethodsTemplateTypes\T', Foo::bar(42));
+assertType('int', Foo::baz(42));
+assertType('StaticMethodsTemplateTypes\T', Foo::qux());

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -470,7 +470,12 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		// discussion https://github.com/phpstan/phpstan/discussions/6249
 		$this->checkThisOnly = false;
 		$this->checkExplicitMixed = true;
-		$this->analyse([__DIR__ . '/data/bug-6249.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-6249.php'], [
+			[
+				'Parameter #1 $iterable of static method Bug6249N3\Cw<(int|string),mixed>::fromIterable() expects iterable<Bug6249N3\TKey, Bug6249N3\T>, Bug6249N2\Eii given.',
+				145,
+			],
+		]);
 	}
 
 	public function testBug5749(): void

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -131,6 +131,10 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 				'Template type U of method TestMethodTypehints\TemplateTypeMissingInParameter::doFoo() is not referenced in a parameter.',
 				130,
 			],
+			[
+				'Method TestMethodTypehints\TemplateInStaticMethod::doBar() has invalid return type TestMethodTypehints\T.',
+				163,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/bug-6249.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-6249.php
@@ -106,6 +106,18 @@ final class Cw implements CollectionInterface
 		return new self($iterable);
 	}
 
+	/**
+	 * @template UKey of array-key
+	 * @template U
+	 * @param iterable<UKey, U> $iterable
+	 *
+	 * @return self<UKey, U>
+	 */
+	public static function fromIterableCorrect(iterable $iterable): self
+	{
+		return new self($iterable);
+	}
+
 	public function count(): int
 	{
 		if (is_array($this->iterable) || $this->iterable instanceof Countable) {
@@ -131,6 +143,7 @@ class Foo
 	public function doFoo()
 	{
 		\Bug6249N3\Cw::fromIterable(new \Bug6249N2\Eii([]));
+		\Bug6249N3\Cw::fromIterableCorrect(new \Bug6249N2\Eii([]));
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/data/typehints.php
+++ b/tests/PHPStan/Rules/Methods/data/typehints.php
@@ -142,3 +142,27 @@ class TemplateTypeMissingInParameter
 	}
 
 }
+
+/**
+ * @template T
+ */
+class TemplateInStaticMethod
+{
+
+	/**
+	 * @return T
+	 */
+	public function doFoo()
+	{
+
+	}
+
+	/**
+	 * @return T
+	 */
+	public static function doBar()
+	{
+
+	}
+
+}


### PR DESCRIPTION
This is a solution I was talking about [previously](https://github.com/phpstan/phpstan-src/pull/2075#issuecomment-1410638235).

The failing test discovered exactly the kind of class-string magic I was afraid people might be doing. I don't know how many actual real-life use cases there are, but it puts doubt in my mind about this.

Nevertheless, I still firmly believe this is a must for static properties, which, sadly, I have no idea how to cover in this way.