### PR TITLE
Detect not existing classes in @method annotations

### DIFF
--- a/src/Rules/PhpDoc/MethodAnnotationReturnTypeClassDoesNotExistRule.php
+++ b/src/Rules/PhpDoc/MethodAnnotationReturnTypeClassDoesNotExistRule.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\ClassCaseSensitivityCheck;
+use PHPStan\Rules\ClassNameNodePair;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function array_merge;
+use function sprintf;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+class MethodAnnotationReturnTypeClassDoesNotExistRule implements Rule
+{
+
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+		private ClassCaseSensitivityCheck $classCaseSensitivityCheck,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return InClassNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$scope->isInClass()) {
+			return [];
+		}
+		$classReflection = $scope->getClassReflection();
+		$errors = [];
+		foreach ($classReflection->getMethodTags() as $methodName => $methodTag) {
+			$type = $methodTag->getReturnType();
+			foreach ($type->getReferencedClasses() as $class) {
+				if (!$this->reflectionProvider->hasClass($class)) {
+					$errors[] = RuleErrorBuilder::message(
+						sprintf(
+							'PHPDoc tag @method %s() has invalid return type "%s", class does not exist',
+							$methodName,
+							$class,
+						),
+					)->build();
+				}
+				$errors = array_merge(
+					$errors,
+					$this->classCaseSensitivityCheck->checkClassNames([
+						new ClassNameNodePair($class, $node),
+					]),
+				);
+			}
+		}
+
+		return $errors;
+	}
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/MethodAnnotationReturnTypeClassDoesNotExistRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/MethodAnnotationReturnTypeClassDoesNotExistRuleTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PHPStan\Rules\ClassCaseSensitivityCheck;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<MethodAnnotationReturnTypeClassDoesNotExistRule>
+ */
+class MethodAnnotationReturnTypeClassDoesNotExistRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$reflectionProvider = $this->createReflectionProvider();
+
+		return new MethodAnnotationReturnTypeClassDoesNotExistRule(
+			$reflectionProvider,
+			new ClassCaseSensitivityCheck($reflectionProvider, true),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/method-tag-return-class-does-not-exist.php'], [
+			[
+				'PHPDoc tag @method missing() has invalid return type "MethodTagReturnClassDoesNotExist\IDoNotExist", class does not exist',
+				17,
+			],
+			[
+				'PHPDoc tag @method baz() has invalid return type "MethodTagReturnClassDoesNotExist\IDoNotExist", class does not exist',
+				17,
+			],
+			[
+				'PHPDoc tag @method zab() has invalid return type "MethodTagReturnClassDoesNotExist\IDoNotExist", class does not exist',
+				17,
+			],
+			[
+				'Class PHPStan\Rules\PhpDoc\MethodAnnotationReturnTypeClassDoesNotExistRule referenced with incorrect case: PHPStan\Rules\PhpDoc\methodannotationreturntypeclassdoesnotexistrule.',
+				17,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/method-tag-return-class-does-not-exist.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/method-tag-return-class-does-not-exist.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MethodTagReturnClassDoesNotExist;
+
+use DateTimeImmutable;
+
+/**
+ * @method \PHPStan\Rules\PhpDoc\MethodAnnotationReturnTypeClassDoesNotExistRule foo()
+ * @method IDoNotExist missing()
+ * @method \DateTime getDate()
+ * @method \DateTime|IDoNotExist baz()
+ * @method IDoNotExist|\DateTime zab()
+ * @method DateTimeImmutable getDateTwo()
+ * @method datetimeimmutable getDateThree()
+ * @method \PHPStan\Rules\PhpDoc\methodannotationreturntypeclassdoesnotexistrule lowerCased()
+ */
+class Bar {}


### PR DESCRIPTION
Monday I asked in the #static-analysis Slack channel of the Symfony Devs workspace if PHPStan is able to detect not-existing classes in the return type of `@method` annotations. I provided [this example](https://phpstan.org/r/9c76cf12-bd31-478d-95db-d3b97f71787a), but looks like this is not handled right now, so here's the Pull Request for that.