### PR TITLE
Enum-case comparison: cheap checks first

### DIFF
--- a/src/Type/Enum/EnumCaseObjectType.php
+++ b/src/Type/Enum/EnumCaseObjectType.php
@@ -53,8 +53,8 @@ class EnumCaseObjectType extends ObjectType
 			return false;
 		}
 
-		return $this->getClassName() === $type->getClassName()
-			&& $this->enumCaseName === $type->enumCaseName;
+		return $this->enumCaseName === $type->enumCaseName &&
+			$this->getClassName() === $type->getClassName();
 	}
 
 	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
@@ -71,8 +71,7 @@ class EnumCaseObjectType extends ObjectType
 	{
 		if ($type instanceof self) {
 			return TrinaryLogic::createFromBoolean(
-				$this->getClassName() === $type->getClassName()
-				&& $this->enumCaseName === $type->enumCaseName,
+				$this->enumCaseName === $type->enumCaseName && $this->getClassName() === $type->getClassName(),
 			);
 		}
 


### PR DESCRIPTION
calls to `getClassName()` show up in the profile of the https://github.com/phpstan/phpstan/issues/10979 repro.

<img width="425" alt="grafik" src="https://github.com/phpstan/phpstan-src/assets/120441/e0bca8f5-1367-47d5-9b59-c13ef448ec49">

not super important but an easy low hanging fruit