### PR TITLE
Catch implicit type conversions

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -82,6 +82,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantTypeHelper;
 use PHPStan\Type\DynamicReturnTypeExtensionRegistry;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\FloatType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
@@ -678,19 +679,59 @@ class MutatingScope implements Scope
 		}
 
 		if ($node instanceof Expr\BinaryOp\Smaller) {
-			return $this->getType($node->left)->isSmallerThan($this->getType($node->right))->toBooleanType();
+			$leftType = $this->getType($node->left);
+			$rightType = $this->getType($node->right);
+
+			$integerType = new IntegerType();
+			$floatType = new FloatType();
+			if ((($integerType->isSuperTypeOf($leftType)->yes() || $floatType->isSuperTypeOf($leftType)->yes()) && $rightType->isObject()->yes()) ||
+				(($integerType->isSuperTypeOf($rightType)->yes() || $floatType->isSuperTypeOf($rightType)->yes()) && $leftType->isObject()->yes())) {
+				return new ErrorType();
+			}
+
+			return $this->initializerExprTypeResolver->resolveSmallerType($leftType, $rightType);
 		}
 
 		if ($node instanceof Expr\BinaryOp\SmallerOrEqual) {
-			return $this->getType($node->left)->isSmallerThanOrEqual($this->getType($node->right))->toBooleanType();
+			$leftType = $this->getType($node->left);
+			$rightType = $this->getType($node->right);
+
+			$integerType = new IntegerType();
+			$floatType = new FloatType();
+			if ((($integerType->isSuperTypeOf($leftType)->yes() || $floatType->isSuperTypeOf($leftType)->yes()) && $rightType->isObject()->yes()) ||
+				(($integerType->isSuperTypeOf($rightType)->yes() || $floatType->isSuperTypeOf($rightType)->yes()) && $leftType->isObject()->yes())) {
+				return new ErrorType();
+			}
+
+			return $this->initializerExprTypeResolver->resolveSmallerOrEqualType($leftType, $rightType);
 		}
 
 		if ($node instanceof Expr\BinaryOp\Greater) {
-			return $this->getType($node->right)->isSmallerThan($this->getType($node->left))->toBooleanType();
+			$leftType = $this->getType($node->left);
+			$rightType = $this->getType($node->right);
+
+			$integerType = new IntegerType();
+			$floatType = new FloatType();
+			if ((($integerType->isSuperTypeOf($leftType)->yes() || $floatType->isSuperTypeOf($leftType)->yes()) && $rightType->isObject()->yes()) ||
+				(($integerType->isSuperTypeOf($rightType)->yes() || $floatType->isSuperTypeOf($rightType)->yes()) && $leftType->isObject()->yes())) {
+				return new ErrorType();
+			}
+
+			return $this->initializerExprTypeResolver->resolveGreaterType($leftType, $rightType);
 		}
 
 		if ($node instanceof Expr\BinaryOp\GreaterOrEqual) {
-			return $this->getType($node->right)->isSmallerThanOrEqual($this->getType($node->left))->toBooleanType();
+			$leftType = $this->getType($node->left);
+			$rightType = $this->getType($node->right);
+
+			$integerType = new IntegerType();
+			$floatType = new FloatType();
+			if ((($integerType->isSuperTypeOf($leftType)->yes() || $floatType->isSuperTypeOf($leftType)->yes()) && $rightType->isObject()->yes()) ||
+				(($integerType->isSuperTypeOf($rightType)->yes() || $floatType->isSuperTypeOf($rightType)->yes()) && $leftType->isObject()->yes())) {
+				return new ErrorType();
+			}
+
+			return $this->initializerExprTypeResolver->resolveGreaterOrEqualType($leftType, $rightType);
 		}
 
 		if ($node instanceof Expr\BinaryOp\Equal) {
@@ -711,6 +752,16 @@ class MutatingScope implements Scope
 		}
 
 		if ($node instanceof Expr\BinaryOp\NotEqual) {
+			$leftType = $this->getType($node->left);
+			$rightType = $this->getType($node->right);
+
+			$integerType = new IntegerType();
+			$floatType = new FloatType();
+			if ((($integerType->isSuperTypeOf($leftType)->yes() || $floatType->isSuperTypeOf($leftType)->yes()) && $rightType->isObject()->yes()) ||
+				(($integerType->isSuperTypeOf($rightType)->yes() || $floatType->isSuperTypeOf($rightType)->yes()) && $leftType->isObject()->yes())) {
+				return new ErrorType();
+			}
+
 			return $this->getType(new Expr\BooleanNot(new BinaryOp\Equal($node->left, $node->right)));
 		}
 

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -816,10 +816,10 @@ class InitializerExprTypeResolver
 		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
 			$resultTypes = [];
 			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
-			foreach ($leftTypes as $leftType) {
-				foreach ($rightTypes as $rightType) {
-					$leftValue = $leftType->getValue();
-					$rightValue = $rightType->getValue();
+			foreach ($leftTypes as $leftTypeInner) {
+				foreach ($rightTypes as $rightTypeInner) {
+					$leftValue = $leftTypeInner->getValue();
+					$rightValue = $rightTypeInner->getValue();
 					$resultType = $this->getTypeFromValue($leftValue <=> $rightValue);
 					if ($generalize) {
 						$resultType = $resultType->generalize(GeneralizePrecision::lessSpecific());
@@ -1470,7 +1470,7 @@ class InitializerExprTypeResolver
 		}
 
 		if ($leftType instanceof ConstantArrayType && $rightType instanceof ConstantArrayType) {
-			return $this->resolveConstantArrayTypeComparison($leftType, $rightType, fn ($leftValueType, $rightValueType): BooleanType => $this->resolveEqualType($leftValueType, $rightValueType));
+			return $this->resolveConstantArrayTypeComparison($leftType, $rightType, fn ($leftValueType, $rightValueType): Type => $this->resolveEqualType($leftValueType, $rightValueType));
 		}
 
 		return $leftType->looseCompare($rightType, $this->phpVersion);
@@ -1497,7 +1497,7 @@ class InitializerExprTypeResolver
 	}
 
 	/**
-	 * @param callable(Type, Type): BooleanType $valueComparisonCallback
+	 * @param callable(Type, Type): Type $valueComparisonCallback
 	 */
 	private function resolveConstantArrayTypeComparison(ConstantArrayType $leftType, ConstantArrayType $rightType, callable $valueComparisonCallback): BooleanType
 	{

--- a/src/Rules/Operators/InvalidBinaryOperationRule.php
+++ b/src/Rules/Operators/InvalidBinaryOperationRule.php
@@ -121,14 +121,28 @@ class InvalidBinaryOperationRule implements Rule
 						if (!($node instanceof Node\Expr\BinaryOp\Mod &&
 							($rightType instanceof ConstantIntegerType && $rightType->getValue() === 0))
 						) {
-							$nodeType = match (get_class($node)) {
-								Node\Expr\BinaryOp\BitwiseAnd::class => 'bitwiseAnd',
-								Node\Expr\BinaryOp\BitwiseOr::class => 'bitwiseOr',
-								Node\Expr\BinaryOp\BitwiseXor::class => 'bitwiseXor',
-								Node\Expr\BinaryOp\Mod::class => 'mod',
-								Node\Expr\BinaryOp\ShiftLeft::class => 'shiftLeft',
-								Node\Expr\BinaryOp\ShiftRight::class => 'shiftRight',
-							};
+							switch (get_class($node)) {
+								case Node\Expr\BinaryOp\BitwiseAnd::class:
+									$nodeType = 'bitwiseAnd';
+									break;
+								case Node\Expr\BinaryOp\BitwiseOr::class:
+									$nodeType = 'bitwiseOr';
+									break;
+								case Node\Expr\BinaryOp\BitwiseXor::class:
+									$nodeType = 'bitwiseXor';
+									break;
+								case Node\Expr\BinaryOp\Mod::class:
+									$nodeType = 'mod';
+									break;
+								case Node\Expr\BinaryOp\ShiftLeft::class:
+									$nodeType = 'shiftLeft';
+									break;
+								case Node\Expr\BinaryOp\ShiftRight::class:
+									$nodeType = 'shiftRight';
+									break;
+								default:
+									throw new ShouldNotHappenException();
+							}
 							return [
 								RuleErrorBuilder::message(sprintf(
 									'Deprecated in PHP 8.1: Implicit conversion from %s to %s loses precision.',

--- a/src/Type/ExponentiateHelper.php
+++ b/src/Type/ExponentiateHelper.php
@@ -6,6 +6,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use function is_float;
 use function is_int;
+use function is_numeric;
 
 final class ExponentiateHelper
 {
@@ -82,11 +83,14 @@ final class ExponentiateHelper
 		if ($exponent instanceof IntegerRangeType) {
 			$min = null;
 			$max = null;
-			if ($exponent->getMin() !== null) {
-				$min = $base->getValue() ** $exponent->getMin();
-			}
-			if ($exponent->getMax() !== null) {
-				$max = $base->getValue() ** $exponent->getMax();
+			$value = $base->getValue();
+			if (is_numeric($value)) {
+				if ($exponent->getMin() !== null) {
+					$min = $value ** $exponent->getMin();
+				}
+				if ($exponent->getMax() !== null) {
+					$max = $value ** $exponent->getMax();
+				}
 			}
 
 			if (!is_float($min) && !is_float($max)) {
@@ -95,11 +99,15 @@ final class ExponentiateHelper
 		}
 
 		if ($exponent instanceof ConstantScalarType) {
-			$result = $base->getValue() ** $exponent->getValue();
-			if (is_int($result)) {
-				return new ConstantIntegerType($result);
+			$baseValue = $base->getValue();
+			$exponentValue = $exponent->getValue();
+			if (is_numeric($baseValue) && is_numeric($exponentValue)) {
+				$result = $baseValue ** $exponentValue;
+				if (is_int($result)) {
+					return new ConstantIntegerType($result);
+				}
+				return new ConstantFloatType($result);
 			}
-			return new ConstantFloatType($result);
 		}
 
 		return null;

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -2036,7 +2036,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'1.2 ** 1.4',
 			],
 			[
-				'1',
+				'*ERROR*',
 				'3.2 % 2.4',
 			],
 			[
@@ -2069,7 +2069,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'1 ** 1.4',
 			],
 			[
-				'1',
+				'*ERROR*',
 				'3 % 2.4',
 			],
 			[
@@ -2118,11 +2118,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$integer ** $integer',
 			],
 			[
-				'1',
+				'*ERROR*',
 				'3.2 % 2',
 			],
 			[
-				'int',
+				'*ERROR*',
 				'$float %= 2.4',
 			],
 			[
@@ -2444,11 +2444,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$string .= "str"',
 			],
 			[
-				'int',
+				'*ERROR*',
 				'$integer <<= 2.2',
 			],
 			[
-				'int',
+				'*ERROR*',
 				'$float >>= 2.2',
 			],
 			[

--- a/tests/PHPStan/Analyser/data/enums.php
+++ b/tests/PHPStan/Analyser/data/enums.php
@@ -324,8 +324,8 @@ class LooseComparisonWithEnums
 		assertType('true', $foo != $bar);
 		assertType('true', $bar != $s);
 		assertType('true', $s != $bar);
-		assertType('true', $baz != $i);
-		assertType('true', $i != $baz);
+		assertType('*ERROR*', $baz != $i);
+		assertType('*ERROR*', $i != $baz);
 
 		assertType('false', true != $foo);
 		assertType('false', $foo != true);

--- a/tests/PHPStan/Analyser/data/modulo-operator.php
+++ b/tests/PHPStan/Analyser/data/modulo-operator.php
@@ -54,7 +54,7 @@ class Foo
 		assertType('0', 0 % '1');
 		assertType('0', 1 % '1');
 		assertType('0', '1' % '1');
-		assertType('0', 1.24 % '1');
+		assertType('*ERROR*', 1.24 % '1');
 
 		assertType('0', $i % 1.0);
 		assertType('0', $f % 1.0);

--- a/tests/PHPStan/Analyser/data/pow.php
+++ b/tests/PHPStan/Analyser/data/pow.php
@@ -15,16 +15,16 @@ function (int $a, int $b): void {
 };
 
 function (\GMP $a, \GMP $b): void {
-	assertType('GMP', pow($a, $b));
-	assertType('GMP', $a ** $b);
+	assertType('*ERROR*', pow($a, $b));
+	assertType('*ERROR*', $a ** $b);
 };
 
 function (\stdClass $a, \GMP $b): void {
-	assertType('GMP|stdClass', pow($a, $b));
-	assertType('GMP|stdClass', $a ** $b);
+	assertType('*ERROR*', pow($a, $b));
+	assertType('*ERROR*', $a ** $b);
 
-	assertType('GMP|stdClass', pow($b, $a));
-	assertType('GMP|stdClass', $b ** $a);
+	assertType('*ERROR*', pow($b, $a));
+	assertType('*ERROR*', $b ** $a);
 };
 
 function (): void {
@@ -112,8 +112,8 @@ function doFoo(int $intA, int $intB, string $s, bool $bool, $numericS, float $fl
 	assertType('int', pow($intA, 1));
 	assertType('int', $intA ** '1');
 
-	assertType('(float|int)', pow($intA, $s));
-	assertType('(float|int)', $intA ** $s);
+	assertType('*ERROR*', pow($intA, $s));
+	assertType('*ERROR*', $intA ** $s);
 
 	assertType('(float|int)', pow($intA, $bool)); // could be int
 	assertType('(float|int)', $intA ** $bool); // could be int
@@ -161,11 +161,11 @@ function doFoo(int $intA, int $intB, string $s, bool $bool, $numericS, float $fl
 
 	assertType('NAN', pow(-1,5.5));
 
-	assertType('1', pow($s, 0));
-	assertType('1', $s ** '0');
-	assertType('1', $s ** false);
-	assertType('(float|int)', pow($s, 1));
-	assertType('(float|int)', $s ** '1');
+	assertType('*ERROR*', pow($s, 0));
+	assertType('*ERROR*', $s ** '0');
+	assertType('*ERROR*', $s ** false);
+	assertType('*ERROR*', pow($s, 1));
+	assertType('*ERROR*', $s ** '1');
 	assertType('*ERROR*', $s ** $arr);
 	assertType('*ERROR*', $s ** []);
 

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -75,12 +75,24 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 				59,
 			],
 			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to \'5\' loses precision.',
+				67,
+			],
+			[
 				'Binary operation "&" between string and 5 results in an error.',
 				69,
 			],
 			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to \'5\' loses precision.',
+				71,
+			],
+			[
 				'Binary operation "|" between string and 5 results in an error.',
 				73,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to \'5\' loses precision.',
+				75,
 			],
 			[
 				'Binary operation "^" between string and 5 results in an error.',
@@ -109,6 +121,10 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 			[
 				'Binary operation "+" between (list<string>|string) and 1 results in an error.',
 				136,
+			],
+			[
+				'Binary operation "==" between stdClass and int results in an error.',
+				156,
 			],
 			[
 				'Binary operation "+" between stdClass and int results in an error.',
@@ -259,6 +275,264 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3515.php'], []);
 	}
 
+	public function testBug8288(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug8288.php'], [
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to float loses precision.',
+				12,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to numeric-string loses precision.',
+				13,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				14,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to float loses precision.',
+				15,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to numeric-string loses precision.',
+				16,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				17,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to float loses precision.',
+				18,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to 15 loses precision.',
+				24,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				25,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				26,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to float loses precision.',
+				42,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to numeric-string loses precision.',
+				43,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				44,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to float loses precision.',
+				45,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to numeric-string loses precision.',
+				46,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				47,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to float loses precision.',
+				48,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to 15 loses precision.',
+				54,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				55,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				56,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to float loses precision.',
+				72,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to numeric-string loses precision.',
+				73,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				74,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to float loses precision.',
+				75,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to numeric-string loses precision.',
+				76,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				77,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to float loses precision.',
+				78,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to 15 loses precision.',
+				84,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				85,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				86,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to float loses precision.',
+				102,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to numeric-string loses precision.',
+				103,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				104,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to float loses precision.',
+				105,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to numeric-string loses precision.',
+				106,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				107,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to float loses precision.',
+				108,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to numeric-string loses precision.',
+				109,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to 15 loses precision.',
+				115,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				116,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				117,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to float loses precision.',
+				133,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to numeric-string loses precision.',
+				134,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				135,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to float loses precision.',
+				136,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to numeric-string loses precision.',
+				137,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				138,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to float loses precision.',
+				139,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to numeric-string loses precision.',
+				140,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to 15 loses precision.',
+				146,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				147,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				148,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to float loses precision.',
+				164,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from int to numeric-string loses precision.',
+				165,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				166,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to float loses precision.',
+				167,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to numeric-string loses precision.',
+				168,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				169,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to float loses precision.',
+				170,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to numeric-string loses precision.',
+				171,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to 15 loses precision.',
+				177,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				178,
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to 15 loses precision.',
+				179,
+			],
+		]);
+	}
+
 	public function testRuleWithNullsafeVariant(): void
 	{
 		if (PHP_VERSION_ID < 80000) {
@@ -272,5 +546,4 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 			],
 		]);
 	}
-
 }

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -546,4 +546,5 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 			],
 		]);
 	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/bug8288.php
+++ b/tests/PHPStan/Rules/Operators/data/bug8288.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Bug8288;
+
+class Bug8288 {
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opBitwiseAnd(int $int, float $float, string $numericString)
+	{
+		$int & $float;
+		$int & $numericString;
+		$float & $int;
+		$float & $float;
+		$float & $numericString;
+		$numericString & $int;
+		$numericString & $float;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 & 15;
+		( 97 / 16 ) & 15;
+		6.0625 & 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 & 15;
+		intdiv( 97, 16 ) & 15;
+		6 & 15;
+	}
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opBitwiseOr(int $int, float $float, string $numericString)
+	{
+		$int | $float;
+		$int | $numericString;
+		$float | $int;
+		$float | $float;
+		$float | $numericString;
+		$numericString | $int;
+		$numericString | $float;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 | 15;
+		( 97 / 16 ) | 15;
+		6.0625 | 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 | 15;
+		intdiv( 97, 16 ) | 15;
+		6 | 15;
+	}
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opBitwiseXor(int $int, float $float, string $numericString)
+	{
+		$int ^ $float;
+		$int ^ $numericString;
+		$float ^ $int;
+		$float ^ $float;
+		$float ^ $numericString;
+		$numericString ^ $int;
+		$numericString ^ $float;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 ^ 15;
+		( 97 / 16 ) ^ 15;
+		6.0625 ^ 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 ^ 15;
+		intdiv( 97, 16 ) ^ 15;
+		6 ^ 15;
+	}
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opMod(int $int, float $float, string $numericString)
+	{
+		$int % $float;
+		$int % $numericString;
+		$float % $int;
+		$float % $float;
+		$float % $numericString;
+		$numericString % $int;
+		$numericString % $float;
+		$numericString % $numericString;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 % 15;
+		( 97 / 16 ) % 15;
+		6.0625 % 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 % 15;
+		intdiv( 97, 16 ) % 15;
+		6 % 15;
+	}
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opShiftLeft(int $int, float $float, string $numericString)
+	{
+		$int << $float;
+		$int << $numericString;
+		$float << $int;
+		$float << $float;
+		$float << $numericString;
+		$numericString << $int;
+		$numericString << $float;
+		$numericString << $numericString;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 << 15;
+		( 97 / 16 ) << 15;
+		6.0625 << 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 << 15;
+		intdiv( 97, 16 ) << 15;
+		6 << 15;
+	}
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opShiftRight(int $int, float $float, string $numericString)
+	{
+		$int >> $float;
+		$int >> $numericString;
+		$float >> $int;
+		$float >> $float;
+		$float >> $numericString;
+		$numericString >> $int;
+		$numericString >> $float;
+		$numericString >> $numericString;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 >> 15;
+		( 97 / 16 ) >> 15;
+		6.0625 >> 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 >> 15;
+		intdiv( 97, 16 ) >> 15;
+		6 >> 15;
+	}
+}


### PR DESCRIPTION
Catch deprecated implicit type conversions that occur in PHP 8.1 and later.
The following BinaryOp that may cause deprecation.

This PR fixes https://github.com/phpstan/phpstan/issues/8288

※O = safe, D = deprecated, X = not safe

## Pattern A
- `%` Mod
- `<<` ShiftLeft
- `>>` ShiftRight

|L \ R|int|float|string|numeric-string|Stringable|array|
|:---------------|:-:|:-:|:-:|:-:|:-:|:-:|
|int                    |O|D|X|D|X|X|
|float                 |D|D|X|D|X|X|
|string               |X|X|X|X|X|X|
|numeric-string  |D|D|X|D|X|X|
|Stringable         |X|X|X|X|X|X|
|array                |X|X|X|X|X|X|

## Pattern B
- `&` BitwiseAnd
- `|` BitwiseOr
- `^` BitwiseXor

|L \ R|int|float|string|numeric-string|Stringable|array|
|:---------------|:-:|:-:|:-:|:-:|:-:|:-:|
|int                    |O|D|X|D|X|X|
|float                 |D|D|X|D|X|X|
|string               |X|X|O|O|X|X|
|numeric-string  |D|D|O|O|X|X|
|Stringable         |X|X|X|X|X|X|
|array                |X|X|X|X|X|X|