### PR TITLE
Add a way to create a RuleLevelHelper in tests

### DIFF
--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -25,6 +25,7 @@ use PHPStan\Rules\Properties\DirectReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtension;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\FileTypeMapper;
 use function array_map;
 use function count;
@@ -64,6 +65,27 @@ abstract class RuleTestCase extends PHPStanTestCase
 	protected function getTypeSpecifier(): TypeSpecifier
 	{
 		return self::getContainer()->getService('typeSpecifier');
+	}
+
+	final protected function getRuleLevelHelper(
+		bool $checkNullables = false,
+		bool $checkThisOnly = false,
+		bool $checkUnionTypes = false,
+		bool $checkExplicitMixed = false,
+		bool $checkImplicitMixed = false,
+		bool $newRuleLevelHelper = false,
+		bool $checkBenevolentUnionTypes = false,
+	): RuleLevelHelper {
+		return new RuleLevelHelper(
+			self::createReflectionProvider(),
+			$checkNullables,
+			$checkThisOnly,
+			$checkUnionTypes,
+			$checkExplicitMixed,
+			$checkImplicitMixed,
+			$newRuleLevelHelper,
+			$checkBenevolentUnionTypes,
+		);
 	}
 
 	private function getAnalyser(): Analyser


### PR DESCRIPTION
Hi,

The `RuleLevelHelper::construct()` method is not covered by Backward compatibility.
If I write my own PHPStan custom rule, I can inject the RuleLevelHelper in the constructor,
but then, in tests, I'll need to write something like this:
https://github.com/phpstan/phpstan-src/blob/1.11.x/tests/PHPStan/Rules/Cast/EchoRuleTest.php#L16-L21

What could be great, would be to provide a `getRuleLevelHelper` method which allow to avoid writing `new RuleLevelHelper()` in my code base. It's just a default RuleLevelHelper with every config check configurable.
If later a new param `checkSomething` is added, it's just needed to add it with a default value and it won't change anything for the users of this method.

WDYT about it @ondrejmirtes ?