### PR TITLE
More efficient file finding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
 		"react/socket": "^1.3",
 		"react/stream": "^1.1",
 		"symfony/console": "^5.4.3",
-		"symfony/finder": "^5.4.3",
 		"symfony/polyfill-intl-grapheme": "^1.23",
 		"symfony/polyfill-intl-normalizer": "^1.23",
 		"symfony/polyfill-mbstring": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3252cbdcb2538946af48029b1f36cee3",
+    "content-hash": "1981b689a518470066bd92a6a01e30ed",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -3413,69 +3413,6 @@
                 }
             ],
             "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v5.4.27",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ff4bce3c33451e7ec778070e45bd23f74214cd5d",
-                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-php80": "^1.16"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Finds files and directories via an intuitive fluent interface",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.27"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-07-31T08:02:31+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -207,15 +207,21 @@ class ContainerFactory
 			return;
 		}
 
-		$finder = new Finder();
-		$finder->name('Container_*')->in($containerDirectory);
+		$flags = \RecursiveDirectoryIterator::SKIP_DOTS;
+		$iterator = new \RecursiveDirectoryIterator($containerDirectory, $flags);
 		$twoDaysAgo = time() - 24 * 60 * 60 * 2;
 
-		foreach ($finder as $containerFile) {
+		/** @var \SplFileInfo $containerFile */
+		foreach ($iterator as $containerFile) {
 			$path = $containerFile->getRealPath();
 			if ($path === false) {
 				continue;
 			}
+
+			if (!str_starts_with($containerFile->getFilename(), 'Container_')) {
+				continue;
+			}
+
 			if ($containerFile->getATime() > $twoDaysAgo) {
 				continue;
 			}

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -33,7 +33,8 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\ObjectType;
-use Symfony\Component\Finder\Finder;
+use RecursiveDirectoryIterator;
+use SplFileInfo;
 use function array_diff_key;
 use function array_map;
 use function array_merge;
@@ -50,6 +51,7 @@ use function is_readable;
 use function spl_object_id;
 use function sprintf;
 use function str_ends_with;
+use function str_starts_with;
 use function substr;
 use function time;
 use function unlink;
@@ -207,11 +209,11 @@ class ContainerFactory
 			return;
 		}
 
-		$flags = \RecursiveDirectoryIterator::SKIP_DOTS;
-		$iterator = new \RecursiveDirectoryIterator($containerDirectory, $flags);
+		$flags = RecursiveDirectoryIterator::SKIP_DOTS;
+		$iterator = new RecursiveDirectoryIterator($containerDirectory, $flags);
 		$twoDaysAgo = time() - 24 * 60 * 60 * 2;
 
-		/** @var \SplFileInfo $containerFile */
+		/** @var SplFileInfo $containerFile */
 		foreach ($iterator as $containerFile) {
 			$path = $containerFile->getRealPath();
 			if ($path === false) {

--- a/src/File/FileFinder.php
+++ b/src/File/FileFinder.php
@@ -2,11 +2,17 @@
 
 namespace PHPStan\File;
 
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use function array_filter;
 use function array_values;
+use function count;
 use function file_exists;
 use function implode;
 use function is_file;
+use function preg_match;
+use function str_ends_with;
 
 class FileFinder
 {
@@ -35,11 +41,11 @@ class FileFinder
 			} elseif (!file_exists($path)) {
 				throw new PathNotFoundException($path);
 			} else {
-				$flags = \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \FilesystemIterator::CURRENT_AS_PATHNAME;
-				$iterator = new \RecursiveDirectoryIterator($path, $flags);
-				$iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::SELF_FIRST);
+				$flags = RecursiveDirectoryIterator::SKIP_DOTS | RecursiveDirectoryIterator::FOLLOW_SYMLINKS | FilesystemIterator::CURRENT_AS_PATHNAME;
+				$iterator = new RecursiveDirectoryIterator($path, $flags);
+				$iterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
 
-				foreach($iterator as $pathName) {
+				foreach ($iterator as $pathName) {
 					if ($this->skipPath($pathName)) {
 						continue;
 					}
@@ -54,10 +60,11 @@ class FileFinder
 		return new FileFinderResult($files, $onlyFiles);
 	}
 
-	private function skipPath(string $pathName): bool {
+	private function skipPath(string $pathName): bool
+	{
 		// fast path without regex for the common case
 		if (count($this->fileExtensions) === 1) {
-			return !str_ends_with($pathName, '.'.$this->fileExtensions[0]);
+			return !str_ends_with($pathName, '.' . $this->fileExtensions[0]);
 		}
 
 		return !preg_match('{\.(' . implode('|', $this->fileExtensions) . ')$}', $pathName);


### PR DESCRIPTION
symfony file-finder is constructing SplFileInfo under the hood which is costly.
using plain file iterators is more efficient

<img width="601" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/f15f5b16-4c02-46f2-be15-b5f1b6749c77">


repro: `blackfire run --ignore-exit-status php bin/phpstan analyze src/Type/FileTypeMapper.php --debug`

before this PR 1.10.x@18a6723fa
```
Wall Time     45.9s
I/O Wait      110ms
CPU Time      45.8s
Memory        170MB
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

after this PR
```
I/O Wait     53.5ms
CPU Time      35.4s
Memory        146MB
Wall Time     35.4s
Network         n/a     n/a     n/a
SQL             n/a     n/a
```

compare

<img width="585" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/c0272340-5b74-4eb6-9460-04ae5c916d80">
