### PR TITLE
fix reflection golden test on push

### DIFF
--- a/.github/workflows/reflection-golden-test.yml
+++ b/.github/workflows/reflection-golden-test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: "Checkout base commit"
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.event.push.before }}
+          ref: ${{ github.event.pull_request.base.sha || github.event.before }}
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
I noticed that the reflection golden test passed on [this commit](https://github.com/phpstan/phpstan-src/commit/c86d4af618446d48fee79f035daa6c349ab8f012). It turns out that I had the ref wrong for push - it generated the golden data from the commit itself.