### PR TITLE
Fix ClassConstFetch Identical specification with Yoda conditions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -86,7 +86,7 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantStringType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantStrings\\(\\) instead\\.$#"
-			count: 2
+			count: 3
 			path: src/Analyser/TypeSpecifier.php
 
 		-

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -270,6 +270,27 @@ class TypeSpecifier
 					$rootExpr,
 				)->unionWith($this->create($expr->left, $rightType, $context, false, $scope, $rootExpr));
 			}
+
+			$leftType = $scope->getType($leftExpr);
+			if (
+				$rightExpr instanceof ClassConstFetch &&
+				$rightExpr->class instanceof Expr &&
+				$rightExpr->name instanceof Node\Identifier &&
+				$leftExpr instanceof ClassConstFetch &&
+				$leftType instanceof ConstantStringType &&
+				strtolower($rightExpr->name->toString()) === 'class'
+			) {
+				return $this->specifyTypesInCondition(
+					$scope,
+					new Instanceof_(
+						$rightExpr->class,
+						new Name($leftType->getValue()),
+					),
+					$context,
+					$rootExpr,
+				)->unionWith($this->create($expr->right, $leftType, $context, false, $scope, $rootExpr));
+			}
+
 			if ($context->false()) {
 				$identicalType = $scope->getType($expr);
 				if ($identicalType instanceof ConstantBooleanType) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -253,6 +253,7 @@ class TypeSpecifier
 			}
 
 			if (
+				$context->true() &&
 				$leftExpr instanceof ClassConstFetch &&
 				$leftExpr->class instanceof Expr &&
 				$leftExpr->name instanceof Node\Identifier &&
@@ -273,6 +274,7 @@ class TypeSpecifier
 
 			$leftType = $scope->getType($leftExpr);
 			if (
+				$context->true() &&
 				$rightExpr instanceof ClassConstFetch &&
 				$rightExpr->class instanceof Expr &&
 				$rightExpr->name instanceof Node\Identifier &&

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1302,6 +1302,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/gettype.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_splice.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-9542.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-5843.php
+++ b/tests/PHPStan/Analyser/data/bug-5843.php
@@ -15,7 +15,7 @@ class Foo
 				assertType(\DateTime::class, $object);
 				break;
 			case \Throwable::class:
-				assertType('Throwable~DateTime', $object);
+				assertType('Throwable', $object);
 				break;
 		}
 	}
@@ -29,7 +29,7 @@ class Bar
 	{
 		match ($object::class) {
 			\DateTime::class => assertType(\DateTime::class, $object),
-			\Throwable::class => assertType('Throwable~DateTime', $object),
+			\Throwable::class => assertType('Throwable', $object),
 		};
 	}
 

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2911,6 +2911,15 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8888.php'], []);
 	}
 
+	public function testBug9542(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-9542.php'], []);
+	}
+
 	public function testTrickyCallables(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/bug-9542.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-9542.php
@@ -33,7 +33,7 @@ class HelloWorld
 	public function testClass(TranslatableInterface $translatable): void
 	{
 		if ($translatable::class !== TranslatableMessage::class) {
-			assertType('Bug9542\TranslatableInterface~Bug9542\TranslatableMessage', $translatable);
+			assertType('Bug9542\TranslatableInterface', $translatable);
 			return;
 		}
 
@@ -44,7 +44,7 @@ class HelloWorld
 	public function testClassReverse(TranslatableInterface $translatable): void
 	{
 		if (TranslatableMessage::class !== $translatable::class) {
-			assertType('Bug9542\TranslatableInterface~Bug9542\TranslatableMessage', $translatable);
+			assertType('Bug9542\TranslatableInterface', $translatable);
 			return;
 		}
 

--- a/tests/PHPStan/Rules/Methods/data/bug-9542.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-9542.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9542;
+
+use function PHPStan\Testing\assertType;
+
+interface TranslatableInterface
+{
+
+}
+
+class TranslatableMessage implements TranslatableInterface
+{
+	public function getMessage(): void
+	{
+		return;
+	}
+}
+
+class HelloWorld
+{
+	public function testInstanceOf(TranslatableInterface $translatable): void
+	{
+		if (! $translatable instanceof TranslatableMessage) {
+			assertType('Bug9542\TranslatableInterface~Bug9542\TranslatableMessage', $translatable);
+			return;
+		}
+
+		assertType('Bug9542\TranslatableMessage', $translatable);
+		$translatable->getMessage();
+	}
+
+	public function testClass(TranslatableInterface $translatable): void
+	{
+		if ($translatable::class !== TranslatableMessage::class) {
+			assertType('Bug9542\TranslatableInterface~Bug9542\TranslatableMessage', $translatable);
+			return;
+		}
+
+		assertType('Bug9542\TranslatableMessage', $translatable);
+		$translatable->getMessage();
+	}
+
+	public function testClassReverse(TranslatableInterface $translatable): void
+	{
+		if (TranslatableMessage::class !== $translatable::class) {
+			assertType('Bug9542\TranslatableInterface~Bug9542\TranslatableMessage', $translatable);
+			return;
+		}
+
+		assertType('Bug9542\TranslatableMessage', $translatable);
+		$translatable->getMessage();
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/9542

Is this how you would have done it? Might be the simplest way I guess. It's just an adapted version to handle the left/right mixed variant of the block directly before it.

UPDATE: I had the urge to somehow simplify/cleanup things, like the way left and right types are fetched from the scope, assigned to variables and used, in Identical in a follow-up but I failed. Better not touch it too much 😅