### PR TITLE
Implement FailWithoutResultCacheErrorFormatter

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1955,6 +1955,9 @@ services:
 			editorUrl: %editorUrl%
 			editorUrlTitle: %editorUrlTitle%
 
+	errorFormatter.failWithoutResultCache:
+		class: PHPStan\Command\ErrorFormatter\FailWithoutResultCacheErrorFormatter
+
 	errorFormatter.checkstyle:
 		class: PHPStan\Command\ErrorFormatter\CheckstyleErrorFormatter
 		arguments:

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -61,6 +61,7 @@ class AnalyseApplication
 		InputInterface $input,
 	): AnalysisResult
 	{
+		$isResultCacheUsed = false;
 		$resultCacheManager = $this->resultCacheManagerFactory->create();
 
 		$ignoredErrorHelperResult = $this->ignoredErrorHelper->initialize();
@@ -106,6 +107,7 @@ class AnalyseApplication
 			$errors = $analyserResult->getErrors();
 			$hasInternalErrors = count($internalErrors) > 0 || $analyserResult->hasReachedInternalErrorsCountLimit();
 			$memoryUsageBytes = $analyserResult->getPeakMemoryUsageBytes();
+			$isResultCacheUsed = !$resultCache->isFullAnalysis();
 
 			if (!$hasInternalErrors) {
 				foreach ($this->getCollectedDataErrors($analyserResult->getCollectedData(), $onlyFiles) as $error) {
@@ -142,6 +144,7 @@ class AnalyseApplication
 			$projectConfigFile,
 			$savedResultCache,
 			$memoryUsageBytes,
+			$isResultCacheUsed,
 		);
 	}
 

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -424,6 +424,7 @@ class AnalyseCommand extends Command
 					$analysisResult->getProjectConfigFile(),
 					$analysisResult->isResultCacheSaved(),
 					$analysisResult->getPeakMemoryUsageBytes(),
+					$analysisResult->isResultCacheUsed(),
 				);
 
 				$stdOutput = $inceptionResult->getStdOutput();

--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -31,6 +31,7 @@ class AnalysisResult
 		private ?string $projectConfigFile,
 		private bool $savedResultCache,
 		private int $peakMemoryUsageBytes,
+		private bool $isResultCacheUsed,
 	)
 	{
 		usort(
@@ -127,6 +128,11 @@ class AnalysisResult
 	public function getPeakMemoryUsageBytes(): int
 	{
 		return $this->peakMemoryUsageBytes;
+	}
+
+	public function isResultCacheUsed(): bool
+	{
+		return $this->isResultCacheUsed;
 	}
 
 }

--- a/src/Command/ErrorFormatter/FailWithoutResultCacheErrorFormatter.php
+++ b/src/Command/ErrorFormatter/FailWithoutResultCacheErrorFormatter.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+
+class FailWithoutResultCacheErrorFormatter implements ErrorFormatter
+{
+
+	public function __construct(
+		private TableErrorFormatter $tableErrorFormatter,
+	)
+	{
+	}
+
+	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+	{
+		if (!$analysisResult->isResultCacheUsed()) {
+			return 2;
+		}
+
+		return $this->tableErrorFormatter->formatErrors($analysisResult, $output);
+	}
+
+}

--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -101,6 +101,7 @@ abstract class ErrorFormatterTestCase extends PHPStanTestCase
 			null,
 			true,
 			0,
+			false,
 		);
 	}
 

--- a/tests/PHPStan/Command/AnalysisResultTest.php
+++ b/tests/PHPStan/Command/AnalysisResultTest.php
@@ -44,6 +44,7 @@ final class AnalysisResultTest extends PHPStanTestCase
 				null,
 				true,
 				0,
+				false,
 			))->getFileSpecificErrors(),
 		);
 	}

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -149,6 +149,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			null,
 			true,
 			0,
+			false,
 		);
 		$formatter->formatErrors(
 			$result,
@@ -187,6 +188,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			null,
 			true,
 			0,
+			false,
 		);
 
 		$formatter->formatErrors(
@@ -252,6 +254,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			null,
 			true,
 			0,
+			false,
 		);
 
 		$formatter->formatErrors(
@@ -410,6 +413,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			null,
 			true,
 			0,
+			false,
 		);
 
 		$resource = fopen('php://memory', 'w', false);

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -155,6 +155,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 			null,
 			true,
 			0,
+			false,
 		), $this->getOutput());
 		$this->assertXmlStringEqualsXmlString('<checkstyle>
 	<file name="FooTrait.php">

--- a/tests/PHPStan/Command/ErrorFormatter/FailWithoutResultCacheErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/FailWithoutResultCacheErrorFormatterTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\File\NullRelativePathHelper;
+use PHPStan\File\SimpleRelativePathHelper;
+use PHPStan\Testing\ErrorFormatterTestCase;
+use function sprintf;
+
+class FailWithoutResultCacheErrorFormatterTest extends ErrorFormatterTestCase
+{
+
+	public function dataFormatterOutputProvider(): iterable
+	{
+		yield [
+			'not used result cache',
+			2,
+			'',
+			false,
+		];
+
+		yield [
+			'result cache used',
+			0,
+			'
+ [OK] No errors
+
+',
+			true,
+		];
+	}
+
+	/**
+	 * @dataProvider dataFormatterOutputProvider
+	 */
+	public function testFormatErrors(
+		string $message,
+		int $exitCode,
+		string $expected,
+		bool $isResultCacheUsed,
+	): void
+	{
+		$formatter = $this->createErrorFormatter();
+
+		$this->assertSame($exitCode, $formatter->formatErrors(
+			$this->createAnalysisResult($isResultCacheUsed),
+			$this->getOutput(),
+		), sprintf('%s: response code do not match', $message));
+
+		$this->assertSame($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+	}
+
+	private function createErrorFormatter(): FailWithoutResultCacheErrorFormatter
+	{
+		$relativePathHelper = new NullRelativePathHelper();
+		return new FailWithoutResultCacheErrorFormatter(
+			new TableErrorFormatter(
+				$relativePathHelper,
+				new SimpleRelativePathHelper(self::DIRECTORY_PATH),
+				new CiDetectedErrorFormatter(
+					new GithubErrorFormatter($relativePathHelper),
+					new TeamcityErrorFormatter($relativePathHelper),
+				),
+				false,
+				null,
+				null,
+			),
+		);
+	}
+
+	private function createAnalysisResult(bool $isResultCacheUsed): AnalysisResult
+	{
+		return new AnalysisResult(
+			[],
+			[],
+			[],
+			[],
+			[],
+			false,
+			null,
+			true,
+			0,
+			$isResultCacheUsed,
+		);
+	}
+
+}

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -253,7 +253,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 		$formatter = new JsonErrorFormatter(false);
 		$formatter->formatErrors(new AnalysisResult([
 			new Error('Foo', '/foo/bar.php', 1, true, null, null, $tip),
-		], [], [], [], [], false, null, true, 0), $this->getOutput());
+		], [], [], [], [], false, null, true, 0, false), $this->getOutput());
 
 		$content = $this->getOutputContent();
 		$json = Json::decode($content, Json::FORCE_ARRAY);

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -211,7 +211,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = $this->createErrorFormatter('editor://%file%/%line%');
 		$error = new Error('Test', 'Foo.php (in context of trait)', 12, true, 'Foo.php', 'Bar.php');
-		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput());
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false), $this->getOutput());
 
 		$this->assertStringContainsString('Bar.php', $this->getOutputContent());
 	}
@@ -224,7 +224,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 		$formatter = $this->createErrorFormatter('editor://custom/path/%relFile%/%line%');
 		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
-		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput(true));
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false), $this->getOutput(true));
 
 		$this->assertStringContainsString('editor://custom/path/rel/Foo.php', $this->getOutputContent(true));
 	}
@@ -233,7 +233,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = $this->createErrorFormatter('editor://any', '%relFile%:%line%');
 		$error = new Error('Test', 'Foo.php', 12, true, self::DIRECTORY_PATH . '/rel/Foo.php');
-		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0), $this->getOutput(true));
+		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false), $this->getOutput(true));
 
 		$this->assertStringContainsString('rel/Foo.php:12', $this->getOutputContent(true));
 	}
@@ -259,6 +259,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 				null,
 				true,
 				0,
+				false,
 			),
 			$this->getOutput(),
 		);


### PR DESCRIPTION
as described in https://github.com/phpstan/phpstan/pull/9857#discussion_r1318676916

use with
```
php bin/phpstan analyze --error-format=failWithoutResultCache -vvv
```

----

tested with

```
$ php bin/phpstan clear-result-cache
Note: Using configuration file C:\dvl\Workspace\phpstan-src-staabm\phpstan.neon.dist.
Result cache cleared from directory:
C:\dvl\Workspace\phpstan-src-staabm/tmp

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (err-formatter)
$ php bin/phpstan analyze --error-format=failWithoutResultCache -vvv
Note: Using configuration file C:\dvl\Workspace\phpstan-src-staabm\phpstan.neon.dist.
Result cache not used because the cache file does not exist.
 1563/1563 [============================] 100% 36 secs/36 secs

Result cache is saved.
Used memory: 3.63 GB

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (err-formatter)
$ echo $?
2

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (err-formatter)
$ php bin/phpstan analyze --error-format=failWithoutResultCache -vvv
Note: Using configuration file C:\dvl\Workspace\phpstan-src-staabm\phpstan.neon.dist.
 1563/1563 [============================] 100% < 1 sec/< 1 sec

Result cache is saved.


 [OK] No errors


Used memory: 130 MB

mstaab@NB-COMPLEX-61 MINGW64 /c/dvl/Workspace/phpstan-src-staabm (err-formatter)
$ echo $?
0
```