### PR TITLE
RuleTestCase: add analyseFileWithErrorsAsComments

### DIFF
--- a/tests/PHPStan/Rules/Cast/InvalidCastRuleTest.php
+++ b/tests/PHPStan/Rules/Cast/InvalidCastRuleTest.php
@@ -21,32 +21,7 @@ class InvalidCastRuleTest extends RuleTestCase
 
 	public function testRule(): void
 	{
-		$this->analyse([__DIR__ . '/data/invalid-cast.php'], [
-			[
-				'Cannot cast stdClass to string.',
-				7,
-			],
-			[
-				'Cannot cast stdClass to int.',
-				23,
-			],
-			[
-				'Cannot cast stdClass to float.',
-				24,
-			],
-			[
-				'Cannot cast object to string.',
-				35,
-			],
-			[
-				'Cannot cast Test\\Foo to string.',
-				41,
-			],
-			[
-				'Cannot cast array|float|int to string.',
-				48,
-			],
-		]);
+		$this->analyseFileWithErrorsAsComments(__DIR__ . '/data/invalid-cast.php');
 	}
 
 	public function testBug5162(): void

--- a/tests/PHPStan/Rules/Cast/data/invalid-cast.php
+++ b/tests/PHPStan/Rules/Cast/data/invalid-cast.php
@@ -4,7 +4,7 @@ function (
 	string $str
 ) {
 	(string) $str;
-	(string) new \stdClass();
+	(string) new \stdClass(); // error: Cannot cast stdClass to string.
 	(string) new \Test\ClassWithToString();
 
 	(object) new \stdClass();
@@ -20,8 +20,8 @@ function (
 	(int) "123"; // ok
 	(int) "blabla";
 
-	(int) new \stdClass();
-	(float) new \stdClass();
+	(int) new \stdClass(); // error: Cannot cast stdClass to int.
+	(float) new \stdClass(); // error: Cannot cast stdClass to float.
 
 	(string) fopen('php://memory', 'r');
 	(int) fopen('php://memory', 'r');
@@ -32,20 +32,20 @@ function (
 ) {
 	/** @var object $object */
 	$object = doFoo();
-	(string) $object;
+	(string) $object; // error: Cannot cast object to string.
 
 	if (method_exists($object, '__toString')) {
 		(string) $object;
 	}
 
-	(string) $foo;
+	(string) $foo; // error: Cannot cast Test\Foo to string.
 	if (method_exists($foo, '__toString')) {
 		(string) $foo;
 	}
 
 	/** @var array|float|int $arrayOrFloatOrInt */
 	$arrayOrFloatOrInt = doFoo();
-	(string) $arrayOrFloatOrInt;
+	(string) $arrayOrFloatOrInt; // error: Cannot cast array|float|int to string.
 };
 
 function (


### PR DESCRIPTION
I'd like to suggest this feature I'm using for about 4-5 years in my projects. E.g. [here](https://github.com/shipmonk-rnd/phpstan-rules/blob/master/tests/RuleTestCase.php#L20).


Benefits:
- **immediately visible where the error is raised** and where not
- **errors float with code**, so you can easily add code in between existing errors without modifying expected errors (currently even a single use statement added breaks everything)

Downsides:
- no support for multiple errors on a single line
- when traits come into play, error lines are not always in ascending order so it mismatches

-------------------

I believe that at least 90% tests could benefit from this. Other can stick with the old approach.