### PR TITLE
add named arguments variants to reflection golden test

### DIFF
--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -229,12 +229,14 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 
 		$nativeParams = $nativeSignature->getParameters();
 		$namedArgumentsVariants = [];
+		$allParamNamesMatchNative = true;
 		foreach ($functionMapSignatures['positional'] as $functionMapSignature) {
 			$isPrevParamVariadic = false;
 			$hasMiddleVariadicParam = false;
 			// avoid weird functions like array_diff_uassoc
 			foreach ($functionMapSignature->getParameters() as $i => $functionParam) {
 				$nativeParam = $nativeParams[$i] ?? null;
+				$allParamNamesMatchNative = $allParamNamesMatchNative && $nativeParam !== null && $functionParam->getName() === $nativeParam->getName();
 				$hasMiddleVariadicParam = $hasMiddleVariadicParam || $isPrevParamVariadic;
 				$isPrevParamVariadic = $functionParam->isVariadic() || (
 					$nativeParam !== null
@@ -273,7 +275,7 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 			);
 		}
 
-		if (count($namedArgumentsVariants) === 0) {
+		if ($allParamNamesMatchNative || count($namedArgumentsVariants) === 0) {
 			$namedArgumentsVariants = null;
 		}
 

--- a/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
@@ -168,7 +168,12 @@ class ReflectionProviderGoldenTest extends PHPStanTestCase
 			$result .= "NOT BUILTIN\n";
 		}
 
-		$result .= self::generateVariantsDescription($functionReflection->getName(), $functionReflection->getVariants());
+		$result .= self::generateVariantsDescription($functionReflection->getName(), $functionReflection->getVariants(), false);
+		$namedArgumentsVariants = $functionReflection->getNamedArgumentsVariants();
+
+		if ($namedArgumentsVariants !== null) {
+			$result .= self::generateVariantsDescription($functionReflection->getName(), $namedArgumentsVariants, true);
+		}
 
 		return $result;
 	}
@@ -309,7 +314,12 @@ class ReflectionProviderGoldenTest extends PHPStanTestCase
 		}
 
 		$result .= 'Visibility: ' . $visibility . "\n";
-		$result .= self::generateVariantsDescription($methodReflection->getName(), $methodReflection->getVariants());
+		$result .= self::generateVariantsDescription($methodReflection->getName(), $methodReflection->getVariants(), false);
+		$namedArgumentsVariants = $methodReflection->getNamedArgumentsVariants();
+
+		if ($namedArgumentsVariants !== null) {
+			$result .= self::generateVariantsDescription($methodReflection->getName(), $namedArgumentsVariants, true);
+		}
 
 		return $result;
 	}
@@ -347,10 +357,13 @@ class ReflectionProviderGoldenTest extends PHPStanTestCase
 	}
 
 	/** @param ParametersAcceptorWithPhpDocs[] $variants */
-	private static function generateVariantsDescription(string $name, array $variants): string
+	private static function generateVariantsDescription(string $name, array $variants, bool $isNamedArguments): string
 	{
 		$variantCount = count($variants);
-		$result = 'Variants: ' . $variantCount . "\n";
+		$result = $isNamedArguments
+			? 'Named arguments variants: '
+			: 'Variants: ';
+		$result .= $variantCount . "\n";
 		$variantIdent = '    ';
 		$verbosityLevel = VerbosityLevel::precise();
 


### PR DESCRIPTION
I'm adding the named arguments variants to the reflection golden test as promised. I added a condition to exclude some cases where the names in the function map are already correct. There are some more duplicates due to the parameter names in the positional variant being fixed later via phpstorm stubs. 

I also found that the phpstorm stubs are sometimes incorrect (at least `XSLTProcessor::setParameter` and `PDOStatement::setFetchMode`). So I'd remove the rename for named params in next PR.