### PR TITLE
Minor refinements to MutatingScope empty() and typehint helper.

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -725,14 +725,7 @@ class MutatingScope implements Scope
 				}
 
 				if ($isNull->yes()) {
-					if ($isFalsey->yes()) {
-						return false;
-					}
-					if ($isFalsey->no()) {
-						return true;
-					}
-
-					return false;
+					return $isFalsey->no();
 				}
 
 				return !$isFalsey->yes();

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -132,22 +132,18 @@ class TypehintHelper
 		}
 
 		$reflectionTypeString = $reflectionType->getName();
-		if (str_ends_with(strtolower($reflectionTypeString), '\\object')) {
+		$loweredReflectionTypeString = strtolower($reflectionTypeString);
+		if (str_ends_with($loweredReflectionTypeString, '\\object')) {
 			$reflectionTypeString = 'object';
-		}
-		if (str_ends_with(strtolower($reflectionTypeString), '\\mixed')) {
+		} elseif (str_ends_with($loweredReflectionTypeString, '\\mixed')) {
 			$reflectionTypeString = 'mixed';
-		}
-		if (str_ends_with(strtolower($reflectionTypeString), '\\true')) {
+		} elseif (str_ends_with($loweredReflectionTypeString, '\\true')) {
 			$reflectionTypeString = 'true';
-		}
-		if (str_ends_with(strtolower($reflectionTypeString), '\\false')) {
+		} elseif (str_ends_with($loweredReflectionTypeString, '\\false')) {
 			$reflectionTypeString = 'false';
-		}
-		if (str_ends_with(strtolower($reflectionTypeString), '\\null')) {
+		} elseif (str_ends_with($loweredReflectionTypeString, '\\null')) {
 			$reflectionTypeString = 'null';
-		}
-		if (str_ends_with(strtolower($reflectionTypeString), '\\never')) {
+		} elseif (str_ends_with($loweredReflectionTypeString, '\\never')) {
 			$reflectionTypeString = 'never';
 		}
 


### PR DESCRIPTION
a simplification to MutatingScope `empty()` handling

and a micro-optimization in `TypehintHelper` to prevent multiple calls to `strtolower` and prevent checking mutually exclusive cases when a match is already found 