### PR TITLE
Fixes incorrect types reported by parse_url

### DIFF
--- a/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
@@ -86,7 +86,7 @@ final class ParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		}
 
 		if ($componentType->getValue() === -1) {
-			return $this->createAllComponentsReturnType();
+			return TypeCombinator::union($this->createComponentsArray(), new ConstantBooleanType(false));
 		}
 
 		return $this->componentTypesPairedConstants[$componentType->getValue()] ?? new ConstantBooleanType(false);
@@ -97,24 +97,31 @@ final class ParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		if ($this->allComponentsTogetherType === null) {
 			$returnTypes = [
 				new ConstantBooleanType(false),
+				new NullType(),
+				IntegerRangeType::fromInterval(0, 65535),
+				new StringType(),
+				$this->createComponentsArray(),
 			];
-
-			$builder = ConstantArrayTypeBuilder::createEmpty();
-
-			if ($this->componentTypesPairedStrings === null) {
-				throw new ShouldNotHappenException();
-			}
-
-			foreach ($this->componentTypesPairedStrings as $componentName => $componentValueType) {
-				$builder->setOffsetValueType(new ConstantStringType($componentName), $componentValueType, true);
-			}
-
-			$returnTypes[] = $builder->getArray();
 
 			$this->allComponentsTogetherType = TypeCombinator::union(...$returnTypes);
 		}
 
 		return $this->allComponentsTogetherType;
+	}
+
+	private function createComponentsArray(): Type
+	{
+			$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		if ($this->componentTypesPairedStrings === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		foreach ($this->componentTypesPairedStrings as $componentName => $componentValueType) {
+			$builder->setOffsetValueType(new ConstantStringType($componentName), $componentValueType, true);
+		}
+
+			return $builder->getArray();
 	}
 
 	private function cacheReturnTypes(): void

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5500,7 +5500,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$parseUrlConstantUrlWithoutComponent2',
 			],
 			[
-				'array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false',
+				'array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|int<0, 65535>|string|false|null',
 				'$parseUrlConstantUrlUnknownComponent',
 			],
 			[

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1485,6 +1485,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10952b.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/case-insensitive-parent.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10893.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4754.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-4754.php
+++ b/tests/PHPStan/Analyser/data/bug-4754.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Bug4754;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * The standard PHP parse_url() function doesn't work with relative URI's only absolute URL's
+ * so this function works around that by adding a http://domain prefix
+ * if needed and passing through the results
+ *
+ * @param string $url
+ * @param int	 $component
+ *
+ * @return string|int|array|bool|null
+ */
+function parseUrl($url, $component = -1)
+{
+	$parsedComponentNotSpecified = parse_url($url);
+	$parsedNotConstant = parse_url($url, $component);
+	$parsedAllConstant = parse_url($url, -1);
+	$parsedSchemeConstant = parse_url($url, PHP_URL_SCHEME);
+	$parsedHostConstant = parse_url($url, PHP_URL_HOST);
+	$parsedPortConstant = parse_url($url, PHP_URL_PORT);
+	$parsedUserConstant = parse_url($url, PHP_URL_USER);
+	$parsedPassConstant = parse_url($url, PHP_URL_PASS);
+	$parsedPathConstant = parse_url($url, PHP_URL_PATH);
+	$parsedQueryConstant = parse_url($url, PHP_URL_QUERY);
+	$parsedFragmentConstant = parse_url($url, PHP_URL_FRAGMENT);
+
+	assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedComponentNotSpecified);
+	assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|int<0, 65535>|string|false|null', $parsedNotConstant);
+	assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $parsedAllConstant);
+	assertType('string|false|null', $parsedSchemeConstant);
+	assertType('string|false|null', $parsedHostConstant);
+	assertType('int<0, 65535>|false|null', $parsedPortConstant);
+	assertType('string|false|null', $parsedUserConstant);
+	assertType('string|false|null', $parsedPassConstant);
+	assertType('string|false|null', $parsedPathConstant);
+	assertType('string|false|null', $parsedQueryConstant);
+	assertType('string|false|null', $parsedFragmentConstant);
+}


### PR DESCRIPTION
Fixes parse_url return type when $component is -1 returning more types than were valid. Adds missing types when $component is not a constant value.

Fixes: https://github.com/phpstan/phpstan/issues/4754