### PR TITLE
make method names non-falsy-string

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -3299,7 +3299,7 @@ return [
 'get_called_class' => ['class-string'],
 'get_cfg_var' => ['mixed', 'option_name'=>'string'],
 'get_class' => ['class-string', 'object='=>'object'],
-'get_class_methods' => ['list<string>', 'class'=>'mixed'],
+'get_class_methods' => ['list<non-falsy-string>', 'class'=>'mixed'],
 'get_class_vars' => ['array', 'class_name'=>'string'],
 'get_current_user' => ['string'],
 'get_declared_classes' => ['list<class-string>'],

--- a/stubs/ReflectionMethod.stub
+++ b/stubs/ReflectionMethod.stub
@@ -8,4 +8,9 @@ class ReflectionMethod
 	 */
 	public $class;
 
+	/**
+	 * @var non-falsy-string
+	 */
+	public $name;
+
 }


### PR DESCRIPTION
Currently it's `string` (https://phpstan.org/r/377d039c-f54b-45c0-afa5-a8d0721c3f5a). I'm not aware of any way of creating methods with falsy names.

It's covered by reflection golden test (it doesn't currently work for properties due to a bug - https://github.com/phpstan/phpstan-src/pull/3109), so I think a separate test is unnecessary.