### PR TITLE
Implement JsonValidateTypeSpecifyingExtension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1538,6 +1538,11 @@ services:
 			- phpstan.dynamicFunctionThrowTypeExtension
 
 	-
+		class: PHPStan\Type\Php\JsonValidateTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
+
+	-
 		class: PHPStan\Type\Php\ReflectionClassConstructorThrowTypeExtension
 		tags:
 			- phpstan.dynamicStaticMethodThrowTypeExtension

--- a/resources/functionMap_php83delta.php
+++ b/resources/functionMap_php83delta.php
@@ -1,0 +1,29 @@
+<?php // phpcs:ignoreFile
+
+/**
+ * Copied over from https://github.com/phan/phan/blob/8866d6b98be94b37996390da226e8c4befea29aa/src/Phan/Language/Internal/FunctionSignatureMap_php80_delta.php
+ * Copyright (c) 2015 Rasmus Lerdorf
+ * Copyright (c) 2015 Andrew Morrison
+ */
+
+/**
+ * This contains the information needed to convert the function signatures for php 8.0 to php 7.4 (and vice versa)
+ *
+ * This has two sections.
+ * The 'new' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php7.4 or have different signatures in php 8.0.
+ *   If they were just updated, the function/method will be present in the 'added' signatures.
+ * The 'old' signatures contains the signatures that are different in php 7.4.
+ *   Functions are expected to be removed only in major releases of php.
+ *
+ * @see FunctionSignatureMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
+ */
+return [
+	'new' => [
+		'json_validate' => ['bool', 'json'=>'string', 'depth='=>'positive-int', 'flags='=>'int-mask<JSON_INVALID_UTF8_IGNORE>'],
+	],
+	'old' => [
+
+	]
+];

--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -233,6 +233,15 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 				$signatureMap = $this->computeSignatureMap($signatureMap, $php82MapDelta);
 			}
 
+			if ($this->phpVersion->getVersionId() >= 80300) {
+				$php83MapDelta = require __DIR__ . '/../../../resources/functionMap_php83delta.php';
+				if (!is_array($php83MapDelta)) {
+					throw new ShouldNotHappenException('Signature map could not be loaded.');
+				}
+
+				$signatureMap = $this->computeSignatureMap($signatureMap, $php83MapDelta);
+			}
+
 			$this->signatureMap = $signatureMap;
 		}
 

--- a/src/Type/Php/JsonValidateTypeSpecifyingExtension.php
+++ b/src/Type/Php/JsonValidateTypeSpecifyingExtension.php
@@ -9,7 +9,7 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use function count;
 
@@ -31,7 +31,7 @@ class JsonValidateTypeSpecifyingExtension implements FunctionTypeSpecifyingExten
 			return new SpecifiedTypes([], []);
 		}
 
-		return $this->typeSpecifier->create($node->getArgs()[0]->value, new AccessoryNonFalsyStringType(), $context, false, $scope);
+		return $this->typeSpecifier->create($node->getArgs()[0]->value, new AccessoryNonEmptyStringType(), $context, false, $scope);
 	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/src/Type/Php/JsonValidateTypeSpecifyingExtension.php
+++ b/src/Type/Php/JsonValidateTypeSpecifyingExtension.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use function count;
+
+class JsonValidateTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private TypeSpecifier $typeSpecifier;
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
+	{
+		return $functionReflection->getName() === 'json_validate' && isset($node->getArgs()[0]) && $context->true();
+	}
+
+	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+	{
+		$args = $node->getArgs();
+
+		if (count($args) < 1) {
+			return new SpecifiedTypes([], []);
+		}
+
+		return $this->typeSpecifier->create($node->getArgs()[0]->value, new AccessoryNonFalsyStringType(), $context, false, $scope);
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1283,8 +1283,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5782b-php7.php');
 		}
 
+		if (PHP_VERSION_ID >= 80300) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/json_validate.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/gettype.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/json_validate.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1284,6 +1284,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/gettype.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/json_validate.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/json_validate.php
+++ b/tests/PHPStan/Analyser/data/json_validate.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JsonValidate;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo($m): void {
+	assertType('bool', json_validate($m));
+
+	if (json_validate($m)) {
+		assertType('non-falsy-string', $m);
+	} else {
+		assertType('mixed', $m);
+	}
+	assertType('mixed', $m);
+}
+
+/**
+ * @param non-empty-string $nonES
+ */
+function doBar($nonES): void {
+	if (json_validate($nonES)) {
+		assertType('non-falsy-string', $nonES);
+	} else {
+		assertType('non-empty-string', $nonES);
+	}
+	assertType('non-empty-string', $nonES);
+}

--- a/tests/PHPStan/Analyser/data/json_validate.php
+++ b/tests/PHPStan/Analyser/data/json_validate.php
@@ -8,7 +8,7 @@ function doFoo($m): void {
 	assertType('bool', json_validate($m));
 
 	if (json_validate($m)) {
-		assertType('non-falsy-string', $m);
+		assertType('non-empty-string', $m);
 	} else {
 		assertType('mixed', $m);
 	}
@@ -20,7 +20,7 @@ function doFoo($m): void {
  */
 function doBar($nonES): void {
 	if (json_validate($nonES)) {
-		assertType('non-falsy-string', $nonES);
+		assertType('non-empty-string', $nonES);
 	} else {
 		assertType('non-empty-string', $nonES);
 	}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1397,8 +1397,8 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			],
 			[
 				'Parameter #3 $flags of function json_validate expects 0|1048576, 2 given.',
-				7
-			]
+				7,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1390,6 +1390,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 	public function testJsonValidate(): void
 	{
+		if (PHP_VERSION_ID < 80300) {
+			$this->markTestSkipped('Test requires PHP 8.3');
+		}
+
 		$this->analyse([__DIR__ . '/data/json_validate.php'], [
 			[
 				'Parameter #2 $depth of function json_validate expects int<1, max>, 0 given.',

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1388,4 +1388,18 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testJsonValidate(): void
+	{
+		$this->analyse([__DIR__ . '/data/json_validate.php'], [
+			[
+				'Parameter #2 $depth of function json_validate expects int<1, max>, 0 given.',
+				6,
+			],
+			[
+				'Parameter #3 $flags of function json_validate expects 0|1048576, 2 given.',
+				7
+			]
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/json_validate.php
+++ b/tests/PHPStan/Rules/Functions/data/json_validate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JsonValidateParams;
+
+function doFoo() {
+	$x = json_validate('{ "test": { "foo": "bar" } }', 0, 0); // invalid depth
+	$x = json_validate('{ "test": { "foo": "bar" } }', 100, JSON_BIGINT_AS_STRING); // invalid flags
+
+	$x = json_validate('{ "test": { "foo": "bar" } }');
+	$x = json_validate('{ "test": { "foo": "bar" } }', 100, 0);
+	$x = json_validate('{ "test": { "foo": "bar" } }', 100, JSON_INVALID_UTF8_IGNORE);
+
+}


### PR DESCRIPTION
PHP8.3 Support for https://wiki.php.net/rfc/json_validate

this type-specifying extension narrows the `$json` arg to a non-empty-string