### PR TITLE
Type projections, part 1: call-site variance in GenericObjectType

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -604,11 +604,17 @@ class TypeNodeResolver
 		$mainTypeName = strtolower($typeNode->type->name);
 		$genericTypes = $this->resolveMultiple($typeNode->genericTypes, $nameScope);
 		$variances = array_map(
-			static fn (string $variance): TemplateTypeVariance => match ($variance) {
-				GenericTypeNode::VARIANCE_INVARIANT => TemplateTypeVariance::createInvariant(),
-				GenericTypeNode::VARIANCE_COVARIANT => TemplateTypeVariance::createCovariant(),
-				GenericTypeNode::VARIANCE_CONTRAVARIANT => TemplateTypeVariance::createContravariant(),
-				GenericTypeNode::VARIANCE_BIVARIANT => TemplateTypeVariance::createBivariant(),
+			static function (string $variance): TemplateTypeVariance {
+				switch ($variance) {
+					case GenericTypeNode::VARIANCE_INVARIANT:
+						return TemplateTypeVariance::createInvariant();
+					case GenericTypeNode::VARIANCE_COVARIANT:
+						return TemplateTypeVariance::createCovariant();
+					case GenericTypeNode::VARIANCE_CONTRAVARIANT:
+						return TemplateTypeVariance::createContravariant();
+					case GenericTypeNode::VARIANCE_BIVARIANT:
+						return TemplateTypeVariance::createBivariant();
+				}
 			},
 			$typeNode->variances,
 		);

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -65,6 +65,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Helper\GetTemplateTypeType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
@@ -602,6 +603,15 @@ class TypeNodeResolver
 	{
 		$mainTypeName = strtolower($typeNode->type->name);
 		$genericTypes = $this->resolveMultiple($typeNode->genericTypes, $nameScope);
+		$variances = array_map(
+			static fn (string $variance): TemplateTypeVariance => match ($variance) {
+				GenericTypeNode::VARIANCE_INVARIANT => TemplateTypeVariance::createInvariant(),
+				GenericTypeNode::VARIANCE_COVARIANT => TemplateTypeVariance::createCovariant(),
+				GenericTypeNode::VARIANCE_CONTRAVARIANT => TemplateTypeVariance::createContravariant(),
+				GenericTypeNode::VARIANCE_BIVARIANT => TemplateTypeVariance::createBivariant(),
+			},
+			$typeNode->variances,
+		);
 
 		if ($mainTypeName === 'array' || $mainTypeName === 'non-empty-array') {
 			if (count($genericTypes) === 1) { // array<ValueType>
@@ -748,7 +758,7 @@ class TypeNodeResolver
 
 		if ($mainTypeClassName !== null) {
 			if (!$this->getReflectionProvider()->hasClass($mainTypeClassName)) {
-				return new GenericObjectType($mainTypeClassName, $genericTypes);
+				return new GenericObjectType($mainTypeClassName, $genericTypes, null, null, $variances);
 			}
 
 			$classReflection = $this->getReflectionProvider()->getClass($mainTypeClassName);
@@ -762,6 +772,9 @@ class TypeNodeResolver
 						return new GenericObjectType($mainTypeClassName, [
 							new MixedType(true),
 							$genericTypes[0],
+						], null, null, [
+							TemplateTypeVariance::createInvariant(),
+							$variances[0],
 						]);
 					}
 
@@ -769,6 +782,9 @@ class TypeNodeResolver
 						return new GenericObjectType($mainTypeClassName, [
 							$genericTypes[0],
 							$genericTypes[1],
+						], null, null, [
+							$variances[0],
+							$variances[1],
 						]);
 					}
 				}
@@ -780,6 +796,11 @@ class TypeNodeResolver
 							$genericTypes[0],
 							$mixed,
 							$mixed,
+						], null, null, [
+							TemplateTypeVariance::createInvariant(),
+							$variances[0],
+							TemplateTypeVariance::createInvariant(),
+							TemplateTypeVariance::createInvariant(),
 						]);
 					}
 
@@ -790,19 +811,24 @@ class TypeNodeResolver
 							$genericTypes[1],
 							$mixed,
 							$mixed,
+						], null, null, [
+							$variances[0],
+							$variances[1],
+							TemplateTypeVariance::createInvariant(),
+							TemplateTypeVariance::createInvariant(),
 						]);
 					}
 				}
 
 				if (!$mainType->isIterable()->yes()) {
-					return new GenericObjectType($mainTypeClassName, $genericTypes);
+					return new GenericObjectType($mainTypeClassName, $genericTypes, null, null, $variances);
 				}
 
 				if (
 					count($genericTypes) !== 1
 					|| $classReflection->getTemplateTypeMap()->count() === 1
 				) {
-					return new GenericObjectType($mainTypeClassName, $genericTypes);
+					return new GenericObjectType($mainTypeClassName, $genericTypes, null, null, $variances);
 				}
 			}
 		}
@@ -824,7 +850,7 @@ class TypeNodeResolver
 		}
 
 		if ($mainTypeClassName !== null) {
-			return new GenericObjectType($mainTypeClassName, $genericTypes);
+			return new GenericObjectType($mainTypeClassName, $genericTypes, null, null, $variances);
 		}
 
 		return new ErrorType();

--- a/src/Type/Generic/TemplateGenericObjectType.php
+++ b/src/Type/Generic/TemplateGenericObjectType.php
@@ -21,7 +21,7 @@ final class TemplateGenericObjectType extends GenericObjectType implements Templ
 		GenericObjectType $bound,
 	)
 	{
-		parent::__construct($bound->getClassName(), $bound->getTypes());
+		parent::__construct($bound->getClassName(), $bound->getTypes(), null, null, $bound->getVariances());
 
 		$this->scope = $scope;
 		$this->strategy = $templateTypeStrategy;
@@ -30,7 +30,7 @@ final class TemplateGenericObjectType extends GenericObjectType implements Templ
 		$this->bound = $bound;
 	}
 
-	protected function recreate(string $className, array $types, ?Type $subtractedType): GenericObjectType
+	protected function recreate(string $className, array $types, ?Type $subtractedType, array $variances = []): GenericObjectType
 	{
 		return new self(
 			$this->scope,

--- a/src/Type/Generic/TemplateTypeVarianceMap.php
+++ b/src/Type/Generic/TemplateTypeVarianceMap.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use function array_key_exists;
+
+/** @api */
+class TemplateTypeVarianceMap
+{
+
+	private static ?TemplateTypeVarianceMap $empty = null;
+
+	/**
+	 * @api
+	 * @param array<string, TemplateTypeVariance> $variances
+	 */
+	public function __construct(private array $variances)
+	{
+	}
+
+	public static function createEmpty(): self
+	{
+		$empty = self::$empty;
+
+		if ($empty !== null) {
+			return $empty;
+		}
+
+		$empty = new self([]);
+		self::$empty = $empty;
+
+		return $empty;
+	}
+
+	/** @return array<string, TemplateTypeVariance> */
+	public function getVariances(): array
+	{
+		return $this->variances;
+	}
+
+	public function hasVariance(string $name): bool
+	{
+		return array_key_exists($name, $this->getVariances());
+	}
+
+	public function getVariance(string $name): ?TemplateTypeVariance
+	{
+		return $this->getVariances()[$name] ?? null;
+	}
+
+}

--- a/src/Type/Generic/TypeProjectionHelper.php
+++ b/src/Type/Generic/TypeProjectionHelper.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+class TypeProjectionHelper
+{
+
+	public static function describe(
+		Type $type,
+		?TemplateTypeVariance $variance,
+		VerbosityLevel $level,
+	): string
+	{
+		$describedType = $type->describe($level);
+
+		if ($variance === null || $variance->invariant()) {
+			return $describedType;
+		}
+
+		if ($variance->bivariant()) {
+			return '*';
+		}
+
+		return sprintf('%s %s', $variance->describe(), $describedType);
+	}
+
+}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -124,6 +124,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return new GenericObjectType(
 			$reflection->getName(),
 			$reflection->typeMapToList($reflection->getActiveTemplateTypeMap()),
+			null,
+			null,
+			$reflection->varianceMapToList($reflection->getActiveTemplateTypeVarianceMap()),
 		);
 	}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -126,7 +126,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			$reflection->typeMapToList($reflection->getActiveTemplateTypeMap()),
 			null,
 			null,
-			$reflection->varianceMapToList($reflection->getActiveTemplateTypeVarianceMap()),
+			$reflection->varianceMapToList($reflection->getCallSiteVarianceMap()),
 		);
 	}
 

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -85,7 +85,7 @@ class StaticType implements TypeWithClassName, SubtractableType
 		if ($this->staticObjectType === null) {
 			if ($this->classReflection->isGeneric()) {
 				$typeMap = $this->classReflection->getActiveTemplateTypeMap()->map(static fn (string $name, Type $type): Type => TemplateTypeHelper::toArgument($type));
-				$varianceMap = $this->classReflection->getActiveTemplateTypeVarianceMap();
+				$varianceMap = $this->classReflection->getCallSiteVarianceMap();
 				return $this->staticObjectType = new GenericObjectType(
 					$this->classReflection->getName(),
 					$this->classReflection->typeMapToList($typeMap),

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -85,10 +85,13 @@ class StaticType implements TypeWithClassName, SubtractableType
 		if ($this->staticObjectType === null) {
 			if ($this->classReflection->isGeneric()) {
 				$typeMap = $this->classReflection->getActiveTemplateTypeMap()->map(static fn (string $name, Type $type): Type => TemplateTypeHelper::toArgument($type));
+				$varianceMap = $this->classReflection->getActiveTemplateTypeVarianceMap();
 				return $this->staticObjectType = new GenericObjectType(
 					$this->classReflection->getName(),
 					$this->classReflection->typeMapToList($typeMap),
 					$this->subtractedType,
+					null,
+					$this->classReflection->varianceMapToList($varianceMap),
 				);
 			}
 

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -17,6 +17,7 @@ use PHPStan\Type\Test\A;
 use PHPStan\Type\Test\B;
 use PHPStan\Type\Test\C;
 use PHPStan\Type\Test\D;
+use PHPStan\Type\Test\E;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -153,11 +154,115 @@ class GenericObjectTypeTest extends PHPStanTestCase
 				]),
 				TrinaryLogic::createNo(),
 			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createInvariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createCovariant()]),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createInvariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createContravariant()]),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createCovariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createInvariant()]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createCovariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createCovariant()]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createCovariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createContravariant()]),
+				TrinaryLogic::createNo(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createContravariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createInvariant()]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createContravariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createInvariant()]),
+				TrinaryLogic::createYes(),
+			],
+			[
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTime')], null, null, [TemplateTypeVariance::createContravariant()]),
+				new GenericObjectType(C\Invariant::class, [new ObjectType('DateTimeInterface')], null, null, [TemplateTypeVariance::createCovariant()]),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	public function dataTypeProjections(): array
+	{
+		$invariantA = new GenericObjectType(E\Foo::class, [new ObjectType(E\A::class)], null, null, [TemplateTypeVariance::createInvariant()]);
+		$invariantB = new GenericObjectType(E\Foo::class, [new ObjectType(E\B::class)], null, null, [TemplateTypeVariance::createInvariant()]);
+		$invariantC = new GenericObjectType(E\Foo::class, [new ObjectType(E\C::class)], null, null, [TemplateTypeVariance::createInvariant()]);
+
+		$covariantA = new GenericObjectType(E\Foo::class, [new ObjectType(E\A::class)], null, null, [TemplateTypeVariance::createCovariant()]);
+		$covariantB = new GenericObjectType(E\Foo::class, [new ObjectType(E\B::class)], null, null, [TemplateTypeVariance::createCovariant()]);
+		$covariantC = new GenericObjectType(E\Foo::class, [new ObjectType(E\C::class)], null, null, [TemplateTypeVariance::createCovariant()]);
+
+		$contravariantA = new GenericObjectType(E\Foo::class, [new ObjectType(E\A::class)], null, null, [TemplateTypeVariance::createContravariant()]);
+		$contravariantB = new GenericObjectType(E\Foo::class, [new ObjectType(E\B::class)], null, null, [TemplateTypeVariance::createContravariant()]);
+		$contravariantC = new GenericObjectType(E\Foo::class, [new ObjectType(E\C::class)], null, null, [TemplateTypeVariance::createContravariant()]);
+
+		$bivariant = new GenericObjectType(E\Foo::class, [new MixedType(true)], null, null, [TemplateTypeVariance::createBivariant()]);
+
+		return [
+			[$invariantB, $invariantA, TrinaryLogic::createNo()],
+			[$invariantB, $invariantB, TrinaryLogic::createYes()],
+			[$invariantB, $invariantC, TrinaryLogic::createNo()],
+			[$invariantB, $covariantA, TrinaryLogic::createNo()],
+			[$invariantB, $covariantB, TrinaryLogic::createNo()],
+			[$invariantB, $covariantC, TrinaryLogic::createNo()],
+			[$invariantB, $contravariantA, TrinaryLogic::createNo()],
+			[$invariantB, $contravariantB, TrinaryLogic::createNo()],
+			[$invariantB, $contravariantC, TrinaryLogic::createNo()],
+			[$invariantB, $bivariant, TrinaryLogic::createNo()],
+
+			[$covariantB, $invariantA, TrinaryLogic::createMaybe()],
+			[$covariantB, $invariantB, TrinaryLogic::createYes()],
+			[$covariantB, $invariantC, TrinaryLogic::createYes()],
+			[$covariantB, $covariantA, TrinaryLogic::createMaybe()],
+			[$covariantB, $covariantB, TrinaryLogic::createYes()],
+			[$covariantB, $covariantC, TrinaryLogic::createYes()],
+			[$covariantB, $contravariantA, TrinaryLogic::createNo()],
+			[$covariantB, $contravariantB, TrinaryLogic::createNo()],
+			[$covariantB, $contravariantC, TrinaryLogic::createNo()],
+			[$covariantB, $bivariant, TrinaryLogic::createNo()],
+
+			[$contravariantB, $invariantA, TrinaryLogic::createYes()],
+			[$contravariantB, $invariantB, TrinaryLogic::createYes()],
+			[$contravariantB, $invariantC, TrinaryLogic::createMaybe()],
+			[$contravariantB, $covariantA, TrinaryLogic::createNo()],
+			[$contravariantB, $covariantB, TrinaryLogic::createNo()],
+			[$contravariantB, $covariantC, TrinaryLogic::createNo()],
+			[$contravariantB, $contravariantA, TrinaryLogic::createYes()],
+			[$contravariantB, $contravariantB, TrinaryLogic::createYes()],
+			[$contravariantB, $contravariantC, TrinaryLogic::createMaybe()],
+			[$contravariantB, $bivariant, TrinaryLogic::createNo()],
+
+			[$bivariant, $invariantA, TrinaryLogic::createYes()],
+			[$bivariant, $invariantB, TrinaryLogic::createYes()],
+			[$bivariant, $invariantC, TrinaryLogic::createYes()],
+			[$bivariant, $covariantA, TrinaryLogic::createYes()],
+			[$bivariant, $covariantB, TrinaryLogic::createYes()],
+			[$bivariant, $covariantC, TrinaryLogic::createYes()],
+			[$bivariant, $contravariantA, TrinaryLogic::createYes()],
+			[$bivariant, $contravariantB, TrinaryLogic::createYes()],
+			[$bivariant, $contravariantC, TrinaryLogic::createYes()],
+			[$bivariant, $bivariant, TrinaryLogic::createYes()],
 		];
 	}
 
 	/**
 	 * @dataProvider dataIsSuperTypeOf
+	 * @dataProvider dataTypeProjections
 	 */
 	public function testIsSuperTypeOf(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
@@ -227,6 +332,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 
 	/**
 	 * @dataProvider dataAccepts
+	 * @dataProvider dataTypeProjections
 	 */
 	public function testAccepts(
 		Type $acceptingType,
@@ -376,6 +482,36 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					new TemplateTypeReference(
 						$templateType('T'),
 						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'param: Invariant<covariant T>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createCovariant(),
+				]),
+				false,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'param: Invariant<contravariant T>' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createContravariant(),
+				]),
+				false,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
 					),
 				],
 			],
@@ -603,6 +739,36 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					new TemplateTypeReference(
 						$templateType('T'),
 						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Invariant<covariant T>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createCovariant(),
+				]),
+				false,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
+			'return: Invariant<contravariant T>' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createContravariant(),
+				]),
+				false,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
 					),
 				],
 			],
@@ -914,6 +1080,36 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					),
 				],
 			],
+			'param: Invariant<covariant T> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createCovariant(),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
+					),
+				],
+			],
+			'param: Invariant<contravariant T> (with invariance composition)' => [
+				TemplateTypeVariance::createContravariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createContravariant(),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
 			'return: Out<Invariant<T>> (with invariance composition)' => [
 				TemplateTypeVariance::createCovariant(),
 				new GenericObjectType(D\Out::class, [
@@ -1005,6 +1201,36 @@ class GenericObjectTypeTest extends PHPStanTestCase
 					new TemplateTypeReference(
 						$templateType('T'),
 						TemplateTypeVariance::createInvariant(),
+					),
+				],
+			],
+			'return: Invariant<covariant T> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createCovariant(),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createCovariant(),
+					),
+				],
+			],
+			'return: Invariant<contravariant T> (with invariance composition)' => [
+				TemplateTypeVariance::createCovariant(),
+				new GenericObjectType(D\Invariant::class, [
+					$templateType('T'),
+				], null, null, [
+					TemplateTypeVariance::createContravariant(),
+				]),
+				true,
+				[
+					new TemplateTypeReference(
+						$templateType('T'),
+						TemplateTypeVariance::createContravariant(),
 					),
 				],
 			],

--- a/tests/PHPStan/Type/Generic/data/generic-classes-e.php
+++ b/tests/PHPStan/Type/Generic/data/generic-classes-e.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Test\E;
+
+class A {}
+class B extends A {}
+class C extends B {}
+
+/** @template T */
+class Foo {}

--- a/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
+++ b/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use stdClass;
 use function sprintf;
 
@@ -138,6 +139,19 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 				new ConstantIntegerType(2),
 			]),
 			'stdClass<1, 2>',
+		];
+
+		yield [
+			new GenericObjectType('stdClass', [
+				new StringType(),
+				new IntegerType(),
+				new MixedType(),
+			], null, null, [
+				TemplateTypeVariance::createInvariant(),
+				TemplateTypeVariance::createContravariant(),
+				TemplateTypeVariance::createBivariant(),
+			]),
+			'stdClass<string, contravariant int, *>',
 		];
 
 		yield [


### PR DESCRIPTION
I think I've got most of type projections figured out and prototyped, so here we go!

As [you suggested](https://github.com/phpstan/phpdoc-parser/pull/138#issuecomment-1328319769), I'm starting small by introducing call-site variance to `GenericObjectType` (and `ClassReflection`, transitively), and adding support for bivariance into `TemplateTypeVariance`.

Looking forward to your thoughts, and to finally having type projections in PHPStan 🤞