### PR TITLE
Fix Closure::fromCallable and first-class callables not propagating templates.

### DIFF
--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -32,7 +32,7 @@ class GenericParametersAcceptorResolver
 		$namedArgTypes = [];
 		foreach ($argTypes as $i => $argType) {
 			if (is_int($i)) {
-				if (isset($parameters[$i])) {
+				if (isset($parameters[$i]) && $parameters[$i]->getName() !== '') {
 					$namedArgTypes[$parameters[$i]->getName()] = $argType;
 					continue;
 				}
@@ -47,15 +47,16 @@ class GenericParametersAcceptorResolver
 						$namedArgTypes[$parameterName] = $argType;
 					}
 				}
-				continue;
 			}
 
 			$namedArgTypes[$i] = $argType;
 		}
 
-		foreach ($parametersAcceptor->getParameters() as $param) {
-			if (isset($namedArgTypes[$param->getName()])) {
+		foreach ($parametersAcceptor->getParameters() as $i => $param) {
+			if ($param->getName() !== '' && isset($namedArgTypes[$param->getName()])) {
 				$argType = $namedArgTypes[$param->getName()];
+			} elseif (isset($namedArgTypes[$i])) {
+				$argType = $namedArgTypes[$i];
 			} elseif ($param->getDefaultValue() !== null) {
 				$argType = $param->getDefaultValue();
 			} else {

--- a/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ClosureFromCallableDynamicReturnTypeExtension.php
@@ -5,11 +5,15 @@ namespace PHPStan\Type\Php;
 use Closure;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\Tag\TemplateTag;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorWithPhpDocs;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -41,6 +45,20 @@ class ClosureFromCallableDynamicReturnTypeExtension implements DynamicStaticMeth
 		$closureTypes = [];
 		foreach ($callableType->getCallableParametersAcceptors($scope) as $variant) {
 			$parameters = $variant->getParameters();
+			$templateTags = [];
+
+			foreach ($variant->getTemplateTypeMap()->getTypes() as $name => $templateType) {
+				if (!$templateType instanceof TemplateType) {
+					throw new ShouldNotHappenException();
+				}
+
+				$templateTags[$name] = new TemplateTag(
+					$name,
+					$templateType->getBound(),
+					TemplateTypeVariance::createInvariant(),
+				);
+			}
+
 			$closureTypes[] = new ClosureType(
 				$parameters,
 				$variant->getReturnType(),
@@ -48,6 +66,7 @@ class ClosureFromCallableDynamicReturnTypeExtension implements DynamicStaticMeth
 				$variant->getTemplateTypeMap(),
 				$variant->getResolvedTemplateTypeMap(),
 				$variant instanceof ParametersAcceptorWithPhpDocs ? $variant->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
+				$templateTags,
 			);
 		}
 

--- a/tests/PHPStan/Analyser/data/generic-callables.php
+++ b/tests/PHPStan/Analyser/data/generic-callables.php
@@ -78,3 +78,146 @@ function testNestedClosures(Closure $closure, string $str, int $int): void
 	$result = $closure1($int);
 	assertType('int|string', $result);
 }
+
+/**
+ * @template T
+ * @param T $arg
+ * @return T
+ */
+function foo(mixed $arg): mixed {}
+
+class Foo
+{
+	/**
+	 * @template T
+	 * @param T $arg
+	 * @return T
+	 */
+	public function foo(mixed $arg): mixed {}
+}
+
+function test(): void
+{
+	assertType('Closure<T of mixed>(T): T', foo(...));
+	assertType('1', foo(...)(1));
+
+	$foo = new Foo();
+	$closure = Closure::fromCallable([$foo, 'foo']);
+	assertType('Closure<T of mixed>(T): T', $closure);
+	assertType('1', $closure(1));
+}
+
+/**
+ * @template A
+ * @param A $value
+ * @return A
+ */
+function identity(mixed $value): mixed
+{
+	return $value;
+}
+
+/**
+ * @template B
+ * @param B $value
+ * @return B
+ */
+function identity2(mixed $value): mixed
+{
+	return $value;
+}
+
+function testIdentity(): void
+{
+	assertType('array{1, 2, 3}', array_map(identity(...), [1, 2, 3]));
+}
+
+/**
+ * @template A
+ * @template B
+ * @param A $value
+ * @param B $value2
+ * @return A|B
+ */
+function identityTwoArgs(mixed $value, mixed $value2): mixed
+{
+	return $value || $value2;
+}
+
+function testIdentityTwoArgs(): void
+{
+	assertType('non-empty-array<int, 1|2|3|4|5|6>', array_map(identityTwoArgs(...), [1, 2, 3], [4, 5, 6]));
+}
+
+/**
+ * @template A
+ * @template B
+ * @param list<A> $a
+ * @param list<B> $b
+ * @return list<array{A, B}>
+ */
+function zip(array $a, array $b): array
+{
+}
+
+function testZip(): void
+{
+	$fn = zip(...);
+
+	assertType('list<array{1, 2}>', $fn([1], [2]));
+}
+
+/**
+ * @template X
+ * @template Y
+ * @template Z
+ * @param callable(X, Y): Z $fn
+ * @return callable(Y, X): Z
+ */
+function flip(callable $fn): callable
+{
+}
+
+/**
+ * @param Closure<A of string, B of int>(A $a, B $b): (A|B) $closure
+ */
+function testFlip($closure): void
+{
+	$fn = flip($closure);
+
+	assertType('callable(B, A): (A|B)', $fn);
+	assertType("1|'one'", $fn(1, 'one'));
+}
+
+function testFlipZip(): void
+{
+	$fn = flip(zip(...));
+
+	assertType('list<array{2, 1}>', $fn([1], [2]));
+}
+
+/**
+ * @template L
+ * @template M
+ * @template N
+ * @template O
+ * @param callable(L): M $ab
+ * @param callable(N): O $cd
+ * @return Closure(array{L, N}): array{M, O}
+ */
+function compose2(callable $ab, callable $cd): Closure
+{
+	throw new \RuntimeException();
+}
+
+function testCompose(): void
+{
+	$composed = compose2(
+		identity(...),
+		identity2(...),
+	);
+
+	assertType('Closure(array{A, B}): array{A, B}', $composed);
+
+	assertType('array{1, 2}', $composed([1, 2]));
+}


### PR DESCRIPTION
Also improves the `array_map` return type extension to be smarter about generic callables, specifically for single argument constant arrays.

This improves the situation of https://github.com/phpstan/phpstan/issues/10685 but i hesitate to say it solves it, there are some underlying issues that i'll add to the relevant test locations on this pr