### PR TITLE
Clarify --xdebug warning message

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -96,7 +96,7 @@ class CommandHelper
 		if ($allowXdebug && !XdebugHandler::isXdebugActive()) {
 			$errorOutput->getStyle()->note('You are running with "--xdebug" enabled, but the Xdebug PHP extension is not active. The process will not halt at breakpoints.');
 		} elseif (!$allowXdebug && XdebugHandler::isXdebugActive()) {
-			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. This may slow down performance and the process will not halt at breakpoints.');
+			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. Using "--xdebug" may slow down performance, but will allow you to debug PHPStan using breakpoints.');
 		}
 
 		if (!$allowXdebug) {


### PR DESCRIPTION
I have seen several developers getting confused by this message thinking that --xdebug will result in better performance.

Since it can be read as:
> "--xdebug" is not used. This may slow down performance

(missing the meaning of the period and surrounding text)

Having xdebug and phpstan installed is common for developers :)