### PR TITLE
Add parameter definitions to AMQPQueue::consume callback

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -150,7 +150,7 @@ return [
 'AMQPQueue::ack' => ['void', 'deliveryTag'=>'int', 'flags='=>'int|null'],
 'AMQPQueue::bind' => ['void', 'exchangeName'=>'string', 'routingKey='=>'string|null', 'arguments='=>'array'],
 'AMQPQueue::cancel' => ['void', 'consumerTag='=>'string'],
-'AMQPQueue::consume' => ['void', 'callback='=>'callable|null', 'flags='=>'int|null', 'consumerTag='=>'string|null'],
+'AMQPQueue::consume' => ['void', 'callback='=>'callable(AMQPEnvelope): mixed|callable(AMQPEnvelope, AMQPQueue): mixed|null', 'flags='=>'int|null', 'consumerTag='=>'string|null'],
 'AMQPQueue::declareQueue' => ['int'],
 'AMQPQueue::delete' => ['int', 'flags='=>'int|null'],
 'AMQPQueue::get' => ['AMQPEnvelope|null', 'flags='=>'int|null'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -150,7 +150,7 @@ return [
 'AMQPQueue::ack' => ['void', 'deliveryTag'=>'int', 'flags='=>'int|null'],
 'AMQPQueue::bind' => ['void', 'exchangeName'=>'string', 'routingKey='=>'string|null', 'arguments='=>'array'],
 'AMQPQueue::cancel' => ['void', 'consumerTag='=>'string'],
-'AMQPQueue::consume' => ['void', 'callback='=>'callable(AMQPEnvelope, AMQPQueue): mixed|null', 'flags='=>'int|null', 'consumerTag='=>'string|null'],
+'AMQPQueue::consume' => ['void', 'callback='=>'null|callable(AMQPEnvelope, AMQPQueue): mixed', 'flags='=>'int|null', 'consumerTag='=>'string|null'],
 'AMQPQueue::declareQueue' => ['int'],
 'AMQPQueue::delete' => ['int', 'flags='=>'int|null'],
 'AMQPQueue::get' => ['AMQPEnvelope|null', 'flags='=>'int|null'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -150,7 +150,7 @@ return [
 'AMQPQueue::ack' => ['void', 'deliveryTag'=>'int', 'flags='=>'int|null'],
 'AMQPQueue::bind' => ['void', 'exchangeName'=>'string', 'routingKey='=>'string|null', 'arguments='=>'array'],
 'AMQPQueue::cancel' => ['void', 'consumerTag='=>'string'],
-'AMQPQueue::consume' => ['void', 'callback='=>'callable(AMQPEnvelope): mixed|callable(AMQPEnvelope, AMQPQueue): mixed|null', 'flags='=>'int|null', 'consumerTag='=>'string|null'],
+'AMQPQueue::consume' => ['void', 'callback='=>'callable(AMQPEnvelope, AMQPQueue): mixed|null', 'flags='=>'int|null', 'consumerTag='=>'string|null'],
 'AMQPQueue::declareQueue' => ['int'],
 'AMQPQueue::delete' => ['int', 'flags='=>'int|null'],
 'AMQPQueue::get' => ['AMQPEnvelope|null', 'flags='=>'int|null'],


### PR DESCRIPTION
```
     * @param callable|null $callback A callback function to which the
     *                                consumed message will be passed. The
     *                                function must accept at a minimum
     *                                one parameter, an AMQPEnvelope object,
     *                                and an optional second parameter
     *                                the AMQPQueue object from which callback
     *                                was invoked. The AMQPQueue::consume() will
     *                                not return the processing thread back to
     *                                the PHP script until the callback
     *                                function returns FALSE.
     *                                If the callback is omitted or null is passed,
     *                                then the messages delivered to this client will
     *                                be made available to the first real callback
     *                                registered. That allows one to have a single
     *                                callback consuming from multiple queues.
```

I was not sure if this could just be defined as `callable(AMQPEnvelope, AMQPQueue=): mixed`, let me know if it can and I'll update.

Note this is an enrichment over `jetbrains/phpstorm-stubs` which only declares it as `callable`.