### PR TITLE
Narrow Closure::bind $newScope param

### DIFF
--- a/resources/functionMap_bleedingEdge.php
+++ b/resources/functionMap_bleedingEdge.php
@@ -2,6 +2,8 @@
 
 return [
 	'new' => [
+		'Closure::bind' => ['Closure', 'old'=>'Closure', 'to'=>'?object', 'scope='=>'object|class-string|\'static\'|null'],
+		'Closure::bindTo' => ['Closure', 'new'=>'?object', 'newscope='=>'object|class-string|\'static\'|null'],
 		'error_log' => ['bool', 'message'=>'string', 'message_type='=>'0|1|2|3|4', 'destination='=>'string', 'extra_headers='=>'string'],
 		'SplFileObject::flock' => ['bool', 'operation'=>'int-mask<LOCK_SH, LOCK_EX, LOCK_UN, LOCK_NB>', '&w_wouldblock='=>'0|1'],
 		'Imagick::adaptiveBlurImage' => ['bool', 'radius'=>'float', 'sigma'=>'float', 'channel='=>'Imagick::CHANNEL_*'],

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -14,6 +14,7 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -189,7 +190,8 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 						'optional' => true,
 						'type' => new UnionType([
 							new ObjectWithoutClassType(),
-							new StringType(),
+							new ClassStringType(),
+							new ConstantStringType('static'),
 							new NullType(),
 						]),
 						'nativeType' => new UnionType([

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -968,6 +968,10 @@ class CallMethodsRuleTest extends RuleTestCase
 				'Call to an undefined method CallClosureBind\Foo::nonexistentMethod().',
 				44,
 			],
+			[
+				'Parameter #2 $newScope of method Closure::bindTo() expects \'static\'|class-string|object|null, \'CallClosureBind\\\Bar3\' given.',
+				74,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -817,4 +817,15 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testClosureBind(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/closure-bind.php'], [
+			[
+				'Parameter #3 $newScope of static method Closure::bind() expects \'static\'|class-string|object|null, \'CallClosureBind\\\Bar3\' given.',
+				68,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/closure-bind.php
+++ b/tests/PHPStan/Rules/Methods/data/closure-bind.php
@@ -49,4 +49,33 @@ class Bar
 		})->call(new Foo());
 	}
 
+	public function x(): bool
+	{
+		return 1.0;
+	}
+
+	public function testClassString(): bool
+	{
+		$fx = function () {
+			return $this->x();
+		};
+
+		$res = 0.0;
+		$res += \Closure::bind($fx, $this)();
+		$res += \Closure::bind($fx, $this, 'static')();
+		$res += \Closure::bind($fx, $this, Foo2::class)();
+		$res += \Closure::bind($fx, $this, 'CallClosureBind\Bar2')();
+		$res += \Closure::bind($fx, $this, 'CallClosureBind\Bar3')();
+
+		$res += $fx->bindTo($this)();
+		$res += $fx->bindTo($this, 'static')();
+		$res += $fx->bindTo($this, Foo2::class)();
+		$res += $fx->bindTo($this, 'CallClosureBind\Bar2')();
+		$res += $fx->bindTo($this, 'CallClosureBind\Bar3')();
+
+		return $res;
+	}
+
 }
+
+class Bar2 extends Bar {}


### PR DESCRIPTION
Same change as in https://github.com/JetBrains/phpstorm-stubs/pull/1591.

Am I right the phpstorm-stubs are used for `Pure` metadata only?

The default type of `newScope` arg is `'static'` which is not subtype of `class-string`, does phpstan imply that from the real reflection?