### PR TITLE
Improve `filter_*` array handling, support `FILTER_REQUIRE_ARRAY`

### DIFF
--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -75,6 +75,19 @@ final class FilterFunctionReturnTypeHelper
 			? new NullType()
 			: new ConstantBooleanType(false));
 
+		$inputIsArray = $inputType->isArray();
+		$hasRequireArrayFlag = $this->hasFlag($this->getConstant('FILTER_REQUIRE_ARRAY'), $flagsType);
+		if ($inputIsArray->no() && $hasRequireArrayFlag) {
+			return $defaultType;
+		}
+
+		$hasForceArrayFlag = $this->hasFlag($this->getConstant('FILTER_FORCE_ARRAY'), $flagsType);
+		$inputArrayKeyType = new MixedType();
+		if ($inputIsArray->yes() && ($hasRequireArrayFlag || $hasForceArrayFlag)) {
+			$inputArrayKeyType = $inputType->getIterableKeyType();
+			$inputType = $inputType->getIterableValueType();
+		}
+
 		if ($inputType->isScalar()->no() && $inputType->isNull()->no()) {
 			return $defaultType;
 		}
@@ -93,14 +106,18 @@ final class FilterFunctionReturnTypeHelper
 			$type = TypeCombinator::intersect($type, $accessory);
 		}
 
+		if ($hasRequireArrayFlag) {
+			$type = new ArrayType($inputArrayKeyType, $type);
+		}
+
 		if ($exactType === null || $hasOptions->maybe() || (!$inputType->equals($type) && $inputType->isSuperTypeOf($type)->yes())) {
 			if ($defaultType->isSuperTypeOf($type)->no()) {
 				$type = TypeCombinator::union($type, $defaultType);
 			}
 		}
 
-		if ($this->hasFlag($this->getConstant('FILTER_FORCE_ARRAY'), $flagsType)) {
-			return new ArrayType(new MixedType(), $type);
+		if (!$hasRequireArrayFlag && $hasForceArrayFlag) {
+			return new ArrayType($inputArrayKeyType, $type);
 		}
 
 		return $type;

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -82,7 +82,6 @@ final class FilterFunctionReturnTypeHelper
 		}
 
 		$hasForceArrayFlag = $this->hasFlag($this->getConstant('FILTER_FORCE_ARRAY'), $flagsType);
-		$inputArrayKeyType = new MixedType();
 		if ($inputIsArray->yes() && ($hasRequireArrayFlag || $hasForceArrayFlag)) {
 			$inputArrayKeyType = $inputType->getIterableKeyType();
 			$inputType = $inputType->getIterableValueType();
@@ -107,7 +106,7 @@ final class FilterFunctionReturnTypeHelper
 		}
 
 		if ($hasRequireArrayFlag) {
-			$type = new ArrayType($inputArrayKeyType, $type);
+			$type = new ArrayType($inputArrayKeyType ?? $mixedType, $type);
 		}
 
 		if ($exactType === null || $hasOptions->maybe() || (!$inputType->equals($type) && $inputType->isSuperTypeOf($type)->yes())) {
@@ -117,7 +116,7 @@ final class FilterFunctionReturnTypeHelper
 		}
 
 		if (!$hasRequireArrayFlag && $hasForceArrayFlag) {
-			return new ArrayType($inputArrayKeyType, $type);
+			return new ArrayType($inputArrayKeyType ?? $mixedType, $type);
 		}
 
 		return $type;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1168,6 +1168,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8485.php');
 		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/discussion-8447.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/discussion-9134.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7805.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-82.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4565.php');

--- a/tests/PHPStan/Analyser/data/discussion-9134.php
+++ b/tests/PHPStan/Analyser/data/discussion-9134.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Discussion9134;
+
+use function PHPStan\Testing\assertType;
+
+$var = $_GET["data"];
+$res = filter_var($var, FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY);
+assertType('array<int>|false', $res);
+if (is_array($res) === false) {
+	throw new \RuntimeException();
+}

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -28,7 +28,7 @@ class FilterVar
 		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
 		assertType('array<string, int>|null', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
 
-        assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+		assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('array<false>', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<null>', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -8,12 +8,40 @@ use function PHPStan\Testing\assertType;
 class FilterVar
 {
 
-	public function doFoo($mixed): void
+	/**
+	 * @param array<string, mixed> $stringMixedMap
+	 */
+	public function doFoo($mixed, array $stringMixedMap): void
 	{
 		assertType('int|false', filter_var($mixed, FILTER_VALIDATE_INT));
 		assertType('int|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_NULL_ON_FAILURE]));
+
+		assertType('17', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_SCALAR]));
+		assertType('false', filter_var([17], FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_SCALAR]));
+
+		assertType('false', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
+		assertType('null', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('false', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
+		assertType('null', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<int>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
+		assertType('array<int>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
+		assertType('array<string, int>|null', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
+
+		assertType('array<false>', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+		assertType('array<null>', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('array<int|false>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<int|null>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<string, int|false>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+		assertType('array<string, int|null>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+
+		assertType('false', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
+		assertType('null', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<int>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
+		assertType('array<int>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
+		assertType('array<string, int>|null', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+
 		assertType('0|int<17, 19>', filter_var($mixed, FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));
 
 		assertType('array<false>', filter_var(false, FILTER_VALIDATE_BOOLEAN, FILTER_FORCE_ARRAY | FILTER_NULL_ON_FAILURE));

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -28,9 +28,11 @@ class FilterVar
 		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
 		assertType('array<string, int>|null', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
 
+        assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+		assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('array<false>', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<null>', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
-		assertType('array<int|false>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
+	 	assertType('array<int|false>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<int|null>', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('array<string, int|false>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<string, int|null>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));

--- a/tests/PHPStan/Analyser/data/filter-var.php
+++ b/tests/PHPStan/Analyser/data/filter-var.php
@@ -39,6 +39,8 @@ class FilterVar
 
 		assertType('false', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
 		assertType('null', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('false', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
+		assertType('null', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('array<int>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
 		assertType('array<int>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -724,6 +724,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8752.php'], []);
 	}
 
+	public function testDiscussion9134(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/discussion-9134.php'], []);
+	}
+
 	public function testImpossibleMethodExistOnGenericClassString(): void
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;


### PR DESCRIPTION
Refs: https://github.com/phpstan/phpstan/discussions/9134

fyi @GMQS

See https://www.php.net/manual/en/filter.filters.flags.php and https://3v4l.org/p8jA9 and 

Support for more specialised arrays like constant arrays or lists as inputs could be improved still, but this is already complicated enough and I'm not sure if it's worth it. Could be added later still I suppose.