### PR TITLE
Relax test version restriction

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1690,19 +1690,30 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	public function testCountArrayShift(): void
 	{
 		if (PHP_VERSION_ID < 80000) {
-			$this->markTestSkipped('Test requires PHP 8.0.');
+			$errors = [
+				[
+					'Parameter #1 $var of function count expects array|Countable, array|false given.',
+					8,
+				],
+				[
+					'Parameter #1 $var of function count expects array|Countable, array|false given.',
+					16,
+				],
+			];
+		} else {
+			$errors = [
+				[
+					'Parameter #1 $value of function count expects array|Countable, array|false given.',
+					8,
+				],
+				[
+					'Parameter #1 $value of function count expects array|Countable, array|false given.',
+					16,
+				],
+			];
 		}
 
-		$this->analyse([__DIR__ . '/data/count-array-shift.php'], [
-			[
-				'Parameter #1 $value of function count expects array|Countable, array|false given.',
-				8,
-			],
-			[
-				'Parameter #1 $value of function count expects array|Countable, array|false given.',
-				16,
-			],
-		]);
+		$this->analyse([__DIR__ . '/data/count-array-shift.php'], $errors);
 	}
 
 }


### PR DESCRIPTION
There is no reason to restrict the version to 8.0 for this test