### PR TITLE
Add regression test

### DIFF
--- a/tests/PHPStan/Analyser/data/bug-3300.php
+++ b/tests/PHPStan/Analyser/data/bug-3300.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Bug3300;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Class FormTypeHelper.
+ */
+class FormTypeHelper
+{
+	private const TYPE_TO_CLASS_MAP = [
+		'text' => 'TextType::class',
+		'group' => 'EntityManagerFormType::class',
+		'number' => 'IntegerType::class',
+		'select' => 'ChoiceType::class',
+		'radio' => 'ChoiceType::class',
+		'checkbox' => 'ChoiceType::class',
+		'bool' => 'CheckboxType::class',
+	];
+
+	/**
+	 * @param string $class
+	 *
+	 * @return string
+	 *
+	 * @throws \Exception
+	 */
+	public static function getTypeFromClass(string $class): string
+	{
+		$type = array_keys(self::TYPE_TO_CLASS_MAP, $class, true);
+
+		if (0 === count($type)) {
+			throw new \Exception(sprintf('No type matched class %s', $class));
+		}
+		if (1 < count($type)) {
+			throw new \Exception(
+				sprintf('Multiple types found, did you mean any of %s', implode(', ', $type))
+			);
+		}
+
+		return $type[0];
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1016,4 +1016,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/data/bug-8366.php'], []);
 	}
 
+	public function testBug3300(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-3300.php'], []);
+	}
+
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/3300

See also https://phpstan.org/r/f16bc296-b26d-4081-a308-7dd0416def71

Not sure if more precision for constant arrays is needed? For such an edge case the current result might be enough? My PR https://github.com/phpstan/phpstan-src/pull/2117 adds some complexity, including changes on `Type::getKeysArray()` and rebasing those changes on latest 1.11.x is not trivial after https://github.com/phpstan/phpstan-src/pull/2516 and I'm worried they would make things even more complex..

The reason why this is fixed is the early exit in https://github.com/phpstan/phpstan-src/blob/d5a4746e91feacdceffe66d00d4976ecaa4a9673/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php#L30-L32 when more than one argument is given which did not exist yet when the bug was reported.