### PR TITLE
Show custom tip for unfound Drupal symbols

### DIFF
--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -96,7 +96,7 @@ class ClassConstantRule implements Rule
 						return [
 							RuleErrorBuilder::message(sprintf('Class %s not found.', $className))
 								->identifier('class.notFound')
-								->discoveringSymbolsTip()
+								->discoveringSymbolsTip($className)
 								->build(),
 						];
 					}
@@ -106,7 +106,7 @@ class ClassConstantRule implements Rule
 							sprintf('Access to constant %s on an unknown class %s.', $constantName, $className),
 						)
 							->identifier('class.notFound')
-							->discoveringSymbolsTip()
+							->discoveringSymbolsTip($className)
 							->build(),
 					];
 				}

--- a/src/Rules/Classes/ExistingClassInClassExtendsRule.php
+++ b/src/Rules/Classes/ExistingClassInClassExtendsRule.php
@@ -49,7 +49,7 @@ class ExistingClassInClassExtendsRule implements Rule
 				))
 					->identifier('class.notFound')
 					->nonIgnorable()
-					->discoveringSymbolsTip()
+					->discoveringSymbolsTip($extendedClassName)
 					->build();
 			}
 		} else {

--- a/src/Rules/Classes/ExistingClassInInstanceOfRule.php
+++ b/src/Rules/Classes/ExistingClassInInstanceOfRule.php
@@ -73,7 +73,7 @@ class ExistingClassInInstanceOfRule implements Rule
 				RuleErrorBuilder::message(sprintf('Class %s not found.', $name))
 					->identifier('class.notFound')
 					->line($class->getLine())
-					->discoveringSymbolsTip()
+					->discoveringSymbolsTip($name)
 					->build(),
 			];
 		} elseif ($this->checkClassCaseSensitivity) {

--- a/src/Rules/Classes/ExistingClassInTraitUseRule.php
+++ b/src/Rules/Classes/ExistingClassInTraitUseRule.php
@@ -67,7 +67,7 @@ class ExistingClassInTraitUseRule implements Rule
 					$messages[] = RuleErrorBuilder::message(sprintf('%s uses unknown trait %s.', $currentName, $traitName))
 						->identifier('trait.notFound')
 						->nonIgnorable()
-						->discoveringSymbolsTip()
+						->discoveringSymbolsTip($traitName)
 						->build();
 				} else {
 					$reflection = $this->reflectionProvider->getClass($traitName);

--- a/src/Rules/Classes/ExistingClassesInClassImplementsRule.php
+++ b/src/Rules/Classes/ExistingClassesInClassImplementsRule.php
@@ -52,7 +52,7 @@ class ExistingClassesInClassImplementsRule implements Rule
 					))
 						->identifier('interface.notFound')
 						->nonIgnorable()
-						->discoveringSymbolsTip()
+						->discoveringSymbolsTip($implementedClassName)
 						->build();
 				}
 			} else {

--- a/src/Rules/Classes/ExistingClassesInEnumImplementsRule.php
+++ b/src/Rules/Classes/ExistingClassesInEnumImplementsRule.php
@@ -49,7 +49,7 @@ class ExistingClassesInEnumImplementsRule implements Rule
 					))
 						->identifier('interface.notFound')
 						->nonIgnorable()
-						->discoveringSymbolsTip()
+						->discoveringSymbolsTip($implementedClassName)
 						->build();
 				}
 			} else {

--- a/src/Rules/Classes/ExistingClassesInInterfaceExtendsRule.php
+++ b/src/Rules/Classes/ExistingClassesInInterfaceExtendsRule.php
@@ -48,7 +48,7 @@ class ExistingClassesInInterfaceExtendsRule implements Rule
 					))
 						->identifier('interface.notFound')
 						->nonIgnorable()
-						->discoveringSymbolsTip()
+						->discoveringSymbolsTip($extendedInterfaceName)
 						->build();
 				}
 			} else {

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -123,7 +123,7 @@ class InstantiationRule implements Rule
 				return [
 					RuleErrorBuilder::message(sprintf('Instantiated class %s not found.', $class))
 						->identifier('class.notFound')
-						->discoveringSymbolsTip()
+						->discoveringSymbolsTip($class)
 						->build(),
 				];
 			}

--- a/src/Rules/Classes/MixinRule.php
+++ b/src/Rules/Classes/MixinRule.php
@@ -88,7 +88,7 @@ class MixinRule implements Rule
 				if (!$this->reflectionProvider->hasClass($class)) {
 					$errors[] = RuleErrorBuilder::message(sprintf('PHPDoc tag @mixin contains unknown class %s.', $class))
 						->identifier('class.notFound')
-						->discoveringSymbolsTip()
+						->discoveringSymbolsTip($class)
 						->build();
 				} elseif ($this->reflectionProvider->getClass($class)->isTrait()) {
 					$errors[] = RuleErrorBuilder::message(sprintf('PHPDoc tag @mixin contains invalid type %s.', $class))

--- a/src/Rules/Constants/ConstantRule.php
+++ b/src/Rules/Constants/ConstantRule.php
@@ -28,7 +28,7 @@ class ConstantRule implements Rule
 					(string) $node->name,
 				))
 					->identifier('constant.notFound')
-					->discoveringSymbolsTip()
+					->discoveringSymbolsTip((string) $node->name)
 					->build(),
 			];
 		}

--- a/src/Rules/Exceptions/CaughtExceptionExistenceRule.php
+++ b/src/Rules/Exceptions/CaughtExceptionExistenceRule.php
@@ -45,7 +45,7 @@ class CaughtExceptionExistenceRule implements Rule
 				$errors[] = RuleErrorBuilder::message(sprintf('Caught class %s not found.', $className))
 					->line($class->getLine())
 					->identifier('class.notFound')
-					->discoveringSymbolsTip()
+					->discoveringSymbolsTip($className)
 					->build();
 				continue;
 			}

--- a/src/Rules/Functions/CallToNonExistentFunctionRule.php
+++ b/src/Rules/Functions/CallToNonExistentFunctionRule.php
@@ -41,7 +41,7 @@ class CallToNonExistentFunctionRule implements Rule
 			}
 
 			return [
-				RuleErrorBuilder::message(sprintf('Function %s not found.', (string) $node->name))->identifier('function.notFound')->discoveringSymbolsTip()->build(),
+				RuleErrorBuilder::message(sprintf('Function %s not found.', (string) $node->name))->identifier('function.notFound')->discoveringSymbolsTip((string) $node->name)->build(),
 			];
 		}
 

--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -124,7 +124,7 @@ class StaticMethodCallCheck
 								'Call to static method %s() on an unknown class %s.',
 								$methodName,
 								$className,
-							))->identifier('class.notFound')->discoveringSymbolsTip()->build(),
+							))->identifier('class.notFound')->discoveringSymbolsTip($className)->build(),
 						],
 						null,
 					];

--- a/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInGroupUseRule.php
@@ -73,7 +73,7 @@ class ExistingNamesInGroupUseRule implements Rule
 	{
 		if (!$this->reflectionProvider->hasConstant($name, null)) {
 			return RuleErrorBuilder::message(sprintf('Used constant %s not found.', (string) $name))
-				->discoveringSymbolsTip()
+				->discoveringSymbolsTip((string) $name)
 				->line($name->getLine())
 				->identifier('constant.notFound')
 				->build();
@@ -86,7 +86,7 @@ class ExistingNamesInGroupUseRule implements Rule
 	{
 		if (!$this->reflectionProvider->hasFunction($name, null)) {
 			return RuleErrorBuilder::message(sprintf('Used function %s not found.', (string) $name))
-				->discoveringSymbolsTip()
+				->discoveringSymbolsTip((string) $name)
 				->line($name->getLine())
 				->identifier('function.notFound')
 				->build();

--- a/src/Rules/Namespaces/ExistingNamesInUseRule.php
+++ b/src/Rules/Namespaces/ExistingNamesInUseRule.php
@@ -72,7 +72,7 @@ class ExistingNamesInUseRule implements Rule
 			$errors[] = RuleErrorBuilder::message(sprintf('Used constant %s not found.', (string) $use->name))
 				->line($use->name->getLine())
 				->identifier('constant.notFound')
-				->discoveringSymbolsTip()
+				->discoveringSymbolsTip((string) $use->name)
 				->build();
 		}
 
@@ -91,7 +91,7 @@ class ExistingNamesInUseRule implements Rule
 				$errors[] = RuleErrorBuilder::message(sprintf('Used function %s not found.', (string) $use->name))
 					->line($use->name->getLine())
 					->identifier('function.notFound')
-					->discoveringSymbolsTip()
+					->discoveringSymbolsTip((string) $use->name)
 					->build();
 			} elseif ($this->checkFunctionNameCase) {
 				$functionReflection = $this->reflectionProvider->getFunction($use->name, null);

--- a/src/Rules/PhpDoc/InvalidPhpDocVarTagTypeRule.php
+++ b/src/Rules/PhpDoc/InvalidPhpDocVarTagTypeRule.php
@@ -144,7 +144,7 @@ class InvalidPhpDocVarTagTypeRule implements Rule
 					$referencedClass,
 				))
 					->identifier('class.notFound')
-					->discoveringSymbolsTip()
+					->discoveringSymbolsTip($referencedClass)
 					->build();
 			}
 

--- a/src/Rules/Properties/AccessStaticPropertiesRule.php
+++ b/src/Rules/Properties/AccessStaticPropertiesRule.php
@@ -131,7 +131,7 @@ class AccessStaticPropertiesRule implements Rule
 							$name,
 							$class,
 						))
-							->discoveringSymbolsTip()
+							->discoveringSymbolsTip($class)
 							->identifier('class.notFound')
 							->build(),
 					];

--- a/src/Rules/Properties/ExistingClassesInPropertiesRule.php
+++ b/src/Rules/Properties/ExistingClassesInPropertiesRule.php
@@ -69,7 +69,7 @@ class ExistingClassesInPropertiesRule implements Rule
 				$propertyReflection->getDeclaringClass()->getDisplayName(),
 				$node->getName(),
 				$referencedClass,
-			))->identifier('class.notFound')->discoveringSymbolsTip()->build();
+			))->identifier('class.notFound')->discoveringSymbolsTip($referencedClass)->build();
 		}
 
 		if ($this->checkClassCaseSensitivity) {

--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -10,6 +10,7 @@ use function count;
 use function implode;
 use function is_file;
 use function sprintf;
+use function substr;
 
 /**
  * @api
@@ -182,8 +183,11 @@ class RuleErrorBuilder
 	 * @phpstan-this-out self<T&TipRuleError>
 	 * @return self<T&TipRuleError>
 	 */
-	public function discoveringSymbolsTip(): self
+	public function discoveringSymbolsTip(?string $className = null): self
 	{
+		if (isset($className) && substr($className, 0, 7) === 'Drupal/') {
+			return $this->tip('Learn more at https://github.com/mglaman/phpstan-drupal');
+		}
 		return $this->tip('Learn more at https://phpstan.org/user-guide/discovering-symbols');
 	}
 

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -344,7 +344,7 @@ class RuleLevelHelper
 			$errors[] = RuleErrorBuilder::message(sprintf($unknownClassErrorPattern, $referencedClass))
 				->line($var->getLine())
 				->identifier('class.notFound')
-				->discoveringSymbolsTip()
+				->discoveringSymbolsTip($referencedClass)
 				->build();
 		}
 


### PR DESCRIPTION
- add optional $className argument to discoveringSymbolsTip() method
- if that name starts with 'Drupal/' show link to phpstan-drupal project
- pass the symbol name to all 22 calls to discoveringSymbolsTip()

Closes #9837