### PR TITLE
Fully qualify the name of the `#[\Override]` attribute in error messages

### DIFF
--- a/src/Rules/Methods/OverridingMethodRule.php
+++ b/src/Rules/Methods/OverridingMethodRule.php
@@ -84,7 +84,7 @@ class OverridingMethodRule implements Rule
 			if ($this->phpVersion->supportsOverrideAttribute() && $this->hasOverrideAttribute($node->getOriginalNode())) {
 				return [
 					RuleErrorBuilder::message(sprintf(
-						'Method %s::%s() has #[Override] attribute but does not override any method.',
+						'Method %s::%s() has #[\Override] attribute but does not override any method.',
 						$method->getDeclaringClass()->getDisplayName(),
 						$method->getName(),
 					))->nonIgnorable()->build(),
@@ -103,7 +103,7 @@ class OverridingMethodRule implements Rule
 			&& !$this->hasOverrideAttribute($node->getOriginalNode())
 		) {
 			$messages[] = RuleErrorBuilder::message(sprintf(
-				'Method %s::%s() overrides method %s::%s() but is missing the #[Override] attribute.',
+				'Method %s::%s() overrides method %s::%s() but is missing the #[\Override] attribute.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
 				$prototype->getDeclaringClass()->getDisplayName($this->genericPrototypeMessage),

--- a/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
@@ -748,7 +748,7 @@ class OverridingMethodRuleTest extends RuleTestCase
 		$this->phpVersionId = PHP_VERSION_ID;
 		$this->analyse([__DIR__ . '/data/override-attribute.php'], [
 			[
-				'Method OverrideAttribute\Bar::test2() has #[Override] attribute but does not override any method.',
+				'Method OverrideAttribute\Bar::test2() has #[\Override] attribute but does not override any method.',
 				24,
 			],
 		]);
@@ -761,7 +761,7 @@ class OverridingMethodRuleTest extends RuleTestCase
 		yield [false, 80300, []];
 		yield [true, 80300, [
 			[
-				'Method CheckMissingOverrideAttr\Bar::doFoo() overrides method CheckMissingOverrideAttr\Foo::doFoo() but is missing the #[Override] attribute.',
+				'Method CheckMissingOverrideAttr\Bar::doFoo() overrides method CheckMissingOverrideAttr\Foo::doFoo() but is missing the #[\Override] attribute.',
 				18,
 			],
 		]];


### PR DESCRIPTION
As previously discussed on https://twitter.com/OndrejMirtes/status/1724492688932688014. Can you point me to the place where I can find the documentation to send a PR?

----------

This makes the attribute definition from the error message copy and paste safe for namespaced classes.

As PHP attributes do not need to be backed by a class, using the non-qualified `#[Override]` variant without a matching `use Override;` appears to look correct at a quick glance, but will not actually do anything useful.