### PR TITLE
Check redeclared readonly properties

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -57,6 +57,7 @@ rules:
 	- PHPStan\Rules\Classes\NewStaticRule
 	- PHPStan\Rules\Classes\NonClassAttributeClassRule
 	- PHPStan\Rules\Classes\ReadOnlyClassRule
+	- PHPStan\Rules\Classes\RedeclareReadOnlyProperty
 	- PHPStan\Rules\Classes\TraitAttributeClassRule
 	- PHPStan\Rules\Constants\DynamicClassConstantFetchRule
 	- PHPStan\Rules\Constants\FinalConstantRule

--- a/src/Rules/Classes/RedeclareReadOnlyProperty.php
+++ b/src/Rules/Classes/RedeclareReadOnlyProperty.php
@@ -1,0 +1,194 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Classes;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Php\PhpPropertyReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function array_key_exists;
+use function is_string;
+use function sprintf;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+class RedeclareReadOnlyProperty implements Rule
+{
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return InClassNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$this->phpVersion->supportsPromotedProperties() || !$this->phpVersion->supportsReadOnlyProperties()) {
+			/** Error is already reported by {@see InvalidPromotedPropertiesRule} and {@see \PHPStan\Rules\Properties\ReadOnlyPropertyRule} */
+			return [];
+		}
+
+		$reflection = $node->getClassReflection();
+		$parentClass = $reflection->getParentClass();
+
+		if ($parentClass === null) {
+			return [];
+		}
+
+		$nodeTraverser = new NodeTraverser();
+		$visitor = new class () extends NodeVisitorAbstract {
+
+			private ?Node\Stmt\ClassMethod $constructorNode = null;
+
+			/** @var list<Node\Stmt\Property> */
+			private array $nonPrivateReadonlyPropertyNodes = [];
+
+			/** @var list<Node\Expr\StaticCall> */
+			private array $constructorCalls = [];
+
+			private bool $enteredClass = false;
+
+			public function enterNode(Node $node): ?int
+			{
+				if ($node instanceof Node\Stmt\Class_) {
+					if ($this->enteredClass) {
+						return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+					}
+
+					$this->enteredClass = true;
+					return null;
+				}
+				if ($node instanceof Node\Stmt\ClassMethod && $node->name->toLowerString() === '__construct') {
+					$this->constructorNode = $node;
+				} elseif ($node instanceof Node\Stmt\Property && !$node->isPrivate() && $node->isReadonly()) {
+					$this->nonPrivateReadonlyPropertyNodes[] = $node;
+				} elseif ($node instanceof Node\Expr\StaticCall && $node->name instanceof Node\Identifier && $node->name->toLowerString() === '__construct') {
+					$this->constructorCalls[] = $node;
+				}
+				return null;
+			}
+
+			public function getConstructorNode(): ?Node\Stmt\ClassMethod
+			{
+				return $this->constructorNode;
+			}
+
+			/** @return list<Node\Stmt\Property> */
+			public function getNonPrivateReadonlyPropertyNodes(): array
+			{
+				return $this->nonPrivateReadonlyPropertyNodes;
+			}
+
+			/** @return list<Node\Expr\StaticCall> */
+			public function getConstructorCalls(): array
+			{
+				return $this->constructorCalls;
+			}
+
+		};
+		$nodeTraverser->addVisitor($visitor);
+		$nodeTraverser->traverse([$node->getOriginalNode()]);
+		if ($visitor->getConstructorCalls() === []) {
+			return [];
+		}
+
+		$redeclaredProperties = [];
+
+		foreach ($visitor->getNonPrivateReadonlyPropertyNodes() as $propertyNode) {
+			foreach ($propertyNode->props as $property) {
+				$propertyName = $property->name->name;
+				$parentProperty = $this->findPrototype($parentClass, $propertyName);
+				if ($parentProperty === null) {
+					continue;
+				}
+
+				$redeclaredProperties[$propertyName] = $property;
+			}
+		}
+
+		foreach ($visitor->getConstructorNode()->params ?? [] as $param) {
+			if (
+				($param->flags & Node\Stmt\Class_::MODIFIER_READONLY) !== Node\Stmt\Class_::MODIFIER_READONLY
+				|| ($param->flags & Node\Stmt\Class_::MODIFIER_PRIVATE) === Node\Stmt\Class_::MODIFIER_PRIVATE
+				|| $param->var instanceof Node\Expr\Error
+				|| !is_string($param->var->name)
+			) {
+				continue;
+			}
+
+			$propertyName = $param->var->name;
+			$parentProperty = $this->findPrototype($parentClass, $propertyName);
+			if ($parentProperty === null) {
+				continue;
+			}
+
+			$redeclaredProperties[$propertyName] = $param;
+		}
+
+		if ($redeclaredProperties === []) {
+			return [];
+		}
+
+		$parentAncestorMap = [];
+		foreach ($parentClass->getAncestors() as $ancestor) {
+			$parentAncestorMap[$ancestor->getName()] = $ancestor;
+		}
+
+		$callsParentConstructor = false;
+		foreach ($visitor->getConstructorCalls() as $constructorCall) {
+			if ($constructorCall->class instanceof Node\Expr) {
+				continue;
+			}
+
+			// TODO: what if we call constructor from deeper ancestor which doesn't have the property yet?
+			$name = $scope->resolveName($constructorCall->class);
+			if (!array_key_exists($name, $parentAncestorMap)) {
+				continue;
+			}
+
+			$callsParentConstructor = true;
+			break;
+		}
+
+		if (!$callsParentConstructor) {
+			return [];
+		}
+
+		$errors = [];
+
+		foreach ($redeclaredProperties as $propertyName => $propertyNode) {
+			$errors[] = RuleErrorBuilder::message(sprintf(
+				'Readonly property %s::$%s cannot be redeclared, because you call the parent constructor.',
+				$reflection->getName(),
+				$propertyName,
+			))->line($propertyNode->getLine())->build();
+		}
+
+		return $errors;
+	}
+
+	private function findPrototype(ClassReflection $parentClass, string $propertyName): ?PhpPropertyReflection
+	{
+		if (!$parentClass->hasNativeProperty($propertyName)) {
+			return null;
+		}
+
+		$property = $parentClass->getNativeProperty($propertyName);
+		if ($property->isPrivate()) {
+			return null;
+		}
+
+		return $property;
+	}
+
+}

--- a/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
@@ -56,4 +56,15 @@ class RedeclareReadonlyPropertyRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8101(): void
+	{
+		$this->phpVersion = 80100;
+		$this->analyse([__DIR__ . '/data/bug-8101.php'], [
+			[
+				'Readonly property Bug8101\B::$myProp cannot be redeclared, because you call the parent constructor.',
+				11,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Classes;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<RedeclareReadOnlyProperty>
+ */
+class RedeclareReadonlyPropertyRuleTest extends RuleTestCase
+{
+
+	private int $phpVersion;
+
+	protected function getRule(): Rule
+	{
+		return new RedeclareReadOnlyProperty(new PhpVersion($this->phpVersion));
+	}
+
+	public function testNotSupportedOnPhp8(): void
+	{
+		$this->phpVersion = 80000;
+		$this->analyse([__DIR__ . '/data/redeclare-readonly-property.php'], []);
+	}
+
+	public function testSupportedOnPhp81(): void
+	{
+		$this->phpVersion = 80100;
+		$this->analyse([__DIR__ . '/data/redeclare-readonly-property.php'], [
+			[
+				'Readonly property RedeclareReadonlyProperty\B1::$myProp cannot be redeclared, because you call the parent constructor.',
+				15,
+			],
+			[
+				'Readonly property RedeclareReadonlyProperty\B4::$nonPromotedProp cannot be redeclared, because you call the parent constructor.',
+				37,
+			],
+			[
+				'Readonly property RedeclareReadonlyProperty\B5::$myProp cannot be redeclared, because you call the parent constructor.',
+				47,
+			],
+			[
+				'Readonly property RedeclareReadonlyProperty\B7::$myProp cannot be redeclared, because you call the parent constructor.',
+				64,
+			],
+			[
+				'Readonly property AnonymousClassd46c4a7fade8fbe381fe74954f5c073f::$nonPromotedProp cannot be redeclared, because you call the parent constructor.',
+				118,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
@@ -49,6 +49,10 @@ class RedeclareReadonlyPropertyRuleTest extends RuleTestCase
 				'Readonly property AnonymousClassd46c4a7fade8fbe381fe74954f5c073f::$nonPromotedProp cannot be redeclared, because you call the parent constructor.',
 				118,
 			],
+			[
+				'Readonly property RedeclareReadonlyProperty\C12_1::$aProp cannot be redeclared, because you call the parent constructor.',
+				155,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
@@ -78,4 +78,20 @@ class RedeclareReadonlyPropertyRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug9863(): void
+	{
+		$this->phpVersion = 80100;
+		$this->analyse([__DIR__ . '/data/bug-9863.php'], [
+			[
+				'Readonly property Bug9863\ReadonlyChildWithoutIsset::$foo cannot be redeclared, because you call the parent constructor.',
+				15,
+			],
+			[
+				// This line doesn't actually cause an error, but we have to draw the line somewhere.
+				'Readonly property Bug9863\ReadonlyChildWithIsset::$foo cannot be redeclared, because you call the parent constructor.',
+				37,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/RedeclareReadonlyPropertyRuleTest.php
@@ -56,6 +56,17 @@ class RedeclareReadonlyPropertyRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testReadonlyClass(): void
+	{
+		$this->phpVersion = 80200;
+		$this->analyse([__DIR__ . '/data/redeclare-property-of-readonly-class.php'], [
+			[
+				'Readonly property RedeclarePropertyOfReadonlyClass\B1::$nonPromotedProp cannot be redeclared, because you call the parent constructor.',
+				15,
+			],
+		]);
+	}
+
 	public function testBug8101(): void
 	{
 		$this->phpVersion = 80100;

--- a/tests/PHPStan/Rules/Classes/data/bug-8101.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-8101.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug8101;
+
+class A {
+	public function __construct(public readonly int $myProp) {}
+}
+
+class B extends A {
+	// This should be reported as an error, as a readonly prop cannot be redeclared.
+	public function __construct(public readonly int $myProp) {
+		parent::__construct($myProp);
+	}
+}
+
+$foo = new B(7);

--- a/tests/PHPStan/Rules/Classes/data/bug-9863.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-9863.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug9863;
+
+class ReadonlyParentWithoutIsset
+{
+	public function __construct(
+		public readonly int $foo
+	) {}
+}
+
+class ReadonlyChildWithoutIsset extends ReadonlyParentWithoutIsset
+{
+	public function __construct(
+		public readonly int $foo = 42
+	) {
+		parent::__construct($foo);
+	}
+}
+
+class ReadonlyParentWithIsset
+{
+	public readonly int $foo;
+
+	public function __construct(
+		int $foo
+	) {
+		if (! isset($this->foo)) {
+			$this->foo = $foo;
+		}
+	}
+}
+
+class ReadonlyChildWithIsset extends ReadonlyParentWithIsset
+{
+	public function __construct(
+		public readonly int $foo = 42
+	) {
+		parent::__construct($foo);
+	}
+}
+
+$a = new ReadonlyParentWithoutIsset(0);
+$b = new ReadonlyChildWithoutIsset();
+$c = new ReadonlyChildWithoutIsset(1);
+
+$x = new ReadonlyParentWithIsset(2);
+$y = new ReadonlyChildWithIsset();
+$z = new ReadonlyChildWithIsset(3);

--- a/tests/PHPStan/Rules/Classes/data/redeclare-property-of-readonly-class.php
+++ b/tests/PHPStan/Rules/Classes/data/redeclare-property-of-readonly-class.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1); // lint >= 8.2
+
+namespace RedeclarePropertyOfReadonlyClass;
+
+readonly class A {
+	protected int $nonPromotedProp;
+	public function __construct(public int $promotedProp)
+	{
+		$this->nonPromotedProp = 7;
+	}
+}
+
+readonly class B1 extends A {
+	// $nonPromotedProp is written twice
+	public function __construct(public int $nonPromotedProp)
+	{
+		parent::__construct(5);
+	}
+}
+
+readonly class B2 extends A {
+	// Don't get confused by standard parameter with same name
+	public function __construct(int $nonPromotedProp)
+	{
+		parent::__construct($nonPromotedProp);
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/redeclare-readonly-property.php
+++ b/tests/PHPStan/Rules/Classes/data/redeclare-readonly-property.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace RedeclareReadonlyProperty;
+
+class A {
+	protected readonly string $nonPromotedProp;
+
+	public function __construct(public readonly int $myProp) {
+		$this->nonPromotedProp = 'aaa';
+	}
+}
+
+class B1 extends A {
+	// This should be reported as an error, as a readonly prop cannot be redeclared.
+	public function __construct(public readonly int $myProp) {
+		parent::__construct($myProp);
+	}
+}
+
+class B2 extends A {
+	// different property
+	public function __construct(public readonly int $foo) {
+		parent::__construct($foo);
+	}
+}
+
+class B3 extends A {
+	// We don't call the parent constructor, so it's fine.
+	public function __construct(public readonly int $myProp) {
+	}
+}
+
+class B4 extends A {
+	protected readonly string
+		$foo,
+		// report overriding non-promoted property as well.
+		$nonPromotedProp;
+	public function __construct() {
+		$this->foo = 'xyz';
+		$this->nonPromotedProp = 'bbb';
+		parent::__construct(5);
+	}
+}
+
+class B5 extends A {
+	// non-promoted property overriding promoted property
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 7;
+		parent::__construct(5);
+	}
+}
+
+class B6 extends A {
+	// This is fine - we don't call parent constructor;
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+	}
+}
+
+class B7 extends A {
+	// Call parent construtor indirectly
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+		$this->foo();
+	}
+
+	private function foo(): void
+	{
+		A::__construct(5);
+	}
+}
+
+class B8 extends A {
+	// Don't get confused by prop declaration in anonymous class.
+	public function __construct() {
+		parent::__construct(5);
+		$c = new class {
+			public readonly int $myProp;
+		};
+	}
+}
+
+class B9 extends A {
+	// Don't get confused by constructor call in anonymous class
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+		$c = new class extends A {
+			public function __construct()
+			{
+				parent::__construct(5);
+			}
+		};
+	}
+}
+
+class B10 extends A {
+	// Don't get confused by promoted properties in anonymous class
+	public function __construct() {
+		parent::__construct(5);
+		$c = new class (5) {
+			public function __construct(public readonly int $myProp)
+			{
+			}
+		};
+	}
+}
+
+class B11 extends A {
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+		$c = new class ('aaa') extends A {
+			// Detect redeclaration even inside anonymous classes.
+			public function __construct(protected readonly string $nonPromotedProp)
+			{
+				parent::__construct(5);
+			}
+		};
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/redeclare-readonly-property.php
+++ b/tests/PHPStan/Rules/Classes/data/redeclare-readonly-property.php
@@ -122,3 +122,37 @@ class B11 extends A {
 		};
 	}
 }
+
+class A12 {
+	public function __construct(public readonly int $aProp)
+	{
+	}
+}
+
+class B12 extends A12 {
+	public function __construct(public readonly int $bProp)
+	{
+		parent::__construct(15);
+	}
+}
+
+class C12 extends B12 {
+	// This is OK, because we call A12's constructor, not B12's.
+	public function __construct(public readonly int $bProp) {
+		A12::__construct(15);
+	}
+}
+
+class B12_1 extends A12 {
+	public function __construct(public readonly int $bProp)
+	{
+		parent::__construct(15);
+	}
+}
+
+class C12_1 extends B12_1 {
+	// Error: we override A's readonly property and call the parent constructor, which may call A's constructor, ...
+	public function __construct(public readonly int $aProp) {
+		parent::__construct(15);
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/redeclare-readonly-property.php
+++ b/tests/PHPStan/Rules/Classes/data/redeclare-readonly-property.php
@@ -156,3 +156,17 @@ class C12_1 extends B12_1 {
 		parent::__construct(15);
 	}
 }
+
+class A13 {
+	public function __construct(private readonly int $privateProp)
+	{
+	}
+}
+
+class B13 extends A13 {
+	// This is OK, A's prop is private
+	public function __construct(public readonly int $privateProp)
+	{
+		parent::__construct(15);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/8101

Readonly properties in PHP work as follows:

- Readonly property can only be assigned once and only from the scope where it was declared. It is not necessary to assign it in the constructor, it can be done later.
- Readonly properties can be redeclared by child classes, but they still must be assigned at most once (either by the child or the parent).

PHPStan enforces that readonly properties are assigned in the constructor right from level 0 (`MissingReadOnlyPropertyAssignRule`). Therefore, I propose that we prohibit redeclaring a readonly property and simultaneously calling a constructor of the parent which also declares it, or any of its children (they may call their parent's constructor and so on).

It could technically be allowed to both redeclare a readonly property and call the parent constructor, as long as the property is not assigned anywhere in the class. ~~However, I cannot think of a reason why anyone would need to redeclare a readonly property, other than to assign it in the child class, instead of in the parent. Therefore, I didn't add an exception for this case.~~ There is a use-case: adding attributes to the property (https://github.com/phpstan/phpstan/issues/9864).

The rule will still reject some valid edge-cases, but IMO it is on par with `MissingReadOnlyPropertyAssignRule`. So I also added it as part of level 0 (which strictly speaking breaks the BC promise, but so did `MissingReadOnlyPropertyAssignRule` - it might need to have an exception for rules which detect code which is highly likely to lead to a runtime error).

----

Additionally, I would like to ask you whether you'd be willing to prohibit redeclaring readonly properties completely (i.e. https://github.com/phpstan/phpstan-src/pull/1788) as part of strict-rules. My reasoning is as follows:

- PHPStan itself already requires readonly properties to be assigned in the constructor (i.e. they must both be assigned and it must be done in the constructor).
- Strict rules require that you call the parent constructor.
- If you follow these rules, while also redeclaring a readonly property you'll get a runtime error. Therefore, strict rules should prohibit you from redeclaring readonly properties.

This would give additional safety for those of us who do not need to redeclare readonly properties, because the general rule that I implemented does not cover everything (e.g. the constructor call could be hidden somehow).