### PR TITLE
Fix parameter names for multi-variant functions

### DIFF
--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -70,6 +70,7 @@ final class ArgumentsNormalizer
 			$scope,
 			$passThruArgs,
 			$calledOnType->getCallableParametersAcceptors($scope),
+			null,
 		);
 
 		return [$parametersAcceptor, new FuncCall(

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1911,7 +1911,7 @@ class MutatingScope implements Scope
 				$this,
 				$node->getArgs(),
 				$functionReflection->getVariants(),
-				$functionReflection->getNamedArgumentsVariant(),
+				$functionReflection->getNamedArgumentsVariants(),
 			);
 			$normalizedNode = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $node);
 			if ($normalizedNode !== null) {
@@ -4865,7 +4865,7 @@ class MutatingScope implements Scope
 			$this,
 			$methodCall->getArgs(),
 			$constructorMethod->getVariants(),
-			$constructorMethod->getNamedArgumentsVariant(),
+			$constructorMethod->getNamedArgumentsVariants(),
 		);
 		$normalizedMethodCall = ArgumentsNormalizer::reorderStaticCallArguments($parametersAcceptor, $methodCall);
 
@@ -4940,7 +4940,7 @@ class MutatingScope implements Scope
 			$this,
 			$methodCall->getArgs(),
 			$constructorMethod->getVariants(),
-			$constructorMethod->getNamedArgumentsVariant(),
+			$constructorMethod->getNamedArgumentsVariants(),
 		);
 
 		if ($this->explicitMixedInUnknownGenericNew) {
@@ -5026,7 +5026,7 @@ class MutatingScope implements Scope
 			$this,
 			$methodCall->getArgs(),
 			$methodReflection->getVariants(),
-			$methodReflection->getNamedArgumentsVariant(),
+			$methodReflection->getNamedArgumentsVariants(),
 		);
 		if ($methodCall instanceof MethodCall) {
 			$normalizedMethodCall = ArgumentsNormalizer::reorderMethodArguments($parametersAcceptor, $methodCall);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1885,6 +1885,7 @@ class MutatingScope implements Scope
 					$this,
 					$node->getArgs(),
 					$calledOnType->getCallableParametersAcceptors($this),
+					null,
 				)->getReturnType();
 			}
 
@@ -1910,6 +1911,7 @@ class MutatingScope implements Scope
 				$this,
 				$node->getArgs(),
 				$functionReflection->getVariants(),
+				$functionReflection->getNamedArgumentsVariant(),
 			);
 			$normalizedNode = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $node);
 			if ($normalizedNode !== null) {
@@ -4863,6 +4865,7 @@ class MutatingScope implements Scope
 			$this,
 			$methodCall->getArgs(),
 			$constructorMethod->getVariants(),
+			$constructorMethod->getNamedArgumentsVariant(),
 		);
 		$normalizedMethodCall = ArgumentsNormalizer::reorderStaticCallArguments($parametersAcceptor, $methodCall);
 
@@ -4937,6 +4940,7 @@ class MutatingScope implements Scope
 			$this,
 			$methodCall->getArgs(),
 			$constructorMethod->getVariants(),
+			$constructorMethod->getNamedArgumentsVariant(),
 		);
 
 		if ($this->explicitMixedInUnknownGenericNew) {
@@ -5022,6 +5026,7 @@ class MutatingScope implements Scope
 			$this,
 			$methodCall->getArgs(),
 			$methodReflection->getVariants(),
+			$methodReflection->getNamedArgumentsVariant(),
 		);
 		if ($methodCall instanceof MethodCall) {
 			$normalizedMethodCall = ArgumentsNormalizer::reorderMethodArguments($parametersAcceptor, $methodCall);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1992,6 +1992,7 @@ class NodeScopeResolver
 						$scope,
 						$expr->getArgs(),
 						$nameType->getCallableParametersAcceptors($scope),
+						null,
 					);
 				}
 
@@ -2018,6 +2019,7 @@ class NodeScopeResolver
 					$scope,
 					$expr->getArgs(),
 					$functionReflection->getVariants(),
+					$functionReflection->getNamedArgumentsVariant(),
 				);
 			}
 
@@ -2215,6 +2217,7 @@ class NodeScopeResolver
 						$scope,
 						$expr->getArgs(),
 						$methodReflection->getVariants(),
+						$methodReflection->getNamedArgumentsVariant(),
 					);
 
 					$methodThrowPoint = $this->getMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
@@ -2326,6 +2329,7 @@ class NodeScopeResolver
 							$scope,
 							$expr->getArgs(),
 							$methodReflection->getVariants(),
+							$methodReflection->getNamedArgumentsVariant(),
 						);
 
 						$methodThrowPoint = $this->getStaticMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
@@ -2714,6 +2718,7 @@ class NodeScopeResolver
 							$scope,
 							$expr->getArgs(),
 							$constructorReflection->getVariants(),
+							$constructorReflection->getNamedArgumentsVariant(),
 						);
 						$constructorThrowPoint = $this->getConstructorThrowPoint($constructorReflection, $parametersAcceptor, $classReflection, $expr, $expr->class, $expr->getArgs(), $scope);
 						if ($constructorThrowPoint !== null) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2019,7 +2019,7 @@ class NodeScopeResolver
 					$scope,
 					$expr->getArgs(),
 					$functionReflection->getVariants(),
-					$functionReflection->getNamedArgumentsVariant(),
+					$functionReflection->getNamedArgumentsVariants(),
 				);
 			}
 
@@ -2217,7 +2217,7 @@ class NodeScopeResolver
 						$scope,
 						$expr->getArgs(),
 						$methodReflection->getVariants(),
-						$methodReflection->getNamedArgumentsVariant(),
+						$methodReflection->getNamedArgumentsVariants(),
 					);
 
 					$methodThrowPoint = $this->getMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
@@ -2329,7 +2329,7 @@ class NodeScopeResolver
 							$scope,
 							$expr->getArgs(),
 							$methodReflection->getVariants(),
-							$methodReflection->getNamedArgumentsVariant(),
+							$methodReflection->getNamedArgumentsVariants(),
 						);
 
 						$methodThrowPoint = $this->getStaticMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
@@ -2718,7 +2718,7 @@ class NodeScopeResolver
 							$scope,
 							$expr->getArgs(),
 							$constructorReflection->getVariants(),
-							$constructorReflection->getNamedArgumentsVariant(),
+							$constructorReflection->getNamedArgumentsVariants(),
 						);
 						$constructorThrowPoint = $this->getConstructorThrowPoint($constructorReflection, $parametersAcceptor, $classReflection, $expr, $expr->class, $expr->getArgs(), $scope);
 						if ($constructorThrowPoint !== null) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -510,7 +510,7 @@ class TypeSpecifier
 					return $extension->specifyTypes($functionReflection, $expr, $scope, $context);
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariant());
 				if (count($expr->getArgs()) > 0) {
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
@@ -550,7 +550,7 @@ class TypeSpecifier
 					}
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariant());
 				if (count($expr->getArgs()) > 0) {
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
@@ -595,7 +595,7 @@ class TypeSpecifier
 					}
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariant());
 				if (count($expr->getArgs()) > 0) {
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -510,7 +510,7 @@ class TypeSpecifier
 					return $extension->specifyTypes($functionReflection, $expr, $scope, $context);
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariant());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariants());
 				if (count($expr->getArgs()) > 0) {
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
@@ -550,7 +550,7 @@ class TypeSpecifier
 					}
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariant());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariants());
 				if (count($expr->getArgs()) > 0) {
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
@@ -595,7 +595,7 @@ class TypeSpecifier
 					}
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariant());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariants());
 				if (count($expr->getArgs()) > 0) {
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {

--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -81,6 +81,11 @@ class AnnotationMethodReflection implements ExtendedMethodReflection
 		return $this->variants;
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Reflection/Dummy/ChangedTypeMethodReflection.php
+++ b/src/Reflection/Dummy/ChangedTypeMethodReflection.php
@@ -60,6 +60,11 @@ class ChangedTypeMethodReflection implements ExtendedMethodReflection
 		return $this->variants;
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return $this->reflection->isDeprecated();

--- a/src/Reflection/Dummy/DummyConstructorReflection.php
+++ b/src/Reflection/Dummy/DummyConstructorReflection.php
@@ -66,6 +66,11 @@ class DummyConstructorReflection implements ExtendedMethodReflection
 		];
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Reflection/Dummy/DummyMethodReflection.php
+++ b/src/Reflection/Dummy/DummyMethodReflection.php
@@ -58,6 +58,11 @@ class DummyMethodReflection implements ExtendedMethodReflection
 		];
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();

--- a/src/Reflection/ExtendedMethodReflection.php
+++ b/src/Reflection/ExtendedMethodReflection.php
@@ -27,6 +27,8 @@ interface ExtendedMethodReflection extends MethodReflection
 	 */
 	public function getVariants(): array;
 
+	public function getNamedArgumentsVariant(): ?ParametersAcceptorWithPhpDocs;
+
 	public function getAsserts(): Assertions;
 
 	public function getSelfOutType(): ?Type;

--- a/src/Reflection/ExtendedMethodReflection.php
+++ b/src/Reflection/ExtendedMethodReflection.php
@@ -27,7 +27,10 @@ interface ExtendedMethodReflection extends MethodReflection
 	 */
 	public function getVariants(): array;
 
-	public function getNamedArgumentsVariant(): ?ParametersAcceptorWithPhpDocs;
+	/**
+	 * @return ParametersAcceptorWithPhpDocs[]|null
+	 */
+	public function getNamedArgumentsVariants(): ?array;
 
 	public function getAsserts(): Assertions;
 

--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -18,6 +18,8 @@ interface FunctionReflection
 	 */
 	public function getVariants(): array;
 
+	public function getNamedArgumentsVariant(): ?ParametersAcceptorWithPhpDocs;
+
 	public function isDeprecated(): TrinaryLogic;
 
 	public function getDeprecatedDescription(): ?string;

--- a/src/Reflection/FunctionReflection.php
+++ b/src/Reflection/FunctionReflection.php
@@ -18,7 +18,10 @@ interface FunctionReflection
 	 */
 	public function getVariants(): array;
 
-	public function getNamedArgumentsVariant(): ?ParametersAcceptorWithPhpDocs;
+	/**
+	 * @return ParametersAcceptorWithPhpDocs[]|null
+	 */
+	public function getNamedArgumentsVariants(): ?array;
 
 	public function isDeprecated(): TrinaryLogic;
 

--- a/src/Reflection/Native/NativeFunctionReflection.php
+++ b/src/Reflection/Native/NativeFunctionReflection.php
@@ -17,10 +17,12 @@ class NativeFunctionReflection implements FunctionReflection
 
 	/**
 	 * @param ParametersAcceptorWithPhpDocs[] $variants
+	 * @param ParametersAcceptorWithPhpDocs[]|null $namedArgumentsVariants
 	 */
 	public function __construct(
 		private string $name,
 		private array $variants,
+		private ?array $namedArgumentsVariants,
 		private ?Type $throwType,
 		private TrinaryLogic $hasSideEffects,
 		private bool $isDeprecated,
@@ -49,6 +51,11 @@ class NativeFunctionReflection implements FunctionReflection
 	public function getVariants(): array
 	{
 		return $this->variants;
+	}
+
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return $this->namedArgumentsVariants;
 	}
 
 	public function getThrowType(): ?Type

--- a/src/Reflection/Native/NativeMethodReflection.php
+++ b/src/Reflection/Native/NativeMethodReflection.php
@@ -21,12 +21,14 @@ class NativeMethodReflection implements ExtendedMethodReflection
 
 	/**
 	 * @param ParametersAcceptorWithPhpDocs[] $variants
+	 * @param ParametersAcceptorWithPhpDocs[]|null $namedArgumentsVariants
 	 */
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
 		private ClassReflection $declaringClass,
 		private BuiltinMethodReflection $reflection,
 		private array $variants,
+		private ?array $namedArgumentsVariants,
 		private TrinaryLogic $hasSideEffects,
 		private ?Type $throwType,
 		private Assertions $assertions,
@@ -100,6 +102,11 @@ class NativeMethodReflection implements ExtendedMethodReflection
 	public function getVariants(): array
 	{
 		return $this->variants;
+	}
+
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return $this->namedArgumentsVariants;
 	}
 
 	public function getDeprecatedDescription(): ?string

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -71,13 +71,13 @@ class ParametersAcceptorSelector
 	/**
 	 * @param Node\Arg[] $args
 	 * @param ParametersAcceptor[] $parametersAcceptors
-	 * @param ParametersAcceptor[]|null $namedArgumentVariants
+	 * @param ParametersAcceptor[]|null $namedArgumentsVariants
 	 */
 	public static function selectFromArgs(
 		Scope $scope,
 		array $args,
 		array $parametersAcceptors,
-		?array $namedArgumentVariants = null,
+		?array $namedArgumentsVariants = null,
 	): ParametersAcceptor
 	{
 		$types = [];

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -76,6 +76,7 @@ class ParametersAcceptorSelector
 		Scope $scope,
 		array $args,
 		array $parametersAcceptors,
+		?ParametersAcceptorWithPhpDocs $namedArgumentsVariant = null,
 	): ParametersAcceptor
 	{
 		$types = [];
@@ -231,15 +232,25 @@ class ParametersAcceptorSelector
 			}
 		}
 
+		$hasName = false;
 		foreach ($args as $i => $arg) {
 			$type = $scope->getType($arg->value);
-			$index = $arg->name !== null ? $arg->name->toString() : $i;
+			if ($arg->name !== null) {
+				$index = $arg->name->toString();
+				$hasName = true;
+			} else {
+				$index = $i;
+			}
 			if ($arg->unpack) {
 				$unpack = true;
 				$types[$index] = $type->getIterableValueType();
 			} else {
 				$types[$index] = $type;
 			}
+		}
+
+		if ($hasName && $namedArgumentsVariant !== null) {
+			return self::selectFromTypes($types, [$namedArgumentsVariant], $unpack);
 		}
 
 		return self::selectFromTypes($types, $parametersAcceptors, $unpack);

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -71,12 +71,13 @@ class ParametersAcceptorSelector
 	/**
 	 * @param Node\Arg[] $args
 	 * @param ParametersAcceptor[] $parametersAcceptors
+	 * @param ParametersAcceptor[]|null $namedArgumentVariants
 	 */
 	public static function selectFromArgs(
 		Scope $scope,
 		array $args,
 		array $parametersAcceptors,
-		?ParametersAcceptorWithPhpDocs $namedArgumentsVariant = null,
+		?array $namedArgumentVariants = null,
 	): ParametersAcceptor
 	{
 		$types = [];
@@ -249,8 +250,8 @@ class ParametersAcceptorSelector
 			}
 		}
 
-		if ($hasName && $namedArgumentsVariant !== null) {
-			return self::selectFromTypes($types, [$namedArgumentsVariant], $unpack);
+		if ($hasName && $namedArgumentsVariants !== null) {
+			return self::selectFromTypes($types, $namedArgumentsVariants, $unpack);
 		}
 
 		return self::selectFromTypes($types, $parametersAcceptors, $unpack);

--- a/src/Reflection/Php/ClosureCallMethodReflection.php
+++ b/src/Reflection/Php/ClosureCallMethodReflection.php
@@ -102,6 +102,11 @@ final class ClosureCallMethodReflection implements ExtendedMethodReflection
 		];
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return $this->nativeMethodReflection->isDeprecated();

--- a/src/Reflection/Php/EnumCasesMethodReflection.php
+++ b/src/Reflection/Php/EnumCasesMethodReflection.php
@@ -75,6 +75,11 @@ class EnumCasesMethodReflection implements ExtendedMethodReflection
 		];
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -111,6 +111,11 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection
 		return $this->variants;
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	/**
 	 * @return ParameterReflectionWithPhpDocs[]
 	 */

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -103,6 +103,11 @@ class PhpFunctionReflection implements FunctionReflection
 		return $this->variants;
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	/**
 	 * @return ParameterReflectionWithPhpDocs[]
 	 */

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -199,6 +199,11 @@ class PhpMethodReflection implements ExtendedMethodReflection
 		return $this->variants;
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	/**
 	 * @return ParameterReflectionWithPhpDocs[]
 	 */

--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -65,7 +65,7 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 			$variantFunctionName = $functionName . '\'' . $i;
 		}
 
-		return $signatures;
+		return ['positional' => $signatures, 'named' => null];
 	}
 
 	private function createSignature(string $functionName, ?string $className, ?ReflectionFunctionAbstract $reflectionFunction): FunctionSignature

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -223,7 +223,6 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 			return ['positional' => [$this->mergeSignatures($nativeSignature, $functionMapSignatures['positional'][0])], 'named' => null];
 		}
 
-
 		if (count($functionMapSignatures['positional']) === 0) {
 			return ['positional' => [], 'named' => null];
 		}
@@ -272,6 +271,10 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 				$functionMapSignature->getNativeReturnType(),
 				$functionMapSignature->isVariadic(),
 			);
+		}
+
+		if (count($namedArgumentsVariants) === 0) {
+			$namedArgumentsVariants = null;
 		}
 
 		return ['positional' => $functionMapSignatures['positional'], 'named' => $namedArgumentsVariants];

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -179,7 +179,7 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 			return $this->getMergedSignatures($signature, $functionMapSignatures);
 		}
 
-		return [$signature];
+		return ['positional' => [$signature], 'named' => null];
 	}
 
 	public function getFunctionSignatures(string $functionName, ?string $className, ReflectionFunctionAbstract|null $reflectionFunction): array
@@ -207,23 +207,24 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 				return $this->getMergedSignatures($signature, $functionMapSignatures);
 			}
 
-			return [$signature];
+			return ['positional' => [$signature], 'named' => null];
 		}
 
 		throw new ShouldNotHappenException(sprintf('Function %s stub not found in %s.', $functionName, $stubFile));
 	}
 
 	/**
-	 * @param array<int, FunctionSignature> $functionMapSignatures
-	 * @return array<int, FunctionSignature>
+	 * @param array{positional: array<int, FunctionSignature>, named: ?array<int, FunctionSignature>} $functionMapSignatures
+	 * @return array{positional: array<int, FunctionSignature>, named: ?array<int, FunctionSignature>}
 	 */
 	private function getMergedSignatures(FunctionSignature $nativeSignature, array $functionMapSignatures): array
 	{
-		if (count($functionMapSignatures) === 1) {
-			return [$this->mergeSignatures($nativeSignature, $functionMapSignatures[0])];
+		if (count($functionMapSignatures['positional']) === 1) {
+			return ['positional' => [$this->mergeSignatures($nativeSignature, $functionMapSignatures['positional'][0])], 'named' => null];
 		}
 
-		return $functionMapSignatures;
+		// TODO: provide named signatures
+		return ['positional' => $functionMapSignatures['positional'], 'named' => null];
 	}
 
 	private function mergeSignatures(FunctionSignature $nativeSignature, FunctionSignature $functionMapSignature): FunctionSignature

--- a/src/Reflection/SignatureMap/SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/SignatureMapProvider.php
@@ -13,10 +13,10 @@ interface SignatureMapProvider
 
 	public function hasFunctionSignature(string $name): bool;
 
-	/** @return array<int, FunctionSignature> */
+	/** @return array{positional: array<int, FunctionSignature>, named: ?array<int, FunctionSignature>} */
 	public function getMethodSignatures(string $className, string $methodName, ?ReflectionMethod $reflectionMethod): array;
 
-	/** @return array<int, FunctionSignature> */
+	/** @return array{positional: array<int, FunctionSignature>, named: ?array<int, FunctionSignature>} */
 	public function getFunctionSignatures(string $functionName, ?string $className, ?ReflectionFunctionAbstract $reflectionFunction): array;
 
 	public function hasMethodMetadata(string $className, string $methodName): bool;

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -95,7 +95,6 @@ class IntersectionTypeMethodReflection implements ExtendedMethodReflection
 
 	public function getNamedArgumentsVariants(): ?array
 	{
-		// TODO: does anything have to be done here?
 		return null;
 	}
 

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -93,6 +93,12 @@ class IntersectionTypeMethodReflection implements ExtendedMethodReflection
 		), $this->methods[0]->getVariants());
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		// TODO: does anything have to be done here?
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::lazyMaxMin($this->methods, static fn (MethodReflection $method): TrinaryLogic => $method->isDeprecated());

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -83,7 +83,6 @@ class UnionTypeMethodReflection implements ExtendedMethodReflection
 
 	public function getNamedArgumentsVariants(): ?array
 	{
-		// TODO: does anything have to be done here?
 		return null;
 	}
 

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -81,6 +81,12 @@ class UnionTypeMethodReflection implements ExtendedMethodReflection
 		return [ParametersAcceptorSelector::combineAcceptors($variants)];
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		// TODO: does anything have to be done here?
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return TrinaryLogic::lazyExtremeIdentity($this->methods, static fn (MethodReflection $method): TrinaryLogic => $method->isDeprecated());

--- a/src/Reflection/WrappedExtendedMethodReflection.php
+++ b/src/Reflection/WrappedExtendedMethodReflection.php
@@ -85,6 +85,11 @@ class WrappedExtendedMethodReflection implements ExtendedMethodReflection
 		return $variants;
 	}
 
+	public function getNamedArgumentsVariants(): ?array
+	{
+		return null;
+	}
+
 	public function isDeprecated(): TrinaryLogic
 	{
 		return $this->method->isDeprecated();

--- a/src/Rules/AttributesCheck.php
+++ b/src/Rules/AttributesCheck.php
@@ -116,7 +116,7 @@ class AttributesCheck
 						$scope,
 						$attribute->args,
 						$attributeConstructor->getVariants(),
-						$attributeConstructor->getNamedArgumentsVariant(),
+						$attributeConstructor->getNamedArgumentsVariants(),
 					),
 					$scope,
 					$attributeConstructor->getDeclaringClass()->isBuiltin(),

--- a/src/Rules/AttributesCheck.php
+++ b/src/Rules/AttributesCheck.php
@@ -116,6 +116,7 @@ class AttributesCheck
 						$scope,
 						$attribute->args,
 						$attributeConstructor->getVariants(),
+						$attributeConstructor->getNamedArgumentsVariant(),
 					),
 					$scope,
 					$attributeConstructor->getDeclaringClass()->isBuiltin(),

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -185,6 +185,7 @@ class InstantiationRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$constructorReflection->getVariants(),
+				$constructorReflection->getNamedArgumentsVariant(),
 			),
 			$scope,
 			$constructorReflection->getDeclaringClass()->isBuiltin(),

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -185,7 +185,7 @@ class InstantiationRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$constructorReflection->getVariants(),
-				$constructorReflection->getNamedArgumentsVariant(),
+				$constructorReflection->getNamedArgumentsVariants(),
 			),
 			$scope,
 			$constructorReflection->getDeclaringClass()->isBuiltin(),

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -371,7 +371,7 @@ class ImpossibleCheckTypeHelper
 		if ($node instanceof FuncCall && $node->name instanceof Node\Name) {
 			if ($this->reflectionProvider->hasFunction($node->name, $scope)) {
 				$functionReflection = $this->reflectionProvider->getFunction($node->name, $scope);
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $functionReflection->getVariants());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariant());
 				$returnType = TypeUtils::resolveLateResolvableTypes($parametersAcceptor->getReturnType());
 
 				return $returnType->isVoid()->yes() ? TypeSpecifierContext::createNull() : TypeSpecifierContext::createTruthy();
@@ -380,7 +380,7 @@ class ImpossibleCheckTypeHelper
 			$methodCalledOnType = $scope->getType($node->var);
 			$methodReflection = $scope->getMethodReflection($methodCalledOnType, $node->name->name);
 			if ($methodReflection !== null) {
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $methodReflection->getVariants());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariant());
 				$returnType = TypeUtils::resolveLateResolvableTypes($parametersAcceptor->getReturnType());
 
 				return $returnType->isVoid()->yes() ? TypeSpecifierContext::createNull() : TypeSpecifierContext::createTruthy();
@@ -394,7 +394,7 @@ class ImpossibleCheckTypeHelper
 
 			$staticMethodReflection = $scope->getMethodReflection($calleeType, $node->name->name);
 			if ($staticMethodReflection !== null) {
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $staticMethodReflection->getVariants());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariant());
 				$returnType = TypeUtils::resolveLateResolvableTypes($parametersAcceptor->getReturnType());
 
 				return $returnType->isVoid()->yes() ? TypeSpecifierContext::createNull() : TypeSpecifierContext::createTruthy();

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -371,7 +371,7 @@ class ImpossibleCheckTypeHelper
 		if ($node instanceof FuncCall && $node->name instanceof Node\Name) {
 			if ($this->reflectionProvider->hasFunction($node->name, $scope)) {
 				$functionReflection = $this->reflectionProvider->getFunction($node->name, $scope);
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariant());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariants());
 				$returnType = TypeUtils::resolveLateResolvableTypes($parametersAcceptor->getReturnType());
 
 				return $returnType->isVoid()->yes() ? TypeSpecifierContext::createNull() : TypeSpecifierContext::createTruthy();
@@ -380,7 +380,7 @@ class ImpossibleCheckTypeHelper
 			$methodCalledOnType = $scope->getType($node->var);
 			$methodReflection = $scope->getMethodReflection($methodCalledOnType, $node->name->name);
 			if ($methodReflection !== null) {
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariant());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariants());
 				$returnType = TypeUtils::resolveLateResolvableTypes($parametersAcceptor->getReturnType());
 
 				return $returnType->isVoid()->yes() ? TypeSpecifierContext::createNull() : TypeSpecifierContext::createTruthy();
@@ -394,7 +394,7 @@ class ImpossibleCheckTypeHelper
 
 			$staticMethodReflection = $scope->getMethodReflection($calleeType, $node->name->name);
 			if ($staticMethodReflection !== null) {
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariant());
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $node->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariants());
 				$returnType = TypeUtils::resolveLateResolvableTypes($parametersAcceptor->getReturnType());
 
 				return $returnType->isVoid()->yes() ? TypeSpecifierContext::createNull() : TypeSpecifierContext::createTruthy();

--- a/src/Rules/Functions/CallCallablesRule.php
+++ b/src/Rules/Functions/CallCallablesRule.php
@@ -96,6 +96,7 @@ class CallCallablesRule implements Rule
 			$scope,
 			$node->getArgs(),
 			$parametersAcceptors,
+			null,
 		);
 
 		if ($type instanceof ClosureType) {

--- a/src/Rules/Functions/CallToFunctionParametersRule.php
+++ b/src/Rules/Functions/CallToFunctionParametersRule.php
@@ -44,7 +44,7 @@ class CallToFunctionParametersRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$function->getVariants(),
-				$function->getNamedArgumentsVariant(),
+				$function->getNamedArgumentsVariants(),
 			),
 			$scope,
 			$function->isBuiltin(),

--- a/src/Rules/Functions/CallToFunctionParametersRule.php
+++ b/src/Rules/Functions/CallToFunctionParametersRule.php
@@ -44,6 +44,7 @@ class CallToFunctionParametersRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$function->getVariants(),
+				$function->getNamedArgumentsVariant(),
 			),
 			$scope,
 			$function->isBuiltin(),

--- a/src/Rules/Methods/CallMethodsRule.php
+++ b/src/Rules/Methods/CallMethodsRule.php
@@ -50,7 +50,7 @@ class CallMethodsRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$methodReflection->getVariants(),
-				$methodReflection->getNamedArgumentsVariant(),
+				$methodReflection->getNamedArgumentsVariants(),
 			),
 			$scope,
 			$declaringClass->isBuiltin(),

--- a/src/Rules/Methods/CallMethodsRule.php
+++ b/src/Rules/Methods/CallMethodsRule.php
@@ -50,6 +50,7 @@ class CallMethodsRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$methodReflection->getVariants(),
+				$methodReflection->getNamedArgumentsVariant(),
 			),
 			$scope,
 			$declaringClass->isBuiltin(),

--- a/src/Rules/Methods/CallStaticMethodsRule.php
+++ b/src/Rules/Methods/CallStaticMethodsRule.php
@@ -58,7 +58,7 @@ class CallStaticMethodsRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$method->getVariants(),
-				$method->getNamedArgumentsVariant(),
+				$method->getNamedArgumentsVariants(),
 			),
 			$scope,
 			$method->getDeclaringClass()->isBuiltin(),

--- a/src/Rules/Methods/CallStaticMethodsRule.php
+++ b/src/Rules/Methods/CallStaticMethodsRule.php
@@ -58,6 +58,7 @@ class CallStaticMethodsRule implements Rule
 				$scope,
 				$node->getArgs(),
 				$method->getVariants(),
+				$method->getNamedArgumentsVariant(),
 			),
 			$scope,
 			$method->getDeclaringClass()->isBuiltin(),

--- a/src/Rules/Methods/MethodCallCheck.php
+++ b/src/Rules/Methods/MethodCallCheck.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\SprintfHelper;
 use PHPStan\Reflection\ExtendedMethodReflection;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;

--- a/src/Rules/Methods/MethodCallCheck.php
+++ b/src/Rules/Methods/MethodCallCheck.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\SprintfHelper;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\RuleError;
@@ -31,7 +32,7 @@ class MethodCallCheck
 	}
 
 	/**
-	 * @return array{RuleError[], MethodReflection|null}
+	 * @return array{RuleError[], ExtendedMethodReflection|null}
 	 */
 	public function check(
 		Scope $scope,

--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\SprintfHelper;
+use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\Native\NativeMethodReflection;
 use PHPStan\Reflection\Php\PhpMethodReflection;
@@ -46,7 +47,7 @@ class StaticMethodCallCheck
 
 	/**
 	 * @param Name|Expr $class
-	 * @return array{RuleError[], MethodReflection|null}
+	 * @return array{RuleError[], ExtendedMethodReflection|null}
 	 */
 	public function check(
 		Scope $scope,

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -139,7 +139,7 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 	{
 		$provider = $this->createProvider();
 		$reflector = self::getContainer()->getByType(Reflector::class);
-		$signatures = $provider->getFunctionSignatures($functionName, null, new ReflectionFunction($reflector->reflectFunction($functionName)));
+		$signatures = $provider->getFunctionSignatures($functionName, null, new ReflectionFunction($reflector->reflectFunction($functionName)))['positional'];
 		$this->assertCount(1, $signatures);
 		$this->assertSignature($parameters, $returnType, $nativeReturnType, $variadic, $signatures[0]);
 	}
@@ -267,7 +267,7 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 	): void
 	{
 		$provider = $this->createProvider();
-		$signatures = $provider->getMethodSignatures($className, $methodName, null);
+		$signatures = $provider->getMethodSignatures($className, $methodName, null)['positional'];
 		$this->assertCount(1, $signatures);
 		$this->assertSignature($parameters, $returnType, $nativeReturnType, $variadic, $signatures[0]);
 	}

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -535,7 +535,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 			}
 
 			try {
-				$signatures = $provider->getFunctionSignatures($functionName, $className, $reflectionFunction);
+				$signatures = $provider->getFunctionSignatures($functionName, $className, $reflectionFunction)['positional'];
 				$count += count($signatures);
 			} catch (ParserException $e) {
 				$this->fail(sprintf('Could not parse %s: %s.', $functionName, $e->getMessage()));

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1450,4 +1450,22 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9803.php'], []);
 	}
 
+	public function testBug9823(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9823.php'], []);
+	}
+
+	public function testNamedParametersForMultiVariantFunctions(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/call-to-function-named-params-multivariant.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1450,6 +1450,50 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9803.php'], []);
 	}
 
+	public function testBug9018(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9018.php'], [
+			[
+				'Unknown parameter $str1 in call to function levenshtein.',
+				13,
+			],
+			[
+				'Unknown parameter $str2 in call to function levenshtein.',
+				13,
+			],
+			[
+				'Missing parameter $string1 (string) in call to function levenshtein.',
+				13,
+			],
+			[
+				'Missing parameter $string2 (string) in call to function levenshtein.',
+				13,
+			],
+		]);
+	}
+
+	public function testBug9399(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9399.php'], []);
+	}
+
+	public function testBug9923(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9923.php'], []);
+	}
+
 	public function testBug9823(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Functions/data/bug-9018.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9018.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace Bug9018;
+
+// This works
+echo levenshtein('test1', 'test2');
+
+// This works but fails analysis
+echo levenshtein(string1: 'test1', string2: 'test2');
+
+// This passes analysis but throws an error
+// Warning: Uncaught Error: Unknown named parameter $str1 in php shell code:1
+echo levenshtein(str1: 'test1', str2: 'test2');

--- a/tests/PHPStan/Rules/Functions/data/bug-9399.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9399.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace Bug9399;
+
+setlocale(category: LC_ALL, locales: 'nl_NL');

--- a/tests/PHPStan/Rules/Functions/data/bug-9823.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9823.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace Bug9823;
+
+$test = getenv(name: 'TEST');

--- a/tests/PHPStan/Rules/Functions/data/bug-9923.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9923.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace Bug9923;
+
+echo join(separator: ' ', array: ['a', 'b', 'c']);
+echo implode(separator: ' ', array: ['a', 'b', 'c']);

--- a/tests/PHPStan/Rules/Functions/data/call-to-function-named-params-multivariant.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-function-named-params-multivariant.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace CallToFunctionNamedParamsMultiVariant;
+
+// docs say that it's not compatible with named params, but it actually works
+setcookie(name: 'aaa', value: 'bbb', expires_or_options: ['httponly' => true]);
+setrawcookie(name: 'aaa1', value: 'bbb', expires_or_options: ['httponly' => true]);
+var_dump(abs(num: 5));
+var_dump(array_rand(array: [5]));
+var_dump(array_rand(array: [5], num: 1));
+var_dump(getenv(name: 'aaa', local_only: true));
+$cal = new \IntlGregorianCalendar();
+var_dump(intlcal_set(calendar: $cal, month: 5, year: 6));
+var_dump(join(separator: 'a', array: []));
+var_dump(join(separator: ['aaa', 'bbb']));
+var_dump(levenshtein(string1: 'aaa', string2: 'bbb', insertion_cost: 1, deletion_cost: 1, replacement_cost: 1));
+var_dump(levenshtein(string1: 'aaa', string2: 'bbb'));
+// Is it possible to call it with multiple named args?
+var_dump(max(value: [5, 6]));
+session_set_cookie_params(lifetime_or_options: []);
+session_set_cookie_params(lifetime_or_options: 1, path: '/');
+session_set_save_handler(open: new class implements \SessionHandlerInterface {
+	public function close(): bool
+	{
+		return true;
+	}
+
+	public function destroy(string $id): bool
+	{
+		return true;
+	}
+
+	public function gc(int $max_lifetime): int|false
+	{
+		return 0;
+	}
+
+	public function open(string $path, string $name): bool
+	{
+		return true;
+	}
+
+	public function read(string $id): string|false
+	{
+		return true;
+	}
+
+	public function write(string $id, string $data): bool
+	{
+		return true;
+	}
+
+}, close: true);
+setlocale(category: 0, locales: 'aaa');
+setlocale(category: 0, locales: []);
+sscanf(string: 'aaa', format: 'aaa');
+$context = fopen('php://input', 'r');
+assert($context !== false);
+stream_context_set_option(context: $context, wrapper_or_options: []);
+stream_context_set_option(context: $context, wrapper_or_options: 'aaa', option_name: "aaa", value: 'aaa');
+var_dump(strtok(string: 'bbb aaa ccc', token: 'a'));
+// docs say it's not compatible with named params, but it actually works
+var_dump(strtok(string: 'a'));
+var_dump(strtr(string: 'aaa', from: 'a', to: 'b'));
+var_dump(strtr(string: 'aaa', from: ['a' => 'b']));

--- a/tests/PHPStan/Rules/Functions/data/call-to-function-named-params-multivariant.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-function-named-params-multivariant.php
@@ -13,6 +13,8 @@ $cal = new \IntlGregorianCalendar();
 var_dump(intlcal_set(calendar: $cal, month: 5, year: 6));
 var_dump(join(separator: 'a', array: []));
 var_dump(join(separator: ['aaa', 'bbb']));
+var_dump(implode(separator: 'a', array: []));
+var_dump(implode(separator: ['aaa', 'bbb']));
 var_dump(levenshtein(string1: 'aaa', string2: 'bbb', insertion_cost: 1, deletion_cost: 1, replacement_cost: 1));
 var_dump(levenshtein(string1: 'aaa', string2: 'bbb'));
 // Is it possible to call it with multiple named args?


### PR DESCRIPTION
This is an attempt to fix parameter names for multi-variant functions (https://github.com/phpstan/phpstan/discussions/9849#discussioncomment-6913474).

As far as I can tell, PHP uses the names from the "main" variant. I'm not sure how to use named and variadic parameters together, so I avoided those.