### PR TITLE
Fix array_slice() dynamic return type

### DIFF
--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -78,6 +78,7 @@ abstract class ErrorFormatterTestCase extends PHPStanTestCase
 			throw new ShouldNotHappenException();
 		}
 
+		/** @var list<Error> */
 		$fileErrors = array_slice([
 			new Error('Foo', self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 4),
 			new Error('Foo', self::DIRECTORY_PATH . '/foo.php', 1),
@@ -86,6 +87,7 @@ abstract class ErrorFormatterTestCase extends PHPStanTestCase
 			new Error("Bar\nBar2", self::DIRECTORY_PATH . '/foo.php', null),
 		], 0, $numFileErrors);
 
+		/** @var list<string> */
 		$genericErrors = array_slice([
 			'first generic error',
 			'second generic error',

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -22,7 +22,7 @@ class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnType
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		if (count($functionCall->getArgs()) < 2) {
 			return null;
 		}
 

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -34,21 +34,13 @@ class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnType
 		$constantArrays = $valueType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$offsetType = $scope->getType($functionCall->getArgs()[1]->value);
-			if ($offsetType instanceof ConstantIntegerType) {
-				$offset = $offsetType->getValue();
-			} elseif (!$offsetType->isNull()->yes()) {
-				return null;
-			} else {
-				$offset = 0;
-			}
+			$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : null;
 
 			$limitType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
-			if ($limitType instanceof ConstantIntegerType) {
-				$limit = $limitType->getValue();
-			} elseif ($limitType !== null && !$limitType->isNull()->yes()) {
+			$limit = $limitType instanceof ConstantIntegerType ? $limitType->getValue() : null;
+
+			if ($offset === null || ($limit === null && $limitType !== null && !$limitType->isNull()->yes())) {
 				return null;
-			} else {
-				$limit = null;
 			}
 
 			$preserveKeysType = isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null;

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -31,13 +31,25 @@ class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnType
 			return null;
 		}
 
-		$offsetType = isset($functionCall->getArgs()[1]) ? $scope->getType($functionCall->getArgs()[1]->value) : null;
-		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : 0;
-
 		$constantArrays = $valueType->getConstantArrays();
 		if (count($constantArrays) > 0) {
+			$offsetType = $scope->getType($functionCall->getArgs()[1]->value);
+			if ($offsetType instanceof ConstantIntegerType) {
+				$offset = $offsetType->getValue();
+			} elseif (!$offsetType->isNull()->yes()) {
+				return null;
+			} else {
+				$offset = 0;
+			}
+
 			$limitType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
-			$limit = $limitType instanceof ConstantIntegerType ? $limitType->getValue() : null;
+			if ($limitType instanceof ConstantIntegerType) {
+				$limit = $limitType->getValue();
+			} elseif ($limitType !== null && !$limitType->isNull()->yes()) {
+				return null;
+			} else {
+				$limit = null;
+			}
 
 			$preserveKeysType = isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null;
 			$preserveKeys = $preserveKeysType !== null && $preserveKeysType->isTrue()->yes();

--- a/tests/PHPStan/Analyser/data/array-slice.php
+++ b/tests/PHPStan/Analyser/data/array-slice.php
@@ -47,6 +47,16 @@ class Foo
 		/** @var array{17: 'foo', 19: 'bar', 21: 'baz'}|array{foo: 17, bar: 19, baz: 21} $arr */
 		assertType('array{\'bar\', \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2));
 		assertType('array{19: \'bar\', 21: \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2, true));
+
+		/** @var int $offset */
+		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+		assertType('array', array_slice($arr, $offset, 2));
+		assertType('array', array_slice($arr, $offset, 2, true));
+
+		/** @var int $limit */
+		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+		assertType('array', array_slice($arr, 1, $limit));
+		assertType('array', array_slice($arr, 1, $limit, true));
 	}
 
 	public function constantArraysWithOptionalKeys(array $arr): void

--- a/tests/PHPStan/Analyser/data/array-slice.php
+++ b/tests/PHPStan/Analyser/data/array-slice.php
@@ -48,13 +48,13 @@ class Foo
 		assertType('array{\'bar\', \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2));
 		assertType('array{19: \'bar\', 21: \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2, true));
 
-		/** @var int $offset */
-		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+		/**
+		 * @var int $offset
+		 * @var int $limit
+		 * @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr
+		 */
 		assertType('array', array_slice($arr, $offset, 2));
 		assertType('array', array_slice($arr, $offset, 2, true));
-
-		/** @var int $limit */
-		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
 		assertType('array', array_slice($arr, 1, $limit));
 		assertType('array', array_slice($arr, 1, $limit, true));
 	}


### PR DESCRIPTION
When `array_slice()` `offset` or `limit` parameters aren't constants we cannot dynamically override return type, so for those cases return type should stay `array`. 

This PR fixes this and as well it includes minor refactor and tests for array_slice offset/limit parameters as variables.