### PR TITLE
check variance of template types in properties

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -34,3 +34,4 @@ parameters:
 		paramOutVariance: true
 		allInvalidPhpDocs: true
 		strictStaticMethodTemplateTypeVariance: true
+		propertyVariance: true

--- a/conf/config.level2.neon
+++ b/conf/config.level2.neon
@@ -53,6 +53,8 @@ conditionalTags:
 		phpstan.rules.rule: %featureToggles.illegalConstructorMethodCall%
 	PHPStan\Rules\PhpDoc\VarTagChangedExpressionTypeRule:
 		phpstan.rules.rule: %featureToggles.varTagType%
+	PHPStan\Rules\Generics\PropertyVarianceRule:
+		phpstan.rules.rule: %featureToggles.propertyVariance%
 
 services:
 	-
@@ -102,3 +104,5 @@ services:
 			checkTypeAgainstNativeType: %featureToggles.varTagType%
 		tags:
 			- phpstan.rules.rule
+	-
+		class: PHPStan\Rules\Generics\PropertyVarianceRule

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -64,6 +64,7 @@ parameters:
 		paramOutVariance: false
 		allInvalidPhpDocs: false
 		strictStaticMethodTemplateTypeVariance: false
+		propertyVariance: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -298,6 +299,7 @@ parametersSchema:
 		paramOutVariance: bool()
 		allInvalidPhpDocs: bool()
 		strictStaticMethodTemplateTypeVariance: bool()
+		propertyVariance: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/Rules/Generics/PropertyVarianceRule.php
+++ b/src/Rules/Generics/PropertyVarianceRule.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Internal\SprintfHelper;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use function sprintf;
+
+/**
+ * @implements Rule<ClassPropertyNode>
+ */
+class PropertyVarianceRule implements Rule
+{
+
+	public function __construct(private VarianceCheck $varianceCheck)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return ClassPropertyNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$classReflection = $scope->getClassReflection();
+		if (!$classReflection instanceof ClassReflection) {
+			return [];
+		}
+
+		if (!$classReflection->hasNativeProperty($node->getName())) {
+			return [];
+		}
+
+		$propertyReflection = $classReflection->getNativeProperty($node->getName());
+
+		if ($propertyReflection->isPrivate()) {
+			return [];
+		}
+
+		return $this->varianceCheck->checkProperty(
+			$propertyReflection,
+			sprintf('in property %s::$%s', SprintfHelper::escapeFormatString($classReflection->getDisplayName()), SprintfHelper::escapeFormatString($node->getName())),
+			$propertyReflection->isReadOnly(),
+		);
+	}
+
+}

--- a/src/Rules/Generics/PropertyVarianceRule.php
+++ b/src/Rules/Generics/PropertyVarianceRule.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Rules\Generics;
 
-use PHPParser\Node;
+use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\SprintfHelper;
 use PHPStan\Node\ClassPropertyNode;

--- a/src/Rules/Generics/VarianceCheck.php
+++ b/src/Rules/Generics/VarianceCheck.php
@@ -88,6 +88,7 @@ class VarianceCheck
 		return $errors;
 	}
 
+	/** @return RuleError[] */
 	public function checkProperty(
 		PropertyReflection $propertyReflection,
 		string $message,

--- a/tests/PHPStan/Rules/Generics/PropertyVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/PropertyVarianceRuleTest.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Generics;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<PropertyVarianceRule>
+ */
+class PropertyVarianceRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new PropertyVarianceRule(
+			self::getContainer()->getByType(VarianceCheck::class),
+		);
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/property-variance.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$a.',
+				51,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$b.',
+				54,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$c.',
+				57,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\B::$d.',
+				60,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$a.',
+				80,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$b.',
+				83,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$c.',
+				86,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\C::$d.',
+				89,
+			],
+		]);
+	}
+
+	public function testPromoted(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$this->analyse([__DIR__ . '/data/property-variance-promoted.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$a.',
+				58,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$b.',
+				59,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$c.',
+				60,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\Promoted\B::$d.',
+				61,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$a.',
+				84,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$b.',
+				85,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$c.',
+				86,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\Promoted\C::$d.',
+				87,
+			],
+		]);
+	}
+
+	public function testReadOnly(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/property-variance-readonly.php'], [
+			[
+				'Template type X is declared as covariant, but occurs in contravariant position in property PropertyVariance\ReadOnly\B::$b.',
+				45,
+			],
+			[
+				'Template type X is declared as covariant, but occurs in invariant position in property PropertyVariance\ReadOnly\B::$d.',
+				51,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\C::$a.',
+				62,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\C::$c.',
+				68,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in invariant position in property PropertyVariance\ReadOnly\C::$d.',
+				71,
+			],
+			[
+				'Template type X is declared as contravariant, but occurs in covariant position in property PropertyVariance\ReadOnly\D::$a.',
+				86,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance-promoted.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance-promoted.php
@@ -1,0 +1,93 @@
+<?php // lint >= 8.0
+
+namespace PropertyVariance\Promoted;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class A {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param Out<X> $c
+	 * @param Invariant<X> $d
+	 * @param X $e
+	 * @param In<X> $f
+	 * @param Out<X> $g
+	 * @param Invariant<X> $h
+	 */
+	public function __construct(
+		public $a,
+		public $b,
+		public $c,
+		public $d,
+		private $e,
+		private $f,
+		private $g,
+		private $h,
+	) {}
+}
+
+/**
+ * @template-covariant X
+ */
+class B {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param Out<X> $c
+	 * @param Invariant<X> $d
+	 * @param X $e
+	 * @param In<X> $f
+	 * @param Out<X> $g
+	 * @param Invariant<X> $h
+	 */
+	public function __construct(
+		public $a,
+		public $b,
+		public $c,
+		public $d,
+		private $e,
+		private $f,
+		private $g,
+		private $h,
+	) {}
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/**
+	 * @param X $a
+	 * @param In<X> $b
+	 * @param Out<X> $c
+	 * @param Invariant<X> $d
+	 * @param X $e
+	 * @param In<X> $f
+	 * @param Out<X> $g
+	 * @param Invariant<X> $h
+	 */
+	public function __construct(
+		public $a,
+		public $b,
+		public $c,
+		public $d,
+		private $e,
+		private $f,
+		private $g,
+		private $h,
+	) {}
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance-readonly.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance-readonly.php
@@ -1,0 +1,89 @@
+<?php // lint >= 8.1
+
+namespace PropertyVariance\ReadOnly;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class A {
+	/** @var X */
+	public readonly mixed $a;
+
+	/** @var In<X> */
+	public readonly mixed $b;
+
+	/** @var Out<X> */
+	public readonly mixed $c;
+
+	/** @var Invariant<X> */
+	public readonly mixed $d;
+
+	/** @var Invariant<X> */
+	private readonly mixed $e;
+}
+
+/**
+ * @template-covariant X
+ */
+class B {
+	/** @var X */
+	public readonly mixed $a;
+
+	/** @var In<X> */
+	public readonly mixed $b;
+
+	/** @var Out<X> */
+	public readonly mixed $c;
+
+	/** @var Invariant<X> */
+	public readonly mixed $d;
+
+	/** @var Invariant<X> */
+	private readonly mixed $e;
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/** @var X */
+	public readonly mixed $a;
+
+	/** @var In<X> */
+	public readonly mixed $b;
+
+	/** @var Out<X> */
+	public readonly mixed $c;
+
+	/** @var Invariant<X> */
+	public readonly mixed $d;
+
+	/** @var Invariant<X> */
+	private readonly mixed $e;
+}
+
+/**
+ * @template-contravariant X
+ */
+class D {
+	/**
+	 * @param X $a
+	 * @param X $b
+	 */
+	public function __construct(
+		public readonly mixed $a,
+		private readonly mixed $b,
+	) {}
+}

--- a/tests/PHPStan/Rules/Generics/data/property-variance.php
+++ b/tests/PHPStan/Rules/Generics/data/property-variance.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace PropertyVariance;
+
+/** @template-contravariant T */
+interface In {
+}
+
+/** @template-covariant T */
+interface Out {
+}
+
+/** @template T */
+interface Invariant {
+}
+
+/**
+ * @template X
+ */
+class A {
+	/** @var X */
+	public $a;
+
+	/** @var In<X> */
+	public $b;
+
+	/** @var Out<X> */
+	public $c;
+
+	/** @var Invariant<X> */
+	public $d;
+
+	/** @var X */
+	private $e;
+
+	/** @var In<X> */
+	private $f;
+
+	/** @var Out<X> */
+	private $g;
+
+	/** @var Invariant<X> */
+	private $h;
+}
+
+/**
+ * @template-covariant X
+ */
+class B {
+	/** @var X */
+	public $a;
+
+	/** @var In<X> */
+	public $b;
+
+	/** @var Out<X> */
+	public $c;
+
+	/** @var Invariant<X> */
+	public $d;
+
+	/** @var X */
+	private $e;
+
+	/** @var In<X> */
+	private $f;
+
+	/** @var Out<X> */
+	private $g;
+
+	/** @var Invariant<X> */
+	private $h;
+}
+
+/**
+ * @template-contravariant X
+ */
+class C {
+	/** @var X */
+	public $a;
+
+	/** @var In<X> */
+	public $b;
+
+	/** @var Out<X> */
+	public $c;
+
+	/** @var Invariant<X> */
+	public $d;
+
+	/** @var X */
+	private $e;
+
+	/** @var In<X> */
+	private $f;
+
+	/** @var Out<X> */
+	private $g;
+
+	/** @var Invariant<X> */
+	private $h;
+}


### PR DESCRIPTION
Picked from #2075. To sum up:

Properties are treated as invariant. The only exception is native readonly properties: I believe we can safely consider them covariant because PHPStan already makes sure that they are initialized in the constructor and only read ever since.

Similarly to methods, private properties are ignored because they do not affect subtyping in any way.

For the time being, this check also covers static properties. I still think static properties should not be allowed to reference class template types at all, but that turns out to be difficult to do the right way (#2232), so I say let's leave it unresolved for now. I doubt people are using template types in static properties anyway, because they are an immediate footgun.