### PR TITLE
`$this` cannot be reassigned when passed by reference

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -4524,8 +4524,10 @@ class NodeScopeResolver
 			if ($assignByReference) {
 				$argValue = $arg->value;
 				if ($argValue instanceof Variable && is_string($argValue->name)) {
-					$nodeCallback(new VariableAssignNode($argValue, new TypeExpr($byRefType), false), $scope);
-					$scope = $scope->assignVariable($argValue->name, $byRefType, new MixedType());
+					if ($argValue->name !== 'this') {
+						$nodeCallback(new VariableAssignNode($argValue, new TypeExpr($byRefType), false), $scope);
+						$scope = $scope->assignVariable($argValue->name, $byRefType, new MixedType());
+					}
 				} else {
 					$scope = $scope->invalidateExpression($argValue);
 				}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1496,6 +1496,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/case-insensitive-parent.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10893.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4754.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10477.php');
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/bug-10477.php
+++ b/tests/PHPStan/Analyser/data/bug-10477.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug10477;
+
+use function PHPStan\Testing\assertType;
+
+class A
+{
+	protected $data;
+	protected $foo = '';
+
+	public function a(): void
+	{
+		assertType('mixed', $this->foo);
+		assertType('$this(Bug10477\A)', $this);
+		(new B())->foo($this);
+		assertType('mixed', $this->foo);
+		assertType('$this(Bug10477\A)', $this);
+		if (isset($this->data['test'])) {
+			$this->foo = $this->data['test'];
+		}
+	}
+}
+
+class B
+{
+	public function foo(mixed &$var): void {}
+}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesInAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesInAssignRuleTest.php
@@ -120,4 +120,9 @@ class AccessPropertiesInAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/conflicting-annotation-property.php'], []);
 	}
 
+	public function testBug10477(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-10477.php'], []);
+	}
+
 }


### PR DESCRIPTION
Closes phpstan/phpstan#10477