### PR TITLE
fix AMQPQueue::unbind routingKey type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -167,7 +167,7 @@ return [
 'AMQPQueue::setArguments' => ['void', 'arguments'=>'array'],
 'AMQPQueue::setFlags' => ['void', 'flags'=>'int|null'],
 'AMQPQueue::setName' => ['void', 'name'=>'string'],
-'AMQPQueue::unbind' => ['void', 'exchangeName'=>'string', 'routingKey='=>'string', 'arguments='=>'array'],
+'AMQPQueue::unbind' => ['void', 'exchangeName'=>'string', 'routingKey='=>'string|null', 'arguments='=>'array'],
 'apache_child_terminate' => ['bool'],
 'apache_get_modules' => ['array'],
 'apache_get_version' => ['string|false'],


### PR DESCRIPTION
I made a mistake in #3139 and `$routingKey` of `AMQPQueue::unbind` was not correctly updated, it accepts null.

https://github.com/php-amqp/php-amqp/blob/a9cbd81ea401d4ba41b72381008b331f5516823c/stubs/AMQPQueue.php#L373-L384