### PR TITLE
InvalidThrowsPhpDocValueRule: support @require-extends, @require-implements

### DIFF
--- a/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
+++ b/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
@@ -63,7 +63,7 @@ class InvalidThrowsPhpDocValueRule implements Rule
 			return [];
 		}
 
-		if ($this->isThrowValid($phpDocThrowsType)) {
+		if ($this->isThrowsValid($phpDocThrowsType)) {
 			return [];
 		}
 
@@ -75,12 +75,12 @@ class InvalidThrowsPhpDocValueRule implements Rule
 		];
 	}
 
-	private function isThrowValid(Type $phpDocThrowsType): bool
+	private function isThrowsValid(Type $phpDocThrowsType): bool
 	{
 		$throwType = new ObjectType(Throwable::class);
 		if ($phpDocThrowsType instanceof UnionType) {
 			foreach ($phpDocThrowsType->getTypes() as $innerType) {
-				if (!$this->isThrowValid($innerType)) {
+				if (!$this->isThrowsValid($innerType)) {
 					return false;
 				}
 			}

--- a/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
+++ b/src/Rules/PhpDoc/InvalidThrowsPhpDocValueRule.php
@@ -76,25 +76,8 @@ class InvalidThrowsPhpDocValueRule implements Rule
 	private function isThrowValid(Type $phpDocThrowsType): bool
 	{
 		$throwType = new ObjectType(Throwable::class);
-		if ($throwType->isSuperTypeOf($phpDocThrowsType)->yes()) {
-			return true;
-		}
 
-		foreach ($phpDocThrowsType->getObjectClassReflections() as $classReflection) {
-			foreach ($classReflection->getRequireExtendsTags() as $requireExtendsTag) {
-				if ($throwType->isSuperTypeOf($requireExtendsTag->getType())->yes()) {
-					return true;
-				}
-			}
-
-			foreach ($classReflection->getRequireImplementsTags() as $requireImplementsTag) {
-				if ($throwType->isSuperTypeOf($requireImplementsTag->getType())->yes()) {
-					return true;
-				}
-			}
-		}
-
-		return false;
+		return $throwType->isSuperTypeOf($phpDocThrowsType)->yes();
 	}
 
 }

--- a/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
@@ -77,40 +77,24 @@ class InvalidThrowsPhpDocValueRuleTest extends RuleTestCase
 		]);
 	}
 
-	public function testThrowsWithRequireExtendsImplements(): void
+	public function testThrowsWithRequireExtends(): void
 	{
 		$this->analyse([__DIR__ . '/data/throws-with-require.php'], [
 			[
 				'PHPDoc tag @throws with type ThrowsWithRequire\\RequiresExtendsStdClassInterface is not subtype of Throwable',
-				42,
-			],
-			[
-				'PHPDoc tag @throws with type ThrowsWithRequire\\RequiresImplementsDateTimeInterfaceTrait is not subtype of Throwable',
-				49,
+				25,
 			],
 			[
 				'PHPDoc tag @throws with type DateTimeInterface|ThrowsWithRequire\\RequiresExtendsExceptionInterface is not subtype of Throwable',
-				70,
-			],
-			[
-				'PHPDoc tag @throws with type DateTimeInterface|ThrowsWithRequire\\RequiresImplementsThrowableTrait is not subtype of Throwable',
-				77,
+				39,
 			],
 			[
 				'PHPDoc tag @throws with type Exception|ThrowsWithRequire\\RequiresExtendsStdClassInterface is not subtype of Throwable',
-				84,
-			],
-			[
-				'PHPDoc tag @throws with type Exception|ThrowsWithRequire\\RequiresImplementsDateTimeInterfaceTrait is not subtype of Throwable',
-				91,
+				46,
 			],
 			[
 				'PHPDoc tag @throws with type Iterator&ThrowsWithRequire\\RequiresExtendsStdClassInterface is not subtype of Throwable',
-				140,
-			],
-			[
-				'PHPDoc tag @throws with type Iterator&ThrowsWithRequire\\RequiresImplementsDateTimeInterfaceTrait is not subtype of Throwable',
-				147,
+				74,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
@@ -77,6 +77,44 @@ class InvalidThrowsPhpDocValueRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testThrowsWithRequireExtendsImplements(): void
+	{
+		$this->analyse([__DIR__ . '/data/throws-with-require.php'], [
+			[
+				'PHPDoc tag @throws with type ThrowsWithRequire\\RequiresExtendsStdClassInterface is not subtype of Throwable',
+				42,
+			],
+			[
+				'PHPDoc tag @throws with type ThrowsWithRequire\\RequiresImplementsDateTimeInterfaceTrait is not subtype of Throwable',
+				49,
+			],
+			[
+				'PHPDoc tag @throws with type DateTimeInterface|ThrowsWithRequire\\RequiresExtendsExceptionInterface is not subtype of Throwable',
+				70,
+			],
+			[
+				'PHPDoc tag @throws with type DateTimeInterface|ThrowsWithRequire\\RequiresImplementsThrowableTrait is not subtype of Throwable',
+				77,
+			],
+			[
+				'PHPDoc tag @throws with type Exception|ThrowsWithRequire\\RequiresExtendsStdClassInterface is not subtype of Throwable',
+				84,
+			],
+			[
+				'PHPDoc tag @throws with type Exception|ThrowsWithRequire\\RequiresImplementsDateTimeInterfaceTrait is not subtype of Throwable',
+				91,
+			],
+			[
+				'PHPDoc tag @throws with type Iterator&ThrowsWithRequire\\RequiresExtendsStdClassInterface is not subtype of Throwable',
+				140,
+			],
+			[
+				'PHPDoc tag @throws with type Iterator&ThrowsWithRequire\\RequiresImplementsDateTimeInterfaceTrait is not subtype of Throwable',
+				147,
+			],
+		]);
+	}
+
 	public function dataMergeInheritedPhpDocs(): array
 	{
 		return [

--- a/tests/PHPStan/Rules/PhpDoc/data/throws-with-require.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/throws-with-require.php
@@ -8,31 +8,14 @@ namespace ThrowsWithRequire;
 interface RequiresExtendsExceptionInterface {}
 
 /**
- * @phpstan-require-implements \Throwable
- */
-trait RequiresImplementsThrowableTrait {}
-
-/**
  * @phpstan-require-extends \stdClass
  */
 interface RequiresExtendsStdClassInterface {}
 
 /**
- * @phpstan-require-implements \DateTimeInterface
- */
-trait RequiresImplementsDateTimeInterfaceTrait {}
-
-/**
  * @throws RequiresExtendsExceptionInterface
  */
 function requiresExtendsExceptionThrows()
-{
-}
-
-/**
- * @throws RequiresImplementsThrowableTrait
- */
-function requiresImplementsThrowableThrows()
 {
 }
 
@@ -44,23 +27,9 @@ function requiresExtendsStdClassThrows()
 }
 
 /**
- * @throws RequiresImplementsDateTimeInterfaceTrait
- */
-function requiresImplementsDateTimeInterfaceThrows()
-{
-}
-
-/**
  * @throws \Exception|RequiresExtendsExceptionInterface
  */
 function unionExceptionAndRequiresExtendsExceptionThrows()
-{
-}
-
-/**
- * @throws \Exception|RequiresImplementsThrowableTrait
- */
-function unionExceptionAndRequiresImplementsThrowableThrows()
 {
 }
 
@@ -72,23 +41,9 @@ function notThrowableUnionDateTimeInterfaceAndRequiresExtendsExceptionThrows()
 }
 
 /**
- * @throws \DateTimeInterface|RequiresImplementsThrowableTrait
- */
-function notThrowableUnionDateTimeInterfaceAndRequiresImplementsThrowableThrows()
-{
-}
-
-/**
  * @throws \Exception|RequiresExtendsStdClassInterface
  */
 function notThrowableUnionExceptionAndRequiresExtendsStdClassThrows()
-{
-}
-
-/**
- * @throws \Exception|RequiresImplementsDateTimeInterfaceTrait
- */
-function notThrowableUnionExceptionAndRequiresImplementsDateTimeInterfaceTraitThrows()
 {
 }
 
@@ -100,23 +55,9 @@ function intersectionExceptionAndRequiresExtendsExceptionThrows()
 }
 
 /**
- * @throws \Exception&RequiresImplementsThrowableTrait
- */
-function intersectionExceptionAndRequiresImplementsThrowableThrows()
-{
-}
-
-/**
  * @throws \DateTimeInterface&RequiresExtendsExceptionInterface
  */
 function intersectionDateTimeInterfaceAndRequiresExtendsExceptionThrows()
-{
-}
-
-/**
- * @throws \DateTimeInterface&RequiresImplementsThrowableTrait
- */
-function intersectionDateTimeInterfaceAndRequiresImplementsThrowableThrows()
 {
 }
 
@@ -128,22 +69,8 @@ function intersectionExceptionAndRequiresExtendsStdClassThrows()
 }
 
 /**
- * @throws \Exception&RequiresImplementsDateTimeInterfaceTrait
- */
-function intersectionExceptionAndRequiresImplementsDateTimeInterfaceTraitThrows()
-{
-}
-
-/**
  * @throws \Iterator&RequiresExtendsStdClassInterface
  */
 function notThrowableIntersectionIteratorAndRequiresExtendsStdClassThrows()
-{
-}
-
-/**
- * @throws \Iterator&RequiresImplementsDateTimeInterfaceTrait
- */
-function notThrowableIntersectionIteratorAndRequiresImplementsDateTimeInterfaceTraitThrows()
 {
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/throws-with-require.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/throws-with-require.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace ThrowsWithRequire;
+
+/**
+ * @phpstan-require-extends \Exception
+ */
+interface RequiresExtendsExceptionInterface {}
+
+/**
+ * @phpstan-require-implements \Throwable
+ */
+trait RequiresImplementsThrowableTrait {}
+
+/**
+ * @phpstan-require-extends \stdClass
+ */
+interface RequiresExtendsStdClassInterface {}
+
+/**
+ * @phpstan-require-implements \DateTimeInterface
+ */
+trait RequiresImplementsDateTimeInterfaceTrait {}
+
+/**
+ * @throws RequiresExtendsExceptionInterface
+ */
+function requiresExtendsExceptionThrows()
+{
+}
+
+/**
+ * @throws RequiresImplementsThrowableTrait
+ */
+function requiresImplementsThrowableThrows()
+{
+}
+
+/**
+ * @throws RequiresExtendsStdClassInterface
+ */
+function requiresExtendsStdClassThrows()
+{
+}
+
+/**
+ * @throws RequiresImplementsDateTimeInterfaceTrait
+ */
+function requiresImplementsDateTimeInterfaceThrows()
+{
+}
+
+/**
+ * @throws \Exception|RequiresExtendsExceptionInterface
+ */
+function unionExceptionAndRequiresExtendsExceptionThrows()
+{
+}
+
+/**
+ * @throws \Exception|RequiresImplementsThrowableTrait
+ */
+function unionExceptionAndRequiresImplementsThrowableThrows()
+{
+}
+
+/**
+ * @throws \DateTimeInterface|RequiresExtendsExceptionInterface
+ */
+function notThrowableUnionDateTimeInterfaceAndRequiresExtendsExceptionThrows()
+{
+}
+
+/**
+ * @throws \DateTimeInterface|RequiresImplementsThrowableTrait
+ */
+function notThrowableUnionDateTimeInterfaceAndRequiresImplementsThrowableThrows()
+{
+}
+
+/**
+ * @throws \Exception|RequiresExtendsStdClassInterface
+ */
+function notThrowableUnionExceptionAndRequiresExtendsStdClassThrows()
+{
+}
+
+/**
+ * @throws \Exception|RequiresImplementsDateTimeInterfaceTrait
+ */
+function notThrowableUnionExceptionAndRequiresImplementsDateTimeInterfaceTraitThrows()
+{
+}
+
+/**
+ * @throws \Exception&RequiresExtendsExceptionInterface
+ */
+function intersectionExceptionAndRequiresExtendsExceptionThrows()
+{
+}
+
+/**
+ * @throws \Exception&RequiresImplementsThrowableTrait
+ */
+function intersectionExceptionAndRequiresImplementsThrowableThrows()
+{
+}
+
+/**
+ * @throws \DateTimeInterface&RequiresExtendsExceptionInterface
+ */
+function intersectionDateTimeInterfaceAndRequiresExtendsExceptionThrows()
+{
+}
+
+/**
+ * @throws \DateTimeInterface&RequiresImplementsThrowableTrait
+ */
+function intersectionDateTimeInterfaceAndRequiresImplementsThrowableThrows()
+{
+}
+
+/**
+ * @throws \Exception&RequiresExtendsStdClassInterface
+ */
+function intersectionExceptionAndRequiresExtendsStdClassThrows()
+{
+}
+
+/**
+ * @throws \Exception&RequiresImplementsDateTimeInterfaceTrait
+ */
+function intersectionExceptionAndRequiresImplementsDateTimeInterfaceTraitThrows()
+{
+}
+
+/**
+ * @throws \Iterator&RequiresExtendsStdClassInterface
+ */
+function notThrowableIntersectionIteratorAndRequiresExtendsStdClassThrows()
+{
+}
+
+/**
+ * @throws \Iterator&RequiresImplementsDateTimeInterfaceTrait
+ */
+function notThrowableIntersectionIteratorAndRequiresImplementsDateTimeInterfaceTraitThrows()
+{
+}


### PR DESCRIPTION
Handle / support `@throws` types which are annotated with `@phpstan-require-extends` or `@phpstan-require-implements`.

Fixes phpstan/phpstan#10475

Currently this is a WIP as support for intersections and unions is lacking and this is more like a "support request" on how I can support this.