### PR TITLE
Change iptcparse return type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5629,7 +5629,7 @@ return [
 'InvalidArgumentException::getTraceAsString' => ['string'],
 'ip2long' => ['int|false', 'ip_address'=>'string'],
 'iptcembed' => ['string|bool', 'iptcdata'=>'string', 'jpeg_file_name'=>'string', 'spool='=>'int'],
-'iptcparse' => ['array|false', 'iptcdata'=>'string'],
+'iptcparse' => ['array<string,array<string>>|false', 'iptcdata'=>'string'],
 'is_a' => ['bool', 'object_or_string'=>'object|string', 'class_name'=>'string', 'allow_string='=>'bool'],
 'is_array' => ['bool', 'var'=>'mixed'],
 'is_bool' => ['bool', 'var'=>'mixed'],


### PR DESCRIPTION
`iptcparse` should only return string-indexed arrays with string[]-data associated, if I am reading the correctly: https://github.com/php/php-src/blob/524b13460752fba908f88e3c4428b91fa66c083a/ext/standard/iptc.c#L355-L365.