### PR TITLE
Add resolution of generic @method tags

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -185,12 +185,24 @@ class PhpDocNodeResolver
 					);
 				}
 
+				$templates = [];
+				foreach ($tagValue->templateTypes as $templateType) {
+					$templates[$templateType->name] = new TemplateTag(
+						$templateType->name,
+						$templateType->bound !== null
+							? $this->typeNodeResolver->resolve($templateType->bound, $nameScope)
+							: new MixedType(),
+						TemplateTypeVariance::createInvariant()
+					);
+				}
+
 				$resolved[$tagValue->methodName] = new MethodTag(
 					$tagValue->returnType !== null
 						? $this->typeNodeResolver->resolve($tagValue->returnType, $nameScope)
 						: new MixedType(),
 					$tagValue->isStatic,
 					$parameters,
+					$templates
 				);
 			}
 		}

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -165,7 +165,7 @@ class PhpDocNodeResolver
 			foreach ($phpDocNode->getMethodTagValues($tagName) as $tagValue) {
 				$templateTags = [];
 
-				if (count($tagValue->templateTypes) > 0) {
+				if (count($tagValue->templateTypes) > 0 && $nameScope->getClassName() !== null) {
 					foreach ($tagValue->templateTypes as $templateType) {
 						$templateTags[$templateType->name] = new TemplateTag(
 							$templateType->name,

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -172,7 +172,7 @@ class PhpDocNodeResolver
 							$templateType->bound !== null
 								? $this->typeNodeResolver->resolve($templateType->bound, $nameScope)
 								: new MixedType(),
-							TemplateTypeVariance::createInvariant()
+							TemplateTypeVariance::createInvariant(),
 						);
 					}
 

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -30,6 +30,9 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\Reflection\PassedByReference;
 use PHPStan\Rules\PhpDoc\UnresolvableTypeHelper;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
@@ -160,6 +163,24 @@ class PhpDocNodeResolver
 
 		foreach (['@method', '@psalm-method', '@phpstan-method'] as $tagName) {
 			foreach ($phpDocNode->getMethodTagValues($tagName) as $tagValue) {
+				$templateTags = [];
+
+				if (count($tagValue->templateTypes) > 0) {
+					foreach ($tagValue->templateTypes as $templateType) {
+						$templateTags[$templateType->name] = new TemplateTag(
+							$templateType->name,
+							$templateType->bound !== null
+								? $this->typeNodeResolver->resolve($templateType->bound, $nameScope)
+								: new MixedType(),
+							TemplateTypeVariance::createInvariant()
+						);
+					}
+
+					$templateTypeScope = TemplateTypeScope::createWithMethod($nameScope->getClassName(), $tagValue->methodName);
+					$templateTypeMap = new TemplateTypeMap(array_map(static fn (TemplateTag $tag): Type => TemplateTypeFactory::fromTemplateTag($templateTypeScope, $tag), $templateTags));
+					$nameScope = $nameScope->withTemplateTypeMap($templateTypeMap);
+				}
+
 				$parameters = [];
 				foreach ($tagValue->parameters as $parameterNode) {
 					$parameterName = substr($parameterNode->parameterName, 1);
@@ -185,24 +206,13 @@ class PhpDocNodeResolver
 					);
 				}
 
-				$templates = [];
-				foreach ($tagValue->templateTypes as $templateType) {
-					$templates[$templateType->name] = new TemplateTag(
-						$templateType->name,
-						$templateType->bound !== null
-							? $this->typeNodeResolver->resolve($templateType->bound, $nameScope)
-							: new MixedType(),
-						TemplateTypeVariance::createInvariant()
-					);
-				}
-
 				$resolved[$tagValue->methodName] = new MethodTag(
 					$tagValue->returnType !== null
 						? $this->typeNodeResolver->resolve($tagValue->returnType, $nameScope)
 						: new MixedType(),
 					$tagValue->isStatic,
 					$parameters,
-					$templates
+					$templateTags,
 				);
 			}
 		}

--- a/src/PhpDoc/Tag/MethodTag.php
+++ b/src/PhpDoc/Tag/MethodTag.php
@@ -10,13 +10,13 @@ class MethodTag
 
 	/**
 	 * @param array<string, MethodTagParameter> $parameters
-	 * @param array<string, TemplateTag> $templates
+	 * @param array<string, TemplateTag> $templateTags
 	 */
 	public function __construct(
 		private Type $returnType,
 		private bool $isStatic,
 		private array $parameters,
-		private array $templates = [],
+		private array $templateTags = [],
 	)
 	{
 	}
@@ -42,9 +42,9 @@ class MethodTag
 	/**
 	 * @return array<string, TemplateTag>
 	 */
-	public function getTemplates(): array
+	public function getTemplateTags(): array
 	{
-		return $this->templates;
+		return $this->templateTags;
 	}
 
 }

--- a/src/PhpDoc/Tag/MethodTag.php
+++ b/src/PhpDoc/Tag/MethodTag.php
@@ -10,11 +10,13 @@ class MethodTag
 
 	/**
 	 * @param array<string, MethodTagParameter> $parameters
+	 * @param array<string, TemplateTag> $templates
 	 */
 	public function __construct(
 		private Type $returnType,
 		private bool $isStatic,
 		private array $parameters,
+		private array $templates = [],
 	)
 	{
 	}
@@ -35,6 +37,14 @@ class MethodTag
 	public function getParameters(): array
 	{
 		return $this->parameters;
+	}
+
+	/**
+	 * @return array<string, TemplateTag>
+	 */
+	public function getTemplates(): array
+	{
+		return $this->templates;
 	}
 
 }

--- a/src/Reflection/Annotations/AnnotationMethodReflection.php
+++ b/src/Reflection/Annotations/AnnotationMethodReflection.php
@@ -30,6 +30,7 @@ class AnnotationMethodReflection implements ExtendedMethodReflection
 		private bool $isStatic,
 		private bool $isVariadic,
 		private ?Type $throwType,
+		private TemplateTypeMap $templateTypeMap,
 	)
 	{
 	}
@@ -69,7 +70,7 @@ class AnnotationMethodReflection implements ExtendedMethodReflection
 		if ($this->variants === null) {
 			$this->variants = [
 				new FunctionVariantWithPhpDocs(
-					TemplateTypeMap::createEmpty(),
+					$this->templateTypeMap,
 					null,
 					$this->parameters,
 					$this->isVariadic,

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Type;
-
+use function array_map;
 use function count;
 
 class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflectionExtension
@@ -67,7 +67,7 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 
 			$templateTypeMap = new TemplateTypeMap(array_map(
 				static fn (TemplateTag $tag): Type => TemplateTypeFactory::fromTemplateTag($templateTypeScope, $tag),
-				$methodTags[$methodName]->getTemplateTags()
+				$methodTags[$methodName]->getTemplateTags(),
 			));
 
 			$isStatic = $methodTags[$methodName]->isStatic();

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -67,7 +67,7 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 
 			$templateTypeMap = new TemplateTypeMap(array_map(
 				static fn (TemplateTag $tag): Type => TemplateTypeFactory::fromTemplateTag($templateTypeScope, $tag),
-				$methodTags[$methodName]->getTemplates()
+				$methodTags[$methodName]->getTemplateTags()
 			));
 
 			$isStatic = $methodTags[$methodName]->isStatic();

--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -2,12 +2,18 @@
 
 namespace PHPStan\Reflection\Annotations;
 
+use PHPStan\PhpDoc\Tag\TemplateTag;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeHelper;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Type;
+
 use function count;
 
 class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflectionExtension
@@ -57,6 +63,13 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 				);
 			}
 
+			$templateTypeScope = TemplateTypeScope::createWithClass($classReflection->getName());
+
+			$templateTypeMap = new TemplateTypeMap(array_map(
+				static fn (TemplateTag $tag): Type => TemplateTypeFactory::fromTemplateTag($templateTypeScope, $tag),
+				$methodTags[$methodName]->getTemplates()
+			));
+
 			$isStatic = $methodTags[$methodName]->isStatic();
 			$nativeCallMethodName = $isStatic ? '__callStatic' : '__call';
 
@@ -75,6 +88,7 @@ class AnnotationsMethodsClassReflectionExtension implements MethodsClassReflecti
 				$classReflection->hasNativeMethod($nativeCallMethodName)
 					? $classReflection->getNativeMethod($nativeCallMethodName)->getThrowType()
 					: null,
+				$templateTypeMap,
 			);
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -22,6 +22,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/narrow_type_with_force_array.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/invalid_type.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/json-decode/json_object_as_array.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-method-tags.php');
 
 		require_once __DIR__ . '/data/bug2574.php';
 

--- a/tests/PHPStan/Analyser/data/generic-method-tags.php
+++ b/tests/PHPStan/Analyser/data/generic-method-tags.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GenericMethodTags;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @method TVal doThing<TVal of mixed>(TVal $param)
+ */
+class Test
+{
+	public function __call(): mixed
+	{
+	}
+}
+
+function test(int $int, string $string): void
+{
+	$test = new Test();
+
+	assertType('int', $test->doThing($int));
+	assertType('string', $test->doThing($string));
+}


### PR DESCRIPTION
Attempt to close: https://github.com/phpstan/phpstan/issues/6371#issuecomment-1032316511

This is as far as i've managed to get today on this issue; thanks to your help i've managed to forward the `TemplateTag`s through and correctly build the template type map, but now i can't get it to resolve the return types correctly :sweat_smile: 

The output i'm getting from the test is:

```
There were 2 failures:

1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/data/generic-method-tags.php:21" ('type', '/home/brad.miller/code/phpsta...gs.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\ObjectType Object (...), 21)
Expected type int, got type GenericMethodTags\TVal in /home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/data/generic-method-tags.php on line 21.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int'
+'GenericMethodTags\TVal'

/home/brad.miller/code/phpstan-src/src/Testing/TypeInferenceTestCase.php:102
/home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:1450

2) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/data/generic-method-tags.php:22" ('type', '/home/brad.miller/code/phpsta...gs.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\ObjectType Object (...), 22)
Expected type string, got type GenericMethodTags\TVal in /home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/data/generic-method-tags.php on line 22.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'string'
+'GenericMethodTags\TVal'
```

i suspect it's because the `$returnType` passed to `AnnotationMethodReflection` is resolved with only the class-level templates and not both class and method level templates in `TemplateTypeHelper::resolveTemplateTypes`. `resolveTemplateTypes()` is returning an `ObjectType()` which seems incorrect, but i'm not sure what it's supposed to be to cause it to be templated properly.

To resolve this i've tried:

1. union the `$classReflection->getActiveTemplateTypeMap()` and my generated `$templateTypeMap` before passing it in to `resolveTemplateTypes()`
2. removed the call to `TemplateTypeHelper::resolveTemplateTypes`, as i suspected it may be resolving too soon? 

Sorry to keep asking, but is there any further pointers you have for me? Thanks.



 