### PR TITLE
Fix ConstantArrayTypeBuilder's isList flag

### DIFF
--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -18,6 +18,7 @@ use function count;
 use function in_array;
 use function is_float;
 use function max;
+use function min;
 use function range;
 
 /** @api */
@@ -158,8 +159,9 @@ class ConstantArrayTypeBuilder
 				$this->valueTypes[] = $valueType;
 
 				if ($offsetType instanceof ConstantIntegerType) {
+					$min = min($this->nextAutoIndexes);
 					$max = max($this->nextAutoIndexes);
-					if ($offsetType->getValue() !== $max) {
+					if ($offsetType->getValue() > $min) {
 						$this->isList = false;
 					}
 					if ($offsetType->getValue() >= $max) {

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -918,4 +918,20 @@ class ReturnTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testLists(): void
+	{
+		$this->analyse([__DIR__ . '/data/return-list.php'], [
+			[
+				"Method ReturnList\Foo::getList1() should return list<string> but returns array{0?: 'foo', 1?: 'bar'}.",
+				10,
+				"array{0?: 'foo', 1?: 'bar'} is not a list.",
+			],
+			[
+				"Method ReturnList\Foo::getList2() should return list<string> but returns array{0?: 'foo', 1?: 'bar'}.",
+				19,
+				"array{0?: 'foo', 1?: 'bar'} is not a list.",
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/return-list.php
+++ b/tests/PHPStan/Rules/Methods/data/return-list.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ReturnList;
+
+class Foo
+{
+	/** @return list<string> */
+	public function getList1(): array
+	{
+		return array_filter(['foo', 'bar'], 'file_exists');
+	}
+
+	/**
+	 * @param array<int, string> $array
+	 * @return list<string>
+	 */
+	public function getList2(array $array): array
+	{
+		return array_intersect_key(['foo', 'bar'], $array);
+	}
+}

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -111,4 +111,21 @@ class ConstantArrayTypeBuilderTest extends TestCase
 		$this->assertSame('non-empty-array<string, string>', $array->describe(VerbosityLevel::precise()));
 	}
 
+	public function testIsList(): void
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		$builder->setOffsetValueType(null, new ConstantIntegerType(0));
+		$this->assertTrue($builder->isList());
+
+		$builder->setOffsetValueType(new ConstantIntegerType(0), new NullType());
+		$this->assertTrue($builder->isList());
+
+		$builder->setOffsetValueType(new ConstantIntegerType(1), new NullType(), true);
+		$this->assertTrue($builder->isList());
+
+		$builder->setOffsetValueType(new ConstantIntegerType(2), new NullType(), true);
+		$this->assertFalse($builder->isList());
+	}
+
 }


### PR DESCRIPTION
This fixes the two `inspect()` calls not being reported in this example: https://phpstan.org/r/2d082d39-0875-4947-a864-0ce2a5ffeae1

Since lists aren't described as `list{}` (yet?), creating a proper test was not so trivial, I hope it's fine like this.