### PR TITLE
Improve `explode` return type precision

### DIFF
--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -48,7 +48,7 @@ class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$delimiterType = $scope->getType($args[0]->value);
 		$isEmptyString = (new ConstantStringType(''))->isSuperTypeOf($delimiterType);
 		if ($isEmptyString->yes()) {
-			if ($this->phpVersion->getVersionId() >= 80000) {
+			if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
 				return new NeverType();
 			}
 			return new ConstantBooleanType(false);
@@ -62,7 +62,7 @@ class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 			$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
 		}
 
-		if ($this->phpVersion->getVersionId() <= 80000 && $isEmptyString->maybe()) {
+		if (!$this->phpVersion->throwsValueErrorForInternalFunctions() && $isEmptyString->maybe()) {
 			$returnType = TypeCombinator::union($returnType, new ConstantBooleanType(false));
 		}
 

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -7292,15 +7292,15 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$sureFalse',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'list<string>|false' : 'list<string>',
+				PHP_VERSION_ID < 80000 ? 'non-empty-list<string>|false' : 'non-empty-list<string>',
 				'$arrayOrFalse',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'list<string>|false' : 'list<string>',
+				PHP_VERSION_ID < 80000 ? 'non-empty-list<string>|false' : 'non-empty-list<string>',
 				'$anotherArrayOrFalse',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? '(list<string>|false)' : 'list<string>',
+				PHP_VERSION_ID < 80000 ? '(non-empty-list<string>|false)' : 'non-empty-list<string>',
 				'$benevolentArrayOrFalse',
 			],
 		];

--- a/tests/PHPStan/Analyser/data/bug-3961-php8.php
+++ b/tests/PHPStan/Analyser/data/bug-3961-php8.php
@@ -14,8 +14,8 @@ class Foo
 		assertType('list<string>', explode('.', $v, -2));
 		assertType('non-empty-list<string>', explode('.', $v, 0));
 		assertType('non-empty-list<string>', explode('.', $v, 1));
-		assertType('list<string>', explode($d, $v));
-		assertType('list<string>', explode($m, $v));
+		assertType('non-empty-list<string>', explode($d, $v));
+		assertType('non-empty-list<string>', explode($m, $v));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-3961.php
+++ b/tests/PHPStan/Analyser/data/bug-3961.php
@@ -14,8 +14,8 @@ class Foo
 		assertType('list<string>', explode('.', $v, -2));
 		assertType('non-empty-list<string>', explode('.', $v, 0));
 		assertType('non-empty-list<string>', explode('.', $v, 1));
-		assertType('list<string>|false', explode($d, $v));
-		assertType('(list<string>|false)', explode($m, $v));
+		assertType('non-empty-list<string>|false', explode($d, $v));
+		assertType('(non-empty-list<string>|false)', explode($m, $v));
 	}
 
 }


### PR DESCRIPTION
inspired by comments in https://github.com/phpstan/phpstan-src/commit/00691075acb1db2d1a6fbdbf607e0b52271815bb#r43325405