### PR TITLE
 fix return type of sprintf with single %s format

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-11201.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11201.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11201;
+
+use function PHPStan\Testing\assertType;
+
+/** @return array<string> */
+function returnsArray(){
+	return [];
+}
+
+/** @return non-empty-string */
+function returnsNonEmptyString(): string
+{
+	return 'a';
+}
+
+/** @return non-falsy-string */
+function returnsNonFalsyString(): string
+{
+	return '1';
+}
+
+/** @return string */
+function returnsJustString(): string
+{
+	return rand(0,1) === 1 ? 'foo' : '';
+}
+
+$s = sprintf("%s", returnsNonEmptyString());
+assertType('non-empty-string', $s);
+
+$s = sprintf("%s", returnsNonFalsyString());
+assertType('non-falsy-string', $s);
+
+$s = sprintf("%s", returnsJustString());
+assertType('string', $s);
+
+$s = sprintf("%s", implode(', ', array_map('intval', returnsArray())));
+assertType('string', $s);
+
+$s = sprintf('%2$s', 1234, returnsNonFalsyString());
+assertType('non-falsy-string', $s);

--- a/tests/PHPStan/Analyser/nsrt/bug-7387.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7387.php
@@ -61,7 +61,7 @@ class HelloWorld
 		assertType('numeric-string', sprintf('%2$14F', $mixed, $f));
 		assertType('numeric-string', sprintf('%2$14F', $mixed, $s));
 
-		assertType('numeric-string', sprintf('%10$14F', $mixed, $s));
+		assertType('string', sprintf('%10$14F', $mixed, $s));
 	}
 
 	public function invalidPositionalArgFormat($mixed, string $s) {


### PR DESCRIPTION
In the return type extension of sprintf(), there was a shortcut to assume the return type to be non-falsy-string when the format-string is non-falsy string.

That's not correct though if the format string is just a single '%s' placeholder (or a single '%x$s' placeholder). In that case, if the requested argument is of stringy-type, then the return type is the type of the stringy argument.

This commit extends the existing support for single-placeholder templates that currently deals with numeric placeholders to also deal with %s

this fixes phpstan/phpstan#11201