### PR TITLE
Fix `Imagick::profileImage()` type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -4874,7 +4874,7 @@ return [
 'Imagick::posterizeImage' => ['bool', 'levels'=>'int', 'dither'=>'bool'],
 'Imagick::previewImages' => ['bool', 'preview'=>'int'],
 'Imagick::previousImage' => ['bool'],
-'Imagick::profileImage' => ['bool', 'name'=>'string', 'profile'=>'string'],
+'Imagick::profileImage' => ['bool', 'name'=>'string', 'profile'=>'?string'],
 'Imagick::quantizeImage' => ['bool', 'numbercolors'=>'int', 'colorspace'=>'int', 'treedepth'=>'int', 'dither'=>'bool', 'measureerror'=>'bool'],
 'Imagick::quantizeImages' => ['bool', 'numbercolors'=>'int', 'colorspace'=>'int', 'treedepth'=>'int', 'dither'=>'bool', 'measureerror'=>'bool'],
 'Imagick::queryFontMetrics' => ['array{characterWidth:float,characterHeight:float,ascender:float,descender:float,textWidth:float,textHeight:float,maxHorizontalAdvance:float,boundingBox:array{x1:float,x2:float,y1:float,y2:float},originX:float,originY:float}', 'properties'=>'imagickdraw', 'text'=>'string', 'multiline='=>'bool'],


### PR DESCRIPTION
[`Imagick::profileImage()`](https://www.php.net/manual/en/imagick.profileimage.php) says <q>If the profile is NULL, it is removed from the image otherwise added.</q>

The original stub is below:
https://github.com/Imagick/imagick/blob/28f27044e435a2b203e32675e942eb8de620ee58/Imagick.stub.php#L1050

PHP manual seems to be wrong as well: https://github.com/php/doc-en/pull/2396