### PR TITLE
Resolve PHPStan issue with deprecated parameter order in PHP 8.1

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -61,6 +61,11 @@ class PhpVersion
 		return $this->versionId >= 80100;
 	}
 
+	public function deprecatesRequiredParameterAfterOptionalUnionOrMixed(): bool
+	{
+		return $this->versionId >= 80300;
+	}
+
 	public function supportsLessOverridenParametersWithVariadic(): bool
 	{
 		return $this->versionId >= 80000;

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -56,6 +56,11 @@ class PhpVersion
 		return $this->versionId >= 80000;
 	}
 
+	public function deprecatesRequiredParameterAfterOptionalNullableAndDefaultNull(): bool
+	{
+		return $this->versionId >= 80100;
+	}
+
 	public function supportsLessOverridenParametersWithVariadic(): bool
 	{
 		return $this->versionId >= 80000;

--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\FunctionLike;
+use PhpParser\Node\NullableType;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -394,6 +395,12 @@ class FunctionDefinitionCheck
 
 			$constantName = $defaultValue->name->toLowerString();
 			if ($constantName === 'null') {
+				if ($this->phpVersion->deprecatesRequiredParameterAfterOptionalNullableAndDefaultNull()) {
+					if ($parameterNode->type instanceof NullableType) {
+						$optionalParameter = $parameterName;
+					}
+				}
+
 				continue;
 			}
 

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -91,7 +91,16 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 		return [
 			[
 				70400,
-				[],
+				[
+					[
+						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
+						17,
+					],
+					[
+						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
+						19,
+					],
+				],
 			],
 			[
 				80000,
@@ -111,6 +120,14 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						13,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
 					],
 				],
 			],
@@ -134,8 +151,57 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 						13,
 					],
 					[
-						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
 						15,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+				],
+			],
+			[
+				80300,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						5,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						9,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						11,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						13,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
+						15,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						19,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						23,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -108,6 +108,35 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						11,
 					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						13,
+					],
+				],
+			],
+			[
+				80100,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						5,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						9,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						11,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						13,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						15,
+					],
 				],
 			],
 		];

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -135,7 +135,16 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 		return [
 			[
 				70400,
-				[],
+				[
+					[
+						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
+						29,
+					],
+					[
+						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
+						33,
+					],
+				],
 			],
 			[
 				80000,
@@ -155,6 +164,14 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						21,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						29,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						37,
 					],
 				],
 			],
@@ -178,8 +195,57 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 						21,
 					],
 					[
-						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
 						25,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						29,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						37,
+					],
+				],
+			],
+			[
+				80300,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						5,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						13,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
+						25,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						29,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						33,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						37,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						41,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -152,6 +152,35 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						17,
 					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+				],
+			],
+			[
+				80100,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						5,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						13,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						25,
+					],
 				],
 			],
 		];

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -216,7 +216,16 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 		return [
 			[
 				70400,
-				[],
+				[
+					[
+						"Function RequiredAfterOptional\doAmet() uses native union types but they're supported only on PHP 8.0 and later.",
+						34,
+					],
+					[
+						"Function RequiredAfterOptional\doConsectetur() uses native union types but they're supported only on PHP 8.0 and later.",
+						38,
+					],
+				],
 			],
 			[
 				80000,
@@ -236,6 +245,14 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						26,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						34,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						42,
 					],
 				],
 			],
@@ -259,8 +276,57 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 						26,
 					],
 					[
-						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
 						30,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						34,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						42,
+					],
+				],
+			],
+			[
+				80300,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						5,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						14,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						18,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						26,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
+						30,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						34,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						38,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						42,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						46,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -233,6 +233,35 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						18,
 					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						26,
+					],
+				],
+			],
+			[
+				80100,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						5,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						14,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						18,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						26,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						30,
+					],
 				],
 			],
 		];

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-arrow.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-arrow.php
@@ -9,3 +9,7 @@ fn (int $foo = null, $bar): int => 1; // is OK
 fn (int $foo = 1, $bar): int => 1; // not OK
 
 fn (bool $foo = true, $bar): int => 1; // not OK
+
+fn (?int $foo = 1, $bar): int => 1; // not OK
+
+fn (?int $foo = null, $bar): int => 1; // not OK

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-arrow.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-arrow.php
@@ -1,4 +1,4 @@
-<?php // lint >= 7.4
+<?php // lint >= 8.0
 
 namespace RequiredAfterOptional;
 
@@ -13,3 +13,11 @@ fn (bool $foo = true, $bar): int => 1; // not OK
 fn (?int $foo = 1, $bar): int => 1; // not OK
 
 fn (?int $foo = null, $bar): int => 1; // not OK
+
+fn (int|null $foo = 1, $bar): int => 1; // not OK
+
+fn (int|null $foo = null, $bar): int => 1; // not OK
+
+fn (mixed $foo = 1, $bar): int => 1; // not OK
+
+fn (mixed $foo = null, $bar): int => 1; // not OK

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-closures.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-closures.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace RequiredAfterOptional;
 
@@ -23,5 +23,21 @@ function (?int $foo = 1, $bar): void // not OK
 };
 
 function (?int $foo = null, $bar): void // not OK
+{
+};
+
+function (int|null $foo = 1, $bar): void // not OK
+{
+};
+
+function (int|null $foo = null, $bar): void // not OK
+{
+};
+
+function (mixed $foo = 1, $bar): void // not OK
+{
+};
+
+function (mixed $foo = null, $bar): void // not OK
 {
 };

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-closures.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-closures.php
@@ -17,3 +17,11 @@ function (int $foo = 1, $bar): void // not OK
 function(bool $foo = true, $bar): void // not OK
 {
 };
+
+function (?int $foo = 1, $bar): void // not OK
+{
+};
+
+function (?int $foo = null, $bar): void // not OK
+{
+};

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace RequiredAfterOptional;
 
@@ -28,5 +28,21 @@ function doDolor(?int $foo = 1, $bar): void // not OK
 }
 
 function doSit(?int $foo = null, $bar): void // not OK
+{
+}
+
+function doAmet(int|null $foo = 1, $bar): void // not OK
+{
+}
+
+function doConsectetur(int|null $foo = null, $bar): void // not OK
+{
+}
+
+function doAdipiscing(mixed $foo = 1, $bar): void // not OK
+{
+}
+
+function doElit(mixed $foo = null, $bar): void // not OK
 {
 }

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional.php
@@ -22,3 +22,11 @@ function doLorem(bool $foo = true, $bar): void // not OK
 function doIpsum(bool $foo = true, ...$bar): void // OK
 {
 }
+
+function doDolor(?int $foo = 1, $bar): void // not OK
+{
+}
+
+function doSit(?int $foo = null, $bar): void // not OK
+{
+}

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -227,6 +227,35 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						21,
 					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						25,
+					],
+				],
+			],
+			[
+				80100,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						8,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						25,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						29,
+					],
 				],
 			],
 		];

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -210,7 +210,16 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 		return [
 			[
 				70400,
-				[],
+				[
+					[
+						"Method RequiredAfterOptional\Foo::doAmet() uses native union types but they're supported only on PHP 8.0 and later.",
+						33,
+					],
+					[
+						"Method RequiredAfterOptional\Foo::doConsectetur() uses native union types but they're supported only on PHP 8.0 and later.",
+						37,
+					],
+				],
 			],
 			[
 				80000,
@@ -230,6 +239,14 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						25,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						33,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						41,
 					],
 				],
 			],
@@ -253,8 +270,57 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 						25,
 					],
 					[
-						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
 						29,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						33,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						41,
+					],
+				],
+			],
+			[
+				80300,
+				[
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						8,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						17,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						21,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						25,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $bar follows optional parameter $foo.',
+						29,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						33,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						37,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
+						41,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						45,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Methods/data/required-parameter-after-optional.php
+++ b/tests/PHPStan/Rules/Methods/data/required-parameter-after-optional.php
@@ -22,4 +22,11 @@ class Foo
 	{
 	}
 
+	public function doDolor(?int $foo = 1, $bar): void // not OK
+	{
+	}
+
+	public function doSit(?int $foo = null, $bar): void // not OK
+	{
+	}
 }

--- a/tests/PHPStan/Rules/Methods/data/required-parameter-after-optional.php
+++ b/tests/PHPStan/Rules/Methods/data/required-parameter-after-optional.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint > 8.0
 
 namespace RequiredAfterOptional;
 
@@ -29,4 +29,20 @@ class Foo
 	public function doSit(?int $foo = null, $bar): void // not OK
 	{
 	}
+
+    public function doAmet(int|null $foo = 1, $bar): void // not OK
+    {
+    }
+
+    public function doConsectetur(int|null $foo = null, $bar): void // not OK
+    {
+    }
+
+    public function doAdipiscing(mixed $foo = 1, $bar): void // not OK
+    {
+    }
+
+    public function doElit(mixed $foo = null, $bar): void // not OK
+    {
+    }
 }


### PR DESCRIPTION
Since PHP 8.1, a nullable, optional parameter with a default value of null followed by a required parameter will generate a warning.
The current PHPStan did not recognize such code as deprecated.
This PR updates PHPStan to properly handle such cases.
Please review.
Thank you.

resolve phpstan/phpstan#6668