### PR TITLE
Fail if a composer patch cannot be applied

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
 		}
 	},
 	"extra": {
+		"composer-exit-on-patch-failure": true,
 		"patches": {
 			"hoa/iterator": [
 				"patches/Buffer.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0429c6ab81e55d2c4dfbcf5a2310284",
+    "content-hash": "775a1e879bce9a6fed0fca9f267fc378",
     "packages": [
         {
             "name": "clue/ndjson-react",


### PR DESCRIPTION
This is now possible to be handled stricter because of https://github.com/phpstan/phpstan-src/commit/c5b386831d5f20dc463fcc639f8b9cd3580628fd

with a prepared test case
before:
```sh
➜ composer install
Gathering patches for root package.
Removing package hoa/iterator so that it can be re-installed and re-patched.
  - Removing hoa/iterator (2.17.01.10)
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Package operations: 1 install, 0 updates, 0 removals
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Installing hoa/iterator (2.17.01.10): Extracting archive
  - Applying patches for hoa/iterator
    patches/Buffer.patch (0)
   Could not apply patch! Skipping. The error was: Cannot apply patch patches/Buffer.patch
    patches/Lookahead.patch (1)

Package hoa/compiler is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/consistency is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/event is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/exception is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/file is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/iterator is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/math is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/protocol is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/regex is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/stream is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/ustring is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/visitor is abandoned, you should avoid using it. No replacement was suggested.
Package hoa/zformat is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
57 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
➜
````

after:
```sh
➜ composer install
Gathering patches for root package.
Removing package hoa/iterator so that it can be re-installed and re-patched.
  - Removing hoa/iterator (2.17.01.10)
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
Package operations: 1 install, 0 updates, 0 removals
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Installing hoa/iterator (2.17.01.10): Extracting archive
  - Applying patches for hoa/iterator
    patches/Buffer.patch (0)
   Could not apply patch! Skipping. The error was: Cannot apply patch patches/Buffer.patch

In Patches.php line 331:

  Cannot apply patch 0 (patches/Buffer.patch)!


install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]

➜
```

Refs: https://github.com/cweagans/composer-patches/blob/1.7.3/README.md
