### PR TITLE
Use preg_qoute() escaping for --filter phpunit option

### DIFF
--- a/.github/workflows/tests-levels-matrix.php
+++ b/.github/workflows/tests-levels-matrix.php
@@ -19,7 +19,7 @@ foreach($simpleXml->testCaseClass as $testCaseClass) {
 		[$className, $testName] = explode('::', $testCaseName, 2);
 		$fileName = 'tests/'. str_replace('\\', DIRECTORY_SEPARATOR, $className) . '.php';
 
-		$filter = str_replace('\\', '\\\\', $testCaseName);
+		$filter = preg_quote($testCaseName);
 
 		$testFilters[] = sprintf("%s --filter %s", escapeshellarg($fileName), escapeshellarg($filter));
 	}


### PR DESCRIPTION
see discussion in https://github.com/phpstan/phpstan-src/pull/2916#discussion_r1493671196

a test-class like

```
<?php
namespace TestNamespace;

use PHPUnit\Framework\TestCase;

class mytest extends TestCase
{
	/**
	 * @dataProvider provider
	 */
	public function testMethod($data)
	{
		$this->assertTrue($data);
	}

	public function provider()
	{
		return [
			'my name(d data' => [true],
			'my $dat)a'       => [true]
		];
	}
}
```

requires a escaped filter

```
➜  phpstan-src git:(1.11.x) ✗ vendor/bin/phpunit mytest.php --filter 'my $dat\)a'
PHPUnit 9.5.23 #StandWithUkraine

Warning:       No code coverage driver available

No tests executed!
➜  phpstan-src git:(1.11.x) ✗ vendor/bin/phpunit mytest.php --filter 'my \$dat\)a'
PHPUnit 9.5.23 #StandWithUkraine

Warning:       No code coverage driver available

.                                                                   1 / 1 (100%)

Time: 00:00.011, Memory: 32.00 MB

OK (1 test, 1 assertion)
```