### PR TITLE
Immediately called function without implicit throw broken for first class callable

### DIFF
--- a/tests/PHPStan/Analyser/ImmediatelyCalledFunctionWithoutImplicitThrowTest.php
+++ b/tests/PHPStan/Analyser/ImmediatelyCalledFunctionWithoutImplicitThrowTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class ImmediatelyCalledFunctionWithoutImplicitThrowTest extends TypeInferenceTestCase
+{
+
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/immediately-called-function-without-implicit-throw.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return array_merge(
+			parent::getAdditionalConfigFiles(),
+			[__DIR__ . '/data/immediately-called-function-without-implicit-throw.neon']
+		);
+	}
+
+}

--- a/tests/PHPStan/Analyser/ImmediatelyCalledFunctionWithoutImplicitThrowTest.php
+++ b/tests/PHPStan/Analyser/ImmediatelyCalledFunctionWithoutImplicitThrowTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use function array_merge;
 
 class ImmediatelyCalledFunctionWithoutImplicitThrowTest extends TypeInferenceTestCase
 {
@@ -29,7 +30,7 @@ class ImmediatelyCalledFunctionWithoutImplicitThrowTest extends TypeInferenceTes
 	{
 		return array_merge(
 			parent::getAdditionalConfigFiles(),
-			[__DIR__ . '/data/immediately-called-function-without-implicit-throw.neon']
+			[__DIR__ . '/data/immediately-called-function-without-implicit-throw.neon'],
 		);
 	}
 

--- a/tests/PHPStan/Analyser/data/immediately-called-function-without-implicit-throw.neon
+++ b/tests/PHPStan/Analyser/data/immediately-called-function-without-implicit-throw.neon
@@ -1,0 +1,3 @@
+parameters:
+    exceptions:
+        implicitThrows: false

--- a/tests/PHPStan/Analyser/data/immediately-called-function-without-implicit-throw.php
+++ b/tests/PHPStan/Analyser/data/immediately-called-function-without-implicit-throw.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ImmediatelyCalledFunctionWithoutImplicitThrow;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+
+try {
+	$result = array_map('ucfirst', []);
+} finally {
+	assertVariableCertainty(TrinaryLogic::createYes(), $result);
+}
+
+class SomeClass
+{
+
+	public function noThrow(): void
+	{
+	}
+
+	public function testFirstClassCallableNoThrow(): void
+	{
+		try {
+			$result = array_map($this->noThrow(...), []);
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createYes(), $result);
+		}
+	}
+
+}


### PR DESCRIPTION
Looks like it got broken in [this commit](https://github.com/phpstan/phpstan-src/commit/8a8b712ff038df9ebea57f16a9e81f777870fe49). Checked by:

```bash
wget https://raw.githubusercontent.com/janedbal/phpstan-src/fd32899a00a58fea6e8db47356f97619c5906b11/tests/PHPStan/Analyser/data/immediately-called-function-without-implicit-throw.php

git checkout 925c0b7343eef8e86d4c65c5d2cd3fe5a65aca9b
bin/phpstan analyse -l 9 -c tests/PHPStan/Rules/Exceptions/data/ability-to-disable-implicit-throws.neon immediately-called-function-without-implicit-throw.php
# no errors

git checkout 8a8b712ff038df9ebea57f16a9e81f777870fe49
bin/phpstan analyse -l 9 -c tests/PHPStan/Rules/Exceptions/data/ability-to-disable-implicit-throws.neon immediately-called-function-without-implicit-throw.php
# error at line 11: Expected variable certainty Yes, actual: Maybe
```

Commits around that: https://github.com/phpstan/phpstan-src/commits/1.11.x/?after=f280c25a28e8fdf9853165324e8672c06065f8a8+139