### PR TITLE
Introduce a common base class for all types

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -90,7 +90,6 @@
 	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit">
 		<exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.UselessElseIf"/>
 	</rule>
-	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
 	<rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
 	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
 		<properties>

--- a/src/Type/AbstractType.php
+++ b/src/Type/AbstractType.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+abstract class AbstractType implements Type
+{
+
+	public function __toString(): string
+	{
+		return $this->describe(VerbosityLevel::precise());
+	}
+
+}

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -28,7 +29,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
 /** @api */
-class AccessoryArrayListType implements CompoundType, AccessoryType
+class AccessoryArrayListType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
@@ -31,7 +32,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class AccessoryLiteralStringType implements CompoundType, AccessoryType
+class AccessoryLiteralStringType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
@@ -32,7 +33,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
+class AccessoryNonEmptyStringType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
@@ -31,7 +32,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
+class AccessoryNonFalsyStringType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
@@ -31,7 +32,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class AccessoryNumericStringType implements CompoundType, AccessoryType
+class AccessoryNumericStringType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use NonArrayTypeTrait;

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\Reflection\Type\CallbackUnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ErrorType;
@@ -27,7 +28,7 @@ use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 use function strtolower;
 
-class HasMethodType implements AccessoryType, CompoundType
+class HasMethodType extends AbstractType implements AccessoryType, CompoundType
 {
 
 	use ObjectTypeTrait;

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -29,7 +30,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
-class HasOffsetType implements CompoundType, AccessoryType
+class HasOffsetType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeArrayTypeTrait;

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -31,7 +32,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
-class HasOffsetValueType implements CompoundType, AccessoryType
+class HasOffsetValueType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeArrayTypeTrait;

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ErrorType;
@@ -21,7 +22,7 @@ use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
-class HasPropertyType implements AccessoryType, CompoundType
+class HasPropertyType extends AbstractType implements AccessoryType, CompoundType
 {
 
 	use ObjectTypeTrait;

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -26,7 +27,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class NonEmptyArrayType implements CompoundType, AccessoryType
+class NonEmptyArrayType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\AcceptsResult;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -26,7 +27,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
-class OversizedArrayType implements CompoundType, AccessoryType
+class OversizedArrayType extends AbstractType implements CompoundType, AccessoryType
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -33,7 +33,7 @@ use function count;
 use function sprintf;
 
 /** @api */
-class ArrayType implements Type
+class ArrayType extends AbstractType implements Type
 {
 
 	use MaybeCallableTypeTrait;

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -22,7 +22,7 @@ use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 
 /** @api */
-class BooleanType implements Type
+class BooleanType extends AbstractType implements Type
 {
 
 	use JustNullableTypeTrait;

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -40,7 +40,7 @@ use function array_merge;
 use function count;
 
 /** @api */
-class CallableType implements CompoundType, CallableParametersAcceptor
+class CallableType extends AbstractType implements CompoundType, CallableParametersAcceptor
 {
 
 	use MaybeArrayTypeTrait;

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -49,7 +49,7 @@ use function array_merge;
 use function count;
 
 /** @api */
-class ClosureType implements TypeWithClassName, CallableParametersAcceptor
+class ClosureType extends AbstractType implements TypeWithClassName, CallableParametersAcceptor
 {
 
 	use NonArrayTypeTrait;

--- a/src/Type/ConditionalType.php
+++ b/src/Type/ConditionalType.php
@@ -12,7 +12,7 @@ use function array_merge;
 use function sprintf;
 
 /** @api */
-final class ConditionalType implements CompoundType, LateResolvableType
+final class ConditionalType extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/ConditionalTypeForParameter.php
+++ b/src/Type/ConditionalTypeForParameter.php
@@ -12,7 +12,7 @@ use function array_merge;
 use function sprintf;
 
 /** @api */
-final class ConditionalTypeForParameter implements CompoundType, LateResolvableType
+final class ConditionalTypeForParameter extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -22,7 +22,7 @@ use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use function get_class;
 
 /** @api */
-class FloatType implements Type
+class FloatType extends AbstractType implements Type
 {
 
 	use NonArrayTypeTrait;

--- a/src/Type/Helper/GetTemplateTypeType.php
+++ b/src/Type/Helper/GetTemplateTypeType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\AbstractType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\LateResolvableType;
@@ -18,7 +19,7 @@ use PHPStan\Type\VerbosityLevel;
 use function sprintf;
 
 /** @api */
-final class GetTemplateTypeType implements CompoundType, LateResolvableType
+final class GetTemplateTypeType extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -20,7 +20,7 @@ use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 
 /** @api */
-class IntegerType implements Type
+class IntegerType extends AbstractType implements Type
 {
 
 	use JustNullableTypeTrait;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -48,7 +48,7 @@ use function strlen;
 use function substr;
 
 /** @api */
-class IntersectionType implements CompoundType
+class IntersectionType extends AbstractType implements CompoundType
 {
 
 	use NonRemoveableTypeTrait;

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -23,7 +23,7 @@ use function array_merge;
 use function sprintf;
 
 /** @api */
-class IterableType implements CompoundType
+class IterableType extends AbstractType implements CompoundType
 {
 
 	use MaybeArrayTypeTrait;

--- a/src/Type/KeyOfType.php
+++ b/src/Type/KeyOfType.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use function sprintf;
 
 /** @api */
-class KeyOfType implements CompoundType, LateResolvableType
+class KeyOfType extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -35,7 +35,7 @@ use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use function sprintf;
 
 /** @api */
-class MixedType implements CompoundType, SubtractableType
+class MixedType extends AbstractType implements CompoundType, SubtractableType
 {
 
 	use NonGenericTypeTrait;

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -21,7 +21,7 @@ use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 
 /** @api */
-class NeverType implements CompoundType
+class NeverType extends AbstractType implements CompoundType
 {
 
 	use UndecidedBooleanTypeTrait;

--- a/src/Type/NewObjectType.php
+++ b/src/Type/NewObjectType.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use function sprintf;
 
 /** @api */
-class NewObjectType implements CompoundType, LateResolvableType
+class NewObjectType extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -23,7 +23,7 @@ use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 
-class NonexistentParentClassType implements Type
+class NonexistentParentClassType extends AbstractType implements Type
 {
 
 	use JustNullableTypeTrait;

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -20,7 +20,7 @@ use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 
 /** @api */
-class NullType implements ConstantScalarType
+class NullType extends AbstractType implements ConstantScalarType
 {
 
 	use NonArrayTypeTrait;

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -36,7 +36,7 @@ use function in_array;
 use function sprintf;
 
 /** @api */
-class ObjectShapeType implements Type
+class ObjectShapeType extends AbstractType implements Type
 {
 
 	use ObjectTypeTrait;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -59,7 +59,7 @@ use function sprintf;
 use function strtolower;
 
 /** @api */
-class ObjectType implements TypeWithClassName, SubtractableType
+class ObjectType extends AbstractType implements TypeWithClassName, SubtractableType
 {
 
 	use MaybeIterableTypeTrait;

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -12,7 +12,7 @@ use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use function sprintf;
 
 /** @api */
-class ObjectWithoutClassType implements SubtractableType
+class ObjectWithoutClassType extends AbstractType implements SubtractableType
 {
 
 	use ObjectTypeTrait;

--- a/src/Type/OffsetAccessType.php
+++ b/src/Type/OffsetAccessType.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use function array_merge;
 
 /** @api */
-final class OffsetAccessType implements CompoundType, LateResolvableType
+final class OffsetAccessType extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -20,7 +20,7 @@ use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 
 /** @api */
-class ResourceType implements Type
+class ResourceType extends AbstractType implements Type
 {
 
 	use JustNullableTypeTrait;

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -25,7 +25,7 @@ use function get_class;
 use function sprintf;
 
 /** @api */
-class StaticType implements TypeWithClassName, SubtractableType
+class StaticType extends AbstractType implements TypeWithClassName, SubtractableType
 {
 
 	use NonGenericTypeTrait;

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -22,7 +22,7 @@ use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 
-class StrictMixedType implements CompoundType
+class StrictMixedType extends AbstractType implements CompoundType
 {
 
 	use UndecidedComparisonCompoundTypeTrait;

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -23,7 +23,7 @@ use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use function count;
 
 /** @api */
-class StringType implements Type
+class StringType extends AbstractType implements Type
 {
 
 	use JustNullableTypeTrait;

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -346,4 +346,6 @@ interface Type
 	 */
 	public static function __set_state(array $properties): self;
 
+	public function __toString(): string;
+
 }

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -40,7 +40,7 @@ use function sprintf;
 use function str_contains;
 
 /** @api */
-class UnionType implements CompoundType
+class UnionType extends AbstractType implements CompoundType
 {
 
 	use NonGeneralizableTypeTrait;

--- a/src/Type/ValueOfType.php
+++ b/src/Type/ValueOfType.php
@@ -11,7 +11,7 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use function sprintf;
 
 /** @api */
-final class ValueOfType implements CompoundType, LateResolvableType
+final class ValueOfType extends AbstractType implements CompoundType, LateResolvableType
 {
 
 	use LateResolvableTypeTrait;

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -18,7 +18,7 @@ use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 
 /** @api */
-class VoidType implements Type
+class VoidType extends AbstractType implements Type
 {
 
 	use NonArrayTypeTrait;


### PR DESCRIPTION
I don't have much hope this will be accepted but I'll give it a try 😆 

I wanted to add a `__toString` method to all types, which can be useful while doing quick and dirty debugging with print. But that's not the point.

I believe that having a common class can be useful when adding new methods to the Type interface which would have a default implementation instead of having to copy/paste the same method in 40 or so files.

I had to disable the related phpcs rule to call it AbstractType, but I can also call it in a different way.. AnyType? BaseType?

What do you think? 