### PR TITLE
Report uses of deprecated constants

### DIFF
--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -365,6 +365,7 @@ class BetterReflectionProvider implements ReflectionProvider
 			$constantName,
 			$constantValueType,
 			$fileName,
+			$this->fileTypeMapper,
 			$constantReflection->getDocComment(),
 		);
 	}

--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Reflection\BetterReflection;
 
 use Closure;
+use Nette\Utils\Strings;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\BetterReflection\Identifier\Exception\InvalidIdentifierName;
@@ -370,7 +371,13 @@ class BetterReflectionProvider implements ReflectionProvider
 			$isDeprecated = TrinaryLogic::createFromBoolean($resolvedPhpDoc->isDeprecated());
 
 			if ($resolvedPhpDoc->isDeprecated() && $resolvedPhpDoc->getDeprecatedTag() !== null) {
-				$deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag()->getMessage();
+				$deprecatedMessage = $resolvedPhpDoc->getDeprecatedTag()->getMessage();
+
+				// filter raw version number messages like in
+				// https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478
+				if (Strings::match($deprecatedMessage ?? '', '#^\d+\.\d+(\.\d+)?$#') === null) {
+					$deprecatedDescription = $deprecatedMessage;
+				}
 			}
 		}
 

--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -365,6 +365,7 @@ class BetterReflectionProvider implements ReflectionProvider
 			$constantName,
 			$constantValueType,
 			$fileName,
+			$constantReflection->getDocComment(),
 		);
 	}
 

--- a/src/Reflection/Constant/RuntimeConstantReflection.php
+++ b/src/Reflection/Constant/RuntimeConstantReflection.php
@@ -10,6 +10,9 @@ use PHPStan\Type\Type;
 class RuntimeConstantReflection implements GlobalConstantReflection
 {
 
+	/**
+	 * @param non-empty-string|null $docComment
+	 */
 	public function __construct(
 		private string $name,
 		private Type $valueType,

--- a/src/Reflection/Constant/RuntimeConstantReflection.php
+++ b/src/Reflection/Constant/RuntimeConstantReflection.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection\Constant;
 
+use PHPStan\BetterReflection\Reflection\Annotation\AnnotationHelper;
 use PHPStan\Reflection\GlobalConstantReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Type;
@@ -13,6 +14,7 @@ class RuntimeConstantReflection implements GlobalConstantReflection
 		private string $name,
 		private Type $valueType,
 		private ?string $fileName,
+		private ?string $docComment,
 	)
 	{
 	}
@@ -34,12 +36,18 @@ class RuntimeConstantReflection implements GlobalConstantReflection
 
 	public function isDeprecated(): TrinaryLogic
 	{
-		return TrinaryLogic::createNo();
+		return TrinaryLogic::createFromBoolean(AnnotationHelper::isDeprecated($this->getDocComment()));
 	}
 
 	public function getDeprecatedDescription(): ?string
 	{
 		return null;
+	}
+
+	/** @return non-empty-string|null */
+	public function getDocComment(): ?string
+	{
+		return $this->docComment;
 	}
 
 	public function isInternal(): TrinaryLogic

--- a/src/Reflection/Constant/RuntimeConstantReflection.php
+++ b/src/Reflection/Constant/RuntimeConstantReflection.php
@@ -2,13 +2,18 @@
 
 namespace PHPStan\Reflection\Constant;
 
-use PHPStan\BetterReflection\Reflection\Annotation\AnnotationHelper;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\Reflection\GlobalConstantReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 
 class RuntimeConstantReflection implements GlobalConstantReflection
 {
+
+	private false|ResolvedPhpDocBlock $resolvedPhpDocBlock = false;
+
+	private ?string $deprecatedDescription = null;
 
 	/**
 	 * @param non-empty-string|null $docComment
@@ -17,6 +22,7 @@ class RuntimeConstantReflection implements GlobalConstantReflection
 		private string $name,
 		private Type $valueType,
 		private ?string $fileName,
+		private FileTypeMapper $fileTypeMapper,
 		private ?string $docComment,
 	)
 	{
@@ -39,18 +45,43 @@ class RuntimeConstantReflection implements GlobalConstantReflection
 
 	public function isDeprecated(): TrinaryLogic
 	{
-		return TrinaryLogic::createFromBoolean(AnnotationHelper::isDeprecated($this->getDocComment()));
+		$resolvedPhpDoc = $this->getResolvedPhpDoc();
+		if ($resolvedPhpDoc === null) {
+			return TrinaryLogic::createNo();
+		}
+
+		return TrinaryLogic::createFromBoolean($resolvedPhpDoc->isDeprecated());
 	}
 
 	public function getDeprecatedDescription(): ?string
 	{
-		return null;
+		if ($this->deprecatedDescription === null && $this->isDeprecated()->yes()) {
+			$resolvedPhpDoc = $this->getResolvedPhpDoc();
+			if ($resolvedPhpDoc !== null && $resolvedPhpDoc->getDeprecatedTag() !== null) {
+				$this->deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag()->getMessage();
+			}
+		}
+
+		return $this->deprecatedDescription;
 	}
 
 	/** @return non-empty-string|null */
 	public function getDocComment(): ?string
 	{
 		return $this->docComment;
+	}
+
+	private function getResolvedPhpDoc(): ?ResolvedPhpDocBlock
+	{
+		if ($this->docComment === null) {
+			return null;
+		}
+
+		if ($this->resolvedPhpDocBlock !== false) {
+			return $this->resolvedPhpDocBlock;
+		}
+
+		return $this->resolvedPhpDocBlock = $this->fileTypeMapper->getResolvedPhpDoc($this->getFileName(), null, null, null, $this->docComment);
 	}
 
 	public function isInternal(): TrinaryLogic

--- a/src/Reflection/Constant/RuntimeConstantReflection.php
+++ b/src/Reflection/Constant/RuntimeConstantReflection.php
@@ -2,28 +2,19 @@
 
 namespace PHPStan\Reflection\Constant;
 
-use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\Reflection\GlobalConstantReflection;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 
 class RuntimeConstantReflection implements GlobalConstantReflection
 {
 
-	private false|ResolvedPhpDocBlock $resolvedPhpDocBlock = false;
-
-	private ?string $deprecatedDescription = null;
-
-	/**
-	 * @param non-empty-string|null $docComment
-	 */
 	public function __construct(
 		private string $name,
 		private Type $valueType,
 		private ?string $fileName,
-		private FileTypeMapper $fileTypeMapper,
-		private ?string $docComment,
+		private TrinaryLogic $isDeprecated,
+		private ?string $deprecatedDescription,
 	)
 	{
 	}
@@ -45,43 +36,12 @@ class RuntimeConstantReflection implements GlobalConstantReflection
 
 	public function isDeprecated(): TrinaryLogic
 	{
-		$resolvedPhpDoc = $this->getResolvedPhpDoc();
-		if ($resolvedPhpDoc === null) {
-			return TrinaryLogic::createNo();
-		}
-
-		return TrinaryLogic::createFromBoolean($resolvedPhpDoc->isDeprecated());
+		return $this->isDeprecated;
 	}
 
 	public function getDeprecatedDescription(): ?string
 	{
-		if ($this->deprecatedDescription === null && $this->isDeprecated()->yes()) {
-			$resolvedPhpDoc = $this->getResolvedPhpDoc();
-			if ($resolvedPhpDoc !== null && $resolvedPhpDoc->getDeprecatedTag() !== null) {
-				$this->deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag()->getMessage();
-			}
-		}
-
 		return $this->deprecatedDescription;
-	}
-
-	/** @return non-empty-string|null */
-	public function getDocComment(): ?string
-	{
-		return $this->docComment;
-	}
-
-	private function getResolvedPhpDoc(): ?ResolvedPhpDocBlock
-	{
-		if ($this->docComment === null) {
-			return null;
-		}
-
-		if ($this->resolvedPhpDocBlock !== false) {
-			return $this->resolvedPhpDocBlock;
-		}
-
-		return $this->resolvedPhpDocBlock = $this->fileTypeMapper->getResolvedPhpDoc($this->getFileName(), null, null, null, $this->docComment);
 	}
 
 	public function isInternal(): TrinaryLogic

--- a/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
+++ b/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\Constant;
+
+use PhpParser\Node\Name;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\TrinaryLogic;
+
+class RuntimeConstantReflectionTest extends PHPStanTestCase
+{
+
+	public function dataDeprecatedConstants(): array
+	{
+		return [
+			[
+				new Name('\DeprecatedConst\FINE'),
+				TrinaryLogic::createNo(),
+				null,
+			],
+			[
+				new Name('\DeprecatedConst\MY_CONST'),
+				TrinaryLogic::createYes(),
+				null,
+			],
+			[
+				new Name('\DeprecatedConst\MY_CONST2'),
+				TrinaryLogic::createYes(),
+				"don't use it!",
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataDeprecatedConstants
+	 */
+	public function testDeprecatedConstants(Name $constName, TrinaryLogic $isDeprecated, ?string $deprecationMessage): void
+	{
+		require_once __DIR__ . '/data/deprecated-constant.php';
+
+		$reflectionProvider = $this->createReflectionProvider();
+
+		$this->assertTrue($reflectionProvider->hasConstant($constName, null));
+		$this->assertSame($isDeprecated, $reflectionProvider->getConstant($constName, null)->isDeprecated());
+		$this->assertSame($deprecationMessage, $reflectionProvider->getConstant($constName, null)->getDeprecatedDescription());
+	}
+
+}

--- a/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
+++ b/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
@@ -16,7 +16,7 @@ class RuntimeConstantReflectionTest extends PHPStanTestCase
 			yield [
 				new Name('\FILTER_SANITIZE_STRING'),
 				TrinaryLogic::createYes(),
-				'8.1', // deprecation message used in e.g. https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478
+				null,
 			];
 		}
 		yield [

--- a/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
+++ b/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
@@ -5,28 +5,40 @@ namespace PHPStan\Reflection\Constant;
 use PhpParser\Node\Name;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use const PHP_VERSION_ID;
 
 class RuntimeConstantReflectionTest extends PHPStanTestCase
 {
 
-	public function dataDeprecatedConstants(): array
+	public function dataDeprecatedConstants(): iterable
 	{
-		return [
-			[
-				new Name('\DeprecatedConst\FINE'),
-				TrinaryLogic::createNo(),
-				null,
-			],
-			[
-				new Name('\DeprecatedConst\MY_CONST'),
+		if (PHP_VERSION_ID >= 80100) {
+			yield [
+				new Name('\FILTER_SANITIZE_STRING'),
 				TrinaryLogic::createYes(),
-				null,
-			],
-			[
-				new Name('\DeprecatedConst\MY_CONST2'),
-				TrinaryLogic::createYes(),
-				"don't use it!",
-			],
+				'8.1', // deprecation message used in e.g. https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478
+			];
+		}
+		yield [
+			new Name('\CURLOPT_FTP_SSL'),
+			TrinaryLogic::createYes(),
+			'use <b>CURLOPT_USE_SSL</b> instead.',
+		];
+
+		yield [
+			new Name('\DeprecatedConst\FINE'),
+			TrinaryLogic::createNo(),
+			null,
+		];
+		yield [
+			new Name('\DeprecatedConst\MY_CONST'),
+			TrinaryLogic::createYes(),
+			null,
+		];
+		yield [
+			new Name('\DeprecatedConst\MY_CONST2'),
+			TrinaryLogic::createYes(),
+			"don't use it!",
 		];
 	}
 

--- a/tests/PHPStan/Reflection/Constant/data/deprecated-constant.php
+++ b/tests/PHPStan/Reflection/Constant/data/deprecated-constant.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DeprecatedConst;
+
+const FINE = '1';
+
+/**
+ * @deprecated
+ */
+const MY_CONST = '1';
+
+/**
+ * @deprecated don't use it!
+ */
+const MY_CONST2 = '1';


### PR DESCRIPTION
implement reflection for constants, to support use of `@deprecated` on const definitions