### PR TITLE
Use dedicated Type methods over isSuperTypeOf()

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1504,7 +1504,7 @@ class MutatingScope implements Scope
 
 				$filteringExprType = $matchScope->getType($filteringExpr);
 
-				if (!(new ConstantBooleanType(false))->isSuperTypeOf($filteringExprType)->yes()) {
+				if (!$filteringExprType->isFalse()->yes()) {
 					$truthyScope = $matchScope->filterByTruthyValue($filteringExpr);
 					$types[] = $truthyScope->getType($arm->body);
 				}
@@ -2433,7 +2433,7 @@ class MutatingScope implements Scope
 			new Arg(new String_(ltrim($className, '\\'))),
 		]);
 
-		return (new ConstantBooleanType(true))->isSuperTypeOf($this->getType($expr))->yes();
+		return $this->getType($expr)->isTrue()->yes();
 	}
 
 	/** @api */
@@ -2443,7 +2443,7 @@ class MutatingScope implements Scope
 			new Arg(new String_(ltrim($functionName, '\\'))),
 		]);
 
-		return (new ConstantBooleanType(true))->isSuperTypeOf($this->getType($expr))->yes();
+		return $this->getType($expr)->isTrue()->yes();
 	}
 
 	/** @api */
@@ -2993,7 +2993,7 @@ class MutatingScope implements Scope
 			&& $expr->name->toLowerString() === 'function_exists'
 			&& isset($expr->getArgs()[0])
 			&& count($this->getType($expr->getArgs()[0]->value)->getConstantStrings()) === 1
-			&& (new ConstantBooleanType(true))->isSuperTypeOf($type)->yes();
+			&& $type->isTrue()->yes();
 	}
 
 	/**

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -729,8 +729,8 @@ class MutatingScope implements Scope
 
 		if ($node instanceof Expr\Empty_) {
 			$result = $this->issetCheck($node->expr, static function (Type $type): ?bool {
-				$isNull = (new NullType())->isSuperTypeOf($type);
-				$isFalsey = (new ConstantBooleanType(false))->isSuperTypeOf($type->toBoolean());
+				$isNull = $type->isNull();
+				$isFalsey = $type->toBoolean()->isFalse();
 				if ($isNull->maybe()) {
 					return null;
 				}
@@ -1519,7 +1519,7 @@ class MutatingScope implements Scope
 			$issetResult = true;
 			foreach ($node->vars as $var) {
 				$result = $this->issetCheck($var, static function (Type $type): ?bool {
-					$isNull = (new NullType())->isSuperTypeOf($type);
+					$isNull = $type->isNull();
 					if ($isNull->maybe()) {
 						return null;
 					}
@@ -1552,7 +1552,7 @@ class MutatingScope implements Scope
 			$leftType = $this->getType($node->left);
 
 			$result = $this->issetCheck($node->left, static function (Type $type): ?bool {
-				$isNull = (new NullType())->isSuperTypeOf($type);
+				$isNull = $type->isNull();
 				if ($isNull->maybe()) {
 					return null;
 				}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -779,7 +779,7 @@ class TypeSpecifier
 		} elseif (
 			$expr instanceof Expr\BinaryOp\Coalesce
 			&& $context->true()
-			&& ((new ConstantBooleanType(false))->isSuperTypeOf($scope->getType($expr->right))->yes())
+			&& $scope->getType($expr->right)->isFalse()->yes()
 		) {
 			return $this->create(
 				$expr->left,
@@ -801,7 +801,7 @@ class TypeSpecifier
 		} elseif (
 			$expr instanceof Expr\Ternary
 			&& !$context->null()
-			&& ((new ConstantBooleanType(false))->isSuperTypeOf($scope->getType($expr->else))->yes())
+			&& $scope->getType($expr->else)->isFalse()->yes()
 		) {
 			$conditionExpr = $expr->cond;
 			if ($expr->if !== null) {

--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Properties\PropertyDescriptor;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 use function is_string;
@@ -44,11 +45,14 @@ class IssetCheck
 						return null;
 					}
 
-					return $this->generateError(
-						$this->treatPhpDocTypesAsCertain ? $scope->getType($expr) : $scope->getNativeType($expr),
-						sprintf('Variable $%s %s always exists and', $expr->name, $operatorDescription),
-						$typeMessageCallback,
-					);
+					$type = $this->treatPhpDocTypesAsCertain ? $scope->getType($expr) : $scope->getNativeType($expr);
+					if (!$type instanceof NeverType) {
+						return $this->generateError(
+							$type,
+							sprintf('Variable $%s %s always exists and', $expr->name, $operatorDescription),
+							$typeMessageCallback,
+						);
+					}
 				}
 
 				return RuleErrorBuilder::message(sprintf('Variable $%s %s is never defined.', $expr->name, $operatorDescription))->build();

--- a/src/Rules/Variables/EmptyRule.php
+++ b/src/Rules/Variables/EmptyRule.php
@@ -6,8 +6,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IssetCheck;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 
 /**
@@ -28,8 +26,8 @@ class EmptyRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$error = $this->issetCheck->check($node->expr, $scope, 'in empty()', static function (Type $type): ?string {
-			$isNull = (new NullType())->isSuperTypeOf($type);
-			$isFalsey = (new ConstantBooleanType(false))->isSuperTypeOf($type->toBoolean());
+			$isNull = $type->isNull();
+			$isFalsey = $type->toBoolean()->isFalse();
 			if ($isNull->maybe()) {
 				return null;
 			}

--- a/src/Rules/Variables/EmptyRule.php
+++ b/src/Rules/Variables/EmptyRule.php
@@ -27,10 +27,10 @@ class EmptyRule implements Rule
 	{
 		$error = $this->issetCheck->check($node->expr, $scope, 'in empty()', static function (Type $type): ?string {
 			$isNull = $type->isNull();
-			$isFalsey = $type->toBoolean()->isFalse();
 			if ($isNull->maybe()) {
 				return null;
 			}
+			$isFalsey = $type->toBoolean()->isFalse();
 			if ($isFalsey->maybe()) {
 				return null;
 			}

--- a/src/Rules/Variables/IssetRule.php
+++ b/src/Rules/Variables/IssetRule.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IssetCheck;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 
 /**
@@ -29,7 +28,7 @@ class IssetRule implements Rule
 		$messages = [];
 		foreach ($node->vars as $var) {
 			$error = $this->issetCheck->check($var, $scope, 'in isset()', static function (Type $type): ?string {
-				$isNull = (new NullType())->isSuperTypeOf($type);
+				$isNull = $type->isNull();
 				if ($isNull->maybe()) {
 					return null;
 				}

--- a/src/Rules/Variables/NullCoalesceRule.php
+++ b/src/Rules/Variables/NullCoalesceRule.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IssetCheck;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 
 /**
@@ -27,7 +26,7 @@ class NullCoalesceRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$typeMessageCallback = static function (Type $type): ?string {
-			$isNull = (new NullType())->isSuperTypeOf($type);
+			$isNull = $type->isNull();
 			if ($isNull->maybe()) {
 				return null;
 			}

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -18,7 +18,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -147,7 +146,7 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 
 	private function getOffsetOrProperty(Type $type, Type $offsetOrProperty, Scope $scope, bool $allowMaybe): ?Type
 	{
-		$offsetIsNull = (new NullType())->isSuperTypeOf($offsetOrProperty);
+		$offsetIsNull = $offsetOrProperty->isNull();
 		if ($offsetIsNull->yes()) {
 			return $type;
 		}

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -38,7 +37,7 @@ class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 
 		$singleArrayArgument = !isset($functionCall->getArgs()[2]);
 		$callableType = $scope->getType($functionCall->getArgs()[0]->value);
-		$callableIsNull = (new NullType())->isSuperTypeOf($callableType)->yes();
+		$callableIsNull = $callableType->isNull()->yes();
 
 		if ($callableType->isCallable()->yes()) {
 			$valueType = new NeverType();

--- a/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
@@ -37,8 +37,8 @@ class Base64DecodeDynamicFunctionReturnTypeExtension implements DynamicFunctionR
 			return new BenevolentUnionType([new StringType(), new ConstantBooleanType(false)]);
 		}
 
-		$isTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($argType);
-		$isFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($argType);
+		$isTrueType = $argType->isTrue();
+		$isFalseType = $argType->isFalse();
 		$compareTypes = $isTrueType->compareTo($isFalseType);
 		if ($compareTypes === $isTrueType) {
 			return new UnionType([new StringType(), new ConstantBooleanType(false)]);

--- a/src/Type/Php/GettimeofdayDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GettimeofdayDynamicFunctionReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\FloatType;
@@ -44,8 +43,8 @@ class GettimeofdayDynamicFunctionReturnTypeExtension implements DynamicFunctionR
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
-		$isTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($argType);
-		$isFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($argType);
+		$isTrueType = $argType->isTrue();
+		$isFalseType = $argType->isFalse();
 		$compareTypes = $isTrueType->compareTo($isFalseType);
 		if ($compareTypes === $isTrueType) {
 			return $floatType;

--- a/src/Type/Php/HrtimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/HrtimeFunctionReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\FloatType;
@@ -35,8 +34,8 @@ class HrtimeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
-		$isTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($argType);
-		$isFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($argType);
+		$isTrueType = $argType->isTrue();
+		$isFalseType = $argType->isFalse();
 		$compareTypes = $isTrueType->compareTo($isFalseType);
 		if ($compareTypes === $isTrueType) {
 			return $numberType;

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -11,7 +11,6 @@ use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
@@ -41,7 +40,7 @@ class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
 		$argsCount = count($node->getArgs());
 		if ($argsCount >= 3) {
 			$strictNodeType = $scope->getType($node->getArgs()[2]->value);
-			$isStrictComparison = (new ConstantBooleanType(true))->isSuperTypeOf($strictNodeType)->yes();
+			$isStrictComparison = $strictNodeType->isTrue()->yes();
 		}
 
 		if ($argsCount < 2) {

--- a/src/Type/Php/MbSubstituteCharacterDynamicReturnTypeExtension.php
+++ b/src/Type/Php/MbSubstituteCharacterDynamicReturnTypeExtension.php
@@ -12,9 +12,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
-use PHPStan\Type\IntegerType;
 use PHPStan\Type\NeverType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function in_array;
@@ -57,8 +55,8 @@ class MbSubstituteCharacterDynamicReturnTypeExtension implements DynamicFunction
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
 		$isString = $argType->isString();
-		$isNull = (new NullType())->isSuperTypeOf($argType);
-		$isInteger = (new IntegerType())->isSuperTypeOf($argType);
+		$isNull = $argType->isNull();
+		$isInteger = $argType->isInteger();
 
 		if ($isString->no() && $isNull->no() && $isInteger->no()) {
 			if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {

--- a/src/Type/Php/MicrotimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MicrotimeFunctionReturnTypeExtension.php
@@ -6,7 +6,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BenevolentUnionType;
-use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\MixedType;
@@ -30,8 +29,8 @@ class MicrotimeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
-		$isTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($argType);
-		$isFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($argType);
+		$isTrueType = $argType->isTrue();
+		$isFalseType = $argType->isFalse();
 		$compareTypes = $isTrueType->compareTo($isFalseType);
 		if ($compareTypes === $isTrueType) {
 			return new FloatType();

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -281,7 +281,7 @@ class IssetRuleTest extends RuleTestCase
 				116,
 			],
 			[
-				'Variable $variableInSecondCase in isset() always exists and is always null.',
+				'Variable $variableInSecondCase in isset() always exists and is not nullable.',
 				117,
 			],
 			[

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -281,7 +281,7 @@ class IssetRuleTest extends RuleTestCase
 				116,
 			],
 			[
-				'Variable $variableInSecondCase in isset() always exists and is not nullable.',
+				'Variable $variableInSecondCase in isset() is never defined.',
 				117,
 			],
 			[


### PR DESCRIPTION
while reviewing https://github.com/phpstan/phpstan-src/pull/2710 I noticed that we can simplify stuff by using dedicated Type methods