### PR TITLE
Constants deprecation depends on php version in comment

### DIFF
--- a/src/Reflection/BetterReflection/BetterReflectionProvider.php
+++ b/src/Reflection/BetterReflection/BetterReflectionProvider.php
@@ -373,9 +373,17 @@ class BetterReflectionProvider implements ReflectionProvider
 			if ($resolvedPhpDoc->isDeprecated() && $resolvedPhpDoc->getDeprecatedTag() !== null) {
 				$deprecatedMessage = $resolvedPhpDoc->getDeprecatedTag()->getMessage();
 
-				// filter raw version number messages like in
-				// https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478
-				if (Strings::match($deprecatedMessage ?? '', '#^\d+\.\d+(\.\d+)?$#') === null) {
+				$matches = Strings::match($deprecatedMessage ?? '', '#^(\d+)\.(\d+)(?:\.(\d+))?$#');
+				if ($matches !== null) {
+					$major = $matches[1];
+					$minor = $matches[2];
+					$patch = $matches[3] ?? 0;
+					$versionId = sprintf('%d%02d%02d', $major, $minor, $patch);
+
+					$isDeprecated = TrinaryLogic::createFromBoolean($this->phpVersion->getVersionId() >= $versionId);
+				} else {
+					// filter raw version number messages like in
+					// https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478
 					$deprecatedDescription = $deprecatedMessage;
 				}
 			}

--- a/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
+++ b/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
@@ -12,13 +12,12 @@ class RuntimeConstantReflectionTest extends PHPStanTestCase
 
 	public function dataDeprecatedConstants(): iterable
 	{
-		if (PHP_VERSION_ID >= 80100) {
-			yield [
-				new Name('\FILTER_SANITIZE_STRING'),
-				TrinaryLogic::createYes(),
-				null,
-			];
-		}
+		yield [
+			new Name('\FILTER_SANITIZE_STRING'),
+			PHP_VERSION_ID >= 80100 ? TrinaryLogic::createYes() : TrinaryLogic::createNo(),
+			null,
+		];
+
 		yield [
 			new Name('\CURLOPT_FTP_SSL'),
 			TrinaryLogic::createYes(),


### PR DESCRIPTION
since support for [`@deprecated` on constants was added into BetterReflection](https://github.com/Roave/BetterReflection/pull/1396) with this PR we now take care of interpreting the phpdoc comment and decide per phpversion when a constant is deprecated or not.

this also makes sure that the deprecation message depends on phpstan.neon `phpVersion`.

closes https://github.com/phpstan/phpstan/issues/10700