### PR TITLE
Prevent false positive on `method_exists()` and `function_exists()`

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -76,6 +76,8 @@ class ImpossibleCheckTypeHelper
 					'interface_exists',
 					'trait_exists',
 					'enum_exists',
+					'method_exists',
+					'function_exists',
 				], true)) {
 					return null;
 				}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -724,6 +724,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
 	}
 
+	public function testBug8980(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8980.php'], []);
+	}
+
 	public function testImpossibleMethodExistOnGenericClassString(): void
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;

--- a/tests/PHPStan/Rules/Comparison/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8980.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bug8980;
+
+function doFoo(): void {
+	$undefined_curl_functions = array_filter(
+		[
+			'curl_multi_add_handle',
+			'curl_multi_exec',
+			'curl_multi_init',
+		],
+		static function ($function_name) {
+			return !function_exists($function_name);
+		}
+	);
+}
+
+
+class HelloWorld
+{
+	/**
+	 * @var HelloWorld
+	 */
+	private static $instance = null;
+
+	public static function getInstance(): HelloWorld
+	{
+		if (self::$instance === null) {
+			self::$instance = new HelloWorld();
+		}
+
+		return self::$instance;
+	}
+
+	public function sayHello(): void
+	{
+		echo 'Hello World!';
+	}
+
+	function doFoo(): void {
+		$helloWorld = method_exists(HelloWorld::class, 'getInstance') ? HelloWorld::getInstance() : new HelloWorld();
+		$helloWorld->sayHello();
+	}
+}
+

--- a/tests/PHPStan/Rules/Comparison/data/bug-8980.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8980.php
@@ -14,32 +14,3 @@ function doFoo(): void {
 		}
 	);
 }
-
-
-class HelloWorld
-{
-	/**
-	 * @var HelloWorld
-	 */
-	private static $instance = null;
-
-	public static function getInstance(): HelloWorld
-	{
-		if (self::$instance === null) {
-			self::$instance = new HelloWorld();
-		}
-
-		return self::$instance;
-	}
-
-	public function sayHello(): void
-	{
-		echo 'Hello World!';
-	}
-
-	function doFoo(): void {
-		$helloWorld = method_exists(HelloWorld::class, 'getInstance') ? HelloWorld::getInstance() : new HelloWorld();
-		$helloWorld->sayHello();
-	}
-}
-


### PR DESCRIPTION
Pre-existing tests have different expectations regarding the "is always true/false" results, then what was discussed in the linked issue.
I wonder when/how we should/can differentiate whether we expect this "is always true/false" error or not.

I just did the trivial version, so we can see how this violates existing expectations and start discussion/feedback from here.

closes https://github.com/phpstan/phpstan/issues/8980