### PR TITLE
Drop wrong float comparison with filter_var()

### DIFF
--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -32,7 +32,6 @@ use function is_int;
 use function octdec;
 use function preg_match;
 use function sprintf;
-use const PHP_FLOAT_EPSILON;
 
 final class FilterFunctionReturnTypeHelper
 {
@@ -293,7 +292,7 @@ final class FilterFunctionReturnTypeHelper
 			}
 
 			if ($in instanceof ConstantFloatType) {
-				return $in->getValue() - (int) $in->getValue() <= PHP_FLOAT_EPSILON
+				return $in->getValue() - (int) $in->getValue() === 0.0
 					? $in->toInteger()
 					: $defaultType;
 			}

--- a/tests/PHPStan/Analyser/nsrt/filter-var.php
+++ b/tests/PHPStan/Analyser/nsrt/filter-var.php
@@ -106,12 +106,14 @@ class FilterVar
 		assertType('bool|null', filter_var($float, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 		assertType('bool|null', filter_var(17.0, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
 		assertType('bool|null', filter_var(17.1, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
+		assertType('bool|null', filter_var(1e-50, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
 		assertType('bool|null', filter_var($int, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 		assertType('bool|null', filter_var($intRange, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 		assertType('bool|null', filter_var(17, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
 		assertType('bool|null', filter_var($string, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 		assertType('bool|null', filter_var($nonEmptyString, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 		assertType('bool|null', filter_var('17', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
+		assertType('bool|null', filter_var('17.0', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
 		assertType('bool|null', filter_var('17.1', FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)); // could be null
 		assertType('null', filter_var(null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE));
 
@@ -121,12 +123,14 @@ class FilterVar
 		assertType('float', filter_var($float, FILTER_VALIDATE_FLOAT));
 		assertType('17.0', filter_var(17.0, FILTER_VALIDATE_FLOAT));
 		assertType('17.1', filter_var(17.1, FILTER_VALIDATE_FLOAT));
+		assertType('1.0E-50', filter_var(1e-50, FILTER_VALIDATE_FLOAT));
 		assertType('float', filter_var($int, FILTER_VALIDATE_FLOAT));
 		assertType('float', filter_var($intRange, FILTER_VALIDATE_FLOAT));
 		assertType('17.0', filter_var(17, FILTER_VALIDATE_FLOAT));
 		assertType('float|false', filter_var($string, FILTER_VALIDATE_FLOAT));
 		assertType('float|false', filter_var($nonEmptyString, FILTER_VALIDATE_FLOAT));
 		assertType('float|false', filter_var('17', FILTER_VALIDATE_FLOAT)); // could be 17.0
+		assertType('float|false', filter_var('17.0', FILTER_VALIDATE_FLOAT)); // could be 17.0
 		assertType('float|false', filter_var('17.1', FILTER_VALIDATE_FLOAT)); // could be 17.1
 		assertType('false', filter_var(null, FILTER_VALIDATE_FLOAT));
 
@@ -136,12 +140,14 @@ class FilterVar
 		assertType('int|false', filter_var($float, FILTER_VALIDATE_INT));
 		assertType('17', filter_var(17.0, FILTER_VALIDATE_INT));
 		assertType('false', filter_var(17.1, FILTER_VALIDATE_INT));
+		assertType('false', filter_var(1e-50, FILTER_VALIDATE_INT));
 		assertType('int', filter_var($int, FILTER_VALIDATE_INT));
 		assertType('int<0, 9>', filter_var($intRange, FILTER_VALIDATE_INT));
 		assertType('17', filter_var(17, FILTER_VALIDATE_INT));
 		assertType('int|false', filter_var($string, FILTER_VALIDATE_INT));
 		assertType('int|false', filter_var($nonEmptyString, FILTER_VALIDATE_INT));
 		assertType('17', filter_var('17', FILTER_VALIDATE_INT));
+		assertType('false', filter_var('17.0', FILTER_VALIDATE_INT));
 		assertType('false', filter_var('17.1', FILTER_VALIDATE_INT));
 		assertType('false', filter_var(null, FILTER_VALIDATE_INT));
 
@@ -151,12 +157,14 @@ class FilterVar
 		assertType('numeric-string', filter_var($float));
 		assertType("'17'", filter_var(17.0));
 		assertType("'17.1'", filter_var(17.1));
+		assertType("'1.0E-50'", filter_var(1e-50));
 		assertType('numeric-string', filter_var($int));
 		assertType('numeric-string', filter_var($intRange));
 		assertType("'17'", filter_var(17));
 		assertType('string', filter_var($string));
 		assertType('non-empty-string', filter_var($nonEmptyString));
 		assertType("'17'", filter_var('17'));
+		assertType("'17.0'", filter_var('17.0'));
 		assertType("'17.1'", filter_var('17.1'));
 		assertType("''", filter_var(null));
 	}


### PR DESCRIPTION
discussion https://github.com/phpstan/phpstan-src/pull/2358#discussion_r1174422409

`... < PHP_FLOAT_EPSILON` condition for small numbers always wrongly returned true, `===` is the only valid cmp as long as both left/right side of the operator are of type float