### PR TITLE
Make extensions that return default types simply `return null;`

### DIFF
--- a/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -42,12 +41,12 @@ class ArgumentBasedFunctionReturnTypeExtension implements DynamicFunctionReturnT
 		return isset($this->functionNames[$functionReflection->getName()]);
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$argumentPosition = $this->functionNames[$functionReflection->getName()];
 
 		if (!isset($functionCall->getArgs()[$argumentPosition])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argument = $functionCall->getArgs()[$argumentPosition];

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -6,7 +6,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -35,11 +34,11 @@ class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		return $functionReflection->getName() === 'array_column';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$numArgs = count($functionCall->getArgs());
 		if ($numArgs < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ArrayCurrentDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCurrentDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
@@ -19,10 +18,10 @@ class ArrayCurrentDynamicReturnTypeExtension implements DynamicFunctionReturnTyp
 		return $functionReflection->getName() === 'current';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -6,7 +6,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -35,10 +34,10 @@ class ArrayFillFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 		return $functionReflection->getName() === 'array_fill';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (count($functionCall->getArgs()) < 3) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$numberType = $scope->getType($functionCall->getArgs()[1]->value);

--- a/src/Type/Php/ArrayKeyDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
@@ -19,10 +18,10 @@ class ArrayKeyDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExt
 		return $functionReflection->getName() === 'key';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -30,10 +29,10 @@ class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return $functionReflection->getName() === 'array_map';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$singleArrayArgument = !isset($functionCall->getArgs()[2]);

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
@@ -30,12 +29,12 @@ class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunctionRet
 		return $functionReflection->getName() === 'array_merge';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$args = $functionCall->getArgs();
 
 		if (!isset($args[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argTypes = [];

--- a/src/Type/Php/ArrayNextDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayNextDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
@@ -20,10 +19,10 @@ class ArrayNextDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return in_array($functionReflection->getName(), ['next', 'prev'], true);
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ArrayRandFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayRandFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -25,11 +24,11 @@ class ArrayRandFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 		return $functionReflection->getName() === 'array_rand';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$argsCount = count($functionCall->getArgs());
 		if ($argsCount < 1) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$firstArgType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -21,15 +21,15 @@ class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		return $functionReflection->getName() === 'array_reduce';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[1])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$callbackType = $scope->getType($functionCall->getArgs()[1]->value);
 		if ($callbackType->isCallable()->no()) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$callbackReturnType = ParametersAcceptorSelector::selectFromArgs(

--- a/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Scalar\LNumber;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
@@ -25,10 +24,10 @@ final class ArraySumFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		return $functionReflection->getName() === 'array_sum';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -39,10 +39,10 @@ class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$delimiterType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/IteratorToArrayFunctionReturnTypeExtension.php
+++ b/src/Type/Php/IteratorToArrayFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -21,12 +20,12 @@ final class IteratorToArrayFunctionReturnTypeExtension implements DynamicFunctio
 		return strtolower($functionReflection->getName()) === 'iterator_to_array';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$arguments = $functionCall->getArgs();
 
 		if ($arguments === []) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$traversableType = $scope->getType($arguments[0]->value);

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -8,7 +8,6 @@ use PhpParser\Node\Expr\Ternary;
 use PHPStan\Analyser\Scope;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\ConstantScalarType;
@@ -35,10 +34,10 @@ class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		return in_array($functionReflection->getName(), ['min', 'max'], true);
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		if (count($functionCall->getArgs()) === 1) {

--- a/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -39,11 +38,11 @@ class NonEmptyStringFunctionsReturnTypeExtension implements DynamicFunctionRetur
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($args[0]->value);

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
@@ -35,7 +34,7 @@ class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		return strtolower($functionReflection->getName()) === 'preg_split';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$flagsArg = $functionCall->getArgs()[3] ?? null;
 
@@ -47,7 +46,7 @@ class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturnTypeEx
 			return TypeCombinator::union(AccessoryArrayListType::intersectWith($type), new ConstantBooleanType(false));
 		}
 
-		return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		return null;
 	}
 
 }

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -36,10 +35,10 @@ class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 		return $functionReflection->getName() === 'range';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$startType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Internal\CombinationsHelper;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
@@ -42,7 +41,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$formatType = $scope->getType($args[0]->value);

--- a/src/Type/Php/StrCaseFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/StrCaseFunctionsReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
@@ -49,18 +48,18 @@ class StrCaseFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeEx
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		$fnName = $functionReflection->getName();
 		$args = $functionCall->getArgs();
 
 		if (count($args) < self::FUNCTIONS[$fnName]) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($args[0]->value);
 		if (!is_callable($fnName)) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$modes = [];

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -31,11 +30,11 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argType = $scope->getType($args[0]->value);
@@ -99,7 +98,7 @@ class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExte
 			return new ConstantIntegerType(0);
 		}
 
-		return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		return null;
 	}
 
 }

--- a/src/Type/Php/SubstrDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SubstrDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -37,7 +36,7 @@ class SubstrDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExten
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		if (count($args) >= 2) {

--- a/src/Type/Php/TriggerErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TriggerErrorDynamicReturnTypeExtension.php
@@ -6,7 +6,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -31,12 +30,12 @@ class TriggerErrorDynamicReturnTypeExtension implements DynamicFunctionReturnTyp
 		return $functionReflection->getName() === 'trigger_error';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$args = $functionCall->getArgs();
 
 		if (count($args) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		if (count($args) === 1) {
@@ -63,7 +62,7 @@ class TriggerErrorDynamicReturnTypeExtension implements DynamicFunctionReturnTyp
 			return new ConstantBooleanType(true);
 		}
 
-		return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		return null;
 	}
 
 }

--- a/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Comparison\ImpossibleCheckTypeHelper;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -48,10 +49,10 @@ class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFuncti
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): ?Type
+	): Type
 	{
 		if (count($functionCall->getArgs()) === 0) {
-			return null;
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
 		$isAlways = $this->getHelper()->findSpecifiedType(
@@ -59,7 +60,7 @@ class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFuncti
 			$functionCall,
 		);
 		if ($isAlways === null) {
-			return null;
+			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
 		}
 
 		return new ConstantBooleanType($isAlways);

--- a/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TypeSpecifyingFunctionsDynamicReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Comparison\ImpossibleCheckTypeHelper;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -49,10 +48,10 @@ class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFuncti
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		if (count($functionCall->getArgs()) === 0) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$isAlways = $this->getHelper()->findSpecifiedType(
@@ -60,7 +59,7 @@ class TypeSpecifyingFunctionsDynamicReturnTypeExtension implements DynamicFuncti
 			$functionCall,
 		);
 		if ($isAlways === null) {
-			return ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		return new ConstantBooleanType($isAlways);


### PR DESCRIPTION
Prevent copy-pasting by referencing existing extensions by simply replacing it with `return null;`.

refs https://github.com/phpstan/phpstan-src/pull/2776#discussion_r1405419842