### PR TITLE
Run integration tests on PHP 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.1"
+          php-version: "8.2"
           tools: pecl
           extensions: ds,mbstring
           ini-file: development
@@ -143,7 +143,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.1"
+          php-version: "8.2"
           tools: pecl
           extensions: ds,mbstring
           ini-file: development
@@ -188,7 +188,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.1"
+          php-version: "8.2"
           extensions: mbstring, intl
 
       - name: "Rector downgrade cache key"


### PR DESCRIPTION
Another try at getting a faster feedback loop.

_edit: I think the PR title is not 100% accurate. the php version changed is the one used to transform the phpstan codebase, before the actual tests run for some jobs._