### PR TITLE
Fix used memory reporting

### DIFF
--- a/src/Command/InceptionResult.php
+++ b/src/Command/InceptionResult.php
@@ -5,6 +5,8 @@ namespace PHPStan\Command;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\File\PathNotFoundException;
 use PHPStan\Internal\BytesHelper;
+use function max;
+use function memory_get_peak_usage;
 use function sprintf;
 
 class InceptionResult
@@ -85,7 +87,10 @@ class InceptionResult
 	public function handleReturn(int $exitCode, ?int $peakMemoryUsageBytes): int
 	{
 		if ($peakMemoryUsageBytes !== null && $this->getErrorOutput()->isVerbose()) {
-			$this->getErrorOutput()->writeLineFormatted(sprintf('Used memory: %s', BytesHelper::bytes($peakMemoryUsageBytes)));
+			$this->getErrorOutput()->writeLineFormatted(sprintf(
+				'Used memory: %s',
+				BytesHelper::bytes(max(memory_get_peak_usage(true), $peakMemoryUsageBytes)),
+			));
 		}
 
 		return $exitCode;


### PR DESCRIPTION
while observing memory consumption of PHPStan I noticed a difference between what PHPStan reports as "used memory" and what the operating system resource monitor reports.

especially in the last few seconds of the phpstan run, I noticed a climb in the very end, which was not at all reflected.

running `php phpstan analyse -c myphpstan.neon.dist -vvv --debug` on my example projects 

... before this PR ends in
```
...
C:\dvl\Workspace\motiontm\models\_Images.php
--- consumed 0 B, total 624 MB, took 0.00 s
C:\dvl\Workspace\motiontm\public\partner\index.php
--- consumed 0 B, total 624 MB, took 0.00 s
Result cache is saved.

 [OK] No errors

Used memory: 624 MB

```

the end-memory result seems identical with what was reported in the last "consumed"-line. the consumption itself is pretty accurate while running but only a climb up to ~690 at the very end is missing.

---

After this PR I am taking the memory-peak of the master process into account right before printing the message.
With this change I am now getting something like

```
...
--- consumed 0 B, total 624 MB, took 0.00 s
C:\dvl\Workspace\motiontm\public\partner\index.php
--- consumed 0 B, total 624 MB, took 0.00 s
Result cache is saved.

 [OK] No errors

Used memory: 692 MB
```

which matches pretty good what I am getting from the operating system.
note the difference between the "used memory" metric and the one of the last "consumed" line