### PR TITLE
Catch implicit conversions in mod operator

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -287,4 +287,9 @@ class PhpVersion
 		return $this->versionId >= 80200;
 	}
 
+	public function deprecatesImplicitConversions(): bool
+	{
+		return $this->versionId >= 80100;
+	}
+
 }

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -874,6 +874,14 @@ class InitializerExprTypeResolver
 			}
 		}
 
+		$leftNumberType = $leftType->toNumber();
+		$rightNumberType = $rightType->toNumber();
+		if ($leftNumberType instanceof ErrorType || $rightNumberType instanceof ErrorType) {
+			return new ErrorType();
+		} elseif ($leftNumberType->isInteger()->or($leftNumberType->isFloat())->no() && $rightNumberType->isInteger()->or($rightNumberType->isFloat())->no()) {
+			return new ErrorType();
+		}
+
 		$positiveInt = IntegerRangeType::fromInterval(0, null);
 		if ($rightType->isInteger()->yes()) {
 			$rangeMin = null;

--- a/src/Rules/Operators/InvalidBinaryOperationRule.php
+++ b/src/Rules/Operators/InvalidBinaryOperationRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\Printer\ExprPrinter;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
@@ -26,6 +27,7 @@ class InvalidBinaryOperationRule implements Rule
 	public function __construct(
 		private ExprPrinter $exprPrinter,
 		private RuleLevelHelper $ruleLevelHelper,
+		private PhpVersion $phpVersion,
 	)
 	{
 	}
@@ -146,7 +148,7 @@ class InvalidBinaryOperationRule implements Rule
 					return [];
 				}
 
-				if (!$leftNumberType->isFloat()->no()) {
+				if (!$leftNumberType->isFloat()->no() && $this->phpVersion->deprecatesImplicitConversions()) {
 					return [
 						RuleErrorBuilder::message(sprintf(
 							'Deprecated in PHP 8.1: Implicit conversion from %s to int loses precision.',
@@ -157,7 +159,7 @@ class InvalidBinaryOperationRule implements Rule
 							->build(),
 					];
 				}
-				if (!$rightNumberType->isFloat()->no()) {
+				if (!$rightNumberType->isFloat()->no() && $this->phpVersion->deprecatesImplicitConversions()) {
 					return [
 						RuleErrorBuilder::message(sprintf(
 							'Deprecated in PHP 8.1: Implicit conversion from %s to int loses precision.',

--- a/src/Rules/Operators/InvalidBinaryOperationRule.php
+++ b/src/Rules/Operators/InvalidBinaryOperationRule.php
@@ -118,9 +118,7 @@ class InvalidBinaryOperationRule implements Rule
 			];
 		} else {
 			if ($node instanceof Node\Expr\BinaryOp\Mod) {
-				$callback = static fn (Type $type): bool => PHP_VERSION_ID >= 80100
-					? $type->toNumber()->isFloat()->no()
-					: $type->toNumber()->isInteger()->yes();
+				$callback = static fn (Type $type): bool => !$type->isFloat()->no();
 
 				$leftType = $this->ruleLevelHelper->findTypeToCheck(
 					$scope,

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Operators;
 
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\Printer\Printer;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -20,6 +21,7 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		return new InvalidBinaryOperationRule(
 			new ExprPrinter(new Printer()),
 			new RuleLevelHelper($this->createReflectionProvider(), true, false, true, false, false, true, false),
+			new PhpVersion(PHP_VERSION_ID),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -268,7 +268,44 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 
 	public function testBug8288(): void
 	{
-		$expectedErrors = [
+		$expectedErrors = [];
+		if (PHP_VERSION_ID >= 80100) {
+			$expectedErrors = [
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					17,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					18,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					19,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					20,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					21,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					22,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					23,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					24,
+				],
+			];
+		}
+		$expectedErrors = array_merge($expectedErrors, [
 			[
 				'Binary operation "%" between int and string results in an error.',
 				26,
@@ -377,42 +414,9 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 				'Binary operation "%" between array and array results in an error.',
 				52,
 			],
-		];
+		]);
 		if (PHP_VERSION_ID >= 80100) {
-			$expectedErrors = [
-				...$expectedErrors,
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-					17,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-					18,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-					19,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-					20,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-					21,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-					22,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-					23,
-				],
-				[
-					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-					24,
-				],
+			$expectedErrors = array_merge($expectedErrors, [
 				[
 					'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to int loses precision.',
 					58,
@@ -425,7 +429,7 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 					'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
 					60,
 				],
-			];
+			]);
 		}
 		$this->analyse([__DIR__ . '/data/bug8288.php'], $expectedErrors);
 	}

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -264,6 +264,164 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8827.php'], []);
 	}
 
+	public function testBug8288(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug8288.php'], [
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				17
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				18
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				19
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				20
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+				21
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				22
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				23
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+				24
+			],
+			[
+				'Binary operation "%" between int and string results in an error.',
+				26
+			],
+			[
+				'Binary operation "%" between int and Stringable results in an error.',
+				27
+			],
+			[
+				'Binary operation "%" between int and array results in an error.',
+				28
+			],
+			[
+				'Binary operation "%" between float and string results in an error.',
+				29
+			],
+			[
+				'Binary operation "%" between float and Stringable results in an error.',
+				30
+			],
+			[
+				'Binary operation "%" between float and array results in an error.',
+				31
+			],
+			[
+				'Binary operation "%" between string and int results in an error.',
+				32
+			],
+			[
+				'Binary operation "%" between string and float results in an error.',
+				33
+			],
+			[
+				'Binary operation "%" between string and string results in an error.',
+				34
+			],
+			[
+				'Binary operation "%" between string and numeric-string results in an error.',
+				35
+			],
+			[
+				'Binary operation "%" between string and Stringable results in an error.',
+				36
+			],
+			[
+				'Binary operation "%" between string and array results in an error.',
+				37
+			],
+			[
+				'Binary operation "%" between numeric-string and string results in an error.',
+				38
+			],
+			[
+				'Binary operation "%" between numeric-string and Stringable results in an error.',
+				39
+			],
+			[
+				'Binary operation "%" between numeric-string and array results in an error.',
+				40
+			],
+			[
+				'Binary operation "%" between Stringable and int results in an error.',
+				41
+			],
+			[
+				'Binary operation "%" between Stringable and float results in an error.',
+				42
+			],
+			[
+				'Binary operation "%" between Stringable and string results in an error.',
+				43
+			],
+			[
+				'Binary operation "%" between Stringable and numeric-string results in an error.',
+				44
+			],
+			[
+				'Binary operation "%" between Stringable and Stringable results in an error.',
+				45
+			],
+			[
+				'Binary operation "%" between Stringable and array results in an error.',
+				46
+			],
+			[
+				'Binary operation "%" between array and int results in an error.',
+				47
+			],
+			[
+				'Binary operation "%" between array and float results in an error.',
+				48
+			],
+			[
+				'Binary operation "%" between array and string results in an error.',
+				49
+			],
+			[
+				'Binary operation "%" between array and numeric-string results in an error.',
+				50
+			],
+			[
+				'Binary operation "%" between array and Stringable results in an error.',
+				51
+			],
+			[
+				'Binary operation "%" between array and array results in an error.',
+				52
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to int loses precision.',
+				58
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
+				59
+			],
+			[
+				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
+				60
+			],
+		]);
+	}
+
 	public function testRuleWithNullsafeVariant(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -8,6 +8,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use function array_merge;
 use const PHP_VERSION_ID;
 
 /**

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -268,39 +268,7 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 
 	public function testBug8288(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug8288.php'], [
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				17,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				18,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				19,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				20,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				21,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				22,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				23,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				24,
-			],
+		$expectedErrors = [
 			[
 				'Binary operation "%" between int and string results in an error.',
 				26,
@@ -409,19 +377,57 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 				'Binary operation "%" between array and array results in an error.',
 				52,
 			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to int loses precision.',
-				58,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
-				59,
-			],
-			[
-				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
-				60,
-			],
-		]);
+		];
+		if (PHP_VERSION_ID >= 80100) {
+			$expectedErrors = [
+				...$expectedErrors,
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					17,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					18,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					19,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					20,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
+					21,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					22,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					23,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
+					24,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to int loses precision.',
+					58,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
+					59,
+				],
+				[
+					'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
+					60,
+				],
+			];
+		}
+		$this->analyse([__DIR__ . '/data/bug8288.php'], $expectedErrors);
 	}
 
 	public function testRuleWithNullsafeVariant(): void

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -269,155 +269,155 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug8288.php'], [
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				17
+				17,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				18
+				18,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				19
+				19,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				20
+				20,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from float to int loses precision.',
-				21
+				21,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				22
+				22,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				23
+				23,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from numeric-string to int loses precision.',
-				24
+				24,
 			],
 			[
 				'Binary operation "%" between int and string results in an error.',
-				26
+				26,
 			],
 			[
 				'Binary operation "%" between int and Stringable results in an error.',
-				27
+				27,
 			],
 			[
 				'Binary operation "%" between int and array results in an error.',
-				28
+				28,
 			],
 			[
 				'Binary operation "%" between float and string results in an error.',
-				29
+				29,
 			],
 			[
 				'Binary operation "%" between float and Stringable results in an error.',
-				30
+				30,
 			],
 			[
 				'Binary operation "%" between float and array results in an error.',
-				31
+				31,
 			],
 			[
 				'Binary operation "%" between string and int results in an error.',
-				32
+				32,
 			],
 			[
 				'Binary operation "%" between string and float results in an error.',
-				33
+				33,
 			],
 			[
 				'Binary operation "%" between string and string results in an error.',
-				34
+				34,
 			],
 			[
 				'Binary operation "%" between string and numeric-string results in an error.',
-				35
+				35,
 			],
 			[
 				'Binary operation "%" between string and Stringable results in an error.',
-				36
+				36,
 			],
 			[
 				'Binary operation "%" between string and array results in an error.',
-				37
+				37,
 			],
 			[
 				'Binary operation "%" between numeric-string and string results in an error.',
-				38
+				38,
 			],
 			[
 				'Binary operation "%" between numeric-string and Stringable results in an error.',
-				39
+				39,
 			],
 			[
 				'Binary operation "%" between numeric-string and array results in an error.',
-				40
+				40,
 			],
 			[
 				'Binary operation "%" between Stringable and int results in an error.',
-				41
+				41,
 			],
 			[
 				'Binary operation "%" between Stringable and float results in an error.',
-				42
+				42,
 			],
 			[
 				'Binary operation "%" between Stringable and string results in an error.',
-				43
+				43,
 			],
 			[
 				'Binary operation "%" between Stringable and numeric-string results in an error.',
-				44
+				44,
 			],
 			[
 				'Binary operation "%" between Stringable and Stringable results in an error.',
-				45
+				45,
 			],
 			[
 				'Binary operation "%" between Stringable and array results in an error.',
-				46
+				46,
 			],
 			[
 				'Binary operation "%" between array and int results in an error.',
-				47
+				47,
 			],
 			[
 				'Binary operation "%" between array and float results in an error.',
-				48
+				48,
 			],
 			[
 				'Binary operation "%" between array and string results in an error.',
-				49
+				49,
 			],
 			[
 				'Binary operation "%" between array and numeric-string results in an error.',
-				50
+				50,
 			],
 			[
 				'Binary operation "%" between array and Stringable results in an error.',
-				51
+				51,
 			],
 			[
 				'Binary operation "%" between array and array results in an error.',
-				52
+				52,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from float|int<0, 15> to int loses precision.',
-				58
+				58,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
-				59
+				59,
 			],
 			[
 				'Deprecated in PHP 8.1: Implicit conversion from 6.0625 to int loses precision.',
-				60
+				60,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Operators/data/bug8288.php
+++ b/tests/PHPStan/Rules/Operators/data/bug8288.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Bug8288;
+
+use Stringable;
+
+class Bug8288 {
+
+	/**
+	 * @param numeric-string $numericString
+	 */
+	public function opMod(int $int, float $float, string $string, string $numericString, Stringable $stringable, array $array)
+	{
+		# Safe
+		$int % $int;
+		# Deprecated in PHP 8.1
+		$int % $float;
+		$int % $numericString;
+		$float % $int;
+		$float % $float;
+		$float % $numericString;
+		$numericString % $int;
+		$numericString % $float;
+		$numericString % $numericString;
+		# Not safe
+		$int % $string;
+		$int % $stringable;
+		$int % $array;
+		$float % $string;
+		$float % $stringable;
+		$float % $array;
+		$string % $int;
+		$string % $float;
+		$string % $string;
+		$string % $numericString;
+		$string % $stringable;
+		$string % $array;
+		$numericString % $string;
+		$numericString % $stringable;
+		$numericString % $array;
+		$stringable % $int;
+		$stringable % $float;
+		$stringable % $string;
+		$stringable % $numericString;
+		$stringable % $stringable;
+		$stringable % $array;
+		$array % $int;
+		$array % $float;
+		$array % $string;
+		$array % $numericString;
+		$array % $stringable;
+		$array % $array;
+
+		// The following three examples should all be flagged as resulting in implicit float to int conversion with potential loss of precision. This behaviour is deprecated in PHP 8.1, and results in a deprecation warning (if deprecation warnings are enabled, which they are by default PHP 8+), if encountered at runtime. It would be helpful if phpstan could catch and flag such cases during static analysis.
+		$singleByteCode = ord('a');
+		$float1 = ( $singleByteCode / 16 );
+		// This is not safe
+		$float1 % 15;
+		( 97 / 16 ) % 15;
+		6.0625 % 15;
+
+		// The following three examples should not result in any error
+		$singleByteCode = ord('a');
+		$int1 = intdiv( $singleByteCode, 16 );
+		// This is safe
+		$int1 % 15;
+		intdiv( 97, 16 ) % 15;
+		6 % 15;
+	}
+}


### PR DESCRIPTION
Catch deprecated implicit type conversions that occur in PHP 8.1 and later.
The following BinaryOp that may cause deprecation.

This PR is part of https://github.com/phpstan/phpstan/issues/8288 and change regarding the mod operator of https://github.com/phpstan/phpstan-src/pull/2450

※O = safe, D = deprecated, X = not safe

## `%` Mod

|L \ R|int|float|string|numeric-string|Stringable|array|
|:---------------|:-:|:-:|:-:|:-:|:-:|:-:|
|int                    |O|D|X|D|X|X|
|float                 |D|D|X|D|X|X|
|string               |X|X|X|X|X|X|
|numeric-string  |D|D|X|D|X|X|
|Stringable         |X|X|X|X|X|X|
|array                |X|X|X|X|X|X|