### PR TITLE
Narrow ReflectionEnum::getBackingType after ReflectionEnum::isBacked

### DIFF
--- a/stubs/ReflectionEnum.stub
+++ b/stubs/ReflectionEnum.stub
@@ -18,4 +18,8 @@ class ReflectionEnum extends ReflectionClass
 	 */
 	public function getCase(string $name): ReflectionEnumUnitCase {}
 
+	/**
+	 * @phpstan-assert-if-true !null $this->getBackingType()
+	 */
+	public function isBacked(): bool {}
 }

--- a/tests/PHPStan/Analyser/data/enum-reflection.php
+++ b/tests/PHPStan/Analyser/data/enum-reflection.php
@@ -5,6 +5,7 @@ namespace EnumReflection;
 use ReflectionEnum;
 use ReflectionEnumBackedCase;
 use ReflectionEnumUnitCase;
+use ReflectionType;
 use function PHPStan\Testing\assertType;
 
 enum Foo: int
@@ -40,4 +41,10 @@ enum Bar
 		assertType(ReflectionEnumUnitCase::class, $r->getCase('FOO'));
 	}
 
+}
+
+$r = new ReflectionEnum(Foo::class);
+assertType(ReflectionType::class . '|null', $r->getBackingType());
+if ($r->isBacked()) {
+	assertType(ReflectionType::class, $r->getBackingType());
 }


### PR DESCRIPTION
Fixes phpstan/phpstan#10167