### PR TITLE
More precise `gc_status()` signature for PHP8.3+

### DIFF
--- a/resources/functionMap_php83delta.php
+++ b/resources/functionMap_php83delta.php
@@ -23,6 +23,7 @@ return [
 	'new' => [
 		'str_decrement' => ['non-empty-string', 'string'=>'non-empty-string'],
 		'str_increment' => ['non-falsy-string', 'string'=>'non-empty-string'],
+		'gc_status' => ['array{running:bool,protected:bool,full:bool,runs:int,collected:int,threshold:int,buffer_size:int,roots:int,application_time:float,collector_time:float,destructor_time:float,free_time:float}'],
 	],
 	'old' => [
 


### PR DESCRIPTION
Noticed while working thru PHPUnit

> gc_status() now returns the following additional fields: "running", "protected", "full", "buffer_size", "application_time", "collector_time", "destructor_time", and "free_time". 

see 
- https://www.php.net/manual/en/function.gc-status.php
- https://3v4l.org/Ok8K6#v8.3.4