### PR TITLE
optimize repeated container creation in tests

### DIFF
--- a/src/Testing/TestCase.neon
+++ b/src/Testing/TestCase.neon
@@ -9,6 +9,9 @@ services:
 		arguments:
 			phpParser: @phpParserDecorator
 			php8Parser: @php8PhpParser
+			fileExtensions: %fileExtensions%
+			obsoleteExcludesAnalyse: %excludes_analyse%
+			excludePaths: %excludePaths%
 
 	cacheStorage:
 		class: PHPStan\Cache\MemoryCacheStorage


### PR DESCRIPTION
I looked into the performance of creating containers in tests and I found out that creating SourceLocators in `ComposerJsonAndInstalledJsonSourceLocatorMaker` is by far the most expensive part (on my machine about 1.1s out of 1.4s for the whole uncached `getContainer`). So here I try to cache it statically for the tests. As far as I can tell, it only depends on a few parameters (at least for now), which seem likely to be the same for most of the tests.

Quick benchmark with `rm -rf /tmp/phpstan-tests/; time make tests` gives me about 1m 22s with this change vs about 1m 46s without it.

Motivation: This is a preliminary step before I attempt to make it possible for individual test methods to use their own config for the container, instead of just relying on `getAdditionalConfigFiles` which is static. That would be useful for https://github.com/phpstan/phpstan-src/pull/2809 and possibly other things as well.