### PR TITLE
Allow baseline generation to detect a PHP format baseline file

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -122,7 +122,7 @@ class AnalyseCommand extends Command
 		if ($generateBaselineFile === false) {
 			$generateBaselineFile = null;
 		} elseif ($generateBaselineFile === null) {
-			$generateBaselineFile = 'phpstan-baseline.neon';
+			$generateBaselineFile = is_file('phpstan-baseline.php') ? 'phpstan-baseline.php' : 'phpstan-baseline.neon';
 		}
 
 		$allowEmptyBaseline = (bool) $input->getOption('allow-empty-baseline');


### PR DESCRIPTION
If there is alreadu a PHP baseline file created using the default naming, this will shorten the command line allowing to use just `--generate-baseline` instead of `--generate-baseline phpstan-baseline.php` to get a PHP baseline.

Question: I don't know how this could be tested the best way, I'd need some help here