### PR TITLE
Narrow down static and $this together

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1180,15 +1180,11 @@ class MutatingScope implements Scope
 			}
 
 			if ($node instanceof Expr\StaticCall) {
-				if (!$node->class instanceof Name) {
-					return new ObjectType(Closure::class);
-				}
-
 				if (!$node->name instanceof Node\Identifier) {
 					return new ObjectType(Closure::class);
 				}
 
-				$classType = $this->resolveTypeByName($node->class);
+				$classType = $this->getType(new Expr\ClassConstFetch($node->class, 'class'))->getClassStringObjectType();
 				$methodName = $node->name->toString();
 				if (!$classType->hasMethod($methodName)->yes()) {
 					return new ObjectType(Closure::class);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3089,12 +3089,17 @@ class MutatingScope implements Scope
 			unset($nativeExpressionTypes['$this']);
 		}
 
+		$context = $this->context;
+
 		if ($scopeClasses === ['static'] && $this->isInClass()) {
 			$scopeClasses = [$this->getClassReflection()->getName()];
+		} elseif (count($scopeClasses) === 1 && $this->reflectionProvider->hasClass($scopeClasses[0])) {
+			$context = ScopeContext::create($this->context->getFile());
+			$context = $context->enterClass($this->reflectionProvider->getClass($scopeClasses[0]));
 		}
 
 		return $this->scopeFactory->create(
-			$this->context,
+			$context,
 			$this->isDeclareStrictTypes(),
 			$this->getFunction(),
 			$this->getNamespace(),
@@ -3123,7 +3128,7 @@ class MutatingScope implements Scope
 		}
 
 		return $this->scopeFactory->create(
-			$this->context,
+			$originalScope->context,
 			$this->isDeclareStrictTypes(),
 			$this->getFunction(),
 			$this->getNamespace(),

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -4871,7 +4871,7 @@ class NodeScopeResolver
 
 		} elseif ($var instanceof Expr\StaticPropertyFetch) {
 			if ($var->class instanceof Node\Name) {
-				$propertyHolderType = $scope->resolveTypeByName($var->class);
+				$propertyHolderType = $scope->getType(new Expr\ClassConstFetch($var->class, 'class'))->getClassStringObjectType();
 			} else {
 				$this->processExprNode($stmt, $var->class, $scope, $nodeCallback, $context);
 				$propertyHolderType = $scope->getType($var->class);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2675,17 +2675,17 @@ class NodeScopeResolver
 							}
 						}
 						$scopeClasses = ['static'];
-							if (isset($expr->getArgs()[2])) {
-								$argValue = $expr->getArgs()[2]->value;
-								$argValueType = $scope->getType($argValue);
-								$scopeObjectType = $argValueType->getObjectTypeOrClassStringObjectType();
-								$thisType = $thisType !== null
-									// $thisType could be mixed, error, ...
-									? TypeCombinator::intersect($thisType, $scopeObjectType)
-									: $scopeObjectType;
-								$scopeClasses = $scopeObjectType->getObjectClassNames();
-							}
-							$closureBindScope = $scope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);
+						if (isset($expr->getArgs()[2])) {
+							$argValue = $expr->getArgs()[2]->value;
+							$argValueType = $scope->getType($argValue);
+							$scopeObjectType = $argValueType->getObjectTypeOrClassStringObjectType();
+							$thisType = $thisType !== null
+								// $thisType could be mixed, error, ...
+								? TypeCombinator::intersect($thisType, $scopeObjectType)
+								: $scopeObjectType;
+							$scopeClasses = $scopeObjectType->getObjectClassNames();
+						}
+						$closureBindScope = $scope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);
 					}
 				} else {
 					$throwPoints[] = ThrowPoint::createImplicit($scope, $expr);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2051,7 +2051,7 @@ class NodeScopeResolver
 					$methodCalledOnType = $scope->getType($expr->var);
 				} else {
 					if ($expr->class instanceof Name) {
-						$methodCalledOnType = $scope->resolveTypeByName($expr->class);
+						$methodCalledOnType = $scope->getType(new Expr\ClassConstFetch($expr->class, 'class'))->getClassStringObjectType();
 					} else {
 						$methodCalledOnType = $scope->getType($expr->class);
 					}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2675,23 +2675,17 @@ class NodeScopeResolver
 							}
 						}
 						$scopeClasses = ['static'];
-						if (isset($expr->getArgs()[2])) {
-							$argValue = $expr->getArgs()[2]->value;
-							$argValueType = $scope->getType($argValue);
-
-								$directClassNames = $argValueType->getObjectClassNames();
-								if (count($directClassNames) > 0) {
-									$scopeClasses = $directClassNames;
-								} else {
-									$scopeObjectType = $argValueType->getClassStringObjectType();
-									$thisType = $thisType !== null
-										// $thisType could be mixed, error, ...
-										? TypeCombinator::intersect($thisType, $scopeObjectType)
-										: $scopeObjectType;
-									$scopeClasses = $scopeObjectType->getObjectClassNames();
-								}
-						}
-						$closureBindScope = $scope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);
+							if (isset($expr->getArgs()[2])) {
+								$argValue = $expr->getArgs()[2]->value;
+								$argValueType = $scope->getType($argValue);
+								$scopeObjectType = $argValueType->getObjectTypeOrClassStringObjectType();
+								$thisType = $thisType !== null
+									// $thisType could be mixed, error, ...
+									? TypeCombinator::intersect($thisType, $scopeObjectType)
+									: $scopeObjectType;
+								$scopeClasses = $scopeObjectType->getObjectClassNames();
+							}
+							$closureBindScope = $scope->enterClosureBind($thisType, $nativeThisType, $scopeClasses);
 					}
 				} else {
 					$throwPoints[] = ThrowPoint::createImplicit($scope, $expr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -485,7 +485,7 @@ class TypeSpecifier
 			return $this->handleDefaultTruthyOrFalseyContext($context, $rootExpr, $expr, $scope);
 		} elseif ($expr instanceof StaticCall && $expr->name instanceof Node\Identifier) {
 			if ($expr->class instanceof Name) {
-				$calleeType = $scope->resolveTypeByName($expr->class);
+				$calleeType = $scope->getType(new ClassConstFetch($expr->class, 'class'))->getClassStringObjectType();
 			} else {
 				$calleeType = $scope->getType($expr->class);
 			}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1649,7 +1649,7 @@ class TypeSpecifier
 		) {
 			$methodName = $expr->name->toString();
 			if ($expr->class instanceof Name) {
-				$calledOnType = $scope->resolveTypeByName($expr->class);
+				$calledOnType = $scope->getType(new ClassConstFetch($expr->class, 'class'))->getClassStringObjectType();
 			} else {
 				$calledOnType = $scope->getType($expr->class);
 			}

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -66,7 +66,9 @@ class ClassConstantRule implements Rule
 					];
 				}
 
-				$classType = $scope->resolveTypeByName($class);
+				$classType = $lowercasedClassName === 'static'
+					? $scope->getType(new ClassConstFetch(new Node\Name('static'), 'class'))->getClassStringObjectType()
+					: $scope->resolveTypeByName($class);
 			} elseif ($lowercasedClassName === 'parent') {
 				if (!$scope->isInClass()) {
 					return [

--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -387,7 +387,7 @@ class ImpossibleCheckTypeHelper
 			}
 		} elseif ($node instanceof StaticCall && $node->name instanceof Node\Identifier) {
 			if ($node->class instanceof Node\Name) {
-				$calleeType = $scope->resolveTypeByName($node->class);
+				$calleeType = $scope->getType(new Expr\ClassConstFetch($node->class, 'class'))->getClassStringObjectType();
 			} else {
 				$calleeType = $scope->getType($node->class);
 			}

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -103,7 +103,7 @@ class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 	): MethodReflection
 	{
 		if ($class instanceof Node\Name) {
-			$calledOnType = $scope->resolveTypeByName($class);
+			$calledOnType = $scope->getType(new Expr\ClassConstFetch($class, 'class'))->getClassStringObjectType();
 		} else {
 			$calledOnType = $scope->getType($class);
 		}

--- a/src/Rules/Methods/CallPrivateMethodThroughStaticRule.php
+++ b/src/Rules/Methods/CallPrivateMethodThroughStaticRule.php
@@ -36,7 +36,7 @@ class CallPrivateMethodThroughStaticRule implements Rule
 			return [];
 		}
 
-		$classType = $scope->resolveTypeByName($className);
+		$classType = $scope->getType(new Node\Expr\ClassConstFetch(new Name('static'), 'class'))->getClassStringObjectType();
 		if (!$classType->hasMethod($methodName)->yes()) {
 			return [];
 		}

--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -146,6 +146,10 @@ class StaticMethodCallCheck
 					}
 				}
 			}
+
+			if ($lowercasedClassName === 'static') {
+				$classType = $scope->getType(new Expr\ClassConstFetch(new Name('static'), 'class'))->getClassStringObjectType();
+			}
 		} else {
 			$classTypeResult = $this->ruleLevelHelper->findTypeToCheck(
 				$scope,

--- a/src/Rules/Properties/AccessStaticPropertiesRule.php
+++ b/src/Rules/Properties/AccessStaticPropertiesRule.php
@@ -85,7 +85,9 @@ class AccessStaticPropertiesRule implements Rule
 						))->identifier(sprintf('outOfClass.%s', $lowercasedClass))->build(),
 					];
 				}
-				$classType = $scope->resolveTypeByName($node->class);
+				$classType = $lowercasedClass === 'static'
+					? $scope->getType(new Node\Expr\ClassConstFetch(new Name('static'), 'class'))->getClassStringObjectType()
+					: $scope->resolveTypeByName($node->class);
 			} elseif ($lowercasedClass === 'parent') {
 				if (!$scope->isInClass()) {
 					return [

--- a/src/Rules/Properties/PropertyReflectionFinder.php
+++ b/src/Rules/Properties/PropertyReflectionFinder.php
@@ -98,7 +98,9 @@ class PropertyReflectionFinder
 		}
 
 		if ($propertyFetch->class instanceof Node\Name) {
-			$propertyHolderType = $scope->resolveTypeByName($propertyFetch->class);
+			$propertyHolderType = $propertyFetch->class->toLowerString() === 'static'
+				? $scope->getType(new Expr\ClassConstFetch($propertyFetch->class, 'class'))->getClassStringObjectType()
+				: $scope->resolveTypeByName($propertyFetch->class);
 		} else {
 			$propertyHolderType = $scope->getType($propertyFetch->class);
 		}

--- a/src/Rules/Properties/PropertyReflectionFinder.php
+++ b/src/Rules/Properties/PropertyReflectionFinder.php
@@ -49,7 +49,7 @@ class PropertyReflectionFinder
 		}
 
 		if ($propertyFetch->class instanceof Node\Name) {
-			$propertyHolderType = $scope->resolveTypeByName($propertyFetch->class);
+			$propertyHolderType = $scope->getType(new Expr\ClassConstFetch($propertyFetch->class, 'class'))->getClassStringObjectType();
 		} else {
 			$propertyHolderType = $scope->getType($propertyFetch->class);
 		}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1364,6 +1364,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8486.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9000.php');
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/enum-from.php');
+			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-instanceof-static-vs-this-1st-class-callable.php');
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-8956.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1477,6 +1477,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-instanceof-static-vs-this.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-instanceof-static-vs-this-type-specifier.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-instanceof-static-vs-this-early-termination.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-instanceof-static-vs-this-prop-assign-scope.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5987.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10468.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6613.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1475,6 +1475,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/set-type-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysqli_fetch_object.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-instanceof-static-vs-this.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-instanceof-static-vs-this-type-specifier.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5987.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10468.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6613.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1474,6 +1474,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/set-type-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysqli_fetch_object.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-instanceof-static-vs-this.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5987.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10468.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6613.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10187.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1473,6 +1473,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-10594.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/set-type-type-specifying.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysqli_fetch_object.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-instanceof-static-vs-this.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10468.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6613.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10187.php');

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1476,6 +1476,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/mysqli_fetch_object.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-instanceof-static-vs-this.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-instanceof-static-vs-this-type-specifier.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-instanceof-static-vs-this-early-termination.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5987.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10468.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6613.php');
@@ -1505,6 +1506,13 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		return [
 			__DIR__ . '/../../../conf/bleedingEdge.neon',
 			__DIR__ . '/typeAliases.neon',
+		];
+	}
+
+	protected static function getEarlyTerminatingMethodCalls(): array
+	{
+		return [
+			'BugInstanceofStaticVsThisEarlyTermination\\FooChild' => ['terminate'],
 		];
 	}
 

--- a/tests/PHPStan/Analyser/data/bug-5987.php
+++ b/tests/PHPStan/Analyser/data/bug-5987.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Bug5987;
+
+class A
+{
+	/** @return 'a' */
+	public function getScope(): string { return 'a'; }
+}
+
+class B extends A
+{
+	/** @return 'b' */
+	public function getScope(): string { return 'b'; } // @phpstan-ignore-line
+	/** @return 'b' */
+	private function getScopePriv(): string { return 'b'; } // @phpstan-ignore-line
+}
+
+class C extends B
+{
+	/** @return 'c' */
+	public function getScope(): string { return 'c'; } // @phpstan-ignore-line
+
+	public function test(): void
+	{
+		\Closure::bind(function () {
+			\PHPStan\Testing\assertType("'Bug5987\\\\B'", self::class);
+			\PHPStan\Testing\assertType("'b'", self::getScope());
+			\PHPStan\Testing\assertType("'b'", (self::class)::getScope());
+
+			\PHPStan\Testing\assertType('class-string<static(Bug5987\\C)>', static::class);
+			\PHPStan\Testing\assertType("'c'", static::getScope());
+			\PHPStan\Testing\assertType("'c'", (static::class)::getScope());
+
+			\PHPStan\Testing\assertType("'Bug5987\\\\A'", parent::class);
+			\PHPStan\Testing\assertType("'a'", parent::getScope());
+			\PHPStan\Testing\assertType("'a'", (parent::class)::getScope());
+
+			\PHPStan\Testing\assertType("'c'", $this->getScope());
+			\PHPStan\Testing\assertType("'b'", $this->getScopePriv());
+		}, $this, B::class)();
+	}
+}
+
+$c = new C();
+$c->test();

--- a/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-early-termination.php
+++ b/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-early-termination.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace BugInstanceofStaticVsThisEarlyTermination;
+
+class FooBase
+{
+	public function run(): void
+	{
+		if ($this instanceof FooChild) {
+			$foo = 1;
+
+			if (rand(0, 1)) {
+				$foo = 'a';
+				$this->terminate();
+			}
+
+			if (rand(0, 1)) {
+				$foo = 'b';
+				$this::terminate();
+			}
+
+			if (rand(0, 1)) {
+				$foo = 'c';
+				static::terminate();
+			}
+
+			\PHPStan\Testing\assertType('1', $foo);
+		}
+
+		if (is_a(static::class, FooChild::class, true)) {
+			$foo = 1;
+
+			if (rand(0, 1)) {
+				$foo = 'a';
+				$this->terminate();
+			}
+
+			if (rand(0, 1)) {
+				$foo = 'b';
+				$this::terminate();
+			}
+
+			if (rand(0, 1)) {
+				$foo = 'c';
+				static::terminate();
+			}
+
+			\PHPStan\Testing\assertType('1', $foo);
+		}
+	}
+}
+
+class FooChild extends FooBase
+{
+	// registered as earlyTerminatingMethodCalls in NodeScopeResolverTest
+	public static function terminate()
+	{
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-prop-assign-scope.php
+++ b/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-prop-assign-scope.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace BugInstanceofStaticVsThisPropAssignScope;
+
+class FooBase
+{
+	public function run(): void
+	{
+		if ($this instanceof FooChild) {
+			$this::$prop = 5;
+			\PHPStan\Testing\assertType('5', $this::$prop);
+
+			static::$prop = 6;
+			\PHPStan\Testing\assertType('6', static::$prop);
+		}
+
+		if (is_a(static::class, FooChild::class, true)) {
+			$this::$prop = 5;
+			\PHPStan\Testing\assertType('5', $this::$prop);
+
+			static::$prop = 6;
+			\PHPStan\Testing\assertType('6', static::$prop);
+		}
+	}
+}
+
+class FooChild extends FooBase
+{
+	public static $prop;
+}

--- a/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-type-specifier.php
+++ b/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-type-specifier.php
@@ -6,6 +6,8 @@ interface FooInterface
 {
 	/** @phpstan-assert-if-true null $v */
 	public static function isNull(?int $v): bool;
+
+	public static function foo(): int;
 }
 
 class FooBase
@@ -16,12 +18,20 @@ class FooBase
 			if ($this->isNull($v)) \PHPStan\Testing\assertType('null', $v);
 			if ($this::isNull($v)) \PHPStan\Testing\assertType('null', $v);
 			if (static::isNull($v)) \PHPStan\Testing\assertType('null', $v);
+
+			if ($this::foo() === 5) \PHPStan\Testing\assertType('5', $this::foo());
+			if ($this->foo() === 5) \PHPStan\Testing\assertType('5', $this->foo());
+			if (static::foo() === 5) \PHPStan\Testing\assertType('5', static::foo());
 		}
 
 		if (is_a(static::class, FooInterface::class, true)) {
 			if ($this->isNull($v)) \PHPStan\Testing\assertType('null', $v);
 			if ($this::isNull($v)) \PHPStan\Testing\assertType('null', $v);
 			if (static::isNull($v)) \PHPStan\Testing\assertType('null', $v);
+
+			if ($this::foo() === 5) \PHPStan\Testing\assertType('5', $this::foo());
+			if ($this->foo() === 5) \PHPStan\Testing\assertType('5', $this->foo());
+			if (static::foo() === 5) \PHPStan\Testing\assertType('5', static::foo());
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-type-specifier.php
+++ b/tests/PHPStan/Analyser/data/bug-instanceof-static-vs-this-type-specifier.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace BugInstanceofStaticVsThisTypeSpecifier;
+
+interface FooInterface
+{
+	/** @phpstan-assert-if-true null $v */
+	public static function isNull(?int $v): bool;
+}
+
+class FooBase
+{
+	public function bar(?int $v): void
+	{
+		if ($this instanceof FooInterface) {
+			if ($this->isNull($v)) \PHPStan\Testing\assertType('null', $v);
+			if ($this::isNull($v)) \PHPStan\Testing\assertType('null', $v);
+			if (static::isNull($v)) \PHPStan\Testing\assertType('null', $v);
+		}
+
+		if (is_a(static::class, FooInterface::class, true)) {
+			if ($this->isNull($v)) \PHPStan\Testing\assertType('null', $v);
+			if ($this::isNull($v)) \PHPStan\Testing\assertType('null', $v);
+			if (static::isNull($v)) \PHPStan\Testing\assertType('null', $v);
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -420,4 +420,10 @@ class ClassConstantRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/../Methods/data/bug-instanceof-static-vs-this.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -181,30 +181,30 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					631,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'method\' will always evaluate to true.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'method\' will always evaluate to true.',
 					634,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'someAnother\' will always evaluate to true.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'someAnother\' will always evaluate to true.',
 					637,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'unknown\' will always evaluate to false.',
 					640,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'method\' will always evaluate to true.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'method\' will always evaluate to true.',
 					643,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'someAnother\' will always evaluate to true.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'someAnother\' will always evaluate to true.',
 					646,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'unknown\' will always evaluate to false.',
 					649,
 				],
 				[
@@ -349,12 +349,12 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					631,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'unknown\' will always evaluate to false.',
 					640,
 					'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExistsWithTrait\' and \'unknown\' will always evaluate to false.',
+					'Call to function method_exists() with class-string<static(CheckTypeFunctionCall\MethodExistsWithTrait)> and \'unknown\' will always evaluate to false.',
 					649,
 				],
 				[

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -248,6 +248,25 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/impossible-method-report-always-true-last-condition.php'], $expectedErrors);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$message = 'Call to method BugInstanceofStaticVsThisImpossibleCheck\FooInterface::isNull() with int will always evaluate to false.';
+		$tip = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-impossible-check.php'], [
+			[
+				$message,
+				17,
+				$tip,
+			],
+			[
+				$message,
+				23,
+				$tip,
+			],
+		]);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -145,6 +145,35 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/impossible-static-method-report-always-true-last-condition.php'], $expectedErrors);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$message = 'Call to static method BugInstanceofStaticVsThisImpossibleCheck\FooInterface::isNull() with int will always evaluate to false.';
+		$tip = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-impossible-check.php'], [
+			[
+				$message,
+				18,
+				$tip,
+			],
+			[
+				$message,
+				19,
+				$tip,
+			],
+			[
+				$message,
+				24,
+				$tip,
+			],
+			[
+				$message,
+				25,
+				$tip,
+			],
+		]);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/PHPStan/Rules/Comparison/data/bug-instanceof-static-vs-this-impossible-check.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-instanceof-static-vs-this-impossible-check.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace BugInstanceofStaticVsThisImpossibleCheck;
+
+interface FooInterface
+{
+	/** @phpstan-assert-if-true null $v */
+	public static function isNull(?int $v): bool;
+}
+
+class FooBase
+{
+	/** @param int $v */
+	public function bar($v): void
+	{
+		if ($this instanceof FooInterface) {
+			if ($this->isNull($v)) echo 'a';
+			if ($this::isNull($v)) echo 'a';
+			if (static::isNull($v)) echo 'a';
+		}
+
+		if (is_a(static::class, FooInterface::class, true)) {
+			if ($this->isNull($v)) echo 'a';
+			if ($this::isNull($v)) echo 'a';
+			if (static::isNull($v)) echo 'a';
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1646,6 +1646,40 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/argon2id-password-hash.php'], []);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/../Properties/data/bug-instanceof-static-vs-this-property-assign.php'], [
+			[
+				'Parameter #1 $var is passed by reference so it does not accept readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$nativeReadonlyProp.',
+				17,
+			],
+			[
+				'Parameter #1 $var of function BugInstanceofStaticVsThisPropertyAssign\set expects int, string given.',
+				24,
+			],
+			[
+				'Parameter #1 $var of function BugInstanceofStaticVsThisPropertyAssign\set expects int, string given.',
+				25,
+			],
+			[
+				'Parameter #1 $var is passed by reference so it does not accept readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$nativeReadonlyProp.',
+				31,
+			],
+			[
+				'Parameter #1 $var of function BugInstanceofStaticVsThisPropertyAssign\set expects int, string given.',
+				38,
+			],
+			[
+				'Parameter #1 $var of function BugInstanceofStaticVsThisPropertyAssign\set expects int, string given.',
+				39,
+			],
+		]);
+	}
+
 	public function testParamClosureThis(): void
 	{
 		if (PHP_VERSION_ID < 70400) {

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3255,6 +3255,15 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this.php'], []);
+	}
+
 	public function testClosureBindToParamClosureThis(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/CallPrivateMethodThroughStaticRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallPrivateMethodThroughStaticRuleTest.php
@@ -26,4 +26,14 @@ class CallPrivateMethodThroughStaticRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testInstanceof(): void
+	{
+		$this->analyse([__DIR__ . '/data/call-private-method-static-instanceof.php'], [
+			[
+				'Unsafe call to private method CallPrivateMethodStaticInstanceof\FooBase::fooPrivate() through static::.',
+				27,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -817,6 +817,13 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this.php'], []);
+	}
+
 	public function testClosureBindParamClosureThis(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -824,6 +824,13 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this.php'], []);
 	}
 
+	public function testBug9465(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-9465.php'], []);
+	}
+
 	public function testClosureBindParamClosureThis(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -115,4 +115,13 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../Comparison/data/impossible-method-exists-on-generic-class-string.php'], []);
 	}
 
+	public function testBugInstanceofStaticVsThis1stClassCallable(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			self::markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-1st-class-callable.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-9465.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-9465.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Bug9465;
+
+interface ISingleton
+{
+	public static function singleton(): ?static;
+}
+
+class Component
+{
+	public function getStuff(): mixed
+	{
+		return [1, 2, 3];
+	}
+
+	/**
+	 * @param mixed[] $args
+	 */
+	public static function __callStatic(string $method, array $args): mixed
+	{
+		if (is_a(static::class, ISingleton::class, true) && ($singleton = static::singleton())) {
+			//Call to an undefined static method static(Component)::singleton().
+
+			$singleton->getStuff();
+		}
+		return null;
+	}
+}
+
+/**
+ * @method static void unavailableStatic()
+ */
+class Application extends Component implements ISingleton
+{
+	protected static Application $_app;
+
+	public function __construct()
+	{
+		static::$_app = $this;
+	}
+
+	public static function singleton(): ?static
+	{
+		return static::$_app; //<- Method Application::singleton() should return static(Application)|null but returns Application.
+	}
+}
+
+Application::unavailableStatic();

--- a/tests/PHPStan/Rules/Methods/data/bug-instanceof-static-vs-this-1st-class-callable.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-instanceof-static-vs-this-1st-class-callable.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1); // lint >= 8.1
+
+namespace BugInstanceofStaticVsThis1stClassCallable;
+
+interface FooInterface
+{
+	public static function foo(): int;
+}
+
+class FooBase
+{
+	use FooTrait;
+
+	public function bar(): void
+	{
+		if ($this instanceof FooInterface) {
+			\PHPStan\Testing\assertType('int', (static::foo(...))());
+			\PHPStan\Testing\assertType('int', ($this::foo(...))());
+			\PHPStan\Testing\assertType('int', ($this->foo(...))());
+		}
+
+		if (is_a(static::class, FooInterface::class, true)) {
+			\PHPStan\Testing\assertType('int', (static::foo(...))());
+			\PHPStan\Testing\assertType('int', ($this::foo(...))());
+			\PHPStan\Testing\assertType('int', ($this->foo(...))());
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-instanceof-static-vs-this.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-instanceof-static-vs-this.php
@@ -19,6 +19,12 @@ class FooBase
 			\PHPStan\Testing\assertType('int', $this::foo());
 			\PHPStan\Testing\assertType('int', $this->foo());
 			\PHPStan\Testing\assertType('int', static::foo());
+
+			\PHPStan\Testing\assertNativeType('$this(BugInstanceofStaticVsThis\FooBase)&BugInstanceofStaticVsThis\FooInterface', $this);
+			\PHPStan\Testing\assertNativeType('class-string<BugInstanceofStaticVsThis\FooInterface&static(BugInstanceofStaticVsThis\FooBase)>', static::class);
+			\PHPStan\Testing\assertNativeType('int', $this::foo());
+			\PHPStan\Testing\assertNativeType('int', $this->foo());
+			\PHPStan\Testing\assertNativeType('int', static::foo());
 		}
 
 		if (is_a(static::class, FooInterface::class, true)) {
@@ -27,6 +33,12 @@ class FooBase
 			\PHPStan\Testing\assertType('int', $this::foo());
 			\PHPStan\Testing\assertType('int', $this->foo());
 			\PHPStan\Testing\assertType('int', static::foo());
+
+			\PHPStan\Testing\assertNativeType('$this(BugInstanceofStaticVsThis\FooBase)&BugInstanceofStaticVsThis\FooInterface', $this);
+			\PHPStan\Testing\assertNativeType('class-string<BugInstanceofStaticVsThis\FooInterface&static(BugInstanceofStaticVsThis\FooBase)>', static::class);
+			\PHPStan\Testing\assertNativeType('int', $this::foo());
+			\PHPStan\Testing\assertNativeType('int', $this->foo());
+			\PHPStan\Testing\assertNativeType('int', static::foo());
 		}
 	}
 }
@@ -50,6 +62,14 @@ trait FooTrait
 			\PHPStan\Testing\assertType("int", $this::$staticProp);
 
 			\PHPStan\Testing\assertType("string", $this->prop);
+
+			\PHPStan\Testing\assertNativeType("'a'", static::CONSTANT);
+			\PHPStan\Testing\assertNativeType("'a'", $this::CONSTANT);
+
+			\PHPStan\Testing\assertNativeType("int", static::$staticProp);
+			\PHPStan\Testing\assertNativeType("int", $this::$staticProp);
+
+			\PHPStan\Testing\assertNativeType("string", $this->prop);
 		}
 
 		if (is_a(static::class, FooChild::class, true)) {
@@ -60,6 +80,14 @@ trait FooTrait
 			\PHPStan\Testing\assertType("int", $this::$staticProp);
 
 			\PHPStan\Testing\assertType("string", $this->prop);
+
+			\PHPStan\Testing\assertNativeType("'a'", static::CONSTANT);
+			\PHPStan\Testing\assertNativeType("'a'", $this::CONSTANT);
+
+			\PHPStan\Testing\assertNativeType("int", static::$staticProp);
+			\PHPStan\Testing\assertNativeType("int", $this::$staticProp);
+
+			\PHPStan\Testing\assertNativeType("string", $this->prop);
 		}
 	}
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-instanceof-static-vs-this.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-instanceof-static-vs-this.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1); // lint >= 7.4
+
+namespace BugInstanceofStaticVsThis;
+
+interface FooInterface
+{
+	public static function foo(): int;
+}
+
+class FooBase
+{
+	use FooTrait;
+
+	public function bar(): void
+	{
+		if ($this instanceof FooInterface) {
+			\PHPStan\Testing\assertType('$this(BugInstanceofStaticVsThis\FooBase)&BugInstanceofStaticVsThis\FooInterface', $this);
+			\PHPStan\Testing\assertType('class-string<BugInstanceofStaticVsThis\FooInterface&static(BugInstanceofStaticVsThis\FooBase)>', static::class);
+			\PHPStan\Testing\assertType('int', $this::foo());
+			\PHPStan\Testing\assertType('int', $this->foo());
+			\PHPStan\Testing\assertType('int', static::foo());
+		}
+
+		if (is_a(static::class, FooInterface::class, true)) {
+			\PHPStan\Testing\assertType('$this(BugInstanceofStaticVsThis\FooBase)&BugInstanceofStaticVsThis\FooInterface', $this);
+			\PHPStan\Testing\assertType('class-string<BugInstanceofStaticVsThis\FooInterface&static(BugInstanceofStaticVsThis\FooBase)>', static::class);
+			\PHPStan\Testing\assertType('int', $this::foo());
+			\PHPStan\Testing\assertType('int', $this->foo());
+			\PHPStan\Testing\assertType('int', static::foo());
+		}
+	}
+}
+
+final class FooChild extends FooBase
+{
+	public const CONSTANT = 'a';
+	public static int $staticProp = 5;
+	public string $prop = 'b';
+}
+
+trait FooTrait
+{
+	public function baz(): void
+	{
+		if ($this instanceof FooChild) {
+			\PHPStan\Testing\assertType("'a'", static::CONSTANT);
+			\PHPStan\Testing\assertType("'a'", $this::CONSTANT);
+
+			\PHPStan\Testing\assertType("int", static::$staticProp);
+			\PHPStan\Testing\assertType("int", $this::$staticProp);
+
+			\PHPStan\Testing\assertType("string", $this->prop);
+		}
+
+		if (is_a(static::class, FooChild::class, true)) {
+			\PHPStan\Testing\assertType("'a'", static::CONSTANT);
+			\PHPStan\Testing\assertType("'a'", $this::CONSTANT);
+
+			\PHPStan\Testing\assertType("int", static::$staticProp);
+			\PHPStan\Testing\assertType("int", $this::$staticProp);
+
+			\PHPStan\Testing\assertType("string", $this->prop);
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/call-private-method-static-instanceof.php
+++ b/tests/PHPStan/Rules/Methods/data/call-private-method-static-instanceof.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace CallPrivateMethodStaticInstanceof;
+
+interface FooInterface
+{
+	public static function fooPrivate(): int;
+}
+
+class FooBase
+{
+	private static function fooPrivate(): string
+	{
+		return 'a';
+	}
+
+	public function bar(): void
+	{
+		if ($this instanceof FooInterface) {
+			static::fooPrivate();
+		}
+
+		if (is_a(static::class, FooInterface::class, true)) {
+			static::fooPrivate();
+		}
+
+		static::fooPrivate();
+	}
+}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -937,6 +937,14 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8629.php'], []);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->checkDynamicProperties = true;
+		$this->analyse([__DIR__ . '/../Methods/data/bug-instanceof-static-vs-this.php'], []);
+	}
+
 	public function testBug9694(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
@@ -463,4 +463,9 @@ class AccessStaticPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		$this->analyse([__DIR__ . '/../Methods/data/bug-instanceof-static-vs-this.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRefRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRefRuleTest.php
@@ -68,4 +68,22 @@ class ReadOnlyByPhpDocPropertyAssignRefRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/readonly-assign-ref-phpdoc-and-native.php'], []);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-property-assign.php'], [
+			[
+				'@readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$phpdocReadonlyProp is assigned by reference.',
+				20,
+			],
+			[
+				'@readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$phpdocReadonlyProp is assigned by reference.',
+				34,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -160,4 +160,22 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/feature-7648.php'], []);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-property-assign.php'], [
+			[
+				'@readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$phpdocReadonlyProp is assigned outside of its declaring class.',
+				16,
+			],
+			[
+				'@readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$phpdocReadonlyProp is assigned outside of its declaring class.',
+				30,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRefRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRefRuleTest.php
@@ -39,4 +39,22 @@ class ReadOnlyPropertyAssignRefRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-property-assign.php'], [
+			[
+				'Readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$nativeReadonlyProp is assigned by reference.',
+				19,
+			],
+			[
+				'Readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$nativeReadonlyProp is assigned by reference.',
+				33,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -154,4 +154,22 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-property-assign.php'], [
+			[
+				'Readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$nativeReadonlyProp is assigned outside of its declaring class.',
+				15,
+			],
+			[
+				'Readonly property BugInstanceofStaticVsThisPropertyAssign\FooChild::$nativeReadonlyProp is assigned outside of its declaring class.',
+				29,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -608,4 +608,32 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugInstanceofStaticVsThis(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->checkExplicitMixed = true;
+		$message = 'Static property BugInstanceofStaticVsThisPropertyAssign\FooChild::$staticStringProp (string) does not accept int.';
+		$this->analyse([__DIR__ . '/data/bug-instanceof-static-vs-this-property-assign.php'], [
+			[
+				$message,
+				22,
+			],
+			[
+				$message,
+				23,
+			],
+			[
+				$message,
+				36,
+			],
+			[
+				$message,
+				37,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-instanceof-static-vs-this-property-assign.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-instanceof-static-vs-this-property-assign.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1); // lint >= 8.1
+
+namespace BugInstanceofStaticVsThisPropertyAssign;
+
+function set(int &$var): void
+{
+	$var = 5;
+}
+
+class FooBase
+{
+	public function run(): void
+	{
+		if ($this instanceof FooChild) {
+			$this->nativeReadonlyProp = 5;
+			$this->phpdocReadonlyProp = 5;
+			set($this->nativeReadonlyProp);
+			set($this->phpdocReadonlyProp);
+			$a = &$this->nativeReadonlyProp;
+			$b = &$this->phpdocReadonlyProp;
+
+			if (rand()) $this::$staticStringProp = 5;
+			if (rand()) static::$staticStringProp = 5;
+			set($this::$staticStringProp);
+			set(static::$staticStringProp);
+		}
+
+		if (is_a(static::class, FooChild::class, true)) {
+			$this->nativeReadonlyProp = 5;
+			$this->phpdocReadonlyProp = 5;
+			set($this->nativeReadonlyProp);
+			set($this->phpdocReadonlyProp);
+			$a = &$this->nativeReadonlyProp;
+			$b = &$this->phpdocReadonlyProp;
+
+			if (rand()) $this::$staticStringProp = 5;
+			if (rand()) static::$staticStringProp = 5;
+			set($this::$staticStringProp);
+			set(static::$staticStringProp);
+		}
+	}
+}
+
+class FooChild extends FooBase
+{
+	public readonly int $nativeReadonlyProp;
+
+	/** @readonly */
+	public int $phpdocReadonlyProp;
+
+	public static string $staticStringProp;
+
+	public function __construct()
+	{
+		$this->nativeReadonlyProp = 5;
+		$this->phpdocReadonlyProp = 5;
+	}
+}


### PR DESCRIPTION
This is an attempt to fix https://phpstan.org/r/7df004e9-cbcd-41b8-a882-363914a91c1a
It also fixes the 1st part of https://github.com/phpstan/phpstan/issues/9465
Fixes https://github.com/phpstan/phpstan/issues/5987

I encountered this use-case here: https://github.com/phpstan/phpstan-src/pull/2940#issuecomment-1962383225 . IMO it's a bit of an edge-case, but it feels like phpstan should understand it.

----

I found one case where this change replaces one bug with another one:

> In non-static contexts, the called class will be the class of the object instance. Since $this-> will try to call private methods from the same scope, using static:: may give different results. Another difference is that static:: can only refer to static properties. 

https://www.php.net/manual/en/language.oop5.late-static-bindings.php
https://3v4l.org/SuYOd#v8.3.4
https://phpstan.org/r/763ec51a-49b0-4ba1-a037-b9939ef3cbd4

Previously phpstan thought that `static::fooPrivate()` inside the ifs would still be string (private), but it should be int (public). With my changes it presumably gets affected by the same bug that affects `$this` in the first if, so it now thinks that it's `*NEVER*`.

Since it is already bugged and probably non-trivial to fix, I decided to ignore it for now.

----

Some open questions:

- Should something be done with `resolveTypeByName`? It returns `TypeWithClassName`, so it cannot return an `IntersectionType`. Therefore, any usage with `static` could result in the kind of bugs that this PR tries to fix.
- Should there be a shortcut method for `$scope->getType(new Expr\ClassConstFetch($className, 'class'))->getClassStringObjectType();`?
