### PR TITLE
Configure composer platform constraint everywhere

### DIFF
--- a/apigen/composer.json
+++ b/apigen/composer.json
@@ -9,5 +9,10 @@
 		"psr-4": {
 			"PHPStan\\ApiGen\\": "src"
 		}
+	},
+	"config": {
+		"platform": {
+			"php": "8.1.99"
+		}
 	}
 }

--- a/apigen/composer.lock
+++ b/apigen/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cca72dc10f8d1df2104049e381d62fcb",
+    "content-hash": "0ca627d71f61e59bea25e66a414c1d81",
     "packages": [],
     "packages-dev": [
         {
@@ -1966,5 +1966,8 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.99"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/build-cs/composer.json
+++ b/build-cs/composer.json
@@ -8,6 +8,12 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"platform": {
+			"php": "8.1.99"
 		}
+	},
+	"require": {
+		"php": "^8.1"
 	}
 }

--- a/build-cs/composer.lock
+++ b/build-cs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e69c1916405a7e3c8001c1b609a0ee61",
+    "content-hash": "1a8bbf1ab1320c04cb2362ceeed38d80",
     "packages": [],
     "packages-dev": [
         {
@@ -324,7 +324,12 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": "^8.1"
+    },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.99"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/changelog-generator/composer.json
+++ b/changelog-generator/composer.json
@@ -17,6 +17,9 @@
 	"config": {
 		"allow-plugins": {
 			"php-http/discovery": true
+		},
+		"platform": {
+			"php": "8.1.99"
 		}
 	}
 }

--- a/changelog-generator/composer.lock
+++ b/changelog-generator/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e1d902170abb95f02293ffeb1aa1b2b",
+    "content-hash": "e57e35f3f34af0af329d36cde955c242",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2197,5 +2197,8 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.99"
+    },
     "plugin-api-version": "2.3.0"
 }

--- a/compiler/composer.json
+++ b/compiler/composer.json
@@ -4,7 +4,7 @@
     "description": "PHAR Compiler for PHPStan",
     "license": ["MIT"],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "nette/neon": "^3.0.0",
         "seld/phar-utils": "^1.2",
         "symfony/console": "^6.0.0",
@@ -28,8 +28,8 @@
     },
 	"config": {
 		"platform": {
-			"php": "8.0.99"
-		},
+            "php": "8.1.99"
+        },
 		"platform-check": false,
 		"sort-packages": true
 	},

--- a/compiler/composer.lock
+++ b/compiler/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7caab5611acadb20806eaeca4e294e98",
+    "content-hash": "a784fd779f26168a88cfc98655e59bf0",
     "packages": [
         {
             "name": "nette/neon",
@@ -2802,11 +2802,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/issue-bot/composer.json
+++ b/issue-bot/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "phpstan/changelog-generator",
+	"name": "phpstan/issue-bot",
     "require": {
 		"php": "^8.1",
 		"guzzlehttp/guzzle": "^7.5",
@@ -19,7 +19,10 @@
 		}
 	},
 	"config": {
-		"sort-packages": true
+		"sort-packages": true,
+		"platform": {
+			"php": "8.1.99"
+		}
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5"

--- a/issue-bot/composer.lock
+++ b/issue-bot/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf2ec250d9b5f3fc5ef955c0229d6395",
+    "content-hash": "cf250f6df7466d64b6f7312077830618",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -4564,5 +4564,8 @@
         "php": "^8.1"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.1.99"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Adds a php require of ^8.1 and a config.platform.php of `8.1.99` everywhere as it exists in the root composer.json already. This basically tells renovate to use PHP 8.1 instead of the latest reachable one (e.g. 8.2) which could otherwise result in invalid update PRs like https://github.com/phpstan/phpstan-src/pull/2285