### PR TITLE
report trait access to unititialized property in the trait instead of class

### DIFF
--- a/src/Node/ClassPropertiesNode.php
+++ b/src/Node/ClassPropertiesNode.php
@@ -92,7 +92,7 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 	/**
 	 * @param string[] $constructors
 	 * @param ReadWritePropertiesExtension[]|null $extensions
-	 * @return array{array<string, ClassPropertyNode>, array<array{string, int, ClassPropertyNode}>, array<array{string, int, ClassPropertyNode}>}
+	 * @return array{array<string, ClassPropertyNode>, array<array{string, int, ClassPropertyNode, string}>, array<array{string, int, ClassPropertyNode}>}
 	 */
 	public function getUninitializedProperties(
 		Scope $scope,
@@ -212,6 +212,7 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 						$propertyName,
 						$fetch->getLine(),
 						$originalProperties[$propertyName],
+						$usageScope->getFileDescription(),
 					];
 				}
 			}

--- a/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
@@ -44,7 +44,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file]) {
 			if (!$propertyNode->isReadOnlyByPhpDoc() || $propertyNode->isReadOnly()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 				'Access to an uninitialized @readonly property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->build();
+			))->line($line)->file($file)->build();
 		}
 
 		foreach ($additionalAssigns as [$propertyName, $line, $propertyNode]) {

--- a/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
@@ -44,7 +44,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file]) {
 			if (!$propertyNode->isReadOnly()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 				'Access to an uninitialized readonly property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->build();
+			))->line($line)->file($file)->build();
 		}
 
 		foreach ($additionalAssigns as [$propertyName, $line, $propertyNode]) {

--- a/src/Rules/Properties/UninitializedPropertyRule.php
+++ b/src/Rules/Properties/UninitializedPropertyRule.php
@@ -44,7 +44,7 @@ class UninitializedPropertyRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file]) {
 			if ($propertyNode->isReadOnly() || $propertyNode->isReadOnlyByPhpDoc()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class UninitializedPropertyRule implements Rule
 				'Access to an uninitialized property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->build();
+			))->line($line)->file($file)->build();
 		}
 
 		return $errors;

--- a/tests/PHPStan/Analyser/traits-integration.neon
+++ b/tests/PHPStan/Analyser/traits-integration.neon
@@ -1,0 +1,2 @@
+parameters:
+    checkUninitializedProperties: true

--- a/tests/PHPStan/Analyser/traits/uninitializedProperty/FooClass.php
+++ b/tests/PHPStan/Analyser/traits/uninitializedProperty/FooClass.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TraitsUnititializedProperty;
+
+class FooClass
+{
+	use FooTrait;
+
+	public function __construct()
+	{
+		$this->foo();
+		$this->x = 5;
+		$this->y = 5;
+		$this->z = 5;
+	}
+}

--- a/tests/PHPStan/Analyser/traits/uninitializedProperty/FooTrait.php
+++ b/tests/PHPStan/Analyser/traits/uninitializedProperty/FooTrait.php
@@ -1,0 +1,19 @@
+<?php // lint >= 8.1
+
+namespace TraitsUnititializedProperty;
+
+trait FooTrait
+{
+	protected readonly int $x;
+
+	/** @readonly */
+	protected int $y;
+	protected int $z;
+
+	public function foo(): void
+	{
+		echo $this->x;
+		echo $this->y;
+		echo $this->z;
+	}
+}


### PR DESCRIPTION
There is a bug in how access to uninitialized properties is reported. If the access is in a trait it was reported as being in the class, but the line number was from the trait, so it didn't make sense. This is an attempt to fix it so that the trait access gets reported similarly to other trait issues (i.e. `trait (in context of class)`).