### PR TITLE
Introduce `new` type

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -80,6 +80,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NewObjectType;
 use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\NonexistentParentClassType;
 use PHPStan\Type\NullType;
@@ -753,6 +754,13 @@ class TypeNodeResolver
 				}
 
 				return TypeCombinator::union(...$result);
+			}
+
+			return new ErrorType();
+		} elseif ($mainTypeName === 'new') {
+			if (count($genericTypes) === 1) {
+				$type = new NewObjectType($genericTypes[0]);
+				return $type->isResolvable() ? $type->resolve() : $type;
 			}
 
 			return new ErrorType();

--- a/src/Type/NewObjectType.php
+++ b/src/Type/NewObjectType.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\LateResolvableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
+use function sprintf;
+
+/** @api */
+class NewObjectType implements CompoundType, LateResolvableType
+{
+
+	use LateResolvableTypeTrait;
+	use NonGeneralizableTypeTrait;
+
+	public function __construct(private Type $type)
+	{
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
+	}
+
+	public function getReferencedClasses(): array
+	{
+		return $this->type->getReferencedClasses();
+	}
+
+	public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+	{
+		return $this->type->getReferencedTemplateTypes($positionVariance);
+	}
+
+	public function equals(Type $type): bool
+	{
+		return $type instanceof self
+			&& $this->type->equals($type->type);
+	}
+
+	public function describe(VerbosityLevel $level): string
+	{
+		return sprintf('new<%s>', $this->type->describe($level));
+	}
+
+	public function isResolvable(): bool
+	{
+		return !TypeUtils::containsTemplateType($this->type);
+	}
+
+	protected function getResult(): Type
+	{
+		return $this->type->getObjectTypeOrClassStringObjectType();
+	}
+
+	/**
+	 * @param callable(Type): Type $cb
+	 */
+	public function traverse(callable $cb): Type
+	{
+		$type = $cb($this->type);
+
+		if ($this->type === $type) {
+			return $this;
+		}
+
+		return new self($type);
+	}
+
+	public function traverseSimultaneously(Type $right, callable $cb): Type
+	{
+		if (!$right instanceof self) {
+			return $this;
+		}
+
+		$type = $cb($this->type, $right->type);
+
+		if ($this->type === $type) {
+			return $this;
+		}
+
+		return new self($type);
+	}
+
+	public function toPhpDocNode(): TypeNode
+	{
+		return new GenericTypeNode(new IdentifierTypeNode('new'), [$this->type->toPhpDocNode()]);
+	}
+
+	/**
+	 * @param mixed[] $properties
+	 */
+	public static function __set_state(array $properties): Type
+	{
+		return new self(
+			$properties['type'],
+		);
+	}
+
+}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -773,6 +773,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4357.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10863.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5817.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-9704.php');
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/array-chunk.php');
 		if (PHP_VERSION_ID >= 80000) {

--- a/tests/PHPStan/Analyser/data/bug-9704.php
+++ b/tests/PHPStan/Analyser/data/bug-9704.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Bug9704;
+
+use DateTime;
+use DateTimeImmutable;
+use function PHPStan\dumpType;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	/**
+	 * @var array<string, class-string>
+	 */
+	private const TYPES = [
+		'foo' => DateTime::class,
+		'bar' => DateTimeImmutable::class,
+	];
+
+	/**
+	 * @template M of self::TYPES
+	 * @template T of key-of<M>
+	 * @param T $type
+	 *
+	 * @return new<M[T]>
+	 */
+	public static function get(string $type) : object
+	{
+		$class = self::TYPES[$type];
+
+		return new $class('now');
+	}
+
+	/**
+	 * @template T of key-of<self::TYPES>
+	 * @param T $type
+	 *
+	 * @return new<self::TYPES[T]>
+	 */
+	public static function get2(string $type) : object
+	{
+		$class = self::TYPES[$type];
+
+		return new $class('now');
+	}
+}
+
+assertType(DateTime::class, Foo::get('foo'));
+assertType(DateTimeImmutable::class, Foo::get('bar'));
+
+assertType(DateTime::class, Foo::get2('foo'));
+assertType(DateTimeImmutable::class, Foo::get2('bar'));
+
+


### PR DESCRIPTION
This makes it possible that a new instance of a class-string will be returned.

```php
/**
 * @var array<string, class-string>
 */
private const TYPES = [
	'foo' => DateTime::class,
	'bar' => DateTimeImmutable::class,
];

/**
 * @template T of key-of<self::TYPES>
 * @param T $type
 *
 * @return new<self::TYPES[T]>
 */
public static function get(string $type) : ?object
{
	$class = self::TYPES[$type];
	return new $class('now');
}
```

See https://github.com/phpstan/phpstan/issues/9704

The work was [done](https://github.com/phpstan/phpstan/issues/9704#issuecomment-2093128708) by @rvanvelzen in a gist. I just created the PR for it.