### PR TITLE
Do not treat definition of functions and class-likes as unreachable

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -251,7 +251,7 @@ class NodeScopeResolver
 				continue;
 			}
 
-			$nextStmt = $this->getFirstNonNopNode(array_slice($nodes, $i + 1));
+			$nextStmt = $this->getFirstUnreachableNode(array_slice($nodes, $i + 1), true);
 			if (!$nextStmt instanceof Node\Stmt) {
 				continue;
 			}
@@ -320,7 +320,7 @@ class NodeScopeResolver
 			}
 
 			$alreadyTerminated = true;
-			$nextStmt = $this->getFirstNonNopNode(array_slice($stmts, $i + 1));
+			$nextStmt = $this->getFirstUnreachableNode(array_slice($stmts, $i + 1), $parentNode instanceof Node\Stmt\Namespace_);
 			if ($nextStmt !== null) {
 				$nodeCallback(new UnreachableStatementNode($nextStmt), $scope);
 			}
@@ -4382,16 +4382,19 @@ class NodeScopeResolver
 	/**
 	 * @template T of Node
 	 * @param array<T> $nodes
-	 * @return T
+	 * @return T|null
 	 */
-	private function getFirstNonNopNode(array $nodes): ?Node
+	private function getFirstUnreachableNode(array $nodes, bool $earlyBinding): ?Node
 	{
 		foreach ($nodes as $node) {
-			if (!$node instanceof Node\Stmt\Nop) {
-				return $node;
+			if ($node instanceof Node\Stmt\Nop) {
+				continue;
 			}
+			if ($earlyBinding && ($node instanceof Node\Stmt\Function_ || $node instanceof Node\Stmt\ClassLike)) {
+				continue;
+			}
+			return $node;
 		}
-
 		return null;
 	}
 

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -149,6 +149,34 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8620.php'], []);
 	}
 
+	public function testBug4002(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-4002.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-4002-2.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-4002-3.php'], [
+			[
+				'Unreachable statement - code above always terminates.',
+				13,
+			],
+		]);
+		$this->analyse([__DIR__ . '/data/bug-4002-4.php'], [
+			[
+				'Unreachable statement - code above always terminates.',
+				9,
+			],
+		]);
+		$this->analyse([__DIR__ . '/data/bug-4002_class.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-4002_interface.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-4002_trait.php'], []);
+	}
+
+	public function testBug8319(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8319.php'], []);
+	}
+
 	public function testBug8966(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -153,21 +153,51 @@ class UnreachableStatementRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002.php'], []);
+	}
+
+	public function testBug4002_2(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002-2.php'], []);
+	}
+
+	public function testBug4002_3(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002-3.php'], [
 			[
 				'Unreachable statement - code above always terminates.',
 				13,
 			],
 		]);
+	}
+
+	public function testBug4002_4(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002-4.php'], [
 			[
 				'Unreachable statement - code above always terminates.',
 				9,
 			],
 		]);
+	}
+
+	public function testBug4002Class(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002_class.php'], []);
+	}
+
+	public function testBug4002Interface(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002_interface.php'], []);
+	}
+
+	public function testBug4002Trait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-4002_trait.php'], []);
 	}
 

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002-2.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002-2.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+// no namespace
+
+bug4002_test();
+exit;
+
+function bug4002_test()
+{
+	echo 'hello';
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002-3.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002-3.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Bug4002;
+
+test3();
+exit;
+
+function test3()
+{
+	echo 'hello';
+}
+
+echo 'unreachable';

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002-4.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002-4.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Bug4002;
+
+if (true) {
+	test4();
+	exit;
+
+	function test4()
+	{
+		echo 'inner';
+	}
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Bug4002;
+
+test();
+exit;
+
+function test()
+{
+	echo 'hello';
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002_class.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002_class.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Bug4002\Class_;
+
+new Foo;
+exit;
+
+class Foo
+{
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002_interface.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002_interface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bug4002\Interface_;
+
+echo Foo::BAR;
+exit;
+
+interface Foo
+{
+	const BAR = 1;
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-4002_trait.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-4002_trait.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bug4002\Trait_;
+
+new class {
+	use Foo;
+};
+exit;
+
+trait Foo
+{
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-8319.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-8319.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8319;
+
+foo();
+
+function foo(): never
+{
+	\var_dump('reachable statement!');
+	exit();
+}


### PR DESCRIPTION
PHPStan treats the statement right after always-terminating statement, like `return` or `exit`, as unreachable statement.
With this PR, definition of classes, interfaces, traits and functions on top level will not marked as unreachable.
Nop nodes will be ignored as well.

I haven't implemented [PHP's early binding](https://www.npopov.com/2021/10/20/Early-binding-in-PHP.html) mechanism since it is so complicated.
This may cause some false negative on code [like this](https://3v4l.org/dnK0M), but I think the advantage of decreasing false positive is larger.

Closes phpstan/phpstan#4002
Closes phpstan/phpstan#8966
Closes phpstan/phpstan#8319 (although the early binding mechanism is not completely compatible with [that of PHP](https://www.npopov.com/2021/10/20/Early-binding-in-PHP.html))