### PR TITLE
remove phpstan/phpstan-php-parser

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -1,7 +1,6 @@
 includes:
 	- ../vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- ../vendor/phpstan/phpstan-nette/rules.neon
-	- ../vendor/phpstan/phpstan-php-parser/extension.neon
 	- ../vendor/phpstan/phpstan-phpunit/extension.neon
 	- ../vendor/phpstan/phpstan-phpunit/rules.neon
 	- ../vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/changelog-generator/phpstan.neon
+++ b/changelog-generator/phpstan.neon
@@ -1,7 +1,6 @@
 includes:
 	- ../vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- ../vendor/phpstan/phpstan-nette/rules.neon
-	- ../vendor/phpstan/phpstan-php-parser/extension.neon
 	- ../vendor/phpstan/phpstan-phpunit/extension.neon
 	- ../vendor/phpstan/phpstan-phpunit/rules.neon
 	- ../vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2.0",
 		"phpstan/phpstan-deprecation-rules": "^1.0",
 		"phpstan/phpstan-nette": "^1.0",
-		"phpstan/phpstan-php-parser": "^1.1",
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpstan/phpstan-strict-rules": "^1.5.1",
 		"phpunit/phpunit": "^9.5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ea3efb3e5847cdfea559ba865f01e49",
+    "content-hash": "fbdcc3287ffd31e18ee07f6d5cbb340e",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -4967,57 +4967,6 @@
                 "source": "https://github.com/phpstan/phpstan-nette/tree/1.2.9"
             },
             "time": "2023-04-12T14:11:53+00:00"
-        },
-        {
-            "name": "phpstan/phpstan-php-parser",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan-php-parser.git",
-                "reference": "1c7670dd92da864b5d019f22d9f512a6ae18b78e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-php-parser/zipball/1c7670dd92da864b5d019f22d9f512a6ae18b78e",
-                "reference": "1c7670dd92da864b5d019f22d9f512a6ae18b78e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^1.3"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                },
-                "phpstan": {
-                    "includes": [
-                        "extension.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHP-Parser extensions for PHPStan",
-            "support": {
-                "issues": "https://github.com/phpstan/phpstan-php-parser/issues",
-                "source": "https://github.com/phpstan/phpstan-php-parser/tree/1.1.0"
-            },
-            "time": "2021-12-16T19:43:32+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",


### PR DESCRIPTION
 `nikic/PHP-Parser` meanwhile ships with all types defined in [stubs of phpstan-php-parser](https://github.com/phpstan/phpstan-php-parser/tree/1.2.x/stubs)