### PR TITLE
Filtering default stub files on Windows

### DIFF
--- a/src/PhpDoc/DefaultStubFilesProvider.php
+++ b/src/PhpDoc/DefaultStubFilesProvider.php
@@ -7,6 +7,7 @@ use PHPStan\Internal\ComposerHelper;
 use function array_filter;
 use function array_values;
 use function strpos;
+use function strtr;
 
 class DefaultStubFilesProvider implements StubFilesProvider
 {
@@ -57,9 +58,12 @@ class DefaultStubFilesProvider implements StubFilesProvider
 			return $this->getStubFiles();
 		}
 
+		$vendorDir = ComposerHelper::getVendorDirFromComposerConfig($this->currentWorkingDirectory, $composerConfig);
+		$vendorDir = strtr($vendorDir, '\\', '/');
+
 		return $this->cachedProjectFiles = array_values(array_filter(
 			$this->getStubFiles(),
-			fn (string $file): bool => strpos($file, ComposerHelper::getVendorDirFromComposerConfig($this->currentWorkingDirectory, $composerConfig)) === false
+			static fn (string $file): bool => strpos(strtr($file, '\\', '/'), $vendorDir) === false
 		));
 	}
 

--- a/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
+++ b/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc;
+
+use PHPStan\Testing\PHPStanTestCase;
+use function sprintf;
+
+class DefaultStubFilesProviderTest extends PHPStanTestCase
+{
+
+	private string $currentWorkingDirectory;
+
+	protected function setUp(): void
+	{
+		$this->currentWorkingDirectory = $this->getContainer()->getParameter('currentWorkingDirectory');
+	}
+
+	public function testGetStubFiles(): void
+	{
+		$thirdPartyStubFile = sprintf('%s/vendor/thirdpartyStub.stub', $this->currentWorkingDirectory);
+		$defaultStubFilesProvider = $this->createDefaultStubFilesProvider(['/projectStub.stub', $thirdPartyStubFile]);
+		$stubFiles = $defaultStubFilesProvider->getStubFiles();
+		$this->assertContains('/projectStub.stub', $stubFiles);
+		$this->assertContains($thirdPartyStubFile, $stubFiles);
+	}
+
+	public function testGetProjectStubFiles(): void
+	{
+		$thirdPartyStubFile = sprintf('%s/vendor/thirdpartyStub.stub', $this->currentWorkingDirectory);
+		$defaultStubFilesProvider = $this->createDefaultStubFilesProvider(['/projectStub.stub', $thirdPartyStubFile]);
+		$projectStubFiles = $defaultStubFilesProvider->getProjectStubFiles();
+		$this->assertContains('/projectStub.stub', $projectStubFiles);
+		$this->assertNotContains($thirdPartyStubFile, $projectStubFiles);
+	}
+
+	public function testGetProjectStubFilesWhenPathContainsWindowsSeparator(): void
+	{
+		$thirdPartyStubFile = sprintf('%s\\vendor\\thirdpartyStub.stub', $this->currentWorkingDirectory);
+		$defaultStubFilesProvider = $this->createDefaultStubFilesProvider(['/projectStub.stub', $thirdPartyStubFile]);
+		$projectStubFiles = $defaultStubFilesProvider->getProjectStubFiles();
+		$this->assertContains('/projectStub.stub', $projectStubFiles);
+		$this->assertNotContains($thirdPartyStubFile, $projectStubFiles);
+	}
+
+	/**
+	 * @param string[] $stubFiles
+	 */
+	private function createDefaultStubFilesProvider(array $stubFiles): DefaultStubFilesProvider
+	{
+		return new DefaultStubFilesProvider($this->getContainer(), $stubFiles, $this->currentWorkingDirectory);
+	}
+
+}


### PR DESCRIPTION
`ComposerHelper::getVendorDirFromComposerConfig($this->currentWorkingDirectory, $composerConfig)`
returns path separated by `/` (`$root . '/' . trim($vendorDirectory, '/')`) and  `$composerConfig['config']['vendor-dir']` could contain both separators.

On Windows, `$this->getStubFiles()` returns paths separated by `\`. So the vendor stub files are never filtered out on Windows.

`getVendorDirFromComposerConfig` could already return it normalized but I was not brave enough to change it.