### PR TITLE
array_slice() returns non-empty array for existing offsets and positive limit

### DIFF
--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -5,9 +5,11 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -22,24 +24,25 @@ class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnType
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 1) {
 			return null;
 		}
 
-		$valueType = $scope->getType($functionCall->getArgs()[0]->value);
+		$valueType = $scope->getType($args[0]->value);
 		if (!$valueType->isArray()->yes()) {
 			return null;
 		}
 
-		$offsetType = isset($functionCall->getArgs()[1]) ? $scope->getType($functionCall->getArgs()[1]->value) : null;
-		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : 0;
+		$offsetType = isset($args[1]) ? $scope->getType($args[1]->value) : null;
+		$limitType = isset($args[2]) ? $scope->getType($args[2]->value) : null;
 
 		$constantArrays = $valueType->getConstantArrays();
 		if (count($constantArrays) > 0) {
-			$limitType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
-			$limit = $limitType instanceof ConstantIntegerType ? $limitType->getValue() : null;
+			$preserveKeysType = isset($args[3]) ? $scope->getType($args[3]->value) : null;
 
-			$preserveKeysType = isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null;
+			$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : 0;
+			$limit = $limitType instanceof ConstantIntegerType ? $limitType->getValue() : null;
 			$preserveKeys = $preserveKeysType !== null && $preserveKeysType->isTrue()->yes();
 
 			$results = [];
@@ -51,7 +54,17 @@ class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnType
 		}
 
 		if ($valueType->isIterableAtLeastOnce()->yes()) {
-			return TypeCombinator::union($valueType, new ConstantArrayType([], []));
+			$optionalOffsetsType = TypeCombinator::union($valueType, new ConstantArrayType([], []));
+
+			$zero = new ConstantIntegerType(0);
+			if (
+				($offsetType === null || $zero->isSuperTypeOf($offsetType)->yes())
+				&& ($limitType === null || IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($limitType)->yes())
+			) {
+				return TypeCombinator::intersect($optionalOffsetsType, new NonEmptyArrayType());
+			}
+
+			return $optionalOffsetsType;
 		}
 
 		return $valueType;

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -1497,6 +1497,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10187.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-5309.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10834.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10721.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-11035.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10952.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-10952b.php');

--- a/tests/PHPStan/Analyser/data/bug-10721.php
+++ b/tests/PHPStan/Analyser/data/bug-10721.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10721;
+
+use function PHPStan\Testing\assertType;
+
+final class HandpickedWordlistProvider
+{
+	/**
+	 * @return non-empty-list<non-empty-string>
+	 */
+	public function retrieve(?int $limit = 20): array
+	{
+		$list = [
+			'zib',
+			'zib 2',
+			'zeit im bild',
+			'soko',
+			'landkrimi',
+			'tatort',
+		];
+
+		assertType("array{'zib', 'zib 2', 'zeit im bild', 'soko', 'landkrimi', 'tatort'}", $list);
+		shuffle($list);
+		assertType("non-empty-array<0|1|2|3|4|5, 'landkrimi'|'soko'|'tatort'|'zeit im bild'|'zib'|'zib 2'>&list", $list);
+
+		assertType("non-empty-array<0|1|2|3|4|5, 'landkrimi'|'soko'|'tatort'|'zeit im bild'|'zib'|'zib 2'>&list", array_slice($list, 0, max($limit, 1)));
+		return array_slice($list, 0, max($limit, 1));
+	}
+
+	public function listVariants(): void
+	{
+		$arr = [
+			2 => 'zib',
+			4 => 'zib 2',
+		];
+
+		assertType("array{2: 'zib', 4: 'zib 2'}", $arr);
+		shuffle($arr);
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", $arr);
+
+		$list = [
+			'zib',
+			'zib 2',
+		];
+
+		assertType("array{'zib', 'zib 2'}", $list);
+		shuffle($list);
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", $list);
+
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1));
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0));
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2));
+
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 1));
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 1));
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 1)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 1));
+
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 2));
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 2));
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 2)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 2));
+
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 3));
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 3));
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 3)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 3));
+
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 3, true));
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 3, true));
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 3, true)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 3, true));
+
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 3, false));
+		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 3, false));
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 3, false)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 3, false));
+	}
+
+	/**
+	 * @param array<int, string> $strings
+	 * @param 0|1 $maybeZero
+	 */
+	public function arrayVariants(array $strings, $maybeZero): void
+	{
+		assertType("array<int, string>", $strings);
+		assertType("array<int, string>", array_slice($strings, 0));
+		assertType("array<int, string>", array_slice($strings, 1));
+		assertType("array<int, string>", array_slice($strings, $maybeZero));
+
+		if (count($strings) > 0) {
+			assertType("non-empty-array<int, string>", $strings);
+			assertType("non-empty-array<int, string>", array_slice($strings, 0));
+			assertType("array<int, string>", array_slice($strings, 1));
+			assertType("array<int, string>", array_slice($strings, $maybeZero));
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -1024,4 +1024,9 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/array-push-preserves-list.php'], []);
 	}
 
+	public function testBug10721(): void
+	{
+		$this->analyse([__DIR__ . '/../../Analyser/data/bug-10721.php'], []);
+	}
+
 }


### PR DESCRIPTION
keep the non-empty-array accessory type when `array_slice` is invoked with a `0` offset and a positive limit.

initially I tried beeing smarter for non-zero offset cases, but this didn't work out because of a [too imprecise type after `shuffle`](https://github.com/phpstan/phpstan-src/pull/3121#discussion_r1625535272).

closes https://github.com/phpstan/phpstan/issues/10721

