### PR TITLE
fix array_splice with non-array replacement

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2010,7 +2010,8 @@ class NodeScopeResolver
 				$arrayArgType = $scope->getType($arrayArg);
 				$valueType = $arrayArgType->getIterableValueType();
 				if (count($expr->getArgs()) >= 4) {
-					$valueType = TypeCombinator::union($valueType, $scope->getType($expr->getArgs()[3]->value)->getIterableValueType());
+					$replacementType = $scope->getType($expr->getArgs()[3]->value)->toArray();
+					$valueType = TypeCombinator::union($valueType, $replacementType->getIterableValueType());
 				}
 				$scope = $scope->invalidateExpression($arrayArg)->assignExpression(
 					$arrayArg,

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1288,6 +1288,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/gettype.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_splice.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/array_splice.php
+++ b/tests/PHPStan/Analyser/data/array_splice.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ArraySplice;
+
+use function PHPStan\Testing\assertType;
+
+final class Foo
+{
+	/** @var bool */
+	public $abc = false;
+
+	/** @var string */
+	public $def = 'def';
+}
+
+/**
+ * @param array<int, int> $arr
+ * @return void
+ */
+function insertViaArraySplice(array $arr): void
+{
+	$brr = $arr;
+	array_splice($brr, 0, 0, 1);
+	assertType('array<int, int>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, [1]);
+	assertType('array<int, int>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, '');
+	assertType('array<int, \'\'|int>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, ['']);
+	assertType('array<int, \'\'|int>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, null);
+	assertType('array<int, int>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, [null]);
+	assertType('array<int, int|null>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, new Foo());
+	assertType('array<int, bool|int|string>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, [new \stdClass()]);
+	assertType('array<int, int|stdClass>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, false);
+	assertType('array<int, int|false>', $brr);
+
+	$brr = $arr;
+	array_splice($brr, 0, 0, [false]);
+	assertType('array<int, int|false>', $brr);
+}


### PR DESCRIPTION
Fixes https://phpstan.org/r/f1506ef5-1320-4bc4-942c-c98c897bd024

[PHP documentation](https://www.php.net/manual/en/function.array-splice.php) says

> Note: If replacement is not an array, it will be typecast to one (i.e. (array) $replacement). This may result in unexpected behavior when using an object or null replacement. 