### PR TITLE
`fgetcsv` accepts `null` for `$length`

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -2932,7 +2932,7 @@ return [
 'ffmpeg_movie::hasAudio' => ['bool'],
 'ffmpeg_movie::hasVideo' => ['bool'],
 'fgetc' => ['string|false', 'fp'=>'resource'],
-'fgetcsv' => ['list<string>|array{0: null}|false|null', 'fp'=>'resource', 'length='=>'0|positive-int', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'fgetcsv' => ['list<string>|array{0: null}|false|null', 'fp'=>'resource', 'length='=>'0|positive-int|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'fgets' => ['string|false', 'fp'=>'resource', 'length='=>'0|positive-int'],
 'fgetss' => ['string|false', 'fp'=>'resource', 'length='=>'0|positive-int', 'allowable_tags='=>'string'],
 'file' => ['list<string>|false', 'filename'=>'string', 'flags='=>'int', 'context='=>'resource'],


### PR DESCRIPTION
fixes 

> Parameter #2 $length of function fgetcsv expects int<0, max>, null given.

on https://phpstan.org/r/856a86eb-7d7b-4265-9aa5-baf3c83d4321
for PHP 7.x see https://www.php.net/manual/en/function.fgetcsv.php