### PR TITLE
Cheap checks first in IgnoredRegexValidator.

### DIFF
--- a/src/Command/IgnoredRegexValidator.php
+++ b/src/Command/IgnoredRegexValidator.php
@@ -86,15 +86,17 @@ class IgnoredRegexValidator
 				continue;
 			}
 
-			if ($type->describe(VerbosityLevel::typeOnly()) !== $matches[1]) {
-				continue;
-			}
-
 			if ($type instanceof ObjectType) {
 				continue;
 			}
 
-			$types[$type->describe(VerbosityLevel::typeOnly())] = $text;
+			$typeDescription = $type->describe(VerbosityLevel::typeOnly());
+
+			if ($typeDescription !== $matches[1]) {
+				continue;
+			}
+
+			$types[$typeDescription] = $text;
 		}
 
 		return $types;


### PR DESCRIPTION
this reduces the time taken to run the `IgnoredRegexValidatorTest` on my pc from this:

```
=> php vendor/bin/phpunit tests/PHPStan/Command/IgnoredRegexValidatorTest.php

..............                                                    14 / 14 (100%)

Time: 00:03.690, Memory: 34.00 MB

OK (14 tests, 42 assertions)
```

to this:

```
=> php vendor/bin/phpunit tests/PHPStan/Command/IgnoredRegexValidatorTest.php

..............                                                    14 / 14 (100%)

Time: 00:00.794, Memory: 28.00 MB

OK (14 tests, 42 assertions)
```

