### PR TITLE
Fix for bug #9654: Unsafe use of new static when trait enforces constructor via abstract method

### DIFF
--- a/src/Rules/Classes/NewStaticRule.php
+++ b/src/Rules/Classes/NewStaticRule.php
@@ -74,6 +74,19 @@ class NewStaticRule implements Rule
 			}
 		}
 
+		if ($scope->isInTrait()) {
+			$traitReflection = $scope->getTraitReflection();
+			if ($traitReflection->hasConstructor()) {
+				$traitConstructor = $traitReflection->getConstructor();
+
+				if ($traitConstructor instanceof PhpMethodReflection) {
+					if ($traitConstructor->isAbstract()) {
+						return [];
+					}
+				}
+			}
+		}
+
 		return $messages;
 	}
 

--- a/tests/PHPStan/Rules/Classes/NewStaticRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/NewStaticRuleTest.php
@@ -39,4 +39,9 @@ class NewStaticRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/new-static-consistent-constructor.php'], []);
 	}
 
+	public function testBug9654(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9654.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-9654.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-9654.php
@@ -1,0 +1,33 @@
+<?php // lint >= 8.0
+
+namespace Bug9654;
+// https://github.com/phpstan/phpstan/issues/9654
+
+trait Abc
+{
+	abstract public function __construct();
+
+	public static function create(): static
+	{
+		return new static();  // this is safe as the constructor is defined abstract in this trait
+	}
+}
+
+class Foo
+{
+	use Abc;
+
+	public function __construct() {
+
+	}
+}
+
+class Bar
+{
+	use Abc;
+
+	public function __construct(int $i = 0)
+	{
+		$i = $i*2;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/9654
