### PR TITLE
PHPDoc: address multiple variables defined in one @param

### DIFF
--- a/issue-bot/src/Playground/TabCreator.php
+++ b/issue-bot/src/Playground/TabCreator.php
@@ -15,7 +15,7 @@ class TabCreator
 {
 
 	/**
-	 * @param array<int, list<PlaygroundError>> $versionedErrors $versionedErrors
+	 * @param array<int, list<PlaygroundError>> $versionedErrors
 	 * @return list<PlaygroundResultTab>
 	 */
 	public function create(array $versionedErrors): array

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -222,7 +222,7 @@ class InstantiationRule implements Rule
 	}
 
 	/**
-	 * @param Node\Expr\New_ $node $node
+	 * @param Node\Expr\New_ $node
 	 * @return array<int, array{string, bool}>
 	 */
 	private function getClassNames(Node $node, Scope $scope): array

--- a/tests/PHPStan/Analyser/data/array-filter.php
+++ b/tests/PHPStan/Analyser/data/array-filter.php
@@ -11,7 +11,7 @@ function withoutAnyArgs(): void
 }
 
 /**
- * @param $var1 $mixed
+ * @param mixed $var1
  */
 function withMixedInsteadOfArray($var1): void
 {


### PR DESCRIPTION
This commit addresses instances where multiple $vars were defined in `@param` PHPDoc.