### PR TITLE
Issue 10626: Do type checks on pass by reference parameters for non-builtin functions and methods.

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -278,7 +278,7 @@ class FunctionCallParametersCheck
 			if ($this->checkArgumentTypes) {
 				$parameterType = TypeUtils::resolveLateResolvableTypes($parameter->getType());
 
-				if (!$parameter->passedByReference()->createsNewVariable()) {
+				if (!$parameter->passedByReference()->createsNewVariable() || !$isBuiltin) {
 					$accepts = $this->ruleLevelHelper->acceptsWithReason($parameterType, $argumentValueType, $scope->isDeclareStrictTypes());
 
 					if (!$accepts->result) {

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -297,6 +297,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #1 $array of function reset expects array|object, null given.',
 				39,
 			],
+			[
+				'Parameter #1 $s of function PassedByReference\bar expects string, int given.',
+				48,
+			],
 		]);
 	}
 
@@ -1623,4 +1627,17 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10626(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10626.php'], [
+			[
+				'Parameter #1 $value of function PassedByReference\intByValue expects int, string given.',
+				16,
+			],
+			[
+				'Parameter #1 $value of function PassedByReference\intByReference expects int, string given.',
+				17,
+			],
+		]);
+	}
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-10626.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-10626.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PassedByReference;
+
+function intByValue(int $value): void
+{
+
+}
+
+function intByReference(int &$value): void
+{
+
+}
+
+$notAnInt = 'not-an-int';
+intByValue($notAnInt);
+intByReference($notAnInt);


### PR DESCRIPTION
Do type checks on pass by reference parameters for non-builtin functions and methods.

Initially, all pass by reference parameters were skipped for type checking. This change continues to skip those checks for builtin PHP methods, but does check parameters for userland methods.