### PR TITLE
Attempt unloading Xdebug before showing warnings

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -93,17 +93,17 @@ class CommandHelper
 			return new SymfonyOutput($symfonyErrorOutput, new SymfonyStyle(new ErrorsConsoleStyle($input, $symfonyErrorOutput)));
 		})();
 
-		if ($allowXdebug && !XdebugHandler::isXdebugActive()) {
-			$errorOutput->getStyle()->note('You are running with "--xdebug" enabled, but the Xdebug PHP extension is not active. The process will not halt at breakpoints.');
-		} elseif (!$allowXdebug && XdebugHandler::isXdebugActive()) {
-			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. This may slow down performance and the process will not halt at breakpoints.');
-		}
-
 		if (!$allowXdebug) {
 			$xdebug = new XdebugHandler('phpstan');
 			$xdebug->setPersistent();
 			$xdebug->check();
 			unset($xdebug);
+		}
+
+		if ($allowXdebug && !XdebugHandler::isXdebugActive()) {
+			$errorOutput->getStyle()->note('You are running with "--xdebug" enabled, but the Xdebug PHP extension is not active. The process will not halt at breakpoints.');
+		} elseif (!$allowXdebug && XdebugHandler::isXdebugActive()) {
+			$errorOutput->getStyle()->note('The Xdebug PHP extension is active, but "--xdebug" is not used. This may slow down performance and the process will not halt at breakpoints.');
 		}
 
 		if ($memoryLimit !== null) {


### PR DESCRIPTION
The Xdebug warning was being shown even when XdebugHandler would avoid the slow down by unloading the extension. This avoids showing the warning for users who have not disabled XdebugHandler via env or other means.

This also has the benefit of making the second message less misleading as it is now only sown when users have a setup that is currently causing a needless slowdown of performance.