### PR TITLE
Reduce memory consumption of TypeInferenceTestCase

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -672,6 +672,11 @@ parameters:
 			path: src/Testing/PHPStanTestCase.php
 
 		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\ConstantScalarType is error\\-prone and deprecated\\. Use Type\\:\\:isConstantScalarValue\\(\\) or Type\\:\\:getConstantScalarTypes\\(\\) or Type\\:\\:getConstantScalarValues\\(\\) instead\\.$#"
+			count: 2
+			path: src/Testing/TypeInferenceTestCase.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\IntersectionType is error\\-prone and deprecated\\.$#"
 			count: 1
 			path: src/Type/Accessory/AccessoryArrayListType.php

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -91,11 +91,8 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	): void
 	{
 		if ($assertType === 'type') {
-			$expectedType = $args[0];
-			$this->assertInstanceOf(ConstantScalarType::class, $expectedType);
-			$expected = $expectedType->getValue();
-			$actualType = $args[1];
-			$actual = $actualType->describe(VerbosityLevel::precise());
+			$expected = $args[0];
+			$actual = $args[1];
 			$this->assertSame(
 				$expected,
 				$actual,
@@ -138,12 +135,20 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				));
 			} elseif ($functionName === 'PHPStan\\Testing\\assertType') {
 				$expectedType = $scope->getType($node->getArgs()[0]->value);
+				if (!$expectedType instanceof ConstantScalarType) {
+					self::fail(sprintf('First argument of %s() must be a constant scalar type', $functionName));
+				}
+
 				$actualType = $scope->getType($node->getArgs()[1]->value);
-				$assert = ['type', $file, $expectedType, $actualType, $node->getLine()];
+				$assert = ['type', $file, $expectedType->getValue(), $actualType->describe(VerbosityLevel::precise()), $node->getLine()];
 			} elseif ($functionName === 'PHPStan\\Testing\\assertNativeType') {
 				$expectedType = $scope->getType($node->getArgs()[0]->value);
+				if (!$expectedType instanceof ConstantScalarType) {
+					self::fail(sprintf('First argument of %s() must be a constant scalar type', $functionName));
+				}
+
 				$actualType = $scope->getNativeType($node->getArgs()[1]->value);
-				$assert = ['type', $file, $expectedType, $actualType, $node->getLine()];
+				$assert = ['type', $file, $expectedType->getValue(), $actualType->describe(VerbosityLevel::precise()), $node->getLine()];
 			} elseif ($functionName === 'PHPStan\\Testing\\assertVariableCertainty') {
 				$certainty = $node->getArgs()[0]->value;
 				if (!$certainty instanceof StaticCall) {


### PR DESCRIPTION
reduce the data beeing transfered between dataProvider and tests, by using just scalar values instead of objects with complex graphs which needs a lot of memory/time to serialize.

----

refs https://github.com/phpstan/phpstan/discussions/9914

repro https://github.com/gnutix/phpstan-typeinferencetest-memory-exhausted

before this PR
```
➜  memopt git:(main) ✗ vendor/bin/phpunit --no-results

PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.10
Configuration: /Users/staabm/workspace/memopt/phpunit.xml.dist

FFF....FF....FFFFFFFFFFFFFFFFFFFFF........FFF....F.F.....FFFFFF  63 / 168 ( 37%)
F......FFFFF.FFF................FFFFF.....F.....FFFFFFFFF...... 126 / 168 ( 75%)
FFFFFFFFF.......F.....FFFF............FF..                      168 / 168 (100%)

Time: 00:27.074, Memory: 5.38 GB
```

after this PR

```
 memopt git:(main) ✗ vendor/bin/phpunit --no-results

PHPUnit 10.3.5 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.10
Configuration: /Users/staabm/workspace/memopt/phpunit.xml.dist

FFF....FF....FFFFFFFFFFFFFFFFFFFFF........FFF....F.F.....FFFFFF  63 / 168 ( 37%)
F......FFFFF.FFF................FFFFF.....F.....FFFFFFFFF...... 126 / 168 ( 75%)
FFFFFFFFF.......F.....FFFF............FF..                      168 / 168 (100%)

Time: 00:00.042, Memory: 82.00 MB
```

=> ~98% memory improvement 