### PR TITLE
fix iterator_to_array, iterator_count for PHP 8.2

### DIFF
--- a/resources/functionMap_php82delta.php
+++ b/resources/functionMap_php82delta.php
@@ -21,6 +21,8 @@
  */
 return [
 	'new' => [
+		'iterator_count' => ['0|positive-int', 'iterator'=>'iterable'],
+		'iterator_to_array' => ['array', 'iterator'=>'iterable', 'use_keys='=>'bool'],
 		'str_split' => ['list<string>', 'str'=>'string', 'split_length='=>'positive-int'],
 	],
 	'old' => [

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1512,4 +1512,41 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/call-to-function-named-params-multivariant.php'], []);
 	}
 
+	public function testBug9793(): void
+	{
+		$errors = [];
+
+		if (PHP_VERSION_ID < 80200) {
+			$errors = [
+				[
+					'Parameter #1 $iterator of function iterator_to_array expects Traversable, array<stdClass> given.',
+					13,
+				],
+				[
+					'Parameter #1 $iterator of function iterator_to_array expects Traversable, array<stdClass>|Iterator<mixed, stdClass> given.',
+					14,
+				],
+				[
+					'Parameter #1 $iterator of function iterator_count expects Traversable, array<stdClass> given.',
+					15,
+				],
+				[
+					'Parameter #1 $iterator of function iterator_count expects Traversable, array<stdClass>|Iterator<mixed, stdClass> given.',
+					16,
+				],
+			];
+		}
+
+		$errors[] = [
+			'Parameter #1 $iterator of function iterator_apply expects Traversable, array<stdClass> given.',
+			17,
+		];
+		$errors[] = [
+			'Parameter #1 $iterator of function iterator_apply expects Traversable, array<stdClass>|Iterator<mixed, stdClass> given.',
+			18,
+		];
+
+		$this->analyse([__DIR__ . '/data/bug-9793.php'], $errors);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-9793.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9793.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug9793;
+
+/**
+ * @param array<\stdClass> $arr
+ * @param \Iterator<\stdClass>|array<\stdClass> $itOrArr
+ */
+function foo(array $arr, $itOrArr): void
+{
+	\iterator_to_array($arr);
+	\iterator_to_array($itOrArr);
+	echo \iterator_count($arr);
+	echo \iterator_count($itOrArr);
+	\iterator_apply($arr, fn ($x) => $x);
+	\iterator_apply($itOrArr, fn ($x) => $x);
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/9793 (and the example given in https://github.com/phpstan/phpstan/issues/7760, though that issue is specified more broadly).

The problem happens here: https://github.com/phpstan/phpstan-src/blob/02ea303a16dab1cd9fb0a256826d5ac24c9c68e1/src/Reflection/SignatureMap/Php8SignatureMapProvider.php#L198 . We get the correct signature from php8-stubs, but the signature in `functionMap.php` was outdated and it overwrote the the correct signature.