### PR TITLE
Fix loose comparison against enum

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -850,7 +850,7 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\ConstantScalarType is error\\-prone and deprecated\\. Use Type\\:\\:isConstantScalarValue\\(\\) or Type\\:\\:getConstantScalarTypes\\(\\) or Type\\:\\:getConstantScalarValues\\(\\) instead\\.$#"
-			count: 4
+			count: 2
 			path: src/Type/Constant/ConstantBooleanType.php
 
 		-

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1333,7 +1333,8 @@ class InitializerExprTypeResolver
 		$floatType = new FloatType();
 
 		if (
-			(count($leftType->getEnumCases()) === 1 && count($rightType->getEnumCases()) === 1)
+			$leftType->isEnum()->yes()
+			|| $rightType->isEnum()->yes()
 			|| ($leftType->isString()->yes() && $rightType->isString()->yes())
 			|| ($integerType->isSuperTypeOf($leftType)->yes() && $integerType->isSuperTypeOf($rightType)->yes())
 			|| ($floatType->isSuperTypeOf($leftType)->yes() && $floatType->isSuperTypeOf($rightType)->yes())

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1333,8 +1333,8 @@ class InitializerExprTypeResolver
 		$floatType = new FloatType();
 
 		if (
-			$leftType->isEnum()->yes()
-			|| $rightType->isEnum()->yes()
+			($leftType->isEnum()->yes() && $rightType->isTrue()->no())
+			|| ($rightType->isEnum()->yes() && $leftType->isTrue()->no())
 			|| ($leftType->isString()->yes() && $rightType->isString()->yes())
 			|| ($integerType->isSuperTypeOf($leftType)->yes() && $integerType->isSuperTypeOf($rightType)->yes())
 			|| ($floatType->isSuperTypeOf($leftType)->yes() && $floatType->isSuperTypeOf($rightType)->yes())

--- a/src/Type/Constant/ConstantBooleanType.php
+++ b/src/Type/Constant/ConstantBooleanType.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\Constant;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
@@ -19,7 +20,9 @@ use PHPStan\Type\VerbosityLevel;
 class ConstantBooleanType extends BooleanType implements ConstantScalarType
 {
 
-	use ConstantScalarTypeTrait;
+	use ConstantScalarTypeTrait {
+		looseCompare as private scalarLooseCompare;
+	}
 
 	/** @api */
 	public function __construct(private bool $value)
@@ -125,6 +128,15 @@ class ConstantBooleanType extends BooleanType implements ConstantScalarType
 	public static function __set_state(array $properties): Type
 	{
 		return new self($properties['value']);
+	}
+
+	public function looseCompare(Type $type, PhpVersion $phpVersion): BooleanType
+	{
+		if ($type->isObject()->yes()) {
+			return $this;
+		}
+
+		return $this->scalarLooseCompare($type, $phpVersion);
 	}
 
 }

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1057,7 +1057,13 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function looseCompare(Type $type, PhpVersion $phpVersion): BooleanType
 	{
-		return new BooleanType();
+		if ($type->isTrue()->yes()) {
+			return new ConstantBooleanType(true);
+		}
+
+		return $type->isFalse()->yes()
+			? new ConstantBooleanType(false)
+			: new BooleanType();
 	}
 
 	private function isExtraOffsetAccessibleClass(): TrinaryLogic

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -80,8 +80,8 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 			|| (
 				$context->false()
 				&& (
-					count(TypeUtils::getConstantScalars($needleType)) > 0
-					|| count(TypeUtils::getEnumCaseObjects($arrayValueType)) > 0
+					count(TypeUtils::getConstantScalars($needleType)) === 1
+					|| count(TypeUtils::getEnumCaseObjects($needleType)) === 1
 				)
 			)
 		) {

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -37,17 +37,22 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		if (count($node->getArgs()) < 3) {
-			return new SpecifiedTypes();
-		}
-		$strictNodeType = $scope->getType($node->getArgs()[2]->value);
-		if (!(new ConstantBooleanType(true))->isSuperTypeOf($strictNodeType)->yes()) {
-			return new SpecifiedTypes();
+		$isStrictComparison = false;
+		if (count($node->getArgs()) >= 3) {
+			$strictNodeType = $scope->getType($node->getArgs()[2]->value);
+			$isStrictComparison = (new ConstantBooleanType(true))->isSuperTypeOf($strictNodeType)->yes();
 		}
 
 		$needleType = $scope->getType($node->getArgs()[0]->value);
 		$arrayType = $scope->getType($node->getArgs()[1]->value);
 		$arrayValueType = $arrayType->getIterableValueType();
+		$isStrictComparison = $isStrictComparison
+			|| $needleType->isEnum()->yes()
+			|| $arrayValueType->isEnum()->yes();
+
+		if (!$isStrictComparison) {
+			return new SpecifiedTypes();
+		}
 
 		$specifiedTypes = new SpecifiedTypes();
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -639,6 +639,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums-import-alias.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7176.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/in-array-enum.php');
 		}
 
 		if (PHP_VERSION_ID >= 80000) {
@@ -989,6 +990,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/constant-array-intersect.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7153.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/in-array-non-empty.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/in-array-haystack-subtract.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4117.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7490.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/remember-possibly-impure-function-values.php');

--- a/tests/PHPStan/Analyser/data/enums.php
+++ b/tests/PHPStan/Analyser/data/enums.php
@@ -284,3 +284,34 @@ class InArrayEnum
 	}
 
 }
+
+class LooseComparisonWithEnums
+{
+	public function testEquality(Foo $foo, Bar $bar, Baz $baz, string $s, int $i): void
+	{
+		assertType('true', $foo == $foo);
+		assertType('false', $foo == $bar);
+		assertType('false', $bar == $s);
+		assertType('false', $s == $bar);
+		assertType('false', $baz == $i);
+		assertType('false', $i == $baz);
+		assertType('bool', (rand() ? $bar : null) == $s);
+		assertType('bool', $s == (rand() ? $bar : null));
+		assertType('bool', (rand() ? $baz : null) == $i);
+		assertType('bool', $i == (rand() ? $baz : null));
+	}
+
+	public function testNonEquality(Foo $foo, Bar $bar, Baz $baz, string $s, int $i): void
+	{
+		assertType('false', $foo != $foo);
+		assertType('true', $foo != $bar);
+		assertType('true', $bar != $s);
+		assertType('true', $s != $bar);
+		assertType('true', $baz != $i);
+		assertType('true', $i != $baz);
+		assertType('bool', (rand() ? $bar : null) != $s);
+		assertType('bool', $s != (rand() ? $bar : null));
+		assertType('bool', (rand() ? $baz : null) != $i);
+		assertType('bool', $i != (rand() ? $baz : null));
+	}
+}

--- a/tests/PHPStan/Analyser/data/enums.php
+++ b/tests/PHPStan/Analyser/data/enums.php
@@ -287,7 +287,7 @@ class InArrayEnum
 
 class LooseComparisonWithEnums
 {
-	public function testEquality(Foo $foo, Bar $bar, Baz $baz, string $s, int $i): void
+	public function testEquality(Foo $foo, Bar $bar, Baz $baz, string $s, int $i, bool $b): void
 	{
 		assertType('true', $foo == $foo);
 		assertType('false', $foo == $bar);
@@ -295,13 +295,30 @@ class LooseComparisonWithEnums
 		assertType('false', $s == $bar);
 		assertType('false', $baz == $i);
 		assertType('false', $i == $baz);
+
+		assertType('true', true == $foo);
+		assertType('true', $foo == true);
+		assertType('false', false == $baz);
+		assertType('false', $baz == false);
+		assertType('false', null == $baz);
+		assertType('false', $baz == null);
+
+		assertType('true', Foo::ONE == true);
+		assertType('true', true == Foo::ONE);
+		assertType('false', Foo::ONE == false);
+		assertType('false', false == Foo::ONE);
+		assertType('false', null == Foo::ONE);
+		assertType('false', Foo::ONE == null);
+
 		assertType('bool', (rand() ? $bar : null) == $s);
 		assertType('bool', $s == (rand() ? $bar : null));
 		assertType('bool', (rand() ? $baz : null) == $i);
 		assertType('bool', $i == (rand() ? $baz : null));
+		assertType('bool', $foo == $b);
+		assertType('bool', $b == $foo);
 	}
 
-	public function testNonEquality(Foo $foo, Bar $bar, Baz $baz, string $s, int $i): void
+	public function testNonEquality(Foo $foo, Bar $bar, Baz $baz, string $s, int $i, bool $b): void
 	{
 		assertType('false', $foo != $foo);
 		assertType('true', $foo != $bar);
@@ -309,6 +326,21 @@ class LooseComparisonWithEnums
 		assertType('true', $s != $bar);
 		assertType('true', $baz != $i);
 		assertType('true', $i != $baz);
+
+		assertType('false', true != $foo);
+		assertType('false', $foo != true);
+		assertType('true', false != $baz);
+		assertType('true', $baz != false);
+		assertType('true', null != $baz);
+		assertType('true', $baz != null);
+
+		assertType('false', Foo::ONE != true);
+		assertType('false', true != Foo::ONE);
+		assertType('true', Foo::ONE != false);
+		assertType('true', false != Foo::ONE);
+		assertType('true', null != Foo::ONE);
+		assertType('true', Foo::ONE != null);
+
 		assertType('bool', (rand() ? $bar : null) != $s);
 		assertType('bool', $s != (rand() ? $bar : null));
 		assertType('bool', (rand() ? $baz : null) != $i);

--- a/tests/PHPStan/Analyser/data/in-array-enum.php
+++ b/tests/PHPStan/Analyser/data/in-array-enum.php
@@ -1,0 +1,58 @@
+<?php // lint >= 8.1
+
+declare(strict_types=1);
+
+namespace InArrayEnum;
+
+use function PHPStan\Testing\assertType;
+
+enum FooUnitEnum
+{
+	case A;
+	case B;
+}
+
+class Foo
+{
+
+	public function looseCheckEnumSpecifyNeedle(mixed $v): void
+	{
+		if (in_array($v, FooUnitEnum::cases())) {
+			assertType('InArrayEnum\FooUnitEnum::A|InArrayEnum\FooUnitEnum::B', $v);
+
+			if (in_array($v, ['A', null, FooUnitEnum::B])) {
+				assertType('InArrayEnum\FooUnitEnum::B', $v);
+			}
+		}
+
+	}
+
+	/** @param array<FooUnitEnum|int> $haystack */
+	public function looseCheckEnumSpecifyHaystack(array $haystack): void
+	{
+		if (! in_array(FooUnitEnum::A, $haystack)) {
+			assertType('array<InArrayEnum\FooUnitEnum::B|int>', $haystack);
+		}
+
+		if (! in_array(rand() ? FooUnitEnum::A : FooUnitEnum::B, $haystack, true)) {
+			assertType('array<InArrayEnum\FooUnitEnum|int>', $haystack);
+		}
+
+		if (! in_array(rand() ? 5 : 6, $haystack, true)) {
+			assertType('array<InArrayEnum\FooUnitEnum|int>', $haystack);
+		}
+
+		if (! in_array(rand() ? 5 : rand(), $haystack, true)) {
+			assertType('array<InArrayEnum\FooUnitEnum|int>', $haystack);
+		}
+	}
+
+	/** @param array<FooUnitEnum|string|null> $haystack */
+	public function skipUnsafeLooseComparison(?FooUnitEnum $v, array $haystack): void
+	{
+		if (in_array($v, $haystack, false)) {
+			assertType('InArrayEnum\FooUnitEnum|null', $v);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/in-array-haystack-subtract.php
+++ b/tests/PHPStan/Analyser/data/in-array-haystack-subtract.php
@@ -1,0 +1,16 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/** @param array<int> $haystack */
+	public function specifyHaystack(array $haystack): void
+	{
+		if (! in_array(rand() ? 5 : 6, $haystack, true)) {
+			assertType('array<int>', $haystack);
+		}
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -813,4 +813,56 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testLooseComparisonAgainstEnums(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/loose-comparison-against-enums.php'], [
+			[
+				'Call to function in_array() with LooseComparisonAgainstEnums\\FooUnitEnum and array{\'A\'} will always evaluate to false.',
+				21,
+			],
+			[
+				'Call to function in_array() with arguments LooseComparisonAgainstEnums\\FooUnitEnum, array{\'A\'} and false will always evaluate to false.',
+				24,
+			],
+			[
+				'Call to function in_array() with LooseComparisonAgainstEnums\\FooBackedEnum and array{\'A\'} will always evaluate to false.',
+				27,
+			],
+			[
+				'Call to function in_array() with arguments LooseComparisonAgainstEnums\\FooBackedEnum, array{\'A\'} and false will always evaluate to false.',
+				30,
+			],
+			[
+				'Call to function in_array() with arguments LooseComparisonAgainstEnums\\FooBackedEnum|LooseComparisonAgainstEnums\\FooUnitEnum, array{\'A\'} and false will always evaluate to false.',
+				33,
+			],
+			[
+				'Call to function in_array() with \'A\' and array{LooseComparisonAgainstEnums\\FooUnitEnum} will always evaluate to false.',
+				39,
+			],
+			[
+				'Call to function in_array() with arguments \'A\', array{LooseComparisonAgainstEnums\\FooUnitEnum} and false will always evaluate to false.',
+				42,
+			],
+			[
+				'Call to function in_array() with \'A\' and array{LooseComparisonAgainstEnums\\FooBackedEnum} will always evaluate to false.',
+				45,
+			],
+			[
+				'Call to function in_array() with arguments \'A\', array{LooseComparisonAgainstEnums\\FooBackedEnum} and false will always evaluate to false.',
+				48,
+			],
+			[
+				'Call to function in_array() with arguments \'A\', array{LooseComparisonAgainstEnums\\FooBackedEnum|LooseComparisonAgainstEnums\\FooUnitEnum} and false will always evaluate to false.',
+				51,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -862,6 +862,54 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				'Call to function in_array() with arguments \'A\', array{LooseComparisonAgainstEnums\\FooBackedEnum|LooseComparisonAgainstEnums\\FooUnitEnum} and false will always evaluate to false.',
 				51,
 			],
+			[
+				'Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum and array{bool} will always evaluate to false.',
+				57,
+			],
+			[
+				'Call to function in_array() with arguments LooseComparisonAgainstEnums\FooUnitEnum, array{bool} and false will always evaluate to false.',
+				60,
+			],
+			[
+				'Call to function in_array() with LooseComparisonAgainstEnums\FooBackedEnum and array{bool} will always evaluate to false.',
+				63,
+			],
+			[
+				'Call to function in_array() with arguments LooseComparisonAgainstEnums\FooBackedEnum, array{bool} and false will always evaluate to false.',
+				66,
+			],
+			[
+				'Call to function in_array() with arguments LooseComparisonAgainstEnums\FooBackedEnum|LooseComparisonAgainstEnums\FooUnitEnum, array{bool} and false will always evaluate to false.',
+				69,
+			],
+			[
+				'Call to function in_array() with bool and array{LooseComparisonAgainstEnums\FooUnitEnum} will always evaluate to false.',
+				75,
+			],
+			[
+				'Call to function in_array() with arguments bool, array{LooseComparisonAgainstEnums\FooUnitEnum} and false will always evaluate to false.',
+				78,
+			],
+			[
+				'Call to function in_array() with bool and array{LooseComparisonAgainstEnums\FooBackedEnum} will always evaluate to false.',
+				81,
+			],
+			[
+				'Call to function in_array() with arguments bool, array{LooseComparisonAgainstEnums\FooBackedEnum} and false will always evaluate to false.',
+				84,
+			],
+			[
+				'Call to function in_array() with arguments bool, array{LooseComparisonAgainstEnums\FooBackedEnum|LooseComparisonAgainstEnums\FooUnitEnum} and false will always evaluate to false.',
+				87,
+			],
+			[
+				'Call to function in_array() with LooseComparisonAgainstEnums\FooUnitEnum and array{null} will always evaluate to false.',
+				93,
+			],
+			[
+				'Call to function in_array() with null and array{LooseComparisonAgainstEnums\FooBackedEnum} will always evaluate to false.',
+				96,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/loose-comparison-against-enums.php
+++ b/tests/PHPStan/Rules/Comparison/data/loose-comparison-against-enums.php
@@ -1,0 +1,64 @@
+<?php // lint >= 8.1
+
+namespace LooseComparisonAgainstEnums;
+
+enum FooUnitEnum
+{
+	case A;
+	case B;
+}
+
+enum FooBackedEnum: string
+{
+	case A = 'A';
+	case B = 'B';
+}
+
+class InArrayTest
+{
+	public function enumVsString(FooUnitEnum $u, FooBackedEnum $b): void
+	{
+		if (in_array($u, ['A'])) {
+		}
+
+		if (in_array($u, ['A'], false)) {
+		}
+
+		if (in_array($b, ['A'])) {
+		}
+
+		if (in_array($b, ['A'], false)) {
+		}
+
+		if (in_array(rand() ? $u : $b, ['A'], false)) {
+		}
+	}
+
+	public function stringVsEnum(FooUnitEnum $u, FooBackedEnum $b): void
+	{
+		if (in_array('A', [$u])) {
+		}
+
+		if (in_array('A', [$u], false)) {
+		}
+
+		if (in_array('A', [$b])) {
+		}
+
+		if (in_array('A', [$b], false)) {
+		}
+
+		if (in_array('A', [rand() ? $u : $b], false)) {
+		}
+	}
+
+	public function nullableEnum(?FooUnitEnum $u, string $s): void
+	{
+		// null == ""
+		if (in_array($u, [$s])) {
+		}
+
+		if (in_array($s, [$u])) {
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/loose-comparison-against-enums.php
+++ b/tests/PHPStan/Rules/Comparison/data/loose-comparison-against-enums.php
@@ -52,6 +52,51 @@ class InArrayTest
 		}
 	}
 
+	public function enumVsBool(FooUnitEnum $u, FooBackedEnum $b, bool $bl): void
+	{
+		if (in_array($u, [$bl])) {
+		}
+
+		if (in_array($u, [$bl], false)) {
+		}
+
+		if (in_array($b, [$bl])) {
+		}
+
+		if (in_array($b, [$bl], false)) {
+		}
+
+		if (in_array(rand() ? $u : $b, [$bl], false)) {
+		}
+	}
+
+	public function boolVsEnum(FooUnitEnum $u, FooBackedEnum $b, bool $bl): void
+	{
+		if (in_array($bl, [$u])) {
+		}
+
+		if (in_array($bl, [$u], false)) {
+		}
+
+		if (in_array($bl, [$b])) {
+		}
+
+		if (in_array($bl, [$b], false)) {
+		}
+
+		if (in_array($bl, [rand() ? $u : $b], false)) {
+		}
+	}
+
+	public function null(FooUnitEnum $u, FooBackedEnum $b): void
+	{
+		if (in_array($u, [null])) {
+		}
+
+		if (in_array(null, [$b])) {
+		}
+	}
+
 	public function nullableEnum(?FooUnitEnum $u, string $s): void
 	{
 		// null == ""


### PR DESCRIPTION
Here is an attempt to make PHPStan understand loose comparisons with enums better.

My motivation for this is that I'm converting a bunch of "enum classes" (based on `consistence/consistence`) into native enums. And I encountered a case like this, which was not reported by PHPStan, even though it doesn't work after the conversion: `in_array($enum, ['A', 'B'])`. Previously it worked because the enum class had `__toString()` implemented.

Here are the results for a bunch of loose comparisons: https://3v4l.org/Huc7t

Note that the PHP documentation says the following:

> While identity comparison (=== and !==) can be applied to arbitrary values, the other comparison operators should only be applied to comparable values. The result of comparing incomparable values is undefined, and should not be relied upon. 

So it is possible, that what I'm trying to achieve either doesn't make sense, or may be too version dependent. However, as far as I can tell, it does not clearly specify which types are comparable.