### PR TITLE
Fix check generic mixed type based on config v2

### DIFF
--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -15,11 +15,13 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	private bool $checkExplicitMixed = false;
 
+	private bool $checkImplicitMixed = false;
+
 	private bool $bleedingEdge = false;
 
 	protected function getRule(): Rule
 	{
-		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, $this->checkExplicitMixed, false, true, false);
+		$ruleLevelHelper = new RuleLevelHelper($this->createReflectionProvider(), true, false, true, $this->checkExplicitMixed, $this->checkImplicitMixed, true, false);
 
 		return new NonexistentOffsetInArrayDimFetchRule(
 			$ruleLevelHelper,
@@ -743,6 +745,26 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Offset \'b\' does not exist on array<\'a\', string>.',
 				23,
+			],
+		]);
+	}
+
+	public function testMixed(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkImplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/offset-access-mixed.php'], [
+			[
+				'Cannot access offset 5 on T of mixed.',
+				11,
+			],
+			[
+				'Cannot access offset 5 on mixed.',
+				16,
+			],
+			[
+				'Cannot access offset 5 on mixed.',
+				21,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/foreach-mixed.php
+++ b/tests/PHPStan/Rules/Arrays/data/foreach-mixed.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace ForeachMixed;
+
+/**
+ * @template T
+ * @param T $t
+ */
+function foo(mixed $t, mixed $explicit, $implicit): void
+{
+	foreach ($t as $v) {
+	}
+
+	foreach ($explicit as $v) {
+	}
+
+	foreach ($implicit as $v) {
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/offset-access-mixed.php
+++ b/tests/PHPStan/Rules/Arrays/data/offset-access-mixed.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace OffsetAccessMixed;
+
+/**
+ * @template T
+ * @param T $a
+ */
+function foo(mixed $a): void
+{
+	var_dump($a[5]);
+}
+
+function foo2(mixed $a): void
+{
+	var_dump($a[5]);
+}
+
+function foo3($a): void
+{
+	var_dump($a[5]);
+}

--- a/tests/PHPStan/Rules/Arrays/data/unpack-mixed.php
+++ b/tests/PHPStan/Rules/Arrays/data/unpack-mixed.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace UnpackMixed;
+
+/**
+ * @template T
+ * @param T $t
+ */
+function foo(mixed $t, mixed $explicit, $implicit): void
+{
+	var_dump([...$t]);
+	var_dump([...$explicit]);
+	var_dump([...$implicit]);
+}

--- a/tests/PHPStan/Rules/Cast/data/mixed-cast.php
+++ b/tests/PHPStan/Rules/Cast/data/mixed-cast.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace MixedCast;
+
+/**
+ * @template T
+ * @param T $t
+ */
+function foo(mixed $t, mixed $explicit, $implicit): void
+{
+	var_dump((int) $t);
+	var_dump((bool) $t);
+	var_dump((float) $t);
+	var_dump((string) $t);
+	var_dump((array) $t);
+	var_dump((object) $t);
+
+	var_dump((int) $explicit);
+	var_dump((bool) $explicit);
+	var_dump((float) $explicit);
+	var_dump((string) $explicit);
+	var_dump((array) $explicit);
+	var_dump((object) $explicit);
+
+	var_dump((int) $implicit);
+	var_dump((bool) $implicit);
+	var_dump((float) $implicit);
+	var_dump((string) $implicit);
+	var_dump((array) $implicit);
+	var_dump((object) $implicit);
+}

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -1548,6 +1548,10 @@ class CallMethodsRuleTest extends RuleTestCase
 						17,
 					],
 					[
+						'Cannot call method foo() on T of mixed.',
+						26,
+					],
+					[
 						'Parameter #1 $i of method CheckExplicitMixedMethodCall\Bar::doBar() expects int, mixed given.',
 						43,
 					],
@@ -1599,10 +1603,6 @@ class CallMethodsRuleTest extends RuleTestCase
 					[
 						'Parameter #1 $i of method CheckImplicitMixedMethodCall\Bar::doBar() expects int, mixed given.',
 						42,
-					],
-					[
-						'Parameter #1 $i of method CheckImplicitMixedMethodCall\Bar::doBar() expects int, T given.',
-						65,
 					],
 					[
 						'Parameter #1 $cb of method CheckImplicitMixedMethodCall\CallableMixed::doBar2() expects callable(): int, Closure(): mixed given.',

--- a/tests/PHPStan/Rules/Methods/data/call-static-method-mixed.php
+++ b/tests/PHPStan/Rules/Methods/data/call-static-method-mixed.php
@@ -1,0 +1,171 @@
+<?php // lint >= 8.0
+
+namespace CallStaticMethodMixed;
+
+class Foo
+{
+
+	/**
+	 * @param mixed $explicit
+	 */
+	public function doFoo(
+		$implicit,
+		$explicit
+	): void
+	{
+		$implicit::foo();
+		$explicit::foo();
+	}
+
+	/**
+	 * @template T
+	 * @param T $t
+	 */
+	public function doBar($t): void
+	{
+		$t::foo();
+	}
+
+}
+
+class Bar
+{
+
+	/**
+	 * @param mixed $explicit
+	 */
+	public function doFoo(
+		$implicit,
+		$explicit
+	): void
+	{
+		self::doBar($implicit);
+		self::doBar($explicit);
+
+		self::acceptImplicitMixed($implicit);
+		self::acceptImplicitMixed($explicit);
+
+		self::acceptExplicitMixed($implicit);
+		self::acceptExplicitMixed($explicit);
+
+		self::acceptVariadicArguments(...$implicit);
+		self::acceptVariadicArguments(...$explicit);
+	}
+
+	public static function doBar(int $i): void
+	{
+
+	}
+
+	public static function acceptImplicitMixed($mixed): void
+	{
+
+	}
+
+	public static function acceptExplicitMixed(mixed $mixed): void
+	{
+
+	}
+
+	public static function acceptVariadicArguments(mixed... $args): void
+	{
+
+	}
+
+	/**
+	 * @template T
+	 * @param T $t
+	 */
+	public function doLorem($t): void
+	{
+		self::doBar($t);
+		self::acceptImplicitMixed($t);
+		self::acceptExplicitMixed($t);
+		self::acceptVariadicArguments(...$t);
+	}
+
+}
+
+class CallableMixed
+{
+
+	/**
+	 * @param callable(mixed): void $cb
+	 */
+	public static function callAcceptsExplicitMixed(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param callable(int): void $cb
+	 */
+	public static function callAcceptsInt(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param callable(): mixed $cb
+	 */
+	public static function callReturnsExplicitMixed(callable $cb): void
+	{
+
+	}
+
+	public static function callReturnsImplicitMixed(callable $cb): void
+	{
+
+	}
+
+	/**
+	 * @param callable(): int $cb
+	 */
+	public static function callReturnsInt(callable $cb): void
+	{
+
+	}
+
+	public static function doLorem(int $i, mixed $explicitMixed, $implicitMixed): void
+	{
+		$acceptsInt = function (int $i): void {
+
+		};
+		self::callAcceptsExplicitMixed($acceptsInt);
+		self::callAcceptsInt($acceptsInt);
+
+		$acceptsExplicitMixed = function (mixed $m): void {
+
+		};
+		self::callAcceptsExplicitMixed($acceptsExplicitMixed);
+		self::callAcceptsInt($acceptsExplicitMixed);
+
+		$acceptsImplicitMixed = function ($m): void {
+
+		};
+		self::callAcceptsExplicitMixed($acceptsImplicitMixed);
+		self::callAcceptsInt($acceptsImplicitMixed);
+
+		$returnsInt = function () use ($i): int {
+			return $i;
+		};
+		self::callReturnsExplicitMixed($returnsInt);
+		self::callReturnsImplicitMixed($returnsInt);
+		self::callReturnsInt($returnsInt);
+
+		$returnsExplicitMixed = function () use ($explicitMixed): mixed {
+			return $explicitMixed;
+		};
+		self::callReturnsExplicitMixed($returnsExplicitMixed);
+		self::callReturnsImplicitMixed($returnsExplicitMixed);
+		self::callReturnsInt($returnsExplicitMixed);
+
+		$returnsImplicitMixed = function () use ($implicitMixed): mixed {
+			return $implicitMixed;
+		};
+		self::callReturnsExplicitMixed($returnsImplicitMixed);
+		self::callReturnsImplicitMixed($returnsImplicitMixed);
+		self::callReturnsInt($returnsImplicitMixed);
+	}
+
+}


### PR DESCRIPTION
This is an alternative to https://github.com/phpstan/phpstan-src/pull/2809 . This time I was able to limit the changes to `RuleLevelHelper` (it kind of makes me wonder how I missed this option in the first place).

The goal is to handle `TemplateMixedType` similarly to explicit `MixedType` with respect to `checkExplicitMixed`. Here is an example of the issues in as many cases as I can think of https://phpstan.org/r/0b58afa8-fd01-4991-922e-d46037106135 . As you can see, even the regular mixed type is not covered completely, but that's a matter for another PR(s).

These are the results for the linked playground code in this branch:

```
  9      Cannot call method foo() on T of mixed.                                          
  10     Cannot call static method bar() on T of mixed.                                   
  11     Cannot access offset 5 on T of mixed.                                            
  12     Parameter #1 $string of function strlen expects string, T given.                 
  16     Cannot cast T to int.                                                            
  17     Anonymous function should return int but returns T.                              
  18     Only iterables can be unpacked, T of mixed given in argument #1.                 
  19     Only iterables can be unpacked, T of mixed given.                                
  21     Argument of an invalid type T of mixed supplied for foreach, only iterables are  
         supported.                                                                       
  36     Cannot call method foo() on mixed.                                               
  37     Cannot call static method bar() on mixed.                                        
  38     Cannot access offset 5 on mixed.                                                 
  39     Parameter #1 $string of function strlen expects string, mixed given.             
  43     Cannot cast mixed to int.                                                        
  44     Anonymous function should return int but returns mixed.                          
  45     Only iterables can be unpacked, mixed given in argument #1.                      
  46     Only iterables can be unpacked, mixed given.                                     
  48     Argument of an invalid type mixed supplied for foreach, only iterables are       
         supported. 
```

