### PR TITLE
DX: Added info about use of `setUp()` and `tearDown()` in `TypeInferenceTestCase`

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -29,6 +29,16 @@ use function sprintf;
 abstract class TypeInferenceTestCase extends PHPStanTestCase
 {
 
+	/** @deprecated Use of setUp() is not supported because of the way TypeInferenceTestCase is implemented */
+	protected function setUp(): void
+	{
+	}
+
+	/** @deprecated Use of tearDown() is not supported because of the way TypeInferenceTestCase is implemented */
+	protected function tearDown(): void
+	{
+	}
+
 	/**
 	 * @param callable(Node , Scope ): void $callback
 	 * @param string[] $dynamicConstantNames


### PR DESCRIPTION
technically these methods are not deprecated, but I think its useful to have a hint to the developer of phpstan-extensions that using `setUp()` and `tearDown()` within a TypeInferenceTestCase because the test-cases/file-asserts are analyzed statically in the background