### PR TITLE
fix infinite cycle due to incorrect implements/extends

### DIFF
--- a/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php
@@ -109,8 +109,26 @@ class ClassAncestorsRuleTest extends RuleTestCase
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 			[
+				'Class ClassAncestorsExtends\FooObjectStorage @extends tag contains incompatible type ClassAncestorsExtends\FooObjectStorage.',
+				226,
+			],
+			[
+				'Class ClassAncestorsExtends\FooObjectStorage extends generic class SplObjectStorage but does not specify its types: TObject, TData',
+				226,
+				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
+				'Class ClassAncestorsExtends\FooCollection @extends tag contains incompatible type ClassAncestorsExtends\FooCollection&iterable<int>.',
+				239,
+			],
+			[
+				'Class ClassAncestorsExtends\FooCollection extends generic class ClassAncestorsExtends\AbstractFooCollection but does not specify its types: T',
+				239,
+				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
 				'Call-site variance annotation of covariant Throwable in generic type ClassAncestorsExtends\FooGeneric<covariant Throwable, InvalidArgumentException> in PHPDoc tag @extends is not allowed.',
-				228,
+				246,
 			],
 		]);
 	}
@@ -199,8 +217,26 @@ class ClassAncestorsRuleTest extends RuleTestCase
 				216,
 			],
 			[
+				'Class ClassAncestorsImplements\FooIterator @implements tag contains incompatible type ClassAncestorsImplements\FooIterator&iterable<int, object>.',
+				222,
+			],
+			[
+				'Class ClassAncestorsImplements\FooIterator implements generic interface Iterator but does not specify its types: TKey, TValue',
+				222,
+				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
+				'Class ClassAncestorsImplements\FooCollection @implements tag contains incompatible type ClassAncestorsImplements\FooCollection&iterable<int>.',
+				235,
+			],
+			[
+				'Class ClassAncestorsImplements\FooCollection implements generic interface ClassAncestorsImplements\AbstractFooCollection but does not specify its types: T',
+				235,
+				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+			[
 				'Call-site variance annotation of covariant Throwable in generic type ClassAncestorsImplements\FooGeneric<covariant Throwable, InvalidArgumentException> in PHPDoc tag @implements is not allowed.',
-				224,
+				242,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Generics/data/class-ancestors-extends.php
+++ b/tests/PHPStan/Rules/Generics/data/class-ancestors-extends.php
@@ -222,6 +222,24 @@ class FilterIteratorChild extends \FilterIterator
 
 }
 
+/** @extends FooObjectStorage<object> */
+class FooObjectStorage extends \SplObjectStorage
+{
+}
+
+/**
+ * @template T
+ * @implements \Iterator<int, T>
+ */
+abstract class AbstractFooCollection implements \Iterator
+{
+}
+
+/** @extends FooCollection<int> */
+class FooCollection extends AbstractFooCollection
+{
+}
+
 /**
  * @extends FooGeneric<covariant \Throwable, \InvalidArgumentException>
  */

--- a/tests/PHPStan/Rules/Generics/data/class-ancestors-implements.php
+++ b/tests/PHPStan/Rules/Generics/data/class-ancestors-implements.php
@@ -218,10 +218,27 @@ class FooGeneric10 implements FooGeneric9
 
 }
 
+/** @implements FooIterator<int, object> */
+class FooIterator implements \Iterator
+{
+}
+
+/**
+ * @template T
+ * @implements \Iterator<int, T>
+ */
+interface AbstractFooCollection extends \Iterator
+{
+}
+
+/** @implements FooCollection<int> */
+class FooCollection implements AbstractFooCollection
+{
+}
+
 /**
  * @implements FooGeneric<covariant \Throwable, \InvalidArgumentException>
  */
 class FooTypeProjection implements FooGeneric
 {
-
 }


### PR DESCRIPTION
This is an attempt to fix an infinite cycle on code like this (playground won't let me share the link, presumably because phpstan crashes):

```php
<?php

/** @extends FooCollection<object> */
class FooCollection extends SplObjectStorage
{
}
```

Here is a shortened stack-trace that I generated from the test with `src/` changes stashed:

```
...
 /phpstan-src/src/Reflection/ClassReflection.php:1534
 /phpstan-src/src/Type/ObjectType.php:801
 /phpstan-src/src/Type/ObjectType.php:921
 /phpstan-src/src/Type/IterableType.php:166
 /phpstan-src/src/Type/ObjectType.php:329
 /phpstan-src/src/Type/TypeCombinator.php:997
 /phpstan-src/src/PhpDoc/TypeNodeResolver.php:844
 /phpstan-src/src/PhpDoc/TypeNodeResolver.php:161
 /phpstan-src/src/PhpDoc/PhpDocNodeResolver.php:209
 /phpstan-src/src/PhpDoc/ResolvedPhpDocBlock.php:428
 /phpstan-src/src/Reflection/ClassReflection.php:1459
 /phpstan-src/src/Reflection/ClassReflection.php:1444
 /phpstan-src/src/Reflection/ClassReflection.php:201
 /phpstan-src/src/Reflection/ClassReflection.php:813
 /phpstan-src/src/Reflection/ClassReflection.php:766
 /phpstan-src/src/Reflection/ClassReflection.php:1504
 /phpstan-src/src/Reflection/ClassReflection.php:1534
 /phpstan-src/src/Type/ObjectType.php:801
 /phpstan-src/src/Type/ObjectType.php:921
 /phpstan-src/src/Type/IterableType.php:166
 /phpstan-src/src/Type/ObjectType.php:329
 /phpstan-src/src/Type/TypeCombinator.php:997
 /phpstan-src/src/PhpDoc/TypeNodeResolver.php:844
 /phpstan-src/src/PhpDoc/TypeNodeResolver.php:161
 /phpstan-src/src/PhpDoc/PhpDocNodeResolver.php:209
 /phpstan-src/src/PhpDoc/ResolvedPhpDocBlock.php:428
 /phpstan-src/src/Reflection/ClassReflection.php:1459
 /phpstan-src/src/Reflection/ClassReflection.php:1444
 /phpstan-src/src/Reflection/ClassReflection.php:201
 /phpstan-src/src/Reflection/ClassReflection.php:813
 /phpstan-src/src/Reflection/ClassReflection.php:766
 /phpstan-src/src/Dependency/DependencyResolver.php:462
 /phpstan-src/src/Dependency/DependencyResolver.php:49
 /phpstan-src/src/Analyser/FileAnalyser.php:158
 /phpstan-src/src/Analyser/NodeScopeResolver.php:396
 /phpstan-src/src/Analyser/NodeScopeResolver.php:294
 /phpstan-src/src/Analyser/NodeScopeResolver.php:653
 /phpstan-src/src/Analyser/NodeScopeResolver.php:252
 /phpstan-src/src/Analyser/FileAnalyser.php:176
 /phpstan-src/src/Analyser/Analyser.php:66
 /phpstan-src/src/Testing/RuleTestCase.php:165
 /phpstan-src/src/Testing/RuleTestCase.php:129
 /phpstan-src/tests/PHPStan/Rules/Generics/ClassAncestorsRuleTest.php:30
 ```
 I briefly tried the other phpdocs (e.g. `@use`, `@mixin`, ...) to see if they have a similar issue, but I wasn't able to find a case where they'd cause an infinite cycle.