### PR TITLE
fix type of $a?->b::c() and $a?->b::$c

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1802,7 +1802,7 @@ class MutatingScope implements Scope
 				if ($node->class instanceof Name) {
 					$staticMethodCalledOnType = $this->resolveTypeByName($node->class);
 				} else {
-					$staticMethodCalledOnType = $this->getType($node->class)->getObjectTypeOrClassStringObjectType();
+					$staticMethodCalledOnType = TypeCombinator::removeNull($this->getType($node->class))->getObjectTypeOrClassStringObjectType();
 				}
 
 				$returnType = $this->methodCallReturnType(
@@ -1894,7 +1894,7 @@ class MutatingScope implements Scope
 				if ($node->class instanceof Name) {
 					$staticPropertyFetchedOnType = $this->resolveTypeByName($node->class);
 				} else {
-					$staticPropertyFetchedOnType = $this->getType($node->class)->getObjectTypeOrClassStringObjectType();
+					$staticPropertyFetchedOnType = TypeCombinator::removeNull($this->getType($node->class))->getObjectTypeOrClassStringObjectType();
 				}
 
 				$returnType = $this->propertyFetchType(

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1232,6 +1232,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		if (PHP_VERSION_ID >= 80000) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10071.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9394.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-nullsafe-prop-static-access.php');
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/allowed-subtypes-datetime.php');

--- a/tests/PHPStan/Analyser/data/bug-nullsafe-prop-static-access.php
+++ b/tests/PHPStan/Analyser/data/bug-nullsafe-prop-static-access.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace BugNullsafePropStaticAccess;
+
+class A
+{
+	public function __construct(public readonly B $b)
+	{}
+}
+
+class B
+{
+	public static int $value = 0;
+
+	public static function get(): string
+	{
+		return 'B';
+	}
+}
+
+function foo(?A $a): void
+{
+	\PHPStan\Testing\assertType('string|null', $a?->b::get());
+	\PHPStan\Testing\assertType('string|null', $a?->b->get());
+
+	\PHPStan\Testing\assertType('int|null', $a?->b::$value);
+	\PHPStan\Testing\assertType('int|null', $a?->b->value);
+}


### PR DESCRIPTION
Fixes https://phpstan.org/r/10e4c51c-e5a4-474c-a5c8-9ac82be27325