### PR TITLE
Ensure exec group CI is executed in default order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ tests:
 	php vendor/bin/paratest --runner WrapperRunner --no-coverage
 
 tests-integration:
-	php vendor/bin/paratest --runner WrapperRunner --no-coverage --group exec
+	php vendor/bin/paratest --runner WrapperRunner --no-coverage --group exec --order-by default
 
 tests-levels:
 	php vendor/bin/paratest --runner WrapperRunner --no-coverage --group levels


### PR DESCRIPTION
Due to the recent addition of the random execution order in phpunit.xml, the test TraitsCachingIssueIntegrationTest::testCachingIssue was failing due to the expectation to be executed exactly in the data order.