### PR TITLE
Fix return type of DOMXPath::query

### DIFF
--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -54,7 +54,7 @@ class DOMElement extends DOMNode
 }
 
 /**
- * @template-covariant TNode as DOMNode
+ * @template-covariant TNode as DOMNode|DOMNameSpaceNode
  * @implements Traversable<int, TNode>
  * @implements IteratorAggregate<int, TNode>
  */
@@ -76,7 +76,7 @@ class DOMXPath
      * @param string $expression
      * @param DOMNode|null $contextNode
      * @param boolean $registerNodeNS
-     * @return DOMNodeList<DOMNode>|false
+     * @return DOMNodeList<DOMNode|DOMNameSpaceNode>|false
      */
     public function query($expression, $contextNode, $registerNodeNS) {}
 

--- a/tests/PHPStan/Analyser/data/bug-6748.php
+++ b/tests/PHPStan/Analyser/data/bug-6748.php
@@ -17,6 +17,6 @@ class Foo
 	/** @param \DOMXPath $path */
 	public function xPathQuery ($path)
 	{
-		assertType('DOMNodeList<DOMNode>|false', $path->query(''));
+		assertType('DOMNodeList<DOMNameSpaceNode|DOMNode>|false', $path->query(''));
 	}
 }


### PR DESCRIPTION
> This can also return namespace nodes, which are not a child class of DOMNode.

analog https://github.com/vimeo/psalm/pull/10443