### PR TITLE
fix enum type subtracting

### DIFF
--- a/build/enums.neon
+++ b/build/enums.neon
@@ -2,6 +2,7 @@ parameters:
 	excludePaths:
 		- ../tests/PHPStan/Fixture/TestEnum.php
 		- ../tests/PHPStan/Fixture/AnotherTestEnum.php
+		- ../tests/PHPStan/Fixture/ManyCasesTestEnum.php
 
 	ignoreErrors:
 		-

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -50,7 +50,6 @@ use Throwable;
 use Traversable;
 use function array_key_exists;
 use function array_map;
-use function array_merge;
 use function array_values;
 use function count;
 use function implode;
@@ -1339,10 +1338,6 @@ class ObjectType implements TypeWithClassName, SubtractableType
 				$subtractedSubTypes = [];
 
 				$subtractedTypesList = TypeUtils::flattenTypes($subtractedType);
-				if ($this->subtractedType !== null) {
-					$subtractedTypesList = array_merge($subtractedTypesList, TypeUtils::flattenTypes($this->subtractedType));
-				}
-
 				$subtractedTypes = [];
 				foreach ($subtractedTypesList as $type) {
 					$subtractedTypes[$type->describe(VerbosityLevel::precise())] = $type;

--- a/tests/PHPStan/Fixture/ManyCasesTestEnum.php
+++ b/tests/PHPStan/Fixture/ManyCasesTestEnum.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace PHPStan\Fixture;
+
+enum ManyCasesTestEnum
+{
+
+	case A;
+	case B;
+	case C;
+	case D;
+	case E;
+	case F;
+
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2151,6 +2151,18 @@ class TypeCombinatorTest extends PHPStanTestCase
 
 		yield [
 			[
+				new ObjectType('PHPStan\Fixture\ManyCasesTestEnum', new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
+				])),
+				new ObjectType('PHPStan\Fixture\ManyCasesTestEnum', new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A')),
+			],
+			ObjectType::class,
+			'PHPStan\Fixture\ManyCasesTestEnum~PHPStan\Fixture\ManyCasesTestEnum::A',
+		];
+
+		yield [
+			[
 				new ThisType(
 					$reflectionProvider->getClass(\ThisSubtractable\Foo::class), // phpcs:ignore
 					new UnionType([new ObjectType(\ThisSubtractable\Bar::class), new ObjectType(\ThisSubtractable\Baz::class)]), // phpcs:ignore


### PR DESCRIPTION
It seems that enum type subtracting doesn't work correctly in some cases. See https://phpstan.org/r/ed7bac55-878e-4ecd-b1b6-6fbba5959741 PHPStan shouldn't complain about the second nested if.

I played around with it in a debugger and this is what I came up with. I checked the usages of `changeSubtractedType` and I wasn't able to figure out why considering `$this->subtractedType` would be necessary/correct. But my knowledge of PHPStan internals is very limited, so it's quite possible that I missed something.

In either case, I'm hoping that at least the test will be useful.