### PR TITLE
fix: stdClass is not a universal base class

### DIFF
--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -14,10 +14,9 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ConstantTypeHelper;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use stdClass;
 use function is_bool;
 use function json_decode;
 
@@ -87,7 +86,7 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 		}
 
 		if ($isArrayWithoutStdClass) {
-			return TypeCombinator::remove($fallbackType, new ObjectType(stdClass::class));
+			return TypeCombinator::remove($fallbackType, new ObjectWithoutClassType());
 		}
 
 		return $fallbackType;

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -75,17 +75,17 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 	private function narrowTypeForJsonDecode(FuncCall $funcCall, Scope $scope, Type $fallbackType): Type
 	{
 		$args = $funcCall->getArgs();
-		$isArrayWithoutStdClass = $this->isForceArrayWithoutStdClass($funcCall, $scope);
+		$isForceArray = $this->isForceArray($funcCall, $scope);
 		if (!isset($args[0])) {
 			return $fallbackType;
 		}
 
 		$firstValueType = $scope->getType($args[0]->value);
 		if ($firstValueType instanceof ConstantStringType) {
-			return $this->resolveConstantStringType($firstValueType, $isArrayWithoutStdClass);
+			return $this->resolveConstantStringType($firstValueType, $isForceArray);
 		}
 
-		if ($isArrayWithoutStdClass) {
+		if ($isForceArray) {
 			return TypeCombinator::remove($fallbackType, new ObjectWithoutClassType());
 		}
 
@@ -95,7 +95,7 @@ class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionRetur
 	/**
 	 * Is "json_decode(..., true)"?
 	 */
-	private function isForceArrayWithoutStdClass(FuncCall $funcCall, Scope $scope): bool
+	private function isForceArray(FuncCall $funcCall, Scope $scope): bool
 	{
 		$args = $funcCall->getArgs();
 		if (!isset($args[1])) {

--- a/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/json_object_as_array.php
@@ -7,19 +7,19 @@ use function PHPStan\Testing\assertType;
 // @see https://3v4l.org/YFlHF
 function ($mixed) {
 	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY);
-	assertType('mixed~stdClass', $value);
+	assertType('mixed~object', $value);
 };
 
 function ($mixed) {
 	$flagsAsVariable = JSON_OBJECT_AS_ARRAY;
 
 	$value = json_decode($mixed, null, 512, $flagsAsVariable);
-	assertType('mixed~stdClass', $value);
+	assertType('mixed~object', $value);
 };
 
 function ($mixed) {
 	$value = json_decode($mixed, null, 512, JSON_OBJECT_AS_ARRAY | JSON_BIGINT_AS_STRING);
-	assertType('mixed~stdClass', $value);
+	assertType('mixed~object', $value);
 };
 
 function ($mixed) {

--- a/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
+++ b/tests/PHPStan/Analyser/data/json-decode/narrow_type_with_force_array.php
@@ -24,5 +24,5 @@ assertType('array{1, 2, 3}', $value);
 
 function ($mixed) {
 	$value = json_decode($mixed, true);
-	assertType('mixed~stdClass', $value);
+	assertType('mixed~object', $value);
 };


### PR DESCRIPTION
https://www.php.net/manual/en/class.stdclass.php

I think we can subtract more than `stdClass` on json_decode when force associative array option is enabled.