### PR TITLE
Run Rules-Tests in 2 parallel CI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,6 +135,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
+    strategy:
+      fail-fast: false
+      matrix:
+        test-class: [ 'tests/PHPStan/Levels/LevelsIntegrationTest.php', 'tests/PHPStan/Generics/GenericsIntegrationTest.php' ]
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3
@@ -153,7 +158,7 @@ jobs:
         run: "composer install --no-interaction --no-progress"
 
       - name: "Tests"
-        run: "make tests-levels"
+        run: "php vendor/bin/paratest --runner WrapperRunner --no-coverage ${{ matrix.test-class }} --group levels"
 
   tests-old-phpunit:
     name: "Tests with old PHPUnit"


### PR DESCRIPTION
The Rule Levels tests are pretty slow. its the slowest part of the CI pipline atm.

try running them in parallel to shorten the feedback loop.