### PR TITLE
Implement AbstractPrivateMethodRule

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -80,6 +80,7 @@ rules:
 	- PHPStan\Rules\Functions\VariadicParametersDeclarationRule
 	- PHPStan\Rules\Keywords\ContinueBreakInLoopRule
 	- PHPStan\Rules\Methods\AbstractMethodInNonAbstractClassRule
+	- PHPStan\Rules\Methods\AbstractPrivateMethodRule
 	- PHPStan\Rules\Methods\CallMethodsRule
 	- PHPStan\Rules\Methods\CallStaticMethodsRule
 	- PHPStan\Rules\Methods\ConstructorReturnTypeRule

--- a/src/Rules/Methods/AbstractPrivateMethodRule.php
+++ b/src/Rules/Methods/AbstractPrivateMethodRule.php
@@ -48,7 +48,7 @@ class AbstractPrivateMethodRule implements Rule
 				'Private method %s::%s() cannot be abstract.',
 				$method->getDeclaringClass()->getDisplayName(),
 				$method->getName(),
-			))->build(),
+			))->nonIgnorable()->build(),
 		];
 	}
 

--- a/src/Rules/Methods/AbstractPrivateMethodRule.php
+++ b/src/Rules/Methods/AbstractPrivateMethodRule.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function sprintf;
+
+/** @implements Rule<InClassMethodNode> */
+class AbstractPrivateMethodRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return InClassMethodNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$method = $node->getMethodReflection();
+
+		if (!$method->isPrivate()) {
+			return [];
+		}
+
+		if (!$method->isAbstract()->yes()) {
+			return [];
+		}
+
+		$classReflection = $scope->getClassReflection();
+		if ($classReflection === null || !$classReflection->isAbstract()) {
+			return [];
+		}
+
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Private method %s::%s() cannot be abstract.',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName(),
+			))->build(),
+		];
+	}
+
+}

--- a/src/Rules/Methods/AbstractPrivateMethodRule.php
+++ b/src/Rules/Methods/AbstractPrivateMethodRule.php
@@ -30,8 +30,16 @@ class AbstractPrivateMethodRule implements Rule
 			return [];
 		}
 
+		if ($scope->isInTrait()) {
+			return [];
+		}
+
 		$classReflection = $scope->getClassReflection();
-		if ($classReflection === null || !$classReflection->isAbstract()) {
+		if ($classReflection === null) {
+			return [];
+		}
+
+		if (!$classReflection->isAbstract() && !$classReflection->isInterface()) {
 			return [];
 		}
 

--- a/tests/PHPStan/Rules/Methods/AbstractPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/AbstractPrivateMethodRuleTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<AbstractPrivateMethodRule> */
+class AbstractPrivateMethodRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new AbstractPrivateMethodRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/abstract-private-method.php'], [
+			[
+				'Private method PrivateAbstractMethod\HelloWorld::sayPrivate() cannot be abstract.',
+				12,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/AbstractPrivateMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/AbstractPrivateMethodRuleTest.php
@@ -21,6 +21,10 @@ class AbstractPrivateMethodRuleTest extends RuleTestCase
 				'Private method PrivateAbstractMethod\HelloWorld::sayPrivate() cannot be abstract.',
 				12,
 			],
+			[
+				'Private method PrivateAbstractMethod\fooInterface::sayPrivate() cannot be abstract.',
+				24,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/data/abstract-private-method.php
+++ b/tests/PHPStan/Rules/Methods/data/abstract-private-method.php
@@ -13,3 +13,15 @@ abstract class HelloWorld
 	abstract protected function sayProtected() : void;
 	abstract public function sayPublic() : void;
 }
+
+trait fooTrait{
+	abstract private function sayPrivate() : void;
+	abstract protected function sayProtected() : void;
+	abstract public function sayPublic() : void;
+}
+
+interface fooInterface {
+	abstract private function sayPrivate() : void;
+	abstract protected function sayProtected() : void;
+	abstract public function sayPublic() : void;
+}

--- a/tests/PHPStan/Rules/Methods/data/abstract-private-method.php
+++ b/tests/PHPStan/Rules/Methods/data/abstract-private-method.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PrivateAbstractMethod;
+
+abstract class HelloWorld
+{
+	public function doFoo(): void  {
+		$this->sayHello();
+		$this->sayWorld();
+	}
+
+	abstract private function sayPrivate() : void;
+	abstract protected function sayProtected() : void;
+	abstract public function sayPublic() : void;
+}


### PR DESCRIPTION
Abstract function cannot be declared private

https://3v4l.org/9V2aN#veol

----

as a followup I would do similar stuff for interfaces: https://3v4l.org/3VBl2