### PR TITLE
Failing test for broken implicitThrows (Throwable returned)

### DIFF
--- a/tests/PHPStan/Rules/Exceptions/ReturnThrowableNoImplicitThrowsTest.php
+++ b/tests/PHPStan/Rules/Exceptions/ReturnThrowableNoImplicitThrowsTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Exceptions;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CatchWithUnthrownExceptionRule>
+ */
+class ReturnThrowableNoImplicitThrowsTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new CatchWithUnthrownExceptionRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/implicit-throws-broken-when-throwable-returned.php'], []);
+	}
+
+}

--- a/tests/PHPStan/Rules/Exceptions/data/implicit-throws-broken-when-throwable-returned.php
+++ b/tests/PHPStan/Rules/Exceptions/data/implicit-throws-broken-when-throwable-returned.php
@@ -8,13 +8,13 @@ class ReturnThrowableNoImplicitThrows
 	{
 		try {
 			$this->returnVoid();
-		} catch (\Throwable $e) { // dead cache properly not reported (implicitThrows is enabled)
+		} catch (\Throwable $e) { // dead catch properly not reported (implicitThrows is enabled)
 
 		}
 
 		try {
 			$this->returnThrowable();
-		} catch (\Throwable $e) { // dead cache REPORTED
+		} catch (\Throwable $e) { // dead catch REPORTED
 
 		}
 	}

--- a/tests/PHPStan/Rules/Exceptions/data/implicit-throws-broken-when-throwable-returned.php
+++ b/tests/PHPStan/Rules/Exceptions/data/implicit-throws-broken-when-throwable-returned.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Exceptions\data;
+
+class ReturnThrowableNoImplicitThrows
+{
+	public function sayHello(): void
+	{
+		try {
+			$this->returnVoid();
+		} catch (\Throwable $e) { // dead cache properly not reported (implicitThrows is enabled)
+
+		}
+
+		try {
+			$this->returnThrowable();
+		} catch (\Throwable $e) { // dead cache REPORTED
+
+		}
+	}
+
+	public function returnVoid(): void {
+
+	}
+
+	public function returnThrowable(): \Exception {
+		return new \Exception();
+	}
+}


### PR DESCRIPTION
I believe this behaviour is not correct, see failing test. The [condition that breaks it](https://github.com/phpstan/phpstan-src/blob/b551135ac79a532309675a3ac28fdae9d3fbb04e/src/Analyser/NodeScopeResolver.php#L3113).