### PR TITLE
Fix mixing property and param attributes on promoted property

### DIFF
--- a/src/Rules/AttributesCheck.php
+++ b/src/Rules/AttributesCheck.php
@@ -28,7 +28,7 @@ class AttributesCheck
 
 	/**
 	 * @param AttributeGroup[] $attrGroups
-	 * @param Attribute::TARGET_* $requiredTarget
+	 * @param int-mask-of<Attribute::TARGET_*> $requiredTarget
 	 * @return RuleError[]
 	 */
 	public function check(

--- a/src/Rules/Functions/ParamAttributesRule.php
+++ b/src/Rules/Functions/ParamAttributesRule.php
@@ -7,7 +7,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\AttributesCheck;
 use PHPStan\Rules\Rule;
-use function count;
 
 /**
  * @implements Rule<Node\Param>
@@ -27,25 +26,16 @@ class ParamAttributesRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$targetName = 'parameter';
+		$targetType = Attribute::TARGET_PARAMETER;
 		if ($node->flags !== 0) {
 			$targetName = 'parameter or property';
-
-			$propertyTargetErrors = $this->attributesCheck->check(
-				$scope,
-				$node->attrGroups,
-				Attribute::TARGET_PROPERTY,
-				$targetName,
-			);
-
-			if (count($propertyTargetErrors) === 0) {
-				return $propertyTargetErrors;
-			}
+			$targetType |= Attribute::TARGET_PROPERTY;
 		}
 
 		return $this->attributesCheck->check(
 			$scope,
 			$node->attrGroups,
-			Attribute::TARGET_PARAMETER,
+			$targetType,
 			$targetName,
 		);
 	}

--- a/tests/PHPStan/Rules/Functions/ParamAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ParamAttributesRuleTest.php
@@ -66,4 +66,9 @@ class ParamAttributesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/sensitive-parameter.php'], []);
 	}
 
+	public function testBug10298(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10298.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-10298.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-10298.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10298;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class PropAttr {}
+
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class ParamAttr {}
+
+class Test
+{
+	public function __construct(
+		#[PropAttr]
+		#[ParamAttr]
+		public string $test
+	) {}
+}


### PR DESCRIPTION
Simplify the ParamAttributesRule by merging AttributeCheck::check calls and using an int mask to check for both TARGET_PARAMETER and TARGET_PROPERTY in one pass.

Fixes phpstan/phpstan#10298