### PR TITLE
fix(DirectoryCreator): Check if directory exists before creating

### DIFF
--- a/src/Internal/DirectoryCreator.php
+++ b/src/Internal/DirectoryCreator.php
@@ -18,6 +18,9 @@ final class DirectoryCreator
 		bool $recursive = true,
 	): void
 	{
+		if (file_exists($directory)) {
+			return;
+		}
 		if (@mkdir($directory, $mode, $recursive)) {
 			return;
 		}


### PR DESCRIPTION
Suppressing the error with '@' still calls custom error handlers.
We can check if the directory exists before calling mkdir.