### PR TITLE
Update array_filter signature in PHP 8.0 to allow null as callback

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -159,6 +159,7 @@ return [
 	],
 	'old' => [
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
+		'array_filter' => ['array', 'input'=>'array', 'callback='=>'callable(mixed,mixed):bool|callable(mixed):bool|null', 'flag='=>'int'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],


### PR DESCRIPTION
The callback parameter of array_filter has been nullable since PHP 8.0 but PHPStan doesn't currently allow it:

https://phpstan.org/r/307000c9-843b-42af-9910-baa02ec72f2f