### PR TITLE
AnnotationsPropertiesClassReflectionExtension: More specific property prevail

### DIFF
--- a/tests/PHPStan/Analyser/data/asymmetric-properties.php
+++ b/tests/PHPStan/Analyser/data/asymmetric-properties.php
@@ -23,7 +23,7 @@ class Foo
 	{
 		assertType('int', $this->asymmetricPropertyRw);
 		assertType('int', $this->asymmetricPropertyXw);
-		assertType('int|string', $this->asymmetricPropertyRx);
+		assertType('int', $this->asymmetricPropertyRx);
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -255,13 +255,13 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends PHPStanTestCase
 					'asymmetricPropertyXw' => [
 						'class' => Asymmetric::class,
 						'readableType' => 'int',
-						'writableType' => 'int',
+						'writableType' => 'int|string',
 						'writable' => true,
 						'readable' => true,
 					],
 					'asymmetricPropertyRx' => [
 						'class' => Asymmetric::class,
-						'readableType' => 'int|string',
+						'readableType' => 'int',
 						'writableType' => 'int|string',
 						'writable' => true,
 						'readable' => true,


### PR DESCRIPTION
Restore the behaviour from before asymmetric properties were introduced, when `@property-read` and `@property-write` would shadow `@property`. This is slightly more intuitive since those tags are more specific.

Another follow-up to https://github.com/phpstan/phpstan-src/pull/2327
