### PR TITLE
fix incorrect doc for inotify_read

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5336,7 +5336,7 @@ return [
 'inotify_add_watch' => ['int<1,max>|false', 'inotify_instance'=>'resource', 'pathname'=>'string', 'mask'=>'int'],
 'inotify_init' => ['resource'],
 'inotify_queue_len' => ['int<0,max>', 'inotify_instance'=>'resource'],
-'inotify_read' => ['array{wd:int<1,max>,mask:int<0,max>,cookie:int<0,max>,name:string}|false', 'inotify_instance'=>'resource'],
+'inotify_read' => ['list<array{wd:int<1,max>,mask:int<0,max>,cookie:int<0,max>,name:string}>|false', 'inotify_instance'=>'resource'],
 'inotify_rm_watch' => ['bool', 'inotify_instance'=>'resource', 'watch_descriptor'=>'int'],
 'intdiv' => ['int', 'numerator'=>'int', 'divisor'=>'int'],
 'interface_exists' => ['bool', 'classname'=>'string', 'autoload='=>'bool'],


### PR DESCRIPTION
https://github.com/phpstan/phpstan-src/pull/2599 attempted to improve the doc for inotify_read but the return type is incorrect (returns an inotify event but should return [array of inotify events](https://www.php.net/manual/en/function.inotify-read.php#refsect1-function.inotify-read-returnvalues)) and threw an error in our code.
This attempts to fix that.

Here is the snippet of our code.
https://phpstan.org/r/bb53cbfc-68cb-44d7-aed8-7efbd7438651

