### PR TITLE
fix baseline for access to uninitialized property from trait

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -179,6 +179,10 @@ jobs:
             extensions: ""
           - script: "bin/phpstan analyse e2e/only-files-not-analysed-trait/src/Foo.php e2e/only-files-not-analysed-trait/src/BarTrait.php -c e2e/only-files-not-analysed-trait/no-ignore.neon"
             extensions: ""
+          - script: |
+              cd e2e/baseline-uninit-prop-trait
+              ../../bin/phpstan analyse --debug --configuration test-no-baseline.neon --generate-baseline test-baseline.neon
+              ../../bin/phpstan analyse --debug --configuration test.neon
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -183,6 +183,10 @@ jobs:
               cd e2e/baseline-uninit-prop-trait
               ../../bin/phpstan analyse --debug --configuration test-no-baseline.neon --generate-baseline test-baseline.neon
               ../../bin/phpstan analyse --debug --configuration test.neon
+          - script: |
+              cd e2e/baseline-uninit-prop-trait
+              ../../bin/phpstan analyse --configuration test-no-baseline.neon --generate-baseline test-baseline.neon
+              ../../bin/phpstan analyse --configuration test.neon
 
     steps:
       - name: "Checkout"

--- a/bin/generate-rule-error-classes.php
+++ b/bin/generate-rule-error-classes.php
@@ -33,17 +33,13 @@ php;
 		}
 		$properties = [];
 		$interfaces = [];
-		foreach ($ruleErrorTypes as $typeNumber => [$interface, $propertyName, $nativePropertyType, $phpDocPropertyType]) {
+		foreach ($ruleErrorTypes as $typeNumber => [$interface, $typeProperties]) {
 			if (!(($typeCombination & $typeNumber) === $typeNumber)) {
 				continue;
 			}
 
 			$interfaces[] = '\\' . $interface;
-			if ($propertyName === null || $nativePropertyType === null || $phpDocPropertyType === null) {
-				continue;
-			}
-
-			$properties[] = [$propertyName, $nativePropertyType, $phpDocPropertyType];
+			$properties = array_merge($properties, $typeProperties);
 		}
 
 		$phpClass = sprintf(

--- a/e2e/baseline-uninit-prop-trait/src/Foo.php
+++ b/e2e/baseline-uninit-prop-trait/src/Foo.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Readonly\Uninit\Bug;
+
+trait Foo
+{
+	protected readonly int $x;
+
+	public function foo(): void
+	{
+		echo $this->x;
+	}
+
+	public function init(): void
+	{
+		$this->x = rand();
+	}
+}

--- a/e2e/baseline-uninit-prop-trait/src/HelloWorld.php
+++ b/e2e/baseline-uninit-prop-trait/src/HelloWorld.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Readonly\Uninit\Bug;
+
+class HelloWorld
+{
+	use Foo;
+
+	public function __construct()
+	{
+		$this->init();
+		$this->foo();
+	}
+}

--- a/e2e/baseline-uninit-prop-trait/test-no-baseline.neon
+++ b/e2e/baseline-uninit-prop-trait/test-no-baseline.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 9
+    paths:
+        - src

--- a/e2e/baseline-uninit-prop-trait/test.neon
+++ b/e2e/baseline-uninit-prop-trait/test.neon
@@ -1,0 +1,3 @@
+includes:
+    - test-baseline.neon
+    - test-no-baseline.neon

--- a/src/Analyser/RuleErrorTransformer.php
+++ b/src/Analyser/RuleErrorTransformer.php
@@ -53,7 +53,7 @@ class RuleErrorTransformer
 				$ruleError instanceof FileRuleError
 				&& $ruleError->getFile() !== ''
 			) {
-				$fileName = $ruleError->getFileDescription() ?? $ruleError->getFile();
+				$fileName = $ruleError->getFileDescription();
 				$filePath = $ruleError->getFile();
 				$traitFilePath = null;
 			}

--- a/src/Analyser/RuleErrorTransformer.php
+++ b/src/Analyser/RuleErrorTransformer.php
@@ -53,7 +53,7 @@ class RuleErrorTransformer
 				$ruleError instanceof FileRuleError
 				&& $ruleError->getFile() !== ''
 			) {
-				$fileName = $ruleError->getFile();
+				$fileName = $ruleError->getFileDescription() ?? $ruleError->getFile();
 				$filePath = $ruleError->getFile();
 				$traitFilePath = null;
 			}

--- a/src/Node/ClassPropertiesNode.php
+++ b/src/Node/ClassPropertiesNode.php
@@ -93,7 +93,7 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 	/**
 	 * @param string[] $constructors
 	 * @param ReadWritePropertiesExtension[]|null $extensions
-	 * @return array{array<string, ClassPropertyNode>, array<array{string, int, ClassPropertyNode, string}>, array<array{string, int, ClassPropertyNode}>}
+	 * @return array{array<string, ClassPropertyNode>, array<array{string, int, ClassPropertyNode, string, string}>, array<array{string, int, ClassPropertyNode}>}
 	 */
 	public function getUninitializedProperties(
 		Scope $scope,
@@ -231,6 +231,7 @@ class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 						$propertyName,
 						$fetch->getLine(),
 						$originalProperties[$propertyName],
+						$usageScope->getFile(),
 						$usageScope->getFileDescription(),
 					];
 				}

--- a/src/Rules/FileRuleError.php
+++ b/src/Rules/FileRuleError.php
@@ -8,4 +8,6 @@ interface FileRuleError extends RuleError
 
 	public function getFile(): string;
 
+	public function getFileDescription(): ?string;
+
 }

--- a/src/Rules/FileRuleError.php
+++ b/src/Rules/FileRuleError.php
@@ -8,6 +8,6 @@ interface FileRuleError extends RuleError
 
 	public function getFile(): string;
 
-	public function getFileDescription(): ?string;
+	public function getFileDescription(): string;
 
 }

--- a/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
@@ -44,7 +44,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $fileDescription]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file, $fileDescription]) {
 			if (!$propertyNode->isReadOnlyByPhpDoc() || $propertyNode->isReadOnly()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 				'Access to an uninitialized @readonly property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->file($scope->getFile(), $fileDescription)->build();
+			))->line($line)->file($file, $fileDescription)->build();
 		}
 
 		foreach ($additionalAssigns as [$propertyName, $line, $propertyNode]) {

--- a/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyByPhpDocPropertyAssignRule.php
@@ -44,7 +44,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $fileDescription]) {
 			if (!$propertyNode->isReadOnlyByPhpDoc() || $propertyNode->isReadOnly()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class MissingReadOnlyByPhpDocPropertyAssignRule implements Rule
 				'Access to an uninitialized @readonly property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->file($file)->build();
+			))->line($line)->file($scope->getFile(), $fileDescription)->build();
 		}
 
 		foreach ($additionalAssigns as [$propertyName, $line, $propertyNode]) {

--- a/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
@@ -44,7 +44,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $fileDescription]) {
 			if (!$propertyNode->isReadOnly()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 				'Access to an uninitialized readonly property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->file($file)->build();
+			))->line($line)->file($scope->getFile(), $fileDescription)->build();
 		}
 
 		foreach ($additionalAssigns as [$propertyName, $line, $propertyNode]) {

--- a/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/MissingReadOnlyPropertyAssignRule.php
@@ -44,7 +44,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $fileDescription]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file, $fileDescription]) {
 			if (!$propertyNode->isReadOnly()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class MissingReadOnlyPropertyAssignRule implements Rule
 				'Access to an uninitialized readonly property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->file($scope->getFile(), $fileDescription)->build();
+			))->line($line)->file($file, $fileDescription)->build();
 		}
 
 		foreach ($additionalAssigns as [$propertyName, $line, $propertyNode]) {

--- a/src/Rules/Properties/UninitializedPropertyRule.php
+++ b/src/Rules/Properties/UninitializedPropertyRule.php
@@ -44,7 +44,7 @@ class UninitializedPropertyRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $fileDescription]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file, $fileDescription]) {
 			if ($propertyNode->isReadOnly() || $propertyNode->isReadOnlyByPhpDoc()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class UninitializedPropertyRule implements Rule
 				'Access to an uninitialized property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->file($scope->getFile(), $fileDescription)->build();
+			))->line($line)->file($file, $fileDescription)->build();
 		}
 
 		return $errors;

--- a/src/Rules/Properties/UninitializedPropertyRule.php
+++ b/src/Rules/Properties/UninitializedPropertyRule.php
@@ -44,7 +44,7 @@ class UninitializedPropertyRule implements Rule
 			))->line($propertyNode->getLine())->build();
 		}
 
-		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $file]) {
+		foreach ($prematureAccess as [$propertyName, $line, $propertyNode, $fileDescription]) {
 			if ($propertyNode->isReadOnly() || $propertyNode->isReadOnlyByPhpDoc()) {
 				continue;
 			}
@@ -52,7 +52,7 @@ class UninitializedPropertyRule implements Rule
 				'Access to an uninitialized property %s::$%s.',
 				$classReflection->getDisplayName(),
 				$propertyName,
-			))->line($line)->file($file)->build();
+			))->line($line)->file($scope->getFile(), $fileDescription)->build();
 		}
 
 		return $errors;

--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -36,52 +36,79 @@ class RuleErrorBuilder
 	}
 
 	/**
-	 * @return array<int, array{string, string|null, string|null, string|null}>
+	 * @return array<int, array{string, array<array{string|null, string|null, string|null}>}>
 	 */
 	public static function getRuleErrorTypes(): array
 	{
 		return [
 			self::TYPE_MESSAGE => [
 				RuleError::class,
-				'message',
-				'string',
-				'string',
+				[
+					[
+						'message',
+						'string',
+						'string',
+					],
+				],
 			],
 			self::TYPE_LINE => [
 				LineRuleError::class,
-				'line',
-				'int',
-				'int',
+				[
+					[
+						'line',
+						'int',
+						'int',
+					],
+				],
 			],
 			self::TYPE_FILE => [
 				FileRuleError::class,
-				'file',
-				'string',
-				'string',
+				[
+					[
+						'file',
+						'string',
+						'string',
+					],
+					[
+						'fileDescription',
+						'?string',
+						'?string',
+					],
+				],
 			],
 			self::TYPE_TIP => [
 				TipRuleError::class,
-				'tip',
-				'string',
-				'string',
+				[
+					[
+						'tip',
+						'string',
+						'string',
+					],
+				],
 			],
 			self::TYPE_IDENTIFIER => [
 				IdentifierRuleError::class,
-				'identifier',
-				'string',
-				'string',
+				[
+					[
+						'identifier',
+						'string',
+						'string',
+					],
+				],
 			],
 			self::TYPE_METADATA => [
 				MetadataRuleError::class,
-				'metadata',
-				'array',
-				'mixed[]',
+				[
+					[
+						'metadata',
+						'array',
+						'mixed[]',
+					],
+				],
 			],
 			self::TYPE_NON_IGNORABLE => [
 				NonIgnorableRuleError::class,
-				null,
-				null,
-				null,
+				[],
 			],
 		];
 	}
@@ -99,9 +126,10 @@ class RuleErrorBuilder
 		return $this;
 	}
 
-	public function file(string $file): self
+	public function file(string $file, ?string $fileDescription = null): self
 	{
 		$this->properties['file'] = $file;
+		$this->properties['fileDescription'] = $fileDescription;
 		$this->type |= self::TYPE_FILE;
 
 		return $this;

--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -7,6 +7,7 @@ use function array_map;
 use function class_exists;
 use function count;
 use function implode;
+use function is_file;
 use function sprintf;
 
 /** @api */
@@ -128,6 +129,9 @@ class RuleErrorBuilder
 
 	public function file(string $file, ?string $fileDescription = null): self
 	{
+		if (!is_file($file)) {
+			throw new ShouldNotHappenException(sprintf('File %s does not exist.', $file));
+		}
 		$this->properties['file'] = $file;
 		$this->properties['fileDescription'] = $fileDescription ?? $file;
 		$this->type |= self::TYPE_FILE;

--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -71,8 +71,8 @@ class RuleErrorBuilder
 					],
 					[
 						'fileDescription',
-						'?string',
-						'?string',
+						'string',
+						'string',
 					],
 				],
 			],
@@ -129,7 +129,7 @@ class RuleErrorBuilder
 	public function file(string $file, ?string $fileDescription = null): self
 	{
 		$this->properties['file'] = $file;
-		$this->properties['fileDescription'] = $fileDescription;
+		$this->properties['fileDescription'] = $fileDescription ?? $file;
 		$this->type |= self::TYPE_FILE;
 
 		return $this;

--- a/src/Rules/RuleErrors/RuleError101.php
+++ b/src/Rules/RuleErrors/RuleError101.php
@@ -17,7 +17,7 @@ class RuleError101 implements RuleError, FileRuleError, MetadataRuleError, NonIg
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	/** @var mixed[] */
 	public array $metadata;
@@ -32,7 +32,7 @@ class RuleError101 implements RuleError, FileRuleError, MetadataRuleError, NonIg
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError101.php
+++ b/src/Rules/RuleErrors/RuleError101.php
@@ -17,6 +17,8 @@ class RuleError101 implements RuleError, FileRuleError, MetadataRuleError, NonIg
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	/** @var mixed[] */
 	public array $metadata;
 
@@ -28,6 +30,11 @@ class RuleError101 implements RuleError, FileRuleError, MetadataRuleError, NonIg
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	/**

--- a/src/Rules/RuleErrors/RuleError103.php
+++ b/src/Rules/RuleErrors/RuleError103.php
@@ -20,6 +20,8 @@ class RuleError103 implements RuleError, LineRuleError, FileRuleError, MetadataR
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	/** @var mixed[] */
 	public array $metadata;
 
@@ -36,6 +38,11 @@ class RuleError103 implements RuleError, LineRuleError, FileRuleError, MetadataR
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	/**

--- a/src/Rules/RuleErrors/RuleError103.php
+++ b/src/Rules/RuleErrors/RuleError103.php
@@ -20,7 +20,7 @@ class RuleError103 implements RuleError, LineRuleError, FileRuleError, MetadataR
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	/** @var mixed[] */
 	public array $metadata;
@@ -40,7 +40,7 @@ class RuleError103 implements RuleError, LineRuleError, FileRuleError, MetadataR
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError109.php
+++ b/src/Rules/RuleErrors/RuleError109.php
@@ -18,7 +18,7 @@ class RuleError109 implements RuleError, FileRuleError, TipRuleError, MetadataRu
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -35,7 +35,7 @@ class RuleError109 implements RuleError, FileRuleError, TipRuleError, MetadataRu
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError109.php
+++ b/src/Rules/RuleErrors/RuleError109.php
@@ -18,6 +18,8 @@ class RuleError109 implements RuleError, FileRuleError, TipRuleError, MetadataRu
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	/** @var mixed[] */
@@ -31,6 +33,11 @@ class RuleError109 implements RuleError, FileRuleError, TipRuleError, MetadataRu
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError111.php
+++ b/src/Rules/RuleErrors/RuleError111.php
@@ -21,7 +21,7 @@ class RuleError111 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -43,7 +43,7 @@ class RuleError111 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError111.php
+++ b/src/Rules/RuleErrors/RuleError111.php
@@ -21,6 +21,8 @@ class RuleError111 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	/** @var mixed[] */
@@ -39,6 +41,11 @@ class RuleError111 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError117.php
+++ b/src/Rules/RuleErrors/RuleError117.php
@@ -18,6 +18,8 @@ class RuleError117 implements RuleError, FileRuleError, IdentifierRuleError, Met
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	/** @var mixed[] */
@@ -31,6 +33,11 @@ class RuleError117 implements RuleError, FileRuleError, IdentifierRuleError, Met
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError117.php
+++ b/src/Rules/RuleErrors/RuleError117.php
@@ -18,7 +18,7 @@ class RuleError117 implements RuleError, FileRuleError, IdentifierRuleError, Met
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -35,7 +35,7 @@ class RuleError117 implements RuleError, FileRuleError, IdentifierRuleError, Met
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError119.php
+++ b/src/Rules/RuleErrors/RuleError119.php
@@ -21,7 +21,7 @@ class RuleError119 implements RuleError, LineRuleError, FileRuleError, Identifie
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -43,7 +43,7 @@ class RuleError119 implements RuleError, LineRuleError, FileRuleError, Identifie
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError119.php
+++ b/src/Rules/RuleErrors/RuleError119.php
@@ -21,6 +21,8 @@ class RuleError119 implements RuleError, LineRuleError, FileRuleError, Identifie
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	/** @var mixed[] */
@@ -39,6 +41,11 @@ class RuleError119 implements RuleError, LineRuleError, FileRuleError, Identifie
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError125.php
+++ b/src/Rules/RuleErrors/RuleError125.php
@@ -19,6 +19,8 @@ class RuleError125 implements RuleError, FileRuleError, TipRuleError, Identifier
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -34,6 +36,11 @@ class RuleError125 implements RuleError, FileRuleError, TipRuleError, Identifier
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError125.php
+++ b/src/Rules/RuleErrors/RuleError125.php
@@ -19,7 +19,7 @@ class RuleError125 implements RuleError, FileRuleError, TipRuleError, Identifier
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -38,7 +38,7 @@ class RuleError125 implements RuleError, FileRuleError, TipRuleError, Identifier
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError127.php
+++ b/src/Rules/RuleErrors/RuleError127.php
@@ -22,6 +22,8 @@ class RuleError127 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -42,6 +44,11 @@ class RuleError127 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError127.php
+++ b/src/Rules/RuleErrors/RuleError127.php
@@ -22,7 +22,7 @@ class RuleError127 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -46,7 +46,7 @@ class RuleError127 implements RuleError, LineRuleError, FileRuleError, TipRuleEr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError13.php
+++ b/src/Rules/RuleErrors/RuleError13.php
@@ -16,6 +16,8 @@ class RuleError13 implements RuleError, FileRuleError, TipRuleError
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public function getMessage(): string
@@ -26,6 +28,11 @@ class RuleError13 implements RuleError, FileRuleError, TipRuleError
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError13.php
+++ b/src/Rules/RuleErrors/RuleError13.php
@@ -16,7 +16,7 @@ class RuleError13 implements RuleError, FileRuleError, TipRuleError
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -30,7 +30,7 @@ class RuleError13 implements RuleError, FileRuleError, TipRuleError
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError15.php
+++ b/src/Rules/RuleErrors/RuleError15.php
@@ -19,6 +19,8 @@ class RuleError15 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public function getMessage(): string
@@ -34,6 +36,11 @@ class RuleError15 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError15.php
+++ b/src/Rules/RuleErrors/RuleError15.php
@@ -19,7 +19,7 @@ class RuleError15 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -38,7 +38,7 @@ class RuleError15 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError21.php
+++ b/src/Rules/RuleErrors/RuleError21.php
@@ -16,6 +16,8 @@ class RuleError21 implements RuleError, FileRuleError, IdentifierRuleError
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	public function getMessage(): string
@@ -26,6 +28,11 @@ class RuleError21 implements RuleError, FileRuleError, IdentifierRuleError
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError21.php
+++ b/src/Rules/RuleErrors/RuleError21.php
@@ -16,7 +16,7 @@ class RuleError21 implements RuleError, FileRuleError, IdentifierRuleError
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -30,7 +30,7 @@ class RuleError21 implements RuleError, FileRuleError, IdentifierRuleError
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError23.php
+++ b/src/Rules/RuleErrors/RuleError23.php
@@ -19,6 +19,8 @@ class RuleError23 implements RuleError, LineRuleError, FileRuleError, Identifier
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	public function getMessage(): string
@@ -34,6 +36,11 @@ class RuleError23 implements RuleError, LineRuleError, FileRuleError, Identifier
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError23.php
+++ b/src/Rules/RuleErrors/RuleError23.php
@@ -19,7 +19,7 @@ class RuleError23 implements RuleError, LineRuleError, FileRuleError, Identifier
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -38,7 +38,7 @@ class RuleError23 implements RuleError, LineRuleError, FileRuleError, Identifier
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError29.php
+++ b/src/Rules/RuleErrors/RuleError29.php
@@ -17,6 +17,8 @@ class RuleError29 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -29,6 +31,11 @@ class RuleError29 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError29.php
+++ b/src/Rules/RuleErrors/RuleError29.php
@@ -17,7 +17,7 @@ class RuleError29 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -33,7 +33,7 @@ class RuleError29 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError31.php
+++ b/src/Rules/RuleErrors/RuleError31.php
@@ -20,7 +20,7 @@ class RuleError31 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -41,7 +41,7 @@ class RuleError31 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError31.php
+++ b/src/Rules/RuleErrors/RuleError31.php
@@ -20,6 +20,8 @@ class RuleError31 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -37,6 +39,11 @@ class RuleError31 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError37.php
+++ b/src/Rules/RuleErrors/RuleError37.php
@@ -16,6 +16,8 @@ class RuleError37 implements RuleError, FileRuleError, MetadataRuleError
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	/** @var mixed[] */
 	public array $metadata;
 
@@ -27,6 +29,11 @@ class RuleError37 implements RuleError, FileRuleError, MetadataRuleError
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	/**

--- a/src/Rules/RuleErrors/RuleError37.php
+++ b/src/Rules/RuleErrors/RuleError37.php
@@ -16,7 +16,7 @@ class RuleError37 implements RuleError, FileRuleError, MetadataRuleError
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	/** @var mixed[] */
 	public array $metadata;
@@ -31,7 +31,7 @@ class RuleError37 implements RuleError, FileRuleError, MetadataRuleError
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError39.php
+++ b/src/Rules/RuleErrors/RuleError39.php
@@ -19,6 +19,8 @@ class RuleError39 implements RuleError, LineRuleError, FileRuleError, MetadataRu
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	/** @var mixed[] */
 	public array $metadata;
 
@@ -35,6 +37,11 @@ class RuleError39 implements RuleError, LineRuleError, FileRuleError, MetadataRu
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	/**

--- a/src/Rules/RuleErrors/RuleError39.php
+++ b/src/Rules/RuleErrors/RuleError39.php
@@ -19,7 +19,7 @@ class RuleError39 implements RuleError, LineRuleError, FileRuleError, MetadataRu
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	/** @var mixed[] */
 	public array $metadata;
@@ -39,7 +39,7 @@ class RuleError39 implements RuleError, LineRuleError, FileRuleError, MetadataRu
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError45.php
+++ b/src/Rules/RuleErrors/RuleError45.php
@@ -17,7 +17,7 @@ class RuleError45 implements RuleError, FileRuleError, TipRuleError, MetadataRul
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -34,7 +34,7 @@ class RuleError45 implements RuleError, FileRuleError, TipRuleError, MetadataRul
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError45.php
+++ b/src/Rules/RuleErrors/RuleError45.php
@@ -17,6 +17,8 @@ class RuleError45 implements RuleError, FileRuleError, TipRuleError, MetadataRul
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	/** @var mixed[] */
@@ -30,6 +32,11 @@ class RuleError45 implements RuleError, FileRuleError, TipRuleError, MetadataRul
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError47.php
+++ b/src/Rules/RuleErrors/RuleError47.php
@@ -20,6 +20,8 @@ class RuleError47 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	/** @var mixed[] */
@@ -38,6 +40,11 @@ class RuleError47 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError47.php
+++ b/src/Rules/RuleErrors/RuleError47.php
@@ -20,7 +20,7 @@ class RuleError47 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -42,7 +42,7 @@ class RuleError47 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError5.php
+++ b/src/Rules/RuleErrors/RuleError5.php
@@ -15,7 +15,7 @@ class RuleError5 implements RuleError, FileRuleError
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public function getMessage(): string
 	{
@@ -27,7 +27,7 @@ class RuleError5 implements RuleError, FileRuleError
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError5.php
+++ b/src/Rules/RuleErrors/RuleError5.php
@@ -15,6 +15,8 @@ class RuleError5 implements RuleError, FileRuleError
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public function getMessage(): string
 	{
 		return $this->message;
@@ -23,6 +25,11 @@ class RuleError5 implements RuleError, FileRuleError
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 }

--- a/src/Rules/RuleErrors/RuleError53.php
+++ b/src/Rules/RuleErrors/RuleError53.php
@@ -17,7 +17,7 @@ class RuleError53 implements RuleError, FileRuleError, IdentifierRuleError, Meta
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -34,7 +34,7 @@ class RuleError53 implements RuleError, FileRuleError, IdentifierRuleError, Meta
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError53.php
+++ b/src/Rules/RuleErrors/RuleError53.php
@@ -17,6 +17,8 @@ class RuleError53 implements RuleError, FileRuleError, IdentifierRuleError, Meta
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	/** @var mixed[] */
@@ -30,6 +32,11 @@ class RuleError53 implements RuleError, FileRuleError, IdentifierRuleError, Meta
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError55.php
+++ b/src/Rules/RuleErrors/RuleError55.php
@@ -20,7 +20,7 @@ class RuleError55 implements RuleError, LineRuleError, FileRuleError, Identifier
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -42,7 +42,7 @@ class RuleError55 implements RuleError, LineRuleError, FileRuleError, Identifier
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError55.php
+++ b/src/Rules/RuleErrors/RuleError55.php
@@ -20,6 +20,8 @@ class RuleError55 implements RuleError, LineRuleError, FileRuleError, Identifier
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	/** @var mixed[] */
@@ -38,6 +40,11 @@ class RuleError55 implements RuleError, LineRuleError, FileRuleError, Identifier
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError61.php
+++ b/src/Rules/RuleErrors/RuleError61.php
@@ -18,6 +18,8 @@ class RuleError61 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -33,6 +35,11 @@ class RuleError61 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError61.php
+++ b/src/Rules/RuleErrors/RuleError61.php
@@ -18,7 +18,7 @@ class RuleError61 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -37,7 +37,7 @@ class RuleError61 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError63.php
+++ b/src/Rules/RuleErrors/RuleError63.php
@@ -21,7 +21,7 @@ class RuleError63 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -45,7 +45,7 @@ class RuleError63 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError63.php
+++ b/src/Rules/RuleErrors/RuleError63.php
@@ -21,6 +21,8 @@ class RuleError63 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -41,6 +43,11 @@ class RuleError63 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError69.php
+++ b/src/Rules/RuleErrors/RuleError69.php
@@ -16,6 +16,8 @@ class RuleError69 implements RuleError, FileRuleError, NonIgnorableRuleError
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public function getMessage(): string
 	{
 		return $this->message;
@@ -24,6 +26,11 @@ class RuleError69 implements RuleError, FileRuleError, NonIgnorableRuleError
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 }

--- a/src/Rules/RuleErrors/RuleError69.php
+++ b/src/Rules/RuleErrors/RuleError69.php
@@ -16,7 +16,7 @@ class RuleError69 implements RuleError, FileRuleError, NonIgnorableRuleError
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public function getMessage(): string
 	{
@@ -28,7 +28,7 @@ class RuleError69 implements RuleError, FileRuleError, NonIgnorableRuleError
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError7.php
+++ b/src/Rules/RuleErrors/RuleError7.php
@@ -18,7 +18,7 @@ class RuleError7 implements RuleError, LineRuleError, FileRuleError
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public function getMessage(): string
 	{
@@ -35,7 +35,7 @@ class RuleError7 implements RuleError, LineRuleError, FileRuleError
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError7.php
+++ b/src/Rules/RuleErrors/RuleError7.php
@@ -18,6 +18,8 @@ class RuleError7 implements RuleError, LineRuleError, FileRuleError
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public function getMessage(): string
 	{
 		return $this->message;
@@ -31,6 +33,11 @@ class RuleError7 implements RuleError, LineRuleError, FileRuleError
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 }

--- a/src/Rules/RuleErrors/RuleError71.php
+++ b/src/Rules/RuleErrors/RuleError71.php
@@ -19,7 +19,7 @@ class RuleError71 implements RuleError, LineRuleError, FileRuleError, NonIgnorab
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public function getMessage(): string
 	{
@@ -36,7 +36,7 @@ class RuleError71 implements RuleError, LineRuleError, FileRuleError, NonIgnorab
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError71.php
+++ b/src/Rules/RuleErrors/RuleError71.php
@@ -19,6 +19,8 @@ class RuleError71 implements RuleError, LineRuleError, FileRuleError, NonIgnorab
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public function getMessage(): string
 	{
 		return $this->message;
@@ -32,6 +34,11 @@ class RuleError71 implements RuleError, LineRuleError, FileRuleError, NonIgnorab
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 }

--- a/src/Rules/RuleErrors/RuleError77.php
+++ b/src/Rules/RuleErrors/RuleError77.php
@@ -17,6 +17,8 @@ class RuleError77 implements RuleError, FileRuleError, TipRuleError, NonIgnorabl
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public function getMessage(): string
@@ -27,6 +29,11 @@ class RuleError77 implements RuleError, FileRuleError, TipRuleError, NonIgnorabl
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError77.php
+++ b/src/Rules/RuleErrors/RuleError77.php
@@ -17,7 +17,7 @@ class RuleError77 implements RuleError, FileRuleError, TipRuleError, NonIgnorabl
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -31,7 +31,7 @@ class RuleError77 implements RuleError, FileRuleError, TipRuleError, NonIgnorabl
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError79.php
+++ b/src/Rules/RuleErrors/RuleError79.php
@@ -20,7 +20,7 @@ class RuleError79 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -39,7 +39,7 @@ class RuleError79 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError79.php
+++ b/src/Rules/RuleErrors/RuleError79.php
@@ -20,6 +20,8 @@ class RuleError79 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public function getMessage(): string
@@ -35,6 +37,11 @@ class RuleError79 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError85.php
+++ b/src/Rules/RuleErrors/RuleError85.php
@@ -17,7 +17,7 @@ class RuleError85 implements RuleError, FileRuleError, IdentifierRuleError, NonI
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -31,7 +31,7 @@ class RuleError85 implements RuleError, FileRuleError, IdentifierRuleError, NonI
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError85.php
+++ b/src/Rules/RuleErrors/RuleError85.php
@@ -17,6 +17,8 @@ class RuleError85 implements RuleError, FileRuleError, IdentifierRuleError, NonI
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	public function getMessage(): string
@@ -27,6 +29,11 @@ class RuleError85 implements RuleError, FileRuleError, IdentifierRuleError, NonI
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError87.php
+++ b/src/Rules/RuleErrors/RuleError87.php
@@ -20,6 +20,8 @@ class RuleError87 implements RuleError, LineRuleError, FileRuleError, Identifier
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $identifier;
 
 	public function getMessage(): string
@@ -35,6 +37,11 @@ class RuleError87 implements RuleError, LineRuleError, FileRuleError, Identifier
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getIdentifier(): string

--- a/src/Rules/RuleErrors/RuleError87.php
+++ b/src/Rules/RuleErrors/RuleError87.php
@@ -20,7 +20,7 @@ class RuleError87 implements RuleError, LineRuleError, FileRuleError, Identifier
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $identifier;
 
@@ -39,7 +39,7 @@ class RuleError87 implements RuleError, LineRuleError, FileRuleError, Identifier
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError93.php
+++ b/src/Rules/RuleErrors/RuleError93.php
@@ -18,6 +18,8 @@ class RuleError93 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -30,6 +32,11 @@ class RuleError93 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/src/Rules/RuleErrors/RuleError93.php
+++ b/src/Rules/RuleErrors/RuleError93.php
@@ -18,7 +18,7 @@ class RuleError93 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -34,7 +34,7 @@ class RuleError93 implements RuleError, FileRuleError, TipRuleError, IdentifierR
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError95.php
+++ b/src/Rules/RuleErrors/RuleError95.php
@@ -21,7 +21,7 @@ class RuleError95 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
-	public ?string $fileDescription;
+	public string $fileDescription;
 
 	public string $tip;
 
@@ -42,7 +42,7 @@ class RuleError95 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 		return $this->file;
 	}
 
-	public function getFileDescription(): ?string
+	public function getFileDescription(): string
 	{
 		return $this->fileDescription;
 	}

--- a/src/Rules/RuleErrors/RuleError95.php
+++ b/src/Rules/RuleErrors/RuleError95.php
@@ -21,6 +21,8 @@ class RuleError95 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 
 	public string $file;
 
+	public ?string $fileDescription;
+
 	public string $tip;
 
 	public string $identifier;
@@ -38,6 +40,11 @@ class RuleError95 implements RuleError, LineRuleError, FileRuleError, TipRuleErr
 	public function getFile(): string
 	{
 		return $this->file;
+	}
+
+	public function getFileDescription(): ?string
+	{
+		return $this->fileDescription;
 	}
 
 	public function getTip(): string

--- a/tests/PHPStan/Rules/RuleErrorBuilderTest.php
+++ b/tests/PHPStan/Rules/RuleErrorBuilderTest.php
@@ -26,24 +26,24 @@ class RuleErrorBuilderTest extends TestCase
 
 	public function testMessageAndFileAndBuild(): void
 	{
-		$builder = RuleErrorBuilder::message('Foo')->file('Bar.php');
+		$builder = RuleErrorBuilder::message('Foo')->file(__FILE__);
 		$ruleError = $builder->build();
 		$this->assertSame('Foo', $ruleError->getMessage());
 
 		$this->assertInstanceOf(FileRuleError::class, $ruleError);
-		$this->assertSame('Bar.php', $ruleError->getFile());
+		$this->assertSame(__FILE__, $ruleError->getFile());
 	}
 
 	public function testMessageAndLineAndFileAndBuild(): void
 	{
-		$builder = RuleErrorBuilder::message('Foo')->line(25)->file('Bar.php');
+		$builder = RuleErrorBuilder::message('Foo')->line(25)->file(__FILE__);
 		$ruleError = $builder->build();
 		$this->assertSame('Foo', $ruleError->getMessage());
 
 		$this->assertInstanceOf(LineRuleError::class, $ruleError);
 		$this->assertInstanceOf(FileRuleError::class, $ruleError);
 		$this->assertSame(25, $ruleError->getLine());
-		$this->assertSame('Bar.php', $ruleError->getFile());
+		$this->assertSame(__FILE__, $ruleError->getFile());
 	}
 
 }


### PR DESCRIPTION
This is a followup fix for https://github.com/phpstan/phpstan-src/pull/2531. That PR made the affected errors effectively unignorable, because it included the "in context of class ..." in path and consequently the `\` from the class namespace were converted to `/` when the baseline was generated and so the path didn't match during analysis.

I checked and other trait errors are saved with the parent classes' path. So this PR does the same for the uninitialized readonly property errors.

I'm not sure what's the best way to write a test for this issue. Should I add it to `e2e-tests.yml`, or should I create a PR in `phpstan/phpstan` and add it to `other-tests.yml`?

## Example

Foo.php:

```php
<?php

namespace Readonly\Uninit\Bug;

trait Foo
{
	protected readonly int $x;

	public function foo(): void
	{
		echo $this->x;
	}

	public function init(): void
	{
		$this->x = rand();
	}
}
```

HelloWorld.php
```php
<?php

namespace Readonly\Uninit\Bug;

class HelloWorld
{
	use Foo;

	public function __construct()
	{
		$this->init();
		$this->foo();
	}
}
```

test.neon
```neon
includes:
    - test-baseline.neon

parameters:
    level: 9
```

## Before the fix

Baseline:
```neon
parameters:
	ignoreErrors:
		-
			message: "#^Access to an uninitialized readonly property Readonly\\\\Uninit\\\\Bug\\\\HelloWorld\\:\\:\\$x\\.$#"
			count: 1
			path: "bug/Foo.php (in context of class Readonly/Uninit/Bug/HelloWorld)"

		-
			message: "#^Readonly property Readonly\\\\Uninit\\\\Bug\\\\HelloWorld\\:\\:\\$x is assigned outside of the constructor\\.$#"
			count: 1
			path: bug/HelloWorld.php
```

The result of analysis with this baseline is:

```
 ------ ---------------------------------------------------------------------------------- 
  Line   Foo.php (in context of class Readonly\Uninit\Bug\HelloWorld)                      
 ------ ---------------------------------------------------------------------------------- 
  11     Access to an uninitialized readonly property Readonly\Uninit\Bug\HelloWorld::$x.  
 ------ ---------------------------------------------------------------------------------- 

 -- ------------------------------------------------------------------------- 
     Error                                                                    
 -- ------------------------------------------------------------------------- 
     Ignored error pattern #^Access to an uninitialized readonly property     
     Readonly\\Uninit\\Bug\\HelloWorld\:\:\$x\.$# in path                     
     /home/schlndh/devel/custom/phpstan-src/bug/Foo.php (in context of class  
     Readonly/Uninit/Bug/HelloWorld) was not matched in reported errors.      
 -- -------------------------------------------------------------------------
```

## After the fix

Here is the diff of the baseline:
```diff
--- test-baseline.neon
+++ test-baseline-fixed.neon
@@ -3,7 +3,7 @@
 		-
 			message: "#^Access to an uninitialized readonly property Readonly\\\\Uninit\\\\Bug\\\\HelloWorld\\:\\:\\$x\\.$#"
 			count: 1
-			path: "bug/Foo.php (in context of class Readonly/Uninit/Bug/HelloWorld)"
+			path: bug/HelloWorld.php
 
 		-
 			message: "#^Readonly property Readonly\\\\Uninit\\\\Bug\\\\HelloWorld\\:\\:\\$x is assigned outside of the constructor\\.$#"
```
And when I run analysis there are no errors reported (as it should be).

