### PR TITLE
feat: treat void as null for null coalescing operator

### DIFF
--- a/src/Rules/Variables/NullCoalesceRule.php
+++ b/src/Rules/Variables/NullCoalesceRule.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\IssetCheck;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
+use PHPStan\Type\VoidType;
 
 /**
  * @implements Rule<Node\Expr>
@@ -27,12 +28,13 @@ class NullCoalesceRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$typeMessageCallback = static function (Type $type): ?string {
+			$isVoid = (new VoidType())->isSuperTypeOf($type);
 			$isNull = (new NullType())->isSuperTypeOf($type);
-			if ($isNull->maybe()) {
+			if ($isNull->maybe() || $isVoid->maybe()) {
 				return null;
 			}
 
-			if ($isNull->yes()) {
+			if ($isNull->yes() || $isVoid->yes()) {
 				return 'is always null';
 			}
 

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -368,4 +368,17 @@ class NullCoalesceRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8084.php'], []);
 	}
 
+	public function testVoid(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/data/null-coalesce-void.php'], [
+			[
+				'Expression on left side of ?? is always null.',
+				22,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/null-coalesce-void.php
+++ b/tests/PHPStan/Rules/Variables/data/null-coalesce-void.php
@@ -1,0 +1,22 @@
+<?php // lint >= 8.0
+
+namespace CoalesceRuleVoid;
+
+/** @return array|void */
+function get_post_custom_keys($maybe = false)
+{
+	if ($maybe) {
+		return;
+	}
+
+	return [];
+}
+
+function foo_bar(): void
+{
+	return;
+}
+
+$test1 = get_post_custom_keys(true) ?? 'foo';
+
+$test2 = foo_bar() ?? 'bar';


### PR DESCRIPTION
Hi :wave: 

WordPress often uses type definitions like `array|void` (e.g. https://github.com/WordPress/wordpress-develop/blob/68be569925ad2a88c97e1308b8a67a57bf17a14f/src/wp-includes/post.php#L2627).

`$custom_keys = get_post_custom_keys( $post_id ) ?? [];`

Shows: Expression on left side of ?? is not nullable.


