### PR TITLE
Allow Redis::pconnect to have 7 parameters

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -9569,7 +9569,7 @@ return [
 'Redis::multi' => ['Redis', 'mode='=>'int'],
 'Redis::object' => ['string|long|false', 'info'=>'string', 'key'=>'string'],
 'Redis::open' => ['bool', 'host'=>'string', 'port='=>'int', 'timeout='=>'float', 'reserved='=>'null', 'retry_interval='=>'?int', 'read_timeout='=>'float'],
-'Redis::pconnect' => ['bool', 'host'=>'string', 'port='=>'int', 'timeout='=>'float', 'persistent_id='=>'string', 'retry_interval='=>'?int'],
+'Redis::pconnect' => ['bool', 'host'=>'string', 'port='=>'int', 'timeout='=>'float', 'persistent_id='=>'?string', 'retry_interval='=>'int', 'read_timeout='=>'float', 'context='=>'?array{auth?:list{string|null|false,string}|list{string},stream?:array<string,mixed>}'],
 'Redis::persist' => ['bool', 'key'=>'string'],
 'Redis::pExpire' => ['bool', 'key'=>'string', 'ttl'=>'int'],
 'Redis::pexpireAt' => ['bool', 'key'=>'string', 'expiry'=>'int'],


### PR DESCRIPTION
This PR fixes a similar issue that was reported in https://github.com/phpstan/phpstan/issues/9413 and subsequently fixed in https://github.com/phpstan/phpstan-src/pull/2442.

The `Redis::pconnect` method also accepts 7 parameters like the `Redis::connect` method, currently using all 7 available parameters on the `pconnect` method will show the error:
```
Method Redis::pconnect() invoked with 7 parameters, 1-5 required.
```

As can be seen here on the [redis.stub.php](https://github.com/phpredis/phpredis/blob/a0c8fcc589bfcf8207ba3d8c7d065109f31cc1c6/redis.stub.php#L2243) the signature in the PHPStan function map is missing 2 parameters:
```
public function pconnect(string $host, int $port = 6379, float $timeout = 0, ?string $persistent_id = null, int $retry_interval = 0, float $read_timeout = 0, ?array $context = null): bool;
```

I've updated the function map to match the method signature.