### PR TITLE
Prune non-wildcard excludePaths directories early

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -146,6 +146,7 @@
 	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
 	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
 		<exclude-pattern>src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php</exclude-pattern>
+		<exclude-pattern>tests/PHPStan/File/FileFinderTest.php</exclude-pattern>
 	</rule>
 	<rule ref="Consistence.NamingConventions.ValidVariableName.NotCamelCaps">
 		<exclude-pattern>src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php</exclude-pattern>

--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -62,6 +62,14 @@ class FileExcluder
 		}
 	}
 
+	/**
+	 * @return string[]
+	 */
+	public function getExcludedLiteralPaths(): array
+	{
+		return $this->literalAnalyseExcludes;
+	}
+
 	public function isExcludedFromAnalysing(string $file): bool
 	{
 		foreach ($this->literalAnalyseExcludes as $exclude) {

--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -62,14 +62,6 @@ class FileExcluder
 		}
 	}
 
-	/**
-	 * @return string[]
-	 */
-	public function getExcludedLiteralPaths(): array
-	{
-		return $this->literalAnalyseExcludes;
-	}
-
 	public function isExcludedFromAnalysing(string $file): bool
 	{
 		foreach ($this->literalAnalyseExcludes as $exclude) {

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -37,9 +37,12 @@ class FileFinder
 			} elseif (!file_exists($path)) {
 				throw new PathNotFoundException($path);
 			} else {
-				$finder = new Finder();
-				$finder->followLinks();
-				foreach ($finder->files()->name('*.{' . implode(',', $this->fileExtensions) . '}')->in($path) as $fileInfo) {
+				$finder = (new Finder())
+					->in($path)
+					->followLinks()
+					->files()
+					->name('*.{' . implode(',', $this->fileExtensions) . '}');
+				foreach ($finder as $fileInfo) {
 					$files[] = $this->fileHelper->normalizePath($fileInfo->getPathname());
 					$onlyFiles = false;
 				}

--- a/src/File/FileFinderSymfonyBackport.php
+++ b/src/File/FileFinderSymfonyBackport.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use Closure;
+use Iterator;
+use IteratorAggregate;
+use RecursiveIteratorIterator;
+use ReturnTypeWillChange;
+use SplFileInfo;
+use Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator;
+use Symfony\Component\Finder\Iterator\FilenameFilterIterator;
+use Symfony\Component\Finder\Iterator\FileTypeFilterIterator;
+use Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator;
+use function rtrim;
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Backport Symfony Finder with early directory prunning for \PHPStan\File\FileFinder.
+ *
+ * Remove this class once Symfony 6.4 with https://github.com/symfony/symfony/pull/50877 optimization
+ * is released and phpstan dependencies allows it.
+ *
+ * @implements IteratorAggregate<string, SplFileInfo>
+ *
+ * @internal
+ */
+class FileFinderSymfonyBackport implements IteratorAggregate
+{
+
+	private string $in;
+
+	private string $name;
+
+	/** @var Closure(SplFileInfo): bool  */
+	private Closure $pruneFilter;
+
+	public function __construct()
+	{
+		// ignore "Class PHPStan\File\FileFinderSymfonyBackport has an uninitialized
+		// property $xxx. Give it default value or assign it in the constructor."
+		$this->in = '';
+		$this->name = '';
+		$this->pruneFilter = static fn () => true;
+	}
+
+	/**
+	 * @return $this
+	 */
+	public function in(string $dir)
+	{
+		$this->in = $this->normalizeDir($dir);
+
+		return $this;
+	}
+
+	private function normalizeDir(string $dir): string
+	{
+		if ($dir === '/') {
+			return $dir;
+		}
+
+		$dir = rtrim($dir, '/' . DIRECTORY_SEPARATOR);
+
+		return $dir;
+	}
+
+	/**
+	 * @return $this
+	 */
+	public function name(string $pattern)
+	{
+		$this->name = $pattern;
+
+		return $this;
+	}
+
+	/**
+	 * @return $this
+	 */
+	public function followLinks()
+	{
+		return $this;
+	}
+
+	/**
+	 * @return $this
+	 */
+	public function files()
+	{
+		return $this;
+	}
+
+	/**
+	 * @param Closure(SplFileInfo): bool $closure
+	 * @param true $prune
+	 *
+	 * @return $this
+	 */
+	public function filter(Closure $closure, bool $prune)
+	{
+		$this->pruneFilter = $closure;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return Iterator<string, SplFileInfo>
+	 */
+	#[ReturnTypeWillChange]
+	public function getIterator(): Iterator
+	{
+		$iterator = new RecursiveDirectoryIterator($this->in, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
+		$iterator = new class($iterator, [$this->pruneFilter]) extends ExcludeDirectoryFilterIterator {
+
+			/** @var list<callable(SplFileInfo): bool> */
+			private array $pruneFilters = [];
+
+			/**
+			 * @param list<Closure(SplFileInfo): bool> $directories
+			 */
+			public function __construct(Iterator $iterator, array $directories)
+			{
+				parent::__construct($iterator, []);
+
+				$this->pruneFilters = $directories;
+			}
+
+			public function accept(): bool
+			{
+				if ($this->hasChildren()) {
+					foreach ($this->pruneFilters as $pruneFilter) {
+						if (!$pruneFilter($this->current())) {
+							return false;
+						}
+					}
+				}
+
+				return parent::accept();
+			}
+
+		};
+		$iterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
+		$iterator = new FileTypeFilterIterator($iterator, FileTypeFilterIterator::ONLY_FILES);
+		$iterator = new FilenameFilterIterator($iterator, [$this->name], []);
+
+		return $iterator;
+	}
+
+}

--- a/src/File/FileFinderSymfonyBackport.php
+++ b/src/File/FileFinderSymfonyBackport.php
@@ -111,7 +111,29 @@ class FileFinderSymfonyBackport implements IteratorAggregate
 	#[ReturnTypeWillChange]
 	public function getIterator(): Iterator
 	{
-		$iterator = new RecursiveDirectoryIterator($this->in, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
+		$iterator = new class($this->in, RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS) extends RecursiveDirectoryIterator {
+
+			private bool $ignoreFirstRewind = true;
+
+			public function next(): void
+			{
+				$this->ignoreFirstRewind = false;
+
+				parent::next();
+			}
+
+			public function rewind(): void
+			{
+				if ($this->ignoreFirstRewind) {
+					$this->ignoreFirstRewind = false;
+
+					return;
+				}
+
+				parent::rewind();
+			}
+
+		};
 		$iterator = new class($iterator, [$this->pruneFilter]) extends ExcludeDirectoryFilterIterator {
 
 			/** @var list<callable(SplFileInfo): bool> */

--- a/tests/PHPStan/File/FileFinderTest.php
+++ b/tests/PHPStan/File/FileFinderTest.php
@@ -237,12 +237,7 @@ class FileFinderTest extends PHPStanTestCase
 			],
 			['x'],
 			['x/d'],
-			// ['x/b.php', 'x/c.php' , 'x/x/d/u2.php'],
-			// x/d exclude should keep x/x/d, but that is currently not possible,
-			// as Symfony Finder impl. escapes all patterns in
-			// https://github.com/symfony/symfony/blob/v6.2.12/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php#L45
-			// so the generated exclude pattern cannot start with "^"
-			['x/b.php', 'x/c.php'],
+			['x/b.php', 'x/c.php' , 'x/x/d/u2.php'],
 			[
 				['x', 'is_dir', true],
 				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
@@ -256,6 +251,9 @@ class FileFinderTest extends PHPStanTestCase
 				['x/x', 'list_dir_open', ['d']],
 				['x/x', 'list_dir_rewind', ['d']],
 				['x/x/d', 'is_dir', true],
+				['x/x/d', 'list_dir_open', ['u2.php']],
+				['x/x/d', 'list_dir_rewind', ['u2.php']],
+				['x/x/d/u2.php', 'is_dir', false],
 			],
 		];
 	}

--- a/tests/PHPStan/File/FileFinderTest.php
+++ b/tests/PHPStan/File/FileFinderTest.php
@@ -38,7 +38,7 @@ class FileFinderTest extends PHPStanTestCase
 	{
 		$this->vfsScheme = 'phpstan-file-finder-test-' . ++self::$vfsNextIndex;
 
-		$wrapperClass = get_class(new class() {
+		$vfsWrapperClass = get_class(new class() {
 
 			/** @var resource */
 			public $context;
@@ -120,7 +120,7 @@ class FileFinderTest extends PHPStanTestCase
 
 		});
 
-		stream_wrapper_register($this->vfsScheme, $wrapperClass);
+		stream_wrapper_register($this->vfsScheme, $vfsWrapperClass);
 	}
 
 	public function tearDown(): void
@@ -168,7 +168,7 @@ class FileFinderTest extends PHPStanTestCase
 		$prependSchemeFx = fn (string $v): string => $this->vfsScheme . '://' . $v;
 		$stripSchemeFx = fn (string $v): string => preg_replace('~^' . $this->vfsScheme . '://~', '', $v) ?? '';
 
-		$fileHelper = @$this->getFileHelper(); // @ is needed at least localy, TODO rmeove before merge
+		$fileHelper = $this->getFileHelper();
 		$fileExcluder = new FileExcluder($fileHelper, array_map($prependSchemeFx, $excludePaths));
 		$fileFinder = new FileFinder($fileExcluder, $fileHelper, ['php', 'p']);
 		$fileFinderResult = $fileFinder->findFiles(array_map($prependSchemeFx, $inPaths));
@@ -204,7 +204,7 @@ class FileFinderTest extends PHPStanTestCase
 			[
 				['x', 'is_dir', true],
 				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd']],
-				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd']], // directory should be opened once only, seems like Symfony Finder issue
+				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd']], // directory should be opened once only, remove once https://github.com/symfony/symfony/issues/50851 is fixed
 				['x', 'list_dir_rewind', ['a.txt', 'b.php', 'c.php', 'd']],
 				['x/a.txt', 'is_dir', false],
 				['x/b.php', 'is_dir', false],

--- a/tests/PHPStan/File/FileFinderTest.php
+++ b/tests/PHPStan/File/FileFinderTest.php
@@ -189,6 +189,7 @@ class FileFinderTest extends PHPStanTestCase
 					'c.php' => '',
 					'd' => [
 						'u.php' => '',
+						'p.p' => '',
 					],
 				],
 				'y' => [
@@ -197,7 +198,7 @@ class FileFinderTest extends PHPStanTestCase
 			],
 			['x'],
 			[],
-			['x/b.php', 'x/c.php', 'x/d/u.php'],
+			['x/b.php', 'x/c.php', 'x/d/u.php', 'x/d/p.p'],
 			[
 				['x', 'is_dir', true],
 				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd']],
@@ -205,8 +206,9 @@ class FileFinderTest extends PHPStanTestCase
 				['x/b.php', 'is_dir', false],
 				['x/c.php', 'is_dir', false],
 				['x/d', 'is_dir', true],
-				['x/d', 'list_dir_open', ['u.php']],
+				['x/d', 'list_dir_open', ['u.php', 'p.p']],
 				['x/d/u.php', 'is_dir', false],
+				['x/d/p.p', 'is_dir', false],
 			],
 		];
 

--- a/tests/PHPStan/File/FileFinderTest.php
+++ b/tests/PHPStan/File/FileFinderTest.php
@@ -204,14 +204,11 @@ class FileFinderTest extends PHPStanTestCase
 			[
 				['x', 'is_dir', true],
 				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd']],
-				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd']], // directory should be opened once only, remove once https://github.com/symfony/symfony/issues/50851 is fixed
-				['x', 'list_dir_rewind', ['a.txt', 'b.php', 'c.php', 'd']],
 				['x/a.txt', 'is_dir', false],
 				['x/b.php', 'is_dir', false],
 				['x/c.php', 'is_dir', false],
 				['x/d', 'is_dir', true],
 				['x/d', 'list_dir_open', ['u.php']],
-				['x/d', 'list_dir_rewind', ['u.php']],
 				['x/d/u.php', 'is_dir', false],
 			],
 		];
@@ -241,18 +238,14 @@ class FileFinderTest extends PHPStanTestCase
 			[
 				['x', 'is_dir', true],
 				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
-				['x', 'list_dir_open', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
-				['x', 'list_dir_rewind', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
 				['x/a.txt', 'is_dir', false],
 				['x/b.php', 'is_dir', false],
 				['x/c.php', 'is_dir', false],
 				['x/d', 'is_dir', true],
 				['x/x', 'is_dir', true],
 				['x/x', 'list_dir_open', ['d']],
-				['x/x', 'list_dir_rewind', ['d']],
 				['x/x/d', 'is_dir', true],
 				['x/x/d', 'list_dir_open', ['u2.php']],
-				['x/x/d', 'list_dir_rewind', ['u2.php']],
 				['x/x/d/u2.php', 'is_dir', false],
 			],
 		];

--- a/tests/PHPStan/File/FileFinderTest.php
+++ b/tests/PHPStan/File/FileFinderTest.php
@@ -1,0 +1,258 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use Closure;
+use Exception;
+use PHPStan\Testing\PHPStanTestCase;
+use function array_keys;
+use function array_map;
+use function array_shift;
+use function assert;
+use function explode;
+use function get_class;
+use function is_array;
+use function is_bool;
+use function parse_url;
+use function preg_replace;
+use function sort;
+use function str_replace;
+use function stream_wrapper_register;
+use function stream_wrapper_unregister;
+use const DIRECTORY_SEPARATOR;
+
+class FileFinderTest extends PHPStanTestCase
+{
+
+	private static int $vfsNextIndex = 0;
+
+	/** @var array<string, Closure(string $path, 'list_dir'|'is_dir' $op): (list<string>|bool)> */
+	public static array $vfsProviders = [];
+
+	private string $vfsScheme;
+
+	/** @var list<array{string, string, mixed}> */
+	private array $vfsLog = [];
+
+	public function setUp(): void
+	{
+		$this->vfsScheme = 'phpstan-file-finder-test-' . ++self::$vfsNextIndex;
+
+		$wrapperClass = get_class(new class() {
+
+			/** @var resource */
+			public $context;
+
+			private string $scheme;
+
+			private string $dirPath;
+
+			/** @var list<string> */
+			private array $dirData;
+
+			private function parsePathAndSetScheme(string $url): string
+			{
+				$urlArr = parse_url($url);
+				assert(is_array($urlArr));
+				assert(isset($urlArr['scheme']));
+				assert(isset($urlArr['host']));
+
+				$this->scheme = $urlArr['scheme'];
+
+				return str_replace(DIRECTORY_SEPARATOR, '/', $urlArr['host'] . ($urlArr['path'] ?? ''));
+			}
+
+			public function dir_opendir(string $url, int $options): bool
+			{
+				$this->dirPath = $this->parsePathAndSetScheme($url);
+
+				return $this->dir_rewinddir();
+			}
+
+			public function dir_readdir(): string|false
+			{
+				return array_shift($this->dirData) ?? false;
+			}
+
+			public function dir_closedir(): bool
+			{
+				unset($this->dirPath);
+				unset($this->dirData);
+
+				return true;
+			}
+
+			public function dir_rewinddir(): bool
+			{
+				$providerFx = FileFinderTest::$vfsProviders[$this->scheme];
+				$data = $providerFx($this->dirPath, 'list_dir');
+				assert(is_array($data));
+				$this->dirData = $data;
+
+				return true;
+			}
+
+			/**
+			 * @return array<string, mixed>
+			 */
+			public function stream_stat(): array
+			{
+				return [];
+			}
+
+			/**
+			 * @return array<string, mixed>
+			 */
+			public function url_stat(string $url): array
+			{
+				$path = $this->parsePathAndSetScheme($url);
+				$providerFx = FileFinderTest::$vfsProviders[$this->scheme];
+				$isDir = $providerFx($path, 'is_dir');
+				assert(is_bool($isDir));
+
+				return ['mode' => $isDir ? 0040755 : 0100644];
+			}
+
+		});
+
+		stream_wrapper_register($this->vfsScheme, $wrapperClass);
+	}
+
+	public function tearDown(): void
+	{
+		stream_wrapper_unregister($this->vfsScheme);
+	}
+
+	/**
+	 * @dataProvider dataTestFindFiles
+	 * @param array<string, mixed>               $fsDefinition
+	 * @param list<string>                       $inPaths
+	 * @param list<string>                       $excludePaths
+	 * @param list<string>                       $expectedPaths
+	 * @param list<array{string, string, mixed}> $expectedAccessLog
+	 */
+	public function testFindFiles(array $fsDefinition, array $inPaths, array $excludePaths, array $expectedPaths, array $expectedAccessLog): void
+	{
+		self::$vfsProviders[$this->vfsScheme] = function (string $path, string $op) use ($fsDefinition) {
+			$pathArr = explode('/', $path);
+			$fileEntry = $fsDefinition;
+			while (($name = array_shift($pathArr)) !== null) {
+				if (!isset($fileEntry[$name])) {
+					$fileEntry = false;
+
+					break;
+				}
+
+				$fileEntry = $fileEntry[$name];
+			}
+
+			if ($op === 'list_dir') {
+				/** @var list<string> $res */
+				$res = array_keys($fileEntry);
+			} elseif ($op === 'is_dir') {
+				$res = is_array($fileEntry);
+			} else {
+				throw new Exception('Unexpected operation type');
+			}
+
+			$this->vfsLog[] = [$path, $op, $res];
+
+			return $res;
+		};
+
+		$prependSchemeFx = fn (string $v): string => $this->vfsScheme . '://' . $v;
+		$stripSchemeFx = fn (string $v): string => preg_replace('~^' . $this->vfsScheme . '://~', '', $v) ?? '';
+
+		$fileHelper = @$this->getFileHelper(); // @ is needed at least localy, TODO rmeove before merge
+		$fileExcluder = new FileExcluder($fileHelper, array_map($prependSchemeFx, $excludePaths));
+		$fileFinder = new FileFinder($fileExcluder, $fileHelper, ['php', 'p']);
+		$fileFinderResult = $fileFinder->findFiles(array_map($prependSchemeFx, $inPaths));
+
+		$expected = str_replace('/', DIRECTORY_SEPARATOR, $expectedPaths);
+		$actual = array_map($stripSchemeFx, $fileFinderResult->getFiles());
+		sort($expected);
+		sort($actual);
+
+		$this->assertSame($expected, $actual);
+		$this->assertSame($expectedAccessLog, $this->vfsLog);
+	}
+
+	public function dataTestFindFiles(): iterable
+	{
+		yield 'basic' => [
+			[
+				'x' => [
+					'a.txt' => '',
+					'b.php' => '',
+					'c.php' => '',
+					'd' => [
+						'u.php' => '',
+					],
+				],
+				'y' => [
+					'c.php' => '',
+				],
+			],
+			['x'],
+			[],
+			['x/b.php', 'x/c.php', 'x/d/u.php'],
+			[
+				['x', 'is_dir', true],
+				['x', 'list_dir', ['a.txt', 'b.php', 'c.php', 'd']],
+				['x', 'list_dir', ['a.txt', 'b.php', 'c.php', 'd']], // directory should be listed once only, seems like Symfony Finder issue
+				['x', 'list_dir', ['a.txt', 'b.php', 'c.php', 'd']], // same Symfony Finder issue
+				['x/a.txt', 'is_dir', false],
+				['x/b.php', 'is_dir', false],
+				['x/c.php', 'is_dir', false],
+				['x/d', 'is_dir', true],
+				['x/d', 'list_dir', ['u.php']],
+				['x/d', 'list_dir', ['u.php']], // same Symfony Finder issue
+				['x/d/u.php', 'is_dir', false],
+			],
+		];
+
+		yield 'excluded directory must prune early' => [
+			[
+				'x' => [
+					'a.txt' => '',
+					'b.php' => '',
+					'c.php' => '',
+					'd' => [
+						'u.php' => '',
+					],
+					'x' => [
+						'd' => [
+							'u2.php' => '',
+						],
+					],
+				],
+				'y' => [
+					'c.php' => '',
+				],
+			],
+			['x'],
+			['x/d'],
+			// ['x/b.php', 'x/c.php' , 'x/x/d/u2.php'],
+			// x/d exclude should keep x/x/d, but that is currently not possible,
+			// as Symfony Finder impl. escapes all patterns in
+			// https://github.com/symfony/symfony/blob/v6.2.12/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php#L45
+			// so the generated exclude pattern cannot start with "^"
+			['x/b.php', 'x/c.php'],
+			[
+				['x', 'is_dir', true],
+				['x', 'list_dir', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
+				['x', 'list_dir', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
+				['x', 'list_dir', ['a.txt', 'b.php', 'c.php', 'd', 'x']],
+				['x/a.txt', 'is_dir', false],
+				['x/b.php', 'is_dir', false],
+				['x/c.php', 'is_dir', false],
+				['x/d', 'is_dir', true],
+				['x/x', 'is_dir', true],
+				['x/x', 'list_dir', ['d']],
+				['x/x', 'list_dir', ['d']],
+				['x/x/d', 'is_dir', true],
+			],
+		];
+	}
+
+}

--- a/tests/PHPStan/File/FileFinderTest.php
+++ b/tests/PHPStan/File/FileFinderTest.php
@@ -15,7 +15,6 @@ use function is_array;
 use function is_bool;
 use function parse_url;
 use function preg_replace;
-use function sort;
 use function str_replace;
 use function stream_wrapper_register;
 use function stream_wrapper_unregister;
@@ -173,12 +172,10 @@ class FileFinderTest extends PHPStanTestCase
 		$fileFinder = new FileFinder($fileExcluder, $fileHelper, ['php', 'p']);
 		$fileFinderResult = $fileFinder->findFiles(array_map($prependSchemeFx, $inPaths));
 
-		$expected = str_replace('/', DIRECTORY_SEPARATOR, $expectedPaths);
-		$actual = array_map($stripSchemeFx, $fileFinderResult->getFiles());
-		sort($expected);
-		sort($actual);
-
-		$this->assertSame($expected, $actual);
+		$this->assertSame(
+			str_replace('/', DIRECTORY_SEPARATOR, $expectedPaths),
+			array_map($stripSchemeFx, $fileFinderResult->getFiles()),
+		);
 		$this->assertSame($expectedAccessLog, $this->vfsLog);
 	}
 


### PR DESCRIPTION
uses backported symfony/symfony/pull/50877 with symfony/symfony/pull/50884 optimization

fix phpstan/phpstan#9554

in projects with massive amount of excluded files, this PR improves phpstan runtime by several times - in our case, the phpstan file scan speedup is 280 times (from 48 seconds to 0.17 seconds)

fully tested using VFS