### PR TITLE
VarTagTypeRuleHelper: fix widening list<array{id: int}> to mixed[]

### DIFF
--- a/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
@@ -154,7 +154,7 @@ class VarTagTypeRuleHelper
 		return $this->checkType($type, $varTagType);
 	}
 
-	private function checkType(Type $type, Type $varTagType): bool
+	private function checkType(Type $type, Type $varTagType, int $depth = 0): bool
 	{
 		if ($type->isConstantArray()->yes()) {
 			if ($type->isIterableAtLeastOnce()->no()) {
@@ -175,10 +175,10 @@ class VarTagTypeRuleHelper
 				return !$innerType->isSuperTypeOf($innerVarTagType)->yes();
 			}
 
-			return $this->checkType($innerType, $innerVarTagType);
+			return $this->checkType($innerType, $innerVarTagType, $depth + 1);
 		}
 
-		if ($type->isConstantValue()->yes()) {
+		if ($type->isConstantValue()->yes() && $depth === 0) {
 			return $type->isSuperTypeOf($varTagType)->no();
 		}
 

--- a/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
@@ -63,6 +63,10 @@ class VarTagChangedExpressionTypeRuleTest extends RuleTestCase
 				'PHPDoc tag @var with type array is not subtype of type array{id: int}.',
 				20,
 			],
+			[
+				'PHPDoc tag @var with type array is not subtype of type list<array{id: int}>.',
+				23,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-10130.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-10130.php
@@ -2,13 +2,13 @@
 
 class Ipsum
 {
-
 	/**
 	 * @param array<int> $map
 	 * @param list<int> $list
 	 * @param array{id: int} $shape
+	 * @param list<array{id: int}> $listOfShapes
 	 */
-	public function doFoo($map, $list, $shape): void
+	public function doFoo($map, $list, $shape, $listOfShapes): void
 	{
 		/** @var mixed[] $map */
 		if ($map) {}
@@ -18,6 +18,9 @@ class Ipsum
 
 		/** @var mixed[] $shape */
 		if ($shape) {}
+
+		/** @var mixed[] $listOfShapes */
+		if ($listOfShapes) {}
 	}
 
 }


### PR DESCRIPTION
Missing case of https://github.com/phpstan/phpstan/issues/10130