### PR TITLE
Improve parameter type of SplObjectStorage::removeAll/Except

### DIFF
--- a/stubs/SplObjectStorage.stub
+++ b/stubs/SplObjectStorage.stub
@@ -42,12 +42,12 @@ class SplObjectStorage implements Countable, Iterator, Serializable, ArrayAccess
     public function getInfo() { }
 
     /**
-     * @param \SplObjectStorage<object, mixed> $storage
+     * @param \SplObjectStorage<*, *> $storage
      */
     public function removeAll(SplObjectStorage $storage): void { }
 
     /**
-     * @param \SplObjectStorage<object, mixed> $storage
+     * @param \SplObjectStorage<*, *> $storage
      */
     public function removeAllExcept(SplObjectStorage $storage): void { }
 

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3240,4 +3240,15 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9009.php'], []);
 	}
 
+	public function testBuSplObjectStorageRemove(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-SplObjectStorage-remove.php'], [
+			// removeNoIntersect should be reported, but unfortunately it cannot be expressed by the type system.
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-SplObjectStorage-remove.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-SplObjectStorage-remove.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace BugSplObjectStorageRemove;
+
+class A {}
+
+class B extends A {}
+
+class C extends B {}
+
+class Foo {}
+
+interface BarInterface {}
+
+/** @phpstan-type ObjectStorage \SplObjectStorage<B, int> */
+class HelloWorld
+{
+	/** @var ObjectStorage */
+	private \SplObjectStorage $foo;
+
+	/**
+	 * @param ObjectStorage $other
+	 * @return ObjectStorage
+	 */
+	public function removeSame(\SplObjectStorage $other): \SplObjectStorage
+	{
+		$this->foo->removeAll($other);
+		$this->foo->removeAllExcept($other);
+
+		return $this->foo;
+	}
+
+	/**
+	 * @param \SplObjectStorage<C, string> $other
+	 * @return ObjectStorage
+	 */
+	public function removeNarrower(\SplObjectStorage $other): \SplObjectStorage
+	{
+		$this->foo->removeAll($other);
+		$this->foo->removeAllExcept($other);
+
+		return $this->foo;
+	}
+
+	/**
+	 * @param \SplObjectStorage<B, string> $other
+	 * @return ObjectStorage
+	 */
+	public function removeWider(\SplObjectStorage $other): \SplObjectStorage
+	{
+		$this->foo->removeAll($other);
+		$this->foo->removeAllExcept($other);
+
+		return $this->foo;
+	}
+
+	/**
+	 * @param \SplObjectStorage<BarInterface, string> $other
+	 * @return ObjectStorage
+	 */
+	public function removePossibleIntersect(\SplObjectStorage $other): \SplObjectStorage
+	{
+		$this->foo->removeAll($other);
+		$this->foo->removeAllExcept($other);
+
+		return $this->foo;
+	}
+
+	/**
+	 * @param \SplObjectStorage<Foo, string> $other
+	 * @return ObjectStorage
+	 */
+	public function removeNoIntersect(\SplObjectStorage $other): \SplObjectStorage
+	{
+		$this->foo->removeAll($other);
+		$this->foo->removeAllExcept($other);
+
+		return $this->foo;
+	}
+}


### PR DESCRIPTION
See https://phpstan.org/r/bff03687-1f39-496b-a23e-0386bcb75362 . Ideally, `removeNoIntersect` should be reported as an issue since it is not possible for the removes to do anything. However, AFAIK there is no way to express such constraint in the current type system (i.e. I'd want to make sure that the key types of the two storages have a non-empty intersection).

I considered using `\SplObjectStorage<covariant TObject, *>|\SplObjectStorage<contravariant TObject, *>`, which would report `removeNoIntersect`, but it would lead to a false positive in `removePossibleIntersect`. And `\SplObjectStorage<*, *>` seems to have been the intention of the previous stub.

Fixes https://github.com/phpstan/phpstan/issues/9411