### PR TITLE
Fix several issues with nullsafe type specification

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1395,7 +1395,7 @@ class TypeSpecifier
 	{
 		if ($scope !== null) {
 			if ($context->true()) {
-				$containsNull = TypeCombinator::containsNull($type) && TypeCombinator::containsNull($scope->getType($expr));
+				$containsNull = ! $type->isNull()->no() && ! $scope->getType($expr)->isNull()->no();
 			} elseif ($context->false()) {
 				$containsNull = !TypeCombinator::containsNull($type) && TypeCombinator::containsNull($scope->getType($expr));
 			}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1395,9 +1395,9 @@ class TypeSpecifier
 	{
 		if ($scope !== null) {
 			if ($context->true()) {
-				$containsNull = ! $type->isNull()->no() && ! $scope->getType($expr)->isNull()->no();
+				$containsNull = !$type->isNull()->no() && !$scope->getType($expr)->isNull()->no();
 			} elseif ($context->false()) {
-				$containsNull = !TypeCombinator::containsNull($type) && TypeCombinator::containsNull($scope->getType($expr));
+				$containsNull = !TypeCombinator::containsNull($type) && !$scope->getType($expr)->isNull()->no();
 			}
 		}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1223,6 +1223,22 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug5172(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5172.php');
+		$this->assertNoErrors($errors);
+	}
+
+	public function testBug9105(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9105.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testNullsafeVsScalar(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/nullsafe-vs-scalar.php');

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1223,6 +1223,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testNullsafeVsScalar(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/nullsafe-vs-scalar.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1233,9 +1233,35 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug7980(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7980.php');
+		$this->assertNoErrors($errors);
+	}
+
+	public function testBug8664(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8664.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug9105(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9105.php');
+		$this->assertNoErrors($errors);
+	}
+
+	public function testBug9293(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9293.php');
 		$this->assertNoErrors($errors);
 	}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1223,54 +1223,6 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
-	public function testBug5172(): void
-	{
-		if (PHP_VERSION_ID < 80000) {
-			$this->markTestSkipped('Test requires PHP 8.0.');
-		}
-
-		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5172.php');
-		$this->assertNoErrors($errors);
-	}
-
-	public function testBug7980(): void
-	{
-		if (PHP_VERSION_ID < 80100) {
-			$this->markTestSkipped('Test requires PHP 8.0.');
-		}
-
-		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7980.php');
-		$this->assertNoErrors($errors);
-	}
-
-	public function testBug8664(): void
-	{
-		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8664.php');
-		$this->assertNoErrors($errors);
-	}
-
-	public function testBug9105(): void
-	{
-		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9105.php');
-		$this->assertNoErrors($errors);
-	}
-
-	public function testBug9293(): void
-	{
-		if (PHP_VERSION_ID < 80000) {
-			$this->markTestSkipped('Test requires PHP 8.0.');
-		}
-
-		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9293.php');
-		$this->assertNoErrors($errors);
-	}
-
-	public function testNullsafeVsScalar(): void
-	{
-		$errors = $this->runAnalyse(__DIR__ . '/data/nullsafe-vs-scalar.php');
-		$this->assertNoErrors($errors);
-	}
-
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1327,9 +1327,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/nullsafe-vs-scalar.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9105.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5172.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8517.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1328,6 +1328,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/nullsafe-vs-scalar.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9105.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5172.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1327,6 +1327,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/nullsafe-vs-scalar.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1327,6 +1327,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9105.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5172.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9293.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/nullsafe-vs-scalar.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8517.php');
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-5172.php
+++ b/tests/PHPStan/Analyser/data/bug-5172.php
@@ -1,0 +1,28 @@
+<?php // lint >= 8.0
+
+namespace Bug5172;
+
+use function PHPStan\Testing\assertType;
+
+class Period
+{
+	public mixed $from;
+	public mixed $to;
+
+	public function year(): ?int
+	{
+		assertType('mixed', $this->from);
+		assertType('mixed', $this->to);
+
+		// let's say $this->from === null && $model->to === null
+
+		if ($this->from?->year !== $this->to?->year) {
+			return null;
+		}
+
+		assertType('mixed', $this->from);
+		assertType('mixed', $this->to);
+
+		return $this->from?->year;
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-7980.php
+++ b/tests/PHPStan/Analyser/data/bug-7980.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7980;
+
+final class Value
+{
+	public function __construct(
+		public readonly mixed $value,
+		public readonly ?int $ttl,
+	) {}
+}
+
+function value(): Value|null {
+	return rand(0, 1)
+		? new Value(
+			rand(0, 1) ? 1 : null,
+			rand(0, 1) ? 1 : null)
+		: null;
+}
+
+function test(int $value, ?int $ttl): void {
+}
+
+$valueObj = value();
+
+$value = is_int($valueObj?->value) ? $valueObj->value : 0;
+
+test($value, $valueObj?->ttl);

--- a/tests/PHPStan/Analyser/data/bug-8517.php
+++ b/tests/PHPStan/Analyser/data/bug-8517.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8517;
+
+use function PHPStan\Testing\assertType;
+
+function test(?\stdClass $request): void
+{
+	assertType('stdClass|null', $request);
+	$routeParams0 = $request?->attributes->get('_route_params', []);
+	assertType('stdClass|null', $request);
+	$routeParams = $request?->attributes->get('_route_params', []) ?? [];
+	$param = $request?->attributes->get('_param') ?? $routeParams['_param'];
+	assertType('stdClass|null', $request);
+}

--- a/tests/PHPStan/Analyser/data/bug-8664.php
+++ b/tests/PHPStan/Analyser/data/bug-8664.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug8664;
+
+class UserObject
+{
+	protected ?int $id = null;
+	protected ?string $username = null;
+
+	public function setId(?int $id = null): void
+	{
+		$this->id = $id;
+	}
+
+	public function getId(): ?int
+	{
+		return $this->id;
+	}
+
+	public function setUsername(?string $username = null): void
+	{
+		$this->username = $username;
+	}
+
+	public function getUsername(): ?string
+	{
+		return $this->username;
+	}
+}
+
+class DataObject
+{
+	protected ?UserObject $user = null;
+
+	public function setUser(?UserObject $user = null): void
+	{
+		$this->user = $user;
+	}
+
+	public function getUser(): ?UserObject
+	{
+		return $this->user;
+	}
+}
+
+class Test
+{
+	public function test(): void
+	{
+		$data = new DataObject();
+
+		$userObject = $data->getUser();
+
+		if ($userObject?->getId() > 0) {
+			$userId = $userObject->getId();
+
+			var_dump($userId);
+		}
+
+		if (null !== $userObject?->getUsername()) {
+			$userUsername = $userObject->getUsername();
+
+			var_dump($userUsername);
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-9105.php
+++ b/tests/PHPStan/Analyser/data/bug-9105.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug9105;
+
+use function PHPStan\Testing\assertType;
+
+class H
+{
+	public int|null $a = null;
+	public self|null $b = null;
+
+	public function h(): void
+	{
+		assertType('Bug9105\H|null', $this->b);
+		if ($this->b?->a < 5) {
+			echo '<5', PHP_EOL;
+		}
+		assertType('Bug9105\H|null', $this->b);
+		if ($this->b?->a > 0) {
+			echo '>0', PHP_EOL;
+		}
+		assertType('Bug9105\H|null', $this->b);
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-9293.php
+++ b/tests/PHPStan/Analyser/data/bug-9293.php
@@ -1,0 +1,33 @@
+<?php // lint >= 8.0
+
+declare(strict_types=1);
+
+namespace Bug9293;
+
+use function PHPStan\Testing\assertType;
+
+class B
+{
+	public function int(): int
+	{
+		return 0;
+	}
+
+	public function mixed(): mixed
+	{
+		return new self();
+	}
+}
+
+/**
+ * @var null|B $b
+ */
+$b = null;
+
+assertType('Bug9293\B|null', $b);
+
+$b?->mixed()->int() ?? 0;
+
+assertType('Bug9293\B|null', $b);
+
+$b?->int() ?? 0;

--- a/tests/PHPStan/Analyser/data/nullsafe-vs-scalar.php
+++ b/tests/PHPStan/Analyser/data/nullsafe-vs-scalar.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace NullsafeVsScalar;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function aaa(?\DateTimeImmutable $date): void
+	{
+		echo $date?->getTimestamp() > 0 ? $date->format('j') : '';
+		echo $date?->getTimestamp() > 0 ? $date->format('j') : '';
+		assertType('DateTimeImmutable|null', $date);
+	}
+
+	public function bbb(?\DateTimeImmutable $date): void
+	{
+		echo 0 < $date?->getTimestamp() ? $date->format('j') : '';
+		echo 0 < $date?->getTimestamp() ? $date->format('j') : '';
+		assertType('DateTimeImmutable|null', $date);
+	}
+
+	/** @param mixed $date */
+	public function ccc($date): void
+	{
+		if ($date?->getTimestamp() > 0) {
+			assertType('mixed~null', $date);
+		}
+
+		echo $date?->getTimestamp() > 0 ? $date->format('j') : '';
+		echo $date?->getTimestamp() > 0 ? $date->format('j') : '';
+		assertType('mixed', $date);
+	}
+}

--- a/tests/PHPStan/Rules/Methods/NullsafeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/NullsafeMethodCallRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Methods;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<NullsafeMethodCallRule>
@@ -24,6 +25,25 @@ class NullsafeMethodCallRuleTest extends RuleTestCase
 				16,
 			],
 		]);
+	}
+
+	public function testNullsafeVsScalar(): void
+	{
+		 $this->analyse([__DIR__ . '/../../Analyser/data/nullsafe-vs-scalar.php'], []);
+	}
+
+	public function testBug8664(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8664.php'], []);
+	}
+
+	public function testBug9293(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-9293.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/NullsafePropertyFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/NullsafePropertyFetchRuleTest.php
@@ -41,4 +41,32 @@ class NullsafePropertyFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7109.php'], []);
 	}
 
+	public function testBug5172(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-5172.php'], []);
+	}
+
+	public function testBug7980(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-7980.php'], []);
+	}
+
+	public function testBug8517(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8517.php'], []);
+	}
+
+	public function testBug9105(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-9105.php'], []);
+	}
+
 }


### PR DESCRIPTION
The goal of this PR is to fix https://phpstan.org/r/c17b503c-a789-4d90-87a7-31f3436f1b68 .

These issues were also fixed:

- https://github.com/phpstan/phpstan/issues/9105
- https://github.com/phpstan/phpstan/issues/5172
- https://github.com/phpstan/phpstan/issues/8517
- https://github.com/phpstan/phpstan/issues/7980
- https://github.com/phpstan/phpstan/issues/8664
- https://github.com/phpstan/phpstan/issues/9293

The problem is that `TypeCombinator::containsNull` returns false for `MixedType` (there's even a test for that and some usages definitely rely on this behavior). That seems quite strange to me and it's possible that there are other issues due to this confusing method. But I replaced only those usages for which I could come up with a test.