### PR TITLE
Support `@phan-` prefixes on recognized phpdoc tags

### DIFF
--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -68,7 +68,7 @@ class PhpDocNodeResolver
 	{
 		$resolved = [];
 		$resolvedByTag = [];
-		foreach (['@var', '@psalm-var', '@phpstan-var', '@phan-var'] as $tagName) {
+		foreach (['@var', '@phan-var', '@psalm-var', '@phpstan-var'] as $tagName) {
 			$tagResolved = [];
 			foreach ($phpDocNode->getVarTagValues($tagName) as $tagValue) {
 				$type = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
@@ -165,7 +165,7 @@ class PhpDocNodeResolver
 		$resolved = [];
 		$originalNameScope = $nameScope;
 
-		foreach (['@method', '@psalm-method', '@phpstan-method', '@phan-method'] as $tagName) {
+		foreach (['@method', '@phan-method', '@psalm-method', '@phpstan-method'] as $tagName) {
 			foreach ($phpDocNode->getMethodTagValues($tagName) as $tagValue) {
 				$nameScope = $originalNameScope;
 				$templateTags = [];
@@ -232,7 +232,7 @@ class PhpDocNodeResolver
 	{
 		$resolved = [];
 
-		foreach (['@extends', '@template-extends', '@phpstan-extends', '@phan-extends', '@phan-inherits'] as $tagName) {
+		foreach (['@extends', '@phan-extends', '@phan-inherits', '@template-extends', '@phpstan-extends'] as $tagName) {
 			foreach ($phpDocNode->getExtendsTagValues($tagName) as $tagValue) {
 				$resolved[$nameScope->resolveStringName($tagValue->type->type->name)] = new ExtendsTag(
 					$this->typeNodeResolver->resolve($tagValue->type, $nameScope),
@@ -301,7 +301,7 @@ class PhpDocNodeResolver
 			}
 
 			$tagName = $phpDocTagNode->name;
-			if (in_array($tagName, ['@template', '@psalm-template', '@phpstan-template', '@phan-template'], true)) {
+			if (in_array($tagName, ['@template', '@phan-template', '@psalm-template', '@phpstan-template'], true)) {
 				$variance = TemplateTypeVariance::createInvariant();
 			} elseif (in_array($tagName, ['@template-covariant', '@psalm-template-covariant', '@phpstan-template-covariant'], true)) {
 				$variance = TemplateTypeVariance::createCovariant();
@@ -311,12 +311,12 @@ class PhpDocNodeResolver
 				continue;
 			}
 
-			if (str_starts_with($tagName, '@psalm-')) {
+			if (str_starts_with($tagName, '@phan-')) {
+				$prefix = 'phan';
+                        } elseif (str_starts_with($tagName, '@psalm-')) {
 				$prefix = 'psalm';
 			} elseif (str_starts_with($tagName, '@phpstan-')) {
 				$prefix = 'phpstan';
-			} elseif (str_starts_with($tagName, '@phan-')) {
-				$prefix = 'phan';
 			} else {
 				$prefix = '';
 			}
@@ -371,7 +371,7 @@ class PhpDocNodeResolver
 
 		$unusedClosureThisTypes = $closureThisTypes;
 
-		foreach (['@param', '@psalm-param', '@phpstan-param', '@phan-param'] as $tagName) {
+		foreach (['@param', '@phan-param', '@psalm-param', '@phpstan-param'] as $tagName) {
 			foreach ($phpDocNode->getParamTagValues($tagName) as $tagValue) {
 				$parameterName = substr($tagValue->parameterName, 1);
 				$parameterType = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
@@ -461,7 +461,7 @@ class PhpDocNodeResolver
 	{
 		$resolved = null;
 
-		foreach (['@return', '@psalm-return', '@phpstan-return', '@phan-return', '@phan-real-return'] as $tagName) {
+		foreach (['@return', '@phan-return', '@phan-real-return', '@psalm-return', '@phpstan-return'] as $tagName) {
 			foreach ($phpDocNode->getReturnTagValues($tagName) as $tagValue) {
 				$type = $this->typeNodeResolver->resolve($tagValue->type, $nameScope);
 				if ($this->shouldSkipType($tagName, $type)) {
@@ -549,7 +549,7 @@ class PhpDocNodeResolver
 	{
 		$resolved = [];
 
-		foreach (['@psalm-type', '@phpstan-type', '@phan-type'] as $tagName) {
+		foreach (['@phan-type', '@psalm-type', '@phpstan-type'] as $tagName) {
 			foreach ($phpDocNode->getTypeAliasTagValues($tagName) as $typeAliasTagValue) {
 				$alias = $typeAliasTagValue->alias;
 				$typeNode = $typeAliasTagValue->type;
@@ -685,7 +685,7 @@ class PhpDocNodeResolver
 	public function resolveIsPure(PhpDocNode $phpDocNode): bool
 	{
 		foreach ($phpDocNode->getTags() as $phpDocTagNode) {
-			if (in_array($phpDocTagNode->name, ['@pure', '@psalm-pure', '@phpstan-pure', '@phan-pure', '@phan-side-effect-free'], true)) {
+			if (in_array($phpDocTagNode->name, ['@pure', '@phan-pure', '@phan-side-effect-free', '@psalm-pure', '@phpstan-pure'], true)) {
 				return true;
 			}
 		}
@@ -706,7 +706,7 @@ class PhpDocNodeResolver
 
 	public function resolveIsReadOnly(PhpDocNode $phpDocNode): bool
 	{
-		foreach (['@readonly', '@psalm-readonly', '@phpstan-readonly', '@phpstan-readonly-allow-private-mutation', '@psalm-readonly-allow-private-mutation', '@phan-read-only'] as $tagName) {
+		foreach (['@readonly', '@phan-read-only', '@psalm-readonly', '@phpstan-readonly', '@phpstan-readonly-allow-private-mutation', '@psalm-readonly-allow-private-mutation'] as $tagName) {
 			$tags = $phpDocNode->getTagsByName($tagName);
 
 			if (count($tags) > 0) {
@@ -719,7 +719,7 @@ class PhpDocNodeResolver
 
 	public function resolveIsImmutable(PhpDocNode $phpDocNode): bool
 	{
-		foreach (['@immutable', '@psalm-immutable', '@phpstan-immutable', '@phan-immutable'] as $tagName) {
+		foreach (['@immutable', '@phan-immutable', '@psalm-immutable', '@phpstan-immutable'] as $tagName) {
 			$tags = $phpDocNode->getTagsByName($tagName);
 
 			if (count($tags) > 0) {

--- a/src/PhpDoc/PhpDocNodeResolver.php
+++ b/src/PhpDoc/PhpDocNodeResolver.php
@@ -313,7 +313,7 @@ class PhpDocNodeResolver
 
 			if (str_starts_with($tagName, '@phan-')) {
 				$prefix = 'phan';
-                        } elseif (str_starts_with($tagName, '@psalm-')) {
+			} elseif (str_starts_with($tagName, '@psalm-')) {
 				$prefix = 'psalm';
 			} elseif (str_starts_with($tagName, '@phpstan-')) {
 				$prefix = 'phpstan';

--- a/src/Rules/PhpDoc/InvalidPhpDocTagValueRule.php
+++ b/src/Rules/PhpDoc/InvalidPhpDocTagValueRule.php
@@ -76,7 +76,7 @@ class InvalidPhpDocTagValueRule implements Rule
 
 		$errors = [];
 		foreach ($phpDocNode->getTags() as $phpDocTag) {
-			if (str_starts_with($phpDocTag->name, '@psalm-')) {
+			if (str_starts_with($phpDocTag->name, '@phan-') || str_starts_with($phpDocTag->name, '@psalm-')) {
 				continue;
 			}
 

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -3620,6 +3620,23 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		);
 	}
 
+	/**
+	 * @dataProvider dataTypeFromFunctionPhpDocs
+	 * @dataProvider dataTypeFromFunctionPrefixedPhpDocs
+	 */
+	public function testTypeFromFunctionPhpDocsPhanPrefix(
+		string $description,
+		string $expression,
+	): void
+	{
+		require_once __DIR__ . '/data/functionPhpDocs-phanPrefix.php';
+		$this->assertTypes(
+			__DIR__ . '/data/functionPhpDocs-phanPrefix.php',
+			$description,
+			$expression,
+		);
+	}
+
 	public function dataTypeFromMethodPhpDocs(): array
 	{
 		return [
@@ -3824,6 +3841,31 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		}
 		$this->assertTypes(
 			__DIR__ . '/data/methodPhpDocs-phpstanPrefix.php',
+			$description,
+			$expression,
+		);
+	}
+
+	/**
+	 * @dataProvider dataTypeFromFunctionPhpDocs
+	 * @dataProvider dataTypeFromMethodPhpDocs
+	 */
+	public function testTypeFromMethodPhpDocsPhanPrefix(
+		string $description,
+		string $expression,
+		bool $replaceClass = true,
+	): void
+	{
+		$description = str_replace('static(MethodPhpDocsNamespace\Foo)', 'static(MethodPhpDocsNamespace\FooPhanPrefix)', $description);
+
+		if ($replaceClass && $expression !== '$this->doFoo()') {
+			$description = str_replace('$this(MethodPhpDocsNamespace\Foo)', '$this(MethodPhpDocsNamespace\FooPhanPrefix)', $description);
+			if ($description === 'MethodPhpDocsNamespace\Foo') {
+				$description = 'MethodPhpDocsNamespace\FooPhanPrefix';
+			}
+		}
+		$this->assertTypes(
+			__DIR__ . '/data/methodPhpDocs-phanPrefix.php',
 			$description,
 			$expression,
 		);

--- a/tests/PHPStan/Analyser/data/classPhpDocs.php
+++ b/tests/PHPStan/Analyser/data/classPhpDocs.php
@@ -9,6 +9,7 @@ use function PHPStan\Testing\assertType;
  * @method array arrayOfStrings()
  * @psalm-method array<string> arrayOfStrings()
  * @phpstan-method array<string, int> arrayOfInts()
+ * @phan-method array<string> arrayOfStrings()
  * @method array arrayOfInts()
  * @method mixed overrodeMethod()
  * @method static mixed overrodeStaticMethod()

--- a/tests/PHPStan/Analyser/data/functionPhpDocs-phanPrefix.php
+++ b/tests/PHPStan/Analyser/data/functionPhpDocs-phanPrefix.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace MethodPhpDocsNamespace;
+
+use SomeNamespace\Amet as Dolor;
+use SomeNamespace\Consecteur;
+
+/**
+ * @phan-param Foo|Bar $unionTypeParameter
+ * @phan-param int $anotherMixedParameter
+ * @phan-param int $anotherMixedParameter
+ * @phan-paran int $yetAnotherMixedProperty
+ * @phan-param int $integerParameter
+ * @phan-param integer $anotherIntegerParameter
+ * @phan-param aRray $arrayParameterOne
+ * @phan-param mixed[] $arrayParameterOther
+ * @phan-param Lorem $objectRelative
+ * @phan-param \SomeOtherNamespace\Ipsum $objectFullyQualified
+ * @phan-param Dolor $objectUsed
+ * @phan-param null|int $nullableInteger
+ * @phan-param Dolor|null $nullableObject
+ * @phan-param Dolor $anotherNullableObject
+ * @phan-param Null $nullType
+ * @phan-param Bar $barObject
+ * @phan-param Foo $conflictedObject
+ * @phan-param Baz $moreSpecifiedObject
+ * @phan-param resource $resource
+ * @phan-param array[array] $yetAnotherAnotherMixedParameter
+ * @phan-param \\Test\Bar $yetAnotherAnotherAnotherMixedParameter
+ * @phan-param New $yetAnotherAnotherAnotherAnotherMixedParameter
+ * @phan-param void $voidParameter
+ * @phan-param Consecteur $useWithoutAlias
+ * @phan-param true $true
+ * @phan-param false $false
+ * @phan-param true $boolTrue
+ * @phan-param false $boolFalse
+ * @phan-param bool $trueBoolean
+ * @phan-param bool $parameterWithDefaultValueFalse
+ * @phan-return Foo
+ */
+function doFooPhanPrefix(
+	$mixedParameter,
+	$unionTypeParameter,
+	$anotherMixedParameter,
+	$yetAnotherMixedParameter,
+	$integerParameter,
+	$anotherIntegerParameter,
+	$arrayParameterOne,
+	$arrayParameterOther,
+	$objectRelative,
+	$objectFullyQualified,
+	$objectUsed,
+	$nullableInteger,
+	$nullableObject,
+	$nullType,
+	$barObject,
+	Bar $conflictedObject,
+	Bar $moreSpecifiedObject,
+	$resource,
+	$yetAnotherAnotherMixedParameter,
+	$yetAnotherAnotherAnotherMixedParameter,
+	$yetAnotherAnotherAnotherAnotherMixedParameter,
+	$voidParameter,
+	$useWithoutAlias,
+	$true,
+	$false,
+	bool $boolTrue,
+	bool $boolFalse,
+	bool $trueBoolean,
+	$parameterWithDefaultValueFalse = false,
+	$anotherNullableObject = null
+)
+{
+	$fooFunctionResult = doFoo();
+
+	foreach ($moreSpecifiedObject->doFluentUnionIterable() as $fluentUnionIterableBaz) {
+		die;
+	}
+}

--- a/tests/PHPStan/Analyser/data/generics.php
+++ b/tests/PHPStan/Analyser/data/generics.php
@@ -1176,6 +1176,7 @@ class PrefixedTemplateWins2
  * @template T of Foo
  * @phpstan-template T of Bar
  * @psalm-template T of Baz
+ * @phan-template T of Quux
  */
 class PrefixedTemplateWins3
 {
@@ -1209,12 +1210,25 @@ class PrefixedTemplateWins5
 
 }
 
+/**
+ * @phan-template T of Foo
+ * @phpstan-template T of Bar
+ */
+class PrefixedTemplateWins6
+{
+
+	/** @var T */
+	public $name;
+
+}
+
 function testPrefixed(
 	PrefixedTemplateWins $a,
 	PrefixedTemplateWins2 $b,
 	PrefixedTemplateWins3 $c,
 	PrefixedTemplateWins4 $d,
-	PrefixedTemplateWins5 $e
+	PrefixedTemplateWins5 $e,
+	PrefixedTemplateWins6 $f
 
 ) {
 	assertType('PHPStan\Generics\FunctionsAssertType\Bar', $a->name);
@@ -1222,6 +1236,7 @@ function testPrefixed(
 	assertType('PHPStan\Generics\FunctionsAssertType\Bar', $c->name);
 	assertType('PHPStan\Generics\FunctionsAssertType\Bar', $d->name);
 	assertType('PHPStan\Generics\FunctionsAssertType\Bar', $e->name);
+	assertType('PHPStan\Generics\FunctionsAssertType\Bar', $f->name);
 };
 
 /**

--- a/tests/PHPStan/Analyser/data/methodPhpDocs-phanPrefix.php
+++ b/tests/PHPStan/Analyser/data/methodPhpDocs-phanPrefix.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace MethodPhpDocsNamespace;
+
+use SomeNamespace\Amet as Dolor;
+use SomeNamespace\Consecteur;
+
+class FooPhanPrefix extends FooParent
+{
+
+	/**
+	 * @phan-return Bar
+	 */
+	public static function doSomethingStatic()
+	{
+
+	}
+
+	/**
+	 * @phan-param Foo|Bar $unionTypeParameter
+	 * @phan-param int $anotherMixedParameter
+	 * @phan-param int $anotherMixedParameter
+	 * @phan-paran int $yetAnotherMixedProperty
+	 * @phan-param int $integerParameter
+	 * @phan-param integer $anotherIntegerParameter
+	 * @phan-param aRray $arrayParameterOne
+	 * @phan-param mixed[] $arrayParameterOther
+	 * @phan-param Lorem $objectRelative
+	 * @phan-param \SomeOtherNamespace\Ipsum $objectFullyQualified
+	 * @phan-param Dolor $objectUsed
+	 * @phan-param null|int $nullableInteger
+	 * @phan-param Dolor|null $nullableObject
+	 * @phan-param Dolor $anotherNullableObject
+	 * @phan-param self $selfType
+	 * @phan-param static $staticType
+	 * @phan-param Null $nullType
+	 * @phan-param Bar $barObject
+	 * @phan-param Foo $conflictedObject
+	 * @phan-param Baz $moreSpecifiedObject
+	 * @phan-param resource $resource
+	 * @phan-param array[array] $yetAnotherAnotherMixedParameter
+	 * @phan-param \\Test\Bar $yetAnotherAnotherAnotherMixedParameter
+	 * @phan-param New $yetAnotherAnotherAnotherAnotherMixedParameter
+	 * @phan-param void $voidParameter
+	 * @phan-param Consecteur $useWithoutAlias
+	 * @phan-param true $true
+	 * @phan-param false $false
+	 * @phan-param true $boolTrue
+	 * @phan-param false $boolFalse
+	 * @phan-param bool $trueBoolean
+	 * @phan-param bool $parameterWithDefaultValueFalse
+	 * @phan-param object $objectWithoutNativeTypehint
+	 * @phan-param object $objectWithNativeTypehint
+	 * @phan-return Foo
+	 */
+	public function doFoo(
+		$mixedParameter,
+		$unionTypeParameter,
+		$anotherMixedParameter,
+		$yetAnotherMixedParameter,
+		$integerParameter,
+		$anotherIntegerParameter,
+		$arrayParameterOne,
+		$arrayParameterOther,
+		$objectRelative,
+		$objectFullyQualified,
+		$objectUsed,
+		$nullableInteger,
+		$nullableObject,
+		$selfType,
+		$staticType,
+		$nullType,
+		$barObject,
+		Bar $conflictedObject,
+		Bar $moreSpecifiedObject,
+		$resource,
+		$yetAnotherAnotherMixedParameter,
+		$yetAnotherAnotherAnotherMixedParameter,
+		$yetAnotherAnotherAnotherAnotherMixedParameter,
+		$voidParameter,
+		$useWithoutAlias,
+		$true,
+		$false,
+		bool $boolTrue,
+		bool $boolFalse,
+		bool $trueBoolean,
+		$objectWithoutNativeTypehint,
+		object $objectWithNativeTypehint,
+		$parameterWithDefaultValueFalse = false,
+		$anotherNullableObject = null
+	)
+	{
+		$parent = new FooParent();
+		$differentInstance = new self();
+
+		/** @phan-var self $inlineSelf */
+		$inlineSelf = doFoo();
+
+		/** @phan-var Bar $inlineBar */
+		$inlineBar = doFoo();
+
+		foreach ($moreSpecifiedObject->doFluentUnionIterable() as $fluentUnionIterableBaz) {
+			die;
+		}
+	}
+
+	/**
+	 * @phan-return self[]
+	 */
+	public function doBar(): array
+	{
+
+	}
+
+	public function returnParent(): parent
+	{
+
+	}
+
+	/**
+	 * @phan-return parent
+	 */
+	public function returnPhpDocParent()
+	{
+
+	}
+
+	/**
+	 * @phan-return NULL[]
+	 */
+	public function returnNulls(): array
+	{
+
+	}
+
+	public function returnObject(): object
+	{
+
+	}
+
+	public function phpDocVoidMethod(): self
+	{
+
+	}
+
+	public function phpDocVoidMethodFromInterface(): self
+	{
+
+	}
+
+	public function phpDocVoidParentMethod(): self
+	{
+
+	}
+
+	public function phpDocWithoutCurlyBracesVoidParentMethod(): self
+	{
+
+	}
+
+	/**
+	 * @phan-return string[]
+	 */
+	public function returnsStringArray(): array
+	{
+
+	}
+
+	private function privateMethodWithPhpDoc()
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionStatementWithoutSideEffectsRuleTest.php
@@ -67,8 +67,16 @@ class CallToFunctionStatementWithoutSideEffectsRuleTest extends RuleTestCase
 				10,
 			],
 			[
-				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pureAndThrowsVoid() on a separate line has no effect.',
+				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure4() on a separate line has no effect.',
 				11,
+			],
+			[
+				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pure5() on a separate line has no effect.',
+				12,
+			],
+			[
+				'Call to function FunctionCallStatementNoSideEffectsPhpDoc\pureAndThrowsVoid() on a separate line has no effect.',
+				13,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc-definition.php
+++ b/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc-definition.php
@@ -20,6 +20,16 @@ function pure2(string $a): string {return $a;}
 function pure3(string $a): string {return $a;}
 
 /**
+ * @phan-pure
+ */
+function pure4(string $a): string {return $a;}
+
+/**
+ * @phan-side-effect-free
+ */
+function pure5(string $a): string {return $a;}
+
+/**
  * @phpstan-pure
  * @throws void
  * @return string

--- a/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Functions/data/function-call-statement-no-side-effects-phpdoc.php
@@ -8,6 +8,8 @@ function(): void
 	pure1('test');
 	pure2('test');
 	pure3('test');
+	pure4('test');
+	pure5('test');
 	pureAndThrowsVoid();
 	pureAndThrowsException();
 };

--- a/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
@@ -63,15 +63,23 @@ class CallToMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects-phpdoc.php'], [
 			[
 				'Call to method MethodCallStatementNoSideEffects\Bzz::pure1() on a separate line has no effect.',
-				39,
+				55,
 			],
 			[
 				'Call to method MethodCallStatementNoSideEffects\Bzz::pure2() on a separate line has no effect.',
-				40,
+				56,
 			],
 			[
 				'Call to method MethodCallStatementNoSideEffects\Bzz::pure3() on a separate line has no effect.',
-				41,
+				57,
+			],
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bzz::pure4() on a separate line has no effect.',
+				58,
+			],
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bzz::pure5() on a separate line has no effect.',
+				59,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
@@ -44,19 +44,27 @@ class CallToStaticMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects-phpdoc.php'], [
 			[
 				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure1() on a separate line has no effect.',
-				39,
+				55,
 			],
 			[
 				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure2() on a separate line has no effect.',
-				40,
+				56,
 			],
 			[
 				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure3() on a separate line has no effect.',
-				41,
+				57,
+			],
+			[
+				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure4() on a separate line has no effect.',
+				58,
+			],
+			[
+				'Call to static method StaticMethodCallStatementNoSideEffects\BzzStatic::pure5() on a separate line has no effect.',
+				59,
 			],
 			[
 				'Call to static method StaticMethodCallStatementNoSideEffects\PureThrows::pureAndThrowsVoid() on a separate line has no effect.',
-				67,
+				85,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/data/method-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Methods/data/method-call-statement-no-side-effects-phpdoc.php
@@ -32,6 +32,22 @@ class Bzz
 	{
 		return $a;
 	}
+
+	/**
+	 * @phan-pure
+	 */
+	function pure4(string $a): string
+	{
+		return $a;
+	}
+
+	/**
+	 * @phan-side-effect-free
+	 */
+	function pure5(string $a): string
+	{
+		return $a;
+	}
 }
 
 function(): void {
@@ -39,4 +55,6 @@ function(): void {
 	(new Bzz())->pure1('test');
 	(new Bzz())->pure2('test');
 	(new Bzz())->pure3('test');
+	(new Bzz())->pure4('test');
+	(new Bzz())->pure5('test');
 };

--- a/tests/PHPStan/Rules/Methods/data/static-method-call-statement-no-side-effects-phpdoc.php
+++ b/tests/PHPStan/Rules/Methods/data/static-method-call-statement-no-side-effects-phpdoc.php
@@ -32,6 +32,22 @@ class BzzStatic
 	{
 		return $a;
 	}
+
+	/**
+	 * @phan-pure
+	 */
+	static function pure4(string $a): string
+	{
+		return $a;
+	}
+
+	/**
+	 * @phan-side-effect-free
+	 */
+	static function pure5(string $a): string
+	{
+		return $a;
+	}
 }
 
 function(): void {
@@ -39,6 +55,8 @@ function(): void {
 	BzzStatic::pure1('test');
 	BzzStatic::pure2('test');
 	BzzStatic::pure3('test');
+	BzzStatic::pure4('test');
+	BzzStatic::pure5('test');
 };
 
 class PureThrows

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleNoBleedingEdgeTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleNoBleedingEdgeTest.php
@@ -132,7 +132,11 @@ class InvalidPhpDocTagValueRuleNoBleedingEdgeTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/invalid-type-type-alias.php'], [
 			[
 				'PHPDoc tag @phpstan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 65',
-				12,
+				15,
+			],
+			[
+				'PHPDoc tag @phan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 193',
+				15,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleNoBleedingEdgeTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleNoBleedingEdgeTest.php
@@ -134,10 +134,6 @@ class InvalidPhpDocTagValueRuleNoBleedingEdgeTest extends RuleTestCase
 				'PHPDoc tag @phpstan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 65',
 				15,
 			],
-			[
-				'PHPDoc tag @phan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 193',
-				15,
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleTest.php
@@ -138,6 +138,10 @@ class InvalidPhpDocTagValueRuleTest extends RuleTestCase
 				'PHPDoc tag @phpstan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 65 on line 3',
 				7,
 			],
+			[
+				'PHPDoc tag @phan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 193 on line 9',
+				13,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleTest.php
@@ -138,10 +138,6 @@ class InvalidPhpDocTagValueRuleTest extends RuleTestCase
 				'PHPDoc tag @phpstan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 65 on line 3',
 				7,
 			],
-			[
-				'PHPDoc tag @phan-type InvalidFoo has invalid value: Unexpected token "{", expected TOKEN_PHPDOC_EOL at offset 193 on line 9',
-				13,
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -73,63 +73,63 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 			],
 			[
 				'Multiple PHPDoc @var tags above single variable assignment are not supported.',
-				125,
+				126,
 			],
 			[
 				'Variable $b in PHPDoc tag @var does not exist.',
-				134,
+				135,
 			],
 			[
 				'PHPDoc tag @var does not specify variable name.',
-				155,
+				156,
 			],
 			[
 				'PHPDoc tag @var does not specify variable name.',
-				176,
+				177,
 			],
 			[
 				'Variable $foo in PHPDoc tag @var does not exist.',
-				210,
+				211,
 			],
 			[
 				'PHPDoc tag @var above foreach loop does not specify variable name.',
-				234,
+				235,
 			],
 			[
 				'Variable $foo in PHPDoc tag @var does not exist.',
-				248,
+				249,
 			],
 			[
 				'Variable $bar in PHPDoc tag @var does not exist.',
-				248,
+				249,
 			],
 			[
 				'Variable $slots in PHPDoc tag @var does not exist.',
-				262,
+				263,
 			],
 			[
 				'Variable $slots in PHPDoc tag @var does not exist.',
-				268,
+				269,
 			],
 			[
 				'PHPDoc tag @var above assignment does not specify variable name.',
-				274,
+				275,
 			],
 			[
 				'Variable $slots in PHPDoc tag @var does not match assigned variable $itemSlots.',
-				280,
+				281,
 			],
 			[
 				'PHPDoc tag @var above a class has no effect.',
-				300,
+				301,
 			],
 			[
 				'PHPDoc tag @var above a method has no effect.',
-				304,
+				305,
 			],
 			[
 				'PHPDoc tag @var above a function has no effect.',
-				312,
+				313,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/PhpDoc/data/invalid-type-type-alias.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/invalid-type-type-alias.php
@@ -8,6 +8,9 @@ namespace InvalidTypeInTypeAlias;
  *
  * @psalm-type Foo array{}
  * @psalm-type InvalidFoo what{}
+ *
+ * @phan-type Foo = array{}
+ * @phan-type InvalidFoo = what{}
  */
 class Foo
 {

--- a/tests/PHPStan/Rules/PhpDoc/data/wrong-variable-name-var.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/wrong-variable-name-var.php
@@ -115,6 +115,7 @@ class Foo
 		 * @var int
 		 * @phpstan-var int
 		 * @psalm-var int
+		 * @phan-var int
 		 */
 		$test = doFoo(); // OK
 

--- a/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingPropertyTypehintRuleTest.php
@@ -39,21 +39,21 @@ class MissingPropertyTypehintRuleTest extends RuleTestCase
 			],
 			[
 				'Property MissingPropertyTypehint\Bar::$foo with generic interface MissingPropertyTypehint\GenericInterface does not specify its types: T, U',
-				74,
+				77,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 			[
 				'Property MissingPropertyTypehint\Bar::$baz with generic class MissingPropertyTypehint\GenericClass does not specify its types: A, B',
-				80,
+				83,
 				'You can turn this off by setting <fg=cyan>checkGenericClassInNonGenericObjectType: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 			[
 				'Property MissingPropertyTypehint\CallableSignature::$cb type has no signature specified for callable.',
-				93,
+				96,
 			],
 			[
 				'Property MissingPropertyTypehint\NestedArrayInProperty::$args type has no value type specified in iterable type array.',
-				103,
+				106,
 				MissingTypehintCheck::MISSING_ITERABLE_VALUE_TYPE_TIP,
 			],
 		]);

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -31,87 +31,99 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/readonly-assign-phpdoc.php'], [
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$foo is assigned outside of the constructor.',
-				40,
+				47,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$phan is assigned outside of the constructor.',
+				49,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$bar is assigned outside of its declaring class.',
-				53,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.',
-				54,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$psalm is assigned outside of its declaring class.',
-				55,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$bar is assigned outside of its declaring class.',
-				60,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$psalm is assigned outside of its declaring class.',
 				61,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.',
-				68,
+				62,
 			],
 			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\FooArrays::$details is assigned outside of the constructor.',
-				87,
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$psalm is assigned outside of its declaring class.',
+				63,
 			],
 			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\FooArrays::$details is assigned outside of the constructor.',
-				88,
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$phan is assigned outside of its declaring class.',
+				64,
 			],
 			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\NotThis::$foo is not assigned on $this.',
-				118,
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$bar is assigned outside of its declaring class.',
+				69,
 			],
 			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.',
-				134,
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$psalm is assigned outside of its declaring class.',
+				70,
 			],
 			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.',
-				135,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.',
-				137,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\ListAssign::$foo is assigned outside of the constructor.',
-				158,
-			],
-			[
-				'@readonly property ReadonlyPropertyAssignPhpDoc\ListAssign::$foo is assigned outside of the constructor.',
-				163,
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$phan is assigned outside of its declaring class.',
+				71,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.',
+				78,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\FooArrays::$details is assigned outside of the constructor.',
+				97,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\FooArrays::$details is assigned outside of the constructor.',
+				98,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\NotThis::$foo is not assigned on $this.',
+				128,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.',
+				144,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.',
+				145,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\PostInc::$foo is assigned outside of the constructor.',
+				147,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\ListAssign::$foo is assigned outside of the constructor.',
+				168,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\ListAssign::$foo is assigned outside of the constructor.',
 				173,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.',
-				174,
+				183,
+			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\Foo::$baz is assigned outside of its declaring class.',
+				184,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\Immutable::$foo is assigned outside of the constructor.',
-				237,
+				247,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\B::$b is assigned outside of the constructor.',
-				269,
+				279,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\A::$a is assigned outside of its declaring class.',
-				270,
+				280,
 			],
 			[
 				'@readonly property ReadonlyPropertyAssignPhpDoc\C::$c is assigned outside of the constructor.',
-				283,
+				293,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Properties/data/missing-property-typehint.php
+++ b/tests/PHPStan/Rules/Properties/data/missing-property-typehint.php
@@ -42,6 +42,9 @@ class PrefixedTags
 	/** @psalm-var int */
 	private $fooPsalm;
 
+	/** @phan-var int */
+	private $fooPhan;
+
 }
 
 /**

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
@@ -29,16 +29,24 @@ class Foo
 	 */
 	public $psalm;
 
+	/**
+	 * @var int
+	 * @phan-read-only
+	 */
+	public $phan;
+
 	public function __construct(int $foo)
 	{
 		$this->foo = $foo; // constructor - fine
 		$this->psalm = $foo; // constructor - fine
+		$this->phan = $foo; // constructor - fine
 	}
 
 	public function setFoo(int $foo): void
 	{
 		$this->foo = $foo; // setter - report
 		$this->psalm = $foo; // do not report -allowed private mutation
+		$this->phan = $foo; // setter - report
 	}
 
 }
@@ -53,12 +61,14 @@ class Bar extends Foo
 		$this->bar = $bar; // report - not in declaring class
 		$this->baz = $baz; // report - not in declaring class
 		$this->psalm = $bar; // report - not in declaring class
+		$this->phan = $bar; // report - not in declaring class
 	}
 
 	public function setBar(int $bar): void
 	{
 		$this->bar = $bar; // report - not in declaring class
 		$this->psalm = $bar; // report - not in declaring class
+		$this->phan = $bar; // report - not in declaring class
 	}
 
 }


### PR DESCRIPTION
Per request at https://github.com/phpstan/phpdoc-parser/pull/235#issuecomment-2035354495

Hopefully I added the right tests in the right places, mostly I grepped for "psalm" then tried to add similar tests. Feel free to update the PR if necessary.