### PR TITLE
[junit formatter] Do not escape the error message twice

### DIFF
--- a/src/Command/ErrorFormatter/JunitErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JunitErrorFormatter.php
@@ -37,7 +37,7 @@ class JunitErrorFormatter implements ErrorFormatter
 			$result .= $this->createTestCase(
 				sprintf('%s:%s', $fileName, (string) $fileSpecificError->getLine()),
 				'ERROR',
-				$this->escape($fileSpecificError->getMessage()),
+				$fileSpecificError->getMessage(),
 			);
 		}
 

--- a/src/Command/ErrorFormatter/JunitErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JunitErrorFormatter.php
@@ -42,11 +42,11 @@ class JunitErrorFormatter implements ErrorFormatter
 		}
 
 		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
-			$result .= $this->createTestCase('General error', 'ERROR', $this->escape($notFileSpecificError));
+			$result .= $this->createTestCase('General error', 'ERROR', $notFileSpecificError);
 		}
 
 		foreach ($analysisResult->getWarnings() as $warning) {
-			$result .= $this->createTestCase('Warning', 'WARNING', $this->escape($warning));
+			$result .= $this->createTestCase('Warning', 'WARNING', $warning);
 		}
 
 		if (!$analysisResult->hasErrors()) {

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -153,12 +153,12 @@ class TableErrorFormatter implements ErrorFormatter
 		}
 
 		if (count($analysisResult->getNotFileSpecificErrors()) > 0) {
-			$style->table(['', 'Error'], array_map(static fn (string $error): array => ['', $error], $analysisResult->getNotFileSpecificErrors()));
+			$style->table(['', 'Error'], array_map(static fn (string $error): array => ['', OutputFormatter::escape($error)], $analysisResult->getNotFileSpecificErrors()));
 		}
 
 		$warningsCount = count($analysisResult->getWarnings());
 		if ($warningsCount > 0) {
-			$style->table(['', 'Warning'], array_map(static fn (string $warning): array => ['', $warning], $analysisResult->getWarnings()));
+			$style->table(['', 'Warning'], array_map(static fn (string $warning): array => ['', OutputFormatter::escape($warning)], $analysisResult->getWarnings()));
 		}
 
 		$finalMessage = sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount());

--- a/src/Testing/ErrorFormatterTestCase.php
+++ b/src/Testing/ErrorFormatterTestCase.php
@@ -80,7 +80,7 @@ abstract class ErrorFormatterTestCase extends PHPStanTestCase
 
 		$fileErrors = array_slice([
 			new Error('Foo', self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 4),
-			new Error('Foo', self::DIRECTORY_PATH . '/foo.php', 1),
+			new Error('Foo<Bar>', self::DIRECTORY_PATH . '/foo.php', 1),
 			new Error("Bar\nBar2", self::DIRECTORY_PATH . '/foo.php', 5, true, null, null, 'a tip'),
 			new Error("Bar\nBar2", self::DIRECTORY_PATH . '/folder with unicode 😃/file name with "spaces" and unicode 😃.php', 2),
 			new Error("Bar\nBar2", self::DIRECTORY_PATH . '/foo.php', null),
@@ -88,7 +88,7 @@ abstract class ErrorFormatterTestCase extends PHPStanTestCase
 
 		$genericErrors = array_slice([
 			'first generic error',
-			'second generic error',
+			'second generic<error>',
 		], 0, $numGenericErrors);
 
 		return new AnalysisResult(

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -74,7 +74,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'foo.php',
 				],
 				[
-					'message' => '#^Foo$#',
+					'message' => '#^Foo\<Bar\>$#',
 					'count' => 1,
 					'path' => 'foo.php',
 				],
@@ -103,7 +103,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 					'path' => 'foo.php',
 				],
 				[
-					'message' => '#^Foo$#',
+					'message' => '#^Foo\<Bar\>$#',
 					'count' => 1,
 					'path' => 'foo.php',
 				],

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -64,7 +64,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
   <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 <file name="foo.php">
-  <error line="1" column="1" severity="error" message="Foo"/>
+  <error line="1" column="1" severity="error" message="Foo&lt;Bar&gt;"/>
   <error line="5" column="1" severity="error" message="Bar Bar2"/>
 </file>
 </checkstyle>
@@ -80,7 +80,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 <checkstyle>
 <file>
   <error message="first generic error" severity="error"/>
-  <error message="second generic error" severity="error"/>
+  <error message="second generic&lt;error&gt;" severity="error"/>
 </file>
 </checkstyle>
 ',
@@ -98,12 +98,12 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
   <error line="4" column="1" severity="error" message="Foo"/>
 </file>
 <file name="foo.php">
-  <error line="1" column="1" severity="error" message="Foo"/>
+  <error line="1" column="1" severity="error" message="Foo&lt;Bar&gt;"/>
   <error line="5" column="1" severity="error" message="Bar Bar2"/>
 </file>
 <file>
   <error message="first generic error" severity="error"/>
-  <error message="second generic error" severity="error"/>
+  <error message="second generic&lt;error&gt;" severity="error"/>
 </file>
 </checkstyle>
 ',

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -45,7 +45,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			'::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar%0ABar2
 ::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
-::error file=foo.php,line=1,col=0::Foo
+::error file=foo.php,line=1,col=0::Foo<Bar>
 ::error file=foo.php,line=5,col=0::Bar%0ABar2
 ',
 		];
@@ -56,7 +56,7 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			2,
 			'::error ::first generic error
-::error ::second generic error
+::error ::second generic<error>
 ',
 		];
 
@@ -67,10 +67,10 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			2,
 			'::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=2,col=0::Bar%0ABar2
 ::error file=folder with unicode 😃/file name with "spaces" and unicode 😃.php,line=4,col=0::Foo
-::error file=foo.php,line=1,col=0::Foo
+::error file=foo.php,line=1,col=0::Foo<Bar>
 ::error file=foo.php,line=5,col=0::Bar%0ABar2
 ::error ::first generic error
-::error ::second generic error
+::error ::second generic<error>
 ',
 		];
 	}

--- a/tests/PHPStan/Command/ErrorFormatter/GitlabFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GitlabFormatterTest.php
@@ -88,8 +88,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "Foo",
-        "fingerprint": "93c79740ed8c6fbaac2087e54d6f6f67fc0918e3ff77840530f32e19857ef63c",
+        "description": "Foo<Bar>",
+        "fingerprint": "d7002959fc192c81d51fc41b0a3f240617a1aa35361867b5e924ae8d7fec39cb",
         "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
@@ -152,8 +152,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "Foo",
-        "fingerprint": "93c79740ed8c6fbaac2087e54d6f6f67fc0918e3ff77840530f32e19857ef63c",
+        "description": "Foo<Bar>",
+        "fingerprint": "d7002959fc192c81d51fc41b0a3f240617a1aa35361867b5e924ae8d7fec39cb",
         "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
@@ -194,8 +194,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "second generic error",
-        "fingerprint": "f49870714e8ce889212aefb50f718f88ae63d00dd01c775b7bac86c4466e96f0",
+        "description": "second generic<error>",
+        "fingerprint": "adc18b2c27b0ecad40aed7975b165cbe357f0cbba58582af91c0a2e7fa5d77ab",
         "severity": "major",
         "location": {
             "path": "",
@@ -236,8 +236,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "Foo",
-        "fingerprint": "93c79740ed8c6fbaac2087e54d6f6f67fc0918e3ff77840530f32e19857ef63c",
+        "description": "Foo<Bar>",
+        "fingerprint": "d7002959fc192c81d51fc41b0a3f240617a1aa35361867b5e924ae8d7fec39cb",
         "severity": "major",
         "location": {
             "path": "with space/and unicode \ud83d\ude03/project/foo.php",
@@ -269,8 +269,8 @@ class GitlabFormatterTest extends ErrorFormatterTestCase
         }
     },
     {
-        "description": "second generic error",
-        "fingerprint": "f49870714e8ce889212aefb50f718f88ae63d00dd01c775b7bac86c4466e96f0",
+        "description": "second generic<error>",
+        "fingerprint": "adc18b2c27b0ecad40aed7975b165cbe357f0cbba58582af91c0a2e7fa5d77ab",
         "severity": "major",
         "location": {
             "path": "",

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -105,7 +105,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 			"errors":2,
 			"messages":[
 				{
-					"message": "Foo",
+					"message": "Foo<Bar>",
 					"line": 1,
 					"ignorable": true
 				},
@@ -136,7 +136,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 	"files":[],
 	"errors": [
 		"first generic error",
-		"second generic error"
+		"second generic<error>"
 	]
 }',
 		];
@@ -172,7 +172,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 			"errors":2,
 			"messages":[
 				{
-					"message": "Foo",
+					"message": "Foo<Bar>",
 					"line": 1,
 					"ignorable": true
 				},
@@ -187,7 +187,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 	},
 	"errors": [
 		"first generic error",
-		"second generic error"
+		"second generic<error>"
 	]
 }',
 		];

--- a/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
@@ -74,7 +74,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
     <failure type="ERROR" message="Foo" />
   </testcase>
   <testcase name="foo.php:1">
-    <failure type="ERROR" message="Foo"/>
+    <failure type="ERROR" message="Foo&lt;Bar&gt;"/>
   </testcase>
   <testcase name="foo.php:5">
     <failure type="ERROR" message="Bar Bar2"/>
@@ -93,7 +93,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
     <failure type="ERROR" message="first generic error" />
   </testcase>
   <testcase name="General error">
-    <failure type="ERROR" message="second generic error"/>
+    <failure type="ERROR" message="second generic&lt;error&gt;"/>
   </testcase>
 </testsuite>
 ',
@@ -112,7 +112,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
     <failure type="ERROR" message="Foo" />
   </testcase>
   <testcase name="foo.php:1">
-    <failure type="ERROR" message="Foo"/>
+    <failure type="ERROR" message="Foo&lt;Bar&gt;"/>
   </testcase>
   <testcase name="foo.php:5">
     <failure type="ERROR" message="Bar Bar2"/>
@@ -121,7 +121,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
     <failure type="ERROR" message="first generic error" />
   </testcase>
   <testcase name="General error">
-    <failure type="ERROR" message="second generic error"/>
+    <failure type="ERROR" message="second generic&lt;error&gt;"/>
   </testcase>
 </testsuite>
 ',

--- a/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
@@ -41,7 +41,7 @@ class RawErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar' . "\nBar2\n" .
 			'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo' . "\n" .
-			'/data/folder/with space/and unicode 😃/project/foo.php:1:Foo' . "\n" .
+			'/data/folder/with space/and unicode 😃/project/foo.php:1:Foo<Bar>' . "\n" .
 			'/data/folder/with space/and unicode 😃/project/foo.php:5:Bar' . "\nBar2\n",
 		];
 
@@ -51,7 +51,7 @@ class RawErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			2,
 			'?:?:first generic error' . "\n" .
-			'?:?:second generic error' . "\n",
+			'?:?:second generic<error>' . "\n",
 		];
 
 		yield [
@@ -60,10 +60,10 @@ class RawErrorFormatterTest extends ErrorFormatterTestCase
 			4,
 			2,
 			'?:?:first generic error' . "\n" .
-		'?:?:second generic error' . "\n" .
+		'?:?:second generic<error>' . "\n" .
 		'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:2:Bar' . "\nBar2\n" .
 		'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php:4:Foo' . "\n" .
-		'/data/folder/with space/and unicode 😃/project/foo.php:1:Foo' . "\n" .
+		'/data/folder/with space/and unicode 😃/project/foo.php:1:Foo<Bar>' . "\n" .
 		'/data/folder/with space/and unicode 😃/project/foo.php:5:Bar' . "\nBar2\n",
 		];
 	}

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -94,7 +94,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  ------ ----------
   Line   foo.php
  ------ ----------
-  1      Foo
+  1      Foo<Bar>
   5      Bar
          Bar2
          💡 a tip
@@ -115,7 +115,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
      Error
  -- ----------------------
      first generic error
-     second generic error
+     second generic<error>
  -- ----------------------
 
 
@@ -141,7 +141,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  ------ ----------
   Line   foo.php
  ------ ----------
-  1      Foo
+  1      Foo<Bar>
   5      Bar
          Bar2
          💡 a tip
@@ -151,7 +151,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
      Error
  -- ----------------------
      first generic error
-     second generic error
+     second generic<error>
  -- ----------------------
 
  [ERROR] Found 6 errors

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -111,12 +111,12 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			'numFileErrors' => 0,
 			'numGenericErrors' => 2,
 			'extraEnvVars' => [],
-			'expected' => ' -- ----------------------
+			'expected' => ' -- -----------------------
      Error
- -- ----------------------
+ -- -----------------------
      first generic error
      second generic<error>
- -- ----------------------
+ -- -----------------------
 
 
  [ERROR] Found 2 errors
@@ -147,12 +147,12 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
          💡 a tip
  ------ ----------
 
- -- ----------------------
+ -- -----------------------
      Error
- -- ----------------------
+ -- -----------------------
      first generic error
      second generic<error>
- -- ----------------------
+ -- -----------------------
 
  [ERROR] Found 6 errors
 

--- a/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
@@ -48,7 +48,7 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			'##teamcity[inspectionType id=\'phpstan\' name=\'phpstan\' category=\'phpstan\' description=\'phpstan Inspection\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'2\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'4\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
-##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'foo.php\' line=\'1\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Foo<Bar>\' file=\'foo.php\' line=\'1\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'a tip\']
 ',
 		];
@@ -60,7 +60,7 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			2,
 			'##teamcity[inspectionType id=\'phpstan\' name=\'phpstan\' category=\'phpstan\' description=\'phpstan Inspection\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'first generic error\' file=\'.\' SEVERITY=\'ERROR\']
-##teamcity[inspection typeId=\'phpstan\' message=\'second generic error\' file=\'.\' SEVERITY=\'ERROR\']
+##teamcity[inspection typeId=\'phpstan\' message=\'second generic<error>\' file=\'.\' SEVERITY=\'ERROR\']
 ',
 		];
 
@@ -72,10 +72,10 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			'##teamcity[inspectionType id=\'phpstan\' name=\'phpstan\' category=\'phpstan\' description=\'phpstan Inspection\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'2\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'folder with unicode 😃/file name with "spaces" and unicode 😃.php\' line=\'4\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
-##teamcity[inspection typeId=\'phpstan\' message=\'Foo\' file=\'foo.php\' line=\'1\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Foo<Bar>\' file=\'foo.php\' line=\'1\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'a tip\']
 ##teamcity[inspection typeId=\'phpstan\' message=\'first generic error\' file=\'.\' SEVERITY=\'ERROR\']
-##teamcity[inspection typeId=\'phpstan\' message=\'second generic error\' file=\'.\' SEVERITY=\'ERROR\']
+##teamcity[inspection typeId=\'phpstan\' message=\'second generic<error>\' file=\'.\' SEVERITY=\'ERROR\']
 ',
 		];
 	}


### PR DESCRIPTION
Currently, the `junit` formatter escapes the error message twice. This makes it hard to read.

The message is escaped once inside `JunitErrorFormatter::createTextCase` and one in `JunitErrorFormatter::formatErrors`. Only of of these is needed.

IMHO this should be the responsibility of `createTestCase` so I removed it from `formatErrors`

## Previous Output

```xml
<failure type="ERROR"
    message="Parameter #4 $options of method App\Auth\Provider::createRequest() expects array&amp;lt;string, mixed&amp;gt;, array&amp;lt;int, string&amp;gt; given."/>
```

## New Output

```xml
<failure type="ERROR"
    message="Parameter #4 $options of method App\Auth\Provider::createRequest() expects array&lt;string, mixed&gt;, array&lt;int, string&gt; given."/>
```