### PR TITLE
Fix wrong fread() length parameter type and return type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3003,7 +3003,7 @@ return [
 'fprintf' => ['int', 'stream'=>'resource', 'format'=>'string', '...values='=>'__stringAndStringable|int|float|null|bool'],
 'fputcsv' => ['0|positive-int|false', 'fp'=>'resource', 'fields'=>'array<int|string, __stringAndStringable|int|float|null|bool>', 'delimiter='=>'string', 'enclosure='=>'string', 'escape_char='=>'string'],
 'fputs' => ['0|positive-int|false', 'fp'=>'resource', 'str'=>'string', 'length='=>'0|positive-int'],
-'fread' => ['string|false', 'fp'=>'resource', 'length'=>'0|positive-int'],
+'fread' => ['string', 'fp'=>'resource', 'length'=>'positive-int'],
 'frenchtojd' => ['int', 'month'=>'int', 'day'=>'int', 'year'=>'int'],
 'fribidi_log2vis' => ['string', 'str'=>'string', 'direction'=>'string', 'charset'=>'int'],
 'fscanf' => ['list<mixed>|int|false', 'stream'=>'resource', 'format'=>'string', '&...w_vars='=>'string|int|float|null'],

--- a/resources/functionMap_php74delta.php
+++ b/resources/functionMap_php74delta.php
@@ -38,6 +38,7 @@ return [
 		'FFI::string' => ['string', '&ptr'=>'FFI\CData', 'size='=>'int'],
 		'FFI::typeof' => ['FFI\CType', '&ptr'=>'FFI\CData'],
 		'FFI::type' => ['FFI\CType', 'type'=>'string'],
+		'fread' => ['string|false', 'fp'=>'resource', 'length'=>'positive-int'],
 		'get_mangled_object_vars' => ['array', 'obj'=>'object'],
 		'mb_str_split' => ['list<string>|false', 'str'=>'string', 'split_length='=>'int', 'encoding='=>'string'],
 		'password_algos' => ['list<string>'],

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -707,7 +707,9 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/array-unpacking-string-keys.php');
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+		if (PHP_VERSION_ID >= 70400) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/filesystem-functions.php');
+		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/filter-input.php');
 		if (PHP_VERSION_ID >= 80000) {


### PR DESCRIPTION
This PR addresses two issues with the `fread()` signature:

1) The `length` parameter requires `int<1, max>` at engine level instead of `int<0, max>`.

2) The return type could never be `false` until php 7.4.0 (unless bogus parameters are passed, but that does not count). Even in case of stream failure. Since php 7.4.0, it can indeed return `false` for example when reading from a valid stream, i.e. a failed socket.

About the return type, i'm not completely sure we should fix this. For forward compatibility, in case of language level < 7.4.x, it might be good that phpstan warns about the possibility of false return value.

Thoughts?
