### PR TITLE
Refactor the data provider for NodeScopeResolverTest

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -252,7 +252,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 
 	/**
 	 * @api
-	 * @return array<string>
+	 * @return array<string, array{string, ?array{string, string}}>
 	 */
 	public static function gatherAssertFilesFromDirectory(string $base, string $path): array
 	{
@@ -283,6 +283,8 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	 * Copyright (c) 2012, Jakub Onderka
 	 *
 	 * Modified to return the parsed requirement instead of verifying it.
+	 *
+	 * @return ?array{string, string}
 	 */
 	private static function getFileLintRequirement(string $file): ?array
 	{

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -191,7 +191,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 	 */
 	public function testFileAsserts(string $file, ?array $requirement = null): void
 	{
-		if ($requirement && version_compare(PHP_VERSION, $requirement[1], $requirement[0]) === false) {
+		if ($requirement !== null && version_compare(PHP_VERSION, $requirement[1], $requirement[0]) === false) {
 			$this->markTestSkipped(sprintf('Requires php %s %s', $requirement[0], $requirement[1]));
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -5,8 +5,12 @@ namespace PHPStan\Analyser;
 use EnumTypeAssertions\Foo;
 use PHPStan\Testing\TypeInferenceTestCase;
 use stdClass;
+use function array_shift;
 use function define;
+use function sprintf;
+use function version_compare;
 use const PHP_INT_SIZE;
+use const PHP_VERSION;
 use const PHP_VERSION_ID;
 
 class NodeScopeResolverTest extends TypeInferenceTestCase
@@ -14,66 +18,66 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypesFromDirectory(__DIR__ . '/nsrt');
+		yield from $this->gatherAssertFilesFromDirectory(__DIR__, 'nsrt');
 
 		if (PHP_VERSION_ID < 80200 && PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/enum-reflection-php81.php');
+			yield [__DIR__ . '/data/enum-reflection-php81.php'];
 		}
 
 		if (PHP_VERSION_ID < 80000 && PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-4902.php');
+			yield [__DIR__ . '/data/bug-4902.php'];
 		}
 
 		if (PHP_VERSION_ID < 80300) {
 			if (PHP_VERSION_ID >= 80200) {
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/mb-strlen-php82.php');
+				yield [__DIR__ . '/data/mb-strlen-php82.php'];
 			} elseif (PHP_VERSION_ID >= 80000) {
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/mb-strlen-php8.php');
+				yield [__DIR__ . '/data/mb-strlen-php8.php'];
 			} elseif (PHP_VERSION_ID < 70300) {
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/mb-strlen-php72.php');
+				yield [__DIR__ . '/data/mb-strlen-php72.php'];
 			} else {
-				yield from $this->gatherAssertTypes(__DIR__ . '/data/mb-strlen-php73.php');
+				yield [__DIR__ . '/data/mb-strlen-php73.php'];
 			}
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-6856.php');
+		yield [__DIR__ . '/../Rules/Methods/data/bug-6856.php'];
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/unionTypes.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/mixedType.php');
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Reflection/data/staticReturnType.php');
+			yield [__DIR__ . '/../Reflection/data/unionTypes.php'];
+			yield [__DIR__ . '/../Reflection/data/mixedType.php'];
+			yield [__DIR__ . '/../Reflection/data/staticReturnType.php'];
 		}
 
 		if (PHP_INT_SIZE === 8) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants-64bit.php');
+			yield [__DIR__ . '/data/predefined-constants-64bit.php'];
 		} else {
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/predefined-constants-32bit.php');
+			yield [__DIR__ . '/data/predefined-constants-32bit.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-10577.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-10610.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-2550.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Properties/data/bug-3777.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-4552.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/infer-array-key.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Generics/data/bug-6301.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-4643.php');
+		yield [__DIR__ . '/../Rules/Variables/data/bug-10577.php'];
+		yield [__DIR__ . '/../Rules/Variables/data/bug-10610.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/bug-2550.php'];
+		yield [__DIR__ . '/../Rules/Properties/data/bug-3777.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/bug-4552.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/infer-array-key.php'];
+		yield [__DIR__ . '/../Rules/Generics/data/bug-3769.php'];
+		yield [__DIR__ . '/../Rules/Generics/data/bug-6301.php'];
+		yield [__DIR__ . '/../Rules/PhpDoc/data/bug-4643.php'];
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-4857.php');
+			yield [__DIR__ . '/../Rules/Comparison/data/bug-4857.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5089.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/unable-to-resolve-callback-parameter-type.php');
+		yield [__DIR__ . '/../Rules/Methods/data/bug-5089.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/unable-to-resolve-callback-parameter-type.php'];
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/varying-acceptor.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-4415.php');
+		yield [__DIR__ . '/../Rules/Functions/data/varying-acceptor.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/bug-4415.php'];
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5372.php');
+			yield [__DIR__ . '/../Rules/Methods/data/bug-5372.php'];
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-5372_2.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5562.php');
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-5372_2.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/bug-5562.php'];
 
 		if (PHP_VERSION_ID >= 80100) {
 			define('TEST_OBJECT_CONSTANT', new stdClass());
@@ -82,116 +86,120 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			define('TEST_FALSE_CONSTANT', false);
 			define('TEST_ARRAY_CONSTANT', [true, false, null]);
 			define('TEST_ENUM_CONSTANT', Foo::ONE);
-			yield from $this->gatherAssertTypes(__DIR__ . '/data/new-in-initializers-runtime.php');
+			yield [__DIR__ . '/data/new-in-initializers-runtime.php'];
 		}
 
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-6473.php');
+			yield [__DIR__ . '/../Rules/Comparison/data/bug-6473.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/filter-iterator-child-class.php');
+		yield [__DIR__ . '/../Rules/Methods/data/filter-iterator-child-class.php'];
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5749.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-5757.php');
+		yield [__DIR__ . '/../Rules/Methods/data/bug-5749.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/bug-5757.php'];
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-6635.php');
+			yield [__DIR__ . '/../Rules/Methods/data/bug-6635.php'];
 		}
 
 		if (PHP_VERSION_ID >= 80300) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Constants/data/bug-10212.php');
+			yield [__DIR__ . '/../Rules/Constants/data/bug-10212.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-3284.php');
+		yield [__DIR__ . '/../Rules/Methods/data/bug-3284.php'];
 
 		if (PHP_VERSION_ID >= 80300) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/return-type-class-constant.php');
+			yield [__DIR__ . '/../Rules/Methods/data/return-type-class-constant.php'];
 		}
 
 		//define('ALREADY_DEFINED_CONSTANT', true);
-		//yield from $this->gatherAssertTypes(__DIR__ . '/data/already-defined-constant.php');
+		//yield [__DIR__ . '/data/already-defined-constant.php'];
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/conditional-complex-templates.php');
+		yield [__DIR__ . '/../Rules/Methods/data/conditional-complex-templates.php'];
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-7511.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-4708.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-7156.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-6364.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-5758.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-3931.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-7417.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7469.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-3391.php');
+		yield [__DIR__ . '/../Rules/Methods/data/bug-7511.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/bug-4708.php'];
+		yield [__DIR__ . '/../Rules/Functions/data/bug-7156.php'];
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-6364.php'];
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-5758.php'];
+		yield [__DIR__ . '/../Rules/Functions/data/bug-3931.php'];
+		yield [__DIR__ . '/../Rules/Variables/data/bug-7417.php'];
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-7469.php'];
+		yield [__DIR__ . '/../Rules/Variables/data/bug-3391.php'];
 
 		if (PHP_VERSION_ID >= 70400) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-anonymous-function-method-constant.php');
+			yield [__DIR__ . '/../Rules/Functions/data/bug-anonymous-function-method-constant.php'];
 		}
 
 		if (PHP_VERSION_ID >= 80200) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/true-typehint.php');
+			yield [__DIR__ . '/../Rules/Methods/data/true-typehint.php'];
 		}
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-6000.php');
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-6000.php'];
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/slevomat-foreach-unset-bug.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/slevomat-foreach-array-key-exists-bug.php');
+		yield [__DIR__ . '/../Rules/Arrays/data/slevomat-foreach-unset-bug.php'];
+		yield [__DIR__ . '/../Rules/Arrays/data/slevomat-foreach-array-key-exists-bug.php'];
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-7898.php');
+			yield [__DIR__ . '/../Rules/Comparison/data/bug-7898.php'];
 		}
 
 		if (PHP_VERSION_ID >= 80000) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-7823.php');
+			yield [__DIR__ . '/../Rules/Functions/data/bug-7823.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-7954.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/docblock-assert-equality.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Properties/data/bug-7839.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Classes/data/bug-5333.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-8174.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8169.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-8280.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8277.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-8113.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-8389.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Arrays/data/bug-8467a.php');
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-7954.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/docblock-assert-equality.php'];
+		yield [__DIR__ . '/../Rules/Properties/data/bug-7839.php'];
+		yield [__DIR__ . '/../Rules/Classes/data/bug-5333.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/bug-8174.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/bug-8169.php'];
+		yield [__DIR__ . '/../Rules/Functions/data/bug-8280.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/bug-8277.php'];
+		yield [__DIR__ . '/../Rules/Variables/data/bug-8113.php'];
+		yield [__DIR__ . '/../Rules/Functions/data/bug-8389.php'];
+		yield [__DIR__ . '/../Rules/Arrays/data/bug-8467a.php'];
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-8485.php');
+			yield [__DIR__ . '/../Rules/Comparison/data/bug-8485.php'];
 		}
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-9007.php');
+			yield [__DIR__ . '/../Rules/Comparison/data/bug-9007.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/DeadCode/data/bug-8620.php');
+		yield [__DIR__ . '/../Rules/DeadCode/data/bug-8620.php'];
 
 		if (PHP_VERSION_ID >= 80200) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Constants/data/bug-8957.php');
+			yield [__DIR__ . '/../Rules/Constants/data/bug-8957.php'];
 		}
 
 		if (PHP_VERSION_ID >= 80100) {
-			yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-9499.php');
+			yield [__DIR__ . '/../Rules/Comparison/data/bug-9499.php'];
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-8609-function.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-5365.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Comparison/data/bug-6551.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Variables/data/bug-9403.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Methods/data/bug-9542.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/Functions/data/bug-9803.php');
-		yield from $this->gatherAssertTypes(__DIR__ . '/../Rules/PhpDoc/data/bug-10594.php');
+		yield [__DIR__ . '/../Rules/PhpDoc/data/bug-8609-function.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/bug-5365.php'];
+		yield [__DIR__ . '/../Rules/Comparison/data/bug-6551.php'];
+		yield [__DIR__ . '/../Rules/Variables/data/bug-9403.php'];
+		yield [__DIR__ . '/../Rules/Methods/data/bug-9542.php'];
+		yield [__DIR__ . '/../Rules/Functions/data/bug-9803.php'];
+		yield [__DIR__ . '/../Rules/PhpDoc/data/bug-10594.php'];
 	}
 
 	/**
 	 * @dataProvider dataFileAsserts
-	 * @param mixed ...$args
+	 * @param ?array{string, string} $requirement
 	 */
-	public function testFileAsserts(
-		string $assertType,
-		string $file,
-		...$args,
-	): void
+	public function testFileAsserts(string $file, ?array $requirement = null): void
 	{
-		$this->assertFileAsserts($assertType, $file, ...$args);
+		if ($requirement && version_compare(PHP_VERSION, $requirement[1], $requirement[0]) === false) {
+			$this->markTestSkipped(sprintf('Requires php %s %s', $requirement[0], $requirement[1]));
+		}
+
+		foreach (self::gatherAssertTypes($file) as $assert) {
+			$assertType = array_shift($assert);
+			$file = array_shift($assert);
+			$this->assertFileAsserts($assertType, $file, ...$assert);
+		}
 	}
 
 	public static function getAdditionalConfigFiles(): array


### PR DESCRIPTION
Refactor the data provider for NodeScopeResolverTest

Instead of yielding resolved analysis for each data file, and then have the
actual test only assert the given result, provide only the paths of the data
files and have the actual analysis and assertion inside the test case.

This brings the following benefits:
1) Listing tests and filtering by one single data file is much faster (showcase 1).
2) Data files skipped due to php version requirement now show as skipped
   instead of silently disappearing (showcase 2).
3) Repeating a test for a single data file many times is much faster while
   debugging the actual source code (showcase 3).
3) If the analysis would fail, instead of busting the whole test suite due to
   an exception inside the data provider, it shows inside the test case (showcase 4).

I believe in particular the showcase 4 happened a lot of times and it's hard
to debug because phpunit does not properly show uncaught exceptions in the
data providers.


## Showcase 1 - List available tests

Setup:
None.

Command:
`time ./vendor/bin/phpunit --no-coverage tests/PHPStan/Analyser/NodeScopeResolverTest.php --list-tests`

Before:
```
Available test(s):
(omitted many many lines, confusing output)

real    0m35.993s
user    0m33.520s
sys     0m0.357s
```

After:
```
Available test(s):
(omitted some lines, nicer output)

real    0m1.636s
user    0m1.488s
sys     0m0.094s
```

## Showcase 2 - Skipped data files due to version requirement now show up as skipped, same time

Setup:
None.

Command:
`time ./vendor/bin/phpunit --no-coverage tests/PHPStan/Analyser/NodeScopeResolverTest.php --list-tests`

Before:
```
.............................................................   61 / 9003 (  0%)
.............................................................  122 / 9003 (  1%)
(omitted dots)
............................................................. 8906 / 9003 ( 98%)
............................................................. 8967 / 9003 ( 99%)
....................................                          9003 / 9003 (100%)

Time: 00:01.579, Memory: 372.00 MB

OK (9003 tests, 9003 assertions)

real    0m36.586s
user    0m34.383s
sys     0m0.438s
```

After:
```
.........S............................S........................  63 / 996 (  6%)
..............S.................S....................S......... 126 / 996 ( 12%)
......S.................S........................S............. 189 / 996 ( 18%)
...............S......S..S...S...........SS..S................. 252 / 996 ( 25%)
...S..S........S....S.......................................... 315 / 996 ( 31%)
.....................S.............S........................... 378 / 996 ( 37%)
.................................S............................. 441 / 996 ( 44%)
..............................S....S........S.............S.... 504 / 996 ( 50%)
...........................................S................... 567 / 996 ( 56%)
............................................................... 630 / 996 ( 63%)
.......................S....................................... 693 / 996 ( 69%)
S............................S................................. 756 / 996 ( 75%)
................................S................SS............ 819 / 996 ( 82%)
........S...................S..S............................... 882 / 996 ( 88%)
.......................................................S....... 945 / 996 ( 94%)
.S......S.........................S................             996 / 996 (100%)

Time: 00:35.047, Memory: 368.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 996, Assertions: 9003, Skipped: 40.

real    0m36.719s
user    0m35.242s
sys     0m0.407s
```



## Showcase 3 - Running a single test data file with an assertion error, much faster

Setup:
Change `int<min, 2>` with `int<min, 42>` in `integer-range-types.php`

Command:
`time ./vendor/bin/phpunit --no-coverage tests/PHPStan/Analyser/NodeScopeResolverTest.php --filter integer-range`

Before:
```
............F..................................................  63 / 198 ( 31%)
............................................................... 126 / 198 ( 63%)
............................................................... 189 / 198 ( 95%)
.........                                                       198 / 198 (100%)

Time: 00:00.130, Memory: 368.00 MB

There was 1 failure:

1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "/home/web/php/phpstan/phpstan-src/tests/PHPStan/Analyser/nsrt/integer-range-types.php:9" ('type', '/home/web/php/phpstan/phpstan...es.php', 'int<min, 42>', 'int<min, 2>', 9)
Expected type int<min, 42>, got type int<min, 2> in /home/web/php/phpstan/phpstan-src/tests/PHPStan/Analyser/nsrt/integer-range-types.php on line 9.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<min, 42>'
+'int<min, 2>'

/home/web/php/phpstan/phpstan-src/src/Testing/TypeInferenceTestCase.php:125
/home/web/php/phpstan/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:194

FAILURES!
Tests: 198, Assertions: 198, Failures: 1.

real    0m35.080s
user    0m33.815s
sys     0m0.369s
```

After:
```
F                                                                   1 / 1 (100%)

Time: 00:00.406, Memory: 64.00 MB

There was 1 failure:

1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "nsrt/integer-range-types.php" ('/home/web/php/phpstan/phpstan...es.php', null)
Expected type int<min, 42>, got type int<min, 2> in /home/web/php/phpstan/phpstan-src/tests/PHPStan/Analyser/nsrt/integer-range-types.php on line 9.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'int<min, 42>'
+'int<min, 2>'

/home/web/php/phpstan/phpstan-src/src/Testing/TypeInferenceTestCase.php:126
/home/web/php/phpstan/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:201

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.

real    0m2.068s
user    0m1.895s
sys     0m0.119s
```



## Showcase 4 - Running a single test data file with a SYNTAX error, faster and better reporting

Setup:
Change `, $i);` with `, $i;` in `integer-range-types.php`

Command:
`time ./vendor/bin/phpunit --no-coverage tests/PHPStan/Analyser/NodeScopeResolverTest.php --filter integer-range`

Before:
```
No tests executed!

real    0m12.093s
user    0m11.542s
sys     0m0.240s
```

After:
```
E                                                                   1 / 1 (100%)

Time: 00:00.074, Memory: 46.00 MB

There was 1 error:

1) PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts with data set "nsrt/integer-range-types.php" ('/home/web/php/phpstan/phpstan...es.php', null)
PHPStan\Parser\ParserErrorsException: Syntax error, unexpected ';', expecting ')'

/home/web/php/phpstan/phpstan-src/src/Parser/RichParser.php:63
/home/web/php/phpstan/phpstan-src/src/Parser/PathRoutingParser.php:44
/home/web/php/phpstan/phpstan-src/src/Parser/CachedParser.php:46
/home/web/php/phpstan/phpstan-src/src/Testing/TypeInferenceTestCase.php:94
/home/web/php/phpstan/phpstan-src/src/Testing/TypeInferenceTestCase.php:244
/home/web/php/phpstan/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:198

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.

real    0m1.676s
user    0m1.510s
sys     0m0.122s
```
