### PR TITLE
Don't use parallel analyser if it doesn't save time

### DIFF
--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -60,6 +60,7 @@ class AnalyserRunner
 			&& function_exists('proc_open')
 			&& $mainScript !== null
 			&& $schedule->getNumberOfProcesses() > 0
+			&& count($files) > 1
 		) {
 			return $this->parallelAnalyser->analyse($schedule, $mainScript, $postFileCallback, $projectConfigFile, $input);
 		}


### PR DESCRIPTION
After doing a bit of a deep dive into the performance of PHPStan and where most of the bottlenecks live, I found that quite a large chunk of time is spent in launching the PHPStan process, which consists of processing arguments (~130ms), finding to-check files (~250ms), building container factories (~750ms) among others. (These are the times taken for our codebase, I can share these stats in more detail if you'd like).

After realizing that (depending on the project config of course) about 1s is spent just on launching the parallel-mode subprocess I figured it might be a good idea to disable parallel mode if it's not "worth it", meaning it'll only end up checking a single file.

I think that this change will help speed up PHPStan because (at least in our codebase) it shaves off 1s from any single-file change. As you can imagine this is quite massive especially when using PHPStan pro.

It could be that this number can be bumped up a little more even, maybe checking 2 files in a row is faster than parallelizing it, but I can't definitively say that because it might differ from codebase to codebase so I'll keep the check at 1 file in this PR.