### PR TITLE
Remove redundant conditions from RemoveUnusedCodeByPhpVersionIdVisitor.

### DIFF
--- a/src/Parser/RemoveUnusedCodeByPhpVersionIdVisitor.php
+++ b/src/Parser/RemoveUnusedCodeByPhpVersionIdVisitor.php
@@ -17,13 +17,6 @@ class RemoveUnusedCodeByPhpVersionIdVisitor extends NodeVisitorAbstract
 
 	public function enterNode(Node $node): Node|int|null
 	{
-		if ($node instanceof Node\Stmt\ClassLike) {
-			return null;
-		}
-		if ($node instanceof Node\FunctionLike) {
-			return null;
-		}
-
 		if (!$node instanceof Node\Stmt\If_) {
 			return null;
 		}
@@ -53,8 +46,7 @@ class RemoveUnusedCodeByPhpVersionIdVisitor extends NodeVisitorAbstract
 		$operator = $cond->getOperatorSigil();
 		if ($operator === '===') {
 			$operator = '==';
-		}
-		if ($operator === '!==') {
+		} elseif ($operator === '!==') {
 			$operator = '!=';
 		}
 


### PR DESCRIPTION
an `If_` cannot be a classlike or functionlike so checking for these specifically is redundant when we check it's not an `If_`