### PR TITLE
Check filter_input* type param type

### DIFF
--- a/resources/functionMap_php80delta_bleedingEdge.php
+++ b/resources/functionMap_php80delta_bleedingEdge.php
@@ -1,0 +1,11 @@
+<?php // phpcs:ignoreFile
+
+return [
+	'new' => [
+		'filter_input' => ['mixed', 'type'=>'INPUT_GET|INPUT_POST|INPUT_COOKIE|INPUT_SERVER|INPUT_ENV', 'variable_name'=>'string', 'filter='=>'int', 'options='=>'array|int'],
+		'filter_input_array' => ['array|false|null', 'type'=>'INPUT_GET|INPUT_POST|INPUT_COOKIE|INPUT_SERVER|INPUT_ENV', 'definition='=>'int|array', 'add_empty='=>'bool'],
+	],
+	'old' => [
+
+	]
+];

--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -186,6 +186,15 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 				}
 
 				$signatureMap = $this->computeSignatureMap($signatureMap, $stricterFunctionMap);
+
+				if ($this->phpVersion->getVersionId() >= 80000) {
+					$php80StricterFunctionMapDelta = require __DIR__ . '/../../../resources/functionMap_php80delta_bleedingEdge.php';
+					if (!is_array($php80StricterFunctionMapDelta)) {
+						throw new ShouldNotHappenException('Signature map could not be loaded.');
+					}
+
+					$signatureMap = $this->computeSignatureMap($signatureMap, $php80StricterFunctionMapDelta);
+				}
 			}
 
 			if ($this->phpVersion->getVersionId() >= 70400) {

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1301,4 +1301,32 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testFilterInputType(): void
+	{
+		$errors = [
+			[
+				'Parameter #1 $type of function filter_input expects 0|1|2|4|5, -1 given.',
+				16,
+			],
+			[
+				'Parameter #1 $type of function filter_input expects 0|1|2|4|5, int given.',
+				17,
+			],
+			[
+				'Parameter #1 $type of function filter_input_array expects 0|1|2|4|5, -1 given.',
+				28,
+			],
+			[
+				'Parameter #1 $type of function filter_input_array expects 0|1|2|4|5, int given.',
+				29,
+			],
+		];
+
+		if (PHP_VERSION_ID < 80000) {
+			$errors = [];
+		}
+
+		$this->analyse([__DIR__ . '/data/filter-input-type.php'], $errors);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/filter-input-type.php
+++ b/tests/PHPStan/Rules/Functions/data/filter-input-type.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FilterInputType;
+
+class Foo
+{
+
+	public function doFoo(int $type): void
+	{
+		filter_input(INPUT_GET, 'foo');
+		filter_input(INPUT_POST, 'foo');
+		filter_input(INPUT_COOKIE, 'foo');
+		filter_input(INPUT_SERVER, 'foo');
+		filter_input(INPUT_ENV, 'foo');
+
+		filter_input(-1, 'foo');
+		filter_input($type, 'foo');
+	}
+
+	public function doBar(int $type): void
+	{
+		filter_input_array(INPUT_GET);
+		filter_input_array(INPUT_POST);
+		filter_input_array(INPUT_COOKIE);
+		filter_input_array(INPUT_SERVER);
+		filter_input_array(INPUT_ENV);
+
+		filter_input_array(-1);
+		filter_input_array($type);
+	}
+
+}


### PR DESCRIPTION
Specifying invalid ints there fails with a fatal error since PHP 8, see https://3v4l.org/2QvBP and https://3v4l.org/EP3T8
It would also be wrong on pre PHP 8 but there's no fatal error there at least.

This is the easiest I could come up with to check this, but it feels a bit weird. Any better ideas?

See also https://www.php.net/manual/en/function.filter-input.php and https://www.php.net/manual/en/function.filter-input-array.php
The 2 failing tests seem unrelated.

Some special handling based on PHP version could also be additionally built into e.g. https://github.com/phpstan/phpstan-src/pull/2010 (which can be merged I believe ;))