### PR TITLE
Fix false positive with `array_combine()` on php8

### DIFF
--- a/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -36,10 +35,10 @@ class ArrayCombineFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		return $functionReflection->getName() === 'array_combine';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$firstArg = $functionCall->getArgs()[0]->value;
@@ -56,6 +55,9 @@ class ArrayCombineFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 			$valueTypes = $valuesParamType->getValueTypes();
 
 			if (count($keyTypes) !== count($valueTypes)) {
+				if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
+					return null;
+				}
 				return new ConstantBooleanType(false);
 			}
 

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4555,7 +4555,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_combine([1], [2])',
 			],
 			[
-				'false',
+				PHP_VERSION_ID < 80000 ? 'false' : 'array',
 				'array_combine([1, 2], [3])',
 			],
 			[

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -846,4 +846,19 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8879.php'], []);
 	}
 
+	public function testBug9011(): void
+	{
+		$errors = [];
+		if (PHP_VERSION_ID < 80000) {
+			$errors = [
+				[
+					'Method Bug9011\HelloWorld::getX() should return array<string> but returns false.',
+					16,
+				],
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9011.php'], $errors);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-9011.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-9011.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug9011;
+
+class HelloWorld
+{
+	/**
+	 * @return string[]
+	 */
+	public function getX(): array
+	{
+		$a = array('green', 'red', 'yellow', 'y');
+		$b = array('avocado', 'apple', 'banana');
+		return array_combine($a, $b);
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/9011

test fails without fix:
```
There was 1 failure:

1) PHPStan\Rules\Methods\ReturnTypeRuleTest::testBug9011
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'16: Method Bug9011\HelloWorld::getX() should return array<string> but returns false.
 '

C:\dvl\Workspace\phpstan-src-staabm\src\Testing\RuleTestCase.php:154
C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Rules\Methods\ReturnTypeRuleTest.php:851
```

----

the [2nd example ](https://github.com/phpstan/phpstan/issues/9011#issuecomment-1458414871) posted in the issue works as expected in my eyes.