### PR TITLE
fix return type of parent calls for SplHeap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
 			],
 			"jetbrains/phpstorm-stubs": [
 				"patches/PDO.patch",
+				"patches/ReflectionProperty.patch",
 				"patches/SessionHandler.patch"
 			],
 			"rector/rector": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1b4d0008b053558b276997e38288b40",
+    "content-hash": "320291e3ee7da174c482bce9b0a0e86c",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -567,12 +567,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Hoa\\Consistency\\": "."
-                },
                 "files": [
                     "Prelude.php"
-                ]
+                ],
+                "psr-4": {
+                    "Hoa\\Consistency\\": "."
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -974,12 +974,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Hoa\\Protocol\\": "."
-                },
                 "files": [
                     "Wrapper.php"
-                ]
+                ],
+                "psr-4": {
+                    "Hoa\\Protocol\\": "."
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/patches/ReflectionProperty.patch
+++ b/patches/ReflectionProperty.patch
@@ -1,0 +1,11 @@
+--- Reflection/ReflectionProperty.php	2023-09-07 12:59:56.000000000 +0200
++++ Reflection/ReflectionProperty.php	2023-09-15 13:24:07.900736741 +0200
+@@ -248,7 +248,7 @@
+      * Gets property type
+      *
+      * @link https://php.net/manual/en/reflectionproperty.gettype.php
+-     * @return ReflectionNamedType|ReflectionUnionType|null Returns a {@see ReflectionType} if the
++     * @return ReflectionType|null Returns a {@see ReflectionType} if the
+      * property has a type, and {@see null} otherwise.
+      * @since 7.4
+      */

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -595,7 +595,7 @@ class PhpClassReflectionExtension
 								$throwType = $throwsTag->getType();
 							}
 							$returnTag = $phpDocBlock->getReturnTag();
-							if ($returnTag !== null) {
+							if ($returnTag !== null && count($methodSignatures) === 1) {
 								$phpDocReturnType = $returnTag->getType();
 							}
 							foreach ($phpDocBlock->getParamTags() as $name => $paramTag) {
@@ -860,10 +860,11 @@ class PhpClassReflectionExtension
 			);
 		}
 
-		$returnType = null;
 		if ($stubPhpDocReturnType !== null) {
 			$returnType = $stubPhpDocReturnType;
 			$phpDocReturnType = $stubPhpDocReturnType;
+		} else {
+			$returnType = TypehintHelper::decideType($methodSignature->getReturnType(), $phpDocReturnType);
 		}
 
 		return new FunctionVariantWithPhpDocs(
@@ -871,7 +872,7 @@ class PhpClassReflectionExtension
 			null,
 			$parameters,
 			$methodSignature->isVariadic(),
-			$returnType ?? $methodSignature->getReturnType(),
+			$returnType,
 			$phpDocReturnType ?? new MixedType(),
 			$methodSignature->getNativeReturnType(),
 		);

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -162,6 +162,10 @@ class TypehintHelper
 		?Type $phpDocType = null,
 	): Type
 	{
+		if ($type instanceof BenevolentUnionType) {
+			return $type;
+		}
+
 		if ($phpDocType !== null && !$phpDocType instanceof ErrorType) {
 			if ($phpDocType instanceof NeverType && $phpDocType->isExplicit()) {
 				return $phpDocType;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -40,6 +40,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-class-string.php');
 		if (PHP_VERSION_ID >= 80100) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-enum-class-string.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7162.php');
 		}
 
 		require_once __DIR__ . '/data/generic-generalization.php';
@@ -81,6 +82,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		if (PHP_VERSION_ID >= 70400) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/native-types.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/reflection-type.php');
 		}
 
 		if (PHP_VERSION_ID >= 80100) {
@@ -1368,6 +1370,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9963.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/str-shuffle.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9995.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9867.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-7162.php
+++ b/tests/PHPStan/Analyser/data/bug-7162.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1); // lint >= 8.1
+
+namespace Bug7162;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+
+	/**
+	 * @param class-string<\BackedEnum> $enumClassString
+	 */
+	public static function casesWithLabel(string $enumClassString): void
+	{
+		foreach ($enumClassString::cases() as $unitEnum) {
+			assertType('BackedEnum', $unitEnum);
+		}
+	}
+}
+
+enum Test{
+	case ONE;
+}
+
+/**
+ * @phpstan-template TEnum of \UnitEnum
+ * @phpstan-param TEnum $case
+ */
+function dumpCases(\UnitEnum $case) : void{
+	assertType('array<TEnum of UnitEnum (function Bug7162\\dumpCases(), argument)>', $case::cases());
+}
+
+function dumpCases2(Test $case) : void{
+	assertType('array{Bug7162\\Test::ONE}', $case::cases());
+}

--- a/tests/PHPStan/Analyser/data/bug-9867.php
+++ b/tests/PHPStan/Analyser/data/bug-9867.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug9867;
+
+use function PHPStan\Testing\assertType;
+
+/** @extends \SplMinHeap<\DateTime> */
+class MyMinHeap extends \SplMinHeap
+{
+	public function test(): void
+	{
+		assertType('DateTime', parent::current());
+		assertType('DateTime', parent::extract());
+		assertType('DateTime', parent::top());
+	}
+
+	public function insert(mixed $value): bool
+	{
+		assertType('DateTime', $value);
+
+		return parent::insert($value);
+	}
+
+	protected function compare(mixed $value1, mixed $value2)
+	{
+		assertType('DateTime', $value1);
+		assertType('DateTime', $value2);
+
+		return parent::compare($value1, $value2);
+	}
+}
+
+/** @extends \SplMaxHeap<\DateTime> */
+class MyMaxHeap extends \SplMaxHeap
+{
+	public function test(): void
+	{
+		assertType('DateTime', parent::current());
+		assertType('DateTime', parent::extract());
+		assertType('DateTime', parent::top());
+	}
+
+	public function insert(mixed $value): bool
+	{
+		assertType('DateTime', $value);
+
+		return parent::insert($value);
+	}
+
+	protected function compare(mixed $value1, mixed $value2)
+	{
+		assertType('DateTime', $value1);
+		assertType('DateTime', $value2);
+
+		return parent::compare($value1, $value2);
+	}
+}
+
+/** @extends \SplHeap<\DateTime> */
+abstract class MyHeap extends \SplHeap
+{
+	public function test(): void
+	{
+		assertType('DateTime', parent::current());
+		assertType('DateTime', parent::extract());
+		assertType('DateTime', parent::top());
+	}
+
+	public function insert(mixed $value): bool
+	{
+		assertType('DateTime', $value);
+
+		return parent::insert($value);
+	}
+}

--- a/tests/PHPStan/Analyser/data/reflection-type.php
+++ b/tests/PHPStan/Analyser/data/reflection-type.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ReflectionTypeTest;
+
+use function PHPStan\Testing\assertType;
+
+function test(
+	\ReflectionProperty $reflectionProperty,
+	\ReflectionFunctionAbstract $reflectionFunctionAbstract,
+	\ReflectionParameter $reflectionParameter
+){
+	assertType('ReflectionType|null', $reflectionProperty->getType());
+	assertType('ReflectionType|null', $reflectionFunctionAbstract->getReturnType());
+	assertType('ReflectionType|null', $reflectionParameter->getType());
+}


### PR DESCRIPTION
This is an attempt to fix https://github.com/phpstan/phpstan/issues/9867

The issue happened because the return type for `SplHeap` methods ignored the phpdoc (as you can see from the change the previous code only considered phpdoc from stubs). I discovered that similar code uses the `TypehintHelper` in these situations, so I used it as well.

But it broke a few tests due to benevolent unions in the `functionaMap.php`. So I added a workaround for it. I couldn't think of any issues, since I haven't found any code uses benevolent unions and which would need a phpdoc as well (e.g. due to generics).

-------

Previously, it worked for `SplMinHeap` because it took a different branch in `PhpClassReflectionExtension::createMethod`:

- Since `SplMinHeap` has the methods duplicated in [phpstorm-stubs](https://github.com/JetBrains/phpstorm-stubs/blob/ed9f6d8b529826bfb82b5d39b2d3697cbfc962bf/SPL/SPL_c1.php#L1499C33-L1499C33), the `$declaringClassName` is `SplMinHeap`.
- Then `$this->signatureMapProvider->hasMethodSignature($declaringClassName, $methodReflection->getName())` returns false, because the `functionMap.php` only has the methods for `SplHeap`. Since this is the branch that contains the incorrect code, the issue was avoided for `SplMinHeap`.
- For `SplMaxHeap` and `SplHeap` the declaring class is `SplHeap` (which is in the `functionMap.php`) and thus the branch was taken and the issue happened.

-----

Here are a few tests that didn't work without the change to `TypehintHelper::decideType` (there were a few more):

- DateTimeModifyReturnTypes.php
- pdo-prepare.php
- bug-6609.php