### PR TITLE
fix detecting @var classes imported

### DIFF
--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -342,6 +342,7 @@ class FileTypeMapper
 					&& !$node instanceof Node\Stmt\TraitUse
 					&& !$node instanceof Node\Stmt\TraitUseAdaptation
 					&& !$node instanceof Node\Stmt\InlineHTML
+					&& !($node instanceof Node\Stmt\Expression && $node->expr instanceof Node\Expr\FuncCall)
 					&& !($node instanceof Node\Stmt\Expression && $node->expr instanceof Node\Expr\Include_)
 					&& !array_key_exists($nameScopeKey, $nameScopeMap)
 				) {

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -151,4 +151,16 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6348.php'], []);
 	}
 
+
+	public function testBug8950(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8950.php'], [
+			[
+				'PHPDoc tag @var for variable $boo contains unknown class Bug8950\BooAlsoNotSubtype.',
+				13,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			]
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-8950-interface.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-8950-interface.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+namespace Bug8950\Interface;
+
+interface Bug8950Interface
+{
+
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-8950.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-8950.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+namespace Bug8950;
+
+define('FOO', 'foo');
+
+use Bug8950\Interface\Bug8950Interface;
+
+/** @var Bug8950Interface $foo */
+$foo = null;
+
+
+/** @var BooAlsoNotSubtype $boo */
+$boo = null;
+


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/8950

This bug report is about the situation when `define` is written before the `use` statements, but I found that it occurs when other functions, example `sleep()`, `unpack()`, etc.