### PR TITLE
ExponentiateHelper: fix internal error and internal warning

### DIFF
--- a/src/Type/ExponentiateHelper.php
+++ b/src/Type/ExponentiateHelper.php
@@ -4,8 +4,10 @@ namespace PHPStan\Type;
 
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use Throwable;
 use function is_float;
 use function is_int;
+use function pow;
 
 final class ExponentiateHelper
 {
@@ -95,7 +97,12 @@ final class ExponentiateHelper
 		}
 
 		if ($exponent instanceof ConstantScalarType) {
-			$result = $base->getValue() ** $exponent->getValue();
+			try {
+				// @ to avoid "Warning: A non-numeric value encountered"
+				$result = @pow($base->getValue(), $exponent->getValue()); // @phpstan-ignore-line
+			} catch (Throwable) {
+				return new ErrorType();
+			}
 			if (is_int($result)) {
 				return new ConstantIntegerType($result);
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -191,6 +191,11 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-1014.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-pr-339.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/pow.php');
+		if (PHP_VERSION_ID >= 80000) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/pow-php8.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/pow-php7.php');
+		}
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/throw-expr.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5351.php');
 

--- a/tests/PHPStan/Analyser/data/pow-php7.php
+++ b/tests/PHPStan/Analyser/data/pow-php7.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PowFunction;
+
+use function PHPStan\Testing\assertType;
+
+assertType('4', '4a' ** 1);
+assertType('0', 'a' ** 1);

--- a/tests/PHPStan/Analyser/data/pow-php8.php
+++ b/tests/PHPStan/Analyser/data/pow-php8.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PowFunction;
+
+use function PHPStan\Testing\assertType;
+
+assertType('4', '4a' ** 1);
+assertType('*ERROR*', 'a' ** 1);

--- a/tests/PHPStan/Analyser/data/pow.php
+++ b/tests/PHPStan/Analyser/data/pow.php
@@ -169,9 +169,6 @@ function doFoo(int $intA, int $intB, string $s, bool $bool, $numericS, float $fl
 	assertType('*ERROR*', $s ** $arr);
 	assertType('*ERROR*', $s ** []);
 
-	assertType('4', '4a' ** 1);
-	assertType('*ERROR*', 'a' ** 1);
-
 	assertType('1', pow($bool, 0));
 	assertType('1', $bool ** '0');
 	assertType('1', $bool ** false);

--- a/tests/PHPStan/Analyser/data/pow.php
+++ b/tests/PHPStan/Analyser/data/pow.php
@@ -169,6 +169,9 @@ function doFoo(int $intA, int $intB, string $s, bool $bool, $numericS, float $fl
 	assertType('*ERROR*', $s ** $arr);
 	assertType('*ERROR*', $s ** []);
 
+	assertType('4', '4a' ** 1);
+	assertType('*ERROR*', 'a' ** 1);
+
 	assertType('1', pow($bool, 0));
 	assertType('1', $bool ** '0');
 	assertType('1', $bool ** false);


### PR DESCRIPTION
Probably fixes even https://github.com/phpstan/phpstan/issues/10125

```
Warning: A non-numeric value encountered on phar:///home/honza/Development/shipmonk/phpstan-rules/vendor/phpstan/phpstan/phpstan.phar/src/Type/ExponentiateHelper.php:72
```

Found in https://github.com/shipmonk-rnd/phpstan-rules tests when run with new https://github.com/phpstan/phpstan-src/commit/204ab2787f88bc31c4b2d30db0715997f3da4549