### PR TITLE
Allow autodiscovery of PHP based configuration files

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -159,7 +159,7 @@ class CommandHelper
 			})($autoloadFile);
 		}
 		if ($projectConfigFile === null) {
-			foreach (['phpstan.neon', 'phpstan.neon.dist', 'phpstan.dist.neon'] as $discoverableConfigName) {
+			foreach (['phpstan.neon', 'phpstan.neon.dist', 'phpstan.dist.neon', 'phpstan.php', 'phpstan.php.dist', 'phpstan.dist.php', 'phpstan.neon.php', 'phpstan.neon.php.dist', 'phpstan.dist.neon.php'] as $discoverableConfigName) {
 				$discoverableConfigFile = $currentWorkingDirectory . DIRECTORY_SEPARATOR . $discoverableConfigName;
 				if (is_file($discoverableConfigFile)) {
 					$projectConfigFile = $discoverableConfigFile;

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -89,12 +89,60 @@ class AnalyseCommandTest extends PHPStanTestCase
 				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-dist-dot-neon' . DIRECTORY_SEPARATOR . 'phpstan.dist.neon',
 			],
 			[
+				__DIR__ . '/test-autodiscover-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-php' . DIRECTORY_SEPARATOR . 'phpstan.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-php-dist',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-php-dist' . DIRECTORY_SEPARATOR . 'phpstan.php.dist',
+			],
+			[
+				__DIR__ . '/test-autodiscover-dist-dot-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-dist-dot-php' . DIRECTORY_SEPARATOR . 'phpstan.dist.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-neon-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-neon-php' . DIRECTORY_SEPARATOR . 'phpstan.neon.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-neon-php-dist',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-neon-php-dist' . DIRECTORY_SEPARATOR . 'phpstan.neon.php.dist',
+			],
+			[
+				__DIR__ . '/test-autodiscover-dist-dot-neon-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-dist-dot-neon-php' . DIRECTORY_SEPARATOR . 'phpstan.dist.neon.php',
+			],
+			[
 				__DIR__ . '/test-autodiscover-priority',
 				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority' . DIRECTORY_SEPARATOR . 'phpstan.neon',
 			],
 			[
 				__DIR__ . '/test-autodiscover-priority-dist-dot-neon',
 				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority-dist-dot-neon' . DIRECTORY_SEPARATOR . 'phpstan.neon',
+			],
+			[
+				__DIR__ . '/test-autodiscover-priority-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority-php' . DIRECTORY_SEPARATOR . 'phpstan.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-priority-dist-dot-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority-dist-dot-php' . DIRECTORY_SEPARATOR . 'phpstan.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-priority-neon-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority-neon-php' . DIRECTORY_SEPARATOR . 'phpstan.neon.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-priority-dist-dot-neon-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-priority-dist-dot-neon-php' . DIRECTORY_SEPARATOR . 'phpstan.neon.php',
+			],
+			[
+				__DIR__ . '/test-autodiscover-extension-priority',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-extension-priority' . DIRECTORY_SEPARATOR . 'phpstan.neon',
+			],
+			[
+				__DIR__ . '/test-autodiscover-extension-priority-php',
+				__DIR__ . DIRECTORY_SEPARATOR . 'test-autodiscover-extension-priority-php' . DIRECTORY_SEPARATOR . 'phpstan.php',
 			],
 		];
 	}

--- a/tests/PHPStan/Command/test-autodiscover-dist-dot-neon-php/phpstan.dist.neon.php
+++ b/tests/PHPStan/Command/test-autodiscover-dist-dot-neon-php/phpstan.dist.neon.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-dist-dot-php/phpstan.dist.php
+++ b/tests/PHPStan/Command/test-autodiscover-dist-dot-php/phpstan.dist.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-extension-priority-php/phpstan.neon.php
+++ b/tests/PHPStan/Command/test-autodiscover-extension-priority-php/phpstan.neon.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-extension-priority-php/phpstan.php
+++ b/tests/PHPStan/Command/test-autodiscover-extension-priority-php/phpstan.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-extension-priority/phpstan.neon
+++ b/tests/PHPStan/Command/test-autodiscover-extension-priority/phpstan.neon
@@ -1,0 +1,4 @@
+includes:
+	- ../../../../conf/bleedingEdge.neon
+
+parameters:

--- a/tests/PHPStan/Command/test-autodiscover-extension-priority/phpstan.php
+++ b/tests/PHPStan/Command/test-autodiscover-extension-priority/phpstan.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-neon-php-dist/phpstan.neon.php.dist
+++ b/tests/PHPStan/Command/test-autodiscover-neon-php-dist/phpstan.neon.php.dist
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-neon-php/phpstan.neon.php
+++ b/tests/PHPStan/Command/test-autodiscover-neon-php/phpstan.neon.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-php-dist/phpstan.php.dist
+++ b/tests/PHPStan/Command/test-autodiscover-php-dist/phpstan.php.dist
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-php/phpstan.php
+++ b/tests/PHPStan/Command/test-autodiscover-php/phpstan.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-neon-php/phpstan.dist.neon.php
+++ b/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-neon-php/phpstan.dist.neon.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-neon-php/phpstan.neon.php
+++ b/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-neon-php/phpstan.neon.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-php/phpstan.dist.php
+++ b/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-php/phpstan.dist.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-php/phpstan.php
+++ b/tests/PHPStan/Command/test-autodiscover-priority-dist-dot-php/phpstan.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-neon-php/phpstan.neon.php
+++ b/tests/PHPStan/Command/test-autodiscover-priority-neon-php/phpstan.neon.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-neon-php/phpstan.neon.php.dist
+++ b/tests/PHPStan/Command/test-autodiscover-priority-neon-php/phpstan.neon.php.dist
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-php/phpstan.php
+++ b/tests/PHPStan/Command/test-autodiscover-priority-php/phpstan.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];

--- a/tests/PHPStan/Command/test-autodiscover-priority-php/phpstan.php.dist
+++ b/tests/PHPStan/Command/test-autodiscover-priority-php/phpstan.php.dist
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+	'includes' => [
+		'../../../../conf/bleedingEdge.neon',
+	],
+	'parameters' => [],
+];


### PR DESCRIPTION
# Context

- we're PHP developers
- I saw in a tweet that PHPStan already supports PHP format for configuration
- PHPStan supports PHP based baseline file since [1.10.2](https://github.com/phpstan/phpstan/releases/tag/1.10.2)
- [NEON support](https://plugins.jetbrains.com/plugin/7060-neon-support) is broken on recent PHPStorm versions and the plugin seems to not be likely to be updated
- PHPStan config file and its baseline were the only files using the NEON format in my project

# Issue

Without this PR, the PHP format configuration file is already supported but must be passed explicitly in the command line.


# Workarounds

- Use VSCode for NEON format support
- Use a make recipe to not have to type the configuration argument

---

Still, I think it could be good if PHPStan autodiscover PHP based configuration 🙂 