### PR TITLE
Add support for generic CallableType.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -268,6 +268,11 @@ parameters:
 			path: src/PhpDoc/TypeNodeResolver.php
 
 		-
+			message: "#^Property PHPStan\\\\PhpDocParser\\\\Ast\\\\Type\\\\CallableTypeNode\\:\\:\\$templateTypes \\(array\\<PHPStan\\\\PhpDocParser\\\\Ast\\\\PhpDoc\\\\TemplateTagValueNode\\>\\) on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: src/PhpDoc/TypeNodeResolver.php
+
+		-
 			message: "#^Dead catch \\- PHPStan\\\\BetterReflection\\\\Identifier\\\\Exception\\\\InvalidIdentifierName is never thrown in the try block\\.$#"
 			count: 3
 			path: src/Reflection/BetterReflection/BetterReflectionProvider.php

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -879,7 +879,7 @@ class TypeNodeResolver
 	{
 		$templateTags = [];
 
-		if (count($typeNode->templateTypes) > 0) {
+		if (count($typeNode->templateTypes ?? []) > 0) {
 			foreach ($typeNode->templateTypes as $templateType) {
 				$templateTags[$templateType->name] = new TemplateTag(
 					$templateType->name,

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -10,6 +10,7 @@ use Nette\Utils\Strings;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\ConstantResolver;
 use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\Tag\TemplateTag;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprArrayNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFalseNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprFloatNode;
@@ -66,6 +67,9 @@ use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeMap;
+use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Helper\GetTemplateTypeType;
 use PHPStan\Type\IntegerRangeType;
@@ -873,7 +877,32 @@ class TypeNodeResolver
 
 	private function resolveCallableTypeNode(CallableTypeNode $typeNode, NameScope $nameScope): Type
 	{
+		$templateTags = [];
+
+		if (count($typeNode->templateTypes) > 0) {
+			foreach ($typeNode->templateTypes as $templateType) {
+				$templateTags[$templateType->name] = new TemplateTag(
+					$templateType->name,
+					$templateType->bound !== null
+						? $this->resolve($templateType->bound, $nameScope)
+						: new MixedType(),
+					TemplateTypeVariance::createInvariant(),
+				);
+			}
+			$templateTypeScope = TemplateTypeScope::createWithAnonymousFunction();
+
+			$templateTypeMap = new TemplateTypeMap(array_map(
+				static fn (TemplateTag $tag): Type => TemplateTypeFactory::fromTemplateTag($templateTypeScope, $tag),
+				$templateTags,
+			));
+
+			$nameScope = $nameScope->withTemplateTypeMap($templateTypeMap);
+		} else {
+			$templateTypeMap = TemplateTypeMap::createEmpty();
+		}
+
 		$mainType = $this->resolve($typeNode->identifier, $nameScope);
+
 		$isVariadic = false;
 		$parameters = array_map(
 			function (CallableTypeParameterNode $parameterNode) use ($nameScope, &$isVariadic): NativeParameterReflection {
@@ -882,6 +911,7 @@ class TypeNodeResolver
 				if (str_starts_with($parameterName, '$')) {
 					$parameterName = substr($parameterName, 1);
 				}
+
 				return new NativeParameterReflection(
 					$parameterName,
 					$parameterNode->isOptional || $parameterNode->isVariadic,
@@ -893,16 +923,17 @@ class TypeNodeResolver
 			},
 			$typeNode->parameters,
 		);
+
 		$returnType = $this->resolve($typeNode->returnType, $nameScope);
 
 		if ($mainType instanceof CallableType) {
-			return new CallableType($parameters, $returnType, $isVariadic);
+			return new CallableType($parameters, $returnType, $isVariadic, $templateTypeMap);
 
 		} elseif (
 			$mainType instanceof ObjectType
 			&& $mainType->getClassName() === Closure::class
 		) {
-			return new ClosureType($parameters, $returnType, $isVariadic);
+			return new ClosureType($parameters, $returnType, $isVariadic, $templateTypeMap);
 		}
 
 		return new ErrorType();

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use Closure;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Php\PhpVersion;
+use PHPStan\PhpDocParser\Ast\PhpDoc\TemplateTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\CallableTypeParameterNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
@@ -23,6 +24,7 @@ use PHPStan\Reflection\Php\DummyParameter;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -618,10 +620,24 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 			);
 		}
 
+		$templateTags = [];
+		foreach ($this->templateTypeMap->getTypes() as $templateName => $templateType) {
+			if (!$templateType instanceof TemplateType) {
+				throw new ShouldNotHappenException();
+			}
+
+			$templateTags[] = new TemplateTagValueNode(
+				$templateName,
+				$templateType->getBound()->toPhpDocNode(),
+				'',
+			);
+		}
+
 		return new CallableTypeNode(
 			new IdentifierTypeNode('Closure'),
 			$parameters,
 			$this->returnType->toPhpDocNode(),
+			$templateTags,
 		);
 	}
 

--- a/src/Type/Generic/TemplateTypeScope.php
+++ b/src/Type/Generic/TemplateTypeScope.php
@@ -7,6 +7,11 @@ use function sprintf;
 class TemplateTypeScope
 {
 
+	public static function createWithAnonymousFunction(): self
+	{
+		return new self(null, null);
+	}
+
 	public static function createWithFunction(string $functionName): self
 	{
 		return new self(null, $functionName);
@@ -48,6 +53,10 @@ class TemplateTypeScope
 	/** @api */
 	public function describe(): string
 	{
+		if ($this->className === null && $this->functionName === null) {
+			return 'anonymous function';
+		}
+
 		if ($this->className === null) {
 			return sprintf('function %s()', $this->functionName);
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -27,6 +27,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		require_once __DIR__ . '/data/bug2574.php';
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug2574.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/generic-callables.php');
 
 		require_once __DIR__ . '/data/bug2577.php';
 

--- a/tests/PHPStan/Analyser/data/generic-callables.php
+++ b/tests/PHPStan/Analyser/data/generic-callables.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace GenericCallables;
+
+use Closure;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template TFuncRet of mixed
+ * @param TFuncRet $mixed
+ *
+ * @return Closure(): TFuncRet
+ */
+function testFuncClosure(mixed $mixed): Closure
+{
+}
+
+/**
+ * @template TFuncRet of mixed
+ * @param TFuncRet $mixed
+ *
+ * @return Closure<TClosureRet of mixed>(TClosureRet $val): (TClosureRet|TFuncRet)
+ */
+function testFuncClosureMixed(mixed $mixed)
+{
+}
+
+/**
+ * @template TFuncRet of mixed
+ * @param TFuncRet $mixed
+ *
+ * @return callable(): TFuncRet
+ */
+function testFuncCallable(mixed $mixed): callable
+{
+}
+
+/**
+ * @param Closure<TRet of mixed>(TRet $val): TRet $callable
+ * @param non-empty-list<Closure<TRet of mixed>(TRet $val): TRet> $callables
+ */
+function testClosure(Closure $callable, int $int, string $str, array $callables): void
+{
+	assertType('Closure<TRet of mixed>(TRet): TRet', $callable);
+	assertType('int', $callable($int));
+	assertType('string', $callable($str));
+	assertType('string', $callables[0]($str));
+	assertType('Closure(): 1', testFuncClosure(1));
+}
+
+function testClosureMixed(int $int, string $str): void
+{
+	$closure = testFuncClosureMixed($int);
+	assertType('Closure<TClosureRet of mixed>(TClosureRet): (int|TClosureRet)', $closure);
+	assertType('int|string', $closure($str));
+}
+
+/**
+ * @param callable<TRet of mixed>(TRet $val): TRet $callable
+ */
+function testCallable(callable $callable, int $int, string $str): void
+{
+	assertType('callable<TRet of mixed>(TRet): TRet', $callable);
+	assertType('int', $callable($int));
+	assertType('string', $callable($str));
+	assertType('callable(): 1', testFuncCallable(1));
+}
+
+/**
+ * @param Closure<TRetFirst of mixed>(TRetFirst $valone): (Closure<TRetSecond of mixed>(TRetSecond $valtwo): (TRetFirst|TRetSecond)) $closure
+ */
+function testNestedClosures(Closure $closure, string $str, int $int): void
+{
+	assertType('Closure<TRetFirst of mixed>(TRetFirst): (Closure<TRetSecond of mixed>(TRetSecond $valtwo): (TRetFirst|TRetSecond))', $closure);
+	$closure1 = $closure($str);
+	assertType('Closure<TRetSecond of mixed>(TRetSecond): (string|TRetSecond)', $closure1);
+	$result = $closure1($int);
+	assertType('int|string', $result);
+}


### PR DESCRIPTION
Trying to follow up the `phpdoc-parser` pr with implementing generic callables and closures. About as far as i can get tonight so putting this up to get some feedback; not sure if this is the right direction at all, just trying to apply what i learned from the other prs.

Right now the test is outputting:

```
1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/data/generic-callables.php:12" ('type', '/home/brad.miller/code/phpsta...es.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\Generic\TemplateMixedType Object (...), 12)
Expected type int, got type TRet (anonymous function, argument) in /home/brad.miller/code/phpstan-src/tests/PHPStan/Analyser/data/generic-callables.php on line 12.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int'
+'TRet (anonymous function, argument)'
```

which seems somewhat familiar to the `$nameScope` thing you mentioned in the generic `@method` pr, but i am calling `->withTemplateTypeMap()` like you suggested over there.

One major thing that i can't seem to find is where the template types are replaced with the actual real types; as i feel like with the addition of `$resolvedTemplateTypeMap` on `CallableType` i'm going to have to do that somewhere to then pass in the resolved type map, but where i should do that escapes me. 