### PR TITLE
Treat get_defined_vars() as using function arguments

### DIFF
--- a/src/Rules/UnusedFunctionParametersCheck.php
+++ b/src/Rules/UnusedFunctionParametersCheck.php
@@ -63,7 +63,7 @@ class UnusedFunctionParametersCheck
 		if ($node instanceof Node) {
 			if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
 				$functionName = $this->reflectionProvider->resolveFunctionName($node->name, $scope);
-				if ($functionName === 'func_get_args') {
+				if ($functionName === 'func_get_args' || $functionName === 'get_defined_vars') {
 					return $scope->getDefinedVariables();
 				}
 			}

--- a/tests/PHPStan/Rules/Classes/UnusedConstructorParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/UnusedConstructorParametersRuleTest.php
@@ -43,4 +43,9 @@ class UnusedConstructorParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-1917.php'], []);
 	}
 
+	public function testBug10865(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10865.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-10865.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10865.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bug10865;
+
+class TestParent {
+
+	/** @param array<string|int, mixed> $args */
+	public function __construct(array $args) {
+
+		var_dump($args);
+	}
+}
+
+class Test extends TestParent {
+
+	public function __construct(int $a) {
+
+		parent::__construct(get_defined_vars());
+		//parent::__construct(func_get_args());
+	}
+}


### PR DESCRIPTION
Fix phpstan/phpstan#10865