### PR TITLE
Restrict "Merge maintained branch" workflow to the main repository

### DIFF
--- a/.github/workflows/merge-maintained-branch.yml
+++ b/.github/workflows/merge-maintained-branch.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   merge:
     name: Merge branch
+    if: github.repository_owner == 'phpstan'
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"


### PR DESCRIPTION
This action is deemed to fail on all forks, plus even if fixed with a local secret token it would generate a desynced 1.11.x branch