### PR TITLE
DateTimeImmutable::modify() can no longer return false since PHP 8.3

### DIFF
--- a/build/baseline-8.3.neon
+++ b/build/baseline-8.3.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Strict comparison using === between DateTime and false will always evaluate to false\\.$#"
+			count: 1
+			path: ../src/Type/Php/DateTimeModifyReturnTypeExtension.php

--- a/build/ignore-by-php-version.neon.php
+++ b/build/ignore-by-php-version.neon.php
@@ -15,6 +15,9 @@ if (PHP_VERSION_ID >= 80100) {
 	$includes[] = __DIR__ . '/enums.neon';
 	$includes[] = __DIR__ . '/readonly-property.neon';
 }
+if (PHP_VERSION_ID >= 80300) {
+	$includes[] = __DIR__ . '/baseline-8.3.neon';
+}
 
 if (PHP_VERSION_ID >= 70400) {
 	$includes[] = __DIR__ . '/ignore-gte-php7.4-errors.neon';

--- a/resources/functionMap_php83delta.php
+++ b/resources/functionMap_php83delta.php
@@ -21,6 +21,8 @@
  */
 return [
 	'new' => [
+		'DateTime::modify' => ['static', 'modify'=>'string'],
+		'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
 		'str_decrement' => ['non-empty-string', 'string'=>'non-empty-string'],
 		'str_increment' => ['non-falsy-string', 'string'=>'non-empty-string'],
 		'gc_status' => ['array{running:bool,protected:bool,full:bool,runs:int,collected:int,threshold:int,buffer_size:int,roots:int,application_time:float,collector_time:float,destructor_time:float,free_time:float}'],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -512,7 +512,13 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeCreateDynamicReturnTypes.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeDynamicReturnTypes.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeModifyReturnTypes.php');
+
+		if (PHP_VERSION_ID < 80300) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeModifyReturnTypes.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/DateTimeModifyReturnTypes-83.php');
+		}
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4821.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4838.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4879.php');
@@ -1058,7 +1064,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/non-empty-string-str-containing-fns.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/fizz-buzz.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4875.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6609.php');
+
+		if (PHP_VERSION_ID < 80300) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6609.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-6609-83.php');
+		}
 
 		//define('ALREADY_DEFINED_CONSTANT', true);
 		//yield from $this->gatherAssertTypes(__DIR__ . '/data/already-defined-constant.php');

--- a/tests/PHPStan/Analyser/data/DateTimeModifyReturnTypes-83.php
+++ b/tests/PHPStan/Analyser/data/DateTimeModifyReturnTypes-83.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace DateTimeModifyReturnTypes83;
+
+use DateTime;
+use DateTimeImmutable;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function modify(DateTime $datetime, DateTimeImmutable $dateTimeImmutable, string $modify): void {
+		assertType('DateTime', $datetime->modify($modify));
+		assertType('DateTimeImmutable', $dateTimeImmutable->modify($modify));
+	}
+
+	/**
+	 * @param '+1 day'|'+2 day' $modify
+	 */
+	public function modifyWithValidConstant(DateTime $datetime, DateTimeImmutable $dateTimeImmutable, string $modify): void {
+		assertType('DateTime', $datetime->modify($modify));
+		assertType('DateTimeImmutable', $dateTimeImmutable->modify($modify));
+	}
+
+	/**
+	 * @param 'kewk'|'koko' $modify
+	 */
+	public function modifyWithInvalidConstant(DateTime $datetime, DateTimeImmutable $dateTimeImmutable, string $modify): void {
+		assertType('*NEVER*', $datetime->modify($modify));
+		assertType('*NEVER*', $dateTimeImmutable->modify($modify));
+	}
+
+	/**
+	 * @param '+1 day'|'koko' $modify
+	 */
+	public function modifyWithBothConstant(DateTime $datetime, DateTimeImmutable $dateTimeImmutable, string $modify): void {
+		assertType('DateTime', $datetime->modify($modify));
+		assertType('DateTimeImmutable', $dateTimeImmutable->modify($modify));
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/bug-6609-83.php
+++ b/tests/PHPStan/Analyser/data/bug-6609-83.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Bug6609Php83;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * This method should return the same type as a parameter passed.
+	 *
+	 * @template T of \DateTime|\DateTimeImmutable
+	 *
+	 * @param T $date
+	 *
+	 * @return T
+	 */
+	function modify(\DateTimeInterface $date) {
+		$date = $date->modify('+1 day');
+		assertType('T of DateTime|DateTimeImmutable (method Bug6609Php83\Foo::modify(), argument)', $date);
+
+		return $date;
+	}
+
+	/**
+	 * This method should return the same type as a parameter passed.
+	 *
+	 * @template T of \DateTime|\DateTimeImmutable
+	 *
+	 * @param T $date
+	 *
+	 * @return T
+	 */
+	function modify2(\DateTimeInterface $date) {
+		$date = $date->modify('invalidd');
+		assertType('*NEVER*', $date);
+
+		return $date;
+	}
+
+	/**
+	 * This method should return the same type as a parameter passed.
+	 *
+	 * @template T of \DateTime|\DateTimeImmutable
+	 *
+	 * @param T $date
+	 *
+	 * @return T
+	 */
+	function modify3(\DateTimeInterface $date, string $s) {
+		$date = $date->modify($s);
+		assertType('DateTime|DateTimeImmutable', $date);
+
+		return $date;
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -812,16 +812,22 @@ class ReturnTypeRuleTest extends RuleTestCase
 	public function testBug8223(): void
 	{
 		$this->checkBenevolentUnionTypes = true;
-		$this->analyse([__DIR__ . '/data/bug-8223.php'], [
-			[
-				'Method Bug8223\HelloWorld::sayHello() should return DateTimeImmutable but returns (DateTimeImmutable|false).',
-				11,
-			],
-			[
-				'Method Bug8223\HelloWorld::sayHello2() should return array<DateTimeImmutable> but returns array<int, (DateTimeImmutable|false)>.',
-				21,
-			],
-		]);
+		$errors = [];
+
+		if (PHP_VERSION_ID < 80300) {
+			$errors = [
+				[
+					'Method Bug8223\HelloWorld::sayHello() should return DateTimeImmutable but returns (DateTimeImmutable|false).',
+					11,
+				],
+				[
+					'Method Bug8223\HelloWorld::sayHello2() should return array<DateTimeImmutable> but returns array<int, (DateTimeImmutable|false)>.',
+					21,
+				],
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-8223.php'], $errors);
 	}
 
 	public function testBug8146bErrors(): void


### PR DESCRIPTION
Since PHP 8.3, `DateTimeImmutable::modify()` can no longer return `false`, and throws `DateMalformedStringException` instead.

Relevant RFC: https://wiki.php.net/rfc/datetime-exceptions

Relevant php-src commit: https://github.com/php/php-src/commit/b7860cd56476d737fcf2e1fdda109b042312e3fa

Relevant code change:

![obrazek](https://github.com/phpstan/phpstan-src/assets/175109/a2a5016c-31ca-40c7-b4b1-ec8ee9620343)
