### PR TITLE
Extension / Rule change will not invalidate the cache

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -135,6 +135,16 @@ jobs:
               echo -n > phpstan-baseline.neon
               ../../bin/phpstan -vvv
           - script: |
+              cd e2e/result-cache-8
+              echo -n > phpstan-baseline.neon
+              ../../bin/phpstan -vvv
+              patch -b CustomRule.php < patch-1.patch
+              cat baseline-1.neon > phpstan-baseline.neon
+              ../../bin/phpstan -vvv
+              mv CustomRule.php.orig CustomRule.php
+              echo -n > phpstan-baseline.neon
+              ../../bin/phpstan -vvv
+          - script: |
               cd e2e/bug10449
               ../../bin/phpstan analyze
               git apply patch.diff

--- a/e2e/result-cache-8/CustomRule.php
+++ b/e2e/result-cache-8/CustomRule.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TestResultCache8;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class CustomRule implements Rule
+{
+	public function getNodeType(): string
+	{
+		return Node\Stmt\ClassMethod::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		return [];
+	}
+}

--- a/e2e/result-cache-8/autoload.php
+++ b/e2e/result-cache-8/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+include_once 'CustomRule.php';
+
+return [];

--- a/e2e/result-cache-8/baseline-1.neon
+++ b/e2e/result-cache-8/baseline-1.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^TestResultCache8$#"
+			count: 1
+			path: src/Foo.php

--- a/e2e/result-cache-8/patch-1.patch
+++ b/e2e/result-cache-8/patch-1.patch
@@ -1,0 +1,12 @@
+--- CustomRule.php
++++ CustomRule.php
+@@ -16,6 +16,8 @@
+
+ 	public function processNode(Node $node, Scope $scope): array
+ 	{
+-		return [];
++		return [
++			RuleErrorBuilder::message('TestResultCache8')->build(),
++		];
+ 	}
+ }

--- a/e2e/result-cache-8/phpstan.neon
+++ b/e2e/result-cache-8/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+	- phpstan-baseline.neon
+	- autoload.php
+rules:
+    - \TestResultCache8\CustomRule
+parameters:
+	level: 8
+	inferPrivatePropertyTypeFromConstructor: true
+	paths:
+		- src

--- a/e2e/result-cache-8/src/Foo.php
+++ b/e2e/result-cache-8/src/Foo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TestResultCache8;
+
+class Foo
+{
+	public function returnCustomRule(): void
+	{
+	}
+}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -702,6 +702,7 @@ return [
 					}
 
 					$allServiceFiles = $this->getAllDependencies($fileName, $dependencies);
+					$projectExtensionFiles[$fileName] = $this->getFileHash($fileName);
 					foreach ($allServiceFiles as $serviceFile) {
 						if (array_key_exists($serviceFile, $projectExtensionFiles)) {
 							continue;


### PR DESCRIPTION
Hey 👋 
we have the problem that the cache file is not invalidated if we change the code inside of a custom rule.

```neon
services:
    -
        class: CustomPHPStanRule\CustomRuleA
parameters:
	inferPrivatePropertyTypeFromConstructor: true
```

```bash
$ cat cache/phpstan/resultCache.php  | grep -A1 "projectExtensionFiles"
        'projectExtensionFiles' => array (
        ),
```

I expected the CustomRuleA in the projectExtensionFile. if this is there the normal cache workflow will also check the sha1 file sum and invalidates the cache.

With the current change the current service is always added as projectExtensionFile and every change on that file will invalidate the cache