### PR TITLE
Update array_filter signature in PHP 8.0 to allow null as callback

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -159,7 +159,6 @@ return [
 	],
 	'old' => [
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
-		'array_filter' => ['array', 'input'=>'array', 'callback='=>'callable(mixed,mixed):bool|callable(mixed):bool|null', 'flag='=>'int'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -159,6 +159,7 @@ return [
 	],
 	'old' => [
 		'array_combine' => ['associative-array|false', 'keys'=>'string[]|int[]', 'values'=>'array'],
+		'array_filter' => ['array', 'input'=>'array', 'callback='=>'callable(mixed,mixed):bool|callable(mixed):bool|null', 'flag='=>'int'],
 		'bcdiv' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcmod' => ['?string', 'dividend'=>'string', 'divisor'=>'string', 'scale='=>'int'],
 		'bcpowmod' => ['?string', 'base'=>'string', 'exponent'=>'string', 'modulus'=>'string', 'scale='=>'int'],

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -171,13 +171,16 @@ class ParametersAcceptorSelector
 				$parameters[1] = new NativeParameterReflection(
 					$parameters[1]->getName(),
 					$parameters[1]->isOptional(),
-					new CallableType(
-						$arrayFilterParameters ?? [
-							new DummyParameter('item', $scope->getIterableValueType($scope->getType($args[0]->value)), false, PassedByReference::createNo(), false, null),
-						],
-						new MixedType(),
-						false,
-					),
+					new UnionType([
+						new CallableType(
+							$arrayFilterParameters ?? [
+								new DummyParameter('item', $scope->getIterableValueType($scope->getType($args[0]->value)), false, PassedByReference::createNo(), false, null),
+							],
+							new MixedType(),
+							false,
+						),
+						new NullType(),
+					]),
 					$parameters[1]->passedByReference(),
 					$parameters[1]->isVariadic(),
 					$parameters[1]->getDefaultValue(),

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1239,7 +1239,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9994.php');
 		$this->assertCount(2, $errors);
 		$this->assertSame('Negated boolean expression is always false.', $errors[0]->getMessage());
-		$this->assertSame('Parameter #2 $callback of function array_filter expects callable(1|2|3|null): mixed, false given.', $errors[1]->getMessage());
+		$this->assertSame('Parameter #2 $callback of function array_filter expects (callable(1|2|3|null): mixed)|null, false given.', $errors[1]->getMessage());
 	}
 
 	public function testBug10049(): void

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1549,4 +1549,12 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9793.php'], $errors);
 	}
 
+	public function testCallToArrayFilterWithNullCallback()
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/array_filter_null_callback.php'], []);
+	}
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1549,7 +1549,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9793.php'], $errors);
 	}
 
-	public function testCallToArrayFilterWithNullCallback()
+	public function testCallToArrayFilterWithNullCallback(): void
 	{
 		if (PHP_VERSION_ID < 80000) {
 			$this->markTestSkipped('Test requires PHP 8.0');
@@ -1557,4 +1557,5 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/array_filter_null_callback.php'], []);
 	}
+
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -868,15 +868,15 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = $checkExplicitMixed;
 		$errors = [
 			[
-				'Parameter #2 $callback of function array_filter expects callable(int): mixed, Closure(string): true given.',
+				'Parameter #2 $callback of function array_filter expects (callable(int): mixed)|null, Closure(string): true given.',
 				17,
 			],
 		];
 		if ($checkExplicitMixed) {
 			$errors[] = [
-				'Parameter #2 $callback of function array_filter expects callable(mixed): mixed, Closure(int): true given.',
+				'Parameter #2 $callback of function array_filter expects (callable(mixed): mixed)|null, Closure(int): true given.',
 				20,
-				'Type int of parameter #1 $i of passed callable needs to be same or wider than parameter type mixed of accepting callable.',
+				'Type #1 from the union: Type int of parameter #1 $i of passed callable needs to be same or wider than parameter type mixed of accepting callable.',
 			];
 		}
 		$this->analyse([__DIR__ . '/data/array_filter_callback.php'], $errors);

--- a/tests/PHPStan/Rules/Functions/data/array_filter_null_callback.php
+++ b/tests/PHPStan/Rules/Functions/data/array_filter_null_callback.php
@@ -1,0 +1,3 @@
+<?php
+
+array_filter([], null);


### PR DESCRIPTION
The callback parameter of array_filter has been nullable since PHP 8.0 but PHPStan doesn't currently allow it:

https://phpstan.org/r/307000c9-843b-42af-9910-baa02ec72f2f