### PR TITLE
NonAcceptingNeverType

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -73,7 +73,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
+use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\NonexistentParentClassType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectShapeType;
@@ -383,12 +383,12 @@ class TypeNodeResolver
 					return $type;
 				}
 
-				return new NeverType(true);
+				return new NonAcceptingNeverType();
 
 			case 'never-return':
 			case 'never-returns':
 			case 'no-return':
-				return new NeverType(true);
+				return new NonAcceptingNeverType();
 
 			case 'list':
 				return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new MixedType()));

--- a/src/Type/NonAcceptingNeverType.php
+++ b/src/Type/NonAcceptingNeverType.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+/** @api */
+class NonAcceptingNeverType extends NeverType
+{
+
+	/** @api */
+	public function __construct()
+	{
+		parent::__construct(true);
+	}
+
+	public function acceptsWithReason(Type $type, bool $strictTypes): AcceptsResult
+	{
+		return AcceptsResult::createNo();
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return 'never';
+	}
+
+}

--- a/src/Type/NonAcceptingNeverType.php
+++ b/src/Type/NonAcceptingNeverType.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\TrinaryLogic;
+
 /** @api */
 class NonAcceptingNeverType extends NeverType
 {
@@ -10,6 +12,18 @@ class NonAcceptingNeverType extends NeverType
 	public function __construct()
 	{
 		parent::__construct(true);
+	}
+
+	public function isSuperTypeOf(Type $type): TrinaryLogic
+	{
+		if ($type instanceof self) {
+			return TrinaryLogic::createYes();
+		}
+		if ($type instanceof parent) {
+			return TrinaryLogic::createMaybe();
+		}
+
+		return TrinaryLogic::createNo();
 	}
 
 	public function acceptsWithReason(Type $type, bool $strictTypes): AcceptsResult

--- a/src/Type/NonAcceptingNeverType.php
+++ b/src/Type/NonAcceptingNeverType.php
@@ -14,6 +14,10 @@ class NonAcceptingNeverType extends NeverType
 
 	public function acceptsWithReason(Type $type, bool $strictTypes): AcceptsResult
 	{
+		if ($type instanceof NeverType) {
+			return AcceptsResult::createYes();
+		}
+
 		return AcceptsResult::createNo();
 	}
 

--- a/src/Type/ParserNodeTypeToPHPStanType.php
+++ b/src/Type/ParserNodeTypeToPHPStanType.php
@@ -93,7 +93,7 @@ class ParserNodeTypeToPHPStanType
 		} elseif ($type === 'mixed') {
 			return new MixedType(true);
 		} elseif ($type === 'never') {
-			return new NeverType(true);
+			return new NonAcceptingNeverType();
 		}
 
 		return new MixedType();

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -86,7 +86,7 @@ class TypehintHelper
 			case 'null':
 				return new NullType();
 			case 'never':
-				return new NeverType(true);
+				return new NonAcceptingNeverType();
 			default:
 				return new ObjectType($typeString);
 		}

--- a/tests/PHPStan/Analyser/data/bug-8242.php
+++ b/tests/PHPStan/Analyser/data/bug-8242.php
@@ -15,7 +15,7 @@ namespace {
 		return new NoReturn;
 	}
 
-	\PHPStan\Testing\assertType('*NEVER*', f1());
+	\PHPStan\Testing\assertType('never', f1());
 	\PHPStan\Testing\assertType('NoReturn', f2());
 }
 
@@ -55,6 +55,6 @@ namespace NoReturnUndefined {
 		throw new \LogicException();
 	}
 
-	\PHPStan\Testing\assertType('*NEVER*', f1());
-	\PHPStan\Testing\assertType('*NEVER*', f2());
+	\PHPStan\Testing\assertType('never', f1());
+	\PHPStan\Testing\assertType('never', f2());
 }

--- a/tests/PHPStan/Analyser/data/conditional-types.php
+++ b/tests/PHPStan/Analyser/data/conditional-types.php
@@ -152,7 +152,7 @@ abstract class Test
 	public function testMaybeNever(): void
 	{
 		assertType('void', $this->maybeNever(0));
-		assertType('*NEVER*', $this->maybeNever(1));
+		assertType('never', $this->maybeNever(1));
 		assertType('void', $this->maybeNever(2));
 	}
 

--- a/tests/PHPStan/Analyser/data/emptyiterator.php
+++ b/tests/PHPStan/Analyser/data/emptyiterator.php
@@ -9,8 +9,8 @@ class Foo
 	public function doFoo(\EmptyIterator $it): void
 	{
 		assertType('EmptyIterator', $it);
-		assertType('*NEVER*', $it->key());
-		assertType('*NEVER*', $it->current());
+		assertType('never', $it->key());
+		assertType('never', $it->current());
 		assertType('void', $it->next());
 		assertType('false', $it->valid());
 	}

--- a/tests/PHPStan/Analyser/data/never.php
+++ b/tests/PHPStan/Analyser/data/never.php
@@ -14,7 +14,7 @@ class Foo
 
 	public function doBar()
 	{
-		assertType('*NEVER*', $this->doFoo());
+		assertType('never', $this->doFoo());
 	}
 
 	public function doBaz(?int $i)

--- a/tests/PHPStan/Analyser/data/phpdoc-pseudotype-global.php
+++ b/tests/PHPStan/Analyser/data/phpdoc-pseudotype-global.php
@@ -25,6 +25,6 @@ function () {
 	assertType('float|int|numeric-string', $numeric);
 	assertType('bool', $boolean);
 	assertType('resource', $resource);
-	assertType('*NEVER*', $never);
+	assertType('never', $never);
 	assertType('float', $double);
 };

--- a/tests/PHPStan/Analyser/data/self-out.php
+++ b/tests/PHPStan/Analyser/data/self-out.php
@@ -79,7 +79,7 @@ function () {
 	$i->setData("test");
 	// IfThisIsMismatch - Class is not a<int> as required
 	assertType('SelfOut\\a<string>', $i);
-	assertType('*NEVER*', $i->test());
+	assertType('never', $i->test());
 };
 
 function () {

--- a/tests/PHPStan/Analyser/data/type-aliases.php
+++ b/tests/PHPStan/Analyser/data/type-aliases.php
@@ -134,7 +134,7 @@ namespace TypeAliasesDataset {
 		 */
 		public function conflictingAlias($parameter)
 		{
-			assertType('*NEVER*', $parameter);
+			assertType('never', $parameter);
 		}
 
 		public function __get(string $name)

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -276,4 +276,14 @@ class CallCallablesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5867.php'], []);
 	}
 
+	public function testBug6485(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-6485.php'], [
+			[
+				'Parameter #1 $ of closure expects never, TBlockType of Bug6485\Block given.',
+				33,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1435,4 +1435,14 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug9133(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9133.php'], [
+			[
+				'Parameter #1 $value of function Bug9133\assertNever expects never, int given.',
+				29,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-6485.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-6485.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6485;
+
+class CompoundTag{}
+
+class Block{
+	public function getTypeId() : int{ return 0; }
+}
+
+final class BlockStateSerializerR13{
+
+	/**
+	 * These callables actually accept Block, but for the sake of type completeness, it has to be never, since we can't
+	 * describe the bottom type of a type hierarchy only containing Block.
+	 * @phpstan-var array<string, array<int, \Closure(never) : CompoundTag>>
+	 */
+	private array $serializers = [];
+
+	/**
+	 * @phpstan-template TBlockType of Block
+	 * @phpstan-param TBlockType $block
+	 */
+	public function serialize(Block $block) : CompoundTag{
+		$class = get_class($block);
+		$serializer = $this->serializers[$class][$block->getTypeId()] ?? null;
+
+		if($serializer === null){
+			//TODO: use a proper exception type for this
+			throw new \InvalidArgumentException("No serializer registered for this block (this is probably a plugin bug)");
+		}
+
+		return $serializer($block);
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-9133.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9133.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bug9133;
+
+/**
+ * @param never $value
+ */
+function assertNever(mixed $value): never
+{
+	throw new \LogicException();
+}
+
+function testOk(int|string $value): void
+{
+	if (is_string($value)) {
+		echo 'STRING';
+	} elseif (is_int($value)) {
+		echo 'INT';
+	} else {
+		assertNever($value);
+	}
+}
+
+function testMissingCheck(int|string $value): void
+{
+	if (is_string($value)) {
+		echo 'STRING';
+	} else {
+		assertNever($value); // this should return error, because int is not a subtype of never
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-5089.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-5089.php
@@ -16,6 +16,6 @@ class HelloWorld
 
 	public function test(): void
 	{
-		assertType('*NEVER*', $this->encode('foo'));
+		assertType('never', $this->encode('foo'));
 	}
 }

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2442,6 +2442,14 @@ class TypeCombinatorTest extends PHPStanTestCase
 			UnionType::class,
 			'ObjectShapesAcceptance\FinalClass|object{foo: int}',
 		];
+		yield [
+			[
+				new NeverType(),
+				new NonAcceptingNeverType(),
+			],
+			NeverType::class,
+			'*NEVER*',
+		];
 	}
 
 	/**
@@ -4013,6 +4021,14 @@ class TypeCombinatorTest extends PHPStanTestCase
 			],
 			PHP_VERSION_ID < 80200 ? IntersectionType::class : NeverType::class,
 			PHP_VERSION_ID < 80200 ? 'ObjectShapesAcceptance\FinalClass&object{foo: int}' : '*NEVER*=implicit',
+		];
+		yield [
+			[
+				new NeverType(true),
+				new NonAcceptingNeverType(),
+			],
+			NonAcceptingNeverType::class,
+			'never=explicit',
 		];
 	}
 


### PR DESCRIPTION
split from #2485, closes phpstan/phpstan#9133 

The idea is that `never` should accept no value at all, so that it can truly act as PHP's bottom type. In the light of that, the naming feels a bit strange: `NeverType` alone should already be non-accepting. But I know that's not possible right now due to how it is used especially with generics.

Perhaps we could rename `NonAcceptingNeverType` to `NeverType` and turn the current (implicit) `NeverType` into something like `UnknownType`? Is it something worth revisiting in PHPStan 2.0?

On a related note, are there other places where I should replace `NeverType` with `NonAcceptingNeverType`? Maybe everywhere NeverType is instantiated as explicit?