### PR TITLE
`Type->getReferencedClasses()` returns a `class-string`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1304,6 +1304,11 @@ parameters:
 			path: src/Type/ObjectType.php
 
 		-
+			message: "#^Method PHPStan\\\\Type\\\\ObjectType\\:\\:getReferencedClasses\\(\\) should return array\\<class\\-string\\> but returns array\\<int, string\\>\\.$#"
+			count: 1
+			path: src/Type/ObjectType.php
+
+		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\ObjectShapeType is error\\-prone and deprecated\\. Use Type\\:\\:isObject\\(\\) and Type\\:\\:hasProperty\\(\\) instead\\.$#"
 			count: 2
 			path: src/Type/ObjectWithoutClassType.php

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -35,9 +35,6 @@ class HasPropertyType implements AccessoryType, CompoundType
 	{
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -64,9 +64,6 @@ class ArrayType implements Type
 		return $this->itemType;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return array_merge(

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -89,9 +89,6 @@ class CallableType implements CompoundType, ParametersAcceptor
 		return $this->templateTags;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		$classes = [];

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -108,9 +108,6 @@ class ClosureType implements TypeWithClassName, ParametersAcceptor
 		return $this->objectType->getAncestorWithClassName($className);
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		$classes = $this->objectType->getReferencedClasses();

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -41,9 +41,6 @@ class FloatType implements Type
 	{
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/Generic/GenericObjectType.php
+++ b/src/Type/Generic/GenericObjectType.php
@@ -91,9 +91,6 @@ class GenericObjectType extends ObjectType
 		return true;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		$classes = parent::getReferencedClasses();

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -52,9 +52,6 @@ class IterableType implements CompoundType
 		return $this->itemType;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return array_merge(

--- a/src/Type/JustNullableTypeTrait.php
+++ b/src/Type/JustNullableTypeTrait.php
@@ -8,9 +8,6 @@ use function get_class;
 trait JustNullableTypeTrait
 {
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -58,9 +58,6 @@ class MixedType implements CompoundType, SubtractableType
 		$this->subtractedType = $subtractedType;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -41,9 +41,6 @@ class NeverType implements CompoundType
 		return $this->isExplicit;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -36,9 +36,6 @@ class NullType implements ConstantScalarType
 	{
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -248,9 +248,6 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $classReflection->getProperty($propertyName, $scope);
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [$this->className];

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -34,9 +34,6 @@ class ObjectWithoutClassType implements SubtractableType
 		$this->subtractedType = $subtractedType;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -101,9 +101,6 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->staticObjectType;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return $this->getStaticObjectType()->getReferencedClasses();

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -28,7 +28,7 @@ interface Type
 {
 
 	/**
-	 * @return string[]
+	 * @return class-string[]
 	 */
 	public function getReferencedClasses(): array;
 

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -105,9 +105,6 @@ class UnionType implements CompoundType
 		return $this->types;
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		$classes = [];

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -37,9 +37,6 @@ class VoidType implements Type
 	{
 	}
 
-	/**
-	 * @return string[]
-	 */
 	public function getReferencedClasses(): array
 	{
 		return [];


### PR DESCRIPTION
declaring the more precise types makes working in phpstan extension easier, as I can use more precise typing in e.g. method parameters to which I pass the result of `getReferencedClasses()` like

```php

class myext {
  function doFoo() {
        foreach($classType->getReferencedClasses() as $referencedClass) {
            $this->myMethod($referencedClass);
        }
  }

  /** @param class-string $class */
  private function myMethod($class) {}
}

```

we could do similar stuff for `Type->getObjectClassNames()`