### PR TITLE
LastConditionVisitor: condition followed by throw is marked as last

### DIFF
--- a/src/Parser/LastConditionVisitor.php
+++ b/src/Parser/LastConditionVisitor.php
@@ -17,8 +17,11 @@ class LastConditionVisitor extends NodeVisitorAbstract
 		if ($node instanceof Node\Stmt\If_ && $node->elseifs !== []) {
 			$lastElseIf = count($node->elseifs) - 1;
 
+			$elseIsMissingOrThrowing = $node->else === null
+				|| (count($node->else->stmts) === 1 && $node->else->stmts[0] instanceof Node\Stmt\Throw_);
+
 			foreach ($node->elseifs as $i => $elseif) {
-				$isLast = $i === $lastElseIf && $node->else === null;
+				$isLast = $i === $lastElseIf && $elseIsMissingOrThrowing;
 				$elseif->cond->setAttribute(self::ATTRIBUTE_NAME, $isLast);
 			}
 		}
@@ -36,6 +39,42 @@ class LastConditionVisitor extends NodeVisitorAbstract
 				$arm->conds[$index]->setAttribute(self::ATTRIBUTE_NAME, $isLast);
 				$arm->conds[$index]->setAttribute(self::ATTRIBUTE_IS_MATCH_NAME, true);
 			}
+		}
+
+		if (
+			$node instanceof Node\Stmt\Function_
+			|| $node instanceof Node\Stmt\ClassMethod
+			|| $node instanceof Node\Stmt\If_
+			|| $node instanceof Node\Stmt\ElseIf_
+			|| $node instanceof Node\Stmt\Else_
+			|| $node instanceof Node\Stmt\Case_
+			|| $node instanceof Node\Stmt\Catch_
+			|| $node instanceof Node\Stmt\Do_
+			|| $node instanceof Node\Stmt\Finally_
+			|| $node instanceof Node\Stmt\For_
+			|| $node instanceof Node\Stmt\Foreach_
+			|| $node instanceof Node\Stmt\Namespace_
+			|| $node instanceof Node\Stmt\TryCatch
+			|| $node instanceof Node\Stmt\While_
+		) {
+			$statements = $node->stmts ?? [];
+			$statementCount = count($statements);
+
+			if ($statementCount < 2) {
+				return null;
+			}
+
+			if (!$statements[$statementCount - 1] instanceof Node\Stmt\Throw_) {
+				return null;
+			}
+
+			if (!$statements[$statementCount - 2] instanceof Node\Stmt\If_ || $statements[$statementCount - 2]->else !== null) {
+				return null;
+			}
+
+			$if = $statements[$statementCount - 2];
+			$cond = count($if->elseifs) > 0 ? $if->elseifs[count($if->elseifs) - 1]->cond : $if->cond;
+			$cond->setAttribute(self::ATTRIBUTE_NAME, true);
 		}
 
 		return null;

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -570,6 +570,10 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 				'Instanceof between Exception and Exception will always evaluate to true.',
 				21,
 			],
+			[
+				'Instanceof between DateTime and DateTime will always evaluate to true.',
+				34,
+			],
 		]];
 	}
 

--- a/tests/PHPStan/Rules/Classes/data/impossible-instanceof-report-always-true-last-condition.php
+++ b/tests/PHPStan/Rules/Classes/data/impossible-instanceof-report-always-true-last-condition.php
@@ -25,4 +25,17 @@ class Foo
 		}
 	}
 
+	public function cloneDateTime(\DateTimeInterface $dateTime): \DateTimeImmutable
+	{
+		if ($dateTime instanceof \DateTimeImmutable) {
+			return $dateTime;
+		}
+
+		if ($dateTime instanceof \DateTime) {
+			return \DateTimeImmutable::createFromMutable($dateTime);
+		}
+
+		throw new \LogicException('Unknown class of DateTimeInterface implementation.');
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -946,18 +946,8 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->checkAlwaysTrueStrictComparison = true;
 		$this->analyse([__DIR__ . '/data/strict-comparison-enum-tips.php'], [
 			[
-				'Strict comparison using === between $this(StrictComparisonEnumTips\SomeEnum)&StrictComparisonEnumTips\SomeEnum::Two and StrictComparisonEnumTips\SomeEnum::Two will always evaluate to true.',
-				15,
-				"• Remove remaining cases below this one and this error will disappear too.\n• Use match expression instead. PHPStan will report unhandled enum cases.",
-			],
-			[
-				'Strict comparison using === between $this(StrictComparisonEnumTips\SomeEnum)&StrictComparisonEnumTips\SomeEnum::Two and StrictComparisonEnumTips\SomeEnum::Two will always evaluate to true.',
-				29,
-				'Use match expression instead. PHPStan will report unhandled enum cases.',
-			],
-			[
 				'Strict comparison using === between StrictComparisonEnumTips\SomeEnum::Two and StrictComparisonEnumTips\SomeEnum::Two will always evaluate to true.',
-				50,
+				52,
 				'Remove remaining cases below this one and this error will disappear too.',
 			],
 		]);

--- a/tests/PHPStan/Rules/Comparison/data/strict-comparison-enum-tips.php
+++ b/tests/PHPStan/Rules/Comparison/data/strict-comparison-enum-tips.php
@@ -10,6 +10,7 @@ enum SomeEnum
 
 	public function exhaustiveWithSafetyCheck(): int
 	{
+		// not reported by this rule at all
 		if ($this === self::One) {
 			return -1;
 		} elseif ($this === self::Two) {
@@ -22,6 +23,7 @@ enum SomeEnum
 
 	public function exhaustiveWithSafetyCheck2(): int
 	{
+		// not reported by this rule at all
 		if ($this === self::One) {
 			return -1;
 		}


### PR DESCRIPTION
This improves LastConditionVisitor to consider as "last condition" any `elseif` that is followed by `else` with throw statement, or any last `if/elseif` condition that is followed throw statement.

This fixes issue, where PHPStan reports error when safety checks are used. Removing the `else` branch leads to less readable and more dangerous code, rewriting to match is not always possible / practical.

```php
if ($color === Color::Red) {
  echo "red\n";

} elseif ($color === Color::Blue) { // this is currently reported as error
  echo "blue\n";

} else {
  throw new LogicException('Unexpected color');
}
```

Removing `else` branch leads to code, that will silently fail when new color is added. 

Besided enums, we are also encountering this pattern when trying to use [sealed classes](https://github.com/jiripudil/phpstan-sealed-classes)