### PR TITLE
Prevent most `$parentPhpDocBlock->getClassReflection()->isBuiltin()` calls

### DIFF
--- a/src/PhpDoc/PhpDocInheritanceResolver.php
+++ b/src/PhpDoc/PhpDocInheritanceResolver.php
@@ -94,9 +94,9 @@ class PhpDocInheritanceResolver
 
 		foreach ($phpDocBlock->getParents() as $parentPhpDocBlock) {
 			if (
-				$parentPhpDocBlock->getClassReflection()->isBuiltin()
-				&& $functionName !== null
+				$functionName !== null
 				&& strtolower($functionName) === '__construct'
+				&& $parentPhpDocBlock->getClassReflection()->isBuiltin()
 			) {
 				continue;
 			}


### PR DESCRIPTION
micro optimizing - re-shuffle conditions, since we only need to call into the reflection class for constructors