### PR TITLE
Consider numeric-string types after string concat

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -83,6 +83,7 @@ use function is_numeric;
 use function max;
 use function min;
 use function sprintf;
+use function str_contains;
 use function strtolower;
 use const INF;
 
@@ -485,7 +486,11 @@ class InitializerExprTypeResolver
 					continue;
 				}
 
-				if (!is_numeric($rightConstantString->getValue()) || $rightConstantString->getValue() < 0) {
+				if (
+					!is_numeric($rightConstantString->getValue())
+					|| str_contains($rightConstantString->getValue(), '.')
+					|| $rightConstantString->getValue() < 0
+				) {
 					$allRightConstantsZeroOrMore = false;
 					break;
 				}

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -28,6 +28,7 @@ use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BenevolentUnionType;
@@ -78,6 +79,7 @@ use function in_array;
 use function is_finite;
 use function is_float;
 use function is_int;
+use function is_numeric;
 use function max;
 use function min;
 use function sprintf;
@@ -473,6 +475,29 @@ class InitializerExprTypeResolver
 
 		if ($leftStringType->isLiteralString()->and($rightStringType->isLiteralString())->yes()) {
 			$accessoryTypes[] = new AccessoryLiteralStringType();
+		}
+
+		$leftNumericStringNonEmpty = TypeCombinator::remove($leftStringType, new ConstantStringType(''));
+		if ($leftNumericStringNonEmpty->isNumericString()->yes()) {
+			$allRightConstantsZeroOrMore = false;
+			foreach ($rightConstantStrings as $rightConstantString) {
+				if ($rightConstantString->getValue() === '') {
+					continue;
+				}
+
+				if (!is_numeric($rightConstantString->getValue()) || $rightConstantString->getValue() < 0) {
+					$allRightConstantsZeroOrMore = false;
+					break;
+				}
+
+				$allRightConstantsZeroOrMore = true;
+			}
+
+			$zeroOrMoreInteger = IntegerRangeType::fromInterval(0, null);
+			$nonNegativeRight = $allRightConstantsZeroOrMore || $zeroOrMoreInteger->isSuperTypeOf($right)->yes();
+			if ($nonNegativeRight) {
+				$accessoryTypes[] = new AccessoryNumericStringType();
+			}
 		}
 
 		if (count($accessoryTypes) > 0) {

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection;
 
+use Nette\Utils\Strings;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp;
@@ -83,7 +84,6 @@ use function is_numeric;
 use function max;
 use function min;
 use function sprintf;
-use function str_contains;
 use function strtolower;
 use const INF;
 
@@ -488,8 +488,7 @@ class InitializerExprTypeResolver
 
 				if (
 					!is_numeric($rightConstantString->getValue())
-					|| str_contains($rightConstantString->getValue(), '.')
-					|| $rightConstantString->getValue() < 0
+					|| Strings::match($rightConstantString->getValue(), '#^[0-9]+$#') === null
 				) {
 					$allRightConstantsZeroOrMore = false;
 					break;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1482,6 +1482,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10122.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10189.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10317.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-11129.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10302-interface-extends.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10302-trait-extends.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10302-trait-implements.php');

--- a/tests/PHPStan/Analyser/data/bug-11129.php
+++ b/tests/PHPStan/Analyser/data/bug-11129.php
@@ -9,6 +9,7 @@ class HelloWorld
 	/**
 	 * @param positive-int $positiveInt
 	 * @param negative-int $negativeInt
+	 * @param numeric-string $numericString
 	 * @param 0|'0'|'1'|'2' $positiveConstStrings
 	 * @param 0|-1|'2' $maybeNegativeConstStrings
 	 * @param 0|1|'a' $maybeNonNumericConstStrings
@@ -16,6 +17,7 @@ class HelloWorld
 	 */
 	public function foo(
 		int $i, $positiveInt, $negativeInt, $positiveConstStrings,
+		$numericString,
 		$maybeNegativeConstStrings, $maybeNonNumericConstStrings, $maybeFloatConstStrings,
 		bool $bool, float $float
 	): void {
@@ -46,7 +48,7 @@ class HelloWorld
 		assertType('non-falsy-string', $i.$maybeNonNumericConstStrings);
 		assertType('non-falsy-string', $maybeNonNumericConstStrings.$i);
 
-		assertType('non-falsy-string&numeric-string', $i.$maybeFloatConstStrings);
+		assertType('non-falsy-string', $i.$maybeFloatConstStrings); // could be 'non-falsy-string&numeric-string'
 		assertType('non-falsy-string', $maybeFloatConstStrings.$i);
 
 		assertType('non-empty-string&numeric-string', $i.$bool);
@@ -61,15 +63,14 @@ class HelloWorld
 		assertType('non-falsy-string', $maybeNegativeConstStrings.$negativeInt);
 		assertType('non-falsy-string', $negativeInt.$maybeNegativeConstStrings);
 
+		// https://3v4l.org/BCS2K
 		assertType('non-falsy-string', $float.$float);
 		assertType('non-falsy-string&numeric-string', $float.$positiveInt);
 		assertType('non-falsy-string', $float.$negativeInt);
 		assertType('non-falsy-string', $float.$i);
 		assertType('non-falsy-string', $i.$float); // could be 'non-falsy-string&numeric-string'
-
-		// https://3v4l.org/BCS2K
-		assertType('true', is_numeric('0.2'));
-		assertType('false', is_numeric('123.23' . '0.2'));
+		assertType('non-falsy-string', $numericString.$float);
+		assertType('non-falsy-string', $numericString.$maybeFloatConstStrings);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-11129.php
+++ b/tests/PHPStan/Analyser/data/bug-11129.php
@@ -71,6 +71,13 @@ class HelloWorld
 		assertType('non-falsy-string', $i.$float); // could be 'non-falsy-string&numeric-string'
 		assertType('non-falsy-string', $numericString.$float);
 		assertType('non-falsy-string', $numericString.$maybeFloatConstStrings);
+
+		// https://3v4l.org/Ia4r0
+		$scientificFloatAsString = '3e4';
+		assertType('non-falsy-string', $numericString.$scientificFloatAsString);
+		assertType('non-falsy-string', $i.$scientificFloatAsString);
+		assertType('non-falsy-string', $scientificFloatAsString.$numericString);
+		assertType('non-falsy-string', $scientificFloatAsString.$i);
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-11129.php
+++ b/tests/PHPStan/Analyser/data/bug-11129.php
@@ -12,8 +12,13 @@ class HelloWorld
 	 * @param 0|'0'|'1'|'2' $positiveConstStrings
 	 * @param 0|-1|'2' $maybeNegativeConstStrings
 	 * @param 0|1|'a' $maybeNonNumericConstStrings
+	 * @param 0|1|0.2 $maybeFloatConstStrings
 	 */
-	public function foo(int $i, $positiveInt, $negativeInt, $positiveConstStrings, $maybeNegativeConstStrings, $maybeNonNumericConstStrings, bool $bool): void {
+	public function foo(
+		int $i, $positiveInt, $negativeInt, $positiveConstStrings,
+		$maybeNegativeConstStrings, $maybeNonNumericConstStrings, $maybeFloatConstStrings,
+		bool $bool, float $float
+	): void {
 		assertType('non-falsy-string', '0'.$i);
 		assertType('non-falsy-string&numeric-string', $i.'0');
 
@@ -41,6 +46,9 @@ class HelloWorld
 		assertType('non-falsy-string', $i.$maybeNonNumericConstStrings);
 		assertType('non-falsy-string', $maybeNonNumericConstStrings.$i);
 
+		assertType('non-falsy-string&numeric-string', $i.$maybeFloatConstStrings);
+		assertType('non-falsy-string', $maybeFloatConstStrings.$i);
+
 		assertType('non-empty-string&numeric-string', $i.$bool);
 		assertType('non-empty-string', $bool.$i);
 		assertType('non-empty-string&numeric-string', $positiveInt.$bool); // could be 'non-falsy-string&numeric-string'
@@ -52,6 +60,16 @@ class HelloWorld
 		assertType('non-falsy-string', $negativeInt.$negativeInt);
 		assertType('non-falsy-string', $maybeNegativeConstStrings.$negativeInt);
 		assertType('non-falsy-string', $negativeInt.$maybeNegativeConstStrings);
+
+		assertType('non-falsy-string', $float.$float);
+		assertType('non-falsy-string&numeric-string', $float.$positiveInt);
+		assertType('non-falsy-string', $float.$negativeInt);
+		assertType('non-falsy-string', $float.$i);
+		assertType('non-falsy-string', $i.$float); // could be 'non-falsy-string&numeric-string'
+
+		// https://3v4l.org/BCS2K
+		assertType('true', is_numeric('0.2'));
+		assertType('false', is_numeric('123.23' . '0.2'));
 	}
 
 }

--- a/tests/PHPStan/Analyser/data/bug-11129.php
+++ b/tests/PHPStan/Analyser/data/bug-11129.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Bug11129;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param positive-int $positiveInt
+	 * @param negative-int $negativeInt
+	 * @param 0|'0'|'1'|'2' $positiveConstStrings
+	 * @param 0|-1|'2' $maybeNegativeConstStrings
+	 * @param 0|1|'a' $maybeNonNumericConstStrings
+	 */
+	public function foo(int $i, $positiveInt, $negativeInt, $positiveConstStrings, $maybeNegativeConstStrings, $maybeNonNumericConstStrings, bool $bool): void {
+		assertType('non-falsy-string', '0'.$i);
+		assertType('non-falsy-string&numeric-string', $i.'0');
+
+		assertType('non-falsy-string&numeric-string', '0'.$positiveInt);
+		assertType('non-falsy-string&numeric-string', $positiveInt.'0');
+
+		assertType('non-falsy-string', '0'.$negativeInt);
+		assertType('non-falsy-string&numeric-string', $negativeInt.'0');
+
+		assertType("'00'|'01'|'02'", '0'.$positiveConstStrings);
+		assertType( "'00'|'10'|'20'", $positiveConstStrings.'0');
+
+		assertType("'0-1'|'00'|'02'", '0'.$maybeNegativeConstStrings);
+		assertType("'-10'|'00'|'20'", $maybeNegativeConstStrings.'0');
+
+		assertType("'00'|'01'|'0a'", '0'.$maybeNonNumericConstStrings);
+		assertType("'00'|'10'|'a0'", $maybeNonNumericConstStrings.'0');
+
+		assertType('non-falsy-string&numeric-string', $i.$positiveConstStrings);
+		assertType( 'non-falsy-string', $positiveConstStrings.$i);
+
+		assertType('non-falsy-string', $i.$maybeNegativeConstStrings);
+		assertType('non-falsy-string', $maybeNegativeConstStrings.$i);
+
+		assertType('non-falsy-string', $i.$maybeNonNumericConstStrings);
+		assertType('non-falsy-string', $maybeNonNumericConstStrings.$i);
+
+		assertType('non-empty-string&numeric-string', $i.$bool);
+		assertType('non-empty-string', $bool.$i);
+		assertType('non-empty-string&numeric-string', $positiveInt.$bool); // could be 'non-falsy-string&numeric-string'
+		assertType('non-empty-string&numeric-string', $bool.$positiveInt); // could be 'non-falsy-string&numeric-string'
+		assertType('non-empty-string&numeric-string', $negativeInt.$bool); // could be 'non-falsy-string&numeric-string'
+		assertType('non-empty-string', $bool.$negativeInt);
+
+		assertType('non-falsy-string', $i.$i);
+		assertType('non-falsy-string', $negativeInt.$negativeInt);
+		assertType('non-falsy-string', $maybeNegativeConstStrings.$negativeInt);
+		assertType('non-falsy-string', $negativeInt.$maybeNegativeConstStrings);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -636,7 +636,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				6,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(int, int): (literal-string&non-falsy-string) given.',
+				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(int, int): (literal-string&non-falsy-string&numeric-string) given.',
 				14,
 			],
 			[


### PR DESCRIPTION
Improving concat types related to https://github.com/phpstan/phpstan/issues/11129

while implementing I realized that the actual [root-cause for 11129 is likely related to some loop related types](https://phpstan.org/r/5fe1a560-a9af-48dc-9ebd-324fcdc0014c), not the concat typing alone.

I currently have no plans to look into the loop related parts, therefore submitting this typing enhancements alone. this means this PR will __not__ close Bug 11129. 