### PR TITLE
Keep ignored errors on a single line

### DIFF
--- a/src/Command/ErrorFormatter/BaselinePhpErrorFormatter.php
+++ b/src/Command/ErrorFormatter/BaselinePhpErrorFormatter.php
@@ -60,7 +60,7 @@ class BaselinePhpErrorFormatter
 
 			foreach ($fileErrorsCounts as $message => $count) {
 				$php .= sprintf(
-					"\$ignoreErrors[] = [\n\t'message' => %s,\n\t'count' => %d,\n\t'path' => __DIR__ . %s,\n];\n",
+					"\$ignoreErrors[] = ['message' => %s, 'count' => %d, 'path' => __DIR__ . %s];\n",
 					var_export(Helpers::escape('#^' . preg_quote($message, '#') . '$#'), true),
 					var_export($count, true),
 					var_export(Helpers::escape($file), true),


### PR DESCRIPTION
When the message contains a newline, it still produces multiple lines. But most errors are single line so that's nice.