### PR TITLE
VarTagTypeRuleHelper: disallow widening list<int> to array<int>

### DIFF
--- a/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
@@ -168,14 +168,21 @@ class VarTagTypeRuleHelper
 				return true;
 			}
 
-			$innerType = $type->getIterableValueType();
-			$innerVarTagType = $varTagType->getIterableValueType();
+			$innerValueType = $type->getIterableValueType();
+			$innerVarTagValueType = $varTagType->getIterableValueType();
 
-			if ($type->equals($innerType) || $varTagType->equals($innerVarTagType)) {
-				return !$innerType->isSuperTypeOf($innerVarTagType)->yes();
+			$innerKeyType = $type->getIterableKeyType();
+			$innerVarTagKeyValueType = $varTagType->getIterableKeyType();
+
+			if ($type->equals($innerValueType) || $varTagType->equals($innerVarTagValueType)) {
+				return !$innerValueType->isSuperTypeOf($innerVarTagValueType)->yes();
 			}
 
-			return $this->checkType($innerType, $innerVarTagType, $depth + 1);
+			if ($innerValueType->equals($innerVarTagValueType)) {
+				return $this->checkType($innerKeyType, $innerVarTagKeyValueType, $depth + 1);
+			}
+
+			return $this->checkType($innerValueType, $innerVarTagValueType, $depth + 1);
 		}
 
 		if ($type->isConstantValue()->yes() && $depth === 0) {

--- a/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
@@ -70,4 +70,14 @@ class VarTagChangedExpressionTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testNarrowListToArray(): void
+	{
+		$this->analyse([__DIR__ . '/data/narrow-list-to-array.php'], [
+			[
+				'PHPDoc tag @var with type array<int> is not subtype of type list<int>.',
+				13,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -270,6 +270,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 				29,
 			],
 			[
+				'PHPDoc tag @var with type array<int> is not subtype of type list<int>.',
+				32,
+			],
+			[
 				'PHPDoc tag @var with type array<string> is not subtype of type list<int>.',
 				35,
 			],
@@ -280,6 +284,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type Iterator<mixed, string> is not subtype of type Iterator<int, int>.',
 				44,
+			],
+			[
+				'PHPDoc tag @var with type array<int> is not subtype of type array<int, int>.',
+				47,
 			],
 			/*[
 				// reported by VarTagChangedExpressionTypeRule
@@ -293,6 +301,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type int is not subtype of native type string.',
 				109,
+			],
+			[
+				'PHPDoc tag @var with type array<string> is not subtype of type array<int, string>.',
+				122,
 			],
 			[
 				'PHPDoc tag @var with type array<int> is not subtype of type array<int, string>.',

--- a/tests/PHPStan/Rules/PhpDoc/data/narrow-list-to-array.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/narrow-list-to-array.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BugList;
+
+class Fof {
+
+	/**
+	 * @param list<int> $list
+	 */
+	public function narrowListToArray($list): void
+	{
+		/** @var int[] $list */
+		if ($list) {}
+
+	}
+}


### PR DESCRIPTION
This looks intentional in [this commit](https://github.com/phpstan/phpstan-src/commit/4e8dea569fc918a6b19230f0b077f6c9dda2c1ed), but it is imo just wrong. No widening should be allowed.