### PR TITLE
Revert calling allowsDynamicPropertiesExtensions ahead of time.

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -385,10 +385,9 @@ class ClassReflection
 		if ($this->isEnum()) {
 			return $this->hasNativeProperty($propertyName);
 		}
-		$allowsDynamicPropertiesExtensions = $this->allowsDynamicPropertiesExtensions();
 
 		foreach ($this->propertiesClassReflectionExtensions as $i => $extension) {
-			if ($i > 0 && !$allowsDynamicPropertiesExtensions) {
+			if ($i > 0 && !$this->allowsDynamicPropertiesExtensions()) {
 				break;
 			}
 			if ($extension->hasProperty($this, $propertyName)) {
@@ -539,10 +538,8 @@ class ClassReflection
 			$key = sprintf('%s-%s', $key, $scope->getClassReflection()->getCacheKey());
 		}
 		if (!isset($this->properties[$key])) {
-			$allowsDynamicPropertiesExtensions = $this->allowsDynamicPropertiesExtensions();
-
 			foreach ($this->propertiesClassReflectionExtensions as $i => $extension) {
-				if ($i > 0 && !$allowsDynamicPropertiesExtensions) {
+				if ($i > 0 && !$this->allowsDynamicPropertiesExtensions()) {
 					break;
 				}
 				if (!$extension->hasProperty($this, $propertyName)) {


### PR DESCRIPTION
reverts part of the change i made before :see_no_evil: sorry for the bad commit, i should've measured more before making the pr

upon further investigation i realized that this actually causes the method to be called way more often than it needs to be, as the majority of cases of property access are managed by the first property reflection extension and as such this wouldn't be called...

keeping the `continue` -> `break` change as that is still useful however