### PR TITLE
Rewrite multi param isset() to and-chain

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -71,6 +71,7 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function array_reverse;
+use function array_shift;
 use function count;
 use function in_array;
 use function is_string;
@@ -683,8 +684,8 @@ class TypeSpecifier
 
 				$first = array_shift($issets);
 				$andChain = null;
-				foreach($issets as $isset) {
-					if ($andChain == null) {
+				foreach ($issets as $isset) {
+					if ($andChain === null) {
 						$andChain = new BooleanAnd($first, $isset);
 						continue;
 					}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1365,6 +1365,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9995.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-isset-certainty.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-empty-certainty.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8366.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7291.php');
 	}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -65,6 +65,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 		$this->scope = $this->scope->assignVariable('bar', new ObjectType('Bar'), new ObjectType('Bar'));
 		$this->scope = $this->scope->assignVariable('stringOrNull', new UnionType([new StringType(), new NullType()]), new UnionType([new StringType(), new NullType()]));
 		$this->scope = $this->scope->assignVariable('string', new StringType(), new StringType());
+		$this->scope = $this->scope->assignVariable('fooOrNull', new UnionType([new ObjectType('Foo'), new NullType()]), new UnionType([new ObjectType('Foo'), new NullType()]));
 		$this->scope = $this->scope->assignVariable('barOrNull', new UnionType([new ObjectType('Bar'), new NullType()]), new UnionType([new ObjectType('Bar'), new NullType()]));
 		$this->scope = $this->scope->assignVariable('barOrFalse', new UnionType([new ObjectType('Bar'), new ConstantBooleanType(false)]), new UnionType([new ObjectType('Bar'), new ConstantBooleanType(false)]));
 		$this->scope = $this->scope->assignVariable('stringOrFalse', new UnionType([new StringType(), new ConstantBooleanType(false)]), new UnionType([new StringType(), new ConstantBooleanType(false)]));
@@ -573,16 +574,37 @@ class TypeSpecifierTest extends PHPStanTestCase
 			[
 				new Expr\Isset_([
 					new Variable('stringOrNull'),
+				]),
+				[
+					'$stringOrNull' => '~null',
+				],
+				[
+					'$stringOrNull' => 'null',
+				],
+			],
+			[
+				new Expr\Isset_([
+					new Variable('stringOrNull'),
 					new Variable('barOrNull'),
 				]),
 				[
 					'$stringOrNull' => '~null',
 					'$barOrNull' => '~null',
 				],
+				[],
+			],
+			[
+				new Expr\Isset_([
+					new Variable('stringOrNull'),
+					new Variable('barOrNull'),
+					new Variable('fooOrNull'),
+				]),
 				[
-					'$stringOrNull' => 'null',
-					'$barOrNull' => 'null',
+					'$stringOrNull' => '~null',
+					'$barOrNull' => '~null',
+					'$fooOrNull' => '~null',
 				],
+				[],
 			],
 			[
 				new Expr\BooleanNot(new Expr\Empty_(new Variable('stringOrNull'))),

--- a/tests/PHPStan/Analyser/data/bug-8366.php
+++ b/tests/PHPStan/Analyser/data/bug-8366.php
@@ -11,16 +11,26 @@ function validateParams(
 ): void {
 
 	if (isset($untilDate, $count)) {
+		assertType('DateTimeImmutable', $untilDate);
+		assertType('int', $count);
+
 		throw new \InvalidArgumentException('Too much params, choose between until and count.');
 	}
 	assertType('DateTimeImmutable|null', $untilDate);
 	assertType('int|null', $count);
 
 	if ($untilDate !== null && $datePeriod > $untilDate) {
+		assertType('DateTimeImmutable', $untilDate);
+		assertType('int|null', $count);
 		throw new \InvalidArgumentException('End date must not be greater than until date.');
 	}
 
 	if ($count !== null && $count < 1) {
+		assertType('DateTimeImmutable|null', $untilDate);
+		assertType('int<min, 0>', $count);
 		throw new \InvalidArgumentException('Count must be positive.');
 	}
+
+	assertType('DateTimeImmutable|null', $untilDate);
+	assertType('int<1, max>|null', $count);
 }

--- a/tests/PHPStan/Analyser/data/bug-8366.php
+++ b/tests/PHPStan/Analyser/data/bug-8366.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug8366;
+
+use function PHPStan\Testing\assertType;
+
+function validateParams(
+	?\DateTimeImmutable $datePeriod,
+	?\DateTimeImmutable $untilDate,
+	?int $count
+): void {
+
+	if (isset($untilDate, $count)) {
+		throw new \InvalidArgumentException('Too much params, choose between until and count.');
+	}
+	assertType('DateTimeImmutable|null', $untilDate);
+	assertType('int|null', $count);
+
+	if ($untilDate !== null && $datePeriod > $untilDate) {
+		throw new \InvalidArgumentException('End date must not be greater than until date.');
+	}
+
+	if ($count !== null && $count < 1) {
+		throw new \InvalidArgumentException('Count must be positive.');
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -990,4 +990,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4061.php'], []);
 	}
 
+	public function testBug8366(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8366.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -467,4 +467,12 @@ class IssetRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10064(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10064.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-10064.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-10064.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10064;
+
+class HelloWorld
+{
+	public function sayHello(int $check): bool
+	{
+		$a = random_int(0, 10) > 5 ? 42: null;  // a possibly null var
+		$b = random_int(0, 10) > 6 ? 47: null;  // a possibly null var
+		if (isset($a, $b)) {
+			return $check > $a && $check < $b;
+		}
+		if (isset($a)) {
+			return $check > $a;
+		}
+		if (isset($b)) {
+			return $check < $b;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
motivation: ease impl of https://github.com/phpstan/phpstan-src/pull/2657 by moving the expr-var loop before the context true/false branches which simplifies the branch cases

closes https://github.com/phpstan/phpstan/issues/8366
closes https://github.com/phpstan/phpstan/issues/10064