### PR TITLE
iterator_*() accepts array since PHP 8.2

### DIFF
--- a/resources/functionMap_php82delta.php
+++ b/resources/functionMap_php82delta.php
@@ -21,6 +21,8 @@
  */
 return [
 	'new' => [
+		'iterator_count' => ['0|positive-int', 'iterator'=>'iterable'],
+		'iterator_to_array' => ['array', 'iterator'=>'iterable', 'preserve_keys='=>'bool'],
 		'str_split' => ['list<string>', 'str'=>'string', 'split_length='=>'positive-int'],
 	],
 	'old' => [


### PR DESCRIPTION
`iterator_to_array()` and `iterator_count()` accept an array since PHP 8.2.
https://wiki.php.net/rfc/iterator_xyz_accept_array