### PR TITLE
Feature check redeclared readonly properties v2

### DIFF
--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -287,4 +287,89 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10822.php'], []);
 	}
 
+	public function testRedeclaredReadonlyProperties(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/redeclare-readonly-property.php'], [
+			[
+				'Readonly property RedeclareReadonlyProperty\B1::$myProp is already assigned.',
+				16,
+			],
+			[
+				'Readonly property RedeclareReadonlyProperty\B5::$myProp is already assigned.',
+				50,
+			],
+			[
+				'Readonly property RedeclareReadonlyProperty\B7::$myProp is already assigned.',
+				70,
+			],
+			[
+				'Readonly property class@anonymous/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php:117::$myProp is already assigned.',
+				121,
+			],
+		]);
+	}
+
+	public function testRedeclaredPropertiesOfReadonlyClass(): void
+	{
+		if (PHP_VERSION_ID < 80200) {
+			$this->markTestSkipped('Test requires PHP 8.2.');
+		}
+
+		$this->analyse([__DIR__ . '/data/redeclare-property-of-readonly-class.php'], [
+			[
+				'Readonly property RedeclarePropertyOfReadonlyClass\B1::$promotedProp is already assigned.',
+				15,
+			],
+		]);
+	}
+
+	public function testBug8101(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-8101.php'], [
+			[
+				'Readonly property Bug8101\B::$myProp is already assigned.',
+				12,
+			],
+		]);
+	}
+
+	public function testBug9863(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9863.php'], [
+			[
+				'Readonly property Bug9863\ReadonlyChildWithoutIsset::$foo is already assigned.',
+				17,
+			],
+			[
+				'Class Bug9863\ReadonlyParentWithIsset has an uninitialized readonly property $foo. Assign it in the constructor.',
+				23,
+			],
+			[
+				'Access to an uninitialized readonly property Bug9863\ReadonlyParentWithIsset::$foo.',
+				28,
+			],
+		]);
+	}
+
+	public function testBug9864(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9864.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -310,6 +310,18 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 				'Readonly property class@anonymous/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php:117::$myProp is already assigned.',
 				121,
 			],
+			[
+				'Class RedeclareReadonlyProperty\B16 has an uninitialized readonly property $myProp. Assign it in the constructor.',
+				195,
+			],
+			[
+				'Class RedeclareReadonlyProperty\C17 has an uninitialized readonly property $aProp. Assign it in the constructor.',
+				218,
+			],
+			[
+				'Class RedeclareReadonlyProperty\B18 has an uninitialized readonly property $aProp. Assign it in the constructor.',
+				233,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/UninitializedPropertyRuleTest.php
@@ -202,4 +202,18 @@ class UninitializedPropertyRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRedeclareReadonlyProperties(): void
+	{
+		$this->analyse([__DIR__ . '/data/redeclare-readonly-property.php'], [
+			[
+				'Class RedeclareReadonlyProperty\B19 has an uninitialized property $prop2. Give it default value or assign it in the constructor.',
+				249,
+			],
+			[
+				'Access to an uninitialized property RedeclareReadonlyProperty\B19::$prop2.',
+				260,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-8101.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8101.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug8101;
+
+class A {
+	public function __construct(public readonly int $myProp) {}
+}
+
+class B extends A {
+	// This should be reported as an error, as a readonly prop cannot be redeclared.
+	public function __construct(public readonly int $myProp) {
+		parent::__construct($myProp);
+	}
+}
+
+$foo = new B(7);

--- a/tests/PHPStan/Rules/Properties/data/bug-9863.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-9863.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug9863;
+
+class ReadonlyParentWithoutIsset
+{
+	public function __construct(
+		public readonly int $foo
+	) {}
+}
+
+class ReadonlyChildWithoutIsset extends ReadonlyParentWithoutIsset
+{
+	public function __construct(
+		public readonly int $foo = 42
+	) {
+		parent::__construct($foo);
+	}
+}
+
+class ReadonlyParentWithIsset
+{
+	public readonly int $foo;
+
+	public function __construct(
+		int $foo
+	) {
+		if (! isset($this->foo)) {
+			$this->foo = $foo;
+		}
+	}
+}
+
+class ReadonlyChildWithIsset extends ReadonlyParentWithIsset
+{
+	public function __construct(
+		public readonly int $foo = 42
+	) {
+		parent::__construct($foo);
+	}
+}
+
+$a = new ReadonlyParentWithoutIsset(0);
+$b = new ReadonlyChildWithoutIsset();
+$c = new ReadonlyChildWithoutIsset(1);
+
+$x = new ReadonlyParentWithIsset(2);
+$y = new ReadonlyChildWithIsset();
+$z = new ReadonlyChildWithIsset(3);

--- a/tests/PHPStan/Rules/Properties/data/bug-9864.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-9864.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1); // lint >= 8.2
+
+namespace Bug9864;
+
+readonly abstract class UuidValueObject
+{
+	public function __construct(public string $value)
+	{
+		$this->ensureIsValidUuid($value);
+	}
+
+	private function ensureIsValidUuid(string $value): void
+	{
+	}
+}
+
+
+final readonly class ProductId extends UuidValueObject
+{
+	public string $value;
+
+	public function __construct(
+		string $value
+	) {
+		parent::__construct($value);
+	}
+}
+
+var_dump(new ProductId('test'));
+
+// property is assigned on parent class, no need to reassing, specially for readonly properties

--- a/tests/PHPStan/Rules/Properties/data/redeclare-property-of-readonly-class.php
+++ b/tests/PHPStan/Rules/Properties/data/redeclare-property-of-readonly-class.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1); // lint >= 8.2
+
+namespace RedeclarePropertyOfReadonlyClass;
+
+readonly class A {
+	public function __construct(public int $promotedProp)
+	{
+	}
+}
+
+readonly class B1 extends A {
+	// $promotedProp is written twice
+	public function __construct(public int $promotedProp)
+	{
+		parent::__construct(5);
+	}
+}
+
+readonly class B2 extends A {
+	// Don't get confused by standard parameter with same name
+	public function __construct(int $promotedProp)
+	{
+		parent::__construct($promotedProp);
+	}
+}
+
+readonly class B3 extends A {
+	// This is allowed, because we don't write to the property.
+	public int $promotedProp;
+
+	public function __construct()
+	{
+		parent::__construct(7);
+	}
+}
+
+readonly class B4 extends A {
+	// The second write is not from the constructor. It is an error, but it is handled by different rule.
+	public int $promotedProp;
+
+	public function __construct()
+	{
+		parent::__construct(7);
+	}
+
+	public function set(): void
+	{
+		$this->promotedProp = 7;
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php
+++ b/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace RedeclareReadonlyProperty;
+
+class A {
+	protected readonly string $nonPromotedProp;
+
+	public function __construct(public readonly int $myProp) {
+		$this->nonPromotedProp = 'aaa';
+	}
+}
+
+class B1 extends A {
+	// This should be reported as an error, as a readonly prop cannot be redeclared.
+	public function __construct(public readonly int $myProp) {
+		parent::__construct($myProp);
+	}
+}
+
+class B2 extends A {
+	// different property
+	public function __construct(public readonly int $foo) {
+		parent::__construct($foo);
+	}
+}
+
+class B3 extends A {
+	// We don't call the parent constructor, so it's fine.
+	public function __construct(public readonly int $myProp) {
+	}
+}
+
+class B4 extends A {
+	protected readonly string
+		$foo,
+		// We can't detect this at the moment.
+		$nonPromotedProp;
+	public function __construct() {
+		$this->foo = 'xyz';
+		$this->nonPromotedProp = 'bbb';
+		parent::__construct(5);
+	}
+}
+
+class B5 extends A {
+	// Error: we can't both write the property ourselves and call the parent constructor.
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 7;
+		parent::__construct(5);
+	}
+}
+
+class B6 extends A {
+	// This is fine - we don't call parent constructor;
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+	}
+}
+
+class B7 extends A {
+	// Call parent constructor indirectly.
+	public function __construct(public readonly int $myProp) {
+		$this->foo();
+	}
+
+	private function foo(): void
+	{
+		A::__construct(5);
+	}
+}
+
+class B8 extends A {
+	// Don't get confused by prop declaration in anonymous class.
+	public function __construct() {
+		parent::__construct(5);
+		$c = new class {
+			public function __construct(public readonly int $myProp)
+			{
+			}
+		};
+	}
+}
+
+class B9 extends A {
+	// Don't get confused by constructor call in anonymous class
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+		$c = new class extends A {
+			public function __construct()
+			{
+				parent::__construct(5);
+			}
+		};
+	}
+}
+
+class B10 extends A {
+	// Don't get confused by promoted properties in anonymous class
+	public function __construct() {
+		parent::__construct(5);
+		$c = new class (5) {
+			public function __construct(public readonly int $myProp)
+			{
+			}
+		};
+	}
+}
+
+class B11 extends A {
+	// This is fine - we don't call the parent constructor.
+	public readonly int $myProp;
+	public function __construct() {
+		$this->myProp = 5;
+		$c = new class ('aaa') extends A {
+			// Detect redeclaration even inside anonymous classes.
+			public function __construct(public readonly int $myProp)
+			{
+				parent::__construct(5);
+			}
+		};
+	}
+}
+
+class A12 {
+	public function __construct(public readonly int $aProp)
+	{
+	}
+}
+
+class B12 extends A12 {
+	public function __construct(public readonly int $bProp)
+	{
+		parent::__construct(15);
+	}
+}
+
+class C12 extends B12 {
+	// This is OK, because we call A12's constructor, not B12's.
+	public function __construct(public readonly int $bProp) {
+		A12::__construct(15);
+	}
+}
+
+class B12_1 extends A12 {
+	public function __construct(public readonly int $bProp)
+	{
+		parent::__construct(15);
+	}
+}
+
+class C12_1 extends B12_1 {
+	// This is an error, but we can't detect it at the moment.
+	public function __construct(public readonly int $aProp) {
+		parent::__construct(15);
+	}
+}
+
+class A13 {
+	public function __construct(private readonly int $privateProp)
+	{
+	}
+}
+
+class B13 extends A13 {
+	// This is OK, A's prop is private
+	public function __construct(public readonly int $privateProp)
+	{
+		parent::__construct(15);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php
+++ b/tests/PHPStan/Rules/Properties/data/redeclare-readonly-property.php
@@ -171,3 +171,92 @@ class B13 extends A13 {
 		parent::__construct(15);
 	}
 }
+
+class B14 {
+	public function __construct(public readonly int $myProp) {
+		// Don't get confused by same property in non-parent's constructor.
+		A::__construct(7);
+	}
+}
+
+class B15 extends A {
+	public function __construct(public readonly int $myProp) {
+		self:foo();
+	}
+
+	public static function foo(): void
+	{
+		// Don't get confused by calling the parent constructor from static scope.
+		parent::__construct(7);
+	}
+}
+
+class B16 extends A {
+	public readonly int $myProp;
+
+	public function __construct(A $other) {
+		// Don't get confused by calling the constructor on other object.
+		$other::__construct(7);
+		$other->__construct(7);
+	}
+}
+
+class A17 {
+	public function __construct(public readonly int $aProp)
+	{
+	}
+}
+
+class B17 extends A17 {
+	public function __construct()
+	{
+	}
+}
+
+class C17 extends B17 {
+	// Error: $aProp may be unassigned, because B's constructor may not call A's
+	public readonly int $aProp;
+
+	public function __construct() {
+		parent::__construct();
+	}
+}
+
+class A18 {
+	public function __construct(private readonly int $aProp)
+	{
+	}
+}
+
+class B18 extends A18 {
+	// Make surer that we don't get confused by parent's private property.
+	public readonly int $aProp;
+
+	public function __construct()
+	{
+		parent::__construct(7);
+	}
+}
+
+class A19 {
+	public function __construct(public int $prop1, public int $prop2)
+	{
+	}
+}
+
+class B19 extends A19 {
+	public int $prop1;
+	public int $prop2;
+
+	public function __construct()
+	{
+		if (rand()) {
+			parent::__construct(5, 6);
+		} else {
+			$this->prop1 = 7;
+		}
+
+		// Error: this may not be assigned
+		var_dump($this->prop2);
+	}
+}


### PR DESCRIPTION
This is a relaxed (and reimplemented) version of the rule from: https://github.com/phpstan/phpstan-src/pull/3041#issuecomment-2094153967

> Considering this example: https://phpstan.org/r/cf781e9e-cfdd-4aae-855d-ead64bf16afa - if (a subclass redeclares readonly property in promoted fashion OR assigns the redeclared readonly property) AND calls parent constructor AND parent constructor declares the readonly property in promoted fashion, then we should always report an error. This can be achieved with local analysis only, without performance impact. PHPStan should see that as duplicate assignment with existing rules in place. So MissingReadOnlyPropertyAssignRule should report "is already assigned" just by modifying the data that is fed into it.

Fixes https://github.com/phpstan/phpstan/issues/8101
Fixes https://github.com/phpstan/phpstan/issues/9863
Fixes https://github.com/phpstan/phpstan/issues/9864