### PR TITLE
Avoid circular reference of issue #9039

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -88,6 +88,7 @@ parameters:
 			count: 1
 			path: ../src/Command/CommandHelper.php
 		- '#^Parameter \#1 \$offsetType of class PHPStan\\Type\\Accessory\\HasOffsetType constructor expects PHPStan\\Type\\Constant\\ConstantIntegerType\|PHPStan\\Type\\Constant\\ConstantStringType#'
+		- '#^Short ternary operator is not allowed#'
 	reportStaticMethodSignatures: true
 	tmpDir: %rootDir%/tmp
 	stubFiles:

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -1046,9 +1046,13 @@ class TypeNodeResolver
 				return new EnumCaseObjectType($classReflection->getName(), $constantName);
 			}
 
-			$reflectionConstant = $classReflection->getConstant($constantName);
+			$reflectionConstant = $classReflection->getNativeReflection()->getReflectionConstant($constantName);
+			if ($reflectionConstant === false) {
+				return new ErrorType();
+			}
+			$declaringClass = $reflectionConstant->getDeclaringClass();
 
-			return $this->initializerExprTypeResolver->getType($reflectionConstant->getValueExpr(), InitializerExprContext::fromClassReflection($reflectionConstant->getDeclaringClass()));
+			return $this->initializerExprTypeResolver->getType($reflectionConstant->getValueExpression(), InitializerExprContext::fromClass($declaringClass->getName(), $declaringClass->getFileName() ?: null));
 		}
 
 		if ($constExpr instanceof ConstExprFloatNode) {

--- a/src/Reflection/InitializerExprContext.php
+++ b/src/Reflection/InitializerExprContext.php
@@ -55,10 +55,13 @@ class InitializerExprContext implements NamespaceAnswerer
 
 	public static function fromClassReflection(ClassReflection $classReflection): self
 	{
-		$className = $classReflection->getName();
+		return self::fromClass($classReflection->getName(), $classReflection->getFileName());
+	}
 
+	public static function fromClass(string $className, ?string $fileName): self
+	{
 		return new self(
-			$classReflection->getFileName(),
+			$fileName,
 			self::parseNamespace($className),
 			$className,
 			null,

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1191,6 +1191,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame(10, $errors[0]->getLine());
 	}
 
+	public function testBug9039(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9039.php');
+		$this->assertCount(1, $errors);
+		$this->assertSame('Constant Bug9039\Test::RULES is unused.', $errors[0]->getMessage());
+	}
+
 	public function testDiscussion9053(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Analyser/data/bug-9039.php
+++ b/tests/PHPStan/Analyser/data/bug-9039.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9039;
+
+/**
+ * @template T
+ */
+class Voter
+{
+}
+
+/**
+ * @template-extends Voter<self::*>
+ */
+class Test extends Voter
+{
+	public const FOO = 'Foo';
+	private const RULES = [self::FOO];
+}


### PR DESCRIPTION
This close https://github.com/phpstan/phpstan/issues/9039 but maybe you'll want another strategy @ondrejmirtes (and have one in mind).

I tried to copy the `CircularTypeAliasDefinitionException`.

There is the following issue:
The first time we're calling `ClassReflection::getParentClass`, we doing:
- `ClassReflection::getFirstExtendsTag`
- `ClassReflection::getExtendsTags`
-  ... We trying to solve `@template-extends Voter<self::*>` so we're solving the constant ...
- `ClassReflection::getConstant`
- `PhpDocInheritanceResolver::resolvePhpDocForConstant`
- ... We trying to solve the FOO constant by looking at the parent classes phpdoc
- `PhpDocBlock:: getParentReflections`
- `ClassReflection::getParentClass`
- And then again we're looking for extends tags...

What's annoying here is the fact that there is no need to look at the generic when resolving the parent phpdoc for the constant since it doesn't exist in the parent. So resolving the `extends` tag is not needed what's why try catching the circular reference is doing the job.

