### PR TITLE
Support different error levels in GithubErrorFormatter

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -225,6 +225,7 @@ parameters:
 	editorUrl: null
 	editorUrlTitle: null
 	errorFormat: null
+	githubErrorLevel: 'error'
 	pro:
 		dnsServers:
 			- '1.1.1.1'
@@ -424,6 +425,7 @@ parametersSchema:
 	editorUrl: schema(string(), nullable())
 	editorUrlTitle: schema(string(), nullable())
 	errorFormat: schema(string(), nullable())
+	githubErrorLevel: string()
 	pro: structure([
 		dnsServers: schema(listOf(string()), min(1)),
 	])
@@ -2161,6 +2163,7 @@ services:
 		class: PHPStan\Command\ErrorFormatter\GithubErrorFormatter
 		arguments:
 			relativePathHelper: @simpleRelativePathHelper
+			errorLevel: %githubErrorLevel%
 
 	errorFormatter.teamcity:
 		class: PHPStan\Command\ErrorFormatter\TeamcityErrorFormatter

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -18,6 +18,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			0,
 			'',
+			'error',
 		];
 
 		yield [
@@ -27,6 +28,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			'::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
 ',
+			'error',
 		];
 
 		yield [
@@ -36,6 +38,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			1,
 			'::error ::first generic error
 ',
+			'error',
 		];
 
 		yield [
@@ -48,6 +51,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 ::error file=foo.php,line=1,col=0::Foo
 ::error file=foo.php,line=5,col=0::Bar%0ABar2
 ',
+			'error',
 		];
 
 		yield [
@@ -58,6 +62,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			'::error ::first generic error
 ::error ::second generic error
 ',
+			'error',
 		];
 
 		yield [
@@ -72,6 +77,17 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 ::error ::first generic error
 ::error ::second generic error
 ',
+			'error',
+		];
+
+		yield [
+			'One generic error as warning',
+			1,
+			0,
+			1,
+			'::warning ::first generic error
+',
+			'warning',
 		];
 	}
 
@@ -85,11 +101,13 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 		int $numFileErrors,
 		int $numGenericErrors,
 		string $expected,
+		string $errorLevel,
 	): void
 	{
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
 		$formatter = new GithubErrorFormatter(
 			$relativePathHelper,
+			$errorLevel,
 		);
 
 		$this->assertSame($exitCode, $formatter->formatErrors(


### PR DESCRIPTION
allows to configure the message severity when formatting phpstan-errors in the GithubErrorFormatter.

Our use case:
we want to run 2 phpstan jobs in parallel. 
- one with our currently supported php version
- another job where we use our future php version (the one we are aiming for to support within the next few months)

we don't want to allow new errors in the currently supported php version. additionally we want github action to report only warnings for the future php version, as not all members of the team are working on that topic.

as soon as we have fixed all future php version problems we will raise the error level in the pipeline for the future php version

-> long story short: would be cool we could configure the message severity of errors reported by the phpstan github formatter

effectivly this will make the errors on the github.com ui yellow instead of red - example (not using phpstan):

![grafik](https://user-images.githubusercontent.com/120441/236835512-bf96320d-0dad-4ed0-98d6-ecf42fff522c.png)
