### PR TITLE
Add support for a not-deprecated annotation

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -517,6 +517,13 @@ class PhpDocNodeResolver
 		return count($deprecatedTags) > 0;
 	}
 
+	public function resolveIsNotDeprecated(PhpDocNode $phpDocNode): bool
+	{
+		$notDeprecatedTags = $phpDocNode->getTagsByName('@not-deprecated');
+
+		return count($notDeprecatedTags) > 0;
+	}
+
 	public function resolveIsInternal(PhpDocNode $phpDocNode): bool
 	{
 		$internalTags = $phpDocNode->getTagsByName('@internal');

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -2,11 +2,14 @@
 
 namespace PHPStan\Reflection\Annotations;
 
+use DeprecatedAnnotations\Baz;
+use DeprecatedAnnotations\BazInterface;
 use DeprecatedAnnotations\DeprecatedBar;
 use DeprecatedAnnotations\DeprecatedFoo;
 use DeprecatedAnnotations\DeprecatedWithMultipleTags;
 use DeprecatedAnnotations\Foo;
 use DeprecatedAnnotations\FooInterface;
+use DeprecatedAnnotations\SubBazInterface;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
@@ -139,6 +142,15 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 		$reflectionProvider = $this->createReflectionProvider();
 		$class = $reflectionProvider->getClass(DeprecatedBar::class);
 		$this->assertTrue($class->getNativeMethod('superDeprecated')->isDeprecated()->yes());
+	}
+
+	public function testNotDeprecatedChildMethods(): void
+	{
+		$reflectionProvider = $this->createReflectionProvider();
+
+		$this->assertTrue($reflectionProvider->getClass(BazInterface::class)->getNativeMethod('superDeprecated')->isDeprecated()->yes());
+		$this->assertTrue($reflectionProvider->getClass(SubBazInterface::class)->getNativeMethod('superDeprecated')->isDeprecated()->no());
+		$this->assertTrue($reflectionProvider->getClass(Baz::class)->getNativeMethod('superDeprecated')->isDeprecated()->no());
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/data/annotations-deprecated.php
+++ b/tests/PHPStan/Reflection/Annotations/data/annotations-deprecated.php
@@ -215,3 +215,26 @@ class DeprecatedBar implements BarInterface
 	}
 
 }
+
+interface BazInterface
+{
+	/**
+	 * @deprecated Use the SubBazInterface instead.
+	 */
+	public function superDeprecated();
+}
+
+interface SubBazInterface extends BazInterface
+{
+	/**
+	 * @not-deprecated
+	 */
+	public function superDeprecated();
+}
+
+class Baz implements SubBazInterface
+{
+	public function superDeprecated()
+	{
+	}
+}


### PR DESCRIPTION
This annotation allows disabling the inheritance of method deprecations when a child class does not want to deprecate its method even though it corresponds to a deprecated parent method.

Solves https://github.com/phpstan/phpstan/discussions/7422