### PR TITLE
make assigning property via reference impure

### DIFF
--- a/src/Analyser/ImpurePoint.php
+++ b/src/Analyser/ImpurePoint.php
@@ -6,7 +6,7 @@ use PhpParser\Node;
 use PHPStan\Node\VirtualNode;
 
 /**
- * @phpstan-type ImpurePointIdentifier = 'echo'|'die'|'exit'|'propertyAssign'|'propertyUnset'|'methodCall'|'new'|'functionCall'|'include'|'require'|'print'|'eval'|'superglobal'|'yield'|'yieldFrom'|'static'|'global'|'betweenPhpTags'
+ * @phpstan-type ImpurePointIdentifier = 'echo'|'die'|'exit'|'propertyAssign'|'propertyAssignByRef'|'propertyUnset'|'methodCall'|'new'|'functionCall'|'include'|'require'|'print'|'eval'|'superglobal'|'yield'|'yieldFrom'|'static'|'global'|'betweenPhpTags'
  * @api
  */
 class ImpurePoint

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2146,8 +2146,8 @@ class NodeScopeResolver
 							$impurePoints[] = new ImpurePoint(
 								$scope,
 								$expr,
-								'propertyAssign',
-								'property assignment',
+								'propertyAssignByRef',
+								'property assignment by reference',
 								false,
 							);
 						}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2135,7 +2135,23 @@ class NodeScopeResolver
 				$nodeCallback,
 				$context,
 				function (MutatingScope $scope) use ($stmt, $expr, $nodeCallback, $context): ExpressionResult {
+					$impurePoints = [];
 					if ($expr instanceof AssignRef) {
+						$referencedExpr = $expr->expr;
+						while ($referencedExpr instanceof ArrayDimFetch) {
+							$referencedExpr = $referencedExpr->var;
+						}
+
+						if ($referencedExpr instanceof PropertyFetch || $referencedExpr instanceof StaticPropertyFetch) {
+							$impurePoints[] = new ImpurePoint(
+								$scope,
+								$expr,
+								'propertyAssign',
+								'property assignment',
+								false,
+							);
+						}
+
 						$scope = $scope->enterExpressionAssign($expr->expr);
 					}
 
@@ -2150,7 +2166,7 @@ class NodeScopeResolver
 					$result = $this->processExprNode($stmt, $expr->expr, $scope, $nodeCallback, $context->enterDeep());
 					$hasYield = $result->hasYield();
 					$throwPoints = $result->getThrowPoints();
-					$impurePoints = $result->getImpurePoints();
+					$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
 					$scope = $result->getScope();
 
 					if ($expr instanceof AssignRef) {

--- a/tests/PHPStan/Rules/Pure/PureMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureMethodRuleTest.php
@@ -157,4 +157,9 @@ class PureMethodRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testImpureAssignRef(): void
+	{
+		$this->analyse([__DIR__ . '/data/impure-assign-ref.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Pure/PureMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureMethodRuleTest.php
@@ -159,7 +159,12 @@ class PureMethodRuleTest extends RuleTestCase
 
 	public function testImpureAssignRef(): void
 	{
-		$this->analyse([__DIR__ . '/data/impure-assign-ref.php'], []);
+		$this->analyse([__DIR__ . '/data/impure-assign-ref.php'], [
+			[
+				'Possibly impure property assignment by reference in pure method ImpureAssignRef\HelloWorld::bar6().',
+				49,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Pure/data/impure-assign-ref.php
+++ b/tests/PHPStan/Rules/Pure/data/impure-assign-ref.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace ImpureAssignRef;
+
+class HelloWorld
+{
+	public int $value = 0;
+	/** @var array<int, int> */
+	public array $arr = [];
+	/** @var array<int, \stdClass> */
+	public array $objectArr = [];
+	public static int $staticValue = 0;
+	/** @var array<int, int> */
+	public static array $staticArr = [];
+
+	private function bar1(): void
+	{
+		$value = &$this->value;
+		$value = 1;
+	}
+
+	private function bar2(): void
+	{
+		$value = &$this->arr[0];
+		$value = 1;
+	}
+
+	private function bar3(): void
+	{
+		$value = &self::$staticValue;
+		$value = 1;
+	}
+
+	private function bar4(): void
+	{
+		$value = &self::$staticArr[0];
+		$value = 1;
+	}
+
+	private function bar5(self $other): void
+	{
+		$value = &$other->value;
+		$value = 1;
+	}
+
+	private function bar6(): void
+	{
+		$value = &$this->objectArr[0]->foo;
+		$value = 1;
+	}
+
+	public function foo(): void
+	{
+		$this->bar1();
+		$this->bar2();
+		$this->bar3();
+		$this->bar4();
+		$this->bar5(new self());
+		$this->bar6();
+	}
+}

--- a/tests/PHPStan/Rules/Pure/data/impure-assign-ref.php
+++ b/tests/PHPStan/Rules/Pure/data/impure-assign-ref.php
@@ -43,10 +43,12 @@ class HelloWorld
 		$value = 1;
 	}
 
-	private function bar6(): void
+	/** @phpstan-pure */
+	private function bar6(): int
 	{
 		$value = &$this->objectArr[0]->foo;
-		$value = 1;
+
+		return 1;
 	}
 
 	public function foo(): void


### PR DESCRIPTION
Fixes https://phpstan.org/r/cbe5c7f9-f5bd-4101-8cf6-37b7732946d4

I set `certain = false`, because theoretically the referenced variable may already be set, and the reference may never be written. In which case it would be pure. But I can't imagine why the reference would be used in such a way in the first place.