### PR TITLE
Fix parent-keyword case-sensitivity

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2484,7 +2484,8 @@ class MutatingScope implements Scope
 	{
 		$originalClass = (string) $name;
 		if ($this->isInClass()) {
-			if (in_array(strtolower($originalClass), [
+			$lowerClass = strtolower($originalClass);
+			if (in_array($lowerClass, [
 				'self',
 				'static',
 			], true)) {
@@ -2492,7 +2493,7 @@ class MutatingScope implements Scope
 					return $this->inClosureBindScopeClasses[0];
 				}
 				return $this->getClassReflection()->getName();
-			} elseif ($originalClass === 'parent') {
+			} elseif ($lowerClass === 'parent') {
 				$currentClassReflection = $this->getClassReflection();
 				if ($currentClassReflection->getParentClass() !== null) {
 					return $currentClassReflection->getParentClass()->getName();

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1791,7 +1791,7 @@ class InitializerExprTypeResolver
 			}
 			if (in_array(strtolower($constantClass), $namesToResolve, true)) {
 				$resolvedName = $this->resolveName($class, $classReflection);
-				if ($resolvedName === 'parent' && strtolower($constantName) === 'class') {
+				if (strtolower($resolvedName) === 'parent' && strtolower($constantName) === 'class') {
 					return new ClassStringType();
 				}
 				$constantClassType = $this->resolveTypeByName($class, $classReflection);

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -2024,12 +2024,14 @@ class InitializerExprTypeResolver
 	{
 		$originalClass = (string) $name;
 		if ($classReflection !== null) {
-			if (in_array(strtolower($originalClass), [
+			$lowerClass = strtolower($originalClass);
+
+			if (in_array($lowerClass, [
 				'self',
 				'static',
 			], true)) {
 				return $classReflection->getName();
-			} elseif ($originalClass === 'parent') {
+			} elseif ($lowerClass === 'parent') {
 				if ($classReflection->getParentClass() !== null) {
 					return $classReflection->getParentClass()->getName();
 				}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1478,6 +1478,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10834.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10952.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10952b.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/case-insensitive-parent.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10893.php');
 	}
 

--- a/tests/PHPStan/Analyser/data/case-insensitive-parent.php
+++ b/tests/PHPStan/Analyser/data/case-insensitive-parent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CaseInsensitiveParent;
+
+use function PHPStan\Testing\assertType;
+
+class A {
+	public function doFoo():string {
+		return "hello";
+	}
+
+}
+
+class B extends A {
+	public function doFoo():string {
+		assertType('string', PARENT::doFoo());
+		assertType('string', parent::doFoo());
+
+		return PARENT::doFoo();
+	}
+}

--- a/tests/PHPStan/Analyser/data/case-insensitive-parent.php
+++ b/tests/PHPStan/Analyser/data/case-insensitive-parent.php
@@ -16,8 +16,15 @@ class B extends A {
 		assertType('string', PARENT::doFoo());
 		assertType('string', parent::doFoo());
 
-		assertType('class-string', PARENT::class);
+		assertType("'CaseInsensitiveParent\\\\A'", PARENT::class);
 
 		return PARENT::doFoo();
 	}
+}
+
+class C extends UnknownParent {
+	public function doFoo():string {
+		assertType('class-string', PARENT::class);
+	}
+
 }

--- a/tests/PHPStan/Analyser/data/case-insensitive-parent.php
+++ b/tests/PHPStan/Analyser/data/case-insensitive-parent.php
@@ -16,6 +16,8 @@ class B extends A {
 		assertType('string', PARENT::doFoo());
 		assertType('string', parent::doFoo());
 
+		assertType('class-string', PARENT::class);
+
 		return PARENT::doFoo();
 	}
 }

--- a/tests/PHPStan/Analyser/data/case-insensitive-parent.php
+++ b/tests/PHPStan/Analyser/data/case-insensitive-parent.php
@@ -5,6 +5,8 @@ namespace CaseInsensitiveParent;
 use function PHPStan\Testing\assertType;
 
 class A {
+	const myConst = '1';
+
 	public function doFoo():string {
 		return "hello";
 	}
@@ -15,6 +17,9 @@ class B extends A {
 	public function doFoo():string {
 		assertType('string', PARENT::doFoo());
 		assertType('string', parent::doFoo());
+
+		assertType("'1'", PARENT::myConst);
+		assertType("'1'", parent::myConst);
 
 		assertType("'CaseInsensitiveParent\\\\A'", PARENT::class);
 


### PR DESCRIPTION
similar to https://github.com/phpstan/phpstan-src/pull/3063 but for the `parent` keyword.

this time I did not look only for `'null'` but all types of hardcoded keyword comparisons 😅