### PR TITLE
Specify `never` for `array_combine` with different number of elements

### DIFF
--- a/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
@@ -56,7 +56,7 @@ class ArrayCombineFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 
 			if (count($keyTypes) !== count($valueTypes)) {
 				if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
-					return null;
+					return new NeverType();
 				}
 				return new ConstantBooleanType(false);
 			}

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4555,7 +4555,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_combine([1], [2])',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'false' : 'array',
+				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
 				'array_combine([1, 2], [3])',
 			],
 			[

--- a/tests/PHPStan/Analyser/data/array-combine-php7.php
+++ b/tests/PHPStan/Analyser/data/array-combine-php7.php
@@ -78,3 +78,8 @@ function withNonEmptyArray(array $a, array $b): void
 {
 	assertType("non-empty-array<'bar'|'baz'|'foo', 'apple'|'avocado'|'banana'>|false", array_combine($a, $b));
 }
+
+function withDifferentNumberOfElements(): void
+{
+	assertType('false', array_combine(['foo'], ['bar', 'baz']));
+}

--- a/tests/PHPStan/Analyser/data/array-combine-php8.php
+++ b/tests/PHPStan/Analyser/data/array-combine-php8.php
@@ -78,3 +78,8 @@ function withNonEmptyArray(array $a, array $b): void
 {
 	assertType("non-empty-array<'bar'|'baz'|'foo', 'apple'|'avocado'|'banana'>", array_combine($a, $b));
 }
+
+function withDifferentNumberOfElements(): void
+{
+	assertType('*NEVER*', array_combine(['foo'], ['bar', 'baz']));
+}


### PR DESCRIPTION
Was found by @gnutix in https://github.com/phpstan/phpstan/issues/9011#issuecomment-1482916959
CC @staabm 