### PR TITLE
Treat ConstantArrayType as covariant in its keys and values

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1368,7 +1368,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
-		$variance = $positionVariance->compose(TemplateTypeVariance::createInvariant());
+		$variance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
 		$references = [];
 
 		foreach ($this->keyTypes as $type) {

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -219,4 +219,9 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug9161(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9161.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Generics/data/bug-9161.php
+++ b/tests/PHPStan/Rules/Generics/data/bug-9161.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace Bug9161;
+
+/**
+ * @template-covariant TKey of int|string
+ * @template-covariant TValue
+ */
+final class Map
+{
+	/**
+	 * @param array<TKey, TValue> $items
+	 */
+	public function __construct(
+		private array $items = [],
+	) {
+	}
+
+	/**
+	 * @return array<TKey, TValue>
+	 */
+	public function toArray(): array
+	{
+		return $this->items;
+	}
+
+	/**
+	 * @return list<array{0: TKey, 1: TValue}>
+	 */
+	public function toPairs(): array
+	{
+		$pairs = [];
+		foreach ($this->items as $key => $value) {
+			$pairs[] = [$key, $value];
+		}
+
+		return $pairs;
+	}
+}


### PR DESCRIPTION
Closes phpstan/phpstan#9161, as argued there, this should be safe because arrays are copy-on-write