### PR TITLE
Check types when argument is passed by reference

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -252,7 +252,7 @@ class FunctionCallParametersCheck
 			if ($this->checkArgumentTypes) {
 				$parameterType = TypeUtils::resolveLateResolvableTypes($parameter->getType());
 
-				if (!$parameter->passedByReference()->createsNewVariable()) {
+				if (!$parameter->passedByReference()->createsNewVariable() || !$isBuiltin) {
 					$accepts = $this->ruleLevelHelper->acceptsWithReason($parameterType, $argumentValueType, $scope->isDeclareStrictTypes());
 
 					if (!$accepts->result) {

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1631,11 +1631,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-10626.php'], [
 			[
-				'Parameter #1 $value of function PassedByReference\intByValue expects int, string given.',
+				'Parameter #1 $value of function Bug10626\intByValue expects int, string given.',
 				16,
 			],
 			[
-				'Parameter #1 $value of function PassedByReference\intByReference expects int, string given.',
+				'Parameter #1 $value of function Bug10626\intByReference expects int, string given.',
 				17,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -297,6 +297,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #1 $array of function reset expects array|object, null given.',
 				39,
 			],
+			[
+				'Parameter #1 $s of function PassedByReference\bar expects string, int given.',
+				48,
+			],
 		]);
 	}
 
@@ -1623,4 +1627,17 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10626(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10626.php'], [
+			[
+				'Parameter #1 $value of function PassedByReference\intByValue expects int, string given.',
+				16,
+			],
+			[
+				'Parameter #1 $value of function PassedByReference\intByReference expects int, string given.',
+				17,
+			],
+		]);
+	}
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1640,4 +1640,5 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			],
 		]);
 	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-10626.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-10626.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PassedByReference;
+
+function intByValue(int $value): void
+{
+
+}
+
+function intByReference(int &$value): void
+{
+
+}
+
+$notAnInt = 'not-an-int';
+intByValue($notAnInt);
+intByReference($notAnInt);

--- a/tests/PHPStan/Rules/Functions/data/bug-10626.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-10626.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PassedByReference;
+namespace Bug10626;
 
 function intByValue(int $value): void
 {

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -634,12 +634,12 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$this->checkThisOnly = false;
 		$this->analyse([__DIR__ . '/data/bug-8296.php'], [
 			[
-				'Parameter #1 $objects of static method VerifyLoginTask::continueDump() expects array<string, object>, array<string, stdClass|true> given.',
-				10,
+				'Parameter #1 $objects of static method Bug8296\VerifyLoginTask::continueDump() expects array<string, object>, array<string, Bug8296\stdClass|true> given.',
+				12,
 			],
 			[
-				'Parameter #1 $string of static method VerifyLoginTask::stringByRef() expects string, int given.',
-				13,
+				'Parameter #1 $string of static method Bug8296\VerifyLoginTask::stringByRef() expects string, int given.',
+				15,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -629,6 +629,21 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8296(): void
+	{
+		$this->checkThisOnly = false;
+		$this->analyse([__DIR__ . '/data/bug-8296.php'], [
+			[
+				'Parameter #1 $objects of static method VerifyLoginTask::continueDump() expects array<string, object>, array<string, stdClass|true> given.',
+				10,
+			],
+			[
+				'Parameter #1 $string of static method VerifyLoginTask::stringByRef() expects string, int given.',
+				13,
+			],
+		]);
+	}
+
 	public function testRequireExtends(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/bug-8296.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-8296.php
@@ -1,0 +1,27 @@
+<?php
+
+class VerifyLoginTask{
+
+	public static function dumpMemory() : void{
+		$dummy = [
+			"a" => new stdClass(),
+			"b" => true
+		];
+		self::continueDump($dummy);
+
+		$string = 12345;
+		self::stringByRef($string);
+	}
+
+	/**
+	 * @phpstan-param array<string, object> $objects
+	 * @phpstan-param-out array<string, object> $objects
+	 */
+	private static function continueDump(array &$objects) : void{
+
+	}
+
+	private static function stringByRef(string &$string) : void{
+
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-8296.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-8296.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Bug8296;
+
 class VerifyLoginTask{
 
 	public static function dumpMemory() : void{


### PR DESCRIPTION
Do type checks on pass by reference parameters for non-builtin functions and methods.

Initially, all pass by reference parameters were skipped for type checking. This change continues to skip those checks for builtin PHP methods, but does check parameters for userland methods.
