### PR TITLE
fix spaceship operator for large constant unions

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -746,17 +746,13 @@ class InitializerExprTypeResolver
 
 		$leftTypesCount = count($leftTypes);
 		$rightTypesCount = count($rightTypes);
-		if ($leftTypesCount > 0 && $rightTypesCount > 0) {
+		if ($leftTypesCount > 0 && $rightTypesCount > 0 && $leftTypesCount * $rightTypesCount <= self::CALCULATE_SCALARS_LIMIT) {
 			$resultTypes = [];
-			$generalize = $leftTypesCount * $rightTypesCount > self::CALCULATE_SCALARS_LIMIT;
 			foreach ($leftTypes as $leftType) {
 				foreach ($rightTypes as $rightType) {
 					$leftValue = $leftType->getValue();
 					$rightValue = $rightType->getValue();
 					$resultType = $this->getTypeFromValue($leftValue <=> $rightValue);
-					if ($generalize) {
-						$resultType = $resultType->generalize(GeneralizePrecision::lessSpecific());
-					}
 					$resultTypes[] = $resultType;
 				}
 			}

--- a/tests/PHPStan/Rules/Functions/ArrowFunctionReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrowFunctionReturnTypeRuleTest.php
@@ -60,4 +60,9 @@ class ArrowFunctionReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8179.php'], []);
 	}
 
+	public function testBugSpaceship(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-spaceship.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-spaceship.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-spaceship.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+
+namespace BugSpaceship;
+
+$arr = range(1, 16);
+usort($arr, static fn (int $a, int $b): int => $a <=> $b);


### PR DESCRIPTION
This PR fixes a false positive encountered by https://github.com/phpstan/phpstan-src/pull/2885 . I simplified it to smaller example: https://phpstan.org/r/892eed14-49b8-4a98-b591-90cf5741a99e

This scenario only happens with bleeding edge enabled. Without it the constant union doesn't make it into `getSpaceshipType` due to https://github.com/phpstan/phpstan-src/blob/4e1bfacafb0cd4a4dd89946d211205fb0ba9cef5/src/Type/Generic/TemplateTypeTrait.php#L269

As far as I can tell, the spaceship operator should always return -1, 0, or 1: https://3v4l.org/FVeq7