### PR TITLE
Allow @phpstan-use and @use tags to be declared into class phpdoc

### DIFF
--- a/src/Rules/Generics/UsedTraitsRule.php
+++ b/src/Rules/Generics/UsedTraitsRule.php
@@ -11,6 +11,8 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 use function array_map;
+use function array_merge;
+use function is_null;
 use function sprintf;
 use function ucfirst;
 
@@ -43,18 +45,21 @@ class UsedTraitsRule implements Rule
 		if ($scope->isInTrait()) {
 			$traitName = $scope->getTraitReflection()->getName();
 		}
-		$useTags = [];
+		$classResolvedPhpDoc = $scope->getClassReflection()->getResolvedPhpDoc();
 		$docComment = $node->getDocComment();
-		if ($docComment !== null) {
-			$resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+		if (isset($docComment)) {
+			$docComment = $docComment->getText();
+		}
+		$useTags = array_merge(
+			is_null($classResolvedPhpDoc) ? [] : $classResolvedPhpDoc->getUsesTags(),
+			is_null($docComment) ? [] : $this->fileTypeMapper->getResolvedPhpDoc(
 				$scope->getFile(),
 				$className,
 				$traitName,
 				null,
-				$docComment->getText(),
-			);
-			$useTags = $resolvedPhpDoc->getUsesTags();
-		}
+				$docComment,
+			)->getUsesTags(),
+		);
 
 		$description = sprintf('class %s', SprintfHelper::escapeFormatString($className));
 		$typeDescription = 'class';

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -32,6 +32,7 @@ use function count;
 use function is_array;
 use function is_callable;
 use function is_file;
+use function is_null;
 use function ltrim;
 use function md5;
 use function sprintf;
@@ -421,7 +422,7 @@ class FileTypeMapper
 		$constUses = [];
 		$this->processNodes(
 			$this->phpParser->parseFile($fileName),
-			function (Node $node) use ($fileName, $lookForTrait, $phpDocNodeMap, &$traitFound, $traitMethodAliases, $originalClassFileName, &$nameScopeMap, &$classStack, &$typeAliasStack, &$namespace, &$functionStack, &$uses, &$typeMapStack, &$constUses): ?int {
+			function (Node $node) use ($fileName, $lookForTrait, $phpDocNodeMap, &$traitFound, $traitMethodAliases, $originalClassFileName, &$nameScopeMap, &$classStack, &$typeAliasStack, &$namespace, &$functionStack, &$uses, &$typeMapStack, &$constUses, &$classNode, &$classUseTags): ?int {
 				if ($node instanceof Node\Stmt\ClassLike) {
 					if ($traitFound && $fileName === $originalClassFileName) {
 						return self::SKIP_NODE;
@@ -460,6 +461,8 @@ class FileTypeMapper
 						}
 						$classStack[] = $className;
 						$classNameScopeKey = $this->getNameScopeKey($originalClassFileName, $className, $lookForTrait, null);
+						$classNode = $node;
+						$classUseTags = null;
 						if (array_key_exists($classNameScopeKey, $phpDocNodeMap)) {
 							$typeAliasStack[] = $this->getTypeAliasesMap($phpDocNodeMap[$classNameScopeKey]);
 						} else {
@@ -629,7 +632,7 @@ class FileTypeMapper
 						);
 						$finalTraitPhpDocMap = [];
 						foreach ($traitPhpDocMap as $nameScopeTraitKey => $callback) {
-							$finalTraitPhpDocMap[$nameScopeTraitKey] = function () use ($callback, $traitReflection, $fileName, $className, $lookForTrait, $useDocComment): NameScope {
+							$finalTraitPhpDocMap[$nameScopeTraitKey] = function () use ($callback, $traitReflection, $fileName, $className, $lookForTrait, $useDocComment, &$classNode, &$classUseTags): NameScope {
 								/** @var NameScope $original */
 								$original = $callback();
 								if (!$traitReflection->isGeneric()) {
@@ -639,27 +642,44 @@ class FileTypeMapper
 								$traitTemplateTypeMap = $traitReflection->getTemplateTypeMap();
 
 								$useType = null;
-								if ($useDocComment !== null) {
-									$useTags = $this->getResolvedPhpDoc(
+								if (is_null($classUseTags)) {
+									$classDocComment = null;
+									if (isset($classNode)) {
+										$classDocComment = $classNode->getDocComment();
+										if (isset($classDocComment)) {
+											$classDocComment = $classDocComment->getText();
+										}
+									}
+									$classUseTags = is_null($classDocComment) ? [] : $this->getResolvedPhpDoc(
+										$fileName,
+										$className,
+										null,
+										null,
+										$classDocComment,
+									)->getUsesTags();
+								}
+								$useTags = array_merge(
+									$classUseTags,
+									is_null($useDocComment) ? [] : $this->getResolvedPhpDoc(
 										$fileName,
 										$className,
 										$lookForTrait,
 										null,
 										$useDocComment,
-									)->getUsesTags();
-									foreach ($useTags as $useTag) {
-										$useTagType = $useTag->getType();
-										if (!$useTagType instanceof GenericObjectType) {
-											continue;
-										}
-
-										if ($useTagType->getClassName() !== $traitReflection->getName()) {
-											continue;
-										}
-
-										$useType = $useTagType;
-										break;
+									)->getUsesTags(),
+								);
+								foreach ($useTags as $useTag) {
+									$useTagType = $useTag->getType();
+									if (!$useTagType instanceof GenericObjectType) {
+										continue;
 									}
+
+									if ($useTagType->getClassName() !== $traitReflection->getName()) {
+										continue;
+									}
+
+									$useType = $useTagType;
+									break;
 								}
 
 								if ($useType === null) {

--- a/tests/PHPStan/Rules/Generics/UsedTraitsRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/UsedTraitsRuleTest.php
@@ -59,6 +59,10 @@ class UsedTraitsRuleTest extends RuleTestCase
 				'Call-site variance annotation of covariant Throwable in generic type UsedTraits\GenericTrait<covariant Throwable> in PHPDoc tag @use is not allowed.',
 				69,
 			],
+			[
+				'Type int in generic type UsedTraits\GenericTrait<int> in PHPDoc tag @use is not subtype of template type T of object of trait UsedTraits\GenericTrait.',
+				91,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generics/data/used-traits.php
+++ b/tests/PHPStan/Rules/Generics/data/used-traits.php
@@ -69,3 +69,25 @@ class Dolor
 	use GenericTrait;
 
 }
+
+/**
+ * @template T of object
+ * @use GenericTrait<T>
+ */
+class Sit
+{
+
+	use GenericTrait;
+
+}
+
+/**
+ * @template T of int
+ * @use GenericTrait<T>
+ */
+class Amet
+{
+
+	use GenericTrait;
+
+}


### PR DESCRIPTION
This implements the feature request here: https://github.com/phpstan/phpstan/issues/7486.
I think this does the job. Hope this will help.