### PR TITLE
[HELP NEEDED] feat: phpstan-assert with throws annotation

### DIFF
--- a/tests/PHPStan/Rules/PhpDoc/data/function-assert.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/function-assert.php
@@ -70,9 +70,35 @@ function negate(int $i): void
 function negate1(int $i): void
 {
 }
+
 /**
  * @phpstan-assert !positive-int $i
  */
 function negate2(int $i): void
+{
+}
+
+/**
+ * @param array<string> $i
+ * @phpstan-assert array<string> $i
+ */
+function arrayShape(array $i): void
+{
+}
+
+/**
+ * @param array<string> $i
+ * @phpstan-assert array<string> $i \InvalidArgumentException
+ */
+function arrayShapeWithException(array $i): void
+{
+}
+
+/**
+ * @template T of array<string>
+ * @param T $i
+ * @phpstan-assert T $i \InvalidArgumentException
+ */
+public function arrayShapeWithGeneric(array $i): void
 {
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/method-assert.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/method-assert.php
@@ -79,4 +79,29 @@ class Foo
 	public function negate2(int $i): void
 	{
 	}
+
+	/**
+	 * @param array<string> $i
+	 * @phpstan-assert array<string> $i
+	 */
+	public function arrayShape(array $i): void
+	{
+	}
+
+	/**
+	 * @param array<string> $i
+	 * @phpstan-assert array<string> $i \InvalidArgumentException
+	 */
+	public function arrayShapeWithException(array $i): void
+	{
+	}
+
+	/**
+	 * @template T of array<string>
+	 * @param T $i
+	 * @phpstan-assert T $i \InvalidArgumentException
+	 */
+	public function arrayShapeWithGeneric(array $i): void
+	{
+	}
 }


### PR DESCRIPTION
I have a library, that has `treatPhpDocTypesAsCertain` set to false, as there are user-facing methods with array shapes that need to be checked to make sure that no invalid arrays are passed by the user of the package as not everyone uses phpstan. I also have checked exceptions enabled. The combination of these results in undocumentable methods;

```
/**
 * @param array<stdClass> $foo
 * @phpstan-assert array<stdClass> $this->foo
 */
public function __construct(
    public readonly array $foo
) {
    foreach ($this->foo as $bar) {
        if ($bar instanceof stdClass === false) {
            throw new \InvalidArgumentException();
        }
    }
}
```

This results in the following errors:
```
Asserted type array<stdClass> for $foo with type array<stdClass> does not narrow down the type.
Method Foo::__construct() throws checked exception InvalidArgumentException but it's missing from the PHPDoc @throws tag.
```

I don't want to mark all InvalidArgumentExceptions as unchecked, but I don't want to let the exception bubble up into methods that do properly call the constructor with an array of stdClass elements:
```
new Foo([new stdClass]);
```

## The solution?

If a new argument is added to the `@phpstan-assert` annotation with a class-string of an exception both errors would disappear:
- The unchecked exception check can read the thrown exception from the phpstan-assert annotation
- The 'does not narrow down the type' error is not true anymore because the phpstan-assert annotation introduces a thrown exception when the type is not correct.

```
/**
 * @phpstan-assert array<stdClass> $foo \InvalidArgumentException
 */
```

Would this be something that you would be open to? I started writing the code for this, but this will take quite a lot of time so I'd first like to check if this will even have a chance to get merged.
