### PR TITLE
Add return type extension for `constant()`

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1364,6 +1364,14 @@ services:
 			checkMaybeUndefinedVariables: %checkMaybeUndefinedVariables%
 
 	-
+		class: PHPStan\Type\Php\ConstantFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
+	    class: PHPStan\Type\Php\ConstantHelper
+
+	-
 		class: PHPStan\Type\Php\CountFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Type/Php/ConstantFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ConstantFunctionReturnTypeExtension.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
+
+class ConstantFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function __construct(private ConstantHelper $constantHelper)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'constant';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope,
+	): ?Type
+	{
+		if (count($functionCall->getArgs()) < 1) {
+			return null;
+		}
+
+		$nameType = $scope->getType($functionCall->getArgs()[0]->value);
+
+		$results = [];
+		foreach ($nameType->getConstantStrings() as $constantName) {
+			$results[] = $scope->getType($this->constantHelper->createExprFromConstantName($constantName->getValue()));
+		}
+
+		if (count($results) > 0) {
+			return TypeCombinator::union(...$results);
+		}
+
+		return null;
+	}
+
+}

--- a/src/Type/Php/ConstantHelper.php
+++ b/src/Type/Php/ConstantHelper.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use function count;
+use function explode;
+use function ltrim;
+
+class ConstantHelper
+{
+
+	public function createExprFromConstantName(string $constantName): Expr
+	{
+		$classConstParts = explode('::', $constantName);
+		if (count($classConstParts) >= 2) {
+			$classConstName = new FullyQualified(ltrim($classConstParts[0], '\\'));
+			if ($classConstName->isSpecialClassName()) {
+				$classConstName = new Name($classConstName->toString());
+			}
+
+			return new ClassConstFetch($classConstName, new Identifier($classConstParts[1]));
+		}
+
+		return new ConstFetch(new FullyQualified($constantName));
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -642,6 +642,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-var-array.php');
 
 		if (PHP_VERSION_ID >= 80100) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/constant.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enums-import-alias.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7176.php');

--- a/tests/PHPStan/Analyser/data/constant.php
+++ b/tests/PHPStan/Analyser/data/constant.php
@@ -1,0 +1,40 @@
+<?php // lint >= 8.1
+
+namespace Constant;
+
+use function PHPStan\Testing\assertType;
+
+define('FOO', 'foo');
+const BAR = 'bar';
+
+class Baz
+{
+	const BAZ = 'baz';
+}
+
+enum Suit
+{
+    case Hearts;
+}
+
+function doFoo(string $constantName): void
+{
+	assertType('mixed', constant($constantName));
+}
+
+assertType("'foo'", FOO);
+assertType("'foo'", constant('FOO'));
+assertType("*ERROR*", constant('\Constant\FOO'));
+
+assertType("'bar'", BAR);
+assertType("*ERROR*", constant('BAR'));
+assertType("'bar'", constant('\Constant\BAR'));
+
+assertType("'bar'|'foo'", constant(rand(0, 1) ? 'FOO' : '\Constant\BAR'));
+
+assertType("'baz'", constant('\Constant\Baz::BAZ'));
+
+assertType('Constant\Suit::Hearts', Suit::Hearts);
+assertType('Constant\Suit::Hearts', constant('\Constant\Suit::Hearts'));
+
+assertType('*ERROR*', constant('UNDEFINED'));


### PR DESCRIPTION
Had that idea when https://github.com/phpstan/phpstan/issues/9295 was created. 

See https://www.php.net/manual/en/function.constant.php and https://3v4l.org/66no7

UPDATE: prior to PHP 8 it would trigger a warning for inexistent constants and return `null`. But not sure if it's worth the effort to implement this. right now it would just return `*ERROR*` for such cases. UPDATE2: this feels related to also support non-existing constants as expressions, so I'll refrain from adding any code for it for now. E.g. https://3v4l.org/FTHPv / https://phpstan.org/r/c649b7bb-8031-4210-9c4b-c469eba63d3b