### PR TITLE
Introduce InvalidLexicalVariablesInClosureUseRule

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -73,6 +73,7 @@ rules:
 	- PHPStan\Rules\Functions\ExistingClassesInTypehintsRule
 	- PHPStan\Rules\Functions\FunctionAttributesRule
 	- PHPStan\Rules\Functions\InnerFunctionRule
+	- PHPStan\Rules\Functions\InvalidLexicalVariablesInClosureUseRule
 	- PHPStan\Rules\Functions\ParamAttributesRule
 	- PHPStan\Rules\Functions\PrintfParametersRule
 	- PHPStan\Rules\Functions\RedefinedParametersRule

--- a/src/Rules/Functions/InvalidLexicalVariablesInClosureUseRule.php
+++ b/src/Rules/Functions/InvalidLexicalVariablesInClosureUseRule.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function array_filter;
+use function array_map;
+use function in_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\Closure>
+ */
+class InvalidLexicalVariablesInClosureUseRule implements Rule
+{
+
+	private const SUPERGLOBAL_NAMES = [
+		'_COOKIE',
+		'_ENV',
+		'_FILES',
+		'_GET',
+		'_POST',
+		'_REQUEST',
+		'_SERVER',
+		'_SESSION',
+		'GLOBALS',
+	];
+
+	public function getNodeType(): string
+	{
+		return Node\Expr\Closure::class;
+	}
+
+	/**
+	 * @param Node\Expr\Closure $node
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$errors = [];
+		$params = array_filter(array_map(
+			static function (Node\Param $param) {
+				if (!$param->var instanceof Node\Expr\Variable) {
+					return false;
+				}
+
+				if (!is_string($param->var->name)) {
+					return false;
+				}
+
+				return $param->var->name;
+			},
+			$node->getParams(),
+		));
+
+		foreach ($node->uses as $use) {
+			if (!is_string($use->var->name)) {
+				continue;
+			}
+
+			$var = $use->var->name;
+
+			if ($var === 'this') {
+				$errors[] = RuleErrorBuilder::message('Cannot use $this as lexical variable.')
+					->line($use->getLine())
+					->nonIgnorable()
+					->build();
+				continue;
+			}
+
+			if (in_array($var, self::SUPERGLOBAL_NAMES, true)) {
+				$errors[] = RuleErrorBuilder::message(sprintf('Cannot use superglobal variable $%s as lexical variable.', $var))
+					->line($use->getLine())
+					->nonIgnorable()
+					->build();
+				continue;
+			}
+
+			if (!in_array($var, $params, true)) {
+				continue;
+			}
+
+			$errors[] = RuleErrorBuilder::message(sprintf('Cannot use lexical variable $%s since a parameter with the same name already exists.', $var))
+				->line($use->getLine())
+				->nonIgnorable()
+				->build();
+		}
+
+		return $errors;
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/InvalidLexicalVariablesInClosureUseRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/InvalidLexicalVariablesInClosureUseRuleTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<InvalidLexicalVariablesInClosureUseRule>
+ */
+class InvalidLexicalVariablesInClosureUseRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new InvalidLexicalVariablesInClosureUseRule();
+	}
+
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/invalid-lexical-variables-in-closure-use.php'], [
+			[
+				'Cannot use $this as lexical variable.',
+				25,
+			],
+			[
+				'Cannot use superglobal variable $GLOBALS as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_COOKIE as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_ENV as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_FILES as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_GET as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_POST as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_REQUEST as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_SERVER as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use superglobal variable $_SESSION as lexical variable.',
+				35,
+			],
+			[
+				'Cannot use lexical variable $baz since a parameter with the same name already exists.',
+				55,
+			],
+			[
+				'Cannot use $this as lexical variable.',
+				68,
+			],
+			[
+				'Cannot use superglobal variable $GLOBALS as lexical variable.',
+				81,
+			],
+			[
+				'Cannot use superglobal variable $_COOKIE as lexical variable.',
+				82,
+			],
+			[
+				'Cannot use superglobal variable $_ENV as lexical variable.',
+				83,
+			],
+			[
+				'Cannot use superglobal variable $_FILES as lexical variable.',
+				84,
+			],
+			[
+				'Cannot use superglobal variable $_GET as lexical variable.',
+				85,
+			],
+			[
+				'Cannot use superglobal variable $_POST as lexical variable.',
+				86,
+			],
+			[
+				'Cannot use superglobal variable $_REQUEST as lexical variable.',
+				87,
+			],
+			[
+				'Cannot use superglobal variable $_SERVER as lexical variable.',
+				88,
+			],
+			[
+				'Cannot use superglobal variable $_SESSION as lexical variable.',
+				89,
+			],
+			[
+				'Cannot use lexical variable $baz since a parameter with the same name already exists.',
+				111,
+			],
+			[
+				'Cannot use lexical variable $bar since a parameter with the same name already exists.',
+				112,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/invalid-lexical-variables-in-closure-use.php
+++ b/tests/PHPStan/Rules/Functions/data/invalid-lexical-variables-in-closure-use.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types = 1);
+
+namespace InvalidLexicalVariablesInClosureUse;
+
+class HelloWorld
+{
+
+    /**
+     * @return \Closure(): string
+     */
+    public function foo(): \Closure
+    {
+        $message = 'hello';
+
+        return function () use ($message): string {
+            return $message;
+        };
+    }
+
+    /**
+     * @return \Closure(): string
+     */
+    public function this(): \Closure
+    {
+        return function () use ($this): string {
+            return ($this->foo())();
+        };
+    }
+
+    /**
+     * @return \Closure(): array<string, string>
+     */
+    public function superglobals(): \Closure
+    {
+        return function () use ($GLOBALS, $_COOKIE, $_ENV, $_FILES, $_GET, $_POST, $_REQUEST, $_SERVER, $_SESSION): array {
+            return array_merge(
+                $GLOBALS,
+                $_COOKIE,
+                $_ENV,
+                $_FILES,
+                $_GET,
+                $_POST,
+                $_REQUEST,
+                $_SERVER,
+                $_SESSION,
+            );
+        };
+    }
+
+    /**
+     * @return \Closure(int, string, bool): bool
+     */
+    public function sameAsParameter(): \Closure
+    {
+        return function (int $foo, string $bar, bool $baz) use ($baz): bool {
+            return $baz;
+        };
+    }
+
+    /**
+     * @return \Closure(): string
+     */
+    public function multilineThis(): \Closure
+    {
+        $message = 'hello';
+
+        return function () use (
+            $this,
+            $message
+        ): string {
+            return ($this->foo())() . $message;
+        };
+    }
+
+    /**
+     * @return \Closure(): array<string, string>
+     */
+    public function multilineSuperglobals(): \Closure
+    {
+        return function () use (
+            $GLOBALS,
+            $_COOKIE,
+            $_ENV,
+            $_FILES,
+            $_GET,
+            $_POST,
+            $_REQUEST,
+            $_SERVER,
+            $_SESSION
+        ): array {
+            return array_merge(
+                $GLOBALS,
+                $_COOKIE,
+                $_ENV,
+                $_FILES,
+                $_GET,
+                $_POST,
+                $_REQUEST,
+                $_SERVER,
+                $_SESSION,
+            );
+        };
+    }
+
+    /**
+     * @return \Closure(int, string, bool): bool
+     */
+    public function multilineSameAsParameter(): \Closure
+    {
+        return function (int $foo, string $bar, bool $baz) use (
+            $baz,
+            $bar,
+        ): bool {
+            return (bool) ($baz . $bar);
+        };
+    }
+
+}


### PR DESCRIPTION
Detect uses of `$this`, superglobals, and same name with parameters for variables used in `use` of closures.

Closes https://github.com/phpstan/phpstan/issues/1855