### PR TITLE
Fixes bug 10980

### DIFF
--- a/tests/PHPStan/Analyser/Bug10980Test.php
+++ b/tests/PHPStan/Analyser/Bug10980Test.php
@@ -24,5 +24,5 @@ class Bug10980Test extends TypeInferenceTestCase
 	{
 		$this->assertFileAsserts($assertType, $file, ...$args);
 	}
-	
+
 }

--- a/tests/PHPStan/Analyser/Bug10980Test.php
+++ b/tests/PHPStan/Analyser/Bug10980Test.php
@@ -6,6 +6,7 @@ use PHPStan\Testing\TypeInferenceTestCase;
 
 class Bug10980Test extends TypeInferenceTestCase
 {
+
 	public function dataFileAsserts(): iterable
 	{
 		yield from self::gatherAssertTypes(__DIR__ . '/data/bug-10980.php');
@@ -23,4 +24,5 @@ class Bug10980Test extends TypeInferenceTestCase
 	{
 		$this->assertFileAsserts($assertType, $file, ...$args);
 	}
+	
 }

--- a/tests/PHPStan/Analyser/Bug10980Test.php
+++ b/tests/PHPStan/Analyser/Bug10980Test.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class Bug10980Test extends TypeInferenceTestCase
+{
+	public function dataFileAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/bug-10980.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+}

--- a/tests/PHPStan/Analyser/data/bug-10980.php
+++ b/tests/PHPStan/Analyser/data/bug-10980.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug10980;
+
+use function PHPStan\Testing\assertType;
+
+class A {}
+
+class B extends A {}
+
+function a(): A {}
+
+while (true) {
+	$type = a();
+	if (!$type instanceof B) {
+		continue;
+	}
+	break;
+}
+
+assertType('Bug10980\B', $type);


### PR DESCRIPTION
When while loop condition is a `while(true)`, the `continue` exit points are never used, and shouldn't be calculated in the final result.

Fixes [#phpstan/phpstan/10980](https://github.com/phpstan/phpstan/issues/10980)
