### PR TITLE
Optimize memory consumption in ResultCacheManager

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -601,19 +601,6 @@ class ResultCacheManager
 			$invertedDependencies[$file]['dependentFiles'] = $dependentFiles;
 		}
 
-		$template = "<?php declare(strict_types = 1);
-
-return [
-	'lastFullAnalysisTime' => %s,
-	'meta' => %s,
-	'projectExtensionFiles' => %s,
-	'errorsCallback' => static function (): array { return %s; },
-	'collectedDataCallback' => static function (): array { return %s; },
-	'dependencies' => %s,
-	'exportedNodesCallback' => static function (): array { return %s; },
-];
-";
-
 		ksort($exportedNodes);
 
 		$file = $this->cacheFilePath;
@@ -624,16 +611,18 @@ return [
 
 		FileWriter::write(
 			$file,
-			sprintf(
-				$template,
-				var_export($lastFullAnalysisTime, true),
-				var_export($meta, true),
-				var_export($this->getProjectExtensionFiles($projectConfigArray, $dependencies), true),
-				var_export($errors, true),
-				var_export($collectedData, true),
-				var_export($invertedDependencies, true),
-				var_export($exportedNodes, true),
-			),
+			"<?php declare(strict_types = 1);
+
+return [
+	'lastFullAnalysisTime' => " . var_export($lastFullAnalysisTime, true) . ",
+	'meta' => " . var_export($meta, true) . ",
+	'projectExtensionFiles' => " . var_export($this->getProjectExtensionFiles($projectConfigArray, $dependencies), true) . ",
+	'errorsCallback' => static function (): array { return " . var_export($errors, true) . "; },
+	'collectedDataCallback' => static function (): array { return " . var_export($collectedData, true) . "; },
+	'dependencies' => " . var_export($invertedDependencies, true) . ",
+	'exportedNodesCallback' => static function (): array { return " . var_export($exportedNodes, true) . '; },
+];
+',
 		);
 	}
 


### PR DESCRIPTION
reproduced with 

`php bin/phpstan clear-result-cache -q && blackfire run --ignore-exit-status php -d memory_limit=448M bin/phpstan`

the master process had a memory spike in sprintf() calls when writing the result cache

before this PR: (1.10.x@7c4ef6b2a)

```
Wall Time       35s
I/O Wait      19.2s
CPU Time      15.7s
Memory        221MB
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

<img width="491" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/be26c62e-8634-4f12-b745-52b4a1b872a9">

-----

after this PR:
```
CPU Time      14.4s
Memory        197MB
Wall Time       33s
I/O Wait      18.7s
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

<img width="502" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/fe848821-be98-4f09-897d-8929ee3f2a8c">
