### PR TITLE
class_exists(Interface::class) is always false

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -75,14 +75,11 @@ class ImpossibleCheckTypeHelper
 					return $assertValue->getValue();
 				}
 				if (in_array($functionName, [
+					'class_exists',
 					'interface_exists',
 					'trait_exists',
 					'enum_exists',
 				], true)) {
-					return null;
-				}
-
-				if ($functionName === 'class_exists') {
 					if (count($node->getArgs()) < 1) {
 						return null;
 					}
@@ -95,9 +92,23 @@ class ImpossibleCheckTypeHelper
 						return null;
 					}
 					$reflection = $this->reflectionProvider->getClass($argConstantString->getValue());
-					if ($reflection->isInterface()) {
+
+					if ($functionName === 'class_exists' && ($reflection->isInterface() || $reflection->isTrait())) {
 						return false;
 					}
+
+					if ($functionName === 'interface_exists' && ($reflection->isClass() || $reflection->isTrait() || $reflection->isEnum())) {
+						return false;
+					}
+
+					if ($functionName === 'trait_exists' && ($reflection->isClass() || $reflection->isInterface() || $reflection->isEnum())) {
+						return false;
+					}
+
+					if ($functionName === 'enum_exists' && ($reflection->isClass() || $reflection->isInterface() || $reflection->isTrait())) {
+						return false;
+					}
+
 					return null;
 				}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -261,6 +261,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					927,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
+				[
+					'Call to function class_exists() with \'DateTimeInterface\' will always evaluate to false.',
+					971,
+				],
 			],
 		);
 	}
@@ -370,6 +374,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					'Call to function in_array() with arguments 1, array<string> and true will always evaluate to false.',
 					927,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+				],
+				[
+					'Call to function class_exists() with \'DateTimeInterface\' will always evaluate to false.',
+					971,
 				],
 			],
 		);

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -261,10 +261,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					927,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
-				[
-					'Call to function class_exists() with \'DateTimeInterface\' will always evaluate to false.',
-					971,
-				],
 			],
 		);
 	}
@@ -375,10 +371,6 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					927,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
-				[
-					'Call to function class_exists() with \'DateTimeInterface\' will always evaluate to false.',
-					971,
-				],
 			],
 		);
 	}
@@ -392,6 +384,25 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				'Call to function is_int() with int will always evaluate to true.',
 				16,
 			],
+		]);
+	}
+
+	public function testStructExists(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/check-type-function-call-struct-exists.php'], [
+			['Call to function class_exists() with \'CheckTypeFunctionCall\\\\_Interface\' will always evaluate to false.', 23],
+			['Call to function class_exists() with \'CheckTypeFunctionCall\\\\_Trait\' will always evaluate to false.', 25],
+			['Call to function interface_exists() with \'CheckTypeFunctionCall\\\\_Enum\' will always evaluate to false.', 27],
+			['Call to function interface_exists() with \'CheckTypeFunctionCall\\\\_Class\' will always evaluate to false.', 29],
+			['Call to function interface_exists() with \'CheckTypeFunctionCall\\\\_Trait\' will always evaluate to false.', 30],
+			['Call to function trait_exists() with \'CheckTypeFunctionCall\\\\_Enum\' will always evaluate to false.', 32],
+			['Call to function trait_exists() with \'CheckTypeFunctionCall\\\\_Interface\' will always evaluate to false.', 33],
+			['Call to function trait_exists() with \'CheckTypeFunctionCall\\\\_Class\' will always evaluate to false.', 34],
+			['Call to function enum_exists() with \'CheckTypeFunctionCall\\\\_Interface\' will always evaluate to false.', 38],
+			['Call to function enum_exists() with \'CheckTypeFunctionCall\\\\_Class\' will always evaluate to false.', 39],
+			['Call to function enum_exists() with \'CheckTypeFunctionCall\\\\_Trait\' will always evaluate to false.', 40],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -389,6 +389,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 
 	public function testStructExists(): void
 	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/check-type-function-call-struct-exists.php'], [

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call-struct-exists.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call-struct-exists.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CheckTypeFunctionCall;
+
+// see https://3v4l.org/V9nmf
+
+interface _Interface {}
+class _Class {}
+trait _Trait {}
+enum _Enum {}
+
+class_exists($mixed);
+interface_exists($mixed);
+enum_exists($mixed);
+trait_exists($mixed);
+
+class_exists();
+interface_exists();
+enum_exists();
+trait_exists();
+
+class_exists(_Enum::class);
+class_exists(_Interface::class); // always false
+class_exists(_Class::class);
+class_exists(_Trait::class); // always false
+
+interface_exists(_Enum::class); // always false
+interface_exists(_Interface::class);
+interface_exists(_Class::class); // always false
+interface_exists(_Trait::class); // always false
+
+trait_exists(_Enum::class); // always false
+trait_exists(_Interface::class); // always false
+trait_exists(_Class::class); // always false
+trait_exists(_Trait::class);
+
+enum_exists(_Enum::class);
+enum_exists(_Interface::class); // always false
+enum_exists(_Class::class); // always false
+enum_exists(_Trait::class); // always false
+
+
+

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call-struct-exists.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call-struct-exists.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.1
 
 namespace CheckTypeFunctionCall;
 

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -967,8 +967,3 @@ function checkSuperGlobals(): void
 		if (is_int($k)) {}
 	}
 }
-
-if (class_exists(\DateTimeInterface::class)) {} // always false for interface
-if (class_exists(\DateTime::class)) {}
-if (class_exists($mixed)) {}
-if (class_exists()) {}

--- a/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
+++ b/tests/PHPStan/Rules/Comparison/data/check-type-function-call.php
@@ -967,3 +967,8 @@ function checkSuperGlobals(): void
 		if (is_int($k)) {}
 	}
 }
+
+if (class_exists(\DateTimeInterface::class)) {} // always false for interface
+if (class_exists(\DateTime::class)) {}
+if (class_exists($mixed)) {}
+if (class_exists()) {}


### PR DESCRIPTION
Recently found [bug caused by this in phpstan-doctrine](https://github.com/phpstan/phpstan-doctrine/blob/1.3.53/src/Type/Doctrine/Query/QueryResultTypeWalker.php#L815).