### PR TITLE
Fix ConstantFloatType value dump precision

### DIFF
--- a/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
@@ -24,6 +24,14 @@ class ConstantFloatTypeTest extends PHPStanTestCase
 				'1.2000000992884E-10',
 			],
 			[
+				new ConstantFloatType(-1.200000099288476E+10),
+				'-12000000992.88476',
+			],
+			[
+				new ConstantFloatType(-1.200000099288476E+20),
+				'-1.200000099288476E+20',
+			],
+			[
 				new ConstantFloatType(1.2 * 1.4),
 				'1.68',
 			],

--- a/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
+++ b/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
@@ -18,6 +18,8 @@ use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use stdClass;
 use function sprintf;
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
 
 class TypeToPhpDocNodeTest extends PHPStanTestCase
 {
@@ -312,23 +314,58 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 		];
 
 		yield [
+			new ConstantIntegerType(PHP_INT_MIN),
+			(string) PHP_INT_MIN,
+		];
+
+		yield [
+			new ConstantIntegerType(PHP_INT_MAX),
+			(string) PHP_INT_MAX,
+		];
+
+		yield [
 			new ConstantFloatType(9223372036854775807),
-			'9223372036854775808',
+			'9.223372036854776E+18',
 		];
 
 		yield [
 			new ConstantFloatType(-9223372036854775808),
-			'-9223372036854775808',
+			'-9.223372036854776E+18',
 		];
 
 		yield [
 			new ConstantFloatType(2.35),
-			'2.35000000000000008882',
+			'2.35',
 		];
 
 		yield [
 			new ConstantFloatType(100),
-			'100',
+			'100.0',
+		];
+
+		yield [
+			new ConstantFloatType(8.202343767574732),
+			'8.202343767574732',
+		];
+
+		yield [
+			new ConstantFloatType(1e80),
+			'1.0E+80',
+		];
+
+		yield [
+			new ConstantFloatType(-5e-80),
+			'-5.0E-80',
+		];
+
+		yield [
+			new ConstantFloatType(0.0),
+			'0.0',
+		];
+
+		yield [
+			new ConstantFloatType(-0.0),
+			'-0.0',
 		];
 	}
 


### PR DESCRIPTION
When dumping a float value, we need:
- ensure `.` is always present in finite values (/wo `.` the number type is integer)
- always dump with full precision (`(string) float_expr` cast is affected by `precision` php.ini)
- never dump more digits than needed