### PR TITLE
Add always used method extension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -975,6 +975,9 @@ services:
 		class: PHPStan\Rules\Constants\LazyAlwaysUsedClassConstantsExtensionProvider
 
 	-
+		class: PHPStan\Rules\Methods\LazyAlwaysUsedMethodExtensionProvider
+
+	-
 		class: PHPStan\Rules\PhpDoc\ConditionalReturnTypeRuleHelper
 
 	-

--- a/src/Rules/DeadCode/UnusedPrivateMethodRule.php
+++ b/src/Rules/DeadCode/UnusedPrivateMethodRule.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassMethodsNode;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Rules\Methods\AlwaysUsedMethodExtensionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -21,6 +22,10 @@ use function strtolower;
  */
 class UnusedPrivateMethodRule implements Rule
 {
+
+	public function __construct(private AlwaysUsedMethodExtensionProvider $extensionProvider)
+	{
+	}
 
 	public function getNodeType(): string
 	{
@@ -54,6 +59,14 @@ class UnusedPrivateMethodRule implements Rule
 			if (strtolower($methodName) === '__clone') {
 				continue;
 			}
+
+			$methodReflection = $classType->getMethod($methodName, $scope);
+			foreach ($this->extensionProvider->getExtensions() as $extension) {
+				if ($extension->isAlwaysUsed($methodReflection)) {
+					continue 2;
+				}
+			}
+
 			$methods[strtolower($methodName)] = $method;
 		}
 

--- a/src/Rules/Methods/AlwaysUsedMethodExtension.php
+++ b/src/Rules/Methods/AlwaysUsedMethodExtension.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Reflection\MethodReflection;
+
+/**
+ * This is the extension interface to implement if you want to describe an always-used class method.
+ *
+ * To register it in the configuration file use the `phpstan.methods.alwaysUsedMethodExtension` service tag:
+ *
+ * ```
+ * services:
+ * 	-
+ *		class: App\PHPStan\MyExtension
+ *		tags:
+ *			- phpstan.methods.alwaysUsedMethodExtension
+ * ```
+ *
+ * @api
+ */
+interface AlwaysUsedMethodExtension
+{
+
+	public function isAlwaysUsed(MethodReflection $methodReflection): bool;
+
+}

--- a/src/Rules/Methods/AlwaysUsedMethodExtensionProvider.php
+++ b/src/Rules/Methods/AlwaysUsedMethodExtensionProvider.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+interface AlwaysUsedMethodExtensionProvider
+{
+
+	public const EXTENSION_TAG = 'phpstan.methods.alwaysUsedMethodExtension';
+
+	/**
+	 * @return AlwaysUsedMethodExtension[]
+	 */
+	public function getExtensions(): array;
+
+}

--- a/src/Rules/Methods/DirectAlwaysUsedMethodExtensionProvider.php
+++ b/src/Rules/Methods/DirectAlwaysUsedMethodExtensionProvider.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+class DirectAlwaysUsedMethodExtensionProvider implements AlwaysUsedMethodExtensionProvider
+{
+
+	/**
+	 * @param AlwaysUsedMethodExtension[] $extensions
+	 */
+	public function __construct(private array $extensions)
+	{
+	}
+
+	public function getExtensions(): array
+	{
+		return $this->extensions;
+	}
+
+}

--- a/src/Rules/Methods/LazyAlwaysUsedMethodExtensionProvider.php
+++ b/src/Rules/Methods/LazyAlwaysUsedMethodExtensionProvider.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\DependencyInjection\Container;
+
+class LazyAlwaysUsedMethodExtensionProvider implements AlwaysUsedMethodExtensionProvider
+{
+
+	/** @var AlwaysUsedMethodExtension[]|null */
+	private ?array $extensions = null;
+
+	public function __construct(private Container $container)
+	{
+	}
+
+	public function getExtensions(): array
+	{
+		return $this->extensions ??= $this->container->getServicesByTag(static::EXTENSION_TAG);
+	}
+
+}

--- a/tests/PHPStan/Rules/DeadCode/data/unused-private-method.php
+++ b/tests/PHPStan/Rules/DeadCode/data/unused-private-method.php
@@ -171,3 +171,14 @@ class StaticMethod
 	}
 
 }
+
+class IgnoredByExtension
+{
+	private function foo(): void
+	{
+	}
+
+	private function bar(): void
+	{
+	}
+}


### PR DESCRIPTION
This PR adds a new extension type to PHPStan. This new extension type allows developers to tell PHPStan when a private method is used.

My personal use case:
I make use of a library that exposes a trait that dynamically calls methods on my objects, since I have no other uses for these methods I typically make them private. Since there are no direct references to these methods PHPStan reports them as unused.

I used #495 as a blueprint for this PR.

Lastly, one thing I'm somewhat unsure about is the positioning of the extension check within the rule, maybe moving it up or down somewhat could be beneficial to performance.