### PR TITLE
Consider a ClosureType() as maybe impure by default when no impurePoints array provided

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -360,7 +360,7 @@ class TypeNodeResolver
 				return new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes());
 
 			case 'pure-closure':
-				return new ClosureType(null, null, true, null, null, null, [], [], []);
+				return ClosureType::createPure();
 
 			case 'resource':
 				$type = $this->tryResolvePseudoTypeClassType($typeNode, $nameScope);

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -360,7 +360,7 @@ class TypeNodeResolver
 				return new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes());
 
 			case 'pure-closure':
-				return new ClosureType();
+				return new ClosureType(impurePoints: []);
 
 			case 'resource':
 				$type = $this->tryResolvePseudoTypeClassType($typeNode, $nameScope);

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -360,7 +360,7 @@ class TypeNodeResolver
 				return new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes());
 
 			case 'pure-closure':
-				return new ClosureType(impurePoints: []);
+				return new ClosureType(null, null, true, null, null, null, [], [], []);
 
 			case 'resource':
 				$type = $this->tryResolvePseudoTypeClassType($typeNode, $nameScope);

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -75,6 +75,7 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 
 	private TemplateTypeVarianceMap $callSiteVarianceMap;
 
+	/** @var SimpleImpurePoint[] */
 	private array $impurePoints;
 
 	/**

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -75,12 +75,14 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 
 	private TemplateTypeVarianceMap $callSiteVarianceMap;
 
+	private array $impurePoints;
+
 	/**
 	 * @api
 	 * @param array<int, ParameterReflection>|null $parameters
 	 * @param array<non-empty-string, TemplateTag> $templateTags
 	 * @param SimpleThrowPoint[] $throwPoints
-	 * @param SimpleImpurePoint[] $impurePoints
+	 * @param ?SimpleImpurePoint[] $impurePoints
 	 * @param InvalidateExprNode[] $invalidateExpressions
 	 * @param string[] $usedVariables
 	 */
@@ -93,7 +95,7 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		?TemplateTypeVarianceMap $callSiteVarianceMap = null,
 		private array $templateTags = [],
 		private array $throwPoints = [],
-		private array $impurePoints = [],
+		?array $impurePoints = null,
 		private array $invalidateExpressions = [],
 		private array $usedVariables = [],
 	)
@@ -105,6 +107,7 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		$this->templateTypeMap = $templateTypeMap ?? TemplateTypeMap::createEmpty();
 		$this->resolvedTemplateTypeMap = $resolvedTemplateTypeMap ?? TemplateTypeMap::createEmpty();
 		$this->callSiteVarianceMap = $callSiteVarianceMap ?? TemplateTypeVarianceMap::createEmpty();
+		$this->impurePoints = $impurePoints ?? [new SimpleImpurePoint('functionCall', 'call to an unknown Closure', false)];
 	}
 
 	/**

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -119,10 +119,8 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return $this->templateTags;
 	}
 
-	/**
-	 * @return self
-	 */
-	public static function createPure(): self {
+	public static function createPure(): self
+	{
 		return new self(null, null, true, null, null, null, [], [], []);
 	}
 

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -119,6 +119,13 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		return $this->templateTags;
 	}
 
+	/**
+	 * @return self
+	 */
+	public static function createPure(): self {
+		return new self(null, null, true, null, null, null, [], [], []);
+	}
+
 	public function isPure(): TrinaryLogic
 	{
 		$impurePoints = $this->getImpurePoints();

--- a/tests/PHPStan/Type/ClosureTypeTest.php
+++ b/tests/PHPStan/Type/ClosureTypeTest.php
@@ -24,7 +24,7 @@ class ClosureTypeTest extends PHPStanTestCase
 				TrinaryLogic::createYes(),
 			],
 			[
-				new ClosureType([], new MixedType(), false, impurePoints: []),
+				new ClosureType([], new MixedType(), false, null, null, null, [], [], []),
 				new ClosureType([], new MixedType(), false),
 				TrinaryLogic::createMaybe(),
 			],

--- a/tests/PHPStan/Type/ClosureTypeTest.php
+++ b/tests/PHPStan/Type/ClosureTypeTest.php
@@ -24,6 +24,11 @@ class ClosureTypeTest extends PHPStanTestCase
 				TrinaryLogic::createYes(),
 			],
 			[
+				new ClosureType([], new MixedType(), false, impurePoints: []),
+				new ClosureType([], new MixedType(), false),
+				TrinaryLogic::createMaybe(),
+			],
+			[
 				new ClosureType([], new UnionType([new IntegerType(), new StringType()]), false),
 				new ClosureType([], new IntegerType(), false),
 				TrinaryLogic::createYes(),

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2535,7 +2535,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		yield [
 			[
 				new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes()),
-				new ClosureType(),
+				new ClosureType(impurePoints: []),
 			],
 			CallableType::class,
 			'pure-callable(): mixed',
@@ -2553,7 +2553,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', true),
 				]),
-				new ClosureType(),
+				new ClosureType(impurePoints: []),
 			],
 			UnionType::class,
 			'(Closure(): mixed)|(pure-Closure)',
@@ -2563,7 +2563,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', false),
 				]),
-				new ClosureType(),
+				new ClosureType(impurePoints: []),
 			],
 			ClosureType::class,
 			'Closure(): mixed',
@@ -4219,7 +4219,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		yield [
 			[
 				new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes()),
-				new ClosureType(),
+				new ClosureType(impurePoints: []),
 			],
 			ClosureType::class,
 			'pure-Closure',
@@ -4237,7 +4237,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', true),
 				]),
-				new ClosureType(),
+				new ClosureType(impurePoints: []),
 			],
 			NeverType::class,
 			'*NEVER*=implicit',
@@ -4247,7 +4247,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', false),
 				]),
-				new ClosureType(),
+				new ClosureType(impurePoints: []),
 			],
 			ClosureType::class,
 			'pure-Closure',

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2535,7 +2535,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		yield [
 			[
 				new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes()),
-				new ClosureType(impurePoints: []),
+				new ClosureType(null, null, true, null, null, null, [], [], []),
 			],
 			CallableType::class,
 			'pure-callable(): mixed',
@@ -2553,7 +2553,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', true),
 				]),
-				new ClosureType(impurePoints: []),
+				new ClosureType(null, null, true, null, null, null, [], [], []),
 			],
 			UnionType::class,
 			'(Closure(): mixed)|(pure-Closure)',
@@ -2563,7 +2563,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', false),
 				]),
-				new ClosureType(impurePoints: []),
+				new ClosureType(null, null, true, null, null, null, [], [], []),
 			],
 			ClosureType::class,
 			'Closure(): mixed',
@@ -4219,7 +4219,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		yield [
 			[
 				new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes()),
-				new ClosureType(impurePoints: []),
+				new ClosureType(null, null, true, null, null, null, [], [], []),
 			],
 			ClosureType::class,
 			'pure-Closure',
@@ -4237,7 +4237,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', true),
 				]),
-				new ClosureType(impurePoints: []),
+				new ClosureType(null, null, true, null, null, null, [], [], []),
 			],
 			NeverType::class,
 			'*NEVER*=implicit',
@@ -4247,7 +4247,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', false),
 				]),
-				new ClosureType(impurePoints: []),
+				new ClosureType(null, null, true, null, null, null, [], [], []),
 			],
 			ClosureType::class,
 			'pure-Closure',

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2535,7 +2535,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		yield [
 			[
 				new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes()),
-				new ClosureType(null, null, true, null, null, null, [], [], []),
+				ClosureType::createPure(),
 			],
 			CallableType::class,
 			'pure-callable(): mixed',
@@ -2553,7 +2553,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', true),
 				]),
-				new ClosureType(null, null, true, null, null, null, [], [], []),
+				ClosureType::createPure(),
 			],
 			UnionType::class,
 			'(Closure(): mixed)|(pure-Closure)',
@@ -2563,7 +2563,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', false),
 				]),
-				new ClosureType(null, null, true, null, null, null, [], [], []),
+				ClosureType::createPure(),
 			],
 			ClosureType::class,
 			'Closure(): mixed',
@@ -4219,7 +4219,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		yield [
 			[
 				new CallableType(null, null, true, null, null, [], TrinaryLogic::createYes()),
-				new ClosureType(null, null, true, null, null, null, [], [], []),
+				ClosureType::createPure(),
 			],
 			ClosureType::class,
 			'pure-Closure',
@@ -4237,7 +4237,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', true),
 				]),
-				new ClosureType(null, null, true, null, null, null, [], [], []),
+				ClosureType::createPure(),
 			],
 			NeverType::class,
 			'*NEVER*=implicit',
@@ -4247,7 +4247,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ClosureType([], new MixedType(), true, null, null, null, [], [], [
 					new SimpleImpurePoint('functionCall', 'foo', false),
 				]),
-				new ClosureType(null, null, true, null, null, null, [], [], []),
+				ClosureType::createPure(),
 			],
 			ClosureType::class,
 			'pure-Closure',


### PR DESCRIPTION
Following the issue [#11135](https://github.com/phpstan/phpstan/issues/11135) 

- `$impurePoints` is no more promoted in the constructor
- Constructor's argument `$impurePoints` can be null, which will lead in a "Maybe" impure `ClosureType`.
- Making sure `TypeNodeResolver`'s return a Pure Closure when `pure-closure`. 
- Added a testcase & updating the testscases that used to create a pure-closure with `ClosureType()`

