### PR TITLE
Add non-zero int type

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -196,6 +196,12 @@ class TypeNodeResolver
 			case 'non-negative-int':
 				return IntegerRangeType::fromInterval(0, null);
 
+			case 'non-zero-int':
+				return new UnionType([
+					IntegerRangeType::fromInterval(null, -1),
+					IntegerRangeType::fromInterval(1, null)
+				]);
+
 			case 'string':
 			case 'lowercase-string':
 				return new StringType();

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -199,7 +199,7 @@ class TypeNodeResolver
 			case 'non-zero-int':
 				return new UnionType([
 					IntegerRangeType::fromInterval(null, -1),
-					IntegerRangeType::fromInterval(1, null)
+					IntegerRangeType::fromInterval(1, null),
 				]);
 
 			case 'string':


### PR DESCRIPTION
For integers and floats that are used as divisors, a non-zero integer/float has to be used. This was easy to implement with integer ranges, but not easy for float ranges. How could we add that?