### PR TITLE
Reject extra keys in ConstantArrayType::acceptsWithReason

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -309,19 +309,18 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		$result = AcceptsResult::createYes();
 		foreach ($this->keyTypes as $i => $keyType) {
 			$valueType = $this->valueTypes[$i];
-			$hasOffsetValueType = $type->hasOffsetValueType($keyType);
-			$hasOffset = new AcceptsResult(
-				$hasOffsetValueType,
-				$hasOffsetValueType->yes() || !$type->isConstantArray()->yes() ? [] : [sprintf('Array %s have offset %s.', $hasOffsetValueType->no() ? 'does not' : 'might not', $keyType->describe(VerbosityLevel::value()))],
-			);
-			if ($hasOffset->no()) {
-				if ($this->isOptionalKey($i)) {
-					continue;
-				}
-				return $hasOffset;
-			}
-			if ($hasOffset->maybe() && $this->isOptionalKey($i)) {
+			if ($this->isOptionalKey($i)) {
 				$hasOffset = AcceptsResult::createYes();
+			} else {
+				$hasOffsetValueType = $type->hasOffsetValueType($keyType);
+				$hasOffset = new AcceptsResult(
+					$hasOffsetValueType,
+					$hasOffsetValueType->yes() || !$type->isConstantArray()->yes() ? [] : [sprintf('Array %s have offset %s.', $hasOffsetValueType->no() ? 'does not' : 'might not', $keyType->describe(VerbosityLevel::value()))],
+				);
+			}
+
+			if ($hasOffset->no()) {
+				return $hasOffset;
 			}
 
 			$result = $result->and($hasOffset);

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -359,6 +359,24 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			}
 		}
 
+		foreach ($type->getConstantArrays() as $otherConstantArray) {
+			foreach ($otherConstantArray->keyTypes as $i => $keyType) {
+				if (!$this->hasOffsetValueType($keyType)->no()) {
+					continue;
+				}
+
+				$isOptionalKey = $otherConstantArray->isOptionalKey($i);
+				$result = $result->and(
+					new AcceptsResult(
+						$isOptionalKey
+							? TrinaryLogic::createMaybe()
+							: TrinaryLogic::createNo(),
+						[sprintf('Offset %s is not accepted.', $keyType->describe(VerbosityLevel::value()))],
+					),
+				);
+			}
+		}
+
 		return $result;
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -309,7 +309,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 	}
 
 	/**
-	 * @return Generator<string, array{errors: list<Error>}>
+	 * @return Generator<string, array{errors: list<Error>, existingBaselineContent: string, expectedNewlinesCount: int}>
 	 */
 	public function endOfFileNewlinesProvider(): Generator
 	{

--- a/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/AppendedArrayItemTypeRuleTest.php
@@ -58,6 +58,16 @@ class AppendedArrayItemTypeRuleTest extends RuleTestCase
 					'Array (array<AppendedArrayItem\Lorem>) does not accept AppendedArrayItem\Baz.',
 					79,
 				],
+				[
+					'Array (array<array{opt?: int, req: int}>) does not accept array{req: 1, foo: 1}.',
+					90,
+					"Offset 'foo' is not accepted.",
+				],
+				[
+					'Array (array<array{opt?: int, req: int}>) does not accept array{req: 1, foo: 1}|array{req: 1, opt: 1}.',
+					91,
+					"Offset 'foo' is not accepted.",
+				],
 			],
 		);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
+++ b/tests/PHPStan/Rules/Arrays/data/appended-array-item.php
@@ -78,3 +78,19 @@ function (Lorem $lorem)
 {
 	$lorem->staticProperty[] = new Baz();
 };
+
+class ArrayShapes
+{
+
+	/** @var array<array{opt?: int, req: int}> */
+	private $arrays = [];
+
+	public function test(): void
+	{
+		$this->arrays[] = ['req' => 1, 'foo' => 1];
+		$this->arrays[] = rand()
+			? ['req' => 1, 'opt' => 1]
+			: ['req' => 1, 'foo' => 1];
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -10,6 +10,7 @@ use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use function implode;
 use function sprintf;
 use const PHP_VERSION_ID;
 
@@ -141,6 +142,31 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	public function testCallToArrayMapVariadic(): void
 	{
 		$this->analyse([__DIR__ . '/data/call-to-array-map-unique.php'], []);
+	}
+
+	public function testArrayShape(): void
+	{
+		$this->analyse([__DIR__ . '/data/call-to-function-array-shape.php'], [
+			[
+				'Parameter #1 $a of function CallToFunctionArrayShape\test expects array{opt?: int, req: int}, array{foo: 1, req: 1} given.',
+				9,
+				"Offset 'foo' is not accepted.",
+			],
+			[
+				'Parameter #1 $a of function CallToFunctionArrayShape\test expects array{opt?: int, req: int}, array{foo: 1} given.',
+				10,
+				"Array does not have offset 'req'.",
+			],
+			[
+				'Parameter #1 $a of function CallToFunctionArrayShape\test expects array{opt?: int, req: int}, array{foo: 1}|array{req: 1, foo2: 2} given.',
+				11,
+				implode("\n", [
+					"• Array might not have offset 'req'.",
+					"• Offset 'foo' is not accepted.",
+					"• Offset 'foo2' is not accepted.",
+				]),
+			],
+		]);
 	}
 
 	public function testCallToWeirdFunctions(): void

--- a/tests/PHPStan/Rules/Functions/IncompatibleDefaultParameterTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/IncompatibleDefaultParameterTypeRuleTest.php
@@ -24,6 +24,11 @@ class IncompatibleDefaultParameterTypeRuleTest extends RuleTestCase
 				'Default value of the parameter #1 $string (false) of function IncompatibleDefaultParameter\takesString() is incompatible with type string.',
 				15,
 			],
+			[
+				'Default value of the parameter #1 $arr (array{req: 1, foo: 2}) of function IncompatibleDefaultParameter\takesArrayShape() is incompatible with type array{opt?: int, req: int}.',
+				22,
+				"Offset 'foo' is not accepted.",
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -6,6 +6,7 @@ use PHPStan\Rules\FunctionReturnTypeCheck;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use function implode;
 use const PHP_VERSION_ID;
 
 /**
@@ -244,6 +245,32 @@ class ReturnTypeRuleTest extends RuleTestCase
 			[
 				'Function Bug10077\mergeMediaQueries() should return list<Bug10077\CssMediaQuery>|null but returns list<Bug10077\MediaQueryMergeResult>.',
 				56,
+			],
+		]);
+	}
+
+	public function testArrayShape(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkNullables = true;
+		$this->analyse([__DIR__ . '/data/return-type-array-shape.php'], [
+			[
+				'Function ReturnTypeArrayShape\test2() should return array{opt?: int, req: int} but returns array{foo: 1}.',
+				13,
+				"Array does not have offset 'req'.",
+			],
+			[
+				'Function ReturnTypeArrayShape\test2() should return array{opt?: int, req: int} but returns array{req: 1, foo2: 1}|array{req: 1, foo: 1}.',
+				17,
+				implode("\n", [
+					"• Offset 'foo' is not accepted.",
+					"• Offset 'foo2' is not accepted.",
+				]),
+			],
+			[
+				'Function ReturnTypeArrayShape\test2() should return array{opt?: int, req: int} but returns array{req: 1, foo: 1}.',
+				22,
+				"Offset 'foo' is not accepted.",
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/call-to-function-array-shape.php
+++ b/tests/PHPStan/Rules/Functions/data/call-to-function-array-shape.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace CallToFunctionArrayShape;
+
+/** @param array{opt?: int, req: int} $a */
+function test(array $a): void
+{}
+
+test(['foo' => 1, 'req' => 1]);
+test(['foo' => 1]);
+test(rand() ? ['foo' => 1] : ['req' => 1, 'foo2' => 2]);

--- a/tests/PHPStan/Rules/Functions/data/incompatible-default-parameter-type-functions.php
+++ b/tests/PHPStan/Rules/Functions/data/incompatible-default-parameter-type-functions.php
@@ -15,3 +15,10 @@ function takesInt($int = 10): void
 function takesString($string = false): void
 {
 }
+
+/**
+ * @param array{opt?: int, req: int} $arr
+ */
+function takesArrayShape($arr = ['req' => 1, 'foo' => 2]): void
+{
+}

--- a/tests/PHPStan/Rules/Functions/data/return-type-array-shape.php
+++ b/tests/PHPStan/Rules/Functions/data/return-type-array-shape.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace ReturnTypeArrayShape;
+
+/** @return array{opt?: int, req: int} */
+function test2(): array
+{
+	if (rand()) {
+		return ['req' => 1];
+	}
+
+	if (rand()) {
+		return ['foo' => 1];
+	}
+
+	if (rand()) {
+		return rand()
+			? ['req' => 1, 'foo' => 1]
+			: ['req' => 1, 'foo2' => 1];
+	}
+
+	return ['req' => 1, 'foo' => 1];
+}

--- a/tests/PHPStan/Rules/Generators/YieldFromTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generators/YieldFromTypeRuleTest.php
@@ -45,6 +45,16 @@ class YieldFromTypeRuleTest extends RuleTestCase
 				'Result of yield from (void) is used.',
 				111,
 			],
+			[
+				'Generator expects value type array{opt?: int, req: int}, array{req: 1, foo: 1} given.',
+				119,
+				"Offset 'foo' is not accepted.",
+			],
+			[
+				'Generator expects value type array{opt?: int, req: int}, array{req: 1, foo: 1}|array{req: 1, opt: 1} given.',
+				120,
+				"Offset 'foo' is not accepted.",
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generators/YieldTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generators/YieldTypeRuleTest.php
@@ -57,6 +57,16 @@ class YieldTypeRuleTest extends RuleTestCase
 				'Result of yield (void) is used.',
 				138,
 			],
+			[
+				'Generator expects value type array{opt?: int, req: int}, array{req: 1, foo: 1} given.',
+				155,
+				"Offset 'foo' is not accepted.",
+			],
+			[
+				'Generator expects value type array{opt?: int, req: int}, array{req: 1, foo: 1}|array{req: 1, opt: 1} given.',
+				156,
+				"Offset 'foo' is not accepted.",
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Generators/data/yield-from.php
+++ b/tests/PHPStan/Rules/Generators/data/yield-from.php
@@ -110,4 +110,17 @@ class Foo
 		yield from $this->yieldWithVoidReturn();
 		$void = yield from $this->yieldWithVoidReturn();
 	}
+
+	/**
+	 * @return \Generator<array{opt?: int, req: int}>
+	 */
+	public function yieldNamedArrayShape(): \Generator
+	{
+		yield from [['req' => 1, 'foo' => 1]];
+		yield from [
+			rand()
+				? ['req' => 1, 'opt' => 1]
+				: ['req' => 1, 'foo' => 1],
+		];
+	}
 }

--- a/tests/PHPStan/Rules/Generators/data/yield.php
+++ b/tests/PHPStan/Rules/Generators/data/yield.php
@@ -146,3 +146,14 @@ function yieldWithoutSendType(){
 	$something = yield 1;
 	var_dump(yield 1);
 }
+
+/**
+ * @return \Generator<array{opt?: int, req: int}>
+ */
+function yieldNamedArrayShape(): \Generator
+{
+	yield ['req' => 1, 'foo' => 1];
+	yield rand()
+		? ['req' => 1, 'opt' => 1]
+		: ['req' => 1, 'foo' => 1];
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -509,6 +509,16 @@ class CallMethodsRuleTest extends RuleTestCase
 				"Array does not have offset 'id'.",
 			],
 			[
+				'Parameter #1 $param of method Test\ConstantArrayAccepts::doBar() expects array{name: string, color?: string}, array{name: string, color: string, year: int} given.',
+				1614,
+				"Offset 'year' is not accepted.",
+			],
+			[
+				'Parameter #1 $params of method Test\ConstantArrayAcceptsOptionalKey::doFoo() expects array{wrapperClass?: class-string}, array{wrapperClass: \'stdClass\', undocumented: 42} given.',
+				1638,
+				"Offset 'undocumented' is not accepted.",
+			],
+			[
 				'Parameter #1 $test of method Test\NumericStringParam::sayHello() expects numeric-string, 123 given.',
 				1657,
 			],
@@ -827,6 +837,16 @@ class CallMethodsRuleTest extends RuleTestCase
 				'Parameter #1 $members of method Test\\ParameterTypeCheckVerbosity::doBar() expects array<array{id: string, code: string}>, array<array{code: string}> given.',
 				1589,
 				"Array does not have offset 'id'.",
+			],
+			[
+				'Parameter #1 $param of method Test\ConstantArrayAccepts::doBar() expects array{name: string, color?: string}, array{name: string, color: string, year: int} given.',
+				1614,
+				"Offset 'year' is not accepted.",
+			],
+			[
+				'Parameter #1 $params of method Test\ConstantArrayAcceptsOptionalKey::doFoo() expects array{wrapperClass?: class-string}, array{wrapperClass: \'stdClass\', undocumented: 42} given.',
+				1638,
+				"Offset 'undocumented' is not accepted.",
 			],
 			[
 				'Parameter #1 $test of method Test\NumericStringParam::sayHello() expects numeric-string, 123 given.',
@@ -2137,7 +2157,18 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->checkThisOnly = false;
 		$this->checkNullables = true;
 		$this->checkUnionTypes = true;
-		$this->analyse([__DIR__ . '/data/bug-5258.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-5258.php'], [
+			[
+				'Parameter #1 $params of method Bug5258\HelloWorld::method2() expects array{other_key: string}, array{some_key: non-falsy-string, other_key: string} given.',
+				12,
+				"Offset 'some_key' is not accepted.",
+			],
+			[
+				'Parameter #1 $params of method Bug5258\HelloWorld::method2() expects array{other_key: string}, array{some_key?: string, other_key: non-falsy-string} given.',
+				14,
+				"Offset 'some_key' is not accepted.",
+			],
+		]);
 	}
 
 	public function testBug5591(): void

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -295,6 +295,16 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 					'Property AppendedArrayItem\Baz::$staticProperty (array<AppendedArrayItem\Lorem>) does not accept array<AppendedArrayItem\Baz>.',
 					79,
 				],
+				[
+					'Property AppendedArrayItem\ArrayShapes::$arrays (array<array{opt?: int, req: int}>) does not accept non-empty-array<array{opt?: int, req: int}|array{req: 1, foo: 1}>.',
+					90,
+					"Offset 'foo' is not accepted.",
+				],
+				[
+					'Property AppendedArrayItem\ArrayShapes::$arrays (array<array{opt?: int, req: int}>) does not accept non-empty-array<array{req: 1, foo: 1}|array{req: int, opt?: int}>.',
+					91,
+					"Offset 'foo' is not accepted.",
+				],
 			],
 		);
 	}
@@ -564,6 +574,22 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 			[
 				'Property WritingToReadOnlyProperties\Foo::$writeOnlyProperty (int) does not accept string.',
 				40,
+			],
+		]);
+	}
+
+	public function testArrayShape(): void
+	{
+		$this->analyse([__DIR__ . '/data/property-assign-array-shape.php'], [
+			[
+				'Property PropertyAssignArrayShape\Foo::$prop (array{opt?: int, req: int}) does not accept array{req: 1, foo: 1}.',
+				13,
+				"Offset 'foo' is not accepted.",
+			],
+			[
+				'Property PropertyAssignArrayShape\Foo::$prop (array{opt?: int, req: int}) does not accept array{req: 1, foo: 1}|array{req: 1, opt: 1}.',
+				14,
+				"Offset 'foo' is not accepted.",
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Properties/data/property-assign-array-shape.php
+++ b/tests/PHPStan/Rules/Properties/data/property-assign-array-shape.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace PropertyAssignArrayShape;
+
+class Foo
+{
+
+	/** @var array{opt?: int, req: int} */
+	public array $prop;
+
+	public function test(): void
+	{
+		$this->prop = ['req' => 1, 'foo' => 1];
+		$this->prop = rand()
+			? ['req' => 1, 'opt' => 1]
+			: ['req' => 1, 'foo' => 1];
+	}
+
+}

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -103,7 +103,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 		yield [
 			new ConstantArrayType([new ConstantStringType('foo')], [new StringType()]),
 			new ConstantArrayType([new ConstantStringType('foo'), new ConstantStringType('bar')], [new StringType(), new StringType()]),
-			TrinaryLogic::createYes(),
+			TrinaryLogic::createNo(),
 		];
 
 		yield [
@@ -142,7 +142,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 				new StringType(),
 				new IntegerType(),
 			]),
-			TrinaryLogic::createYes(),
+			TrinaryLogic::createNo(),
 		];
 
 		yield [
@@ -307,7 +307,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 			], [
 				new ConstantStringType('test'),
 			]),
-			TrinaryLogic::createYes(),
+			TrinaryLogic::createNo(),
 		];
 
 		yield [


### PR DESCRIPTION
This PR attempts to make acceptsWithReason reject extra keys in ConstantArrayType. I discovered the issue with the options array in `setcookie`:

https://phpstan.org/r/a55864e0-64be-431a-b40a-64a01c6d708c
https://3v4l.org/v6AL2

But even in functions which ignore the extra keys it seems generally undesirable to allow them. E.g. a programmer could pass a key thinking that it will do something, but then it wouldn't. Though I guess in some cases it could be a bit annoying/controversial.