### PR TITLE
Update phpcs config with proper exclude pattern

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,6 @@
 	<arg name="encoding" value="utf-8"/>
 	<arg name="tab-width" value="4"/>
 	<arg name="cache" value="tmp/cache/phpcs"/>
-	<arg name="ignore" value="compiler/tests/*/data,tests/*/data,tests/*/traits,tests/notAutoloaded,tests/*/cache,src/Reflection/SignatureMap/functionMap.php,tests/e2e/magic-setter,tests/e2e/anon-class"/>
 	<arg value="sp"/>
 	<file>bin</file>
 	<file>src</file>
@@ -204,15 +203,17 @@
 			<property name="enable" value="true"/>
 		</properties>
 	</rule>
-	<exclude-pattern>tests/*/data</exclude-pattern>
-	<exclude-pattern>tests/PHPStan/Analyser/nsrt</exclude-pattern>
-	<exclude-pattern>tests/*/Fixture</exclude-pattern>
+	<exclude-pattern>compiler/tests/*/data/</exclude-pattern>
+	<exclude-pattern>tests/*/Fixture/</exclude-pattern>
+	<exclude-pattern>tests/*/cache/</exclude-pattern>
+	<exclude-pattern>tests/*/data/</exclude-pattern>
+	<exclude-pattern>tests/*/traits/</exclude-pattern>
+	<exclude-pattern>tests/PHPStan/Analyser/nsrt/</exclude-pattern>
+	<exclude-pattern>tests/e2e/anon-class/</exclude-pattern>
+	<exclude-pattern>tests/e2e/magic-setter/</exclude-pattern>
 	<exclude-pattern>tests/e2e/resultCache_1.php</exclude-pattern>
 	<exclude-pattern>tests/e2e/resultCache_2.php</exclude-pattern>
 	<exclude-pattern>tests/e2e/resultCache_3.php</exclude-pattern>
-	<exclude-pattern>tests/*/traits</exclude-pattern>
-	<exclude-pattern>tests/tmp</exclude-pattern>
-	<exclude-pattern>tests/notAutoloaded</exclude-pattern>
-	<exclude-pattern>src/Reflection/SignatureMap/functionMap.php</exclude-pattern>
-	<exclude-pattern>src/Reflection/SignatureMap/functionMetadata.php</exclude-pattern>
+	<exclude-pattern>tests/notAutoloaded/</exclude-pattern>
+	<exclude-pattern>tests/tmp/</exclude-pattern>
 </ruleset>

--- a/tests/PHPStan/Analyser/TraitStubFilesTest.php
+++ b/tests/PHPStan/Analyser/TraitStubFilesTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Analyser;
 

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Parser;
 
+use Generator;
+use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
@@ -13,22 +15,20 @@ class CachedParserTest extends PHPStanTestCase
 
 	/**
 	 * @dataProvider dataParseFileClearCache
-	 * @param int $cachedNodesByStringCountMax
-	 * @param int $cachedNodesByStringCountExpected
 	 */
 	public function testParseFileClearCache(
 		int $cachedNodesByStringCountMax,
-		int $cachedNodesByStringCountExpected
+		int $cachedNodesByStringCountExpected,
 	): void
 	{
 		$parser = new CachedParser(
 			$this->getParserMock(),
-			$cachedNodesByStringCountMax
+			$cachedNodesByStringCountMax,
 		);
 
 		$this->assertEquals(
 			$cachedNodesByStringCountMax,
-			$parser->getCachedNodesByStringCountMax()
+			$parser->getCachedNodesByStringCountMax(),
 		);
 
 		// Add strings to cache
@@ -38,16 +38,16 @@ class CachedParserTest extends PHPStanTestCase
 
 		$this->assertEquals(
 			$cachedNodesByStringCountExpected,
-			$parser->getCachedNodesByStringCount()
+			$parser->getCachedNodesByStringCount(),
 		);
 
 		$this->assertCount(
 			$cachedNodesByStringCountExpected,
-			$parser->getCachedNodesByString()
+			$parser->getCachedNodesByString(),
 		);
 	}
 
-	public function dataParseFileClearCache(): \Generator
+	public function dataParseFileClearCache(): Generator
 	{
 		yield 'even' => [
 			'cachedNodesByStringCountMax' => 50,
@@ -70,9 +70,9 @@ class CachedParserTest extends PHPStanTestCase
 		return $mock;
 	}
 
-	private function getPhpParserNodeMock(): \PhpParser\Node&MockObject
+	private function getPhpParserNodeMock(): Node&MockObject
 	{
-		return $this->createMock(\PhpParser\Node::class);
+		return $this->createMock(Node::class);
 	}
 
 	public function testParseTheSameFileWithDifferentMethod(): void


### PR DESCRIPTION
The pattern is actually matched as a regexp, so the trailing slash is necessary to avoid excluding unwanted files.

Also unified the patterns declared as 'arg' to the proper list.

Detailed list of changes:

1) Unified 'arg' ignores with the 'exclude-pattern' list, sorted and removed duplicates

2) Removed the following obsolete exclusions:
  - src/Reflection/SignatureMap/functionMap.php
  - src/Reflection/SignatureMap/functionMetadata.php

3) Ran phpcbf on the following files that were wrongly excluded:
  - tests/PHPStan/Analyser/TraitStubFilesTest.php
  - tests/PHPStan/Parser/CachedParserTest.php
