### PR TITLE
Add the curl microsecond timing fields for HTTP requests

### DIFF
--- a/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
@@ -190,6 +190,13 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'protocol' => $integerType,
 			'ssl_verifyresult' => $integerType,
 			'scheme' => $stringType,
+			'appconnect_time_us' => $integerType,
+			'connect_time_us' => $integerType,
+			'namelookup_time_us' => $integerType,
+			'pretransfer_time_us' => $integerType,
+			'redirect_time_us' => $integerType,
+			'starttransfer_time_us' => $integerType,
+			'total_time_us' => $integerType,
 		];
 		foreach ($componentTypesPairedStrings as $componentName => $componentValueType) {
 			$builder->setOffsetValueType(new ConstantStringType($componentName), $componentValueType);


### PR DESCRIPTION
These are the `*_TIME_T` fields that are included in the results from `curl_getinfo()`, when no option is provided.

See https://www.php.net/manual/en/function.curl-getinfo.php for more info on each field.

---

You can see that phpstan will incorrectly flag problems currently when using these fields:

```php
<?php
declare( strict_types = 1 );

$url = "http://example.com/";
$ch = curl_init($url);
curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
curl_setopt($ch, CURLOPT_HEADER, true);
curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
curl_setopt($ch, CURLOPT_VERBOSE, false);

$response = curl_exec($ch);
if ( $response === false ) {
    echo 'Curl error ( ' . curl_errno($ch) . ' ): ' . curl_error($ch);
    exit;
}
$info = curl_getinfo($ch);
curl_close($ch);

echo "DNS: {$info['namelookup_time_us']}\n\n";

print_r( $info );
```