### PR TITLE
Improve type for predefined constant

### DIFF
--- a/src/Analyser/ConstantResolver.php
+++ b/src/Analyser/ConstantResolver.php
@@ -6,7 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Reflection\NamespaceAnswerer;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\ReflectionProvider\ReflectionProviderProvider;
-use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -73,7 +73,7 @@ class ConstantResolver
 		if ($resolvedConstantName === 'PHP_VERSION') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_MAJOR_VERSION') {
@@ -106,7 +106,7 @@ class ConstantResolver
 		if ($resolvedConstantName === 'PHP_OS') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_OS_FAMILY') {
@@ -132,7 +132,7 @@ class ConstantResolver
 				new ConstantStringType('phpdbg'),
 				new IntersectionType([
 					new StringType(),
-					new AccessoryNonEmptyStringType(),
+					new AccessoryNonFalsyStringType(),
 				]),
 			]);
 		}
@@ -165,61 +165,61 @@ class ConstantResolver
 		if ($resolvedConstantName === 'PHP_EXTENSION_DIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_PREFIX') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_BINDIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_BINARY') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_MANDIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_LIBDIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_DATADIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_SYSCONFDIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_LOCALSTATEDIR') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_CONFIG_FILE_PATH') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		if ($resolvedConstantName === 'PHP_SHLIB_SUFFIX') {
@@ -232,7 +232,7 @@ class ConstantResolver
 			return IntegerRangeType::fromInterval(1, null);
 		}
 		if ($resolvedConstantName === '__COMPILER_HALT_OFFSET__') {
-			return IntegerRangeType::fromInterval(0, null);
+			return IntegerRangeType::fromInterval(1, null);
 		}
 		// core other, https://www.php.net/manual/en/info.constants.php
 		if ($resolvedConstantName === 'PHP_WINDOWS_VERSION_MAJOR') {
@@ -261,7 +261,7 @@ class ConstantResolver
 		if ($resolvedConstantName === 'ICONV_IMPL') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		// libxml, https://www.php.net/manual/en/libxml.constants.php
@@ -271,7 +271,7 @@ class ConstantResolver
 		if ($resolvedConstantName === 'LIBXML_DOTTED_VERSION') {
 			return new IntersectionType([
 				new StringType(),
-				new AccessoryNonEmptyStringType(),
+				new AccessoryNonFalsyStringType(),
 			]);
 		}
 		// openssl, https://www.php.net/manual/en/openssl.constants.php

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -245,7 +245,7 @@ class ScopeTest extends PHPStanTestCase
 		$scope = $scopeFactory->create(ScopeContext::create(__DIR__ . '/data/compiler-halt-offset.php'));
 		$node = new ConstFetch(new FullyQualified('__COMPILER_HALT_OFFSET__'));
 		$type = $scope->getType($node);
-		$this->assertSame('int<0, max>', $type->describe(VerbosityLevel::precise()));
+		$this->assertSame('int<1, max>', $type->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/predefined-constants.php
+++ b/tests/PHPStan/Analyser/data/predefined-constants.php
@@ -3,7 +3,7 @@
 use function PHPStan\Testing\assertType;
 
 // core, https://www.php.net/manual/en/reserved.constants.php
-assertType('non-empty-string', PHP_VERSION);
+assertType('non-falsy-string', PHP_VERSION);
 assertType('int<5, max>', PHP_MAJOR_VERSION);
 assertType('int<0, max>', PHP_MINOR_VERSION);
 assertType('int<0, max>', PHP_RELEASE_VERSION);
@@ -12,23 +12,23 @@ assertType('string', PHP_EXTRA_VERSION);
 assertType('0|1', PHP_ZTS);
 assertType('0|1', PHP_DEBUG);
 assertType('int<1, max>', PHP_MAXPATHLEN);
-assertType('non-empty-string', PHP_OS);
-assertType('\'apache\'|\'apache2handler\'|\'cgi\'|\'cli\'|\'cli-server\'|\'embed\'|\'fpm-fcgi\'|\'litespeed\'|\'phpdbg\'|non-empty-string', PHP_SAPI);
+assertType('non-falsy-string', PHP_OS);
+assertType('\'apache\'|\'apache2handler\'|\'cgi\'|\'cli\'|\'cli-server\'|\'embed\'|\'fpm-fcgi\'|\'litespeed\'|\'phpdbg\'|non-falsy-string', PHP_SAPI);
 assertType('"\n"|"\r\n"', PHP_EOL);
 assertType('4|8', PHP_INT_SIZE);
 assertType('string', DEFAULT_INCLUDE_PATH);
 assertType('string', PEAR_INSTALL_DIR);
 assertType('string', PEAR_EXTENSION_DIR);
-assertType('non-empty-string', PHP_EXTENSION_DIR);
-assertType('non-empty-string', PHP_PREFIX);
-assertType('non-empty-string', PHP_BINDIR);
-assertType('non-empty-string', PHP_BINARY);
-assertType('non-empty-string', PHP_MANDIR);
-assertType('non-empty-string', PHP_LIBDIR);
-assertType('non-empty-string', PHP_DATADIR);
-assertType('non-empty-string', PHP_SYSCONFDIR);
-assertType('non-empty-string', PHP_LOCALSTATEDIR);
-assertType('non-empty-string', PHP_CONFIG_FILE_PATH);
+assertType('non-falsy-string', PHP_EXTENSION_DIR);
+assertType('non-falsy-string', PHP_PREFIX);
+assertType('non-falsy-string', PHP_BINDIR);
+assertType('non-falsy-string', PHP_BINARY);
+assertType('non-falsy-string', PHP_MANDIR);
+assertType('non-falsy-string', PHP_LIBDIR);
+assertType('non-falsy-string', PHP_DATADIR);
+assertType('non-falsy-string', PHP_SYSCONFDIR);
+assertType('non-falsy-string', PHP_LOCALSTATEDIR);
+assertType('non-falsy-string', PHP_CONFIG_FILE_PATH);
 assertType('string', PHP_CONFIG_FILE_SCAN_DIR);
 assertType('\'dll\'|\'so\'', PHP_SHLIB_SUFFIX);
 assertType('1', E_ERROR);
@@ -47,7 +47,7 @@ assertType('8192', E_DEPRECATED);
 assertType('16384', E_USER_DEPRECATED);
 assertType('32767', E_ALL);
 assertType('2048', E_STRICT);
-assertType('int<0, max>', __COMPILER_HALT_OFFSET__);
+assertType('int<1, max>', __COMPILER_HALT_OFFSET__);
 assertType('true', true);
 assertType('false', false);
 assertType('null', null);
@@ -62,11 +62,11 @@ assertType('\'/\'|\'\\\\\'', DIRECTORY_SEPARATOR);
 assertType('\':\'|\';\'', PATH_SEPARATOR);
 
 // iconv, https://www.php.net/manual/en/iconv.constants.php
-assertType('non-empty-string', ICONV_IMPL);
+assertType('non-falsy-string', ICONV_IMPL);
 
 // libxml, https://www.php.net/manual/en/libxml.constants.php
 assertType('int<1, max>', LIBXML_VERSION);
-assertType('non-empty-string', LIBXML_DOTTED_VERSION);
+assertType('non-falsy-string', LIBXML_DOTTED_VERSION);
 
 // openssl, https://www.php.net/manual/en/openssl.constants.php
 assertType('int<1, max>', OPENSSL_VERSION_NUMBER);


### PR DESCRIPTION
All these constants are strings that are neither `''` nor `'0'` and are replaced by `AccessoryNonFalsyStringType`.