### PR TITLE
Remove unnecessary IO

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -12,7 +12,6 @@ use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileReader;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Php\PhpVersion;
-use function array_filter;
 use function array_key_exists;
 use function array_map;
 use function array_merge;
@@ -109,16 +108,20 @@ class ComposerJsonAndInstalledJsonSourceLocatorMaker
 			)),
 		);
 
-		$classMapDirectories = array_filter($classMapPaths, 'is_dir');
-		foreach ($classMapDirectories as $classMapDirectory) {
-			$locators[] = $this->optimizedDirectorySourceLocatorRepository->getOrCreate($classMapDirectory);
-		}
-
 		$files = [];
-
-		$classMapFiles = array_filter($classMapPaths, 'is_file');
-		$filePaths = array_filter($filePaths, 'is_file');
-		foreach (array_merge($classMapFiles, $filePaths) as $file) {
+		foreach ($classMapPaths as $classMapPath) {
+			if (is_dir($classMapPath)) {
+				$locators[] = $this->optimizedDirectorySourceLocatorRepository->getOrCreate($classMapPath);
+			}
+			if (!is_file($classMapPath)) {
+				continue;
+			}
+			$files[] = $classMapPath;
+		}
+		foreach ($filePaths as $file) {
+			if (!is_file($file)) {
+				continue;
+			}
 			$files[] = $file;
 		}
 

--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -73,8 +73,6 @@ class ComposerJsonAndInstalledJsonSourceLocatorMaker
 				$this->packagePrefixPath($installedJsonDirectoryPath, $package, $vendorDirectory),
 			), $installed),
 		);
-		$classMapFiles = array_filter($classMapPaths, 'is_file');
-		$classMapDirectories = array_filter($classMapPaths, 'is_dir');
 		$filePaths = array_merge(
 			$this->prefixPaths($this->packageToFilePaths($composer), $projectInstallationPath . '/'),
 			$dev ? $this->prefixPaths($this->packageToFilePaths($composer, 'autoload-dev'), $projectInstallationPath . '/') : [],
@@ -111,12 +109,14 @@ class ComposerJsonAndInstalledJsonSourceLocatorMaker
 			)),
 		);
 
+		$classMapDirectories = array_filter($classMapPaths, 'is_dir');
 		foreach ($classMapDirectories as $classMapDirectory) {
 			$locators[] = $this->optimizedDirectorySourceLocatorRepository->getOrCreate($classMapDirectory);
 		}
 
 		$files = [];
 
+		$classMapFiles = array_filter($classMapPaths, 'is_file');
 		foreach (array_merge($classMapFiles, $filePaths) as $file) {
 			$files[] = $file;
 		}

--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -117,6 +117,7 @@ class ComposerJsonAndInstalledJsonSourceLocatorMaker
 		$files = [];
 
 		$classMapFiles = array_filter($classMapPaths, 'is_file');
+		$filePaths = array_filter($filePaths, 'is_file');
 		foreach (array_merge($classMapFiles, $filePaths) as $file) {
 			$files[] = $file;
 		}

--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -112,18 +112,12 @@ class ComposerJsonAndInstalledJsonSourceLocatorMaker
 		);
 
 		foreach ($classMapDirectories as $classMapDirectory) {
-			if (!is_dir($classMapDirectory)) {
-				continue;
-			}
 			$locators[] = $this->optimizedDirectorySourceLocatorRepository->getOrCreate($classMapDirectory);
 		}
 
 		$files = [];
 
 		foreach (array_merge($classMapFiles, $filePaths) as $file) {
-			if (!is_file($file)) {
-				continue;
-			}
 			$files[] = $file;
 		}
 


### PR DESCRIPTION
re-submit less controversial part of https://github.com/phpstan/phpstan-src/pull/2596

----

we don't need this `is_file` call (and also not the one below for `is_dir`), because of

```
$classMapFiles = array_filter($classMapPaths, 'is_file');
$classMapDirectories = array_filter($classMapPaths, 'is_dir');
```

[above](https://github.com/phpstan/phpstan-src/pull/2613/files#diff-0fcf29f793b89662fb527a0ee50db9a7238efbb5c18122309ec8b275c14d7c87L76-L77)