### PR TITLE
`CURLOPT_HTTPHEADER` should not accept a dictionary

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -785,10 +785,18 @@ class ParametersAcceptorSelector
 			}
 		}
 
+		$intArrayStringKeysConstants = [
+			'CURLOPT_HTTPHEADER',
+		];
+		foreach ($intArrayStringKeysConstants as $constName) {
+			if (defined($constName) && constant($constName) === $curlOpt) {
+				return new ArrayType(new IntegerType(), new StringType());
+			}
+		}
+
 		$arrayConstants = [
 			'CURLOPT_CONNECT_TO',
 			'CURLOPT_HTTP200ALIASES',
-			'CURLOPT_HTTPHEADER',
 			'CURLOPT_POSTQUOTE',
 			'CURLOPT_PROXYHEADER',
 			'CURLOPT_QUOTE',

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1208,7 +1208,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				14,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects array, int given.',
+				'Parameter #3 $value of function curl_setopt expects array<int, string>, int given.',
 				15,
 			],
 			[
@@ -1234,6 +1234,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			[
 				'Parameter #3 $value of function curl_setopt expects array|string, int given.',
 				26,
+			],
+			[
+				'Parameter #3 $value of function curl_setopt expects array<int, string>, array<string, string> given.',
+				65,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -55,4 +55,18 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_PROXY, '');
 		curl_setopt($curl, CURLOPT_PRIVATE, '');
 	}
+
+	public function bug9263() {
+		$curl = curl_init();
+
+		$header_dictionary = [
+			'Accept' => 'application/json',
+		];
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $header_dictionary);
+
+		$header_list = [
+			'Accept: application/json',
+		];
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $header_list);
+	}
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/9263