### PR TITLE
Make result-cache independent from configs include order

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -264,6 +264,8 @@ class ResultCacheManager
 	{
 		$projectConfig = $currentMeta['projectConfig'];
 		if ($projectConfig !== null) {
+			ksort($currentMeta['projectConfig']);
+
 			$currentMeta['projectConfig'] = Neon::encode($currentMeta['projectConfig']);
 		}
 
@@ -728,6 +730,8 @@ return [
 			unset($projectConfigArray['parameters']['memoryLimitFile']);
 			unset($projectConfigArray['parameters']['pro']);
 			unset($projectConfigArray['parametersSchema']);
+
+			ksort($projectConfigArray);
 		}
 
 		return [


### PR DESCRIPTION
closes  https://github.com/phpstan/phpstan/issues/8778

tested via https://github.com/phpstan/phpstan/pull/9857