### PR TITLE
Add rule to check for existing classes, type aliases and shadowing of generic callables in properties.

### DIFF
--- a/src/PhpDoc/StubValidator.php
+++ b/src/PhpDoc/StubValidator.php
@@ -157,6 +157,7 @@ class StubValidator
 		$phpVersion = $container->getByType(PhpVersion::class);
 		$localTypeAliasesCheck = $container->getByType(LocalTypeAliasesCheck::class);
 		$phpClassReflectionExtension = $container->getByType(PhpClassReflectionExtension::class);
+		$genericCallableRuleHelper = $container->getByType(GenericCallableRuleHelper::class);
 
 		$rules = [
 			// level 0
@@ -182,13 +183,8 @@ class StubValidator
 			new MethodTemplateTypeRule($fileTypeMapper, $templateTypeCheck),
 			new MethodSignatureVarianceRule($varianceCheck),
 			new TraitTemplateTypeRule($fileTypeMapper, $templateTypeCheck),
-			new IncompatiblePhpDocTypeRule(
-				$fileTypeMapper,
-				$genericObjectTypeCheck,
-				$unresolvableTypeHelper,
-				$container->getByType(GenericCallableRuleHelper::class),
-			),
-			new IncompatiblePropertyPhpDocTypeRule($genericObjectTypeCheck, $unresolvableTypeHelper),
+			new IncompatiblePhpDocTypeRule($fileTypeMapper, $genericObjectTypeCheck, $unresolvableTypeHelper, $genericCallableRuleHelper),
+			new IncompatiblePropertyPhpDocTypeRule($genericObjectTypeCheck, $unresolvableTypeHelper, $genericCallableRuleHelper),
 			new InvalidPhpDocTagValueRule(
 				$container->getByType(Lexer::class),
 				$container->getByType(PhpDocParser::class),

--- a/src/Rules/PhpDoc/GenericCallableRuleHelper.php
+++ b/src/Rules/PhpDoc/GenericCallableRuleHelper.php
@@ -37,7 +37,7 @@ class GenericCallableRuleHelper
 		Scope $scope,
 		string $location,
 		Type $callableType,
-		string $functionName,
+		?string $functionName,
 		array $functionTemplateTags,
 		?ClassReflection $classReflection,
 	): array
@@ -64,26 +64,31 @@ class GenericCallableRuleHelper
 
 			$templateTags = $type->getTemplateTags();
 
-			$functionDescription = sprintf('function %s', $functionName);
 			$classDescription = null;
 			if ($classReflection !== null) {
 				$classDescription = $classReflection->getDisplayName();
-				$functionDescription = sprintf('method %s::%s', $classDescription, $functionName);
 			}
 
-			foreach (array_keys($functionTemplateTags) as $name) {
-				if (!isset($templateTags[$name])) {
-					continue;
+			if ($functionName !== null) {
+				$functionDescription = sprintf('function %s', $functionName);
+				if ($classReflection !== null) {
+					$functionDescription = sprintf('method %s::%s', $classDescription, $functionName);
 				}
 
-				$errors[] = RuleErrorBuilder::message(sprintf(
-					'PHPDoc tag %s template %s of %s shadows @template %s for %s.',
-					$location,
-					$name,
-					$typeDescription,
-					$name,
-					$functionDescription,
-				))->build();
+				foreach (array_keys($functionTemplateTags) as $name) {
+					if (!isset($templateTags[$name])) {
+						continue;
+					}
+
+					$errors[] = RuleErrorBuilder::message(sprintf(
+						'PHPDoc tag %s template %s of %s shadows @template %s for %s.',
+						$location,
+						$name,
+						$typeDescription,
+						$name,
+						$functionDescription,
+					))->build();
+				}
 			}
 
 			if ($classReflection !== null) {

--- a/src/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRule.php
+++ b/src/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRule.php
@@ -24,6 +24,7 @@ class IncompatiblePropertyPhpDocTypeRule implements Rule
 	public function __construct(
 		private GenericObjectTypeCheck $genericObjectTypeCheck,
 		private UnresolvableTypeHelper $unresolvableTypeHelper,
+		private GenericCallableRuleHelper $genericCallableRuleHelper,
 	)
 	{
 	}
@@ -92,6 +93,18 @@ class IncompatiblePropertyPhpDocTypeRule implements Rule
 
 		$className = SprintfHelper::escapeFormatString($classReflection->getDisplayName());
 		$escapedPropertyName = SprintfHelper::escapeFormatString($propertyName);
+
+		if ($node->isPromoted() === false) {
+			$messages = array_merge($messages, $this->genericCallableRuleHelper->check(
+				$node,
+				$scope,
+				'@var',
+				$phpDocType,
+				null,
+				[],
+				$classReflection,
+			));
+		}
 
 		$messages = array_merge($messages, $this->genericObjectTypeCheck->check(
 			$phpDocType,

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -417,6 +417,10 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 				'PHPDoc tag @return template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\shadowsReturnArray.',
 				191,
 			],
+			[
+				'PHPDoc tag @param for parameter $shadows template T of Closure<T of mixed>(T): T shadows @template T for class GenericCallablesIncompatible\Test3.',
+				203,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-callable-properties.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-callable-properties.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace GenericCallableProperties;
+
+use Closure;
+use stdClass;
+
+/**
+ * @template T
+ */
+class Test
+{
+	/**
+	 * @var Closure<T>(T): T
+	 */
+	private Closure $shadows;
+
+	/**
+	 * @var Closure<stdClass>(stdClass): stdClass
+	 */
+	private Closure $existingClass;
+
+	/**
+	 * @var callable<TypeAlias>(TypeAlias): TypeAlias
+	 */
+	private $typeAlias;
+
+	/**
+	 * @var callable<TNull of null>(TNull): TNull
+	 */
+	private $unsupported;
+
+	/**
+	 * @var callable<TInvalid of Invalid>(TInvalid): TInvalid
+	 */
+	private $invalid;
+
+	/**
+	 * @param Closure<T>(T): T $notReported
+	 */
+	public function __construct(private Closure $notReported) {}
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-callables-incompatible.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-callables-incompatible.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types=1); // lint > 8.0
 
 namespace GenericCallablesIncompatible;
 
@@ -190,4 +190,15 @@ function shadowsParamOutArray(array &$existingClasses): void
  */
 function shadowsReturnArray(): array
 {
+}
+
+/**
+ * @template T
+ */
+class Test3
+{
+	/**
+	 * @param Closure<T>(T): T $shadows
+	 */
+	public function __construct(private Closure $shadows) {}
 }


### PR DESCRIPTION
another follow up to: https://github.com/phpstan/phpstan-src/pull/2938#pullrequestreview-1899509254

covers native properties