### PR TITLE
Lazier creation of parameter-acceptor

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -406,23 +406,31 @@ class TypeSpecifier
 					return $extension->specifyTypes($functionReflection, $expr, $scope, $context);
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariants());
+				// lazy create parametersAcceptor, as creation can be expensive
+				$parametersAcceptor = null;
 				if (count($expr->getArgs()) > 0) {
+					$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariants());
+
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
 						return $specifiedTypes;
 					}
 				}
 
-				$asserts = $functionReflection->getAsserts()->mapTypes(static fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes(
-					$type,
-					$parametersAcceptor->getResolvedTemplateTypeMap(),
-					$parametersAcceptor instanceof ParametersAcceptorWithPhpDocs ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
-					TemplateTypeVariance::createInvariant(),
-				));
-				$specifiedTypes = $this->specifyTypesFromAsserts($context, $expr, $asserts, $parametersAcceptor, $scope);
-				if ($specifiedTypes !== null) {
-					return $specifiedTypes;
+				$assertions = $functionReflection->getAsserts();
+				if ($assertions->getAll() !== []) {
+					$parametersAcceptor ??= ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $functionReflection->getVariants(), $functionReflection->getNamedArgumentsVariants());
+
+					$asserts = $assertions->mapTypes(static fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes(
+						$type,
+						$parametersAcceptor->getResolvedTemplateTypeMap(),
+						$parametersAcceptor instanceof ParametersAcceptorWithPhpDocs ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
+						TemplateTypeVariance::createInvariant(),
+					));
+					$specifiedTypes = $this->specifyTypesFromAsserts($context, $expr, $asserts, $parametersAcceptor, $scope);
+					if ($specifiedTypes !== null) {
+						return $specifiedTypes;
+					}
 				}
 			}
 
@@ -446,23 +454,31 @@ class TypeSpecifier
 					}
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariants());
+				// lazy create parametersAcceptor, as creation can be expensive
+				$parametersAcceptor = null;
 				if (count($expr->getArgs()) > 0) {
+					$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariants());
+
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
 						return $specifiedTypes;
 					}
 				}
 
-				$asserts = $methodReflection->getAsserts()->mapTypes(static fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes(
-					$type,
-					$parametersAcceptor->getResolvedTemplateTypeMap(),
-					$parametersAcceptor instanceof ParametersAcceptorWithPhpDocs ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
-					TemplateTypeVariance::createInvariant(),
-				));
-				$specifiedTypes = $this->specifyTypesFromAsserts($context, $expr, $asserts, $parametersAcceptor, $scope);
-				if ($specifiedTypes !== null) {
-					return $specifiedTypes;
+				$assertions = $methodReflection->getAsserts();
+				if ($assertions->getAll() !== []) {
+					$parametersAcceptor ??= ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $methodReflection->getVariants(), $methodReflection->getNamedArgumentsVariants());
+
+					$asserts = $assertions->mapTypes(static fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes(
+						$type,
+						$parametersAcceptor->getResolvedTemplateTypeMap(),
+						$parametersAcceptor instanceof ParametersAcceptorWithPhpDocs ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
+						TemplateTypeVariance::createInvariant(),
+					));
+					$specifiedTypes = $this->specifyTypesFromAsserts($context, $expr, $asserts, $parametersAcceptor, $scope);
+					if ($specifiedTypes !== null) {
+						return $specifiedTypes;
+					}
 				}
 			}
 
@@ -491,23 +507,31 @@ class TypeSpecifier
 					}
 				}
 
-				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariants());
+				// lazy create parametersAcceptor, as creation can be expensive
+				$parametersAcceptor = null;
 				if (count($expr->getArgs()) > 0) {
+					$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariants());
+
 					$specifiedTypes = $this->specifyTypesFromConditionalReturnType($context, $expr, $parametersAcceptor, $scope);
 					if ($specifiedTypes !== null) {
 						return $specifiedTypes;
 					}
 				}
 
-				$asserts = $staticMethodReflection->getAsserts()->mapTypes(static fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes(
-					$type,
-					$parametersAcceptor->getResolvedTemplateTypeMap(),
-					$parametersAcceptor instanceof ParametersAcceptorWithPhpDocs ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
-					TemplateTypeVariance::createInvariant(),
-				));
-				$specifiedTypes = $this->specifyTypesFromAsserts($context, $expr, $asserts, $parametersAcceptor, $scope);
-				if ($specifiedTypes !== null) {
-					return $specifiedTypes;
+				$assertions = $staticMethodReflection->getAsserts();
+				if ($assertions->getAll() !== []) {
+					$parametersAcceptor ??= ParametersAcceptorSelector::selectFromArgs($scope, $expr->getArgs(), $staticMethodReflection->getVariants(), $staticMethodReflection->getNamedArgumentsVariants());
+
+					$asserts = $assertions->mapTypes(static fn (Type $type) => TemplateTypeHelper::resolveTemplateTypes(
+						$type,
+						$parametersAcceptor->getResolvedTemplateTypeMap(),
+						$parametersAcceptor instanceof ParametersAcceptorWithPhpDocs ? $parametersAcceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
+						TemplateTypeVariance::createInvariant(),
+					));
+					$specifiedTypes = $this->specifyTypesFromAsserts($context, $expr, $asserts, $parametersAcceptor, $scope);
+					if ($specifiedTypes !== null) {
+						return $specifiedTypes;
+					}
 				}
 			}
 


### PR DESCRIPTION
we only need to create the acceptor for calls with at least 1 arg or if assert-tags are present

----

after this change running the repro of https://github.com/phpstan/phpstan/issues/8865 is consistently 3-4 seconds faster.
(because we call `getVariants()` only 20 times, instead of 25 times)


before this PR  ~ 46,5-47 seconds
after this PR ~ 43 seconds

```
php vendor/bin/phpstan analyze --memory-limit=1G -l 5 src/Pyz/Zed/CategoryDataImport/Business/QueryExpander/FooQueryExpander.php --debug -vvv 

Note: Using configuration file /Users/staabm/workspace/spryker-phpstan-issue/phpstan.neon.
Result cache not used because of debug mode.
/Users/staabm/workspace/spryker-phpstan-issue/src/Pyz/Zed/CategoryDataImport/Business/QueryExpander/FooQueryExpander.php
--- consumed 288.33 MB, total 356.5 MB, took 43.67 s
Result cache was not saved because only files were passed as analysed paths.
                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        
Used memory: 356.5 MB
```

----

before profile

<img width="1147" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/0bcb13bb-ca35-45bf-8fc7-c2352ee1794f">
