### PR TITLE
Change Cloudflare DNS to a less-known version

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -230,7 +230,7 @@ parameters:
 	errorFormat: null
 	pro:
 		dnsServers:
-			- '1.1.1.1'
+			- '1.1.1.2'
 	__validate: true
 
 extensions:


### PR DESCRIPTION
1.1.1.1 (and 1.0.0.1) is often blocked on network level due to either buggy network devices or intentionally (like in [#9106](https://github.com/phpstan/phpstan/issues/9106)).

1.1.1.2 together with 1.0.0.2 (malware-blocking DNS) and 1.1.1.3 with 1.0.0.3 (malware and adult blocking) are less-known Cloudflare DNS addresses and as such may work more often than 1.1.1.1. It certainly helps here, I can't reach 1.1.1.1 due to buggy ISP router but can go to 1.1.1.2 easily. See Cloudflare's own docs https://developers.cloudflare.com/1.1.1.1/setup/#1111-for-families

I have checked what the DNS is used for (for PHPStan Pro resolving only) and I know this is a workaround but it may help more users see the "Try different DNS servers" message less often. What do you think?