### PR TITLE
Added regression test

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1406,4 +1406,9 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug4608(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-4608.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-4608.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-4608.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bug4608;
+
+function doFoo() {
+	$c = new class {
+		public function abc(): void {}
+	};
+
+	$s = rand(0, 1) ? 'abc' : 'not_abc';
+
+	$c->{$s}();
+	call_user_func([$c, $s]);
+	[$c, $s]();
+}


### PR DESCRIPTION
phpstanbot told us this issue is fixed: https://github.com/phpstan/phpstan/issues/4608#issuecomment-1235674970
just locally confirmed that this no longer errors with 

> Parameter #1 $callback of function call_user_func expects callable(): mixed, array(class@anonymous/tmp.php:3, 'abc'|'not_abc') given.

refs https://github.com/phpstan/phpstan/issues/4608