### PR TITLE
Update return type of `spl_autoload_functions` on PHP8.0+

### DIFF
--- a/build/baseline-8.0.neon
+++ b/build/baseline-8.0.neon
@@ -1,7 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Strict comparison using \\=\\=\\= between array and false will always evaluate to false\\.$#"
+			message: "#^Strict comparison using \\=\\=\\= between list<callable\\(string\\): void> and false will always evaluate to false\\.$#"
 			count: 1
 			path: ../src/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocator.php
 

--- a/build/spl-autoload-functions-php-8.neon
+++ b/build/spl-autoload-functions-php-8.neon
@@ -1,6 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^PHPDoc tag @var with type array\\<callable\\>\\|false is not subtype of native type array\\.$#"
+			message: "#^PHPDoc tag @var with type list\\<callable\\(string\\): void\\>\\|false is not subtype of native type list\\<callable\\(string\\): void\\>\\.$#"
 			count: 2
 			path: ../src/Command/CommandHelper.php

--- a/build/spl-autoload-functions-pre-php-7.neon
+++ b/build/spl-autoload-functions-pre-php-7.neon
@@ -1,10 +1,5 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^PHPDoc tag @var with type array\\<callable\\(\\)\\: mixed\\>\\|false is not subtype of native type list\\<callable\\(string\\)\\: void\\>\\|false\\.$#"
-			count: 2
-			path: ../src/Command/CommandHelper.php
-
-		-
 			message: '#^Parameter \#1 \$array \(list<PHPStan\\Type\\Type>\) of array_values is already a list, call has no effect\.$#'
 			path: ../src/Type/TypeCombinator.php

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -98,6 +98,7 @@ return [
 		'socket_addrinfo_lookup' => ['AddressInfo[]', 'node'=>'string', 'service='=>'mixed', 'hints='=>'array'],
 		'socket_select' => ['int|false', '&w_read'=>'Socket[]|null', '&w_write'=>'Socket[]|null', '&w_except'=>'Socket[]|null', 'seconds'=>'int|null', 'microseconds='=>'int'],
 		'sodium_crypto_aead_chacha20poly1305_ietf_decrypt' => ['string|false', 'confidential_message'=>'string', 'public_message'=>'string', 'nonce'=>'string', 'key'=>'string'],
+		'spl_autoload_functions' => ['list<callable(string):void>'],
 		'str_contains' => ['bool', 'haystack'=>'string', 'needle'=>'string'],
 		'str_split' => ['non-empty-list<string>', 'str'=>'string', 'split_length='=>'positive-int'],
 		'str_ends_with' => ['bool', 'haystack'=>'string', 'needle'=>'string'],

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -164,7 +164,7 @@ final class CommandHelper
 		$currentWorkingDirectoryFileHelper = new FileHelper($currentWorkingDirectory);
 		$currentWorkingDirectory = $currentWorkingDirectoryFileHelper->getWorkingDirectory();
 
-		/** @var array<callable>|false $autoloadFunctionsBefore */
+		/** @var list<callable(string): void>|false $autoloadFunctionsBefore */
 		$autoloadFunctionsBefore = spl_autoload_functions();
 
 		if ($autoloadFile !== null) {
@@ -459,7 +459,7 @@ final class CommandHelper
 			self::executeBootstrapFile($bootstrapFileFromArray, $container, $errorOutput, $debugEnabled);
 		}
 
-		/** @var array<callable>|false $autoloadFunctionsAfter */
+		/** @var list<callable(string): void>|false $autoloadFunctionsAfter */
 		$autoloadFunctionsAfter = spl_autoload_functions();
 
 		if ($autoloadFunctionsBefore !== false && $autoloadFunctionsAfter !== false) {


### PR DESCRIPTION
The [PHP documentation](https://www.php.net/manual/en/function.spl-autoload-functions.php) states that `spl_autoload_functions` might only return `false` on PHP versions up to 7.4; it will return an empty array on PHP8+.

* `functionMap.php` contains the PHP 7.4 signature. **This is unchanged. Is this correct?**
* The updated signature was **only** added to `functionMap_php80delta.php`
* The PHP8.x stubs already have the (only) correct native return type `array` specified. Before this PR, PHPStan assumes a return type of `array` (as `list<...>|false` in functionMap.php is not a subtype of the native type `array`)
* with this change the functionMap type should be a proper subtype of the native return type from the subs.

This PR also fixes some static analysis errors in PHPStan's source code that resulted from the functionMap changes.