### PR TITLE
Add rule to check for existing classes, type aliases and shadowing of CallableType and ClosureType templates on methods and functions.

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -992,6 +992,9 @@ services:
 		class: PHPStan\Rules\PhpDoc\UnresolvableTypeHelper
 
 	-
+		class: PHPStan\Rules\PhpDoc\GenericCallableRuleHelper
+
+	-
 		class: PHPStan\Rules\PhpDoc\VarTagTypeRuleHelper
 		arguments:
 			checkTypeAgainstPhpDocType: %reportWrongPhpDocTypeInVarTag%

--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -52,6 +52,7 @@ use PHPStan\Rules\Methods\MissingMethodParameterTypehintRule;
 use PHPStan\Rules\Methods\MissingMethodReturnTypehintRule;
 use PHPStan\Rules\Methods\OverridingMethodRule;
 use PHPStan\Rules\MissingTypehintCheck;
+use PHPStan\Rules\PhpDoc\GenericCallableRuleHelper;
 use PHPStan\Rules\PhpDoc\IncompatiblePhpDocTypeRule;
 use PHPStan\Rules\PhpDoc\IncompatiblePropertyPhpDocTypeRule;
 use PHPStan\Rules\PhpDoc\InvalidPhpDocTagValueRule;
@@ -185,6 +186,7 @@ class StubValidator
 				$fileTypeMapper,
 				$genericObjectTypeCheck,
 				$unresolvableTypeHelper,
+				$container->getByType(GenericCallableRuleHelper::class),
 			),
 			new IncompatiblePropertyPhpDocTypeRule($genericObjectTypeCheck, $unresolvableTypeHelper),
 			new InvalidPhpDocTagValueRule(

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -927,13 +927,13 @@ class TypeNodeResolver
 		$returnType = $this->resolve($typeNode->returnType, $nameScope);
 
 		if ($mainType instanceof CallableType) {
-			return new CallableType($parameters, $returnType, $isVariadic, $templateTypeMap);
+			return new CallableType($parameters, $returnType, $isVariadic, $templateTypeMap, null, $templateTags);
 
 		} elseif (
 			$mainType instanceof ObjectType
 			&& $mainType->getClassName() === Closure::class
 		) {
-			return new ClosureType($parameters, $returnType, $isVariadic, $templateTypeMap);
+			return new ClosureType($parameters, $returnType, $isVariadic, $templateTypeMap, null, null, $templateTags);
 		}
 
 		return new ErrorType();

--- a/src/Rules/Generics/TemplateTypeCheck.php
+++ b/src/Rules/Generics/TemplateTypeCheck.php
@@ -98,7 +98,6 @@ class TemplateTypeCheck
 			$classNameNodePairs = array_map(static fn (string $referencedClass): ClassNameNodePair => new ClassNameNodePair($referencedClass, $node), $boundType->getReferencedClasses());
 			$messages = array_merge($messages, $this->classCheck->checkClassNames($classNameNodePairs, $this->checkClassCaseSensitivity));
 
-			$boundType = $templateTag->getBound();
 			$boundTypeClass = get_class($boundType);
 			if (
 				$boundTypeClass !== MixedType::class

--- a/src/Rules/PhpDoc/GenericCallableRuleHelper.php
+++ b/src/Rules/PhpDoc/GenericCallableRuleHelper.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\PhpDoc;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\Tag\TemplateTag;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Generics\TemplateTypeCheck;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Generic\TemplateTypeScope;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\VerbosityLevel;
+use function array_keys;
+use function sprintf;
+
+class GenericCallableRuleHelper
+{
+
+	public function __construct(
+		private TemplateTypeCheck $templateTypeCheck,
+	)
+	{
+	}
+
+	/**
+	 * @param array<string, TemplateTag> $functionTemplateTags
+	 *
+	 * @return array<RuleError>
+	 */
+	public function check(
+		Node $node,
+		Scope $scope,
+		string $location,
+		Type $callableType,
+		string $functionName,
+		array $functionTemplateTags,
+		?ClassReflection $classReflection,
+	): array
+	{
+		$errors = [];
+
+		TypeTraverser::map($callableType, function (Type $type, callable $traverse) use (&$errors, $node, $scope, $location, $functionName, $functionTemplateTags, $classReflection) {
+			if (!($type instanceof CallableType || $type instanceof ClosureType)) {
+				return $traverse($type);
+			}
+
+			$typeDescription = $type->describe(VerbosityLevel::precise());
+
+			$errors = $this->templateTypeCheck->check(
+				$scope,
+				$node,
+				TemplateTypeScope::createWithAnonymousFunction(),
+				$type->getTemplateTags(),
+				sprintf('PHPDoc tag %s template of %s cannot have existing class %%s as its name.', $location, $typeDescription),
+				sprintf('PHPDoc tag %s template of %s cannot have existing type alias %%s as its name.', $location, $typeDescription),
+				sprintf('PHPDoc tag %s template %%s of %s has invalid bound type %%s.', $location, $typeDescription),
+				sprintf('PHPDoc tag %s template %%s of %s with bound type %%s is not supported.', $location, $typeDescription),
+			);
+
+			$templateTags = $type->getTemplateTags();
+
+			$functionDescription = sprintf('function %s', $functionName);
+			$classDescription = null;
+			if ($classReflection !== null) {
+				$classDescription = $classReflection->getDisplayName();
+				$functionDescription = sprintf('method %s::%s', $classDescription, $functionName);
+			}
+
+			foreach (array_keys($functionTemplateTags) as $name) {
+				if (!isset($templateTags[$name])) {
+					continue;
+				}
+
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'PHPDoc tag %s template %s of %s shadows @template %s for %s.',
+					$location,
+					$name,
+					$typeDescription,
+					$name,
+					$functionDescription,
+				))->build();
+			}
+
+			if ($classReflection !== null) {
+				foreach (array_keys($classReflection->getTemplateTags()) as $name) {
+					if (!isset($templateTags[$name])) {
+						continue;
+					}
+
+					$errors[] = RuleErrorBuilder::message(sprintf(
+						'PHPDoc tag %s template %s of %s shadows @template %s for class %s.',
+						$location,
+						$name,
+						$typeDescription,
+						$name,
+						$classDescription,
+					))->build();
+				}
+			}
+
+			return $traverse($type);
+		});
+
+		return $errors;
+	}
+
+}

--- a/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePhpDocTypeRule.php
@@ -31,6 +31,7 @@ class IncompatiblePhpDocTypeRule implements Rule
 		private FileTypeMapper $fileTypeMapper,
 		private GenericObjectTypeCheck $genericObjectTypeCheck,
 		private UnresolvableTypeHelper $unresolvableTypeHelper,
+		private GenericCallableRuleHelper $genericCallableRuleHelper,
 	)
 	{
 	}
@@ -137,6 +138,16 @@ class IncompatiblePhpDocTypeRule implements Rule
 						),
 					));
 
+					$errors = array_merge($errors, $this->genericCallableRuleHelper->check(
+						$node,
+						$scope,
+						sprintf('%s for parameter $%s', $escapedTagName, $escapedParameterName),
+						$phpDocParamType,
+						$functionName,
+						$resolvedPhpDoc->getTemplateTags(),
+						$scope->isInClass() ? $scope->getClassReflection() : null,
+					));
+
 					if ($phpDocParamTag instanceof ParamOutTag) {
 						if (!$byRefParameters[$parameterName]) {
 							$errors[] = RuleErrorBuilder::message(sprintf(
@@ -215,6 +226,16 @@ class IncompatiblePhpDocTypeRule implements Rule
 
 					$errors[] = $errorBuilder->build();
 				}
+
+				$errors = array_merge($errors, $this->genericCallableRuleHelper->check(
+					$node,
+					$scope,
+					'@return',
+					$phpDocReturnType,
+					$functionName,
+					$resolvedPhpDoc->getTemplateTags(),
+					$scope->isInClass() ? $scope->getClassReflection() : null,
+				));
 			}
 		}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-callables-incompatible.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-callables-incompatible.php
@@ -1,0 +1,193 @@
+<?php declare(strict_types=1);
+
+namespace GenericCallablesIncompatible;
+
+use Closure;
+use stdClass;
+
+/**
+ * @param Closure<stdClass>(stdClass $val): stdClass $existingClass
+ */
+function existingClass(Closure $existingClass): void
+{
+}
+
+/**
+ * @param Closure<TypeAlias>(TypeAlias $val): TypeAlias $existingTypeAlias
+ */
+function existingTypeAlias(Closure $existingTypeAlias): void
+{
+}
+
+/**
+ * @param Closure<T of Invalid>(T $val): T $invalidBoundType
+ */
+function invalidBoundType(Closure $invalidBoundType): void
+{
+}
+
+/**
+ * @param Closure<T of null>(T $val): T $notSupported
+ */
+function notSupported(Closure $notSupported): void
+{
+}
+
+/**
+ * @template T
+ * @param Closure<T>(T $val): T $shadows
+ */
+function testShadowFunction(Closure $shadows): void
+{
+}
+
+/**
+ * @param-out Closure<stdClass>(stdClass $val): stdClass $existingClass
+ */
+function existingClassParamOut(Closure &$existingClass): void
+{
+}
+
+/**
+ * @template U
+ */
+class Test
+{
+	/**
+	 * @template T
+	 * @param Closure<T, U>(T $val): T $shadows
+	 */
+	function testShadowMethod(Closure $shadows): void
+	{
+	}
+
+	/**
+	 * @template T
+	 * @return Closure<T, U>(T $val): T
+	 */
+	function testShadowMethodReturn(): Closure
+	{
+	}
+}
+
+/**
+ * @return Closure<stdClass>(stdClass $val): stdClass
+ */
+function existingClassReturn(): Closure
+{
+}
+
+/**
+ * @return Closure<TypeAlias>(TypeAlias $val): TypeAlias
+ */
+function existingTypeAliasReturn(): Closure
+{
+}
+
+/**
+ * @return Closure<T of Invalid>(T $val): T
+ */
+function invalidBoundTypeReturn(): Closure
+{
+}
+
+/**
+ * @return Closure<T of null>(T $val): T
+ */
+function notSupportedReturn(): Closure
+{
+}
+
+/**
+ * @template T
+ * @return Closure<T>(T $val): T
+ */
+function testShadowFunctionReturn(): Closure
+{
+}
+
+/**
+ * @template U
+ */
+class Test2
+{
+	/**
+	 * @param Closure<stdClass>(stdClass $val): stdClass $existingClass
+	 */
+	public function existingClass(Closure $existingClass): void
+	{
+	}
+
+	/**
+	 * @param Closure<TypeAlias>(TypeAlias $val): TypeAlias $existingTypeAlias
+	 */
+	public function existingTypeAlias(Closure $existingTypeAlias): void
+	{
+	}
+
+	/**
+	 * @param Closure<T of Invalid>(T $val): T $invalidBoundType
+	 */
+	public function invalidBoundType(Closure $invalidBoundType): void
+	{
+	}
+
+	/**
+	 * @param Closure<T of null>(T $val): T $notSupported
+	 */
+	public function notSupported(Closure $notSupported): void
+	{
+	}
+
+	/**
+	 * @return Closure<stdClass>(stdClass $val): stdClass
+	 */
+	public function existingClassReturn(): Closure
+	{
+	}
+
+	/**
+	 * @return Closure<TypeAlias>(TypeAlias $val): TypeAlias
+	 */
+	public function existingTypeAliasReturn(): Closure
+	{
+	}
+
+	/**
+	 * @return Closure<T of Invalid>(T $val): T
+	 */
+	public function invalidBoundTypeReturn(): Closure
+	{
+	}
+
+	/**
+	 * @return Closure<T of null>(T $val): T
+	 */
+	public function notSupportedReturn(): Closure
+	{
+	}
+}
+
+/**
+ * @template T
+ * @param-out Closure<T>(T $val): T $existingClass
+ */
+function shadowsParamOut(Closure &$existingClass): void
+{
+}
+
+/**
+ * @template T
+ * @param-out list<Closure<T>(T $val): T> $existingClasses
+ */
+function shadowsParamOutArray(array &$existingClasses): void
+{
+}
+
+/**
+ * @template T
+ * @return list<Closure<T>(T $val): T>
+ */
+function shadowsReturnArray(): array
+{
+}


### PR DESCRIPTION
follow up to: https://github.com/phpstan/phpstan-src/pull/2938#pullrequestreview-1899509254

covers `@param` `@param-out` and `@return` on functions / methods