### PR TITLE
Added text regarding patch issues during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ composer install
 
 If you encounter dependency problem, try using `export COMPOSER_ROOT_VERSION=1.10.x-dev`
 
-If you are using macOS and are using an older version of patch, you may have problems with patch application failure.
-Try using `brew install gpatch`
+If you are using macOS and are using an older version of `patch`, you may have problems with patch application failure during `composer install`. Try using `brew install gpatch` to install a newer and supported `patch` version.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ composer install
 
 If you encounter dependency problem, try using `export COMPOSER_ROOT_VERSION=1.10.x-dev`
 
+If you are using macOS and are using an older version of patch, you may have problems with patch application failure.
+Try using `brew install gpatch`
+
 ### Building
 
 PHPStan's source code is developed on PHP 8.1. For distribution in `phpstan/phpstan` package and as a PHAR file, the source code is transformed to run on PHP 7.2 and higher.


### PR DESCRIPTION
## Why did I submit this PR?
When performing `composer install`, the patch to `hoa/protocol` failed to apply.
```
  - Applying patches for hoa/protocol
    patches/Node.patch (0)
   Could not apply patch! Skipping. The error was: The process "patch '-p1' --no-backup-if-mismatch -d '/Users/satak/dev/phpstan-src/vendor/hoa/protocol' < '/Users/satak/dev/phpstan-src/patches/Node.patch'" exceeded the timeout of 300 seconds.

In Patches.php line 331:
                                              
  Cannot apply patch 0 (patches/Node.patch)! 
```

This error is caused by an out-of-date version of patch pre-installed on macOS, and can be resolved by doing `brew install gpatch` before running `composer install` to bring it up to date.

## Purpose of this PR
To add the above solution to the README to leave a clue for solving similar errors when they occur.