### PR TITLE
Update param and return type for `db2_autocommit()`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -146,6 +146,7 @@ parameters:
 		- ../stubs/ImagickPixel.stub
 		- ../stubs/PDOStatement.stub
 		- ../stubs/date.stub
+		- ../stubs/ibm_db2.stub
 		- ../stubs/mysqli.stub
 		- ../stubs/zip.stub
 		- ../stubs/dom.stub

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1644,7 +1644,7 @@ return [
 'DateTimeZone::getTransitions' => ['list<array{ts: int, time: string, offset: int, isdst: bool, abbr: string}>', 'timestamp_begin='=>'int', 'timestamp_end='=>'int'],
 'DateTimeZone::listAbbreviations' => ['array<string, list<array{dst: bool, offset: int, timezone_id: string|null}>>'],
 'DateTimeZone::listIdentifiers' => ['list<string>', 'what='=>'int', 'country='=>'string'],
-'db2_autocommit' => ['mixed', 'connection'=>'resource', 'value='=>'int'],
+'db2_autocommit' => ['DB2_AUTOCOMMIT_OFF|DB2_AUTOCOMMIT_ON|bool', 'connection'=>'resource', 'value='=>'DB2_AUTOCOMMIT_OFF|DB2_AUTOCOMMIT_ON'],
 'db2_bind_param' => ['bool', 'stmt'=>'resource', 'parameter_number'=>'int', 'variable_name'=>'string', 'parameter_type='=>'int', 'data_type='=>'int', 'precision='=>'int', 'scale='=>'int'],
 'db2_client_info' => ['object|false', 'connection'=>'resource'],
 'db2_close' => ['bool', 'connection'=>'resource'],

--- a/stubs/ibm_db2.stub
+++ b/stubs/ibm_db2.stub
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @param resource                               $connection
+ * @param \DB2_AUTOCOMMIT_OFF|\DB2_AUTOCOMMIT_ON $value
+ *
+ * @return ($value is null ? \DB2_AUTOCOMMIT_OFF|\DB2_AUTOCOMMIT_ON : bool)
+ */
+function db2_autocommit($connection, int $value = null) {}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1201,6 +1201,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql-stmt.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/list-shapes.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7607.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/ibm_db2.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/ibm_db2.php
+++ b/tests/PHPStan/Analyser/data/ibm_db2.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace IBMDB2;
+
+use function db2_autocommit;
+use function db2_connect;
+use function PHPStan\Testing\assertType;
+
+use const DB2_AUTOCOMMIT_OFF;
+use const DB2_AUTOCOMMIT_ON;
+
+final class IBMDB2
+{
+	public function testAutocommit(): void
+	{
+		assertType('0|1', db2_autocommit(db2_connect()));
+		assertType('bool', db2_autocommit(db2_connect(), DB2_AUTOCOMMIT_OFF));
+		assertType('bool', db2_autocommit(db2_connect(), DB2_AUTOCOMMIT_ON));
+	}
+}


### PR DESCRIPTION
Prior to version ibm_db2 2.1, the `db2_autocommit()` function was expecting a boolean as argument 2.

See:
* https://www.php.net/manual/en/function.db2-autocommit.php
* https://bugs.php.net/bug.php?id=77591
* php/pecl-database-ibm_db2@e9fb4b173046ab4fa1bb69125adf3de8d3818b97
* php/doc-en#2300

Additionally, the return type of this function can be `DB2_AUTOCOMMIT_OFF|DB2_AUTOCOMMIT_ON|bool` depending on the received arguments:
>When db2_autocommit() receives only the connection parameter, it returns the current state of AUTOCOMMIT for the requested connection as an integer value. A value of DB2_AUTOCOMMIT_OFF indicates that AUTOCOMMIT is off, while a value of DB2_AUTOCOMMIT_ON indicates that AUTOCOMMIT is on.
>
>When db2_autocommit() receives both the connection parameter and autocommit parameter, it attempts to set the AUTOCOMMIT state of the requested connection to the corresponding state. Returns true on success or false on failure.