### PR TITLE
Fix BackedEnum::tryFrom not being nullable

### DIFF
--- a/tests/PHPStan/Analyser/data/enum-from.php
+++ b/tests/PHPStan/Analyser/data/enum-from.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.1
+<?php declare(strict_types=1); // lint >= 8.1
 
 namespace EnumFrom;
 
@@ -12,11 +12,25 @@ enum FooIntegerEnum: int
 
 }
 
+enum FooIntegerEnumSubset: int
+{
+
+	case BAR = 1;
+
+}
+
 enum FooStringEnum: string
 {
 
 	case BAR = 'bar';
 	case BAZ = 'baz';
+
+}
+
+enum FooNumericStringEnum: string
+{
+
+	case ONE = '1';
 
 }
 
@@ -49,6 +63,24 @@ class Foo
 		assertType('EnumFrom\FooStringEnum::BAZ', FooStringEnum::tryFrom('baz'));
 		assertType('EnumFrom\FooStringEnum::BAZ', FooStringEnum::tryFrom(FooStringEnum::BAZ->value));
 		assertType('EnumFrom\FooStringEnum::BAZ', FooStringEnum::from(FooStringEnum::BAZ->value));
+
+		assertType('null', FooIntegerEnum::tryFrom('1'));
+		assertType('null', FooIntegerEnum::tryFrom(1.0));
+		assertType('null', FooIntegerEnum::tryFrom(1.0001));
+		assertType('null', FooIntegerEnum::tryFrom(true));
+		assertType('null', FooNumericStringEnum::tryFrom(1));
+	}
+
+	public function supersetToSubset(FooIntegerEnum $foo): void
+	{
+		assertType('EnumFrom\FooIntegerEnumSubset::BAR|null', FooIntegerEnumSubset::tryFrom($foo->value));
+		assertType('EnumFrom\FooIntegerEnumSubset::BAR', FooIntegerEnumSubset::from($foo->value));
+	}
+
+	public function subsetToSuperset(FooIntegerEnumSubset $foo): void
+	{
+		assertType('EnumFrom\FooIntegerEnum::BAR', FooIntegerEnum::tryFrom($foo->value));
+		assertType('EnumFrom\FooIntegerEnum::BAR', FooIntegerEnum::from($foo->value));
 	}
 
 }


### PR DESCRIPTION
I encountered this case: https://phpstan.org/r/c1013cf7-d2ea-4d7a-91a9-9839456e5740 where the result of `tryFrom` is incorrectly being reported as not nullable when converting a superset enum to a subset enum. Here is my attempt to fix it.

In addition, the original extension ignores the possibility of `strict_types` not being enabled. I kept this behavior, as I'm not sure what the policy is with regards to `strict_types` (i.e. it seems that `isDeclareStrictTypes` is not called from any other type extension). But I at least added a few tests for `strict_types=1`.