### PR TITLE
Enforce magic signatures

### DIFF
--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -78,6 +78,13 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 		if ($name === '__set_state') {
 			$realReturnType = TypeCombinator::intersect(new ObjectWithoutClassType(), $realReturnType);
 		}
+		if ($name === '__set') {
+			$realReturnType = new VoidType();
+		}
+
+		if ($name === '__debuginfo') {
+			$realReturnType = TypeCombinator::addNull(new ArrayType(new MixedType(true), new MixedType(true)));
+		}
 
 		if ($name === '__unserialize') {
 			$realReturnType = new VoidType();

--- a/tests/PHPStan/Levels/data/propertyAccesses-6.json
+++ b/tests/PHPStan/Levels/data/propertyAccesses-6.json
@@ -20,11 +20,6 @@
         "ignorable": true
     },
     {
-        "message": "Method Levels\\PropertyAccesses\\ClassWithMagicMethod::__set() has no return type specified.",
-        "line": 83,
-        "ignorable": true
-    },
-    {
         "message": "Method Levels\\PropertyAccesses\\AnotherClassWithMagicMethod::doFoo() has no return type specified.",
         "line": 93,
         "ignorable": true

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -880,4 +880,42 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../Classes/data/bug-7574.php'], []);
 	}
 
+	public function testMagicSignatures(): void
+	{
+		$this->analyse([__DIR__ . '/data/magic-signatures.php'], [
+			[
+				'Method MagicSignatures\WrongSignature::__isset() should return bool but returns string.',
+				39,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__clone() with return type void returns string but should not return anything.',
+				43,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__debugInfo() should return array|null but returns string.',
+				47,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__set() with return type void returns string but should not return anything.',
+				51,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__set_state() should return object but returns string.',
+				55,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__sleep() should return array<int, string> but returns string.',
+				59,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__unset() with return type void returns string but should not return anything.',
+				63,
+			],
+			[
+				'Method MagicSignatures\WrongSignature::__wakeup() with return type void returns string but should not return anything.',
+				67,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/magic-signatures.php
+++ b/tests/PHPStan/Rules/Methods/data/magic-signatures.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MagicSignatures;
+
+class Ok {
+
+    function __isset(string $name): bool
+	{
+		return true;
+	}
+
+	function __clone(): void {}
+
+	function __debugInfo(): ?array {
+		return [];
+	}
+
+	function __set(string $name, mixed $value): void {
+	}
+
+	function __set_state(array $properties): object {
+		return new self();
+	}
+
+	function __sleep(): array {
+		return [];
+	}
+
+	function __unset(string $name): void {
+	}
+
+	function __wakeup(): void {
+	}
+}
+
+class WrongSignature {
+	function __isset(string $name)
+	{
+		return '';
+	}
+
+	function __clone() {
+		return '';
+	}
+
+	function __debugInfo() {
+		return '';
+	}
+
+	function __set(string $name, mixed $value) {
+		return '';
+	}
+
+	function __set_state(array $properties) {
+		return '';
+	}
+
+	function __sleep() {
+		return '';
+	}
+
+	function __unset(string $name) {
+		return '';
+	}
+
+	function __wakeup() {
+		return '';
+	}
+
+}


### PR DESCRIPTION
make sure all magic signatures defined in https://www.php.net/manual/en/migration80.incompatible.php are covered

followup to https://github.com/phpstan/phpstan-src/pull/2372/