### PR TITLE
Fix int-range return type for range()

### DIFF
--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -112,7 +112,7 @@ class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 		$isStepInteger = $stepType->isInteger()->yes();
 
 		if ($isInteger && $isStepInteger) {
-			return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new IntegerType()));
+			return AccessoryArrayListType::intersectWith(new ArrayType($argType, $argType));
 		}
 
 		if ($argType->isFloat()->yes()) {

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -113,7 +113,7 @@ class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 
 		if ($isInteger && $isStepInteger) {
 			if ($argType instanceof IntegerRangeType) {
-				return AccessoryArrayListType::intersectWith(new ArrayType($argType, $argType));
+				return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), $argType));
 			}
 			return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new IntegerType()));
 		}

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -112,7 +112,10 @@ class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExten
 		$isStepInteger = $stepType->isInteger()->yes();
 
 		if ($isInteger && $isStepInteger) {
-			return AccessoryArrayListType::intersectWith(new ArrayType($argType, $argType));
+			if ($argType instanceof IntegerRangeType) {
+				return AccessoryArrayListType::intersectWith(new ArrayType($argType, $argType));
+			}
+			return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new IntegerType()));
 		}
 
 		if ($argType->isFloat()->yes()) {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1193,6 +1193,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame(10, $errors[0]->getLine());
 	}
 
+	public function testBug9573(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9573.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug9039(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9039.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -588,6 +588,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-unshift.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array_map_multiple.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/range-numeric-string.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/range-int-range.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/missing-closure-native-return-typehint.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4741.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/more-type-strings.php');

--- a/tests/PHPStan/Analyser/data/bug-9573.php
+++ b/tests/PHPStan/Analyser/data/bug-9573.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9573;
+
+class MyClass {
+
+	/** @var list<positive-int> */
+	public array $array;
+
+	/**
+	 * @param positive-int $count
+	 */
+	public function __construct(int $count) {
+		$this->array = range(1, $count);
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/range-int-range.php
+++ b/tests/PHPStan/Analyser/data/range-int-range.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace RangeNumericString;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param int<0,max> $a
+	 * @param int<0,max> $b
+	 */
+	public function doFoo(
+		int $a,
+		int $b
+	): void
+	{
+		assertType('list<int<0, max>>', range($a, $b));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/range-int-range.php
+++ b/tests/PHPStan/Analyser/data/range-int-range.php
@@ -11,7 +11,7 @@ class Foo
 	 * @param int<0,max> $a
 	 * @param int<0,max> $b
 	 */
-	public function doFoo(
+	public function zeroToMax(
 		int $a,
 		int $b
 	): void
@@ -19,4 +19,43 @@ class Foo
 		assertType('list<int<0, max>>', range($a, $b));
 	}
 
+	/**
+	 * @param int<2,10> $a
+	 * @param int<5,20> $b
+	 */
+	public function twoToTwenty(
+		int $a,
+		int $b
+	): void
+	{
+		assertType('list<int<2, 20>>', range($a, $b));
+	}
+
+	/**
+	 * @param int<10,30> $a
+	 * @param int<5,20> $b
+	 */
+	public function fifteenTo5(
+		int $a,
+		int $b
+	): void
+	{
+		assertType('list<int<5, 30>>', range($a, $b));
+	}
+
+	public function knownRange(
+	): void
+	{
+		$a = 5;
+		$b = 10;
+		assertType('array{5, 6, 7, 8, 9, 10}', range($a, $b));
+	}
+
+	public function knownLargeRange(
+	): void
+	{
+		$a = 5;
+		$b = 100;
+		assertType('non-empty-list<int<5, 100>>', range($a, $b));
+	}
 }

--- a/tests/PHPStan/Analyser/data/range-int-range.php
+++ b/tests/PHPStan/Analyser/data/range-int-range.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RangeNumericString;
+namespace RangeIntRange;
 
 use function PHPStan\Testing\assertType;
 


### PR DESCRIPTION
Fixes the return type of `range` when passed `IntegerRange`

Fixes https://github.com/phpstan/phpstan/issues/10213