### PR TITLE
fix named arguments for few multi-variant methods

### DIFF
--- a/src/Reflection/Dummy/ChangedTypeMethodReflection.php
+++ b/src/Reflection/Dummy/ChangedTypeMethodReflection.php
@@ -16,8 +16,9 @@ class ChangedTypeMethodReflection implements ExtendedMethodReflection
 
 	/**
 	 * @param ParametersAcceptorWithPhpDocs[] $variants
+	 * @param ParametersAcceptorWithPhpDocs[]|null $namedArgumentsVariants
 	 */
-	public function __construct(private ClassReflection $declaringClass, private ExtendedMethodReflection $reflection, private array $variants)
+	public function __construct(private ClassReflection $declaringClass, private ExtendedMethodReflection $reflection, private array $variants, private ?array $namedArgumentsVariants)
 	{
 	}
 
@@ -63,7 +64,7 @@ class ChangedTypeMethodReflection implements ExtendedMethodReflection
 
 	public function getNamedArgumentsVariants(): ?array
 	{
-		return null;
+		return $this->namedArgumentsVariants;
 	}
 
 	public function isDeprecated(): TrinaryLogic

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -593,6 +593,10 @@ class PhpClassReflectionExtension
 
 								$phpDocParameterNameMapping[$signatureParameters[$paramI]->getName()] = $reflectionParameter->getName();
 							}
+
+							if ($signatureType === 'named') {
+								$phpDocParameterNameMapping = [];
+							}
 						}
 					}
 					$variantsByType[$signatureType][] = $this->createNativeMethodVariant($methodSignature, $stubPhpDocParameterTypes, $stubPhpDocParameterVariadicity, $stubPhpDocReturnType, $phpDocParameterTypes, $phpDocReturnType, $phpDocParameterNameMapping, $stubPhpParameterOutTypes, $phpDocParameterOutTypes);

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -593,13 +593,9 @@ class PhpClassReflectionExtension
 
 								$phpDocParameterNameMapping[$signatureParameters[$paramI]->getName()] = $reflectionParameter->getName();
 							}
-
-							if ($signatureType === 'named') {
-								$phpDocParameterNameMapping = [];
-							}
 						}
 					}
-					$variantsByType[$signatureType][] = $this->createNativeMethodVariant($methodSignature, $stubPhpDocParameterTypes, $stubPhpDocParameterVariadicity, $stubPhpDocReturnType, $phpDocParameterTypes, $phpDocReturnType, $phpDocParameterNameMapping, $stubPhpParameterOutTypes, $phpDocParameterOutTypes);
+					$variantsByType[$signatureType][] = $this->createNativeMethodVariant($methodSignature, $stubPhpDocParameterTypes, $stubPhpDocParameterVariadicity, $stubPhpDocReturnType, $phpDocParameterTypes, $phpDocReturnType, $phpDocParameterNameMapping, $stubPhpParameterOutTypes, $phpDocParameterOutTypes, $signatureType !== 'named');
 				}
 			}
 
@@ -792,6 +788,7 @@ class PhpClassReflectionExtension
 		array $phpDocParameterNameMapping,
 		array $stubPhpDocParameterOutTypes,
 		array $phpDocParameterOutTypes,
+		bool $usePhpDocParameterNames,
 	): FunctionVariantWithPhpDocs
 	{
 		$parameters = [];
@@ -816,7 +813,9 @@ class PhpClassReflectionExtension
 			}
 
 			$parameters[] = new NativeParameterWithPhpDocsReflection(
-				$phpDocParameterName,
+				$usePhpDocParameterNames
+					? $phpDocParameterName
+					: $parameterSignature->getName(),
 				$parameterSignature->isOptional(),
 				$type ?? $parameterSignature->getType(),
 				$phpDocType ?? new MixedType(),

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -255,8 +255,14 @@ class Php8SignatureMapProvider implements SignatureMapProvider
 					continue 2;
 				}
 
+				// it seems that variadic parameters cannot be named in native functions/methods.
+				$nativeParam = $nativeParams[$i];
+				if ($nativeParam->isVariadic()) {
+					break;
+				}
+
 				$parameters[] = new ParameterSignature(
-					$nativeParams[$i]->getName(),
+					$nativeParam->getName(),
 					$functionParam->isOptional(),
 					$functionParam->getType(),
 					$functionParam->getNativeType(),

--- a/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
@@ -82,7 +82,7 @@ class CallbackUnresolvedMethodPrototypeReflection implements UnresolvedMethodPro
 
 	private function transformMethodWithStaticType(ClassReflection $declaringClass, ExtendedMethodReflection $method): ExtendedMethodReflection
 	{
-		$variants = array_map(fn (ParametersAcceptorWithPhpDocs $acceptor): ParametersAcceptorWithPhpDocs => new FunctionVariantWithPhpDocs(
+		$variantFn = fn (ParametersAcceptorWithPhpDocs $acceptor): ParametersAcceptorWithPhpDocs => new FunctionVariantWithPhpDocs(
 			$acceptor->getTemplateTypeMap(),
 			$acceptor->getResolvedTemplateTypeMap(),
 			array_map(
@@ -104,9 +104,14 @@ class CallbackUnresolvedMethodPrototypeReflection implements UnresolvedMethodPro
 			$this->transformStaticType($acceptor->getPhpDocReturnType()),
 			$this->transformStaticType($acceptor->getNativeReturnType()),
 			$acceptor->getCallSiteVarianceMap(),
-		), $method->getVariants());
+		);
+		$variants = array_map($variantFn, $method->getVariants());
+		$namedArgumentVariants = $method->getNamedArgumentsVariants();
+		$namedArgumentVariants = $namedArgumentVariants !== null
+			? array_map($variantFn, $namedArgumentVariants)
+			: null;
 
-		return new ChangedTypeMethodReflection($declaringClass, $method, $variants);
+		return new ChangedTypeMethodReflection($declaringClass, $method, $variants, $namedArgumentVariants);
 	}
 
 	private function transformStaticType(Type $type): Type

--- a/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
@@ -77,7 +77,7 @@ class CalledOnTypeUnresolvedMethodPrototypeReflection implements UnresolvedMetho
 
 	private function transformMethodWithStaticType(ClassReflection $declaringClass, ExtendedMethodReflection $method): ExtendedMethodReflection
 	{
-		$variants = array_map(fn (ParametersAcceptorWithPhpDocs $acceptor): ParametersAcceptorWithPhpDocs => new FunctionVariantWithPhpDocs(
+		$variantFn = fn (ParametersAcceptorWithPhpDocs $acceptor): ParametersAcceptorWithPhpDocs => new FunctionVariantWithPhpDocs(
 			$acceptor->getTemplateTypeMap(),
 			$acceptor->getResolvedTemplateTypeMap(),
 			array_map(
@@ -99,9 +99,14 @@ class CalledOnTypeUnresolvedMethodPrototypeReflection implements UnresolvedMetho
 			$this->transformStaticType($acceptor->getPhpDocReturnType()),
 			$this->transformStaticType($acceptor->getNativeReturnType()),
 			$acceptor->getCallSiteVarianceMap(),
-		), $method->getVariants());
+		);
+		$variants = array_map($variantFn, $method->getVariants());
+		$namedArgumentsVariants = $method->getNamedArgumentsVariants();
+		$namedArgumentsVariants = $namedArgumentsVariants !== null
+			? array_map($variantFn, $namedArgumentsVariants)
+			: null;
 
-		return new ChangedTypeMethodReflection($declaringClass, $method, $variants);
+		return new ChangedTypeMethodReflection($declaringClass, $method, $variants, $namedArgumentsVariants);
 	}
 
 	private function transformStaticType(Type $type): Type

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3079,4 +3079,43 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/return-type-class-constant.php'], []);
 	}
 
+	public function testNamedParametersForMultiVariantFunctions(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/call-methods-named-params-multivariant.php'], [
+			[
+				'Unknown parameter $options in call to method XSLTProcessor::setParameter().',
+				10,
+			],
+			[
+				'Missing parameter $name (array) in call to method XSLTProcessor::setParameter().',
+				10,
+			],
+			[
+				'Unknown parameter $colno in call to method PDO::query().',
+				15,
+			],
+			[
+				'Unknown parameter $className in call to method PDO::query().',
+				17,
+			],
+			[
+				'Unknown parameter $constructorArgs in call to method PDO::query().',
+				17,
+			],
+			[
+				'Unknown parameter $className in call to method PDOStatement::setFetchMode().',
+				22,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/call-methods-named-params-multivariant.php
+++ b/tests/PHPStan/Rules/Methods/data/call-methods-named-params-multivariant.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace CallMethodsNamedParamsMultivariant;
+
+
+$xslt = new \XSLTProcessor();
+$xslt->setParameter(namespace: 'ns', name:'aaa', value: 'bbb');
+$xslt->setParameter(namespace: 'ns', name: ['aaa' => 'bbb']);
+// wrong
+$xslt->setParameter(namespace: 'ns', options: ['aaa' => 'bbb']);
+
+$pdo = new \PDO('123');
+$pdo->query(query: 'SELECT 1', fetchMode: \PDO::FETCH_ASSOC);
+// wrong
+$pdo->query(query: 'SELECT 1', fetchMode: \PDO::FETCH_ASSOC, colno: 1);
+// wrong
+$pdo->query(query: 'SELECT 1', fetchMode: \PDO::FETCH_ASSOC, className: 'Foo', constructorArgs: []);
+
+$stmt = new \PDOStatement();
+$stmt->setFetchMode(mode: 5);
+// wrong
+$stmt->setFetchMode(mode: 5, className: 'aa');


### PR DESCRIPTION
There are a few cases where PHPStorm stubs have the wrong parameter names. So I'd remove the parameter rename for named params. Since named params are only available from PHP 8, we should have the correct names from php-8-stubs.