### PR TITLE
Fix !isset() with Variable

### DIFF
--- a/src/Analyser/EnsuredNonNullabilityResultExpression.php
+++ b/src/Analyser/EnsuredNonNullabilityResultExpression.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PhpParser\Node\Expr;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
 
 class EnsuredNonNullabilityResultExpression
@@ -12,6 +13,7 @@ class EnsuredNonNullabilityResultExpression
 		private Expr $expression,
 		private Type $originalType,
 		private Type $originalNativeType,
+		private TrinaryLogic $certainty,
 	)
 	{
 	}
@@ -29,6 +31,11 @@ class EnsuredNonNullabilityResultExpression
 	public function getOriginalNativeType(): Type
 	{
 		return $this->originalNativeType;
+	}
+
+	public function getCertainty(): TrinaryLogic
+	{
+		return $this->certainty;
 	}
 
 }

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3850,22 +3850,18 @@ class MutatingScope implements Scope
 			if ($expr instanceof IssetExpr) {
 				$issetExpr = $expr;
 				$expr = $issetExpr->getExpr();
-				$certainty = $issetExpr->getCertainty();
 
-				if ($certainty->no()) {
-					$scope = $scope->unsetExpression($expr);
-
-					if ($expr instanceof Variable) {
-						$exprString = $this->getNodeKey($expr);
-
-						unset($scope->expressionTypes[$exprString]);
-						unset($scope->nativeExpressionTypes[$exprString]);
-					}
-				} else {
+				if ($typeSpecification['sure']) {
 					$scope = $scope->setExpressionCertainty(
 						$expr,
-						$certainty,
+						TrinaryLogic::createMaybe(),
 					);
+				} else {
+					$scope = $scope->unsetExpression($expr);
+					$exprString = $this->getNodeKey($expr);
+
+					unset($scope->expressionTypes[$exprString]);
+					unset($scope->nativeExpressionTypes[$exprString]);
 				}
 
 				continue;

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3891,10 +3891,11 @@ class MutatingScope implements Scope
 
 		foreach ($conditions as $conditionalExprString => $expressions) {
 			$certainty = TrinaryLogic::lazyExtremeIdentity($expressions, static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getCertainty());
-			$type = TypeCombinator::union(...array_map(static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getType(), $expressions));
 			if ($certainty->no()) {
 				unset($scope->expressionTypes[$conditionalExprString]);
 			} else {
+				$type = TypeCombinator::union(...array_map(static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getType(), $expressions));
+
 				$scope->expressionTypes[$conditionalExprString] = array_key_exists($conditionalExprString, $scope->expressionTypes)
 					? new ExpressionTypeHolder(
 						$scope->expressionTypes[$conditionalExprString]->getExpr(),

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3840,6 +3840,7 @@ class MutatingScope implements Scope
 			$specifiedExpressions[$this->getNodeKey($expr)] = ExpressionTypeHolder::createYes($expr, $scope->getType($expr));
 		}
 
+		$conditions = [];
 		foreach ($scope->conditionalExpressions as $conditionalExprString => $conditionalExpressions) {
 			foreach ($conditionalExpressions as $conditionalExpression) {
 				foreach ($conditionalExpression->getConditionExpressionTypeHolders() as $holderExprString => $conditionalTypeHolder) {
@@ -3848,18 +3849,24 @@ class MutatingScope implements Scope
 					}
 				}
 
-				if ($conditionalExpression->getTypeHolder()->getCertainty()->no()) {
-					unset($scope->expressionTypes[$conditionalExprString]);
-				} else {
-					$scope->expressionTypes[$conditionalExprString] = array_key_exists($conditionalExprString, $scope->expressionTypes)
-						? new ExpressionTypeHolder(
-							$scope->expressionTypes[$conditionalExprString]->getExpr(),
-							TypeCombinator::intersect($scope->expressionTypes[$conditionalExprString]->getType(), $conditionalExpression->getTypeHolder()->getType()),
-							TrinaryLogic::maxMin($scope->expressionTypes[$conditionalExprString]->getCertainty(), $conditionalExpression->getTypeHolder()->getCertainty()),
-						)
-						: $conditionalExpression->getTypeHolder();
-					$specifiedExpressions[$conditionalExprString] = $conditionalExpression->getTypeHolder();
-				}
+				$conditions[$conditionalExprString][] = $conditionalExpression;
+				$specifiedExpressions[$conditionalExprString] = $conditionalExpression->getTypeHolder();
+			}
+		}
+
+		foreach ($conditions as $conditionalExprString => $expressions) {
+			$certainty = TrinaryLogic::lazyExtremeIdentity($expressions, static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getCertainty());
+			$type = TypeCombinator::union(...array_map(static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getType(), $expressions));
+			if ($certainty->no()) {
+				unset($scope->expressionTypes[$conditionalExprString]);
+			} else {
+				$scope->expressionTypes[$conditionalExprString] = array_key_exists($conditionalExprString, $scope->expressionTypes)
+					? new ExpressionTypeHolder(
+						$scope->expressionTypes[$conditionalExprString]->getExpr(),
+						TypeCombinator::intersect($scope->expressionTypes[$conditionalExprString]->getType(), $type),
+						TrinaryLogic::maxMin($scope->expressionTypes[$conditionalExprString]->getCertainty(), $certainty),
+					)
+					: $expressions[0]->getTypeHolder();
 			}
 		}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2348,6 +2348,10 @@ class MutatingScope implements Scope
 	/** @api */
 	public function hasExpressionType(Expr $node): TrinaryLogic
 	{
+		if ($node instanceof Variable && is_string($node->name)) {
+			return $this->hasVariableType($node->name);
+		}
+
 		$exprString = $this->getNodeKey($node);
 		if (!isset($this->expressionTypes[$exprString])) {
 			return TrinaryLogic::createNo();
@@ -3440,7 +3444,7 @@ class MutatingScope implements Scope
 		return $scope->invalidateExpression($expr);
 	}
 
-	public function specifyExpressionType(Expr $expr, Type $type, Type $nativeType): self
+	public function specifyExpressionType(Expr $expr, Type $type, Type $nativeType, ?TrinaryLogic $certainty = null): self
 	{
 		if ($expr instanceof ConstFetch) {
 			$loweredConstName = strtolower($expr->name->toString());
@@ -3474,6 +3478,7 @@ class MutatingScope implements Scope
 					if ($dimType instanceof ConstantIntegerType) {
 						$types[] = new StringType();
 					}
+
 					$scope = $scope->specifyExpressionType(
 						$expr->var,
 						TypeCombinator::intersect(
@@ -3481,16 +3486,23 @@ class MutatingScope implements Scope
 							new HasOffsetValueType($dimType, $type),
 						),
 						$scope->getNativeType($expr->var),
+						$certainty,
 					);
 				}
 			}
 		}
 
+		if ($certainty === null) {
+			$certainty = TrinaryLogic::createYes();
+		} elseif ($certainty->no()) {
+			throw new ShouldNotHappenException();
+		}
+
 		$exprString = $this->getNodeKey($expr);
 		$expressionTypes = $scope->expressionTypes;
-		$expressionTypes[$exprString] = ExpressionTypeHolder::createYes($expr, $type);
+		$expressionTypes[$exprString] = new ExpressionTypeHolder($expr, $type, $certainty);
 		$nativeTypes = $scope->nativeExpressionTypes;
-		$nativeTypes[$exprString] = ExpressionTypeHolder::createYes($expr, $nativeType);
+		$nativeTypes[$exprString] = new ExpressionTypeHolder($expr, $nativeType, $certainty);
 
 		return $this->scopeFactory->create(
 			$this->context,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3720,6 +3720,23 @@ class MutatingScope implements Scope
 		);
 	}
 
+	private function setExpressionCertainty(Expr $expr, TrinaryLogic $certainty): self
+	{
+		if ($this->hasExpressionType($expr)->no()) {
+			throw new ShouldNotHappenException();
+		}
+
+		$originalExprType = $this->getType($expr);
+		$nativeType = $this->getNativeType($expr);
+
+		return $this->specifyExpressionType(
+			$expr,
+			$originalExprType,
+			$nativeType,
+			$certainty,
+		);
+	}
+
 	private function addTypeToExpression(Expr $expr, Type $type): self
 	{
 		$originalExprType = $this->getType($expr);
@@ -3844,6 +3861,11 @@ class MutatingScope implements Scope
 						unset($scope->expressionTypes[$exprString]);
 						unset($scope->nativeExpressionTypes[$exprString]);
 					}
+				} else {
+					$scope = $scope->setExpressionCertainty(
+						$expr,
+						$certainty,
+					);
 				}
 
 				continue;

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3894,7 +3894,7 @@ class MutatingScope implements Scope
 			if ($certainty->no()) {
 				unset($scope->expressionTypes[$conditionalExprString]);
 			} else {
-				$type = TypeCombinator::union(...array_map(static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getType(), $expressions));
+				$type = TypeCombinator::intersect(...array_map(static fn (ConditionalExpressionHolder $holder) => $holder->getTypeHolder()->getType(), $expressions));
 
 				$scope->expressionTypes[$conditionalExprString] = array_key_exists($conditionalExprString, $scope->expressionTypes)
 					? new ExpressionTypeHolder(

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3858,10 +3858,6 @@ class MutatingScope implements Scope
 					);
 				} else {
 					$scope = $scope->unsetExpression($expr);
-					$exprString = $this->getNodeKey($expr);
-
-					unset($scope->expressionTypes[$exprString]);
-					unset($scope->nativeExpressionTypes[$exprString]);
 				}
 
 				continue;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3811,10 +3811,16 @@ class NodeScopeResolver
 				$falsyScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
 				$truthyType = $truthyScope->getType($if);
 				$falseyType = $falsyScope->getType($assignedExpr->else);
-				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
-				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
-				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
-				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+
+				if (
+					$truthyType->isSuperTypeOf($falseyType)->no()
+					&& $falseyType->isSuperTypeOf($truthyType)->no()
+				) {
+					$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
+					$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
+					$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+					$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+				}
 			}
 
 			$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $assignedExpr, TypeSpecifierContext::createTruthy());

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2577,7 +2577,7 @@ class NodeScopeResolver
 			$scope = $this->revertNonNullability($condResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 			$scope = $this->lookForUnsetAllowedUndefinedExpressions($scope, $expr->left);
 
-			$rightScope = $scope->filterByFalseyValue(new Expr\Isset_([$expr->left]));
+			$rightScope = $scope->filterByFalseyValue($expr);
 			$rightResult = $this->processExprNode($expr->right, $rightScope, $nodeCallback, $context->enterDeep());
 			$rightExprType = $scope->getType($expr->right);
 			if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2786,8 +2786,8 @@ class NodeScopeResolver
 
 			$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $expr->cond, TypeSpecifierContext::createTruthy());
 			$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $expr->cond, TypeSpecifierContext::createFalsey());
-			$ifTrueScope = $condScope->filterBySpecifiedTypes($truthySpecifiedTypes);
-			$ifFalseScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
+			$ifTrueScope = $ternaryCondResult->getTruthyScope()->filterBySpecifiedTypes($truthySpecifiedTypes);
+			$ifFalseScope = $ternaryCondResult->getFalseyScope()->filterBySpecifiedTypes($falseySpecifiedTypes);
 
 			$restoreIssetExprCertainty = static function (MutatingScope $previousScope, MutatingScope $scope, SpecifiedTypes $specifiedTypes): MutatingScope {
 				foreach ($specifiedTypes->getSureNotTypes() as [$expr, $exprType]) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2796,15 +2796,22 @@ class NodeScopeResolver
 			$throwPoints = array_merge($throwPoints, $elseResult->getThrowPoints());
 			$ifFalseScope = $elseResult->getScope();
 
-			if ($ifTrueType instanceof NeverType && $ifTrueType->isExplicit()) {
+			$condType = $scope->getType($expr->cond);
+			if ($condType->isTrue()->yes()) {
+				$finalScope = $ifTrueScope;
+			} elseif ($condType->isFalse()->yes()) {
 				$finalScope = $ifFalseScope;
 			} else {
-				$ifFalseType = $ifFalseScope->getType($expr->else);
-
-				if ($ifFalseType instanceof NeverType && $ifFalseType->isExplicit()) {
-					$finalScope = $ifTrueScope;
+				if ($ifTrueType instanceof NeverType && $ifTrueType->isExplicit()) {
+					$finalScope = $ifFalseScope;
 				} else {
-					$finalScope = $ifTrueScope->mergeWith($ifFalseScope);
+					$ifFalseType = $ifFalseScope->getType($expr->else);
+
+					if ($ifFalseType instanceof NeverType && $ifFalseType->isExplicit()) {
+						$finalScope = $ifTrueScope;
+					} else {
+						$finalScope = $ifTrueScope->mergeWith($ifFalseScope);
+					}
 				}
 			}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3762,14 +3762,18 @@ class NodeScopeResolver
 			$type = $scope->getType($assignedExpr);
 
 			$conditionalExpressions = [];
-			if ($assignedExpr instanceof Ternary && $assignedExpr->if !== null) {
+			if ($assignedExpr instanceof Ternary) {
+				$if = $assignedExpr->if;
+				if ($if === null) {
+					$if = $assignedExpr->cond;
+				}
 				$condScope = $this->processExprNode($assignedExpr->cond, $scope, static function (): void {
 				}, ExpressionContext::createDeep())->getScope();
 				$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $assignedExpr->cond, TypeSpecifierContext::createTruthy());
 				$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $assignedExpr->cond, TypeSpecifierContext::createFalsey());
 				$truthyScope = $condScope->filterBySpecifiedTypes($truthySpecifiedTypes);
 				$falsyScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
-				$truthyType = $truthyScope->getType($assignedExpr->if);
+				$truthyType = $truthyScope->getType($if);
 				$falseyType = $falsyScope->getType($assignedExpr->else);
 				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
 				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1759,6 +1759,14 @@ class NodeScopeResolver
 		if ($isNull->yes()) {
 			return new EnsuredNonNullabilityResult($scope, []);
 		}
+
+		// keep certainty
+		$certainty = TrinaryLogic::createYes();
+		$hasExpressionType = $originalScope->hasExpressionType($exprToSpecify);
+		if (!$hasExpressionType->no()) {
+			$certainty = $hasExpressionType;
+		}
+
 		$exprTypeWithoutNull = TypeCombinator::removeNull($exprType);
 		if ($exprType->equals($exprTypeWithoutNull)) {
 			$originalExprType = $originalScope->getType($exprToSpecify);
@@ -1766,7 +1774,7 @@ class NodeScopeResolver
 				$originalNativeType = $originalScope->getNativeType($exprToSpecify);
 
 				return new EnsuredNonNullabilityResult($scope, [
-					new EnsuredNonNullabilityResultExpression($exprToSpecify, $originalExprType, $originalNativeType),
+					new EnsuredNonNullabilityResultExpression($exprToSpecify, $originalExprType, $originalNativeType, $certainty),
 				]);
 			}
 			return new EnsuredNonNullabilityResult($scope, []);
@@ -1782,7 +1790,7 @@ class NodeScopeResolver
 		return new EnsuredNonNullabilityResult(
 			$scope,
 			[
-				new EnsuredNonNullabilityResultExpression($exprToSpecify, $exprType, $nativeType),
+				new EnsuredNonNullabilityResultExpression($exprToSpecify, $exprType, $nativeType, $certainty),
 			],
 		);
 	}
@@ -1812,6 +1820,7 @@ class NodeScopeResolver
 				$specifiedExpressionResult->getExpression(),
 				$specifiedExpressionResult->getOriginalType(),
 				$specifiedExpressionResult->getOriginalNativeType(),
+				$specifiedExpressionResult->getCertainty(),
 			);
 		}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3775,10 +3775,10 @@ class NodeScopeResolver
 				$falsyScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
 				$truthyType = $truthyScope->getType($if);
 				$falseyType = $falsyScope->getType($assignedExpr->else);
-				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
-				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
-				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
-				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
+				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
+				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($condScope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
 			}
 
 			$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $assignedExpr, TypeSpecifierContext::createTruthy());

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3760,10 +3760,25 @@ class NodeScopeResolver
 			$throwPoints = $result->getThrowPoints();
 			$assignedExpr = $this->unwrapAssign($assignedExpr);
 			$type = $scope->getType($assignedExpr);
-			$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $assignedExpr, TypeSpecifierContext::createTruthy());
-			$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $assignedExpr, TypeSpecifierContext::createFalsey());
 
 			$conditionalExpressions = [];
+			if ($assignedExpr instanceof Ternary && $assignedExpr->if !== null) {
+				$condScope = $this->processExprNode($assignedExpr->cond, $scope, static function (): void {
+				}, ExpressionContext::createDeep())->getScope();
+				$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $assignedExpr->cond, TypeSpecifierContext::createTruthy());
+				$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $assignedExpr->cond, TypeSpecifierContext::createFalsey());
+				$truthyScope = $condScope->filterBySpecifiedTypes($truthySpecifiedTypes);
+				$falsyScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
+				$truthyType = $truthyScope->getType($assignedExpr->if);
+				$falseyType = $falsyScope->getType($assignedExpr->else);
+				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
+				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $truthySpecifiedTypes, $truthyType);
+				$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+				$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
+			}
+
+			$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $assignedExpr, TypeSpecifierContext::createTruthy());
+			$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($scope, $assignedExpr, TypeSpecifierContext::createFalsey());
 
 			$truthyType = TypeCombinator::removeFalsey($type);
 			$falseyType = TypeCombinator::intersect($type, StaticTypeFactory::falsey());
@@ -3773,7 +3788,6 @@ class NodeScopeResolver
 			$conditionalExpressions = $this->processSureTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
 			$conditionalExpressions = $this->processSureNotTypesForConditionalExpressionsAfterAssign($scope, $var->name, $conditionalExpressions, $falseySpecifiedTypes, $falseyType);
 
-			// TODO conditional expressions for native type should be handled too
 			$scope = $result->getScope()->assignVariable($var->name, $type, $scope->getNativeType($assignedExpr));
 			foreach ($conditionalExpressions as $exprString => $holders) {
 				$scope = $scope->addConditionalExpressions($exprString, $holders);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -90,6 +90,7 @@ use PHPStan\Node\InForeachNode;
 use PHPStan\Node\InFunctionNode;
 use PHPStan\Node\InstantiationCallableNode;
 use PHPStan\Node\InTraitNode;
+use PHPStan\Node\IssetExpr;
 use PHPStan\Node\LiteralArrayItem;
 use PHPStan\Node\LiteralArrayNode;
 use PHPStan\Node\MatchExpressionArm;
@@ -2781,9 +2782,41 @@ class NodeScopeResolver
 			)->getScope();
 		} elseif ($expr instanceof Ternary) {
 			$ternaryCondResult = $this->processExprNode($expr->cond, $scope, $nodeCallback, $context->enterDeep());
+			$condScope = $ternaryCondResult->getScope();
+
+			$truthySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $expr->cond, TypeSpecifierContext::createTruthy());
+			$falseySpecifiedTypes = $this->typeSpecifier->specifyTypesInCondition($condScope, $expr->cond, TypeSpecifierContext::createFalsey());
+			$ifTrueScope = $condScope->filterBySpecifiedTypes($truthySpecifiedTypes);
+			$ifFalseScope = $condScope->filterBySpecifiedTypes($falseySpecifiedTypes);
+
+			$restoreIssetExprCertainty = static function (MutatingScope $previousScope, MutatingScope $scope, SpecifiedTypes $specifiedTypes): MutatingScope {
+				foreach ($specifiedTypes->getSureNotTypes() as [$expr, $exprType]) {
+					if (!$expr instanceof IssetExpr) {
+						continue;
+					}
+
+					$expr = $expr->getExpr();
+					if ($scope->hasExpressionType($expr)->no()) {
+						continue;
+					}
+
+					$previousScopeHasExpressionType = $previousScope->hasExpressionType($expr);
+					if ($previousScopeHasExpressionType->no()) {
+						continue;
+					}
+
+					$scope = $scope->specifyExpressionType(
+						$expr,
+						$scope->getType($expr),
+						$scope->getNativeType($expr),
+						$previousScopeHasExpressionType,
+					);
+				}
+
+				return $scope;
+			};
+
 			$throwPoints = $ternaryCondResult->getThrowPoints();
-			$ifTrueScope = $ternaryCondResult->getTruthyScope();
-			$ifFalseScope = $ternaryCondResult->getFalseyScope();
 			$ifTrueType = null;
 			if ($expr->if !== null) {
 				$ifResult = $this->processExprNode($expr->if, $ifTrueScope, $nodeCallback, $context);
@@ -2807,6 +2840,9 @@ class NodeScopeResolver
 					$finalScope = $ifTrueScope->mergeWith($ifFalseScope);
 				}
 			}
+
+			$finalScope = $restoreIssetExprCertainty($scope, $finalScope, $truthySpecifiedTypes);
+			$finalScope = $restoreIssetExprCertainty($scope, $finalScope, $falseySpecifiedTypes);
 
 			return new ExpressionResult(
 				$finalScope,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1315,8 +1315,28 @@ class TypeSpecifier
 					$holders[$exprString] = [];
 				}
 
+				$conditions = $conditionExpressionTypes;
+				foreach ($conditions as $conditionExprString => $conditionExprTypeHolder) {
+					$conditionExpr = $conditionExprTypeHolder->getExpr();
+					if (!$conditionExpr instanceof Expr\Variable) {
+						continue;
+					}
+					if (!is_string($conditionExpr->name)) {
+						continue;
+					}
+					if ($conditionExpr->name !== $expr->name) {
+						continue;
+					}
+
+					unset($conditions[$conditionExprString]);
+				}
+
+				if (count($conditions) === 0) {
+					continue;
+				}
+
 				$holder = new ConditionalExpressionHolder(
-					$conditionExpressionTypes,
+					$conditions,
 					new ExpressionTypeHolder($expr, TypeCombinator::intersect($scope->getType($expr), $type), TrinaryLogic::createYes()),
 				);
 				$holders[$exprString][$holder->getKey()] = $holder;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -605,11 +605,14 @@ class TypeSpecifier
 
 			$types = null;
 			foreach ($vars as $var) {
+				$type = new SpecifiedTypes();
+
 				if ($var instanceof Expr\Variable && is_string($var->name)) {
 					if ($scope->hasVariableType($var->name)->no()) {
 						return new SpecifiedTypes([], [], false, [], $rootExpr);
 					}
 				}
+
 				if (
 					$var instanceof ArrayDimFetch
 					&& $var->dim !== null
@@ -626,35 +629,31 @@ class TypeSpecifier
 							$scope,
 							$rootExpr,
 						);
-					} else {
-						$type = new SpecifiedTypes();
 					}
-
-					$type = $type->unionWith(
-						$this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope, $rootExpr),
-					);
-				} else {
-					$type = $this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope, $rootExpr);
 				}
 
 				if (
 					$var instanceof PropertyFetch
 					&& $var->name instanceof Node\Identifier
 				) {
-					$type = $type->unionWith($this->create($var->var, new IntersectionType([
+					$type = $this->create($var->var, new IntersectionType([
 						new ObjectWithoutClassType(),
 						new HasPropertyType($var->name->toString()),
-					]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr));
+					]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr);
 				} elseif (
 					$var instanceof StaticPropertyFetch
 					&& $var->class instanceof Expr
 					&& $var->name instanceof Node\VarLikeIdentifier
 				) {
-					$type = $type->unionWith($this->create($var->class, new IntersectionType([
+					$type = $this->create($var->class, new IntersectionType([
 						new ObjectWithoutClassType(),
 						new HasPropertyType($var->name->toString()),
-					]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr));
+					]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr);
 				}
+
+				$type = $type->unionWith(
+					$this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope, $rootExpr),
+				);
 
 				if ($types === null) {
 					$types = $type;
@@ -680,6 +679,15 @@ class TypeSpecifier
 		} elseif (
 			$expr instanceof Expr\Empty_
 		) {
+			if (!$scope instanceof MutatingScope) {
+				throw new ShouldNotHappenException();
+			}
+
+			$isset = $scope->issetCheck($expr->expr, static fn () => true);
+			if ($isset === false) {
+				return new SpecifiedTypes();
+			}
+
 			return $this->specifyTypesInCondition($scope, new BooleanOr(
 				new Expr\BooleanNot(new Expr\Isset_([$expr->expr])),
 				new Expr\BooleanNot($expr->expr),

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -624,7 +624,7 @@ class TypeSpecifier
 					$nullType = new NullType();
 					if (!$nullType->isSuperTypeOf($type)->no()) {
 						return $exprType->unionWith($this->create(
-							new IssetExpr($issetExpr, TrinaryLogic::createMaybe()),
+							new IssetExpr($issetExpr),
 							new NullType(),
 							$context->negate(),
 							false,
@@ -634,9 +634,9 @@ class TypeSpecifier
 					}
 
 					return $this->create(
-						new IssetExpr($issetExpr, TrinaryLogic::createNo()),
+						new IssetExpr($issetExpr),
 						new NullType(),
-						$context->negate(),
+						$context,
 						false,
 						$scope,
 						$rootExpr,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -621,7 +621,8 @@ class TypeSpecifier
 				if ($issetExpr instanceof Expr\Variable && is_string($issetExpr->name)) {
 					$type = $scope->getType($issetExpr);
 
-					if ($type instanceof MixedType || TypeCombinator::containsNull($type)) {
+					$nullType = new NullType();
+					if (!$nullType->isSuperTypeOf($type)->no()) {
 						return $exprType->unionWith($this->create(
 							new IssetExpr($issetExpr, TrinaryLogic::createMaybe()),
 							new NullType(),

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -71,6 +71,7 @@ use function array_key_exists;
 use function array_map;
 use function array_merge;
 use function array_reverse;
+use function array_shift;
 use function count;
 use function in_array;
 use function is_string;
@@ -562,59 +563,75 @@ class TypeSpecifier
 			&& count($expr->vars) > 0
 			&& !$context->null()
 		) {
+			// rewrite multi param isset() to and-chained single param isset()
+			if (count($expr->vars) > 1) {
+				$issets = [];
+				foreach ($expr->vars as $var) {
+					$issets[] = new Expr\Isset_([$var], $expr->getAttributes());
+				}
+
+				$first = array_shift($issets);
+				$andChain = null;
+				foreach ($issets as $isset) {
+					if ($andChain === null) {
+						$andChain = new BooleanAnd($first, $isset);
+						continue;
+					}
+
+					$andChain = new BooleanAnd($andChain, $isset);
+				}
+
+				if ($andChain === null) {
+					throw new ShouldNotHappenException();
+				}
+
+				return $this->specifyTypesInCondition($scope, $andChain, $context, $rootExpr);
+			}
+
+			$issetExpr = $expr->vars[0];
+
 			if (!$context->true()) {
 				if (!$scope instanceof MutatingScope) {
 					throw new ShouldNotHappenException();
 				}
 
-				$specifiedTypes = new SpecifiedTypes();
-				foreach ($expr->vars as $var) {
-					$isset = $scope->issetCheck($var, static fn () => true);
+				$isset = $scope->issetCheck($issetExpr, static fn () => true);
 
-					if ($isset !== true) {
-						continue;
-					}
-
-					$specifiedTypes = $specifiedTypes->unionWith($this->create(
-						$var,
-						new NullType(),
-						$context->negate(),
-						false,
-						$scope,
-						$rootExpr,
-					));
+				if ($isset !== true) {
+					return new SpecifiedTypes();
 				}
 
-				return $specifiedTypes;
+				return $this->create(
+					$issetExpr,
+					new NullType(),
+					$context->negate(),
+					false,
+					$scope,
+					$rootExpr,
+				);
 			}
 
-			$vars = [];
-			foreach ($expr->vars as $var) {
-				$tmpVars = [$var];
-
-				while (
-					$var instanceof ArrayDimFetch
-					|| $var instanceof PropertyFetch
-					|| (
-						$var instanceof StaticPropertyFetch
-						&& $var->class instanceof Expr
-					)
-				) {
-					if ($var instanceof StaticPropertyFetch) {
-						/** @var Expr $var */
-						$var = $var->class;
-					} else {
-						$var = $var->var;
-					}
-					$tmpVars[] = $var;
+			$tmpVars = [$issetExpr];
+			while (
+				$issetExpr instanceof ArrayDimFetch
+				|| $issetExpr instanceof PropertyFetch
+				|| (
+					$issetExpr instanceof StaticPropertyFetch
+					&& $issetExpr->class instanceof Expr
+				)
+			) {
+				if ($issetExpr instanceof StaticPropertyFetch) {
+					/** @var Expr $issetExpr */
+					$issetExpr = $issetExpr->class;
+				} else {
+					$issetExpr = $issetExpr->var;
 				}
-
-				$vars = array_merge($vars, array_reverse($tmpVars));
+				$tmpVars[] = $issetExpr;
 			}
+			$vars = array_reverse($tmpVars);
 
-			$types = null;
+			$types = new SpecifiedTypes();
 			foreach ($vars as $var) {
-				$type = new SpecifiedTypes();
 
 				if ($var instanceof Expr\Variable && is_string($var->name)) {
 					if ($scope->hasVariableType($var->name)->no()) {
@@ -630,13 +647,15 @@ class TypeSpecifier
 					$dimType = $scope->getType($var->dim);
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
-						$type = $this->create(
-							$var->var,
-							new HasOffsetType($dimType),
-							$context,
-							false,
-							$scope,
-							$rootExpr,
+						$types = $types->unionWith(
+							$this->create(
+								$var->var,
+								new HasOffsetType($dimType),
+								$context,
+								false,
+								$scope,
+								$rootExpr,
+							),
 						);
 					}
 				}
@@ -645,30 +664,28 @@ class TypeSpecifier
 					$var instanceof PropertyFetch
 					&& $var->name instanceof Node\Identifier
 				) {
-					$type = $this->create($var->var, new IntersectionType([
-						new ObjectWithoutClassType(),
-						new HasPropertyType($var->name->toString()),
-					]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr);
+					$types = $types->unionWith(
+						$this->create($var->var, new IntersectionType([
+							new ObjectWithoutClassType(),
+							new HasPropertyType($var->name->toString()),
+						]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr),
+					);
 				} elseif (
 					$var instanceof StaticPropertyFetch
 					&& $var->class instanceof Expr
 					&& $var->name instanceof Node\VarLikeIdentifier
 				) {
-					$type = $this->create($var->class, new IntersectionType([
-						new ObjectWithoutClassType(),
-						new HasPropertyType($var->name->toString()),
-					]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr);
+					$types = $types->unionWith(
+						$this->create($var->class, new IntersectionType([
+							new ObjectWithoutClassType(),
+							new HasPropertyType($var->name->toString()),
+						]), TypeSpecifierContext::createTruthy(), false, $scope, $rootExpr),
+					);
 				}
 
-				$type = $type->unionWith(
+				$types = $types->unionWith(
 					$this->create($var, new NullType(), TypeSpecifierContext::createFalse(), false, $scope, $rootExpr),
 				);
-
-				if ($types === null) {
-					$types = $type;
-				} else {
-					$types = $types->unionWith($type);
-				}
 			}
 
 			return $types;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -608,8 +608,7 @@ class TypeSpecifier
 
 				if ($issetExpr instanceof Expr\Variable && is_string($issetExpr->name)) {
 					$type = $scope->getType($issetExpr);
-					$nullType = new NullType();
-					$isNullable = !$nullType->isSuperTypeOf($type)->no();
+					$isNullable = !$type->isNull()->no();
 
 					$exprType = $this->create(
 						$issetExpr,

--- a/src/Node/IssetExpr.php
+++ b/src/Node/IssetExpr.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Node;
+
+use PhpParser\Node\Expr;
+use PHPStan\TrinaryLogic;
+
+class IssetExpr extends Expr implements VirtualNode
+{
+
+	public function __construct(
+		private Expr $expr,
+		private TrinaryLogic $certainty,
+	)
+	{
+		parent::__construct([]);
+	}
+
+	public function getExpr(): Expr
+	{
+		return $this->expr;
+	}
+
+	public function getCertainty(): TrinaryLogic
+	{
+		return $this->certainty;
+	}
+
+	public function getType(): string
+	{
+		return 'PHPStan_Node_IssetExpr';
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getSubNodeNames(): array
+	{
+		return [];
+	}
+
+}

--- a/src/Node/IssetExpr.php
+++ b/src/Node/IssetExpr.php
@@ -3,14 +3,12 @@
 namespace PHPStan\Node;
 
 use PhpParser\Node\Expr;
-use PHPStan\TrinaryLogic;
 
 class IssetExpr extends Expr implements VirtualNode
 {
 
 	public function __construct(
 		private Expr $expr,
-		private TrinaryLogic $certainty,
 	)
 	{
 		parent::__construct([]);
@@ -19,11 +17,6 @@ class IssetExpr extends Expr implements VirtualNode
 	public function getExpr(): Expr
 	{
 		return $this->expr;
-	}
-
-	public function getCertainty(): TrinaryLogic
-	{
-		return $this->certainty;
 	}
 
 	public function getType(): string

--- a/src/Node/Printer/Printer.php
+++ b/src/Node/Printer/Printer.php
@@ -11,6 +11,7 @@ use PHPStan\Node\Expr\OriginalPropertyTypeExpr;
 use PHPStan\Node\Expr\PropertyInitializationExpr;
 use PHPStan\Node\Expr\SetOffsetValueTypeExpr;
 use PHPStan\Node\Expr\TypeExpr;
+use PHPStan\Node\IssetExpr;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
@@ -60,6 +61,11 @@ class Printer extends Standard
 	protected function pPHPStan_Node_PropertyInitializationExpr(PropertyInitializationExpr $expr): string // phpcs:ignore
 	{
 		return sprintf('__phpstanPropertyInitialization(%s)', $expr->getPropertyName());
+	}
+
+	protected function pPHPStan_Node_IssetExpr(IssetExpr $expr): string // phpcs:ignore
+	{
+		return sprintf('__phpstanIssetExpr(%s)', $this->p($expr->getExpr()));
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1380,6 +1380,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9867.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-isset-certainty.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-empty-certainty.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8366.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7291.php');
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -916,6 +916,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-reverse.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6889.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6891.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10088.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/shuffle.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/simplexml.php');
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1362,6 +1362,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/trigger-error-php7.php');
 		}
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsy-isset.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9105.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1377,6 +1377,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/enum_exists.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9778.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9867.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-isset-certainty.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-empty-certainty.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7291.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1385,6 +1385,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-empty-certainty.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8366.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7291.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/conditional-vars.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1364,6 +1364,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsy-isset.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-coalesce.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9105.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1365,6 +1365,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsy-isset.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-coalesce.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/falsey-ternary-certainty.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-7915.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9714.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9105.php');

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -580,8 +580,8 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$barOrNull' => '~null',
 				],
 				[
-					'$stringOrNull' => self::SURE_NOT_TRUTHY,
-					'$barOrNull' => self::SURE_NOT_TRUTHY,
+					'$stringOrNull' => 'null',
+					'$barOrNull' => 'null',
 				],
 			],
 			[
@@ -606,7 +606,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 			[
 				new Expr\Empty_(new Variable('array')),
 				[
-					'$array' => 'array{}',
+					'$array' => 'array{}|null',
 				],
 				[
 					'$array' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
@@ -618,7 +618,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$array' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
 				],
 				[
-					'$array' => 'array{}',
+					'$array' => 'array{}|null',
 				],
 			],
 			[

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -65,6 +65,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 		$this->scope = $this->scope->assignVariable('bar', new ObjectType('Bar'), new ObjectType('Bar'));
 		$this->scope = $this->scope->assignVariable('stringOrNull', new UnionType([new StringType(), new NullType()]), new UnionType([new StringType(), new NullType()]));
 		$this->scope = $this->scope->assignVariable('string', new StringType(), new StringType());
+		$this->scope = $this->scope->assignVariable('fooOrNull', new UnionType([new ObjectType('Foo'), new NullType()]), new UnionType([new ObjectType('Foo'), new NullType()]));
 		$this->scope = $this->scope->assignVariable('barOrNull', new UnionType([new ObjectType('Bar'), new NullType()]), new UnionType([new ObjectType('Bar'), new NullType()]));
 		$this->scope = $this->scope->assignVariable('barOrFalse', new UnionType([new ObjectType('Bar'), new ConstantBooleanType(false)]), new UnionType([new ObjectType('Bar'), new ConstantBooleanType(false)]));
 		$this->scope = $this->scope->assignVariable('stringOrFalse', new UnionType([new StringType(), new ConstantBooleanType(false)]), new UnionType([new StringType(), new ConstantBooleanType(false)]));
@@ -573,16 +574,37 @@ class TypeSpecifierTest extends PHPStanTestCase
 			[
 				new Expr\Isset_([
 					new Variable('stringOrNull'),
+				]),
+				[
+					'$stringOrNull' => '~null',
+				],
+				[
+					'$stringOrNull' => 'null',
+				],
+			],
+			[
+				new Expr\Isset_([
+					new Variable('stringOrNull'),
 					new Variable('barOrNull'),
 				]),
 				[
 					'$stringOrNull' => '~null',
 					'$barOrNull' => '~null',
 				],
+				[],
+			],
+			[
+				new Expr\Isset_([
+					new Variable('stringOrNull'),
+					new Variable('barOrNull'),
+					new Variable('fooOrNull'),
+				]),
 				[
-					'$stringOrNull' => 'null',
-					'$barOrNull' => 'null',
+					'$stringOrNull' => '~null',
+					'$barOrNull' => '~null',
+					'$fooOrNull' => '~null',
 				],
+				[],
 			],
 			[
 				new Expr\BooleanNot(new Expr\Empty_(new Variable('stringOrNull'))),

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -19,7 +19,11 @@ class Foo
 
 		$link_mode = isset($shortcut_id) ? "remove" : "add";
 		if ($link_mode === "add") {
-			assertVariableCertainty(TrinaryLogic::createNo(), $shortcut_id);
+			assertVariableCertainty(
+				// should be NO, see https://github.com/phpstan/phpstan-src/pull/2710#issuecomment-1793677703
+				TrinaryLogic::createMaybe(),
+				$shortcut_id
+			);
 		} else {
 			assertVariableCertainty(TrinaryLogic::createYes(), $shortcut_id);
 		}

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -4,6 +4,7 @@ namespace Bug10088;
 
 use PHPStan\TrinaryLogic;
 use stdClass;
+use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 
 class Foo
@@ -68,6 +69,35 @@ class Foo
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $date);
 		assert(($date ?? null) instanceof stdClass);
 		assertVariableCertainty(TrinaryLogic::createYes(), $date);
+	}
+
+	function constantIfElse(int $x): void {
+		$link_mode = $x > 10 ? "remove" : "add";
+		if ($link_mode === "add") {
+			assertType('int<min, 10>', $x);
+		} else {
+			assertType('int<11, max>', $x);
+		}
+	}
+
+	function constantIfElseShort(int $x): void {
+		$link_mode = $x > 10 ?: "remove";
+		if ($link_mode === "remove") {
+			assertType('int<min, 10>', $x);
+		} else {
+			assertType('int<11, max>', $x);
+		}
+	}
+
+	/**
+	 * @param string[] $arr
+	 * @param 0|positive-int $posInt
+	 */
+	function overlappingIfElseType($arr, int $x, int $posInt): void {
+		$link_mode = $arr ? $posInt : $x;
+		assert($link_mode >= 0);
+
+		assertType('array<string>', $arr);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bug10088;
+
+use PHPStan\TrinaryLogic;
+use stdClass;
+use function PHPStan\Testing\assertVariableCertainty;
+
+class Foo
+{
+
+	function doFoo(): void {
+		if (rand(0,1)) {
+			$shortcut_id = 1;
+			assertVariableCertainty(TrinaryLogic::createYes(), $shortcut_id);
+		}
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $shortcut_id);
+
+		$link_mode = isset($shortcut_id) ? "remove" : "add";
+		if ($link_mode === "add") {
+			assertVariableCertainty(TrinaryLogic::createNo(), $shortcut_id);
+		} else {
+			assertVariableCertainty(TrinaryLogic::createYes(), $shortcut_id);
+		}
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $shortcut_id);
+	}
+
+	/**
+	 * @param mixed[] $period
+	 */
+	public function testCarbon(array $period): void
+	{
+		foreach ($period as $date) {
+			break;
+		}
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $date);
+		$this->assertInstanceOfStdClass($date ?? null);
+		assertVariableCertainty(TrinaryLogic::createYes(), $date);
+	}
+
+	/**
+	 * @param mixed $m
+	 * @phpstan-assert stdClass $m
+	 */
+	private function assertInstanceOfStdClass($m): void
+	{
+		if (!$m instanceof stdClass) {
+			throw new \Exception();
+		}
+	}
+
+	/**
+	 * @param mixed[] $period
+	 */
+	public function testCarbon2(array $period): void
+	{
+		foreach ($period as $date) {
+			break;
+		}
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $date);
+		assert(($date ?? null) instanceof stdClass);
+		assertVariableCertainty(TrinaryLogic::createYes(), $date);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -66,20 +66,4 @@ class Foo
 		assertVariableCertainty(TrinaryLogic::createYes(), $date);
 	}
 
-	function testDrupal():void {
-		assertVariableCertainty(TrinaryLogic::createNo(), $book_links);
-		if (isset($x)) {
-			$book_links = 1;
-			assertVariableCertainty(TrinaryLogic::createYes(), $book_links);
-		}
-
-		assertVariableCertainty(TrinaryLogic::createMaybe(), $book_links);
-		if (isset($book_links)) {
-			assertVariableCertainty(TrinaryLogic::createYes(), $book_links);
-			var_dump($book_links);
-		}
-		assertVariableCertainty(TrinaryLogic::createMaybe(), $book_links);
-	}
-
-
 }

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -89,6 +89,28 @@ class Foo
 		}
 	}
 
+	function nonEmptyArray(array $arr): void {
+		$link_mode = $arr ? "truethy-arr" : "falsey-arr";
+		if ($link_mode === "truethy-arr") {
+			assertType('non-empty-array', $arr);
+		} else {
+			assertType('array{}', $arr);
+		}
+	}
+
+	/**
+	 * @param array $arr
+	 * @param 0|positive-int $intRange
+	 */
+	function nonEmptyArrayViaInt(array $arr, $intRange): void {
+		$link_mode = $arr ? $intRange : -10;
+		if ($link_mode >= 0) {
+			assertType('non-empty-array', $arr);
+		} else {
+			assertType('array{}', $arr);
+		}
+	}
+
 	/**
 	 * @param string[] $arr
 	 * @param 0|positive-int $posInt

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -73,29 +73,37 @@ class Foo
 
 	function constantIfElse(int $x): void {
 		$link_mode = $x > 10 ? "remove" : "add";
+
+		assertType('int', $x);
 		if ($link_mode === "add") {
 			assertType('int<min, 10>', $x);
 		} else {
 			assertType('int<11, max>', $x);
 		}
+		assertType('int', $x);
 	}
 
 	function constantIfElseShort(int $x): void {
 		$link_mode = $x > 10 ?: "remove";
+
+		assertType('int', $x);
 		if ($link_mode === "remove") {
 			assertType('int<min, 10>', $x);
 		} else {
 			assertType('int<11, max>', $x);
 		}
+		assertType('int', $x);
 	}
 
 	function nonEmptyArray(array $arr): void {
 		$link_mode = $arr ? "truethy-arr" : "falsey-arr";
+		assertType('array', $arr);
 		if ($link_mode === "truethy-arr") {
 			assertType('non-empty-array', $arr);
 		} else {
 			assertType('array{}', $arr);
 		}
+		assertType('array', $arr);
 	}
 
 	/**
@@ -104,11 +112,13 @@ class Foo
 	 */
 	function nonEmptyArrayViaInt(array $arr, $intRange): void {
 		$link_mode = $arr ? $intRange : -10;
+		assertType('array', $arr);
 		if ($link_mode >= 0) {
 			assertType('non-empty-array', $arr);
 		} else {
 			assertType('array{}', $arr);
 		}
+		assertType('array', $arr);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-10088.php
+++ b/tests/PHPStan/Analyser/data/bug-10088.php
@@ -66,4 +66,20 @@ class Foo
 		assertVariableCertainty(TrinaryLogic::createYes(), $date);
 	}
 
+	function testDrupal():void {
+		assertVariableCertainty(TrinaryLogic::createNo(), $book_links);
+		if (isset($x)) {
+			$book_links = 1;
+			assertVariableCertainty(TrinaryLogic::createYes(), $book_links);
+		}
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $book_links);
+		if (isset($book_links)) {
+			assertVariableCertainty(TrinaryLogic::createYes(), $book_links);
+			var_dump($book_links);
+		}
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $book_links);
+	}
+
+
 }

--- a/tests/PHPStan/Analyser/data/bug-4733.php
+++ b/tests/PHPStan/Analyser/data/bug-4733.php
@@ -23,6 +23,23 @@ class HelloWorld
 		assertType('string', $someObject);
 	}
 
+	public function getDescriptionn(?\DateTimeImmutable $start, ?string $someObject): void
+	{
+		if ($start !== null && $someObject !== null) {
+			return;
+		}
+
+		// $start === null || $someObject === null
+
+		if ($start === null) {
+			return;
+		}
+
+		// $start !== null therefore $someObject === null
+
+		assertType('null', $someObject);
+	}
+
 	public function getDescription2(?\DateTimeImmutable $start, ?string $someObject): void
 	{
 		if ($start !== null || $someObject !== null) {

--- a/tests/PHPStan/Analyser/data/bug-7291.php
+++ b/tests/PHPStan/Analyser/data/bug-7291.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Bug7291;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+class HelloWorld
+{
+	public function doFoo(): void
+	{
+		if (rand(0, 1)) {
+			$a = rand(0, 1) ? new \stdClass() : null;
+		}
+
+		assertType('stdClass|null', $a);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+
+		echo $a?->foo;
+
+		assertType('stdClass|null', $a);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-8366.php
+++ b/tests/PHPStan/Analyser/data/bug-8366.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Bug8366;
+
+use function PHPStan\Testing\assertType;
+
+function validateParams(
+	?\DateTimeImmutable $datePeriod,
+	?\DateTimeImmutable $untilDate,
+	?int $count
+): void {
+
+	if (isset($untilDate, $count)) {
+		assertType('DateTimeImmutable', $untilDate);
+		assertType('int', $count);
+
+		throw new \InvalidArgumentException('Too much params, choose between until and count.');
+	}
+	assertType('DateTimeImmutable|null', $untilDate);
+	assertType('int|null', $count);
+
+	if ($untilDate !== null && $datePeriod > $untilDate) {
+		assertType('DateTimeImmutable', $untilDate);
+		assertType('int|null', $count);
+		throw new \InvalidArgumentException('End date must not be greater than until date.');
+	}
+
+	if ($count !== null && $count < 1) {
+		assertType('DateTimeImmutable|null', $untilDate);
+		assertType('int<min, 0>', $count);
+		throw new \InvalidArgumentException('Count must be positive.');
+	}
+
+	assertType('DateTimeImmutable|null', $untilDate);
+	assertType('int<1, max>|null', $count);
+}

--- a/tests/PHPStan/Analyser/data/bug-8366.php
+++ b/tests/PHPStan/Analyser/data/bug-8366.php
@@ -21,12 +21,12 @@ function validateParams(
 
 	if ($untilDate !== null && $datePeriod > $untilDate) {
 		assertType('DateTimeImmutable', $untilDate);
-		assertType('int|null', $count);
+		assertType('null', $count);
 		throw new \InvalidArgumentException('End date must not be greater than until date.');
 	}
 
 	if ($count !== null && $count < 1) {
-		assertType('DateTimeImmutable|null', $untilDate);
+		assertType('null', $untilDate);
 		assertType('int<min, 0>', $count);
 		throw new \InvalidArgumentException('Count must be positive.');
 	}

--- a/tests/PHPStan/Analyser/data/bug-9753.php
+++ b/tests/PHPStan/Analyser/data/bug-9753.php
@@ -17,8 +17,8 @@ function (): void {
 				$items[] = $entry;
 			}
 		}
-		assertType('list<1|2|3|4|5>|null', $items);
+		assertType('non-empty-list<1|2|3|4|5>|null', $items);
 	}
 
-	assertType('list<1|2|3|4|5>|null', $items);
+	assertType('non-empty-list<1|2|3|4|5>|null', $items);
 };

--- a/tests/PHPStan/Analyser/data/conditional-vars.php
+++ b/tests/PHPStan/Analyser/data/conditional-vars.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace ConditionalVars;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/** @param array<mixed> $innerHits */
+	public function conditionalVarInTernary(array $innerHits): void
+	{
+		if (array_key_exists('nearest_premise', $innerHits) || array_key_exists('matching_premises', $innerHits)) {
+			assertType('array', $innerHits);
+			$x = array_key_exists('nearest_premise', $innerHits)
+				? assertType("array&hasOffset('nearest_premise')", $innerHits)
+				: assertType('array', $innerHits);
+
+			assertType('array', $innerHits);
+		}
+	}
+
+	/** @param array<mixed> $innerHits */
+	public function conditionalVarInIf(array $innerHits): void
+	{
+		if (array_key_exists('nearest_premise', $innerHits) || array_key_exists('matching_premises', $innerHits)) {
+			assertType('array', $innerHits);
+			if (array_key_exists('nearest_premise', $innerHits)) {
+				assertType("array&hasOffset('nearest_premise')", $innerHits);
+			} else {
+				assertType('array', $innerHits);
+			}
+
+			assertType('array', $innerHits);
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/data/falsey-coalesce.php
+++ b/tests/PHPStan/Analyser/data/falsey-coalesce.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace FalseyCoalesce;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+
+interface TipPluginInterface
+{
+
+	/**
+	 * Used for returning values by key.
+	 *
+	 * @return string
+	 *   Value of the key.
+	 * @var string
+	 *   Key of the value.
+	 *
+	 */
+	public function get($key);
+
+}
+
+abstract class TipPluginBase implements TipPluginInterface
+{
+
+	public function getLocation(): void
+	{
+		$location = $this->get('position');
+		assertVariableCertainty(TrinaryLogic::createYes(), $location);
+
+			$location ?? '';
+		assertVariableCertainty(TrinaryLogic::createYes(), $location);
+	}
+
+}
+

--- a/tests/PHPStan/Analyser/data/falsey-coalesce.php
+++ b/tests/PHPStan/Analyser/data/falsey-coalesce.php
@@ -3,6 +3,7 @@
 namespace FalseyCoalesce;
 
 use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 
 interface TipPluginInterface
@@ -35,3 +36,92 @@ abstract class TipPluginBase implements TipPluginInterface
 
 }
 
+function maybeTrueVarAssign():void {
+	if (rand(0,1)) {
+		$a = true;
+	}
+	$x = $a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $x);
+	assertType('1|true', $x);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	assertType('true', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}
+
+function nullableVarAssign():void {
+	if (rand(0,1)) {
+		$a = true;
+	} else {
+		$a = null;
+	}
+	$x = $a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $x);
+	assertType('1|true', $x);
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	assertType('true|null', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}
+
+function maybeNullableVarAssign():void {
+	if (rand(0,1)) {
+		$a = null;
+	}
+	$x = $a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $x);
+	assertType('1', $x);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	assertType('null', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}
+
+function notExistsAssign():void {
+	$x = $a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $x);
+	assertType('1', $x);
+	assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	assertType('*ERROR*', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}
+
+function nullableVarExpr():void {
+	if (rand(0,1)) {
+		$a = true;
+	} else {
+		$a = null;
+	}
+	$a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	assertType('true|null', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}
+
+function maybeNullableVarExpr():void {
+	if (rand(0,1)) {
+		$a = null;
+	}
+	$a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	assertType('null', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}
+
+function notExistsExpr():void {
+	$a ?? ($y=1) ?? 1;
+
+	assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	assertType('*ERROR*', $a);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $y);
+	assertType('1', $y);
+}

--- a/tests/PHPStan/Analyser/data/falsey-empty-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-empty-certainty.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace FalseyEmptyCertainty;
+
+use function PHPStan\Testing\assertVariableCertainty;
+use PHPStan\TrinaryLogic;
+
+function falseyEmptyArrayDimFetch(): void
+{
+	if (rand() % 2) {
+		$a = ['bar' => null];
+		if (rand() % 3) {
+			$a = ['bar' => 'hello'];
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (empty($a['bar'])) {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyEmptyUncertainPropertyFetch(): void
+{
+	if (rand() % 2) {
+		$a = new \stdClass();
+		if (rand() % 3) {
+			$a->x = 'hello';
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (empty($a->x)) {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function justEmpty(): void
+{
+	assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	if (!empty($foo)) {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+}
+
+function maybeEmpty(): void
+{
+	if (rand() % 2) {
+		$foo = 1;
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	if (!empty($foo)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+}

--- a/tests/PHPStan/Analyser/data/falsey-empty-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-empty-certainty.php
@@ -85,3 +85,14 @@ function maybeEmptyUnset(): void
 	}
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
 }
+
+
+function parseVariableSymbolFromXmlNode(SimpleXMLElement $transactionXmlElement): string
+{
+	if (
+		!empty($transactionXmlElement->invoice_number)
+		&& preg_match('~^\d+/\d+\-0*(\d+)$~', (string) $transactionXmlElement->invoice_number, $matches) === 1
+	) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $matches);
+	}
+}

--- a/tests/PHPStan/Analyser/data/falsey-empty-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-empty-certainty.php
@@ -66,4 +66,22 @@ function maybeEmpty(): void
 	} else {
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
 	}
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+}
+
+function maybeEmptyUnset(): void
+{
+	if (rand() % 2) {
+		$foo = 1;
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	if (!empty($foo)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+		unset($foo);
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	}
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
 }

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -111,7 +111,7 @@ function falseyIssetVariable(): void
 	if (isset($a)) {
 		assertVariableCertainty(TrinaryLogic::createYes(), $a);
 	} else {
-		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+		assertVariableCertainty(TrinaryLogic::createNo(), $a);
 	}
 
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace FalseyIssetCertainty;
+
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+use PHPStan\TrinaryLogic;
+
+
+function falseyIssetArrayDimFetchOnProperty(): void
+{
+	$a = new \stdClass();
+	$a->bar = null;
+	if (rand() % 3) {
+		$a->bar = 'hello';
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	if (isset($a->bar)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function falseyIssetUncertainArrayDimFetchOnProperty(): void
+{
+	if (rand() % 2) {
+		$a = new \stdClass();
+		$a->bar = null;
+		$a = ['bar' => null];
+		if (rand() % 3) {
+			$a->bar = 'hello';
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a->bar)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyIssetUncertainPropertyFetch(): void
+{
+	if (rand() % 2) {
+		$a = new \stdClass();
+		if (rand() % 3) {
+			$a->x = 'hello';
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a->x)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyIssetArrayDimFetch(): void
+{
+	$a = ['bar' => null];
+	if (rand() % 3) {
+		$a = ['bar' => 'hello'];
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	if (isset($a['bar'])) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function falseyIssetUncertainArrayDimFetch(): void
+{
+	if (rand() % 2) {
+		$a = ['bar' => null];
+		if (rand() % 3) {
+			$a = ['bar' => 'hello'];
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a['bar'])) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyIssetVariable(): void
+{
+	if (rand() % 2) {
+		$a = 'bar';
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyIssetWithAssignment(): void
+{
+	if (rand() % 2) {
+		$x = ['x' => 1];
+	}
+
+	if (isset($x[$z = getFoo()])) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $z);
+		assertVariableCertainty(TrinaryLogic::createYes(), $x);
+
+	} else {
+		assertVariableCertainty(TrinaryLogic::createYes(), $z);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $x);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $z);
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $x);
+}
+
+function justIsset(): void
+{
+	if (isset($foo)) {
+		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+	}
+}
+
+function maybeIsset(): void
+{
+	if (rand() % 2) {
+		$foo = 1;
+	}
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $foo);
+	if (isset($foo)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $foo);
+		assertType('1', $foo);
+	}
+}
+
+function isStringNarrowsMaybeCertainty(int $i, string $s): void
+{
+	if (rand(0, 1)) {
+		$a = rand(0,1) ? $i : $s;
+	}
+
+	if (is_string($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+		echo $a;
+	}
+}

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -2,7 +2,6 @@
 
 namespace FalseyIssetCertainty;
 
-use function PHPStan\dumpType;
 use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 use PHPStan\TrinaryLogic;
@@ -119,6 +118,37 @@ function falseyIssetVariable(): void
 	}
 
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function nullableVariable(): void
+{
+	$a = 'bar';
+	if (rand() % 2) {
+		$a = null;
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function nonNullableVariable(): void
+{
+	$a = 'bar';
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
 }
 
 function falseyIssetNullableVariable(): void

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -174,6 +174,7 @@ function falseySubtractedMixedIssetVariable(): void
 
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
 }
+
 function falseyIssetWithAssignment(): void
 {
 	if (rand() % 2) {

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -6,6 +6,9 @@ use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 use PHPStan\TrinaryLogic;
 
+function doFoo():mixed {
+	return 1;
+}
 
 function falseyIssetArrayDimFetchOnProperty(): void
 {
@@ -112,6 +115,22 @@ function falseyIssetVariable(): void
 		assertVariableCertainty(TrinaryLogic::createYes(), $a);
 	} else {
 		assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyMixedIssetVariable(): void
+{
+	if (rand() % 2) {
+		$a = getFoo();
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
 	}
 
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -270,3 +270,13 @@ function isStringNarrowsMaybeCertainty(int $i, string $s): void
 		echo $a;
 	}
 }
+
+function parseVariableSymbolFromXmlNode(SimpleXMLElement $transactionXmlElement): string
+{
+	if (
+		isset($transactionXmlElement->invoice_number)
+		&& preg_match('~^\d+/\d+\-0*(\d+)$~', (string) $transactionXmlElement->invoice_number, $matches) === 1
+	) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $matches);
+	}
+}

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -2,11 +2,12 @@
 
 namespace FalseyIssetCertainty;
 
+use function PHPStan\dumpType;
 use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 use PHPStan\TrinaryLogic;
 
-function doFoo():mixed {
+function getFoo():mixed {
 	return 1;
 }
 
@@ -120,6 +121,25 @@ function falseyIssetVariable(): void
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
 }
 
+function falseyIssetNullableVariable(): void
+{
+	if (rand() % 2) {
+		$a = 'bar';
+		if (rand() % 3) {
+			$a = null;
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
 function falseyMixedIssetVariable(): void
 {
 	if (rand() % 2) {
@@ -136,6 +156,24 @@ function falseyMixedIssetVariable(): void
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
 }
 
+function falseySubtractedMixedIssetVariable(): void
+{
+	if (rand() % 2) {
+		$a = getFoo();
+		if ($a === null) {
+			return;
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
 function falseyIssetWithAssignment(): void
 {
 	if (rand() % 2) {

--- a/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-isset-certainty.php
@@ -151,6 +151,22 @@ function nonNullableVariable(): void
 	assertVariableCertainty(TrinaryLogic::createYes(), $a);
 }
 
+function nonNullableVariableUnset(): void
+{
+	$a = 'bar';
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	if (isset($a)) {
+		assertVariableCertainty(TrinaryLogic::createYes(), $a);
+		unset($a);
+		assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	} else {
+		assertVariableCertainty(TrinaryLogic::createNo(), $a);
+	}
+
+	assertVariableCertainty(TrinaryLogic::createNo(), $a);
+}
+
 function falseyIssetNullableVariable(): void
 {
 	if (rand() % 2) {

--- a/tests/PHPStan/Analyser/data/falsey-ternary-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-ternary-certainty.php
@@ -216,3 +216,11 @@ function falseySubtractedMixedTernaryVariable(): void
 
 	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
 }
+
+function parseVariableSymbolFromXmlNode(SimpleXMLElement $transactionXmlElement): string
+{
+	return isset($transactionXmlElement->invoice_number)
+		&& preg_match('~^\d+/\d+\-0*(\d+)$~', (string) $transactionXmlElement->invoice_number, $matches) === 1
+		? assertVariableCertainty(TrinaryLogic::createYes(), $matches)
+		: '';
+}

--- a/tests/PHPStan/Analyser/data/falsey-ternary-certainty.php
+++ b/tests/PHPStan/Analyser/data/falsey-ternary-certainty.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace FalseyTernaryCertainty;
+
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+use PHPStan\TrinaryLogic;
+
+function getFoo():mixed {
+	return 1;
+}
+
+function falseyTernaryArrayDimFetchOnProperty(): void
+{
+	$a = new \stdClass();
+	$a->bar = null;
+	if (rand() % 3) {
+		$a->bar = 'hello';
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	isset($a->bar)?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function falseyTernaryUncertainArrayDimFetchOnProperty(): void
+{
+	if (rand() % 2) {
+		$a = new \stdClass();
+		$a->bar = null;
+		$a = ['bar' => null];
+		if (rand() % 3) {
+			$a->bar = 'hello';
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a->bar) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyTernaryUncertainPropertyFetch(): void
+{
+	if (rand() % 2) {
+		$a = new \stdClass();
+		if (rand() % 3) {
+			$a->x = 'hello';
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a->x) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyTernaryArrayDimFetch(): void
+{
+	$a = ['bar' => null];
+	if (rand() % 3) {
+		$a = ['bar' => 'hello'];
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	isset($a['bar']) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function falseyTernaryUncertainArrayDimFetch(): void
+{
+	if (rand() % 2) {
+		$a = ['bar' => null];
+		if (rand() % 3) {
+			$a = ['bar' => 'hello'];
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a['bar']) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyTernaryVariable(): void
+{
+	if (rand() % 2) {
+		$a = 'bar';
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createNo(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function nullableVariable(): void
+{
+	$a = 'bar';
+	if (rand() % 2) {
+		$a = null;
+	}
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	isset($a) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function nonNullableVariable(): void
+{
+	$a = 'bar';
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	isset($a) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createNo(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function nonNullableVariableShort(): void
+{
+	$a = 'bar';
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+	isset($a) ?:
+		assertVariableCertainty(TrinaryLogic::createNo(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createYes(), $a);
+}
+
+function falseyTernaryNullableVariable(): void
+{
+	if (rand() % 2) {
+		$a = 'bar';
+		if (rand() % 3) {
+			$a = null;
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseyMixedTernaryVariable(): void
+{
+	if (rand() % 2) {
+		$a = getFoo();
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}
+
+function falseySubtractedMixedTernaryVariable(): void
+{
+	if (rand() % 2) {
+		$a = getFoo();
+		if ($a === null) {
+			return;
+		}
+	}
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+	isset($a) ?
+		assertVariableCertainty(TrinaryLogic::createYes(), $a)
+	:
+		assertVariableCertainty(TrinaryLogic::createNo(), $a)
+	;
+
+	assertVariableCertainty(TrinaryLogic::createMaybe(), $a);
+}

--- a/tests/PHPStan/Analyser/data/falsy-isset.php
+++ b/tests/PHPStan/Analyser/data/falsy-isset.php
@@ -40,6 +40,20 @@ function maybeNullableVariable(): void
 	}
 }
 
+function subtractedMixedIsset(mixed $m): void
+{
+	if ($m === null) {
+		return;
+	}
+
+	assertType("mixed~null", $m);
+	if (isset($m)) {
+		assertType("mixed~null", $m);
+	} else {
+		assertType("*NEVER*", $m);
+	}
+}
+
 function mixedIsset(mixed $m): void
 {
 	if (isset($m)) {

--- a/tests/PHPStan/Analyser/data/falsy-isset.php
+++ b/tests/PHPStan/Analyser/data/falsy-isset.php
@@ -6,6 +6,40 @@ use function PHPStan\Testing\assertType;
 use function PHPStan\Testing\assertVariableCertainty;
 use PHPStan\TrinaryLogic;
 
+function doFoo():mixed {
+	return 1;
+}
+
+function maybeMixedVariable(): void
+{
+	if (rand(0,1)) {
+		$a = doFoo();
+	}
+
+	if (isset($a)) {
+		assertType("mixed~null", $a);
+	} else {
+		assertType("null", $a);
+	}
+}
+
+function maybeNullableVariable(): void
+{
+	if (rand(0,1)) {
+		$a = 'hello';
+
+		if (rand(0,2)) {
+			$a = null;
+		}
+	}
+
+	if (isset($a)) {
+		assertType("'hello'", $a);
+	} else {
+		assertType("null", $a);
+	}
+}
+
 function mixedIsset(mixed $m): void
 {
 	if (isset($m)) {

--- a/tests/PHPStan/Analyser/data/falsy-isset.php
+++ b/tests/PHPStan/Analyser/data/falsy-isset.php
@@ -50,7 +50,7 @@ function subtractedMixedIsset(mixed $m): void
 	if (isset($m)) {
 		assertType("mixed~null", $m);
 	} else {
-		assertType("*NEVER*", $m);
+		assertType("*ERROR*", $m);
 	}
 }
 

--- a/tests/PHPStan/Analyser/data/falsy-isset.php
+++ b/tests/PHPStan/Analyser/data/falsy-isset.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FalsyIsset;
+
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+use PHPStan\TrinaryLogic;
+
+function mixedIsset(mixed $m): void
+{
+	if (isset($m)) {
+		assertType("mixed~null", $m);
+	} else {
+		assertType("null", $m);
+	}
+}
+
+function stdclassIsset(?\stdClass $m): void
+{
+	if (isset($m)) {
+		assertType("stdClass", $m);
+	} else {
+		assertType("null", $m);
+	}
+}
+
+function nullableVariable(?string $a): void
+{
+	if (isset($a)) {
+		assertType("string", $a);
+	} else {
+		assertType("null", $a);
+	}
+}
+
+function nullableUnionVariable(null|string|int $a): void
+{
+	if (isset($a)) {
+		assertType("int|string", $a);
+	} else {
+		assertType("null", $a);
+	}
+}
+

--- a/tests/PHPStan/Analyser/data/falsy-isset.php
+++ b/tests/PHPStan/Analyser/data/falsy-isset.php
@@ -90,3 +90,10 @@ function nullableUnionVariable(null|string|int $a): void
 	}
 }
 
+function render(?int $noteListLimit, int $count): void
+{
+	$showAllLink = $noteListLimit !== null && $count > $noteListLimit;
+	if ($showAllLink) {
+		assertType('int', $noteListLimit);
+	}
+}

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -604,5 +604,20 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			],
 		]);
 	}
+	
+	public function testBug3632(): void
+	{
+		$this->checkAlwaysTrueInstanceOf = true;
+		$this->treatPhpDocTypesAsCertain = true;
+
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/bug-3632.php'], [
+			[
+				'Instanceof between Bug3632\NiceClass and Bug3632\NiceClass will always evaluate to true.',
+				36,
+				$tipText,
+			],
+		]);
+	}
 
 }

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -515,6 +515,10 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 				'Instanceof between UnreachableTernaryElseBranchNotPhpDoc\Foo and UnreachableTernaryElseBranchNotPhpDoc\Foo will always evaluate to true.',
 				17,
 			],
+			[
+				'Instanceof between UnreachableTernaryElseBranchNotPhpDoc\Foo and UnreachableTernaryElseBranchNotPhpDoc\Foo will always evaluate to true.',
+				20,
+			],
 		]);
 	}
 
@@ -540,7 +544,6 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			[
 				'Instanceof between UnreachableTernaryElseBranchNotPhpDoc\Foo and UnreachableTernaryElseBranchNotPhpDoc\Foo will always evaluate to true.',
 				20,
-				$tipText,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -604,7 +604,7 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			],
 		]);
 	}
-	
+
 	public function testBug3632(): void
 	{
 		$this->checkAlwaysTrueInstanceOf = true;

--- a/tests/PHPStan/Rules/Classes/data/bug-3632.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-3632.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Bug3632;
+
+class NiceClass
+{
+
+}
+
+function (): string {
+	$a = null;
+	$b = null;
+
+	if(rand(2,10) == 4) {
+		$a = new NiceClass();
+	}
+
+	if(rand(2,10) == 8) {
+		$b = new NiceClass();
+	}
+
+	if (!$a instanceof NiceClass && !$b instanceof NiceClass) {
+		// none have been set, ignore
+		return null;
+	}
+
+	if ($a instanceof NiceClass && $b instanceof NiceClass) {
+		// both have been set, ignore
+		return null;
+	}
+
+	if ($a instanceof NiceClass && !$b instanceof NiceClass) {
+		return 'A has been added';
+	}
+
+	if (!$a instanceof NiceClass && $b instanceof NiceClass) {
+		return 'A has been removed';
+	}
+
+	return 'Foo';
+};

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1010,4 +1010,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9723b.php'], []);
 	}
 
+	public function testBug8366(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8366.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/UnreachableTernaryElseBranchRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/UnreachableTernaryElseBranchRuleTest.php
@@ -64,6 +64,10 @@ class UnreachableTernaryElseBranchRuleTest extends RuleTestCase
 				'Else branch is unreachable because ternary operator condition is always true.',
 				17,
 			],
+			[
+				'Else branch is unreachable because ternary operator condition is always true.',
+				20,
+			],
 		]);
 	}
 
@@ -88,7 +92,6 @@ class UnreachableTernaryElseBranchRuleTest extends RuleTestCase
 			[
 				'Else branch is unreachable because ternary operator condition is always true.',
 				20,
-				$tipText,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1584,4 +1584,14 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8659(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8659.php'], []);
+	}
+
+	public function testBug9580(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9580.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-8659.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8659.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bug8659;
+
+function acceptsString(string $input): string
+{
+	return $input;
+}
+
+function foo1(?string $bar, ?string $baz): string
+{
+	assert($bar !== null || $baz !== null);
+
+	// In this case, baz cannot be null (because $bar is and assert above makes sure that at least one value is not-null. Yet phpstan fails.
+	return $bar ?? acceptsString($baz);
+}
+
+
+function foo2(?string $bar, ?string $baz): string
+{
+	assert($bar !== null || $baz !== null);
+
+	// In this case, PHPStan can resolve that $baz must be string and is OK.
+	return $bar ?? $baz;
+}
+
+function doBar() {
+	echo foo1(null, 'a');
+	echo foo2(null, 'a');
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-9580.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9580.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bug9580;
+
+
+function test(): int|string|float|null
+{
+	return $_GET['value'];
+}
+
+function onlyNull(null $value): void
+{
+
+}
+
+function doFoo() {
+	$value = test();
+	if (isset($value)) {
+		exit;
+	}
+	onlyNull($value);
+}

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -568,4 +568,10 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8190(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-8190.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-8190.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8190.php
@@ -1,0 +1,57 @@
+<?php // lint >= 7.4
+
+namespace Bug8190;
+
+/**
+ * @phpstan-type OwnerBackup array{name: string, isTest?: bool}
+ */
+class ClassA
+{
+	/** @var OwnerBackup */
+	public array $ownerBackup;
+
+	/**
+	 * @param OwnerBackup|null $ownerBackup
+	 */
+	public function __construct(?array $ownerBackup)
+	{
+		$this->ownerBackup = $ownerBackup ?? [
+			'name' => 'Deleted',
+		];
+	}
+
+
+	/**
+	 * @param OwnerBackup|null $ownerBackup
+	 */
+	public function setOwnerBackup(?array $ownerBackup): void
+	{
+		$this->ownerBackup = $ownerBackup ?: [
+			'name' => 'Deleted',
+		];
+	}
+
+	/**
+	 * @param OwnerBackup|null $ownerBackup
+	 */
+	public function setOwnerBackupWorksForSomeReason(?array $ownerBackup): void
+	{
+		$this->ownerBackup = $ownerBackup !== null ? $ownerBackup : [
+			'name' => 'Deleted',
+		];
+	}
+
+	/**
+	 * @param OwnerBackup|null $ownerBackup
+	 */
+	public function setOwnerBackupAlsoWorksForSomeReason(?array $ownerBackup): void
+	{
+		if ($ownerBackup) {
+			$this->ownerBackup = $ownerBackup;
+		} else {
+			$this->ownerBackup = [
+				'name' => 'Deleted',
+			];
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -103,6 +103,10 @@ class DefinedVariableRuleTest extends RuleTestCase
 				145,
 			],
 			[
+				'Undefined variable: $negatedVariableInEmpty',
+				152,
+			],
+			[
 				'Undefined variable: $variableInEmpty',
 				155,
 			],
@@ -1000,6 +1004,24 @@ class DefinedVariableRuleTest extends RuleTestCase
 		$this->checkMaybeUndefinedVariables = true;
 		$this->polluteScopeWithAlwaysIterableForeach = true;
 		$this->analyse([__DIR__ . '/data/bug-5266.php'], []);
+	}
+
+	public function testIsStringNarrowsCertainty(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = true;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/isstring-certainty.php'], [
+			[
+				'Variable $a might not be defined.',
+				11,
+			],
+			[
+				'Undefined variable: $a',
+				19,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -458,4 +458,21 @@ class IssetRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10151.php'], []);
 	}
 
+	public function testBug3985(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-3985.php'], [
+			[
+				'Variable $foo in isset() is never defined.',
+				13,
+			],
+			[
+				'Variable $foo in isset() is never defined.',
+				21,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -475,4 +475,12 @@ class IssetRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10064(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->strictUnnecessaryNullsafePropertyFetch = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10064.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-10064.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-10064.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10064;
+
+class HelloWorld
+{
+	public function sayHello(int $check): bool
+	{
+		$a = random_int(0, 10) > 5 ? 42: null;  // a possibly null var
+		$b = random_int(0, 10) > 6 ? 47: null;  // a possibly null var
+		if (isset($a, $b)) {
+			return $check > $a && $check < $b;
+		}
+		if (isset($a)) {
+			return $check > $a;
+		}
+		if (isset($b)) {
+			return $check < $b;
+		}
+
+		return false;
+	}
+}

--- a/tests/PHPStan/Rules/Variables/data/isstring-certainty.php
+++ b/tests/PHPStan/Rules/Variables/data/isstring-certainty.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace IsStringCertainty;
+
+function maybeDefinedVariable(int $i, string $s): void
+{
+	if (rand(0, 1)) {
+		$a = rand(0,1) ? $i : $s;
+	}
+
+	if (is_string($a)) {
+		echo $a; // we don't want an error here
+	}
+}
+
+
+function isStringNoCertainty(): void
+{
+	if (is_string($a)) {
+		echo $a; // we don't want an error here
+	}
+}


### PR DESCRIPTION
Another split out of https://github.com/phpstan/phpstan-src/pull/2657

implements the 

> Because for $foo with certainty maybe and not-nullable, the only !isset($foo) is that the variable does not exist, so the certainty needs to be no.

part of https://github.com/phpstan/phpstan-src/pull/2657#pullrequestreview-1651857463

---

closes https://github.com/phpstan/phpstan/issues/3632
closes https://github.com/phpstan/phpstan/issues/8190
closes https://github.com/phpstan/phpstan/issues/8366
closes https://github.com/phpstan/phpstan/issues/8659
closes https://github.com/phpstan/phpstan/issues/9580
closes https://github.com/phpstan/phpstan/issues/10064
closes https://github.com/phpstan/phpstan/issues/10088

