### PR TITLE
Simplify arrow-function return type inference

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1242,7 +1242,7 @@ class MutatingScope implements Scope
 						new VoidType(),
 					]);
 				} else {
-					$returnType = $arrowScope->getKeepVoidType($node->expr);
+					$returnType = $arrowScope->getType($node->expr);
 					if ($node->returnType !== null) {
 						$returnType = TypehintHelper::decideType($this->getFunctionType($node->returnType, false, false), $returnType);
 					}


### PR DESCRIPTION
Arrow-functions can't have a void return type

refs https://github.com/phpstan/phpstan-src/pull/2778#discussion_r1451778501