### PR TITLE
VarTagTypeRuleHelper: remove all useless/wrong complexity

### DIFF
--- a/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
@@ -154,41 +154,8 @@ class VarTagTypeRuleHelper
 		return $this->checkType($type, $varTagType);
 	}
 
-	private function checkType(Type $type, Type $varTagType, int $depth = 0): bool
+	private function checkType(Type $type, Type $varTagType): bool
 	{
-		if ($type->isConstantArray()->yes()) {
-			if ($type->isIterableAtLeastOnce()->no()) {
-				$type = new ArrayType(new MixedType(), new MixedType());
-				return $type->isSuperTypeOf($varTagType)->no();
-			}
-		}
-
-		if ($type->isIterable()->yes() && $varTagType->isIterable()->yes()) {
-			if ($type->isSuperTypeOf($varTagType)->no()) {
-				return true;
-			}
-
-			$innerValueType = $type->getIterableValueType();
-			$innerVarTagValueType = $varTagType->getIterableValueType();
-
-			$innerKeyType = $type->getIterableKeyType();
-			$innerVarTagKeyValueType = $varTagType->getIterableKeyType();
-
-			if ($type->equals($innerValueType) || $varTagType->equals($innerVarTagValueType)) {
-				return !$innerValueType->isSuperTypeOf($innerVarTagValueType)->yes();
-			}
-
-			if ($innerValueType->equals($innerVarTagValueType)) {
-				return $this->checkType($innerKeyType, $innerVarTagKeyValueType, $depth + 1);
-			}
-
-			return $this->checkType($innerValueType, $innerVarTagValueType, $depth + 1);
-		}
-
-		if ($type->isConstantValue()->yes() && $depth === 0) {
-			return $type->isSuperTypeOf($varTagType)->no();
-		}
-
 		return !$type->isSuperTypeOf($varTagType)->yes();
 	}
 

--- a/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
@@ -168,14 +168,21 @@ class VarTagTypeRuleHelper
 				return true;
 			}
 
-			$innerType = $type->getIterableValueType();
-			$innerVarTagType = $varTagType->getIterableValueType();
+			$innerValueType = $type->getIterableValueType();
+			$innerVarTagValueType = $varTagType->getIterableValueType();
 
-			if ($type->equals($innerType) || $varTagType->equals($innerVarTagType)) {
-				return !$innerType->isSuperTypeOf($innerVarTagType)->yes();
+			$innerKeyType = $type->getIterableKeyType();
+			$innerVarTagKeyValueType = $varTagType->getIterableKeyType();
+
+			if ($type->equals($innerValueType) || $varTagType->equals($innerVarTagValueType)) {
+				return !$innerValueType->isSuperTypeOf($innerVarTagValueType)->yes();
 			}
 
-			return $this->checkType($innerType, $innerVarTagType, $depth + 1);
+			if ($innerValueType->equals($innerVarTagValueType)) {
+				return $this->checkType($innerKeyType, $innerVarTagKeyValueType, $depth + 1);
+			}
+
+			return $this->checkType($innerValueType, $innerVarTagValueType, $depth + 1);
 		}
 
 		if ($type->isConstantValue()->yes() && $depth === 0) {

--- a/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
@@ -70,4 +70,14 @@ class VarTagChangedExpressionTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testNarrowListToArray(): void
+	{
+		$this->analyse([__DIR__ . '/data/narrow-list-to-array.php'], [
+			[
+				'PHPDoc tag @var with type array<int> is not subtype of type list<int>.',
+				13,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -270,6 +270,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 				29,
 			],
 			[
+				'PHPDoc tag @var with type array<int> is not subtype of type list<int>.',
+				32,
+			],
+			[
 				'PHPDoc tag @var with type array<string> is not subtype of type list<int>.',
 				35,
 			],
@@ -280,6 +284,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type Iterator<mixed, string> is not subtype of type Iterator<int, int>.',
 				44,
+			],
+			[
+				'PHPDoc tag @var with type array<int> is not subtype of type array<int, int>.',
+				47,
 			],
 			/*[
 				// reported by VarTagChangedExpressionTypeRule
@@ -293,6 +301,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @var with type int is not subtype of native type string.',
 				109,
+			],
+			[
+				'PHPDoc tag @var with type array<string> is not subtype of type array<int, string>.',
+				122,
 			],
 			[
 				'PHPDoc tag @var with type array<int> is not subtype of type array<int, string>.',

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -323,6 +323,14 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 				148,
 			],
 			[
+				'PHPDoc tag @var with type array<array<string>> is not subtype of type array<list<string|null>>.',
+				154,
+			],
+			[
+				'PHPDoc tag @var with type array<array<string>> is not subtype of type array<list<string|null>>.',
+				157,
+			],
+			[
 				'PHPDoc tag @var with type array<array<int>> is not subtype of type array<list<string|null>>.',
 				160,
 			],
@@ -369,8 +377,16 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			? []
 			: [
 				[
+					'PHPDoc tag @var with type int|null is not subtype of native type null.',
+					6,
+				],
+				[
 					'PHPDoc tag @var with type int is not subtype of native type array{}.',
 					24,
+				],
+				[
+					'PHPDoc tag @var with type array is not subtype of native type array{}.',
+					29,
 				],
 			];
 

--- a/tests/PHPStan/Rules/PhpDoc/data/narrow-list-to-array.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/narrow-list-to-array.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BugList;
+
+class Fof {
+
+	/**
+	 * @param list<int> $list
+	 */
+	public function narrowListToArray($list): void
+	{
+		/** @var int[] $list */
+		if ($list) {}
+
+	}
+}


### PR DESCRIPTION
This is a better version of https://github.com/phpstan/phpstan-src/pull/2804, adding more and more conditions for edgecases will always leave rooms for errors. Lets keep it simple & correct.

Maybe we can enable this strict & proper behaviour only for bleedingEdge?