### PR TITLE
Enforce magic __serialize() and __unserialize() return types

### DIFF
--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -14,6 +14,7 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -76,6 +77,13 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		}
 		if ($name === '__set_state') {
 			$realReturnType = TypeCombinator::intersect(new ObjectWithoutClassType(), $realReturnType);
+		}
+
+		if ($name === '__unserialize') {
+			$realReturnType = new VoidType();
+		}
+		if ($name === '__serialize') {
+			$realReturnType = new ArrayType(new MixedType(), new MixedType());
 		}
 
 		parent::__construct(

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -861,4 +861,18 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9011.php'], $errors);
 	}
 
+	public function testMagicSerialization(): void
+	{
+		$this->analyse([__DIR__ . '/data/magic-serialization.php'], [
+			[
+				'Method MagicSerialization\WrongSignature::__serialize() should return array but returns string.',
+				23,
+			],
+			[
+				'Method MagicSerialization\WrongSignature::__unserialize() with return type void returns string but should not return anything.',
+				28,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/magic-serialization.php
+++ b/tests/PHPStan/Rules/Methods/data/magic-serialization.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace MagicSerialization;
+
+class Ok {
+
+	/** @return array<mixed> */
+	public function __serialize(): array
+	{
+		return [];
+	}
+
+	/** @param array<mixed> $data */
+	public function __unserialize(array $data): void
+	{
+	}
+}
+
+class WrongSignature {
+
+	public function __serialize(): string
+	{
+		return '';
+	}
+
+	public function __unserialize(string $data): string
+	{
+		return '';
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/magic-serialization.php
+++ b/tests/PHPStan/Rules/Methods/data/magic-serialization.php
@@ -18,12 +18,12 @@ class Ok {
 
 class WrongSignature {
 
-	public function __serialize(): string
+	public function __serialize()
 	{
 		return '';
 	}
 
-	public function __unserialize(string $data): string
+	public function __unserialize($data)
 	{
 		return '';
 	}


### PR DESCRIPTION
types as defined in php-src

https://www.php.net/manual/en/language.oop5.magic.php#language.oop5.magic.serialize
https://3v4l.org/bLjLG

my motivation for this change is, as I am upgrading a php7 app for php8 compat per https://wiki.php.net/rfc/phase_out_serializable and [I experienced php segfaults](https://github.com/php/php-src/issues/11187) when I use the wrong signature or return the wrong data

returning the wrong result is a fatal error on php8