### PR TITLE
Fix signature of `DOMNode::lookupNamespaceURI`

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1988,7 +1988,7 @@ return [
 'DOMNode::isDefaultNamespace' => ['bool', 'namespaceuri'=>'string'],
 'DOMNode::isSameNode' => ['bool', 'node'=>'DOMNode'],
 'DOMNode::isSupported' => ['bool', 'feature'=>'string', 'version'=>'string'],
-'DOMNode::lookupNamespaceURI' => ['string', 'prefix'=>'string'],
+'DOMNode::lookupNamespaceURI' => ['?string', 'prefix'=>'?string'],
 'DOMNode::lookupPrefix' => ['string', 'namespaceuri'=>'string'],
 'DOMNode::normalize' => ['void'],
 'DOMNode::removeChild' => ['DOMNode', 'oldnode'=>'DOMNode'],


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/9504

Ref:
- https://github.com/php/php-src/blob/c40dcf93d0b95d9a1026476b202f5aa965fb3fdd/ext/dom/node.c#L1622-L1650
- https://github.com/php/php-src/blob/b3553159a7b15d1ddd485aba9f83485f08e2e800/ext/dom/node.c#L1515-L1543
- https://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespaceURI

I think phpstorm-stubs should also be updated.