### PR TITLE
Add support for constructor assertions

### DIFF
--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1211,6 +1211,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-offset-unset.php');
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-constructor.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-docblock.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-empty.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/assert-method.php');

--- a/tests/PHPStan/Analyser/data/assert-constructor.php
+++ b/tests/PHPStan/Analyser/data/assert-constructor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AssertConstructor;
+
+use function PHPStan\Testing\assertType;
+
+class Person
+{
+	/**
+	 * @phpstan-assert non-empty-string $firstName
+	 */
+	public function __construct(
+		public string $firstName,
+	) {
+		assert($firstName !== '');
+	}
+}
+
+function (string $firstName) {
+	new Person($firstName);
+	assertType('non-empty-string', $firstName);
+};


### PR DESCRIPTION
Enables the following:

```php
class Person
{
    /** @phpstan-assert non-empty-string $firstName */
    public function __construct(string $firstName) {}
}

$person = new Person($firstName);
// $firstName can no longer be empty
```

Fixes https://github.com/phpstan/phpstan/issues/10645 (partially)