### PR TITLE
Fix class-const resolving will always evaluate to true/false in traits

### DIFF
--- a/build/enum-adapter-errors.neon
+++ b/build/enum-adapter-errors.neon
@@ -352,7 +352,7 @@ parameters:
 
 		-
 			message: "#^Call to method getProperty\\(\\) on an unknown class PHPStan\\\\BetterReflection\\\\Reflection\\\\Adapter\\\\ReflectionEnum\\.$#"
-			count: 1
+			count: 2
 			path: ../tests/PHPStan/Analyser/AnalyserIntegrationTest.php
 
 		-

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1605,11 +1605,13 @@ class MutatingScope implements Scope
 			if ($this->hasExpressionType($node)->yes()) {
 				return $this->expressionTypes[$exprString]->getType();
 			}
+
 			return $this->initializerExprTypeResolver->getClassConstFetchTypeByReflection(
 				$node->class,
 				$node->name->name,
 				$this->isInClass() ? $this->getClassReflection() : null,
 				fn (Expr $expr): Type => $this->getType($expr),
+				InitializerExprContext::fromScope($this),
 			);
 		}
 

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -166,7 +166,7 @@ class InitializerExprTypeResolver
 			return $var->getOffsetValueType($dim);
 		}
 		if ($expr instanceof ClassConstFetch && $expr->name instanceof Identifier) {
-			return $this->getClassConstFetchType($expr->class, $expr->name->toString(), $context->getClassName(), fn (Expr $expr): Type => $this->getType($expr, $context));
+			return $this->getClassConstFetchType($expr->class, $expr->name->toString(), $context->getClassName(), fn (Expr $expr): Type => $this->getType($expr, $context), $context);
 		}
 		if ($expr instanceof Expr\UnaryPlus) {
 			return $this->getType($expr->expr, $context)->toNumber();
@@ -1769,7 +1769,7 @@ class InitializerExprTypeResolver
 	/**
 	 * @param callable(Expr): Type $getTypeCallback
 	 */
-	public function getClassConstFetchTypeByReflection(Name|Expr $class, string $constantName, ?ClassReflection $classReflection, callable $getTypeCallback): Type
+	public function getClassConstFetchTypeByReflection(Name|Expr $class, string $constantName, ?ClassReflection $classReflection, callable $getTypeCallback, InitializerExprContext $context): Type
 	{
 		$isObject = false;
 		if ($class instanceof Name) {
@@ -1796,6 +1796,19 @@ class InitializerExprTypeResolver
 				if ($resolvedName === 'parent' && strtolower($constantName) === 'class') {
 					return new ClassStringType();
 				}
+
+				if ($classReflection !== null && $resolvedName === $classReflection->getName()) {
+					if ($context->getTraitName() !== null) {
+						if (strtolower($constantName) === 'class') {
+							return TypeCombinator::intersect(
+								new ClassStringType(),
+								new AccessoryLiteralStringType(),
+							);
+						}
+						return new MixedType();
+					}
+				}
+
 				$constantClassType = $this->resolveTypeByName($class, $classReflection);
 			}
 
@@ -1919,14 +1932,14 @@ class InitializerExprTypeResolver
 	/**
 	 * @param callable(Expr): Type $getTypeCallback
 	 */
-	public function getClassConstFetchType(Name|Expr $class, string $constantName, ?string $className, callable $getTypeCallback): Type
+	public function getClassConstFetchType(Name|Expr $class, string $constantName, ?string $className, callable $getTypeCallback, InitializerExprContext $context): Type
 	{
 		$classReflection = null;
 		if ($className !== null && $this->getReflectionProvider()->hasClass($className)) {
 			$classReflection = $this->getReflectionProvider()->getClass($className);
 		}
 
-		return $this->getClassConstFetchTypeByReflection($class, $constantName, $classReflection, $getTypeCallback);
+		return $this->getClassConstFetchTypeByReflection($class, $constantName, $classReflection, $getTypeCallback, $context);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1319,6 +1319,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/trait-generalized-consts.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-4288b.php
+++ b/tests/PHPStan/Analyser/data/bug-4288b.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug4288b;
+
+trait PaginationTrait
+{
+
+	/** @var int */
+	private $test = MyClass::DEFAULT_SIZE;
+
+	private function paginate(int $size = MyClass::DEFAULT_SIZE): void
+	{
+		echo $size;
+	}
+}
+
+class MyClass
+{
+	use PaginationTrait;
+
+	const DEFAULT_SIZE = 10;
+
+	public function test(): void
+	{
+		$this->paginate();
+	}
+}
+

--- a/tests/PHPStan/Analyser/data/trait-generalized-consts.php
+++ b/tests/PHPStan/Analyser/data/trait-generalized-consts.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace TraitGeneralizedConsts;
+
+use function PHPStan\Testing\assertType;
+
+trait MyLogic
+{
+	public function fetchValue() : string
+	{
+		assertType('mixed', self::MY_CONST);
+		assertType('mixed', static::MY_CONST);
+
+		if (self::MY_CONST === 'hallo') {
+			assertType("'hallo'", self::MY_CONST);
+			return 'foo';
+		}
+		assertType("mixed~'hallo'", self::MY_CONST);
+		if (self::MY_CONST === 1) {
+			assertType('1', self::MY_CONST);
+			return 'foo1';
+		}
+		assertType("mixed~1|'hallo'", self::MY_CONST);
+
+		assertType('class-string&literal-string', self::class);
+		assertType('class-string&literal-string', static::class);
+
+		assertType('1', FirstConsumer::MY_CONST);
+	}
+
+	public function fetchValue2() : string {
+		assertType('mixed', self::MY_CONST_ARRAY);
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			assertType("array&hasOffset('valueToFetch')", self::MY_CONST_ARRAY);
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+		assertType("mixed~hasOffset('valueToFetch')", self::MY_CONST_ARRAY);
+
+		assertType("array{someValue: 'abc', valueToFetch: '123'}", FirstConsumer::MY_CONST_ARRAY);
+
+		return 'defaultValue';
+	}
+}
+
+final class FirstConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST = 1;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'    => 'abc',
+		'valueToFetch' => '123',
+	];
+
+	public function fetchOwnValue() : string
+	{
+		assertType('1', self::MY_CONST);
+		if (self::MY_CONST === 'hallo') {
+			assertType('*NEVER*', self::MY_CONST);
+			return 'foo';
+		}
+		assertType('1', self::MY_CONST);
+		if (self::MY_CONST === 1) {
+			assertType('1', self::MY_CONST);
+			return 'foo1';
+		}
+		assertType('*NEVER*', self::MY_CONST);
+	}
+
+	public function fetchOwnValue2() : string {
+		assertType("array{someValue: 'abc', valueToFetch: '123'}", self::MY_CONST_ARRAY);
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			assertType("array{someValue: 'abc', valueToFetch: '123'}", self::MY_CONST_ARRAY);
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+		assertType("array{someValue: 'abc', valueToFetch: '123'}", self::MY_CONST_ARRAY);
+
+		return 'defaultValue';
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -196,18 +196,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'method\' will always evaluate to true.',
-					643,
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'someAnother\' will always evaluate to true.',
-					646,
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
-					649,
-				],
-				[
 					'Call to function is_string() with string will always evaluate to true.',
 					678,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
@@ -352,10 +340,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
 					640,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
-					649,
 				],
 				[
 					'Call to function assert() with false will always evaluate to false.',
@@ -1034,6 +1018,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$issues = self::getLooseComparisonAgainsEnumsIssues();
 		$issues = array_values(array_filter($issues, static fn (array $i) => count($i) === 2));
 		$this->analyse([__DIR__ . '/data/loose-comparison-against-enums.php'], $issues);
+	}
+
+	public function testBug4570(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-4570.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -181,21 +181,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					631,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'method\' will always evaluate to true.',
-					634,
-					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'someAnother\' will always evaluate to true.',
-					637,
-					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
-					640,
-					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
-				],
-				[
 					'Call to function is_string() with string will always evaluate to true.',
 					678,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
@@ -335,11 +320,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				[
 					'Call to function method_exists() with $this(CheckTypeFunctionCall\MethodExistsWithTrait) and \'unknown\' will always evaluate to false.',
 					631,
-				],
-				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
-					640,
-					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
 				[
 					'Call to function assert() with false will always evaluate to false.',

--- a/tests/PHPStan/Rules/Comparison/data/bug-4570.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4570.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4570;
+
+trait MyLogic
+{
+	public function fetchValue() : string {
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+
+		return 'defaultValue';
+	}
+}
+
+final class FirstConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'    => 'abc',
+		'valueToFetch' => '123',
+	];
+}
+
+final class SecondConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'      => 'abc',
+		'someOtherValue' => '123',
+	];
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/4570

see initial discussion and reviews in https://github.com/phpstan/phpstan-src/pull/2046

test fails without the src changes like
```diff
1) PHPStan\Rules\Comparison\ImpossibleCheckTypeFunctionCallRuleTest::testBug4570
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'08: Call to function array_key_exists() with 'valueToFetch' and array{someValue: 'abc', valueToFetch: '123'} will always evaluate to true.
+08: Call to function array_key_exists() with 'valueToFetch' and array{someValue: 'abc', someOtherValue: '123'} will always evaluate to false.
 '
```