### PR TITLE
Optimize memory consumption

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -10,8 +10,8 @@ use PHPStan\Collectors\CollectedData;
 use PHPStan\Command\Output;
 use PHPStan\Dependency\ExportedNodeFetcher;
 use PHPStan\Dependency\RootExportedNode;
+use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileFinder;
-use PHPStan\File\FileReader;
 use PHPStan\File\FileWriter;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\PhpDoc\StubFilesProvider;
@@ -33,10 +33,9 @@ use function is_array;
 use function is_file;
 use function is_string;
 use function ksort;
-use function sha1;
+use function sha1_file;
 use function sort;
 use function sprintf;
-use function str_replace;
 use function time;
 use function unlink;
 use function var_export;
@@ -790,6 +789,9 @@ return [
 		}
 
 		$hash = sha1_file($path);
+		if ($hash === false) {
+			throw new CouldNotReadFileException($path);
+		}
 		$this->fileHashes[$path] = $hash;
 
 		return $hash;

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -789,10 +789,7 @@ return [
 			return $this->fileHashes[$path];
 		}
 
-		$contents = FileReader::read($path);
-		$contents = str_replace("\r\n", "\n", $contents);
-
-		$hash = sha1($contents);
+		$hash = sha1_file($path);
 		$this->fileHashes[$path] = $hash;
 
 		return $hash;

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -5,12 +5,11 @@ namespace PHPStan\DependencyInjection;
 use Nette\DI\Config\Loader;
 use Nette\DI\Container as OriginalNetteContainer;
 use Nette\DI\ContainerLoader;
-use PHPStan\File\FileReader;
 use function array_keys;
 use function error_reporting;
 use function restore_error_handler;
 use function set_error_handler;
-use function sha1;
+use function sha1_file;
 use const E_USER_DEPRECATED;
 use const PHP_RELEASE_VERSION;
 use const PHP_VERSION_ID;
@@ -92,7 +91,7 @@ class Configurator extends \Nette\Bootstrap\Configurator
 	{
 		$hashes = [];
 		foreach ($this->allConfigFiles as $file) {
-			$hashes[$file] = sha1(FileReader::read($file));
+			$hashes[$file] = sha1_file($file);
 		}
 
 		return $hashes;

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -5,6 +5,7 @@ namespace PHPStan\DependencyInjection;
 use Nette\DI\Config\Loader;
 use Nette\DI\Container as OriginalNetteContainer;
 use Nette\DI\ContainerLoader;
+use PHPStan\File\CouldNotReadFileException;
 use function array_keys;
 use function error_reporting;
 use function restore_error_handler;
@@ -91,7 +92,13 @@ class Configurator extends \Nette\Bootstrap\Configurator
 	{
 		$hashes = [];
 		foreach ($this->allConfigFiles as $file) {
-			$hashes[$file] = sha1_file($file);
+			$hash = sha1_file($file);
+
+			if ($hash === false) {
+				throw new CouldNotReadFileException($file);
+			}
+
+			$hashes[$file] = $hash;
 		}
 
 		return $hashes;

--- a/src/File/FileMonitor.php
+++ b/src/File/FileMonitor.php
@@ -6,7 +6,7 @@ use PHPStan\ShouldNotHappenException;
 use function array_key_exists;
 use function array_keys;
 use function count;
-use function sha1;
+use function sha1_file;
 
 class FileMonitor
 {
@@ -81,7 +81,7 @@ class FileMonitor
 
 	private function getFileHash(string $filePath): string
 	{
-		return sha1(FileReader::read($filePath));
+		return sha1_file($filePath);
 	}
 
 }

--- a/src/File/FileMonitor.php
+++ b/src/File/FileMonitor.php
@@ -81,7 +81,13 @@ class FileMonitor
 
 	private function getFileHash(string $filePath): string
 	{
-		return sha1_file($filePath);
+		$hash = sha1_file($filePath);
+
+		if ($hash === false) {
+			throw new CouldNotReadFileException($filePath);
+		}
+
+		return $hash;
 	}
 
 }

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -3,9 +3,7 @@
 namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 
 use PHPStan\Cache\Cache;
-use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileFinder;
-use PHPStan\File\FileReader;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstantNameHelper;
 use function array_key_exists;
@@ -15,7 +13,7 @@ use function ltrim;
 use function php_strip_whitespace;
 use function preg_match_all;
 use function preg_replace;
-use function sha1;
+use function sha1_file;
 use function sprintf;
 use function strtolower;
 
@@ -42,12 +40,11 @@ class OptimizedDirectorySourceLocatorFactory
 		$files = $this->fileFinder->findFiles([$directory])->getFiles();
 		$fileHashes = [];
 		foreach ($files as $file) {
-			try {
-				$contents = FileReader::read($file);
-			} catch (CouldNotReadFileException) {
+			$hash = sha1_file($file);
+			if ($hash === false) {
 				continue;
 			}
-			$fileHashes[$file] = sha1($contents);
+			$fileHashes[$file] = $hash;
 		}
 
 		$cacheKey = sprintf('odsl-%s', $directory);

--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -135,7 +135,8 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 	private function export(string $value): string
 	{
-		if (Strings::match($value, '([\000-\037])') !== null) {
+		$escapedValue = addcslashes($value, "\0..\37");
+		if ($escapedValue !== $value) {
 			return '"' . addcslashes($value, "\0..\37\\\"") . '"';
 		}
 


### PR DESCRIPTION
tested with 

`blackfire run --ignore-exit-status php vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php`

before this PR: (1.10.x@7c4ef6b2a)
```
I/O Wait      171ms
CPU Time   2min 13s
Memory        368MB
Wall Time  2min 13s
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

after this PR:
```
Wall Time  2min 16s
I/O Wait      183ms
CPU Time   2min 16s
Memory        345MB
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

<img width="304" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/5f1f2a56-44aa-40a5-806c-a1458f06299e">
