### PR TITLE
Simplify access to class reflections in InClassNode rules.

### DIFF
--- a/src/Rules/Classes/DuplicateDeclarationRule.php
+++ b/src/Rules/Classes/DuplicateDeclarationRule.php
@@ -28,10 +28,7 @@ class DuplicateDeclarationRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		$classReflection = $scope->getClassReflection();
-		if ($classReflection === null) {
-			throw new ShouldNotHappenException();
-		}
+		$classReflection = $node->getClassReflection();
 
 		$errors = [];
 

--- a/src/Rules/Classes/MixinRule.php
+++ b/src/Rules/Classes/MixinRule.php
@@ -42,10 +42,7 @@ class MixinRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 		$mixinTags = $classReflection->getMixinTags();
 		$errors = [];
 		foreach ($mixinTags as $mixinTag) {

--- a/src/Rules/Generics/ClassAncestorsRule.php
+++ b/src/Rules/Generics/ClassAncestorsRule.php
@@ -38,10 +38,7 @@ class ClassAncestorsRule implements Rule
 		if (!$originalNode instanceof Node\Stmt\Class_) {
 			return [];
 		}
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 		if ($classReflection->isAnonymous()) {
 			return [];
 		}

--- a/src/Rules/Generics/ClassTemplateTypeRule.php
+++ b/src/Rules/Generics/ClassTemplateTypeRule.php
@@ -29,10 +29,7 @@ class ClassTemplateTypeRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 		if (!$classReflection->isClass()) {
 			return [];
 		}

--- a/src/Rules/Generics/EnumAncestorsRule.php
+++ b/src/Rules/Generics/EnumAncestorsRule.php
@@ -38,10 +38,7 @@ class EnumAncestorsRule implements Rule
 		if (!$originalNode instanceof Node\Stmt\Enum_) {
 			return [];
 		}
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 
 		$enumName = $classReflection->getName();
 		$escapedEnumName = SprintfHelper::escapeFormatString($enumName);

--- a/src/Rules/Generics/EnumTemplateTypeRule.php
+++ b/src/Rules/Generics/EnumTemplateTypeRule.php
@@ -23,10 +23,7 @@ class EnumTemplateTypeRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 		if (!$classReflection->isEnum()) {
 			return [];
 		}

--- a/src/Rules/Generics/InterfaceAncestorsRule.php
+++ b/src/Rules/Generics/InterfaceAncestorsRule.php
@@ -38,10 +38,7 @@ class InterfaceAncestorsRule implements Rule
 		if (!$originalNode instanceof Node\Stmt\Interface_) {
 			return [];
 		}
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 
 		$interfaceName = $classReflection->getName();
 		$escapedInterfaceName = SprintfHelper::escapeFormatString($interfaceName);

--- a/src/Rules/Generics/InterfaceTemplateTypeRule.php
+++ b/src/Rules/Generics/InterfaceTemplateTypeRule.php
@@ -29,10 +29,7 @@ class InterfaceTemplateTypeRule implements Rule
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$scope->isInClass()) {
-			return [];
-		}
-		$classReflection = $scope->getClassReflection();
+		$classReflection = $node->getClassReflection();
 		if (!$classReflection->isInterface()) {
 			return [];
 		}


### PR DESCRIPTION
`InClassNodes` are guaranteed to be inside classes and can access the class reflection safely through the node instead of unsafely through the scope