### PR TITLE
composer-dependency-analyser: update to 1.5.0 (support functions)

### DIFF
--- a/build/composer-dependency-analyser.php
+++ b/build/composer-dependency-analyser.php
@@ -26,7 +26,6 @@ return $config
 	->ignoreErrorsOnPackages(
 		[
 			'hoa/regex', // used only via stream wrapper hoa://
-			'react/async', // function usage (https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/67)
 			...$pinnedToSupportPhp72, // those are unused, but we need to pin them to support PHP 7.2
 			...$polyfills, // not detected by composer-dependency-analyser
 		],
@@ -34,7 +33,7 @@ return $config
 	)
 	->ignoreErrorsOnPackage('phpunit/phpunit', [ErrorType::DEV_DEPENDENCY_IN_PROD]) // prepared test tooling
 	->ignoreErrorsOnPackage('jetbrains/phpstorm-stubs', [ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV]) // there is no direct usage, but we need newer version then required by ondrejmirtes/BetterReflection
-	->ignoreErrorsOnPath(__DIR__ . '/../tests', [ErrorType::UNKNOWN_CLASS]) // to be able to test invalid symbols
+	->ignoreErrorsOnPath(__DIR__ . '/../tests', [ErrorType::UNKNOWN_CLASS, ErrorType::UNKNOWN_FUNCTION]) // to be able to test invalid symbols
 	->ignoreUnknownClasses([
 		'JetBrains\PhpStorm\Pure', // not present on composer's classmap
 		'PHPStan\ExtensionInstaller\GeneratedConfig', // generated

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpstan/phpstan-strict-rules": "^1.5.1",
 		"phpunit/phpunit": "^9.5.4",
-		"shipmonk/composer-dependency-analyser": "^1.0",
+		"shipmonk/composer-dependency-analyser": "^1.5",
 		"shipmonk/name-collision-detector": "^2.0"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73a1542d12c830ba7c5850e9cef8f6bf",
+    "content-hash": "32eff230a57b8a7ecf43325017abcdca",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -6500,26 +6500,29 @@
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
-            "version": "1.3.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/composer-dependency-analyser.git",
-                "reference": "b67036e64429bcddbbb65ba218f031d58ffda02e"
+                "reference": "da9eb497b1c7aac8fcc20e8f6a1364c4ad2ad110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/b67036e64429bcddbbb65ba218f031d58ffda02e",
-                "reference": "b67036e64429bcddbbb65ba218f031d58ffda02e",
+                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/da9eb497b1c7aac8fcc20e8f6a1364c4ad2ad110",
+                "reference": "da9eb497b1c7aac8fcc20e8f6a1364c4ad2ad110",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
+                "ext-tokenizer": "*",
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.3.0",
                 "ergebnis/composer-normalize": "^2.19",
-                "phpstan/phpstan": "^1.10.30",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "phpstan/phpstan": "^1.10.63",
                 "phpstan/phpstan-phpunit": "^1.1.1",
                 "phpstan/phpstan-strict-rules": "^1.2.3",
                 "phpunit/phpunit": "^8.5.28 || ^9.5.20",
@@ -6556,9 +6559,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/composer-dependency-analyser/issues",
-                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/1.3.1"
+                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/1.5.0"
             },
-            "time": "2024-03-05T20:19:03+00:00"
+            "time": "2024-04-11T06:43:04+00:00"
         },
         {
             "name": "shipmonk/name-collision-detector",


### PR DESCRIPTION
- [composer-dependency-analyser 1.5.0](https://github.com/shipmonk-rnd/composer-dependency-analyser/?tab=readme-ov-file#composer-dependency-analyser)
