### PR TITLE
include path when counting errors ignored by identifier

### DIFF
--- a/src/Analyser/Ignore/IgnoredErrorHelper.php
+++ b/src/Analyser/Ignore/IgnoredErrorHelper.php
@@ -68,9 +68,9 @@ class IgnoredErrorHelper
 				continue;
 			}
 
-			$key = '';
+			$key = $ignoreError['path'];
 			if (isset($ignoreError['message'])) {
-				$key = sprintf("%s\n%s", $ignoreError['message'], $ignoreError['path']);
+				$key = sprintf("%s\n%s", $key, $ignoreError['message']);
 			}
 			if (isset($ignoreError['identifier'])) {
 				$key = sprintf("%s\n%s", $key, $ignoreError['identifier']);

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -210,6 +210,32 @@ class AnalyserTest extends PHPStanTestCase
 	/**
 	 * @dataProvider dataTrueAndFalse
 	 */
+	public function testIgnoreErrorByPathAndIdentifierCountsCorrectly(bool $onlyFiles): void
+	{
+		$ignoreErrors = [
+			[
+				'identifier' => 'tests.alwaysFail',
+				'count' => 3,
+				'path' => __DIR__ . '/data/two-fails.php',
+			],
+			[
+				'identifier' => 'tests.alwaysFail',
+				'count' => 2,
+				'path' => __DIR__ . '/data/two-different-fails.php',
+			],
+		];
+
+		$filesToAnalyze = [
+			__DIR__ . '/data/two-fails.php',
+			__DIR__ . '/data/two-different-fails.php',
+		];
+		$result = $this->runAnalyser($ignoreErrors, true, $filesToAnalyze, $onlyFiles);
+		$this->assertSame([], $result);
+	}
+
+	/**
+	 * @dataProvider dataTrueAndFalse
+	 */
 	public function testIgnoreErrorByPathAndCountMoreThanExpected(bool $onlyFiles): void
 	{
 		$ignoreErrors = [


### PR DESCRIPTION
this fixes phpstan/phpstan#11177