### PR TITLE
Lazy create ClassReflection in enum-cases

### DIFF
--- a/src/Type/Enum/EnumCaseObjectType.php
+++ b/src/Type/Enum/EnumCaseObjectType.php
@@ -79,7 +79,7 @@ class EnumCaseObjectType extends ObjectType
 			return $type->isSubTypeOf($this);
 		}
 
-		$parent = new parent($this->getClassName(), $this->getSubtractedType());
+		$parent = new parent($this->getClassName(), $this->getSubtractedType(), $this->getClassReflectionOrNull());
 
 		return $parent->isSuperTypeOf($type)->and(TrinaryLogic::createMaybe());
 	}
@@ -165,7 +165,7 @@ class EnumCaseObjectType extends ObjectType
 
 	public function generalize(GeneralizePrecision $precision): Type
 	{
-		return new parent($this->getClassName());
+		return new parent($this->getClassName(), null, $this->getClassReflectionOrNull());
 	}
 
 	public function isSmallerThan(Type $otherType): TrinaryLogic

--- a/src/Type/Enum/EnumCaseObjectType.php
+++ b/src/Type/Enum/EnumCaseObjectType.php
@@ -165,7 +165,7 @@ class EnumCaseObjectType extends ObjectType
 
 	public function generalize(GeneralizePrecision $precision): Type
 	{
-		return new parent($this->getClassName(), null, $this->getClassReflection());
+		return new parent($this->getClassName());
 	}
 
 	public function isSmallerThan(Type $otherType): TrinaryLogic

--- a/src/Type/Enum/EnumCaseObjectType.php
+++ b/src/Type/Enum/EnumCaseObjectType.php
@@ -79,7 +79,7 @@ class EnumCaseObjectType extends ObjectType
 			return $type->isSubTypeOf($this);
 		}
 
-		$parent = new parent($this->getClassName(), $this->getSubtractedType(), $this->getClassReflection());
+		$parent = new parent($this->getClassName(), $this->getSubtractedType());
 
 		return $parent->isSuperTypeOf($type)->and(TrinaryLogic::createMaybe());
 	}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1479,6 +1479,11 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		return $classReflection;
 	}
 
+	protected function getClassReflectionOrNull(): ?ClassReflection
+	{
+		return $this->classReflection;
+	}
+
 	/**
 	 * @return self|null
 	 */


### PR DESCRIPTION
the enum-case object will lazy create the class-reflection when used the first time.
in our slow repro case this means we don't need to create class-reflection for millions of objects over and over, since we are only check `isSuperTypeOf`.

refs https://github.com/phpstan/phpstan/issues/10979

before this PR

```
time php bin/phpstan analyze --debug LibraryMasterEnum.php  
23.83s user 0.15s system 99% cpu 24.065 total
```

after this PR:

```
time php bin/phpstan analyze --debug LibraryMasterEnum.php  
17.21s user 0.16s system 98% cpu 17.610 total
```

not perfect yet, but still good progress