### PR TITLE
Prevent unnecessary calls into reflection from JSON extensions

### DIFF
--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -45,7 +45,7 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 			return true;
 		}
 
-		return $this->reflectionProvider->hasConstant(new FullyQualified('JSON_THROW_ON_ERROR'), null) && $functionReflection->getName() === 'json_encode';
+		return $functionReflection->getName() === 'json_encode' && $this->reflectionProvider->hasConstant(new FullyQualified('JSON_THROW_ON_ERROR'), null);
 	}
 
 	public function getTypeFromFunctionCall(

--- a/src/Type/Php/JsonThrowTypeExtension.php
+++ b/src/Type/Php/JsonThrowTypeExtension.php
@@ -32,14 +32,14 @@ class JsonThrowTypeExtension implements DynamicFunctionThrowTypeExtension
 		FunctionReflection $functionReflection,
 	): bool
 	{
-		return $this->reflectionProvider->hasConstant(new Name\FullyQualified('JSON_THROW_ON_ERROR'), null) && in_array(
+		return in_array(
 			$functionReflection->getName(),
 			[
 				'json_encode',
 				'json_decode',
 			],
 			true,
-		);
+		) && $this->reflectionProvider->hasConstant(new Name\FullyQualified('JSON_THROW_ON_ERROR'), null);
 	}
 
 	public function getThrowTypeFromFunctionCall(


### PR DESCRIPTION
In todays debugging session I realized that the json throw extensions call into reflection even for non `json_*` calls.
accidentally spotted while working on https://github.com/Roave/BetterReflection/issues/1415

move the cheaper check in front to prevent this unnecessary reflection stuff.

see

![grafik](https://github.com/phpstan/phpstan-src/assets/120441/e3746166-271e-4d2c-8d7f-6810f122421c)

I looked arround for similar problems in other extensions but could not see additional ones.