### PR TITLE
require-extends should not error on interfaces

### DIFF
--- a/src/Rules/Classes/RequireExtendsRule.php
+++ b/src/Rules/Classes/RequireExtendsRule.php
@@ -26,16 +26,16 @@ class RequireExtendsRule implements Rule
 	{
 		$classReflection = $node->getClassReflection();
 
+		if ($classReflection->isInterface()) {
+			return [];
+		}
+
 		$errors = [];
 		foreach ($classReflection->getImmediateInterfaces() as $interface) {
 			$extendsTags = $interface->getRequireExtendsTags();
 			foreach ($extendsTags as $extendsTag) {
 				$type = $extendsTag->getType();
 				if (!$type instanceof ObjectType) {
-					continue;
-				}
-
-				if ($classReflection->isInterface()) {
 					continue;
 				}
 

--- a/src/Rules/Classes/RequireExtendsRule.php
+++ b/src/Rules/Classes/RequireExtendsRule.php
@@ -31,7 +31,7 @@ class RequireExtendsRule implements Rule
 		}
 
 		$errors = [];
-		foreach ($classReflection->getImmediateInterfaces() as $interface) {
+		foreach ($classReflection->getInterfaces() as $interface) {
 			$extendsTags = $interface->getRequireExtendsTags();
 			foreach ($extendsTags as $extendsTag) {
 				$type = $extendsTag->getType();
@@ -54,7 +54,7 @@ class RequireExtendsRule implements Rule
 			}
 		}
 
-		foreach ($classReflection->getTraits() as $trait) {
+		foreach ($classReflection->getTraits(true) as $trait) {
 			$extendsTags = $trait->getRequireExtendsTags();
 			foreach ($extendsTags as $extendsTag) {
 				$type = $extendsTag->getType();

--- a/src/Rules/Classes/RequireExtendsRule.php
+++ b/src/Rules/Classes/RequireExtendsRule.php
@@ -35,7 +35,11 @@ class RequireExtendsRule implements Rule
 					continue;
 				}
 
-				if ($classReflection->isSubclassOf($type->getClassName())) {
+				if ($classReflection->isInterface()) {
+					continue;
+				}
+
+				if ($classReflection->is($type->getClassName())) {
 					continue;
 				}
 
@@ -58,7 +62,7 @@ class RequireExtendsRule implements Rule
 					continue;
 				}
 
-				if ($classReflection->isSubclassOf($type->getClassName())) {
+				if ($classReflection->is($type->getClassName())) {
 					continue;
 				}
 

--- a/src/Rules/Classes/RequireImplementsRule.php
+++ b/src/Rules/Classes/RequireImplementsRule.php
@@ -27,7 +27,7 @@ class RequireImplementsRule implements Rule
 		$classReflection = $node->getClassReflection();
 
 		$errors = [];
-		foreach ($classReflection->getTraits() as $trait) {
+		foreach ($classReflection->getTraits(true) as $trait) {
 			$implementsTags = $trait->getRequireImplementsTags();
 			foreach ($implementsTags as $implementsTag) {
 				$type = $implementsTag->getType();

--- a/tests/PHPStan/Rules/Classes/RequireExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RequireExtendsRuleTest.php
@@ -59,7 +59,22 @@ class RequireExtendsRuleTest extends RuleTestCase
 
 	public function testExtendedInterfaceBug(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-10302-extended-interface.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-10302-extended-interface.php'], [
+			[
+				'Interface Bug10302ExtendedInterface\BatchAware requires implementing class to extend Bug10302ExtendedInterface\Model, but Bug10302ExtendedInterface\AnotherModel does not.',
+				34,
+			],
+		]);
+	}
+
+	public function testExtendedTraitBug(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10302-extended-trait.php'], [
+			[
+				'Trait Bug10302ExtendedTrait\Foo requires using class to extend Bug10302ExtendedTrait\Father, but Bug10302ExtendedTrait\Baz does not.',
+				21,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/RequireExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RequireExtendsRuleTest.php
@@ -57,4 +57,9 @@ class RequireExtendsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../PhpDoc/data/incompatible-require-extends.php'], $expectedErrors);
 	}
 
+	public function testExtendedInterfaceBug(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10302-extended-interface.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/RequireImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RequireImplementsRuleTest.php
@@ -73,4 +73,14 @@ class RequireImplementsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../PhpDoc/data/incompatible-require-implements.php'], $expectedErrors);
 	}
 
+	public function testExtendedTraitBug(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10302-extended-implements-trait.php'], [
+			[
+				'Trait Bug10302ExtendedImplementsTrait\Foo requires using class to implement Bug10302ExtendedImplementsTrait\Interface1, but Bug10302ExtendedImplementsTrait\Baz does not.',
+				21,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-implements-trait.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-implements-trait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bug10302ExtendedImplementsTrait;
+
+interface Interface1
+{
+
+}
+
+/** @phpstan-require-implements Interface1 */
+trait Foo
+{
+
+}
+
+trait Bar
+{
+	use Foo;
+}
+
+class Baz
+{
+
+	use Bar;
+
+}
+
+class Baz2 implements Interface1
+{
+
+	use Bar;
+
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
@@ -31,6 +31,11 @@ class Model implements BatchAware
 	}
 }
 
+class AnotherModel implements BatchAwareExtended
+{
+
+}
+
 
 /**
  * @property-read bool $busy

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Bug10302ExtendedInterface;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @property-read bool $busy
+ * @phpstan-require-extends Model
+ */
+interface BatchAware
+{
+
+}
+
+interface BatchAwareExtended extends BatchAware
+{
+
+}
+
+/**
+ * @property-read bool $busy2
+ */
+class Model implements BatchAware
+{
+	/**
+	 * @return mixed
+	 */
+	public function __get(string $name)
+	{
+		return 1;
+	}
+}
+
+function (BatchAware $b): void
+{
+	assertType('bool', $b->busy);
+	assertType('bool', $b->busy2);
+};
+
+class ModelWithoutAllowDynamicProperties
+{
+
+}
+
+/**
+ * @property-read bool $busy
+ * @phpstan-require-extends ModelWithoutAllowDynamicProperties
+ */
+interface BatchAwareWithoutAllowDynamicProperties
+{
+
+}
+
+function (BatchAwareWithoutAllowDynamicProperties $b): void
+{
+	$result = $b->busy;
+
+	assertType('*ERROR*', $result);
+};
+

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
@@ -10,7 +10,6 @@ use function PHPStan\Testing\assertType;
  */
 interface BatchAware
 {
-
 }
 
 interface BatchAwareExtended extends BatchAware
@@ -32,30 +31,15 @@ class Model implements BatchAware
 	}
 }
 
-function (BatchAware $b): void
-{
-	assertType('bool', $b->busy);
-	assertType('bool', $b->busy2);
-};
-
-class ModelWithoutAllowDynamicProperties
-{
-
-}
 
 /**
  * @property-read bool $busy
- * @phpstan-require-extends ModelWithoutAllowDynamicProperties
+ * @phpstan-require-extends Model
  */
-interface BatchAwareWithoutAllowDynamicProperties
+trait BatchAwareTrait
 {
-
 }
 
-function (BatchAwareWithoutAllowDynamicProperties $b): void
-{
-	$result = $b->busy;
-
-	assertType('*ERROR*', $result);
-};
-
+class Model {
+	use BatchAwareTrait;
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-interface.php
@@ -34,12 +34,12 @@ class Model implements BatchAware
 
 /**
  * @property-read bool $busy
- * @phpstan-require-extends Model
+ * @phpstan-require-extends TraitModel
  */
 trait BatchAwareTrait
 {
 }
 
-class Model {
+class TraitModel {
 	use BatchAwareTrait;
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-trait.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-trait.php
@@ -24,3 +24,11 @@ class Baz // should report: Trait Foo requires using class to extend Father, but
 	use Bar;
 
 }
+
+
+class Baz2 extends Father
+{
+
+	use Bar;
+
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-10302-extended-trait.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10302-extended-trait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug10302ExtendedTrait;
+
+class Father
+{
+
+}
+
+/** @phpstan-require-extends Father */
+trait Foo
+{
+
+}
+
+trait Bar
+{
+	use Foo;
+}
+
+class Baz // should report: Trait Foo requires using class to extend Father, but Baz does not.
+{
+
+	use Bar;
+
+}


### PR DESCRIPTION
There are two issues:

1) Interface should not complain about not extending a class
2) When the interface is being implemented by the class required, the rule should not complain

Both are reproduced here: 
https://phpstan.org/r/25925129-a872-4300-8437-a8edd6dc825a
