### PR TITLE
Implement ClassReflection->getParentClassName()

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -189,7 +189,11 @@ class ClassReflection
 	/** @return class-string|null */
 	public function getParentClassName(): string|null
 	{
-		return $this->getParentClassName();
+		if ($this->reflection instanceof ReflectionEnum) {
+			return null;
+		}
+
+		return $this->reflection->getParentClassName();
 	}
 
 	public function getParentClass(): ?ClassReflection

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -186,6 +186,12 @@ class ClassReflection
 		return $this->getFileName();
 	}
 
+	/** @return class-string|null */
+	public function getParentClassName(): string|null
+	{
+		return $this->getParentClassName();
+	}
+
 	public function getParentClass(): ?ClassReflection
 	{
 		if (!is_bool($this->cachedParentClass)) {

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -325,12 +325,12 @@ class ClassReflectionTest extends PHPStanTestCase
 
 	public function testGetParentWithUnknownClassName(): void
 	{
-		$className = \FunctionReflectionDocTest\ClassWithUnknownParent::class;
+		$className = ClassWithUnknownParent::class;
 
 		$reflectionProvider = $this->createReflectionProvider();
 		$classReflection = $reflectionProvider->getClass($className);
 
-		$this->assertSame('UnknownParentClass', $classReflection->getParentClassName());
+		$this->assertSame('\FunctionReflectionDocTest\UnknownParentClass', $classReflection->getParentClassName());
 		$this->assertNull($classReflection->getParentClass());
 	}
 

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -7,6 +7,7 @@ use Attributes\IsAttribute;
 use Attributes\IsAttribute2;
 use Attributes\IsAttribute3;
 use Attributes\IsNotAttribute;
+use FunctionReflectionDocTest\ClassWithUnknownParent;
 use GenericInheritance\C;
 use HasTraitUse\Bar;
 use HasTraitUse\Baz;
@@ -320,6 +321,17 @@ class ClassReflectionTest extends PHPStanTestCase
 		$this->assertTrue($classReflection->is(PHPStanTestCase::class));
 		$this->assertTrue($classReflection->is(TestCase::class));
 		$this->assertFalse($classReflection->is(RuleTestCase::class));
+	}
+
+	public function testGetParentWithUnknownClassName(): void
+	{
+		$className = \FunctionReflectionDocTest\ClassWithUnknownParent::class;
+
+		$reflectionProvider = $this->createReflectionProvider();
+		$classReflection = $reflectionProvider->getClass($className);
+
+		$this->assertSame('UnknownParentClass', $classReflection->getParentClassName());
+		$this->assertNull($classReflection->getParentClass());
 	}
 
 }

--- a/tests/PHPStan/Reflection/data/ClassWithUnknownParent.php
+++ b/tests/PHPStan/Reflection/data/ClassWithUnknownParent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace FunctionReflectionDocTest;
+
+class ClassWithUnknownParent extends UnknownParentClass{
+
+}


### PR DESCRIPTION
A class can declare a parent which we cannot locate via autoloading mechanics.
For some static analysis cases its still useful to know, whether a parent class is defined - even if we can't reflect on it for some reason.

I was not able to find a API which allows me to dermine whether a class has a parent declared but only BetterReflection cannot find its definition from whether there is no parent class declared at all.

Before this PR we had to use reflection hacks to get the private property out of the BetterReflection class, see https://github.com/rectorphp/rector/issues/8093#issuecomment-1657057947

requires https://github.com/ondrejmirtes/BetterReflection/pull/31

----

TODO: requires a similar thing for interfaces and traits