### PR TITLE
Impl StrIncrementDecrementFunctionReturnTypeExtension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1530,6 +1530,11 @@ services:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\StrIncrementDecrementFunctionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\StrPadFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1493,6 +1493,11 @@ parameters:
 			path: src/Type/Php/SscanfFunctionDynamicReturnTypeExtension.php
 
 		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantStringType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantStrings\\(\\) instead\\.$#"
 			count: 1
 			path: src/Type/Php/StrRepeatFunctionReturnTypeExtension.php

--- a/src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use ValueError;
+use function chr;
+use function count;
+use function function_exists;
+use function implode;
+use function in_array;
+use function is_float;
+use function is_int;
+use function is_numeric;
+use function ord;
+use function preg_match;
+use function str_split;
+use function stripos;
+
+class StrIncrementDecrementFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), ['str_increment', 'str_decrement'], true);
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope,
+	): Type
+	{
+		$fnName = $functionReflection->getName();
+		$args = $functionCall->getArgs();
+
+		if (count($args) !== 1) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$argType = $scope->getType($args[0]->value);
+		if (count($argType->getConstantScalarValues()) === 0) {
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		}
+
+		$value = $argType->getConstantScalarValues()[0];
+		if (!(is_string($value) || is_int($value) || is_float($value))) {
+			return new ErrorType();
+		}
+		$string = (string) $value;
+
+		if (preg_match('/\A(?:0|[1-9A-Za-z][0-9A-Za-z]*)+\z/', $string) < 1) {
+			return new ErrorType();
+		}
+
+		$value = null;
+		if ($fnName === 'str_increment') {
+			$value = $this->increment($string);
+		} elseif ($fnName === 'str_decrement') {
+			$value = $this->decrement($string);
+		}
+
+		return $value === null
+			? new ErrorType()
+			: new ConstantStringType($value);
+	}
+
+	private function increment(string $s): string
+	{
+		if (is_numeric($s)) {
+			$offset = stripos($s, 'e');
+			if ($offset !== false) {
+				// Using increment operator would cast the string to float
+				// Therefore we manually increment it to convert it to an "f"/"F" that doesn't get affected
+				$c = $s[$offset];
+				$c++;
+				$s[$offset] = $c;
+				$s++;
+				$s[$offset] = [
+					'f' => 'e',
+					'F' => 'E',
+					'g' => 'f',
+					'G' => 'F',
+				][$s[$offset]];
+
+				return $s;
+			}
+		}
+
+		return (string) ++$s;
+	}
+
+	private function decrement(string $s): ?string
+	{
+		if (in_array($s, ['a', 'A', '0'], true)) {
+			return null;
+		}
+
+		$decremented = str_split($s, 1);
+		$position = count($decremented) - 1;
+		$carry = false;
+		$map = [
+			'0' => '9',
+			'A' => 'Z',
+			'a' => 'z',
+		];
+		do {
+			$c = $decremented[$position];
+			if (!in_array($c, ['a', 'A', '0'], true)) {
+				$carry = false;
+				$decremented[$position] = chr(ord($c) - 1);
+			} else {
+				$carry = true;
+				$decremented[$position] = $map[$c];
+			}
+		} while ($carry && $position-- > 0);
+
+		if ($carry || count($decremented) > 1 && $decremented[0] === '0') {
+			if (count($decremented) === 1) {
+				return null;
+			}
+
+			unset($decremented[0]);
+		}
+
+		return implode($decremented);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1411,6 +1411,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5961.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10189.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10317.php');
+		if (PHP_VERSION_ID >= 80300) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/str_increment.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/str_decrement.php');
+		}
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/str_decrement.php
+++ b/tests/PHPStan/Analyser/data/str_decrement.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace StrIncrementFunctionReturn;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param non-empty-string $s
+ */
+function foo(string $s): void
+{
+	assertType('non-empty-string', str_decrement($s));
+	assertType('*ERROR*', str_decrement(''));
+	assertType('*ERROR*', str_decrement('0'));
+	assertType('*ERROR*', str_decrement('0.0'));
+	assertType('*ERROR*', str_decrement('1.0'));
+	assertType('*ERROR*', str_decrement('a'));
+	assertType('*ERROR*', str_decrement('A'));
+	assertType('*ERROR*', str_decrement('='));
+	assertType('*ERROR*', str_decrement('字'));
+	assertType("'0'", str_decrement('1'));
+	assertType("'8'", str_decrement('9'));
+	assertType("'9'", str_decrement('10'));
+	assertType("'10'", str_decrement('11'));
+	assertType("'1d'", str_decrement('1e'));
+	assertType("'1e'", str_decrement('1f'));
+	assertType("'18'", str_decrement('19'));
+	assertType("'19'", str_decrement('20'));
+	assertType("'z'", str_decrement('1a'));
+	assertType("'1f0'", str_decrement('1f1'));
+	assertType("'x'", str_decrement('y'));
+	assertType("'y'", str_decrement('z'));
+	assertType("'y9'", str_decrement('z0'));
+	assertType("'z'", str_decrement('aa'));
+	assertType("'zy'", str_decrement('zz'));
+}
+
+/**
+ * @param 'b'|'1' $s1
+ * @param 1|string $s2
+ */
+function union($s1, $s2): void
+{
+	assertType("'0'|'a'", str_decrement($s1));
+	assertType('non-empty-string', str_decrement($s2));
+}
+
+/**
+ * @param 'b'|'' $s
+ */
+function unionContainsInvalidInput($s): void
+{
+	assertType("'a'", str_decrement($s));
+}

--- a/tests/PHPStan/Analyser/data/str_increment.php
+++ b/tests/PHPStan/Analyser/data/str_increment.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace StrIncrementFunctionReturn;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param non-empty-string $s
+ */
+function foo(string $s)
+{
+	assertType('non-falsy-string', str_increment($s));
+	assertType('*ERROR*', str_increment(''));
+	assertType('*ERROR*', str_increment('='));
+	assertType('*ERROR*', str_increment('0.0'));
+	assertType('*ERROR*', str_increment('1.0'));
+	assertType('*ERROR*', str_increment('字'));
+	assertType("'1'", str_increment('0'));
+	assertType("'2'", str_increment('1'));
+	assertType("'b'", str_increment('a'));
+	assertType("'B'", str_increment('A'));
+	assertType("'10'", str_increment('9'));
+	assertType("'11'", str_increment('10'));
+	assertType("'20'", str_increment('19'));
+	assertType("'1b'", str_increment('1a'));
+	assertType("'1f'", str_increment('1e'));
+	assertType("'1g'", str_increment('1f'));
+	assertType("'2a'", str_increment('1z'));
+	assertType("'10a'", str_increment('9z'));
+	assertType("'b'", str_increment('a'));
+	assertType("'1f2'", str_increment('1f1'));
+	assertType("'z'", str_increment('y'));
+	assertType("'aa'", str_increment('z'));
+	assertType("'z1'", str_increment('z0'));
+	assertType("'aaa'", str_increment('zz'));
+}
+
+/**
+ * @param 'b'|'1' $s1
+ * @param 1|string $s2
+ */
+function union($s1, $s2): void
+{
+	assertType("'2'|'c'", str_increment($s1));
+	assertType('non-falsy-string', str_increment($s2));
+}
+
+/**
+ * @param 'b'|'' $s
+ */
+function unionContainsInvalidInput($s): void
+{
+	assertType("'c'", str_increment($s));
+}


### PR DESCRIPTION
Add types to [`str_increment()`](https://php.net/str_increment) and [`str_decrement()`](https://php.net/str_decrement) added in PHP 8.3.

However, unlike something like `strtolower()`, I can't think of many use cases for incrementing/decrementing constants, so it makes sense to reject this PR.