### PR TITLE
Union of enum cases accepts the enum class type with negated cases

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -174,6 +174,13 @@ class UnionType implements CompoundType
 			return $result->or($type->isAcceptedWithReasonBy($this, $strictTypes));
 		}
 
+		if ($type->isEnum()->yes() && !$this->isEnum()->no()) {
+			$enumCasesUnion = TypeCombinator::union(...$type->getEnumCases());
+			if (!$type->equals($enumCasesUnion)) {
+				return $this->acceptsWithReason($enumCasesUnion, $strictTypes);
+			}
+		}
+
 		return $result;
 	}
 

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -224,4 +224,11 @@ class ReturnTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8846(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkNullables = true;
+		$this->analyse([__DIR__ . '/data/bug-8846.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-8846.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8846.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8846;
+
+use Exception;
+
+enum Foo
+{
+	case ONE;
+	case TWO;
+	case THREE;
+}
+
+/**
+ * @param Foo $foo
+ * @return Foo::TWO|Foo::THREE
+ */
+function test(Foo $foo): Foo
+{
+	if ($foo === Foo::ONE) {
+		throw new Exception();
+	}
+	return $foo;
+}

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -1066,6 +1066,21 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				TrinaryLogic::createYes(),
 			];
+
+			yield [
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
+					new NullType(),
+				]),
+				new UnionType([
+					new ObjectType(
+						'PHPStan\Fixture\TestEnum',
+						new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'TWO'),
+					),
+					new NullType(),
+				]),
+				TrinaryLogic::createYes(),
+			];
 		}
 
 		yield from [

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -6,6 +6,9 @@ use DateTime;
 use DateTimeImmutable;
 use Exception;
 use Iterator;
+use PHPStan\Fixture\AnotherTestEnum;
+use PHPStan\Fixture\ManyCasesTestEnum;
+use PHPStan\Fixture\TestEnum;
 use PHPStan\Reflection\Native\NativeParameterReflection;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\Testing\PHPStanTestCase;
@@ -21,6 +24,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
@@ -1182,6 +1186,63 @@ class UnionTypeTest extends PHPStanTestCase
 					),
 					new ObjectType('Countable'),
 				]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new UnionType([
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'A'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'B'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'C'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'D'),
+				]),
+				new ObjectType(
+					ManyCasesTestEnum::class,
+					new UnionType([
+						new EnumCaseObjectType(ManyCasesTestEnum::class, 'E'),
+						new EnumCaseObjectType(ManyCasesTestEnum::class, 'F'),
+					]),
+				),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new UnionType([
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'A'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'B'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'C'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'D'),
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'E'),
+				]),
+				new ObjectType(
+					ManyCasesTestEnum::class,
+					new EnumCaseObjectType(ManyCasesTestEnum::class, 'F'),
+				),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new UnionType([
+					new EnumCaseObjectType(TestEnum::class, 'ONE'),
+					new EnumCaseObjectType(TestEnum::class, 'TWO'),
+				]),
+				new ObjectType(TestEnum::class),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new UnionType([
+					new EnumCaseObjectType(TestEnum::class, 'ONE'),
+					new EnumCaseObjectType(AnotherTestEnum::class, 'TWO'),
+				]),
+				new ObjectType(TestEnum::class),
+				TrinaryLogic::createMaybe(),
+			],
+			[
+				new UnionType([
+					new EnumCaseObjectType(TestEnum::class, 'ONE'),
+					new NullType(),
+				]),
+				new ObjectType(
+					TestEnum::class,
+					new EnumCaseObjectType(TestEnum::class, 'TWO'),
+				),
 				TrinaryLogic::createYes(),
 			],
 

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -1001,6 +1001,74 @@ class UnionTypeTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), false),
 				TrinaryLogic::createYes(),
 			],
+
+		];
+
+		if (PHP_VERSION_ID >= 80100) {
+			yield [
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'C'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'D'),
+				]),
+				new ObjectType(
+					'PHPStan\Fixture\ManyCasesTestEnum',
+					new UnionType([
+						new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'E'),
+						new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'F'),
+					]),
+				),
+				TrinaryLogic::createYes(),
+			];
+
+			yield [
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'C'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'D'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'E'),
+				]),
+				new ObjectType(
+					'PHPStan\Fixture\ManyCasesTestEnum',
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'F'),
+				),
+				TrinaryLogic::createYes(),
+			];
+
+			yield [
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
+					new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'TWO'),
+				]),
+				new ObjectType('PHPStan\Fixture\TestEnum'),
+				TrinaryLogic::createYes(),
+			];
+
+			yield [
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
+					new EnumCaseObjectType('PHPStan\Fixture\AnotherTestEnum', 'TWO'),
+				]),
+				new ObjectType('PHPStan\Fixture\TestEnum'),
+				TrinaryLogic::createMaybe(),
+			];
+
+			yield [
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
+					new NullType(),
+				]),
+				new ObjectType(
+					'PHPStan\Fixture\TestEnum',
+					new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'TWO'),
+				),
+				TrinaryLogic::createYes(),
+			];
+		}
+
+		yield from [
 			'accepts template-of-union with same members' => [
 				new UnionType([
 					new IntegerType(),
@@ -1186,73 +1254,6 @@ class UnionTypeTest extends PHPStanTestCase
 				]),
 				TrinaryLogic::createYes(),
 			],
-
-		];
-
-		if (PHP_VERSION_ID < 80100) {
-			return;
-		}
-
-		yield [
-			new UnionType([
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'C'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'D'),
-			]),
-			new ObjectType(
-				'PHPStan\Fixture\ManyCasesTestEnum',
-				new UnionType([
-					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'E'),
-					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'F'),
-				]),
-			),
-			TrinaryLogic::createYes(),
-		];
-
-		yield [
-			new UnionType([
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'C'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'D'),
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'E'),
-			]),
-			new ObjectType(
-				'PHPStan\Fixture\ManyCasesTestEnum',
-				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'F'),
-			),
-			TrinaryLogic::createYes(),
-		];
-
-		yield [
-			new UnionType([
-				new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
-				new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'TWO'),
-			]),
-			new ObjectType('PHPStan\Fixture\TestEnum'),
-			TrinaryLogic::createYes(),
-		];
-
-		yield [
-			new UnionType([
-				new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
-				new EnumCaseObjectType('PHPStan\Fixture\AnotherTestEnum', 'TWO'),
-			]),
-			new ObjectType('PHPStan\Fixture\TestEnum'),
-			TrinaryLogic::createMaybe(),
-		];
-
-		yield [
-			new UnionType([
-				new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'ONE'),
-				new NullType(),
-			]),
-			new ObjectType(
-				'PHPStan\Fixture\TestEnum',
-				new EnumCaseObjectType('PHPStan\Fixture\TestEnum', 'TWO'),
-			),
-			TrinaryLogic::createYes(),
 		];
 	}
 


### PR DESCRIPTION
This PR changes the result of removing an enum case from its class.

```php
enum TestEnum
{
    case A;
    case B;
    case C;
}

function test(TestEnum $enum): void
{
    if ($enum !== TestEnum::A) {
        \PHPStan\dumpType($enum);
    }
}
```
 - Before: `TestEnum~TestEnum::A`
 - After: `TestEnum::B|TestEnum::C`

Closes phpstan/phpstan#8846