### PR TITLE
Add `FilterVarArrayDynamicReturnTypeExtension`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1467,6 +1467,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\FilterVarArrayDynamicReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\GetCalledClassDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -11,7 +11,6 @@ use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
-use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -29,7 +28,6 @@ use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
 use function array_merge;
 use function hexdec;
-use function in_array;
 use function is_int;
 use function octdec;
 use function preg_match;
@@ -171,50 +169,6 @@ final class FilterFunctionReturnTypeHelper
 		}
 
 		return $type;
-	}
-
-	/**
-	 * @param array<Type> $inputTypesMap
-	 * @param array<Type> $filterTypesMap
-	 * @param list<array-key> $optionalKeys
-	 */
-	public function buildTypeForArray(
-		Type $keysType,
-		array $inputTypesMap,
-		array $filterTypesMap,
-		bool $addEmpty,
-		array $optionalKeys,
-	): Type {
-		$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
-		$keysType = $keysType->getConstantArrays()[0];
-
-		foreach ($keysType->getKeyTypes() as $keyType) {
-			$optional = false;
-			$key = $keyType->getValue();
-			$inputType = $inputTypesMap[$key] ?? null;
-			if ($inputType === null) {
-				if ($addEmpty) {
-					$valueTypesBuilder->setOffsetValueType($keyType, new NullType());
-				}
-
-				continue;
-			}
-
-			[$filterType, $flagsType] = $this->getFilterAndOptionsForArray($filterTypesMap[$key] ?? new MixedType());
-			$valueType = $this->getTypeFromFunctionCall($inputType, $filterType, $flagsType);
-
-			if (in_array($key, $optionalKeys, true)) {
-				if ($addEmpty) {
-					$valueType = TypeCombinator::addNull($valueType);
-				} else {
-					$optional = true;
-				}
-			}
-
-			$valueTypesBuilder->setOffsetValueType($keyType, $valueType, $optional);
-		}
-
-		return $valueTypesBuilder->getArray();
 	}
 
 	/**
@@ -488,26 +442,6 @@ final class FilterFunctionReturnTypeHelper
 		}
 
 		return true;
-	}
-
-	/** @return array{?Type, ?Type} */
-	private function getFilterAndOptionsForArray(Type $type): array
-	{
-		$constantType = $type->getConstantArrays()[0] ?? null;
-
-		if ($constantType === null) {
-			return [$type, null];
-		}
-
-		$filterType = null;
-		foreach ($constantType->getKeyTypes() as $keyType) {
-			if ($keyType->getValue() === 'filter') {
-				$filterType = $constantType->getOffsetValueType($keyType)->getConstantScalarTypes()[0] ?? null;
-				break;
-			}
-		}
-
-		return [$filterType, $constantType];
 	}
 
 }

--- a/src/Type/Php/FilterVarArrayDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarArrayDynamicReturnTypeExtension.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function array_fill_keys;
+use function array_combine;
+use function array_map;
+use function count;
+use function in_array;
+use function strtolower;
+
+class FilterVarArrayDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function __construct(private FilterFunctionReturnTypeHelper $filterFunctionReturnTypeHelper)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return strtolower($functionReflection->getName()) === 'filter_var_array';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+	{
+		if (count($functionCall->getArgs()) < 2) {
+			return null;
+		}
+
+		$inputArgType = $scope->getType($functionCall->getArgs()[0]->value);
+		if ($inputArgType->isArray()->no()) {
+			return new NeverType();
+		}
+
+		$inputConstantArrayType = $inputArgType->getConstantArrays()[0] ?? null;
+		$filterArgType = $scope->getType($functionCall->getArgs()[1]->value);
+		$filterConstantArrayType = $filterArgType->getConstantArrays()[0] ?? null;
+		$addEmptyType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
+		$addEmpty = $addEmptyType === null || $addEmptyType->isTrue()->yes();
+
+		$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
+		$inputTypesMap = [];
+		$optionalKeys = [];
+
+		if ($filterArgType instanceof ConstantIntegerType) {
+			if ($inputConstantArrayType === null) {
+				$inputArgType = $inputArgType->getArrays()[0] ?? null;
+				$valueType = $this->filterFunctionReturnTypeHelper->getTypeFromFunctionCall($inputArgType->getItemType(), $filterArgType, null);
+
+				if ($addEmpty) {
+					$valueType = TypeCombinator::addNull($valueType);
+				}
+
+				$arrayType = new ArrayType(
+					$inputArgType !== null ? $inputArgType->getKeyType() : new MixedType(),
+					$valueType,
+				);
+
+				return $inputArgType !== null && $inputArgType->isList()->yes()
+					? AccessoryArrayListType::intersectWith($arrayType)
+					: $arrayType;
+			}
+
+			// Override $add_empty option
+			$addEmpty = false;
+
+			$keysType = $inputConstantArrayType;
+			$inputKeysList = array_map(static fn($type) => $type->getValue(), $inputConstantArrayType->getKeyTypes());
+			$filterTypesMap = array_fill_keys($inputKeysList, $filterArgType);
+			$inputTypesMap = array_combine($inputKeysList, $inputConstantArrayType->getValueTypes());
+			$optionalKeys = [];
+			foreach ($inputConstantArrayType->getOptionalKeys() as $index) {
+				if (isset($inputKeysList[$index])) {
+					$optionalKeys[] = $inputKeysList[$index];
+				}
+			}
+		} elseif ($filterConstantArrayType === null) {
+			if ($inputConstantArrayType === null) {
+				$inputArgType = $inputArgType->getArrays()[0] ?? null;
+				$valueType = $this->filterFunctionReturnTypeHelper->getTypeFromFunctionCall(new MixedType(), $filterArgType, null);
+
+				return new ArrayType(
+					$inputArgType !== null ? $inputArgType->getKeyType() : new MixedType(),
+					$addEmpty ? TypeCombinator::addNull($valueType) : $valueType,
+				);
+			}
+
+			return null;
+		} else {
+			$keysType = $filterConstantArrayType;
+			$filterKeyTypes = $filterConstantArrayType->getKeyTypes();
+			$filterKeysList = array_map(static fn($type) => $type->getValue(), $filterKeyTypes);
+			$filterTypesMap = array_combine($filterKeysList, $keysType->getValueTypes());
+
+			if ($inputConstantArrayType !== null) {
+				$inputKeysList = array_map(static fn($type) => $type->getValue(), $inputConstantArrayType->getKeyTypes());
+				$inputTypesMap = array_combine($inputKeysList, $inputConstantArrayType->getValueTypes());
+
+				$optionalKeys = [];
+				foreach ($inputConstantArrayType->getOptionalKeys() as $index) {
+					if (isset($inputKeysList[$index])) {
+						$optionalKeys[] = $inputKeysList[$index];
+					}
+				}
+			} else {
+				$optionalKeys = $filterKeysList;
+				$inputTypesMap = array_combine(
+					$optionalKeys,
+					array_map(static fn() => new MixedType(), $filterKeyTypes),
+				);
+			}
+		}
+
+		foreach ($keysType->getKeyTypes() as $keyType) {
+			$optional = false;
+			$key = $keyType->getValue();
+			$inputType = $inputTypesMap[$key] ?? null;
+			if ($inputType === null) {
+				if ($addEmpty) {
+					$valueTypesBuilder->setOffsetValueType($keyType, new NullType());
+				}
+
+				continue;
+			}
+
+			[$filterType, $flagsType] = $this->parseFilter($filterTypesMap[$key] ?? new MixedType());
+			$valueType = $this->filterFunctionReturnTypeHelper->getTypeFromFunctionCall($inputType, $filterType, $flagsType);
+
+			if (in_array($key, $optionalKeys, true)) {
+				if ($addEmpty) {
+					$valueType = TypeCombinator::addNull($valueType);
+				} else {
+					$optional = true;
+				}
+			}
+
+			$valueTypesBuilder->setOffsetValueType($keyType, $valueType, $optional);
+		}
+
+		return $valueTypesBuilder->getArray();
+	}
+
+	/** @return array{?Type, ?Type} */
+	public function parseFilter(Type $type): array
+	{
+		$constantType = $type->getConstantArrays()[0] ?? null;
+
+		if ($constantType === null) {
+			return [$type, null];
+		}
+
+		$filterType = null;
+		foreach ($constantType->getKeyTypes() as $keyType) {
+			if ($keyType->getValue() === 'filter') {
+				$filterType = $constantType->getOffsetValueType($keyType)->getConstantScalarTypes()[0] ?? null;
+				break;
+			}
+		}
+
+		return [$filterType, $constantType];
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -631,6 +631,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input-php7.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var-array.php');
 
 		if (PHP_VERSION_ID >= 80100) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -630,6 +630,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		} else {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input-php7.php');
 		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input-array.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var-array.php');
 

--- a/tests/PHPStan/Analyser/data/filter-input-array.php
+++ b/tests/PHPStan/Analyser/data/filter-input-array.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace FilterVarArray;
+
+use function PHPStan\Testing\assertType;
+
+class FilterInput
+{
+	function superGlobalVariables(): void
+	{
+		$filter = [
+			'filter' => FILTER_VALIDATE_INT,
+			'flag' => FILTER_REQUIRE_SCALAR,
+			'options' => ['min_range' => 1],
+		];
+
+		// filter array with add_empty=default
+		assertType('array{int: int|false|null, positive_int: int<1, max>|false|null}', filter_input_array(INPUT_GET, [
+			'int' => FILTER_VALIDATE_INT,
+			'positive_int' => $filter,
+		]));
+
+		// filter array with add_empty=true
+		assertType('array{int: int|false|null, positive_int: int<1, max>|false|null}', filter_input_array(INPUT_GET, [
+			'int' => FILTER_VALIDATE_INT,
+			'positive_int' => $filter,
+		], true));
+
+		// filter array with add_empty=false
+		assertType('array{int?: int|false, positive_int?: int<1, max>|false}', filter_input_array(INPUT_GET, [
+			'int' => FILTER_VALIDATE_INT,
+			'positive_int' => $filter,
+		], false));
+
+		// filter flag with add_empty=default
+		assertType('array<string, int|false>', filter_input_array(INPUT_GET, FILTER_VALIDATE_INT));
+		// filter flag with add_empty=true
+		assertType('array<string, int|false>', filter_input_array(INPUT_GET, FILTER_VALIDATE_INT, true));
+		// filter flag with add_empty=false
+		assertType('array<string, int|false>', filter_input_array(INPUT_GET, FILTER_VALIDATE_INT, false));
+	}
+
+	/**
+	 * @param array<mixed> $arrayFilter
+	 * @param FILTER_VALIDATE_* $intFilter
+	 */
+	function dynamicFilter(array $input, array $arrayFilter, int $intFilter): void
+	{
+		// filter array with add_empty=default
+		assertType('array<string, mixed>', filter_input_array(INPUT_GET, $arrayFilter));
+		// filter array with add_empty=true
+		assertType('array<string, mixed>', filter_input_array(INPUT_GET, $arrayFilter, true));
+		// filter array with add_empty=false
+		assertType('array<string, mixed>', filter_input_array(INPUT_GET, $arrayFilter, false));
+
+		// filter flag with add_empty=default
+		assertType('array<string, mixed>', filter_input_array(INPUT_GET, $intFilter));
+		// filter flag with add_empty=true
+		assertType('array<string, mixed>', filter_input_array(INPUT_GET, $intFilter, true));
+		// filter flag with add_empty=false
+		assertType('array<string, mixed>', filter_input_array(INPUT_GET, $intFilter, false));
+	}
+
+	/**
+	 * @param INPUT_GET|INPUT_POST $union
+	 */
+	public function dynamicInputType($union, mixed $mixed): void
+	{
+		$filter = [
+			'filter' => FILTER_VALIDATE_INT,
+			'flag' => FILTER_REQUIRE_SCALAR,
+			'options' => ['min_range' => 1],
+		];
+
+		assertType('array{foo: int<1, max>|false|null}', filter_input_array($union, ['foo' => $filter]));
+		assertType('array|false|null', filter_input_array($mixed, ['foo' => $filter]));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/filter-var-array.php
+++ b/tests/PHPStan/Analyser/data/filter-var-array.php
@@ -127,19 +127,28 @@ function emptyArrayInput(): void
 
 function superGlobalVariables(): void
 {
+	$filter = [
+		'filter' => FILTER_VALIDATE_INT,
+		'flag' => FILTER_REQUIRE_SCALAR,
+		'options' => ['min_range' => 1],
+	];
+
 	// filter array with add_empty=default
-	assertType('array{int: int|false|null}', filter_var_array($_POST, [
+	assertType('array{int: int|false|null, positive_int: int<1, max>|false|null}', filter_var_array($_POST, [
 		'int' => FILTER_VALIDATE_INT,
+		'positive_int' => $filter,
 	]));
 
 	// filter array with add_empty=true
-	assertType('array{int: int|false|null}', filter_var_array($_POST, [
+	assertType('array{int: int|false|null, positive_int: int<1, max>|false|null}', filter_var_array($_POST, [
 		'int' => FILTER_VALIDATE_INT,
+		'positive_int' => $filter,
 	], true));
 
 	// filter array with add_empty=false
-	assertType('array{int?: int|false}', filter_var_array($_POST, [
+	assertType('array{int?: int|false, positive_int?: int<1, max>|false}', filter_var_array($_POST, [
 		'int' => FILTER_VALIDATE_INT,
+		'positive_int' => $filter,
 	], false));
 
 	// filter flag with add_empty=default
@@ -148,33 +157,6 @@ function superGlobalVariables(): void
 	assertType('array<string, int|false>', filter_var_array($_POST, FILTER_VALIDATE_INT, true));
 	// filter flag with add_empty=false
 	assertType('array<string, int|false>', filter_var_array($_POST, FILTER_VALIDATE_INT, false));
-
-	$filter = [
-		'filter' => FILTER_VALIDATE_INT,
-		'flag' => FILTER_REQUIRE_SCALAR,
-		'options' => ['min_range' => 1, 'max_range' => 10],
-	];
-
-	// filter array with add_empty=default
-	assertType('array{valid: int<1, 10>|false|null, invalid: int<1, 10>|false|null, missing: int<1, 10>|false|null}', filter_var_array($_POST, [
-		'valid' => $filter,
-		'invalid' => $filter,
-		'missing' => $filter,
-	]));
-
-	// filter array with add_empty=default
-	assertType('array{valid: int<1, 10>|false|null, invalid: int<1, 10>|false|null, missing: int<1, 10>|false|null}', filter_var_array($_POST, [
-		'valid' => $filter,
-		'invalid' => $filter,
-		'missing' => $filter,
-	], true));
-
-	// filter array with add_empty=default
-	assertType('array{valid?: int<1, 10>|false, invalid?: int<1, 10>|false, missing?: int<1, 10>|false}', filter_var_array($_POST, [
-		'valid' => $filter,
-		'invalid' => $filter,
-		'missing' => $filter,
-	], false));
 }
 
 /**

--- a/tests/PHPStan/Analyser/data/filter-var-array.php
+++ b/tests/PHPStan/Analyser/data/filter-var-array.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace FilterVarArray;
+
+use function PHPStan\Testing\assertType;
+
+function constantValues(): void
+{
+	$input = [
+		'valid' => '1',
+		'invalid' => 'a',
+	];
+
+	// filter array with add_empty=default
+	assertType('array{valid: 1, invalid: false, missing: null}', filter_var_array($input, [
+		'valid' => FILTER_VALIDATE_INT,
+		'invalid' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	]));
+
+	// filter array with add_empty=true
+	assertType('array{valid: 1, invalid: false, missing: null}', filter_var_array($input, [
+		'valid' => FILTER_VALIDATE_INT,
+		'invalid' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	], true));
+
+	// filter array with add_empty=false
+	assertType('array{valid: 1, invalid: false}', filter_var_array($input, [
+		'valid' => FILTER_VALIDATE_INT,
+		'invalid' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	], false));
+
+	// filter flag with add_empty=default
+	assertType('array{valid: 1, invalid: false}', filter_var_array($input, FILTER_VALIDATE_INT));
+	// filter flag with add_empty=true
+	assertType('array{valid: 1, invalid: false}', filter_var_array($input, FILTER_VALIDATE_INT, true));
+	// filter flag with add_empty=false
+	assertType('array{valid: 1, invalid: false}', filter_var_array($input, FILTER_VALIDATE_INT, false));
+
+	$filter = [
+		'filter' => FILTER_VALIDATE_INT,
+		'flag' => FILTER_REQUIRE_SCALAR,
+		'options' => ['min_range' => 1, 'max_range' => 10],
+	];
+
+	// filter array with add_empty=default
+	assertType('array{valid: 1, invalid: false, missing: null}', filter_var_array($input, [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	]));
+
+	// filter array with add_empty=default
+	assertType('array{valid: 1, invalid: false, missing: null}', filter_var_array($input, [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	], true));
+
+	// filter array with add_empty=default
+	assertType('array{valid: 1, invalid: false}', filter_var_array($input, [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	], false));
+}
+
+function emptyArrayInput(): void
+{
+	// filter array with add_empty=default
+	assertType('array{valid: null, invalid: null, missing: null}', filter_var_array([], [
+		'valid' => FILTER_VALIDATE_INT,
+		'invalid' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	]));
+
+	// filter array with add_empty=true
+	assertType('array{valid: null, invalid: null, missing: null}', filter_var_array([], [
+		'valid' => FILTER_VALIDATE_INT,
+		'invalid' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	], true));
+
+	// filter array with add_empty=false
+	assertType('array{}', filter_var_array([], [
+		'valid' => FILTER_VALIDATE_INT,
+		'invalid' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	], false));
+
+	// filter flag with add_empty=default
+	assertType('array{}', filter_var_array([], FILTER_VALIDATE_INT));
+	// filter flag with add_empty=true
+	assertType('array{}', filter_var_array([], FILTER_VALIDATE_INT, true));
+	// filter flag with add_empty=false
+	assertType('array{}', filter_var_array([], FILTER_VALIDATE_INT, false));
+
+	$filter = [
+		'filter' => FILTER_VALIDATE_INT,
+		'flag' => FILTER_REQUIRE_SCALAR,
+		'options' => ['min_range' => 1, 'max_range' => 10],
+	];
+
+	// filter array with add_empty=default
+	assertType('array{valid: null, invalid: null, missing: null}', filter_var_array([], [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	]));
+
+	// filter array with add_empty=default
+	assertType('array{valid: null, invalid: null, missing: null}', filter_var_array([], [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	], true));
+
+	// filter array with add_empty=default
+	assertType('array{}', filter_var_array([], [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	], false));
+}
+
+function superGlobalVariables(): void
+{
+	// filter array with add_empty=default
+	assertType('array{int: int|false|null}', filter_var_array($_POST, [
+		'int' => FILTER_VALIDATE_INT,
+	]));
+
+	// filter array with add_empty=true
+	assertType('array{int: int|false|null}', filter_var_array($_POST, [
+		'int' => FILTER_VALIDATE_INT,
+	], true));
+
+	// filter array with add_empty=false
+	assertType('array{int?: int|false}', filter_var_array($_POST, [
+		'int' => FILTER_VALIDATE_INT,
+	], false));
+
+	// filter flag with add_empty=default
+	assertType('array<string, int|false|null>', filter_var_array($_POST, FILTER_VALIDATE_INT));
+	// filter flag with add_empty=true
+	assertType('array<string, int|false|null>', filter_var_array($_POST, FILTER_VALIDATE_INT, true));
+	// filter flag with add_empty=false
+	assertType('array<string, int|false>', filter_var_array($_POST, FILTER_VALIDATE_INT, false));
+
+	$filter = [
+		'filter' => FILTER_VALIDATE_INT,
+		'flag' => FILTER_REQUIRE_SCALAR,
+		'options' => ['min_range' => 1, 'max_range' => 10],
+	];
+
+	// filter array with add_empty=default
+	assertType('array{valid: int<1, 10>|false|null, invalid: int<1, 10>|false|null, missing: int<1, 10>|false|null}', filter_var_array($_POST, [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	]));
+
+	// filter array with add_empty=default
+	assertType('array{valid: int<1, 10>|false|null, invalid: int<1, 10>|false|null, missing: int<1, 10>|false|null}', filter_var_array($_POST, [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	], true));
+
+	// filter array with add_empty=default
+	assertType('array{valid?: int<1, 10>|false, invalid?: int<1, 10>|false, missing?: int<1, 10>|false}', filter_var_array($_POST, [
+		'valid' => $filter,
+		'invalid' => $filter,
+		'missing' => $filter,
+	], false));
+}
+
+/**
+ * @param array{exists: int, optional?: int, extra: int} $input
+ */
+function dynamicVariables(array $input): void
+{
+	// filter array with add_empty=default
+	assertType('array{exists: int, optional: int|null, missing: null}', filter_var_array($input, [
+		'exists' => FILTER_VALIDATE_INT,
+		'optional' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	]));
+
+	// filter array with add_empty=true
+	assertType('array{exists: int, optional: int|null, missing: null}', filter_var_array($input, [
+		'exists' => FILTER_VALIDATE_INT,
+		'optional' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	], true));
+
+	// filter array with add_empty=false
+	assertType('array{exists: int, optional?: int}', filter_var_array($input, [
+		'exists' => FILTER_VALIDATE_INT,
+		'optional' => FILTER_VALIDATE_INT,
+		'missing' => FILTER_VALIDATE_INT,
+	], false));
+
+	// filter flag with add_empty=default
+	assertType('array{exists: int, optional?: int, extra: int}', filter_var_array($input, FILTER_VALIDATE_INT));
+	// filter flag with add_empty=true
+	assertType('array{exists: int, optional?: int, extra: int}', filter_var_array($input, FILTER_VALIDATE_INT, true));
+	// filter flag with add_empty=false
+	assertType('array{exists: int, optional?: int, extra: int}', filter_var_array($input, FILTER_VALIDATE_INT, false));
+
+	$filter = [
+		'filter' => FILTER_VALIDATE_INT,
+		'flag' => FILTER_REQUIRE_SCALAR,
+		'options' => ['min_range' => 1, 'max_range' => 10],
+	];
+
+	// filter array with add_empty=default
+	assertType('array{exists: int<1, 10>|false, optional: int<1, 10>|false|null, missing: null}', filter_var_array($input, [
+		'exists' => $filter,
+		'optional' => $filter,
+		'missing' => $filter,
+	]));
+
+	// filter array with add_empty=default
+	assertType('array{exists: int<1, 10>|false, optional: int<1, 10>|false|null, missing: null}', filter_var_array($input, [
+		'exists' => $filter,
+		'optional' => $filter,
+		'missing' => $filter,
+	], true));
+
+	// filter array with add_empty=default
+	assertType('array{exists: int<1, 10>|false, optional?: int<1, 10>|false}', filter_var_array($input, [
+		'exists' => $filter,
+		'optional' => $filter,
+		'missing' => $filter,
+	], false));
+}
+
+/**
+ * @param array{exists: int, optional?: int, extra: int} $input
+ * @param array<mixed> $arrayFilter
+ * @param FILTER_VALIDATE_* $intFilter
+ */
+function dynamicFilter(array $input, array $arrayFilter, int $intFilter): void
+{
+	// filter array with add_empty=default
+	assertType('array|false|null', filter_var_array($input, $arrayFilter));
+	// filter array with add_empty=true
+	assertType('array|false|null', filter_var_array($input, $arrayFilter, true));
+	// filter array with add_empty=false
+	assertType('array|false|null', filter_var_array($input, $arrayFilter, false));
+
+	// filter flag with add_empty=default
+	assertType('array|false|null', filter_var_array($input, $intFilter));
+	// filter flag with add_empty=true
+	assertType('array|false|null', filter_var_array($input, $intFilter, true));
+	// filter flag with add_empty=false
+	assertType('array|false|null', filter_var_array($input, $intFilter, false));
+
+	// filter array with add_empty=default
+	assertType('array|false|null', filter_var_array([], $arrayFilter));
+	// filter array with add_empty=true
+	assertType('array|false|null', filter_var_array([], $arrayFilter, true));
+	// filter array with add_empty=false
+	assertType('array|false|null', filter_var_array([], $arrayFilter, false));
+
+	// filter flag with add_empty=default
+	assertType('array|false|null', filter_var_array([], $intFilter));
+	// filter flag with add_empty=true
+	assertType('array|false|null', filter_var_array([], $intFilter, true));
+	// filter flag with add_empty=false
+	assertType('array|false|null', filter_var_array([], $intFilter, false));
+}

--- a/tests/PHPStan/Analyser/data/filter-var-array.php
+++ b/tests/PHPStan/Analyser/data/filter-var-array.php
@@ -143,9 +143,9 @@ function superGlobalVariables(): void
 	], false));
 
 	// filter flag with add_empty=default
-	assertType('array<string, int|false|null>', filter_var_array($_POST, FILTER_VALIDATE_INT));
+	assertType('array<string, int|false>', filter_var_array($_POST, FILTER_VALIDATE_INT));
 	// filter flag with add_empty=true
-	assertType('array<string, int|false|null>', filter_var_array($_POST, FILTER_VALIDATE_INT, true));
+	assertType('array<string, int|false>', filter_var_array($_POST, FILTER_VALIDATE_INT, true));
 	// filter flag with add_empty=false
 	assertType('array<string, int|false>', filter_var_array($_POST, FILTER_VALIDATE_INT, false));
 
@@ -175,6 +175,43 @@ function superGlobalVariables(): void
 		'invalid' => $filter,
 		'missing' => $filter,
 	], false));
+}
+
+/**
+ * @param list<int> $input
+ */
+function typedList($input): void
+{
+	$filter = [
+		'filter' => FILTER_VALIDATE_INT,
+		'flag' => FILTER_REQUIRE_SCALAR,
+		'options' => ['min_range' => 1],
+	];
+
+	// filter array with add_empty=default
+	assertType('array{int: int|null, positive_int: int<1, max>|false|null}', filter_var_array($input, [
+		'int' => FILTER_VALIDATE_INT,
+		'positive_int' => $filter,
+	]));
+
+	// filter array with add_empty=true
+	assertType('array{int: int|null, positive_int: int<1, max>|false|null}', filter_var_array($input, [
+		'int' => FILTER_VALIDATE_INT,
+		'positive_int' => $filter,
+	], true));
+
+	// filter array with add_empty=false
+	assertType('array{int?: int, positive_int?: int<1, max>|false}', filter_var_array($input, [
+		'int' => FILTER_VALIDATE_INT,
+		'positive_int' => $filter,
+	], false));
+
+	// filter flag with add_empty=default
+	assertType('list<int>', filter_var_array($input, FILTER_VALIDATE_INT));
+	// filter flag with add_empty=true
+	assertType('list<int>', filter_var_array($input, FILTER_VALIDATE_INT, true));
+	// filter flag with add_empty=false
+	assertType('list<int>', filter_var_array($input, FILTER_VALIDATE_INT, false));
 }
 
 /**


### PR DESCRIPTION
Add a return type extension for [`filter_var_array()`](https://www.php.net/filter_var_array) and [`filter_input_array()`](https://www.php.net/filter_input_array).

This function is defined with the following signature:

```php
filter_var_array(array $array, array|int $options = FILTER_DEFAULT, bool $add_empty = true): array|false|null
```

This function supports three types of filters:

```php
// bit flag
$values = filter_var_array($_POST, FILTER_VALIDATE_INT);

// simple array
$values = filter_var_array($_POST, [
    'key' => FILTER_VALIDATE_INT,
]);

// complex array
$values = filter_var_array($_POST,[
    'key' => [
        'filter' => FILTER_VALIDATE_INT,
        'options' => ['min_range' => 1, 'max_range' => 10],
    ],
]);
```

The array keys returned from `filter_var_array()` change depending on how the filter is passed, so the implementation is complex.

| filter passed by | key is determined by |
|------------------|----------------------|
| bit flag         | `$options`           |
| simple array     | `$array`             |
| complex array    | `$array`             |

This PR was implemented thanks to @herndlm's `FilterFunctionReturnTypeHelper` https://github.com/phpstan/phpstan-src/pull/2190 and https://github.com/phpstan/phpstan-src/pull/2010.
