### PR TITLE
Break in ClassReflection when not allowing dynamic property extensions.

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -385,10 +385,11 @@ class ClassReflection
 		if ($this->isEnum()) {
 			return $this->hasNativeProperty($propertyName);
 		}
+		$allowsDynamicPropertiesExtensions = $this->allowsDynamicPropertiesExtensions();
 
 		foreach ($this->propertiesClassReflectionExtensions as $i => $extension) {
-			if ($i > 0 && !$this->allowsDynamicPropertiesExtensions()) {
-				continue;
+			if ($i > 0 && !$allowsDynamicPropertiesExtensions) {
+				break;
 			}
 			if ($extension->hasProperty($this, $propertyName)) {
 				return true;
@@ -538,9 +539,11 @@ class ClassReflection
 			$key = sprintf('%s-%s', $key, $scope->getClassReflection()->getCacheKey());
 		}
 		if (!isset($this->properties[$key])) {
+			$allowsDynamicPropertiesExtensions = $this->allowsDynamicPropertiesExtensions();
+
 			foreach ($this->propertiesClassReflectionExtensions as $i => $extension) {
-				if ($i > 0 && !$this->allowsDynamicPropertiesExtensions()) {
-					continue;
+				if ($i > 0 && !$allowsDynamicPropertiesExtensions) {
+					break;
 				}
 				if (!$extension->hasProperty($this, $propertyName)) {
 					continue;


### PR DESCRIPTION
break is more appropriate here as the condition will never become false after the first time it is true

additionally `allowsDynamicPropertyExtensions()` is a non-trivial method that is not memoized, so lets avoid calling it more than we have to given it's value will not change between iterations