### PR TITLE
Forbidd PHPUnitPhar prefixed classes

### DIFF
--- a/src/Rules/ClassForbiddenNameCheck.php
+++ b/src/Rules/ClassForbiddenNameCheck.php
@@ -19,6 +19,7 @@ class ClassForbiddenNameCheck
 		'PHPStan' => '_PHPStan_',
 		'Rector' => 'RectorPrefix',
 		'PHP-Scoper' => '_PhpScoper',
+		'PHPUnit' => 'PHPUnitPHAR',
 	];
 
 	public function __construct(private Container $container)

--- a/tests/PHPStan/Rules/Classes/ExistingClassInClassExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInClassExtendsRuleTest.php
@@ -108,13 +108,18 @@ class ExistingClassInClassExtendsRuleTest extends RuleTestCase
 			],
 			[
 				'Referencing prefixed Rector class: RectorPrefix202302\AClass.',
-				52,
+				56,
 				$tip,
 			],
 			[
 				'Referencing prefixed PHP-Scoper class: _PhpScoper19ae93be897e\AClass.',
-				55,
+				59,
 				$tip,
+			],
+			[
+				'Referencing prefixed PHPUnit class: PHPUnitPHAR\SebastianBergmann\Diff\Exception.',
+				62,
+				'This is most likely unintentional. Did you mean to type \SebastianBergmann\Diff\Exception?',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/data/phpstan-internal-class.php
+++ b/tests/PHPStan/Rules/Classes/data/phpstan-internal-class.php
@@ -47,6 +47,10 @@ class AClass {
 	const Test = 1;
 }
 
+namespace PHPUnitPHAR\SebastianBergmann\Diff; // mimicks a prefixed class, as contained in PHPUnit phar
+
+class Exception{}
+
 namespace TestPhpstanInternalClass2;
 
 class FooBar extends \RectorPrefix202302\AClass
@@ -54,3 +58,7 @@ class FooBar extends \RectorPrefix202302\AClass
 
 class Baz extends \_PhpScoper19ae93be897e\AClass
 {}
+
+class BazBar extends \PHPUnitPHAR\SebastianBergmann\Diff\Exception
+{}
+


### PR DESCRIPTION
PHPUnit uses this unique prefix since the latest release, so we can easily detect prefixed classes.

see https://github.com/sebastianbergmann/phpunit/commit/4d829e0740db0cbcbcd39ec5656161b4326004a4#diff-840c8b2ea07ab3c49b8c509c41e0de93231d36254f4f4ac621bcf2d21063ce5b

regular PHPUnit classes will have a `PHPUnit` namespace (these are not prefixed)