### PR TITLE
get_debug_type() DynamicFunctionReturnTypeExtension bugfix

### DIFF
--- a/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
@@ -62,17 +62,15 @@ class GetDebugTypeFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		// "resources" type+state is skipped since we cannot infer the state
 
 		if ($type->isObject()->yes()) {
-			$classNames = $type->getObjectClassNames();
 			$reflections = $type->getObjectClassReflections();
-
 			$types = [];
-			foreach ($classNames as $index => $className) {
+			foreach ($reflections as $reflection) {
 				// if the class is not final, the actual returned string might be of a child class
-				if ($reflections[$index]->isFinal() && !$reflections[$index]->isAnonymous()) {
-					$types[] = new ConstantStringType($className);
+				if ($reflection->isFinal() && !$reflection->isAnonymous()) {
+					$types[] = new ConstantStringType($reflection->getName());
 				}
 
-				if ($reflections[$index]->isAnonymous()) { // phpcs:ignore
+				if ($reflection->isAnonymous()) { // phpcs:ignore
 					$types[] = new ConstantStringType('class@anonymous');
 				}
 			}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1373,6 +1373,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug11147(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11147.php');
+		$this->assertCount(1, $errors);
+		$this->assertSame('Method Bug11147\RedisAdapter::createConnection() has invalid return type Bug11147\NonExistentClass.', $errors[0]->getMessage());
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-11147.php
+++ b/tests/PHPStan/Analyser/data/bug-11147.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug11147;
+
+use Exception;
+use Redis;
+use function get_debug_type;
+use function sprintf;
+
+class RedisAdapter {
+	public static function createConnection(mixed $url): \Redis|NonExistentClass
+	{
+		return new \Redis();
+	}
+}
+
+final class RedisFactory
+{
+	public function __invoke(): Redis
+	{
+		$connection = RedisAdapter::createConnection($_ENV['REDISCLOUD_URL']);
+
+		if (! $connection instanceof Redis) {
+			throw new Exception(
+				sprintf('Wrong Redis instance %s expected %s', get_debug_type($connection), Redis::class),
+			);
+		}
+
+		return $connection;
+	}
+}


### PR DESCRIPTION
Closes: https://github.com/phpstan/phpstan/issues/11147

Bug where I incorrectly assumed that the lists of class names and class reflections line up.