### PR TITLE
Disable result-cache in LevelsTestCase

### DIFF
--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -213,20 +213,20 @@ class AnalyseApplication
 			$errorOutput->getStyle()->progressAdvance($allAnalysedFilesCount - $filesCount);
 		} else {
 			$startTime = null;
-			$preFileCallback = static function (string $file) use ($stdOutput, &$startTime): void {
-				$stdOutput->writeLineFormatted($file);
+			$preFileCallback = static function (string $file) use ($stdOutput, $errorOutput, &$startTime): void {
+				$errorOutput->writeLineFormatted($file);
 				$startTime = microtime(true);
 			};
 			$postFileCallback = null;
 			if ($stdOutput->isDebug()) {
 				$previousMemory = memory_get_peak_usage(true);
-				$postFileCallback = static function () use ($stdOutput, &$previousMemory, &$startTime): void {
+				$postFileCallback = static function () use ($stdOutput, $errorOutput, &$previousMemory, &$startTime): void {
 					if ($startTime === null) {
 						throw new ShouldNotHappenException();
 					}
 					$currentTotalMemory = memory_get_peak_usage(true);
 					$elapsedTime = microtime(true) - $startTime;
-					$stdOutput->writeLineFormatted(sprintf('--- consumed %s, total %s, took %.2f s', BytesHelper::bytes($currentTotalMemory - $previousMemory), BytesHelper::bytes($currentTotalMemory), $elapsedTime));
+					$errorOutput->writeLineFormatted(sprintf('--- consumed %s, total %s, took %.2f s', BytesHelper::bytes($currentTotalMemory - $previousMemory), BytesHelper::bytes($currentTotalMemory), $elapsedTime));
 					$previousMemory = $currentTotalMemory;
 				};
 			}

--- a/src/Testing/LevelsTestCase.php
+++ b/src/Testing/LevelsTestCase.php
@@ -63,14 +63,9 @@ abstract class LevelsTestCase extends TestCase
 
 		$exceptions = [];
 
-		exec(sprintf('%s %s clear-result-cache %s 2>&1', escapeshellarg(PHP_BINARY), $command, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : ''), $clearResultCacheOutputLines, $clearResultCacheExitCode);
-		if ($clearResultCacheExitCode !== 0) {
-			throw new ShouldNotHappenException('Could not clear result cache: ' . implode("\n", $clearResultCacheOutputLines));
-		}
-
 		foreach (range(0, 9) as $level) {
 			unset($outputLines);
-			exec(sprintf('%s %s analyse --no-progress --error-format=prettyJson --level=%d %s %s %s', escapeshellarg(PHP_BINARY), $command, $level, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : '', $this->shouldAutoloadAnalysedFile() ? sprintf('--autoload-file %s', escapeshellarg($file)) : '', escapeshellarg($file)), $outputLines);
+			exec(sprintf('%s %s analyse --debug --no-progress --error-format=prettyJson --level=%d %s %s %s', escapeshellarg(PHP_BINARY), $command, $level, $configPath !== null ? '--configuration ' . escapeshellarg($configPath) : '', $this->shouldAutoloadAnalysedFile() ? sprintf('--autoload-file %s', escapeshellarg($file)) : '', escapeshellarg($file)), $outputLines);
 
 			$output = implode("\n", $outputLines);
 


### PR DESCRIPTION
The Rule Levels tests are pretty slow. its the slowest part of the CI pipline at.

Before this PR, it takes about 11m30s to run Rule Levels in CI.

Instead of writing and clearing the result cache, use `--debug` instead which prevents usage of the result cache

----

I have reduced the test locally to short the feedback loop for the change:

After the PR:
```
➜  phpstan-src git:(1.10.x) ✗ time make tests-levels
php vendor/bin/paratest --runner WrapperRunner --no-coverage --group levels
ParaTest v6.6.3 upon PHPUnit 9.5.23 #StandWithUkraine

..                                                                  2 / 2 (100%)

Time: 00:31.752, Memory: 44.00 MB

OK (2 tests, 52 assertions)
make tests-levels  28.26s user 3.87s system 101% cpu 31.788 total          ##  After
```

Before the PR
```
➜  phpstan-src git:(debug-levels) ✗ time make tests-levels
php vendor/bin/paratest --runner WrapperRunner --no-coverage --group levels
ParaTest v6.6.3 upon PHPUnit 9.5.23 #StandWithUkraine

..                                                                  2 / 2 (100%)

Time: 00:39.511, Memory: 54.00 MB

OK (2 tests, 52 assertions)
make tests-levels  32.79s user 6.68s system 99% cpu 39.562 total    ## Before
```


I think its now ~30% faster