### PR TITLE
Test invalidated object in static closure

### DIFF
--- a/tests/PHPStan/Analyser/data/bug-10566.php
+++ b/tests/PHPStan/Analyser/data/bug-10566.php
@@ -150,4 +150,22 @@ final class StreamSelectLoop
 		}
 	}
 
+	function run8(): void
+	{
+		$s = new self();
+
+		while ($s->running) {
+			assertType('true', $s->running);
+			call_user_func(static function () use ($s) {
+				$s->stop();
+			});
+			assertType('bool', $s->running);
+
+			if (!$s->running) {
+				$timeout = 0;
+				break;
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
looks like its a case we do not test yet.

followup to https://github.com/phpstan/phpstan-src/commit/9bb4ef961960a1056060209b3ed7e09b93c06f36

