### PR TITLE
Improve return type precision of `filter_input` with invalid first args

### DIFF
--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -2,23 +2,17 @@
 
 namespace PHPStan\Type\Php;
 
-use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use function count;
 
 class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 
-	public function __construct(private FilterFunctionReturnTypeHelper $filterFunctionReturnTypeHelper, private ReflectionProvider $reflectionProvider)
+	public function __construct(private FilterFunctionReturnTypeHelper $filterFunctionReturnTypeHelper)
 	{
 	}
 
@@ -33,24 +27,8 @@ class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnType
 			return null;
 		}
 
-		$supportedTypes = TypeCombinator::union(
-			$this->reflectionProvider->getConstant(new Node\Name('INPUT_GET'), null)->getValueType(),
-			$this->reflectionProvider->getConstant(new Node\Name('INPUT_POST'), null)->getValueType(),
-			$this->reflectionProvider->getConstant(new Node\Name('INPUT_COOKIE'), null)->getValueType(),
-			$this->reflectionProvider->getConstant(new Node\Name('INPUT_SERVER'), null)->getValueType(),
-			$this->reflectionProvider->getConstant(new Node\Name('INPUT_ENV'), null)->getValueType(),
-		);
-		$typeType = $scope->getType($functionCall->getArgs()[0]->value);
-		if (!$typeType->isInteger()->yes() || $supportedTypes->isSuperTypeOf($typeType)->no()) {
-			return null;
-		}
-
-		// Pragmatical solution since global expressions are not passed through the scope for performance reasons
-		// See https://github.com/phpstan/phpstan-src/pull/2012 for details
-		$inputType = new ArrayType(new StringType(), new MixedType());
-
-		return $this->filterFunctionReturnTypeHelper->getOffsetValueType(
-			$inputType,
+		return $this->filterFunctionReturnTypeHelper->getInputType(
+			$scope->getType($functionCall->getArgs()[0]->value),
 			$scope->getType($functionCall->getArgs()[1]->value),
 			isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null,
 			isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -623,7 +623,13 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input-php8.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input-php7.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var.php');
 
 		if (PHP_VERSION_ID >= 80100) {

--- a/tests/PHPStan/Analyser/data/filter-input-php7.php
+++ b/tests/PHPStan/Analyser/data/filter-input-php7.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace FilterInputPhp7;
+
+use function PHPStan\Testing\assertType;
+
+class FilterInputPhp7
+{
+
+	public function invalidTypesOrVarNames($mixed): void
+	{
+		assertType('null', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
+		assertType('false', filter_input(-1, 'foo', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/filter-input-php8.php
+++ b/tests/PHPStan/Analyser/data/filter-input-php8.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace FilterInputPhp8;
+
+use function PHPStan\Testing\assertType;
+
+class FilterInputPhp8
+{
+
+	public function invalidTypesOrVarNames($mixed): void
+	{
+		assertType('*NEVER*', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
+		assertType('*NEVER*', filter_input(-1, 'foo', FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/filter-input.php
+++ b/tests/PHPStan/Analyser/data/filter-input.php
@@ -10,7 +10,6 @@ class FilterInput
 	public function invalidTypesOrVarNames($mixed): void
 	{
 		assertType('int|false|null', filter_input(INPUT_GET, $mixed, FILTER_VALIDATE_INT));
-		assertType('mixed', filter_input(-1, 'foo', FILTER_VALIDATE_INT));
 		assertType('null', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT));
 		assertType('false', filter_input(INPUT_GET, 17, FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE));
 	}


### PR DESCRIPTION
This is essentially https://3v4l.org/vLIZK / makes the return type more precise when the first arg (type constant) is invalid.

In order to do that I had to refactor this thing again and move more into the helper. I added caching for `supportedFilterInputTypes` at the same time as the helper was also doing it for other similar props.

The idea is also to keep the return type correct in combination with https://github.com/phpstan/phpstan-src/pull/2271