### PR TITLE
Indicate file on TypeInferenceTestCase validation errors

### DIFF
--- a/src/File/SystemAgnosticSimpleRelativePathHelper.php
+++ b/src/File/SystemAgnosticSimpleRelativePathHelper.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\File;
+
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+class SystemAgnosticSimpleRelativePathHelper implements RelativePathHelper
+{
+
+	public function __construct(private FileHelper $fileHelper)
+	{
+	}
+
+	public function getRelativePath(string $filename): string
+	{
+		$cwd = $this->fileHelper->getWorkingDirectory();
+		if ($cwd !== '' && str_starts_with($filename, $cwd)) {
+			return substr($filename, strlen($cwd) + 1);
+		}
+
+		return $filename;
+	}
+
+}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -12,7 +12,7 @@ use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
 use PHPStan\File\FileHelper;
-use PHPStan\File\RelativePathHelper;
+use PHPStan\File\SystemAgnosticSimpleRelativePathHelper;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
@@ -146,8 +146,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	{
 		$fileHelper = self::getContainer()->getByType(FileHelper::class);
 
-		/** @var RelativePathHelper $relativePathHelper */
-		$relativePathHelper = self::getContainer()->getService('simpleRelativePathHelper');
+		$relativePathHelper = new SystemAgnosticSimpleRelativePathHelper($fileHelper);
 
 		$file = $fileHelper->normalizePath($file);
 

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -12,14 +12,13 @@ use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
 use PHPStan\File\FileHelper;
-use PHPStan\File\SimpleRelativePathHelper;
+use PHPStan\File\RelativePathHelper;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\FileTypeMapper;
@@ -32,7 +31,6 @@ use function count;
 use function fclose;
 use function fgets;
 use function fopen;
-use function getcwd;
 use function in_array;
 use function is_dir;
 use function is_string;
@@ -146,11 +144,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	 */
 	public static function gatherAssertTypes(string $file): array
 	{
-		$currentWorkingDirectory = getcwd();
-		if ($currentWorkingDirectory === false) {
-			throw new ShouldNotHappenException();
-		}
-		$pathHelper = new SimpleRelativePathHelper($currentWorkingDirectory);
+		$pathHelper = self::getContainer()->getByType(RelativePathHelper::class);
 
 		$asserts = [];
 		self::processFile($file, static function (Node $node, Scope $scope) use (&$asserts, $file, $pathHelper): void {

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -39,6 +39,7 @@ use function sprintf;
 use function stripos;
 use function strpos;
 use function strtolower;
+use function strtr;
 use function version_compare;
 use const PHP_VERSION;
 

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -144,7 +144,8 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	 */
 	public static function gatherAssertTypes(string $file): array
 	{
-		$pathHelper = self::getContainer()->getByType(RelativePathHelper::class);
+		/** @var RelativePathHelper $pathHelper */
+		$pathHelper = self::getContainer()->getService('relativePathHelper');
 
 		$asserts = [];
 		self::processFile($file, static function (Node $node, Scope $scope) use (&$asserts, $file, $pathHelper): void {

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -32,11 +32,11 @@ use function count;
 use function fclose;
 use function fgets;
 use function fopen;
+use function getcwd;
 use function in_array;
 use function is_dir;
 use function is_string;
 use function preg_match;
-use function realpath;
 use function sprintf;
 use function stripos;
 use function strpos;
@@ -146,11 +146,11 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	 */
 	public static function gatherAssertTypes(string $file): array
 	{
-		$projectRoot = realpath(__DIR__ . '/../../');
-		if ($projectRoot === false) {
+		$currentWorkingDirectory = getcwd();
+		if ($currentWorkingDirectory === false) {
 			throw new ShouldNotHappenException();
 		}
-		$pathHelper = new SimpleRelativePathHelper($projectRoot);
+		$pathHelper = new SimpleRelativePathHelper($currentWorkingDirectory);
 
 		$asserts = [];
 		self::processFile($file, static function (Node $node, Scope $scope) use (&$asserts, $file, $pathHelper): void {

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -163,7 +163,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				self::fail(sprintf(
 					'Missing use statement for %s() in %s on line %d.',
 					$functionName,
-					$pathHelper->getRelativePath($file),
+					$pathHelper->getRelativePath(strtr($file, '\\', '/')),
 					$node->getStartLine(),
 				));
 			} elseif ($functionName === 'PHPStan\\Testing\\assertType') {
@@ -172,7 +172,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 					self::fail(sprintf(
 						'Expected type must be a literal string, %s given in %s on line %d.',
 						$expectedType->describe(VerbosityLevel::precise()),
-						$pathHelper->getRelativePath($file),
+						$pathHelper->getRelativePath(strtr($file, '\\', '/')),
 						$node->getLine(),
 					));
 				}
@@ -184,7 +184,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 					self::fail(sprintf(
 						'Expected type must be a literal string, %s given in %s on line %d.',
 						$expectedType->describe(VerbosityLevel::precise()),
-						$pathHelper->getRelativePath($file),
+						$pathHelper->getRelativePath(strtr($file, '\\', '/')),
 						$node->getLine(),
 					));
 				}
@@ -244,7 +244,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 					'Function %s imported with wrong namespace %s called in %s on line %d.',
 					$correctFunction,
 					$functionName,
-					$pathHelper->getRelativePath($file),
+					$pathHelper->getRelativePath(strtr($file, '\\', '/')),
 					$node->getStartLine(),
 				));
 			}
@@ -253,7 +253,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				self::fail(sprintf(
 					'ERROR: Wrong %s() call in %s on line %d.',
 					$functionName,
-					$pathHelper->getRelativePath($file),
+					$pathHelper->getRelativePath(strtr($file, '\\', '/')),
 					$node->getStartLine(),
 				));
 			}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -145,8 +145,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	 */
 	public static function gatherAssertTypes(string $file): array
 	{
-		/** @var SimpleRelativePathHelper $pathHelper */
-		$pathHelper = self::getContainer()->getService('simpleRelativePathHelper');
+		$pathHelper = new SimpleRelativePathHelper(dirname(__DIR__, 2));
 
 		$asserts = [];
 		self::processFile($file, static function (Node $node, Scope $scope) use (&$asserts, $file, $pathHelper): void {
@@ -164,7 +163,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				self::fail(sprintf(
 					'Missing use statement for %s() in %s on line %d.',
 					$functionName,
-					$pathHelper->getRelativePath(strtr($file, '\\', '/')),
+					$pathHelper->getRelativePath($file),
 					$node->getStartLine(),
 				));
 			} elseif ($functionName === 'PHPStan\\Testing\\assertType') {
@@ -173,7 +172,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 					self::fail(sprintf(
 						'Expected type must be a literal string, %s given in %s on line %d.',
 						$expectedType->describe(VerbosityLevel::precise()),
-						$pathHelper->getRelativePath(strtr($file, '\\', '/')),
+						$pathHelper->getRelativePath($file),
 						$node->getLine(),
 					));
 				}
@@ -185,7 +184,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 					self::fail(sprintf(
 						'Expected type must be a literal string, %s given in %s on line %d.',
 						$expectedType->describe(VerbosityLevel::precise()),
-						$pathHelper->getRelativePath(strtr($file, '\\', '/')),
+						$pathHelper->getRelativePath($file),
 						$node->getLine(),
 					));
 				}
@@ -245,7 +244,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 					'Function %s imported with wrong namespace %s called in %s on line %d.',
 					$correctFunction,
 					$functionName,
-					$pathHelper->getRelativePath(strtr($file, '\\', '/')),
+					$pathHelper->getRelativePath($file),
 					$node->getStartLine(),
 				));
 			}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -12,7 +12,7 @@ use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
 use PHPStan\File\FileHelper;
-use PHPStan\File\RelativePathHelper;
+use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
@@ -144,8 +144,8 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	 */
 	public static function gatherAssertTypes(string $file): array
 	{
-		/** @var RelativePathHelper $pathHelper */
-		$pathHelper = self::getContainer()->getService('relativePathHelper');
+		/** @var SimpleRelativePathHelper $pathHelper */
+		$pathHelper = self::getContainer()->getService('simpleRelativePathHelper');
 
 		$asserts = [];
 		self::processFile($file, static function (Node $node, Scope $scope) use (&$asserts, $file, $pathHelper): void {

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -157,21 +157,22 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$functionName = $nameNode->toString();
 			if (in_array(strtolower($functionName), ['asserttype', 'assertnativetype', 'assertvariablecertainty'], true)) {
 				self::fail(sprintf(
-					'Missing use statement for %s() on line %d.',
+					'Missing use statement for %s() in %s on line %d.',
 					$functionName,
+					$file,
 					$node->getStartLine(),
 				));
 			} elseif ($functionName === 'PHPStan\\Testing\\assertType') {
 				$expectedType = $scope->getType($node->getArgs()[0]->value);
 				if (!$expectedType instanceof ConstantScalarType) {
-					self::fail(sprintf('Expected type must be a literal string, %s given on line %d.', $expectedType->describe(VerbosityLevel::precise()), $node->getLine()));
+					self::fail(sprintf('Expected type must be a literal string, %s given in %s on line %d.', $expectedType->describe(VerbosityLevel::precise()), $file, $node->getLine()));
 				}
 				$actualType = $scope->getType($node->getArgs()[1]->value);
 				$assert = ['type', $file, $expectedType->getValue(), $actualType->describe(VerbosityLevel::precise()), $node->getStartLine()];
 			} elseif ($functionName === 'PHPStan\\Testing\\assertNativeType') {
 				$expectedType = $scope->getType($node->getArgs()[0]->value);
 				if (!$expectedType instanceof ConstantScalarType) {
-					self::fail(sprintf('Expected type must be a literal string, %s given on line %d.', $expectedType->describe(VerbosityLevel::precise()), $node->getLine()));
+					self::fail(sprintf('Expected type must be a literal string, %s given in %s on line %d.', $expectedType->describe(VerbosityLevel::precise()), $file, $node->getLine()));
 				}
 
 				$actualType = $scope->getNativeType($node->getArgs()[1]->value);
@@ -226,17 +227,19 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				}
 
 				self::fail(sprintf(
-					'Function %s imported with wrong namespace %s called on line %d.',
+					'Function %s imported with wrong namespace %s called in %s on line %d.',
 					$correctFunction,
 					$functionName,
+					$file,
 					$node->getStartLine(),
 				));
 			}
 
 			if (count($node->getArgs()) !== 2) {
 				self::fail(sprintf(
-					'ERROR: Wrong %s() call on line %d.',
+					'ERROR: Wrong %s() call in %s on line %d.',
 					$functionName,
+					$file,
 					$node->getStartLine(),
 				));
 			}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -40,7 +40,6 @@ use function sprintf;
 use function stripos;
 use function strpos;
 use function strtolower;
-use function strtr;
 use function version_compare;
 use const PHP_VERSION;
 
@@ -254,7 +253,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 				self::fail(sprintf(
 					'ERROR: Wrong %s() call in %s on line %d.',
 					$functionName,
-					$pathHelper->getRelativePath(strtr($file, '\\', '/')),
+					$pathHelper->getRelativePath($file),
 					$node->getStartLine(),
 				));
 			}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -28,6 +28,7 @@ use Symfony\Component\Finder\Finder;
 use function array_map;
 use function array_merge;
 use function count;
+use function dirname;
 use function fclose;
 use function fgets;
 use function fopen;

--- a/tests/PHPStan/Analyser/PathConstantsTest.php
+++ b/tests/PHPStan/Analyser/PathConstantsTest.php
@@ -3,13 +3,18 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use const DIRECTORY_SEPARATOR;
 
 class PathConstantsTest extends TypeInferenceTestCase
 {
 
 	public function dataFileAsserts(): iterable
 	{
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/pathConstants.php');
+		if (DIRECTORY_SEPARATOR === '\\') {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/pathConstants-win.php');
+		} else {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/pathConstants.php');
+		}
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/pathConstants-win.php
+++ b/tests/PHPStan/Analyser/data/pathConstants-win.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace PathConstantsTestWin;
+
+\PHPStan\Testing\assertType('\'Analyser\\\\data\'', substr(__DIR__, -13));
+\PHPStan\Testing\assertType('\'pathConstants-win.php\'', substr(__FILE__, -21));

--- a/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
+++ b/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
@@ -11,39 +11,39 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 	{
 		yield [
 			__DIR__ . '/data/assert-certainty-missing-namespace.php',
-			'Missing use statement for assertVariableCertainty() on line 8.',
+			'Missing use statement for assertVariableCertainty() in tests/PHPStan/Testing/data/assert-certainty-missing-namespace.php on line 8.',
 		];
 		yield [
 			__DIR__ . '/data/assert-native-type-missing-namespace.php',
-			'Missing use statement for assertNativeType() on line 6.',
+			'Missing use statement for assertNativeType() in tests/PHPStan/Testing/data/assert-native-type-missing-namespace.php on line 6.',
 		];
 		yield [
 			__DIR__ . '/data/assert-type-missing-namespace.php',
-			'Missing use statement for assertType() on line 6.',
+			'Missing use statement for assertType() in tests/PHPStan/Testing/data/assert-type-missing-namespace.php on line 6.',
 		];
 		yield [
 			__DIR__ . '/data/assert-certainty-wrong-namespace.php',
-			'Function PHPStan\Testing\assertVariableCertainty imported with wrong namespace SomeWrong\Namespace\assertVariableCertainty called on line 9.',
+			'Function PHPStan\Testing\assertVariableCertainty imported with wrong namespace SomeWrong\Namespace\assertVariableCertainty called in tests/PHPStan/Testing/data/assert-certainty-wrong-namespace.php on line 9.',
 		];
 		yield [
 			__DIR__ . '/data/assert-native-type-wrong-namespace.php',
-			'Function PHPStan\Testing\assertNativeType imported with wrong namespace SomeWrong\Namespace\assertNativeType called on line 8.',
+			'Function PHPStan\Testing\assertNativeType imported with wrong namespace SomeWrong\Namespace\assertNativeType called in tests/PHPStan/Testing/data/assert-native-type-wrong-namespace.php on line 8.',
 		];
 		yield [
 			__DIR__ . '/data/assert-type-wrong-namespace.php',
-			'Function PHPStan\Testing\assertType imported with wrong namespace SomeWrong\Namespace\assertType called on line 8.',
+			'Function PHPStan\Testing\assertType imported with wrong namespace SomeWrong\Namespace\assertType called in tests/PHPStan/Testing/data/assert-type-wrong-namespace.php on line 8.',
 		];
 		yield [
 			__DIR__ . '/data/assert-certainty-case-insensitive.php',
-			'Missing use statement for assertvariablecertainty() on line 8.',
+			'Missing use statement for assertvariablecertainty() in tests/PHPStan/Testing/data/assert-certainty-case-insensitive.php on line 8.',
 		];
 		yield [
 			__DIR__ . '/data/assert-native-type-case-insensitive.php',
-			'Missing use statement for assertNATIVEType() on line 6.',
+			'Missing use statement for assertNATIVEType() in tests/PHPStan/Testing/data/assert-native-type-case-insensitive.php on line 6.',
 		];
 		yield [
 			__DIR__ . '/data/assert-type-case-insensitive.php',
-			'Missing use statement for assertTYPe() on line 6.',
+			'Missing use statement for assertTYPe() in tests/PHPStan/Testing/data/assert-type-case-insensitive.php on line 6.',
 		];
 	}
 

--- a/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
+++ b/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
@@ -2,48 +2,80 @@
 
 namespace PHPStan\Testing;
 
+use PHPStan\File\FileHelper;
 use PHPUnit\Framework\AssertionFailedError;
+use function sprintf;
 
 final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 {
 
 	public static function dataFileAssertionFailedErrors(): iterable
 	{
+		/** @var FileHelper $fileHelper */
+		$fileHelper = self::getContainer()->getByType(FileHelper::class);
+
 		yield [
 			__DIR__ . '/data/assert-certainty-missing-namespace.php',
-			'Missing use statement for assertVariableCertainty() in tests/PHPStan/Testing/data/assert-certainty-missing-namespace.php on line 8.',
+			sprintf(
+				'Missing use statement for assertVariableCertainty() in %s on line 8.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-certainty-missing-namespace.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-native-type-missing-namespace.php',
-			'Missing use statement for assertNativeType() in tests/PHPStan/Testing/data/assert-native-type-missing-namespace.php on line 6.',
+			sprintf(
+				'Missing use statement for assertNativeType() in %s on line 6.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-native-type-missing-namespace.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-type-missing-namespace.php',
-			'Missing use statement for assertType() in tests/PHPStan/Testing/data/assert-type-missing-namespace.php on line 6.',
+			sprintf(
+				'Missing use statement for assertType() in %s on line 6.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-type-missing-namespace.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-certainty-wrong-namespace.php',
-			'Function PHPStan\Testing\assertVariableCertainty imported with wrong namespace SomeWrong\Namespace\assertVariableCertainty called in tests/PHPStan/Testing/data/assert-certainty-wrong-namespace.php on line 9.',
+			sprintf(
+				'Function PHPStan\Testing\assertVariableCertainty imported with wrong namespace SomeWrong\Namespace\assertVariableCertainty called in %s on line 9.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-certainty-wrong-namespace.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-native-type-wrong-namespace.php',
-			'Function PHPStan\Testing\assertNativeType imported with wrong namespace SomeWrong\Namespace\assertNativeType called in tests/PHPStan/Testing/data/assert-native-type-wrong-namespace.php on line 8.',
+			sprintf(
+				'Function PHPStan\Testing\assertNativeType imported with wrong namespace SomeWrong\Namespace\assertNativeType called in %s on line 8.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-native-type-wrong-namespace.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-type-wrong-namespace.php',
-			'Function PHPStan\Testing\assertType imported with wrong namespace SomeWrong\Namespace\assertType called in tests/PHPStan/Testing/data/assert-type-wrong-namespace.php on line 8.',
+			sprintf(
+				'Function PHPStan\Testing\assertType imported with wrong namespace SomeWrong\Namespace\assertType called in %s on line 8.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-type-wrong-namespace.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-certainty-case-insensitive.php',
-			'Missing use statement for assertvariablecertainty() in tests/PHPStan/Testing/data/assert-certainty-case-insensitive.php on line 8.',
+			sprintf(
+				'Missing use statement for assertvariablecertainty() in %s on line 8.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-certainty-case-insensitive.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-native-type-case-insensitive.php',
-			'Missing use statement for assertNATIVEType() in tests/PHPStan/Testing/data/assert-native-type-case-insensitive.php on line 6.',
+			sprintf(
+				'Missing use statement for assertNATIVEType() in %s on line 6.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-native-type-case-insensitive.php'),
+			),
 		];
 		yield [
 			__DIR__ . '/data/assert-type-case-insensitive.php',
-			'Missing use statement for assertTYPe() in tests/PHPStan/Testing/data/assert-type-case-insensitive.php on line 6.',
+			sprintf(
+				'Missing use statement for assertTYPe() in %s on line 6.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-type-case-insensitive.php'),
+			),
 		];
 	}
 


### PR DESCRIPTION
was just hunting down a bug in one of my PRs, but wasn't able to find the offending file, because the error message did not indicate which file the error related to

before this PR:
```
There was 1 error:

1) Error
The data provider specified for PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts is invalid.
PHPUnit\Framework\AssertionFailedError: Expected type must be a literal string, string given on line 78.
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:166
/Users/staabm/workspace/phpstan-src/src/Node/ClassStatementsGatherer.php:128
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:650
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:759
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:3938
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:2124
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:758
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:339
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:649
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:339
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:835
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:339
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:803
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:296
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:92
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:145
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:271
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:17
```

after this PR:
```
1) Error
The data provider specified for PHPStan\Analyser\NodeScopeResolverTest::testFileAsserts is invalid.
PHPUnit\Framework\AssertionFailedError: Expected type must be a literal string, string given in tests/PHPStan/Analyser/nsrt/param-closure-this.php on line 78.
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:166
/Users/staabm/workspace/phpstan-src/src/Node/ClassStatementsGatherer.php:128
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:650
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:759
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:3938
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:2124
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:758
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:339
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:649
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:339
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:835
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:339
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:803
/Users/staabm/workspace/phpstan-src/src/Analyser/NodeScopeResolver.php:296
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:92
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:145
/Users/staabm/workspace/phpstan-src/src/Testing/TypeInferenceTestCase.php:273
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:17
```

note the added filename in the error message