### PR TITLE
Made ParentClass reflection resolving lazier

### DIFF
--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -87,22 +87,20 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 		$parentClass = $classReflection->getParentClass();
 		while ($parentClass !== null) {
 			$methodWithDeclaringClass = $this->findClassReflectionWithMethod($parentClass, $parentClass, $methodName);
-			if ($methodWithDeclaringClass === null) {
-				foreach ($parentClass->getTraits() as $traitClass) {
-					$parentTraitMethodWithDeclaringClass = $this->findClassReflectionWithMethod($traitClass, $parentClass, $methodName);
-					if ($parentTraitMethodWithDeclaringClass === null) {
-						continue;
-					}
-
-					return $parentTraitMethodWithDeclaringClass;
-				}
-
-				$parentClass = $parentClass->getParentClass();
-
-				continue;
+			if ($methodWithDeclaringClass !== null) {
+				return $methodWithDeclaringClass;
 			}
 
-			return $methodWithDeclaringClass;
+			foreach ($parentClass->getTraits() as $traitClass) {
+				$parentTraitMethodWithDeclaringClass = $this->findClassReflectionWithMethod($traitClass, $parentClass, $methodName);
+				if ($parentTraitMethodWithDeclaringClass === null) {
+					continue;
+				}
+
+				return $parentTraitMethodWithDeclaringClass;
+			}
+
+			$parentClass = $parentClass->getParentClass();
 		}
 
 		foreach ($classReflection->getInterfaces() as $interfaceClass) {

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -84,7 +84,8 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 			return $methodWithDeclaringClass;
 		}
 
-		foreach ($classReflection->getParents() as $parentClass) {
+		$parentClass = $classReflection->getParentClass();
+		while ($parentClass !== null) {
 			$methodWithDeclaringClass = $this->findClassReflectionWithMethod($parentClass, $parentClass, $methodName);
 			if ($methodWithDeclaringClass === null) {
 				foreach ($parentClass->getTraits() as $traitClass) {
@@ -95,6 +96,9 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 
 					return $parentTraitMethodWithDeclaringClass;
 				}
+
+				$parentClass = $parentClass->getParentClass();
+
 				continue;
 			}
 

--- a/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
@@ -77,22 +77,20 @@ class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassRe
 		$parentClass = $classReflection->getParentClass();
 		while ($parentClass !== null) {
 			$methodWithDeclaringClass = $this->findClassReflectionWithProperty($parentClass, $parentClass, $propertyName);
-			if ($methodWithDeclaringClass === null) {
-				foreach ($parentClass->getTraits() as $traitClass) {
-					$parentTraitMethodWithDeclaringClass = $this->findClassReflectionWithProperty($traitClass, $parentClass, $propertyName);
-					if ($parentTraitMethodWithDeclaringClass === null) {
-						continue;
-					}
-
-					return $parentTraitMethodWithDeclaringClass;
-				}
-
-				$parentClass = $parentClass->getParentClass();
-
-				continue;
+			if ($methodWithDeclaringClass !== null) {
+				return $methodWithDeclaringClass;
 			}
 
-			return $methodWithDeclaringClass;
+			foreach ($parentClass->getTraits() as $traitClass) {
+				$parentTraitMethodWithDeclaringClass = $this->findClassReflectionWithProperty($traitClass, $parentClass, $propertyName);
+				if ($parentTraitMethodWithDeclaringClass === null) {
+					continue;
+				}
+
+				return $parentTraitMethodWithDeclaringClass;
+			}
+
+			$parentClass = $parentClass->getParentClass();
 		}
 
 		foreach ($classReflection->getInterfaces() as $interfaceClass) {

--- a/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
@@ -74,7 +74,8 @@ class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassRe
 			return $methodWithDeclaringClass;
 		}
 
-		foreach ($classReflection->getParents() as $parentClass) {
+		$parentClass = $classReflection->getParentClass();
+		while ($parentClass !== null) {
 			$methodWithDeclaringClass = $this->findClassReflectionWithProperty($parentClass, $parentClass, $propertyName);
 			if ($methodWithDeclaringClass === null) {
 				foreach ($parentClass->getTraits() as $traitClass) {
@@ -85,6 +86,9 @@ class AnnotationsPropertiesClassReflectionExtension implements PropertiesClassRe
 
 					return $parentTraitMethodWithDeclaringClass;
 				}
+
+				$parentClass = $parentClass->getParentClass();
+
 				continue;
 			}
 

--- a/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinMethodsClassReflectionExtension.php
@@ -74,13 +74,14 @@ class MixinMethodsClassReflectionExtension implements MethodsClassReflectionExte
 			return new MixinMethodReflection($method, $static);
 		}
 
-		foreach ($classReflection->getParents() as $parentClass) {
+		$parentClass = $classReflection->getParentClass();
+		while ($parentClass !== null) {
 			$method = $this->findMethod($parentClass, $methodName);
-			if ($method === null) {
-				continue;
+			if ($method !== null) {
+				return $method;
 			}
 
-			return $method;
+			$parentClass = $parentClass->getParentClass();
 		}
 
 		return null;

--- a/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Mixin/MixinPropertiesClassReflectionExtension.php
@@ -65,13 +65,14 @@ class MixinPropertiesClassReflectionExtension implements PropertiesClassReflecti
 			return $property;
 		}
 
-		foreach ($classReflection->getParents() as $parentClass) {
+		$parentClass = $classReflection->getParentClass();
+		while ($parentClass !== null) {
 			$property = $this->findProperty($parentClass, $propertyName);
-			if ($property === null) {
-				continue;
+			if ($property !== null) {
+				return $property;
 			}
 
-			return $property;
+			$parentClass = $parentClass->getParentClass();
 		}
 
 		return null;


### PR DESCRIPTION
before this PR we looked up the whole parent class hierarchy, even though we work thru the results one by one and early exit on success. this means we are doing more reflection then necessary.


## perf comparison

with 1.10.x@6754c2308
```
mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (1.10.x)
$ php bin/phpstan clear-result-cache -c ../motiontm/app/partner/phpstan.neon.dist -q && time php bin/phpstan analyse -c ../motiontm/app/partner/phpstan.neon.dist -q

real    0m39.625s
user    0m0.031s
sys     0m0.046s

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (1.10.x)
$ php bin/phpstan clear-result-cache -c ../motiontm/app/partner/phpstan.neon.dist -q && time php bin/phpstan analyse -c ../motiontm/app/partner/phpstan.neon.dist -q

real    0m42.209s
user    0m0.000s
sys     0m0.046s

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (1.10.x)
$ php bin/phpstan clear-result-cache -c ../motiontm/app/partner/phpstan.neon.dist -q && time php bin/phpstan analyse -c ../motiontm/app/partner/phpstan.neon.dist -q

real    0m40.986s
user    0m0.000s
sys     0m0.031s
```

with this PR:
```
mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (lazy-class-parent-reflection)
$ php bin/phpstan clear-result-cache -c ../motiontm/app/partner/phpstan.neon.dist -q && time php bin/phpstan analyse -c ../motiontm/app/partner/phpstan.neon.dist -q

real    0m39.760s
user    0m0.062s
sys     0m0.015s

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (lazy-class-parent-reflection)
$ php bin/phpstan clear-result-cache -c ../motiontm/app/partner/phpstan.neon.dist -q && time php bin/phpstan analyse -c ../motiontm/app/partner/phpstan.neon.dist -q

real    0m40.682s
user    0m0.000s
sys     0m0.015s

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (lazy-class-parent-reflection)
$ php bin/phpstan clear-result-cache -c ../motiontm/app/partner/phpstan.neon.dist -q && time php bin/phpstan analyse -c ../motiontm/app/partner/phpstan.neon.dist -q

real    0m38.821s
user    0m0.000s
sys     0m0.046s
```

its not a huge win, but I think the improvemnt adds up as more worker processes are started, as every worker has some overhead in doing too much reflection.


----

we could even consider marking `getParents()` as `@deprecated`, to make sure other 3rd party rules/extension don't do overaggressive reflection?