### PR TITLE
More precise ignore_user_abort() return type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -4514,7 +4514,7 @@ return [
 'ifxus_write_slob' => ['int', 'bid'=>'int', 'content'=>'string'],
 'igbinary_serialize' => ['string|null', 'value'=>'mixed'],
 'igbinary_unserialize' => ['mixed', 'str'=>'string'],
-'ignore_user_abort' => ['int', 'value='=>'bool'],
+'ignore_user_abort' => ['0|1', 'value='=>'bool'],
 'iis_add_server' => ['int', 'path'=>'string', 'comment'=>'string', 'server_ip'=>'string', 'port'=>'int', 'host_name'=>'string', 'rights'=>'int', 'start_server'=>'int'],
 'iis_get_dir_security' => ['int', 'server_instance'=>'int', 'virtual_path'=>'string'],
 'iis_get_script_map' => ['string', 'server_instance'=>'int', 'virtual_path'=>'string', 'script_extension'=>'string'],


### PR DESCRIPTION
as [we recently stumbled over this functions ](https://github.com/sabre-io/http/pull/207/files#r1241885349) return type I figured it would be helpful to cover this more precisely in PHPStan.

The setter expects a bool, but the getter returns a int.


https://3v4l.org/jmCa8
https://www.php.net/manual/en/function.ignore-user-abort.php