### PR TITLE
Add type for ini_get() 'default_socket_timeout' and 'precision'

### DIFF
--- a/src/Type/Php/IniGetReturnTypeExtension.php
+++ b/src/Type/Php/IniGetReturnTypeExtension.php
@@ -41,6 +41,8 @@ class IniGetReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 			'memory_limit' => new StringType(),
 			'max_execution_time' => $numericString,
 			'max_input_time' => $numericString,
+			'default_socket_timeout' => $numericString,
+			'precision' => $numericString,
 		];
 
 		$argType = $scope->getType($args[0]->value);

--- a/tests/PHPStan/Analyser/data/ini-get.php
+++ b/tests/PHPStan/Analyser/data/ini-get.php
@@ -9,6 +9,8 @@ function doFoo() {
 	assertType('string', ini_get("memory_limit"));
 	assertType('numeric-string', ini_get("max_execution_time"));
 	assertType('numeric-string', ini_get("max_input_time"));
+	assertType('numeric-string', ini_get("default_socket_timeout"));
+	assertType('numeric-string', ini_get("precision"));
 
 	if (rand(1, 0)) {
 		$x = ini_get("date.timezone");


### PR DESCRIPTION
`default_socket_timeout` is pretty commonly used and `precision` seems to be something we need for https://github.com/phpstan/phpstan-src/pull/2358