### PR TITLE
Lazy initialization of AnalyserResult::$errors

### DIFF
--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -9,18 +9,18 @@ use function usort;
 class AnalyserResult
 {
 
-	/** @var list<Error> */
-	private array $unorderedErrors;
+	/** @var list<Error>|null */
+	private ?array $errors = null;
 
 	/**
-	 * @param list<Error> $errors
+	 * @param list<Error> $unorderedErrors
 	 * @param list<CollectedData> $collectedData
 	 * @param list<string> $internalErrors
 	 * @param array<string, array<string>>|null $dependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
 	 */
 	public function __construct(
-		private array $errors,
+		private array $unorderedErrors,
 		private array $internalErrors,
 		private array $collectedData,
 		private ?array $dependencies,
@@ -29,20 +29,6 @@ class AnalyserResult
 		private int $peakMemoryUsageBytes,
 	)
 	{
-		$this->unorderedErrors = $errors;
-
-		usort(
-			$this->errors,
-			static fn (Error $a, Error $b): int => [
-				$a->getFile(),
-				$a->getLine(),
-				$a->getMessage(),
-			] <=> [
-				$b->getFile(),
-				$b->getLine(),
-				$b->getMessage(),
-			],
-		);
 	}
 
 	/**
@@ -58,6 +44,22 @@ class AnalyserResult
 	 */
 	public function getErrors(): array
 	{
+		if (!isset($this->errors)) {
+			$this->errors = $this->unorderedErrors;
+			usort(
+				$this->errors,
+				static fn (Error $a, Error $b): int => [
+					$a->getFile(),
+					$a->getLine(),
+					$a->getMessage(),
+				] <=> [
+					$b->getFile(),
+					$b->getLine(),
+					$b->getMessage(),
+				],
+			);
+		}
+
 		return $this->errors;
 	}
 

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -92,7 +92,7 @@ class AnalyseApplication
 			if ($resultCache->isFullAnalysis() && count($projectStubFiles) !== 0) {
 				$stubErrors = $this->stubValidator->validate($projectStubFiles, $debug);
 				$intermediateAnalyserResult = new AnalyserResult(
-					array_merge($intermediateAnalyserResult->getErrors(), $stubErrors),
+					array_merge($intermediateAnalyserResult->getUnorderedErrors(), $stubErrors),
 					$intermediateAnalyserResult->getInternalErrors(),
 					$intermediateAnalyserResult->getCollectedData(),
 					$intermediateAnalyserResult->getDependencies(),


### PR DESCRIPTION
`AnalyserResult::$errors` array is sorted in the class' constructor, but it doesn't always need to be sorted.
This PR makes the property be initialized when `getErrors` is called.

In `AnalyseApplication::analyse` we may get two `AnalyserResult` instances. One of them is just an intermediate result, so its error array doesn't have to be sorted.
Sorting an array with `usort` may take a few seconds if the array has thousands of elements.