### PR TITLE
Fix ConstantFloatType::toPhpDocNode() for whole numbers ending with 0

### DIFF
--- a/src/Type/Constant/ConstantFloatType.php
+++ b/src/Type/Constant/ConstantFloatType.php
@@ -110,7 +110,7 @@ class ConstantFloatType extends FloatType implements ConstantScalarType
 	 */
 	public function toPhpDocNode(): TypeNode
 	{
-		return new ConstTypeNode(new ConstExprFloatNode(rtrim(sprintf('%.20f', $this->value), '0.')));
+		return new ConstTypeNode(new ConstExprFloatNode(rtrim(rtrim(sprintf('%.20f', $this->value), '0'), '.')));
 	}
 
 	/**

--- a/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
+++ b/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
@@ -292,6 +292,11 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 			new ConstantFloatType(2.35),
 			'2.35000000000000008882',
 		];
+
+		yield [
+			new ConstantFloatType(100),
+			'100',
+		];
 	}
 
 	/**


### PR DESCRIPTION
Per https://github.com/phpstan/phpstan-src/commit/d2a94c788a34e285450f2bd17c0c795c405276f6#r109774384