### PR TITLE
Micro-optimize with `in_array()`

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -974,7 +974,7 @@ class TypeSpecifier
 			if ($constantType->getValue() === 'boolean') {
 				$type = new BooleanType();
 			}
-			if ($constantType->getValue() === 'resource' || $constantType->getValue() === 'resource (closed)') {
+			if (in_array($constantType->getValue(), ['resource', 'resource (closed)'], true)) {
 				$type = new ResourceType();
 			}
 			if ($constantType->getValue() === 'integer') {

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -619,7 +619,7 @@ class TypeNodeResolver
 			$typeNode->variances,
 		);
 
-		if ($mainTypeName === 'array' || $mainTypeName === 'non-empty-array') {
+		if (in_array($mainTypeName, ['array', 'non-empty-array'], true)) {
 			if (count($genericTypes) === 1) { // array<ValueType>
 				$arrayType = new ArrayType(new BenevolentUnionType([new IntegerType(), new StringType()]), $genericTypes[0]);
 			} elseif (count($genericTypes) === 2) { // array<KeyType, ValueType>
@@ -637,7 +637,7 @@ class TypeNodeResolver
 			}
 
 			return $arrayType;
-		} elseif ($mainTypeName === 'list' || $mainTypeName === 'non-empty-list') {
+		} elseif (in_array($mainTypeName, ['list', 'non-empty-list'], true)) {
 			if (count($genericTypes) === 1) { // list<ValueType>
 				$listType = AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), $genericTypes[0]));
 				if ($mainTypeName === 'non-empty-list') {

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\ConstantNameHelper;
 use function array_key_exists;
 use function count;
 use function ltrim;
+use function in_array;
 use function php_strip_whitespace;
 use function preg_match_all;
 use function preg_replace;
@@ -201,7 +202,7 @@ class OptimizedDirectorySourceLocatorFactory
 			$name = $matches['name'][$i];
 
 			// skip anon classes extending/implementing
-			if ($name === 'extends' || $name === 'implements') {
+			if (in_array($name, ['extends', 'implements'], true)) {
 				continue;
 			}
 

--- a/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpMethodFromParserNodeReflection.php
@@ -20,6 +20,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VoidType;
+use function in_array;
 use function strtolower;
 
 /**
@@ -57,13 +58,7 @@ class PhpMethodFromParserNodeReflection extends PhpFunctionFromParserNodeReflect
 	)
 	{
 		$name = strtolower($classMethod->name->name);
-		if (
-			$name === '__construct'
-			|| $name === '__destruct'
-			|| $name === '__unset'
-			|| $name === '__wakeup'
-			|| $name === '__clone'
-		) {
+		if (in_array($name, ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
 			$realReturnType = new VoidType();
 		}
 		if ($name === '__tostring') {

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -37,6 +37,7 @@ use ReflectionException;
 use function array_map;
 use function explode;
 use function filemtime;
+use function in_array;
 use function is_bool;
 use function sprintf;
 use function strtolower;
@@ -319,13 +320,7 @@ class PhpMethodReflection implements ExtendedMethodReflection
 			$name = strtolower($this->getName());
 			$returnType = $this->reflection->getReturnType();
 			if ($returnType === null) {
-				if (
-					$name === '__construct'
-					|| $name === '__destruct'
-					|| $name === '__unset'
-					|| $name === '__wakeup'
-					|| $name === '__clone'
-				) {
+				if (in_array($name, ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
 					return $this->returnType = TypehintHelper::decideType(new VoidType(), $this->phpDocReturnType);
 				}
 				if ($name === '__tostring') {

--- a/src/Rules/Classes/EnumSanityRule.php
+++ b/src/Rules/Classes/EnumSanityRule.php
@@ -13,6 +13,7 @@ use PHPStan\Type\VerbosityLevel;
 use Serializable;
 use function array_key_exists;
 use function count;
+use function in_array;
 use function implode;
 use function sprintf;
 
@@ -88,7 +89,7 @@ class EnumSanityRule implements Rule
 				continue;
 			}
 
-			if ($lowercasedMethodName !== 'from' && $lowercasedMethodName !== 'tryfrom') {
+			if (!in_array($lowercasedMethodName, ['from', 'tryfrom'], true)) {
 				continue;
 			}
 
@@ -101,8 +102,7 @@ class EnumSanityRule implements Rule
 
 		if (
 			$enumNode->scalarType !== null
-			&& $enumNode->scalarType->name !== 'int'
-			&& $enumNode->scalarType->name !== 'string'
+			&& !in_array($enumNode->scalarType->name, ['int', 'string'], true)
 		) {
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'Backed enum %s can have only "int" or "string" type.',
@@ -124,7 +124,7 @@ class EnumSanityRule implements Rule
 			}
 			$caseName = $stmt->name->name;
 
-			if (($stmt->expr instanceof Node\Scalar\LNumber || $stmt->expr instanceof Node\Scalar\String_)) {
+			if ($stmt->expr instanceof Node\Scalar\LNumber || $stmt->expr instanceof Node\Scalar\String_) {
 				if ($enumNode->scalarType === null) {
 					$errors[] = RuleErrorBuilder::message(sprintf(
 						'Enum %s is not backed, but case %s has value %s.',

--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -41,6 +41,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use function addcslashes;
+use function in_array;
 use function is_float;
 use function is_int;
 use function is_numeric;
@@ -325,7 +326,7 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	public function isNonFalsyString(): TrinaryLogic
 	{
-		return TrinaryLogic::createFromBoolean($this->getValue() !== '' && $this->getValue() !== '0');
+		return TrinaryLogic::createFromBoolean(!in_array($this->getValue(), ['', '0'], true));
 	}
 
 	public function isLiteralString(): TrinaryLogic

--- a/src/Type/Php/DsMapDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DsMapDynamicReturnTypeExtension.php
@@ -10,6 +10,7 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;
 use function count;
+use function in_array;
 
 final class DsMapDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -21,7 +22,7 @@ final class DsMapDynamicReturnTypeExtension implements DynamicMethodReturnTypeEx
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool
 	{
-		return $methodReflection->getName() === 'get' || $methodReflection->getName() === 'remove';
+		return in_array($methodReflection->getName(), ['get', 'remove'], true);
 	}
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type

--- a/src/Type/Php/MbSubstituteCharacterDynamicReturnTypeExtension.php
+++ b/src/Type/Php/MbSubstituteCharacterDynamicReturnTypeExtension.php
@@ -105,7 +105,7 @@ class MbSubstituteCharacterDynamicReturnTypeExtension implements DynamicFunction
 			if ($argType instanceof ConstantStringType) {
 				$value = strtolower($argType->getValue());
 
-				if ($value === 'none' || $value === 'long' || $value === 'entity') {
+				if (in_array($value, ['none', 'long', 'entity'], true)) {
 					return new ConstantBooleanType(true);
 				}
 


### PR DESCRIPTION
These points are definitely not the bottleneck, but the chain of comparisons is compiled into fewer bytecode instructions by `in_array()`.

It appears to be valid not only for method calls and property accesses, but also for comparing variables twice.
https://3v4l.org/QQQMr/vld