### PR TITLE
Simplify default-return path in Extensions

### DIFF
--- a/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
@@ -6,7 +6,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;

--- a/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
@@ -27,11 +27,11 @@ class ArrayIntersectKeyFunctionReturnTypeExtension implements DynamicFunctionRet
 		return $functionReflection->getName() === 'array_intersect_key';
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		$args = $functionCall->getArgs();
 		if (count($args) === 0) {
-			return ParametersAcceptorSelector::selectFromArgs($scope, $args, $functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$argTypes = [];

--- a/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
@@ -22,10 +22,10 @@ class ArraySpliceFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		if (!isset($functionCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectFromArgs($scope, $functionCall->getArgs(), $functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$arrayArg = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;

--- a/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
@@ -28,14 +28,10 @@ class ClosureFromCallableDynamicReturnTypeExtension implements DynamicStaticMeth
 		return $methodReflection->getName() === 'fromCallable';
 	}
 
-	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
 	{
 		if (!isset($methodCall->getArgs()[0])) {
-			return ParametersAcceptorSelector::selectFromArgs(
-				$scope,
-				$methodCall->getArgs(),
-				$methodReflection->getVariants(),
-			)->getReturnType();
+			return null;
 		}
 
 		$callableType = $scope->getType($methodCall->getArgs()[0]->value);

--- a/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
@@ -6,7 +6,6 @@ use Closure;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;

--- a/src/Type/Php/DsMapDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DsMapDynamicReturnTypeExtension.php
@@ -25,41 +25,35 @@ final class DsMapDynamicReturnTypeExtension implements DynamicMethodReturnTypeEx
 		return in_array($methodReflection->getName(), ['get', 'remove'], true);
 	}
 
-	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
 	{
-		$returnType = ParametersAcceptorSelector::selectFromArgs(
-			$scope,
-			$methodCall->getArgs(),
-			$methodReflection->getVariants(),
-		)->getReturnType();
-
 		$argsCount = count($methodCall->getArgs());
 		if ($argsCount > 1) {
-			return $returnType;
+			return null;
 		}
 
 		if ($argsCount === 0) {
-			return $returnType;
+			return null;
 		}
 
 		$mapType = $scope->getType($methodCall->var);
 		if (!$mapType instanceof TypeWithClassName) {
-			return $returnType;
+			return null;
 		}
 
 		$mapAncestor = $mapType->getAncestorWithClassName('Ds\Map');
 		if ($mapAncestor === null) {
-			return $returnType;
+			return null;
 		}
 
 		$mapAncestorClass = $mapAncestor->getClassReflection();
 		if ($mapAncestorClass === null) {
-			return $returnType;
+			return null;
 		}
 
 		$valueType = $mapAncestorClass->getActiveTemplateTypeMap()->getType('TValue');
 		if ($valueType === null) {
-			return $returnType;
+			return null;
 		}
 
 		return $valueType;

--- a/src/Type/Php/DsMapDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DsMapDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeWithClassName;

--- a/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
@@ -26,14 +26,14 @@ class RandomIntFunctionReturnTypeExtension implements DynamicFunctionReturnTypeE
 		return in_array($functionReflection->getName(), ['random_int', 'rand', 'mt_rand'], true);
 	}
 
-	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
 		if (in_array($functionReflection->getName(), ['rand', 'mt_rand'], true) && count($functionCall->getArgs()) === 0) {
 			return IntegerRangeType::fromInterval(0, null);
 		}
 
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectFromArgs($scope, $functionCall->getArgs(), $functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$minType = $scope->getType($functionCall->getArgs()[0]->value)->toInteger();

--- a/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;

--- a/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;

--- a/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
@@ -28,10 +28,10 @@ class VersionCompareFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		FunctionReflection $functionReflection,
 		FuncCall $functionCall,
 		Scope $scope,
-	): Type
+	): ?Type
 	{
 		if (count($functionCall->getArgs()) < 2) {
-			return ParametersAcceptorSelector::selectFromArgs($scope, $functionCall->getArgs(), $functionReflection->getVariants())->getReturnType();
+			return null;
 		}
 
 		$version1Strings = $scope->getType($functionCall->getArgs()[0]->value)->getConstantStrings();


### PR DESCRIPTION
similar to https://github.com/phpstan/phpstan-src/pull/2782

Not sure why my previous search pattern did not match these. 

I think there is no more occurrences left which can be simplified in a similar fashion 