### PR TITLE
fix property descriptions in ReflectionProviderGoldenTest

### DIFF
--- a/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
@@ -31,6 +31,7 @@ use function implode;
 use function mkdir;
 use function sort;
 use function strpos;
+use function substr;
 use function trim;
 use const PHP_INT_MAX;
 use const PHP_VERSION_ID;
@@ -410,6 +411,8 @@ class ReflectionProviderGoldenTest extends PHPStanTestCase
 	private static function generateClassPropertyDescription(string $propertyName): string
 	{
 		[$className, $propertyName] = explode('::', $propertyName);
+		// remove $
+		$propertyName = substr($propertyName, 1);
 
 		$reflectionProvider = self::getContainer()->getByType(ReflectionProvider::class);
 


### PR DESCRIPTION
I noticed that all properties in the reflection golden test look like this:

```
-----
PROPERTY ReflectionMethod::$name
-----
MISSING
```

It turns out to be due to a simple mismatch between the property names in the test input (start with `$`) and the names expected by the reflection provider (no `$`).