### PR TITLE
Fix #10176 - Optional 4th parameter for Redis::restore

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -9631,7 +9631,7 @@ return [
 'Redis::renameNx' => ['__benevolent<Redis|bool>', 'old_name'=>'string', 'new_name'=>'string'],
 'Redis::reset' => ['__benevolent<Redis|bool>'],
 'Redis::resetStat' => ['bool'],
-'Redis::restore' => ['__benevolent<Redis|bool>', 'key'=>'string', 'ttl'=>'int', 'value'=>'string', 'options'=>'?array{ABSTTL?:bool,REPLACE?:bool,IDLETIME?:int,FREQ?:int}'],
+'Redis::restore' => ['__benevolent<Redis|bool>', 'key'=>'string', 'ttl'=>'int', 'value'=>'string', 'options='=>'?array{ABSTTL?:bool,REPLACE?:bool,IDLETIME?:int,FREQ?:int}'],
 'Redis::role' => ['mixed'],
 'Redis::rPop' => ['__benevolent<Redis|array<string, mixed>|string|bool>', 'key'=>'string', 'count='=>'int'],
 'Redis::rpoplpush' => ['__benevolent<Redis|string|false>', 'srckey'=>'string', 'dstkey'=>'string'],


### PR DESCRIPTION
This PR fixes the 4th parameter of the Redis::restore method to be optional.

See issue [#10176](https://github.com/phpstan/phpstan/issues/10176)