### PR TITLE
curl_multi_init() cannot return false

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1501,7 +1501,7 @@ return [
 'curl_multi_exec' => ['int', 'mh'=>'resource', '&w_still_running'=>'int'],
 'curl_multi_getcontent' => ['string', 'ch'=>'resource'],
 'curl_multi_info_read' => ['array|false', 'mh'=>'resource', '&w_msgs_in_queue='=>'int'],
-'curl_multi_init' => ['resource|false'],
+'curl_multi_init' => ['resource'],
 'curl_multi_remove_handle' => ['int', 'mh'=>'resource', 'ch'=>'resource'],
 'curl_multi_select' => ['int', 'mh'=>'resource', 'timeout='=>'float'],
 'curl_multi_setopt' => ['bool', 'mh'=>'resource', 'option'=>'int', 'value'=>'mixed'],


### PR DESCRIPTION
even in php 7.4 it could not return false. it used to return `resource` and this changed with PHP8 to `CurlMultiHandle`:
https://www.php.net/manual/en/function.curl-multi-init.php

https://phpstan.org/r/3d26ccc3-01a7-424c-8dee-f5c4cac8db9d

https://github.com/php/php-src/blob/a0f6c5474ecba5693c5b5e45ffe802f375a8c0e4/ext/curl/multi.c#L62-L69