### PR TITLE
Replaced text string "does not do anything" to "does nothing."

### DIFF
--- a/src/Rules/DeadCode/NoopRule.php
+++ b/src/Rules/DeadCode/NoopRule.php
@@ -53,7 +53,7 @@ class NoopRule implements Rule
 
 		return [
 			RuleErrorBuilder::message(sprintf(
-				'Expression "%s" on a separate line does not do anything.',
+				'Expression "%s" on a separate line does nothing.',
 				$this->exprPrinter->printExpr($originalExpr),
 			))->line($expr->getLine())
 				->identifier('expr.resultUnused')

--- a/tests/PHPStan/Rules/DeadCode/NoopRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/NoopRuleTest.php
@@ -22,59 +22,59 @@ class NoopRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/noop.php'], [
 			[
-				'Expression "$arr" on a separate line does not do anything.',
+				'Expression "$arr" on a separate line does nothing.',
 				9,
 			],
 			[
-				'Expression "$arr[\'test\']" on a separate line does not do anything.',
+				'Expression "$arr[\'test\']" on a separate line does nothing.',
 				10,
 			],
 			[
-				'Expression "$foo::$test" on a separate line does not do anything.',
+				'Expression "$foo::$test" on a separate line does nothing.',
 				11,
 			],
 			[
-				'Expression "$foo->test" on a separate line does not do anything.',
+				'Expression "$foo->test" on a separate line does nothing.',
 				12,
 			],
 			[
-				'Expression "\'foo\'" on a separate line does not do anything.',
+				'Expression "\'foo\'" on a separate line does nothing.',
 				14,
 			],
 			[
-				'Expression "1" on a separate line does not do anything.',
+				'Expression "1" on a separate line does nothing.',
 				15,
 			],
 			[
-				'Expression "@\'foo\'" on a separate line does not do anything.',
+				'Expression "@\'foo\'" on a separate line does nothing.',
 				17,
 			],
 			[
-				'Expression "+1" on a separate line does not do anything.',
+				'Expression "+1" on a separate line does does nothing.',
 				18,
 			],
 			[
-				'Expression "-1" on a separate line does not do anything.',
+				'Expression "-1" on a separate line does does nothing.',
 				19,
 			],
 			[
-				'Expression "isset($test)" on a separate line does not do anything.',
+				'Expression "isset($test)" on a separate line does nothing.',
 				25,
 			],
 			[
-				'Expression "empty($test)" on a separate line does not do anything.',
+				'Expression "empty($test)" on a separate line does nothing.',
 				26,
 			],
 			[
-				'Expression "true" on a separate line does not do anything.',
+				'Expression "true" on a separate line does nothing.',
 				27,
 			],
 			[
-				'Expression "\DeadCodeNoop\Foo::TEST" on a separate line does not do anything.',
+				'Expression "\DeadCodeNoop\Foo::TEST" on a separate line does nothing.',
 				28,
 			],
 			[
-				'Expression "(string) 1" on a separate line does not do anything.',
+				'Expression "(string) 1" on a separate line does nothing.',
 				30,
 			],
 		]);
@@ -84,7 +84,7 @@ class NoopRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/nullsafe-property-fetch-noop.php'], [
 			[
-				'Expression "$ref?->name" on a separate line does not do anything.',
+				'Expression "$ref?->name" on a separate line does nothing.',
 				10,
 			],
 		]);

--- a/tests/e2e/baseline.neon
+++ b/tests/e2e/baseline.neon
@@ -31,7 +31,7 @@ parameters:
 			path: PHP-Parser/lib/PhpParser/BuilderFactory.php
 
 		-
-			message: "#^Expression \"@\\$undefinedVariable\" on a separate line does not do anything\\.$#"
+			message: "#^Expression \"@\\$undefinedVariable\" on a separate line does nothing\\.$#"
 			count: 1
 			path: PHP-Parser/lib/PhpParser/Lexer.php
 


### PR DESCRIPTION
Should say "does nothing" to be simplified, more transparent, and proper English.