### PR TITLE
Add new ClosureTypeChangingExtension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -646,6 +646,10 @@ services:
 		factory: PHPStan\DependencyInjection\Type\LazyDynamicThrowTypeExtensionProvider
 
 	-
+		class: PHPStan\DependencyInjection\Type\ClosureTypeChangingExtensionProvider
+		factory: PHPStan\DependencyInjection\Type\LazyClosureTypeChangingExtensionProvider
+
+	-
 		class: PHPStan\File\FileHelper
 		arguments:
 			workingDirectory: %currentWorkingDirectory%

--- a/src/DependencyInjection/Type/ClosureTypeChangingExtensionProvider.php
+++ b/src/DependencyInjection/Type/ClosureTypeChangingExtensionProvider.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\Type;
+
+use PHPStan\Type\FunctionClosureTypeChangingExtension;
+use PHPStan\Type\MethodClosureTypeChangingExtension;
+use PHPStan\Type\StaticMethodClosureTypeChangingExtension;
+
+interface ClosureTypeChangingExtensionProvider
+{
+
+	/** @return FunctionClosureTypeChangingExtension[] */
+	public function getFunctionClosureTypeChangingExtensions(): array;
+
+	/** @return MethodClosureTypeChangingExtension[] */
+	public function getMethodClosureTypeChangingExtensions(): array;
+
+	/** @return StaticMethodClosureTypeChangingExtension[] */
+	public function getStaticMethodClosureTypeChangingExtensions(): array;
+
+}

--- a/src/DependencyInjection/Type/LazyClosureTypeChangingExtensionProvider.php
+++ b/src/DependencyInjection/Type/LazyClosureTypeChangingExtensionProvider.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\Type;
+
+use PHPStan\DependencyInjection\Container;
+
+class LazyClosureTypeChangingExtensionProvider implements ClosureTypeChangingExtensionProvider
+{
+
+	public const FUNCTION_TAG = 'phpstan.functionClosureTypeChangingExtension';
+	public const METHOD_TAG = 'phpstan.methodClosureTypeChangingExtension';
+	public const STATIC_METHOD_TAG = 'phpstan.staticMethodClosureTypeChangingExtension';
+
+	public function __construct(private Container $container)
+	{
+	}
+
+	public function getFunctionClosureTypeChangingExtensions(): array
+	{
+		return $this->container->getServicesByTag(self::FUNCTION_TAG);
+	}
+
+	public function getMethodClosureTypeChangingExtensions(): array
+	{
+		return $this->container->getServicesByTag(self::METHOD_TAG);
+	}
+
+	public function getStaticMethodClosureTypeChangingExtensions(): array
+	{
+		return $this->container->getServicesByTag(self::STATIC_METHOD_TAG);
+	}
+
+}

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Collectors\Collector;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Dependency\DependencyResolver;
+use PHPStan\DependencyInjection\Type\ClosureTypeChangingExtensionProvider;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\File\FileHelper;
 use PHPStan\Php\PhpVersion;
@@ -91,6 +92,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 				$typeSpecifier,
 				self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
 				$readWritePropertiesExtensions !== [] ? new DirectReadWritePropertiesExtensionProvider($readWritePropertiesExtensions) : self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
+				self::getContainer()->getByType(ClosureTypeChangingExtensionProvider::class),
 				self::createScopeFactory($reflectionProvider, $typeSpecifier),
 				$this->shouldPolluteScopeWithLoopInitialAssignments(),
 				$this->shouldPolluteScopeWithAlwaysIterableForeach(),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\ScopeContext;
+use PHPStan\DependencyInjection\Type\ClosureTypeChangingExtensionProvider;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\File\FileHelper;
 use PHPStan\Php\PhpVersion;
@@ -62,6 +63,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$typeSpecifier,
 			self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
 			self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
+			self::getContainer()->getByType(ClosureTypeChangingExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			self::getContainer()->getParameter('polluteScopeWithLoopInitialAssignments'),
 			self::getContainer()->getParameter('polluteScopeWithAlwaysIterableForeach'),

--- a/src/Type/FunctionClosureTypeChangingExtension.php
+++ b/src/Type/FunctionClosureTypeChangingExtension.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+
+interface FunctionClosureTypeChangingExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool;
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type;
+
+}

--- a/src/Type/MethodClosureTypeChangingExtension.php
+++ b/src/Type/MethodClosureTypeChangingExtension.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+
+interface MethodClosureTypeChangingExtension
+{
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool;
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type;
+
+}

--- a/src/Type/StaticMethodClosureTypeChangingExtension.php
+++ b/src/Type/StaticMethodClosureTypeChangingExtension.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+
+interface StaticMethodClosureTypeChangingExtension
+{
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool;
+
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type;
+
+}

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -10,6 +10,7 @@ use PHPStan\Analyser\Ignore\IgnoreLexer;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Dependency\DependencyResolver;
 use PHPStan\Dependency\ExportedNodeResolver;
+use PHPStan\DependencyInjection\Type\ClosureTypeChangingExtensionProvider;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\Printer\Printer;
@@ -702,6 +703,7 @@ class AnalyserTest extends PHPStanTestCase
 			$typeSpecifier,
 			self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
 			self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
+			self::getContainer()->getByType(ClosureTypeChangingExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			false,
 			true,

--- a/tests/PHPStan/Analyser/ClosureTypeChangingExtensionTest.php
+++ b/tests/PHPStan/Analyser/ClosureTypeChangingExtensionTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class ClosureTypeChangingExtensionTest extends TypeInferenceTestCase
+{
+
+	public function dataFileAsserts(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/closure-type-changing-extension.php');
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 * @param mixed ...$args
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/closure-type-changing-extension.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/closure-type-changing-extension.neon
+++ b/tests/PHPStan/Analyser/closure-type-changing-extension.neon
@@ -1,0 +1,16 @@
+services:
+	-
+		class: ClosureTypeChangingExtension\FunctionClosureTypeChangingExtension
+		tags:
+			- phpstan.functionClosureTypeChangingExtension
+
+	-
+		class: ClosureTypeChangingExtension\MethodClosureTypeChangingExtension
+		tags:
+			- phpstan.methodClosureTypeChangingExtension
+
+	-
+		class: ClosureTypeChangingExtension\StaticMethodClosureTypeChangingExtension
+		tags:
+			- phpstan.staticMethodClosureTypeChangingExtension
+

--- a/tests/PHPStan/Analyser/data/closure-type-changing-extension.php
+++ b/tests/PHPStan/Analyser/data/closure-type-changing-extension.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace ClosureTypeChangingExtension;
+
+use Closure;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\PassedByReference;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VoidType;
+use function PHPStan\Testing\assertType;
+
+class FunctionClosureTypeChangingExtension implements \PHPStan\Type\FunctionClosureTypeChangingExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'ClosureTypeChangingExtension\functionWithClosure';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope
+	): ?Type {
+		$args = $functionCall->getArgs();
+
+		if (count($args) < 2) {
+			return null;
+		}
+
+		$integer = $scope->getType($args[0]->value)->getConstantScalarValues()[0];
+
+		if ($integer === 1) {
+			return new ClosureType(
+				[
+					new NativeParameterReflection('test', false, new GenericObjectType(Generic::class, [new IntegerType()]), PassedByReference::createNo(), false, null),
+				],
+				new VoidType()
+			);
+		}
+
+		return new ClosureType(
+			[
+				new NativeParameterReflection('test', false, new GenericObjectType(Generic::class, [new StringType()]), PassedByReference::createNo(), false, null),
+			],
+			new VoidType()
+		);
+	}
+}
+
+class MethodClosureTypeChangingExtension implements \PHPStan\Type\MethodClosureTypeChangingExtension
+{
+
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'methodWithClosure';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): ?Type {
+		$args = $methodCall->getArgs();
+
+		if (count($args) < 2) {
+			return null;
+		}
+
+		$integer = $scope->getType($args[0]->value)->getConstantScalarValues()[0];
+
+		if ($integer === 1) {
+			return new ClosureType(
+				[
+					new NativeParameterReflection('test', false, new GenericObjectType(Generic::class, [new IntegerType()]), PassedByReference::createNo(), false, null),
+				],
+				new VoidType()
+			);
+		}
+
+		return new ClosureType(
+			[
+				new NativeParameterReflection('test', false, new GenericObjectType(Generic::class, [new StringType()]), PassedByReference::createNo(), false, null),
+			],
+			new VoidType()
+		);
+	}
+}
+
+class StaticMethodClosureTypeChangingExtension implements \PHPStan\Type\StaticMethodClosureTypeChangingExtension
+{
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'staticMethodWithClosure';
+	}
+
+	public function getTypeFromStaticMethodCall(
+		MethodReflection $methodReflection,
+		StaticCall $methodCall,
+		Scope $scope
+	): ?Type {
+		return new ClosureType(
+			[
+				new NativeParameterReflection('test', false, new FloatType(), PassedByReference::createNo(), false, null),
+			],
+			new VoidType()
+		);
+	}
+}
+
+class Foo
+{
+
+	/**
+	 * @param int $foo
+	 * @param Closure(Generic<array-key>): void $callback
+	 *
+	 * @return void
+	 */
+	public function methodWithClosure(int $foo, Closure $callback)
+	{
+
+	}
+
+	/**
+	 * @param Closure(): void $callback
+	 *
+	 * @return void
+	 */
+	public static function staticMethodWithClosure(Closure $callback)
+	{
+
+	}
+
+}
+
+/**
+ * @template T
+ */
+class Generic
+{
+	private mixed $value;
+
+	/**
+	 * @param T $value
+	 */
+	public function __construct(mixed $value)
+	{
+		$this->value = $value;
+	}
+
+	/**
+	 * @return T
+	 */
+	public function getValue()
+	{
+		return $this->value;
+	}
+}
+
+/**
+ * @param int $foo
+ * @param Closure(Generic<array-key>): void $callback
+ *
+ * @return void
+ */
+function functionWithClosure(int $foo, Closure $callback)
+{
+
+}
+
+/**
+ * @param class-string<Foo> $fooString
+ */
+function test(Foo $foo, string $fooString): void
+{
+	$foo->methodWithClosure(1, function ($i) {
+		assertType('int', $i->getValue());
+	});
+
+	(new Foo)->methodWithClosure(2, function (Generic $i) {
+		assertType('string', $i->getValue());
+	});
+
+	Foo::staticMethodWithClosure(function ($i) {
+		assertType('float', $i);
+	});
+
+	$fooString::staticMethodWithClosure(function ($i) {
+		assertType('float', $i);
+	});
+}
+
+functionWithClosure(1, function ($i) {
+	assertType('int', $i->getValue());
+});
+
+functionWithClosure(2, function (Generic $i) {
+	assertType('string', $i->getValue());
+});


### PR DESCRIPTION
Hello 👋🏽 

This PR adds new `ClosureTypeChangingExtension` extension that enables changing the closure type on the receiving side when necessary.

There are couple of issues I want solve before merging it though so I'm making a draft first:
- Naming 😄 Not sure any of the names I picked. Also I see `Dynamic` prefix in other extensions, not sure if we should use it here too.
- The extension finding loop stops as soon as it finds a matching extension. That made sense to me. But we can also gather every type and then union them at the end.
- I think I tested it enough, but not sure if there is any edge case that I should test also.