### PR TITLE
Add `ConstantsInTraitsRule`

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -88,6 +88,7 @@ rules:
 	- PHPStan\Rules\Properties\MissingReadOnlyPropertyAssignRule
 	- PHPStan\Rules\Properties\PropertyAttributesRule
 	- PHPStan\Rules\Properties\ReadOnlyPropertyRule
+	- PHPStan\Rules\Traits\ConstantsInTraitsRule
 	- PHPStan\Rules\Variables\UnsetRule
 	- PHPStan\Rules\Whitespace\FileWhitespaceRule
 

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -232,4 +232,9 @@ class PhpVersion
 		return $this->versionId >= 80300;
 	}
 
+	public function supportsConstantsInTraits(): bool
+	{
+		return $this->versionId >= 80200;
+	}
+
 }

--- a/src/Rules/Traits/ConstantsInTraitsRule.php
+++ b/src/Rules/Traits/ConstantsInTraitsRule.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Traits;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use function array_map;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Stmt\ClassConst>
+ */
+class ConstantsInTraitsRule implements Rule
+{
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return Node\Stmt\ClassConst::class;
+	}
+
+	/**
+	 * @param Node\Stmt\ClassConst $node
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if ($this->phpVersion->supportsConstantsInTraits()) {
+			return [];
+		}
+
+		if (!$scope->isInTrait()) {
+			return [];
+		}
+
+		return array_map(
+			static fn (Node\Const_ $const): RuleError => RuleErrorBuilder::message(sprintf(
+				'Constant %s::%s is declared inside a trait but is only supported on PHP 8.2 and later.',
+				$scope->getTraitReflection()->getDisplayName(),
+				$const->name->toString(),
+			))->identifier('constants.inTraits')->nonIgnorable()->build(),
+			$node->consts,
+		);
+	}
+
+}

--- a/src/Rules/Traits/ConstantsInTraitsRule.php
+++ b/src/Rules/Traits/ConstantsInTraitsRule.php
@@ -44,7 +44,7 @@ class ConstantsInTraitsRule implements Rule
 				'Constant %s::%s is declared inside a trait but is only supported on PHP 8.2 and later.',
 				$scope->getTraitReflection()->getDisplayName(),
 				$const->name->toString(),
-			))->identifier('constants.inTraits')->nonIgnorable()->build(),
+			))->identifier('classConstant.inTrait')->nonIgnorable()->build(),
 			$node->consts,
 		);
 	}

--- a/tests/PHPStan/Rules/Traits/ConstantsInTraitsRuleTest.php
+++ b/tests/PHPStan/Rules/Traits/ConstantsInTraitsRuleTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Traits;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\Traits\TraitConstantsCollector;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ConstantsInTraitsRule>
+ */
+class ConstantsInTraitsRuleTest extends RuleTestCase
+{
+
+	private int $phpVersionId;
+
+	protected function getRule(): Rule
+	{
+		return new ConstantsInTraitsRule(new PhpVersion($this->phpVersionId));
+	}
+
+	public function dataRule(): array
+	{
+		return [
+			[
+				80100,
+				[
+					[
+						'Constant ConstantsInTraits\FooBar::FOO is declared inside a trait but is only supported on PHP 8.2 and later.',
+						7,
+					],
+					[
+						'Constant ConstantsInTraits\FooBar::BAR is declared inside a trait but is only supported on PHP 8.2 and later.',
+						8,
+					],
+					[
+						'Constant ConstantsInTraits\FooBar::QUX is declared inside a trait but is only supported on PHP 8.2 and later.',
+						8,
+					],
+				],
+			],
+			[
+				80200,
+				[],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataRule
+	 *
+	 * @param list<array{0: string, 1: int, 2?: string}> $errors
+	 */
+	public function testRule(int $phpVersionId, array $errors): void
+	{
+		$this->phpVersionId = $phpVersionId;
+		$this->analyse([__DIR__ . '/data/constants-in-traits.php'], $errors);
+	}
+
+}

--- a/tests/PHPStan/Rules/Traits/data/constants-in-traits.php
+++ b/tests/PHPStan/Rules/Traits/data/constants-in-traits.php
@@ -1,0 +1,14 @@
+<?php // lint >= 8.2
+
+namespace ConstantsInTraits;
+
+trait FooBar
+{
+    const FOO = 'foo';
+    public const BAR = 'bar', QUX = 'qux';
+}
+
+class Consumer
+{
+    use FooBar;
+}


### PR DESCRIPTION
This PR adds a rule to flag usage of constants inside traits, which feature is only available on PHP 8.2 and later.

Ref: https://php.watch/versions/8.2/constants-in-traits