### PR TITLE
Fix deprecated warning version display

### DIFF
--- a/src/Rules/FunctionDefinitionCheck.php
+++ b/src/Rules/FunctionDefinitionCheck.php
@@ -390,6 +390,7 @@ class FunctionDefinitionCheck
 						$optionalParameter,
 					),
 				)->line($parameterNode->getStartLine())->build();
+				$targetPhpVersion = null;
 				continue;
 			}
 			if ($parameterNode->default === null) {

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -100,6 +100,10 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
 						19,
 					],
+					[
+						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
+						25,
+					],
 				],
 			],
 			[
@@ -128,6 +132,10 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						21,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						25,
 					],
 				],
 			],
@@ -161,6 +169,14 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						21,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						25,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						25,
 					],
 				],
 			],
@@ -202,6 +218,18 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
 						23,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						25,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						25,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						25,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -144,6 +144,10 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
 						33,
 					],
+					[
+						"Anonymous function uses native union types but they're supported only on PHP 8.0 and later.",
+						45,
+					],
 				],
 			],
 			[
@@ -172,6 +176,10 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						37,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						45,
 					],
 				],
 			],
@@ -205,6 +213,14 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						37,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						45,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						45,
 					],
 				],
 			],
@@ -246,6 +262,18 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
 						41,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						45,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						45,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						45,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -225,6 +225,10 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 						"Function RequiredAfterOptional\doConsectetur() uses native union types but they're supported only on PHP 8.0 and later.",
 						38,
 					],
+					[
+						"Function RequiredAfterOptional\doSed() uses native union types but they're supported only on PHP 8.0 and later.",
+						50,
+					],
 				],
 			],
 			[
@@ -253,6 +257,10 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						42,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						50,
 					],
 				],
 			],
@@ -286,6 +294,14 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						42,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						50,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						50,
 					],
 				],
 			],
@@ -327,6 +343,18 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
 						46,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						50,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						50,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						50,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-arrow.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-arrow.php
@@ -21,3 +21,5 @@ fn (int|null $foo = null, $bar): int => 1; // not OK
 fn (mixed $foo = 1, $bar): int => 1; // not OK
 
 fn (mixed $foo = null, $bar): int => 1; // not OK
+
+fn (int|null $foo = null, $bar, ?int $baz = null, $qux, int $quux = 1, $quuz): int => 1; // not OK

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-closures.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional-closures.php
@@ -41,3 +41,7 @@ function (mixed $foo = 1, $bar): void // not OK
 function (mixed $foo = null, $bar): void // not OK
 {
 };
+
+function (int|null $foo = null, $bar, ?int $baz = null, $qux, int $quux = 1, $quuz): void // not OK
+{
+};

--- a/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional.php
+++ b/tests/PHPStan/Rules/Functions/data/required-parameter-after-optional.php
@@ -46,3 +46,7 @@ function doAdipiscing(mixed $foo = 1, $bar): void // not OK
 function doElit(mixed $foo = null, $bar): void // not OK
 {
 }
+
+function doSed(int|null $foo = null, $bar, ?int $baz = null, $qux, int $quux = 1, $quuz): void // not OK
+{
+}

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -219,6 +219,10 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 						"Method RequiredAfterOptional\Foo::doConsectetur() uses native union types but they're supported only on PHP 8.0 and later.",
 						37,
 					],
+					[
+						"Method RequiredAfterOptional\Foo::doSed() uses native union types but they're supported only on PHP 8.0 and later.",
+						49,
+					],
 				],
 			],
 			[
@@ -247,6 +251,10 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						41,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						49,
 					],
 				],
 			],
@@ -280,6 +288,14 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.0: Required parameter $bar follows optional parameter $foo.',
 						41,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						49,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						49,
 					],
 				],
 			],
@@ -321,6 +337,18 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 					[
 						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
 						45,
+					],
+					[
+						'Deprecated in PHP 8.3: Required parameter $bar follows optional parameter $foo.',
+						49,
+					],
+					[
+						'Deprecated in PHP 8.1: Required parameter $qux follows optional parameter $baz.',
+						49,
+					],
+					[
+						'Deprecated in PHP 8.0: Required parameter $quuz follows optional parameter $quux.',
+						49,
 					],
 				],
 			],

--- a/tests/PHPStan/Rules/Methods/data/required-parameter-after-optional.php
+++ b/tests/PHPStan/Rules/Methods/data/required-parameter-after-optional.php
@@ -30,19 +30,23 @@ class Foo
 	{
 	}
 
-    public function doAmet(int|null $foo = 1, $bar): void // not OK
-    {
-    }
+	public function doAmet(int|null $foo = 1, $bar): void // not OK
+	{
+	}
 
-    public function doConsectetur(int|null $foo = null, $bar): void // not OK
-    {
-    }
+	public function doConsectetur(int|null $foo = null, $bar): void // not OK
+	{
+	}
 
-    public function doAdipiscing(mixed $foo = 1, $bar): void // not OK
-    {
-    }
+	public function doAdipiscing(mixed $foo = 1, $bar): void // not OK
+	{
+	}
 
-    public function doElit(mixed $foo = null, $bar): void // not OK
-    {
-    }
+	public function doElit(mixed $foo = null, $bar): void // not OK
+	{
+	}
+
+	public function doSed(int|null $foo = null, $bar, ?int $baz = null, $qux, int $quux = 1, $quuz): void // not OK
+	{
+	}
 }


### PR DESCRIPTION
I modified it to display the appropriate version when the conditions for displaying the deprecated warning are different in the code, and added tests.

ref #2963 