### PR TITLE
NULL and null as a property default value are treated differently when overriding a parent property

### DIFF
--- a/src/Rules/Properties/DefaultValueTypesAssignedToPropertiesRule.php
+++ b/src/Rules/Properties/DefaultValueTypesAssignedToPropertiesRule.php
@@ -39,7 +39,7 @@ class DefaultValueTypesAssignedToPropertiesRule implements Rule
 		$propertyReflection = $classReflection->getNativeProperty($node->getName());
 		$propertyType = $propertyReflection->getWritableType();
 		if ($propertyReflection->getNativeType() instanceof MixedType) {
-			if ($default instanceof Node\Expr\ConstFetch && (string) $default->name === 'null') {
+			if ($default instanceof Node\Expr\ConstFetch && $default->name->toLowerString() === 'null') {
 				return [];
 			}
 		}

--- a/tests/PHPStan/Rules/Properties/DefaultValueTypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/DefaultValueTypesAssignedToPropertiesRuleTest.php
@@ -64,4 +64,9 @@ class DefaultValueTypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7933.php'], []);
 	}
 
+	public function testBug10987(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10987.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-10987.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-10987.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug10987;
+
+class Base
+{
+	/** @var string */
+	public $layout;
+}
+
+class A extends Base
+{
+	public $layout = null;
+}
+
+class B extends Base
+{
+	public $layout = NULL;
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/10987

I looked thru the codebase but could not see any other occurence with the same problem