### PR TITLE
Make rule errors a little bit more DRY

### DIFF
--- a/src/Rules/Classes/ImpossibleInstanceOfRule.php
+++ b/src/Rules/Classes/ImpossibleInstanceOfRule.php
@@ -71,7 +71,7 @@ class ImpossibleInstanceOfRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		if (!$instanceofType->getValue()) {

--- a/src/Rules/Comparison/BooleanAndConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanAndConstantConditionRule.php
@@ -42,9 +42,8 @@ class BooleanAndConstantConditionRule implements Rule
 		$nodeText = $this->bleedingEdge ? $originalNode->getOperatorSigil() : '&&';
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$identifierType = $originalNode instanceof Node\Expr\BinaryOp\BooleanAnd ? 'booleanAnd' : 'logicalAnd';
-		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		if ($leftType instanceof ConstantBooleanType) {
-			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $tipText, $originalNode): RuleErrorBuilder {
+			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
 				}
@@ -54,7 +53,7 @@ class BooleanAndConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip($tipText);
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
@@ -79,7 +78,7 @@ class BooleanAndConstantConditionRule implements Rule
 			$originalNode->right,
 		);
 		if ($rightType instanceof ConstantBooleanType && !$scope->isInFirstLevelStatement()) {
-			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($rightScope, $originalNode, $tipText): RuleErrorBuilder {
+			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($rightScope, $originalNode): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
 				}
@@ -92,7 +91,7 @@ class BooleanAndConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip($tipText);
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
@@ -114,7 +113,7 @@ class BooleanAndConstantConditionRule implements Rule
 		if (count($errors) === 0 && !$scope->isInFirstLevelStatement()) {
 			$nodeType = $this->treatPhpDocTypesAsCertain ? $scope->getType($originalNode) : $scope->getNativeType($originalNode);
 			if ($nodeType instanceof ConstantBooleanType) {
-				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode, $tipText): RuleErrorBuilder {
+				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
 					if (!$this->treatPhpDocTypesAsCertain) {
 						return $ruleErrorBuilder;
 					}
@@ -124,7 +123,7 @@ class BooleanAndConstantConditionRule implements Rule
 						return $ruleErrorBuilder;
 					}
 
-					return $ruleErrorBuilder->tip($tipText);
+					return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 				};
 
 				$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);

--- a/src/Rules/Comparison/BooleanNotConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanNotConstantConditionRule.php
@@ -46,7 +46,7 @@ class BooleanNotConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);

--- a/src/Rules/Comparison/BooleanOrConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanOrConstantConditionRule.php
@@ -42,9 +42,8 @@ class BooleanOrConstantConditionRule implements Rule
 		$messages = [];
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$identifierType = $originalNode instanceof Node\Expr\BinaryOp\BooleanOr ? 'booleanOr' : 'logicalOr';
-		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		if ($leftType instanceof ConstantBooleanType) {
-			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode, $tipText): RuleErrorBuilder {
+			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
 				}
@@ -54,7 +53,7 @@ class BooleanOrConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip($tipText);
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
@@ -79,7 +78,7 @@ class BooleanOrConstantConditionRule implements Rule
 			$originalNode->right,
 		);
 		if ($rightType instanceof ConstantBooleanType && !$scope->isInFirstLevelStatement()) {
-			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($rightScope, $originalNode, $tipText): RuleErrorBuilder {
+			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($rightScope, $originalNode): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
 				}
@@ -92,7 +91,7 @@ class BooleanOrConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip($tipText);
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
@@ -114,7 +113,7 @@ class BooleanOrConstantConditionRule implements Rule
 		if (count($messages) === 0 && !$scope->isInFirstLevelStatement()) {
 			$nodeType = $this->treatPhpDocTypesAsCertain ? $scope->getType($originalNode) : $scope->getNativeType($originalNode);
 			if ($nodeType instanceof ConstantBooleanType) {
-				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode, $tipText): RuleErrorBuilder {
+				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
 					if (!$this->treatPhpDocTypesAsCertain) {
 						return $ruleErrorBuilder;
 					}
@@ -124,7 +123,7 @@ class BooleanOrConstantConditionRule implements Rule
 						return $ruleErrorBuilder;
 					}
 
-					return $ruleErrorBuilder->tip($tipText);
+					return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 				};
 
 				$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);

--- a/src/Rules/Comparison/ConstantLooseComparisonRule.php
+++ b/src/Rules/Comparison/ConstantLooseComparisonRule.php
@@ -51,7 +51,7 @@ class ConstantLooseComparisonRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		if (!$nodeType->getValue()) {

--- a/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
+++ b/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
@@ -71,7 +71,7 @@ class DoWhileLoopConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			return [

--- a/src/Rules/Comparison/ElseIfConstantConditionRule.php
+++ b/src/Rules/Comparison/ElseIfConstantConditionRule.php
@@ -46,7 +46,7 @@ class ElseIfConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->cond->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);

--- a/src/Rules/Comparison/IfConstantConditionRule.php
+++ b/src/Rules/Comparison/IfConstantConditionRule.php
@@ -44,7 +44,7 @@ class IfConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			return [

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -55,7 +55,7 @@ class ImpossibleCheckTypeFunctionCallRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		if (!$isAlways) {

--- a/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
@@ -53,7 +53,7 @@ class ImpossibleCheckTypeMethodCallRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		if (!$isAlways) {

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -53,7 +53,7 @@ class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		if (!$isAlways) {

--- a/src/Rules/Comparison/LogicalXorConstantConditionRule.php
+++ b/src/Rules/Comparison/LogicalXorConstantConditionRule.php
@@ -34,9 +34,8 @@ class LogicalXorConstantConditionRule implements Rule
 	{
 		$errors = [];
 		$leftType = $this->helper->getBooleanType($scope, $node->left);
-		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
 		if ($leftType instanceof ConstantBooleanType) {
-			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $tipText, $node): RuleErrorBuilder {
+			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
 				}
@@ -46,7 +45,7 @@ class LogicalXorConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip($tipText);
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
@@ -66,7 +65,7 @@ class LogicalXorConstantConditionRule implements Rule
 
 		$rightType = $this->helper->getBooleanType($scope, $node->right);
 		if ($rightType instanceof ConstantBooleanType) {
-			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node, $tipText): RuleErrorBuilder {
+			$addTipRight = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
 					return $ruleErrorBuilder;
 				}
@@ -79,7 +78,7 @@ class LogicalXorConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip($tipText);
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);

--- a/src/Rules/Comparison/NumberComparisonOperatorsConstantConditionRule.php
+++ b/src/Rules/Comparison/NumberComparisonOperatorsConstantConditionRule.php
@@ -56,7 +56,7 @@ class NumberComparisonOperatorsConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			switch (get_class($node)) {

--- a/src/Rules/Comparison/StrictComparisonOfDifferentTypesRule.php
+++ b/src/Rules/Comparison/StrictComparisonOfDifferentTypesRule.php
@@ -54,7 +54,7 @@ class StrictComparisonOfDifferentTypesRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		if (!$nodeType->getValue()) {

--- a/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
+++ b/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
@@ -44,7 +44,7 @@ class TernaryOperatorConstantConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 			return [
 				$addTip(RuleErrorBuilder::message(sprintf(

--- a/src/Rules/Comparison/UnreachableIfBranchesRule.php
+++ b/src/Rules/Comparison/UnreachableIfBranchesRule.php
@@ -49,7 +49,7 @@ class UnreachableIfBranchesRule implements Rule
 				return $ruleErrorBuilder;
 			}
 
-			return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 		};
 
 		foreach ($node->elseifs as $elseif) {

--- a/src/Rules/Comparison/UnreachableTernaryElseBranchRule.php
+++ b/src/Rules/Comparison/UnreachableTernaryElseBranchRule.php
@@ -50,7 +50,7 @@ class UnreachableTernaryElseBranchRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 			return [
 				$addTip(RuleErrorBuilder::message('Else branch is unreachable because ternary operator condition is always true.'))

--- a/src/Rules/Comparison/WhileLoopAlwaysFalseConditionRule.php
+++ b/src/Rules/Comparison/WhileLoopAlwaysFalseConditionRule.php
@@ -44,7 +44,7 @@ class WhileLoopAlwaysFalseConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			return [

--- a/src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
+++ b/src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
@@ -71,7 +71,7 @@ class WhileLoopAlwaysTrueConditionRule implements Rule
 					return $ruleErrorBuilder;
 				}
 
-				return $ruleErrorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+				return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
 			};
 
 			return [

--- a/src/Rules/Functions/ArrayFilterRule.php
+++ b/src/Rules/Functions/ArrayFilterRule.php
@@ -80,7 +80,7 @@ class ArrayFilterRule implements Rule
 			if ($this->treatPhpDocTypesAsCertain) {
 				$nativeArrayType = $scope->getNativeType($args[0]->value);
 				if (!$nativeArrayType->isIterableAtLeastOnce()->no()) {
-					$errorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
 				}
 			}
 			return [
@@ -102,7 +102,7 @@ class ArrayFilterRule implements Rule
 				$nativeArrayType = $scope->getNativeType($args[0]->value);
 				$isNativeSuperType = $falsyType->isSuperTypeOf($nativeArrayType->getIterableValueType());
 				if (!$isNativeSuperType->no()) {
-					$errorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
 				}
 			}
 
@@ -122,7 +122,7 @@ class ArrayFilterRule implements Rule
 				$nativeArrayType = $scope->getNativeType($args[0]->value);
 				$isNativeSuperType = $falsyType->isSuperTypeOf($nativeArrayType->getIterableValueType());
 				if (!$isNativeSuperType->yes()) {
-					$errorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
 				}
 			}
 

--- a/src/Rules/Functions/ArrayValuesRule.php
+++ b/src/Rules/Functions/ArrayValuesRule.php
@@ -85,7 +85,7 @@ class ArrayValuesRule implements Rule
 			if ($this->treatPhpDocTypesAsCertain) {
 				$nativeArrayType = $scope->getNativeType($args[0]->value);
 				if (!$nativeArrayType->isIterableAtLeastOnce()->no()) {
-					$errorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
 				}
 			}
 
@@ -103,7 +103,7 @@ class ArrayValuesRule implements Rule
 			if ($this->treatPhpDocTypesAsCertain) {
 				$nativeArrayType = $scope->getNativeType($args[0]->value);
 				if (!$nativeArrayType->isList()->yes()) {
-					$errorBuilder->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
 				}
 			}
 

--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -202,6 +202,15 @@ class RuleErrorBuilder
 	}
 
 	/**
+	 * @phpstan-this-out self<T&TipRuleError>
+	 * @return self<T&TipRuleError>
+	 */
+	public function treatPhpDocTypesAsCertainTip(): self
+	{
+		return $this->tip('Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.');
+	}
+
+	/**
 	 * Sets an error identifier.
 	 *
 	 * List of all current error identifiers in PHPStan: https://phpstan.org/error-identifiers


### PR DESCRIPTION
Noticed this message is used a lot throughout the codebase, and it could probably use a bit of DRYness, this would make it easier to change the message down the line it ever became necessary.

Additionally, this also makes it easier for PHPStan extensions' rules to use the exact same tip as PHPStan itself, if they do respect this setting being on or off