### PR TITLE
Treat ArrayType as covariant in its keys and values

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -22,7 +22,6 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\TemplateMixedType;
-use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
@@ -636,24 +635,11 @@ class ArrayType implements Type
 
 	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
 	{
-		$keyVariance = $positionVariance;
-		$itemVariance = $positionVariance;
-
-		if (!$positionVariance->contravariant()) {
-			$keyType = $this->getKeyType();
-			if ($keyType instanceof TemplateType) {
-				$keyVariance = $keyType->getVariance();
-			}
-
-			$itemType = $this->getItemType();
-			if ($itemType instanceof TemplateType) {
-				$itemVariance = $itemType->getVariance();
-			}
-		}
+		$variance = $positionVariance->compose(TemplateTypeVariance::createCovariant());
 
 		return array_merge(
-			$this->getKeyType()->getReferencedTemplateTypes($keyVariance),
-			$this->getItemType()->getReferencedTemplateTypes($itemVariance),
+			$this->getKeyType()->getReferencedTemplateTypes($variance),
+			$this->getItemType()->getReferencedTemplateTypes($variance),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -224,4 +224,14 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9161.php'], []);
 	}
 
+	public function testPr2465(): void
+	{
+		$this->analyse([__DIR__ . '/data/pr-2465.php'], [
+			[
+				'Template type T is declared as covariant, but occurs in invariant position in parameter thing of method Pr2465\UnitOfTest::foo().',
+				16,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Generics/data/pr-2465.php
+++ b/tests/PHPStan/Rules/Generics/data/pr-2465.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Pr2465;
+
+/** @template T */
+class InvariantThing {}
+
+/**
+ * @template-covariant T
+ */
+class UnitOfTest
+{
+	/**
+	 * @param InvariantThing<array<T>> $thing
+	 */
+	public function foo(InvariantThing $thing): void {}
+}


### PR DESCRIPTION
Following up on #2464, I believe the implementation in ArrayType can be simplified accordingly