### PR TITLE
Retain list type via `array_push()` and `array_unshift()`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2928,7 +2928,7 @@ class NodeScopeResolver
 					return;
 				}
 
-				$arrayType = new ArrayType($arrayType->getIterableKeyType(), $arrayType->getIterableValueType());
+				$arrayType = TypeCombinator::union($arrayType, new ConstantArrayType([], []));
 			},
 		);
 

--- a/tests/PHPStan/Analyser/data/array-push.php
+++ b/tests/PHPStan/Analyser/data/array-push.php
@@ -12,8 +12,9 @@ use function PHPStan\Testing\assertType;
  * @param int[] $b
  * @param non-empty-array<int> $c
  * @param array<int|string> $d
+ * @param list<string> $e
  */
-function arrayPush(array $a, array $b, array $c, array $d, array $arr): void
+function arrayPush(array $a, array $b, array $c, array $d, array $e, array $arr): void
 {
 	array_push($a, ...$b);
 	assertType('array<int|string>', $a);
@@ -32,6 +33,11 @@ function arrayPush(array $a, array $b, array $c, array $d, array $arr): void
 	$d1 = [];
 	array_push($d, ...$d1);
 	assertType('array<bool|int|string|null>', $d);
+
+	/** @var list<bool> $e1 */
+	$e1 = [];
+	array_push($e, ...$e1);
+	assertType('list<bool|string>', $e);
 }
 
 function arrayPushConstantArray(): void

--- a/tests/PHPStan/Analyser/data/array-unshift.php
+++ b/tests/PHPStan/Analyser/data/array-unshift.php
@@ -12,8 +12,9 @@ use function PHPStan\Testing\assertType;
  * @param int[] $b
  * @param non-empty-array<int> $c
  * @param array<int|string> $d
+ * @param list<string> $e
  */
-function arrayUnshift(array $a, array $b, array $c, array $d, array $arr): void
+function arrayUnshift(array $a, array $b, array $c, array $d, array $e, array $arr): void
 {
 	array_unshift($a, ...$b);
 	assertType('array<int|string>', $a);
@@ -32,6 +33,11 @@ function arrayUnshift(array $a, array $b, array $c, array $d, array $arr): void
 	$d1 = [];
 	array_unshift($d, ...$d1);
 	assertType('array<bool|int|string|null>', $d);
+
+	/** @var list<bool> $e1 */
+	$e1 = [];
+	array_unshift($e, ...$e1);
+	assertType('list<bool|string>', $e);
 }
 
 function arrayUnshiftConstantArray(): void

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1252,6 +1252,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8389.php'], []);
 	}
 
+	public function testBug8449(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8449.php'], []);
+	}
+
 	public function testBug5288(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-5288.php'], []);

--- a/tests/PHPStan/Rules/Functions/data/bug-8449.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8449.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8449;
+
+/** @var list<int> $a */
+$a = [1];
+/** @var list<int> $b */
+$b = [2];
+
+array_push($a, ...$b);
+
+/**
+ * @param list<int> $parameter
+ */
+function test(array $parameter): void
+{
+}
+
+test($a);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8449

it has been a while :) I know I have still 2 open PRs, but I didn't feel like finishing them yet. soon™

I was wondering why the array here is even re-created like that. The reason is that this is after the isIterableAtLeastOnce / optional check and the re-creation is just there to _remove_ a NonEmptyArrayType. So if there would be a simpler/better way of removing it (maybe calling `->popArray()` but I'm not sure, that feels like a hack), the list would not be removed and this new code would not be needed 🤔

another more explicit way might be to intersect the union of `->getArrays()` with a `TypeUtils::getAccessoryTypes()` where NonEmptyArrayType is filtered away. also feels ugly. I'm not a 100% happy with any of the solutions so far.. like e.g.
```php
$arrayType = TypeCombinator::intersect(
	TypeCombinator::union(...$arrayType->getArrays()),
	...array_filter(
		TypeUtils::getAccessoryTypes($arrayType),
		static fn (AccessoryType $type) => !$type instanceof NonEmptyArrayType,
	),
);
```