### PR TITLE
Remove unneded code in `ConstantArrayType::hasOffsetValueType()`

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -548,9 +548,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
 		$offsetType = $offsetType->toArrayKey();
-		if ($offsetType instanceof UnionType) {
-			return TrinaryLogic::lazyExtremeIdentity($offsetType->getTypes(), fn (Type $innerType) => $this->hasOffsetValueType($innerType));
-		}
 
 		$result = TrinaryLogic::createNo();
 		foreach ($this->keyTypes as $i => $keyType) {


### PR DESCRIPTION
was added in 28c5ff61, but everything seems to be still fine without it. not sure yet if this changes something performance-wise, I hope CI tells me