### PR TITLE
Hide internal commands

### DIFF
--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -74,7 +74,8 @@ class FixerWorkerCommand extends Command
 				new InputOption('memory-limit', null, InputOption::VALUE_REQUIRED, 'Memory limit for analysis'),
 				new InputOption('xdebug', null, InputOption::VALUE_NONE, 'Allow running with Xdebug for debugging purposes'),
 				new InputOption('server-port', null, InputOption::VALUE_REQUIRED, 'Server port for FixerApplication'),
-			]);
+			])
+			->setHidden(true);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -60,7 +60,8 @@ class WorkerCommand extends Command
 				new InputOption('xdebug', null, InputOption::VALUE_NONE, 'Allow running with Xdebug for debugging purposes'),
 				new InputOption('port', null, InputOption::VALUE_REQUIRED),
 				new InputOption('identifier', null, InputOption::VALUE_REQUIRED),
-			]);
+			])
+			->setHidden(true);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
Showing internal commands in the command listing may be confusing and isn't necessary.