### PR TITLE
Cast non-zero IntegerRangeType toString() is a non-falsy-string

### DIFF
--- a/src/Type/IntegerRangeType.php
+++ b/src/Type/IntegerRangeType.php
@@ -9,6 +9,8 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use function array_filter;
@@ -443,6 +445,23 @@ class IntegerRangeType extends IntegerType implements CompoundType
 		}
 
 		return new ConstantBooleanType(false);
+	}
+
+	public function toString(): Type
+	{
+		$isZero = (new ConstantIntegerType(0))->isSuperTypeOf($this);
+		if ($isZero->no()) {
+			return new IntersectionType([
+				new StringType(),
+				new AccessoryNumericStringType(),
+				new AccessoryNonFalsyStringType(),
+			]);
+		}
+
+		return new IntersectionType([
+			new StringType(),
+			new AccessoryNumericStringType(),
+		]);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/bug-11129.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11129.php
@@ -53,10 +53,10 @@ class HelloWorld
 
 		assertType('non-empty-string&numeric-string', $i.$bool);
 		assertType('non-empty-string', $bool.$i);
-		assertType('non-empty-string&numeric-string', $positiveInt.$bool); // could be 'non-falsy-string&numeric-string'
-		assertType('non-empty-string&numeric-string', $bool.$positiveInt); // could be 'non-falsy-string&numeric-string'
-		assertType('non-empty-string&numeric-string', $negativeInt.$bool); // could be 'non-falsy-string&numeric-string'
-		assertType('non-empty-string', $bool.$negativeInt);
+		assertType('non-falsy-string&numeric-string', $positiveInt.$bool);
+		assertType('non-falsy-string&numeric-string', $bool.$positiveInt);
+		assertType('non-falsy-string&numeric-string', $negativeInt.$bool); 
+		assertType('non-falsy-string', $bool.$negativeInt);
 
 		assertType('non-falsy-string', $i.$i);
 		assertType('non-falsy-string', $negativeInt.$negativeInt);

--- a/tests/PHPStan/Analyser/nsrt/cast-to-numeric-string.php
+++ b/tests/PHPStan/Analyser/nsrt/cast-to-numeric-string.php
@@ -18,8 +18,8 @@ function foo(int $a, float $b, $numeric, $numeric2, $number, $positive, $negativ
 	assertType('numeric-string', (string)$numeric);
 	assertType('numeric-string', (string)$numeric2);
 	assertType('numeric-string', (string)$number);
-	assertType('numeric-string', (string)$positive);
-	assertType('numeric-string', (string)$negative);
+	assertType('non-falsy-string&numeric-string', (string)$positive);
+	assertType('non-falsy-string&numeric-string', (string)$negative);
 	assertType("'1'", (string)$constantInt);
 }
 
@@ -37,8 +37,8 @@ function concatEmptyString(int $a, float $b, $numeric, $numeric2, $number, $posi
 	assertType('numeric-string', '' . $numeric);
 	assertType('numeric-string', '' . $numeric2);
 	assertType('numeric-string', '' . $number);
-	assertType('numeric-string', '' . $positive);
-	assertType('numeric-string', '' . $negative);
+	assertType('non-falsy-string&numeric-string', '' . $positive);
+	assertType('non-falsy-string&numeric-string', '' . $negative);
 	assertType("'1'", '' . $constantInt);
 
 	assertType('numeric-string', $a . '');
@@ -46,8 +46,8 @@ function concatEmptyString(int $a, float $b, $numeric, $numeric2, $number, $posi
 	assertType('numeric-string', $numeric . '');
 	assertType('numeric-string', $numeric2 . '');
 	assertType('numeric-string', $number . '');
-	assertType('numeric-string', $positive . '');
-	assertType('numeric-string', $negative . '');
+	assertType('non-falsy-string&numeric-string', $positive . '');
+	assertType('non-falsy-string&numeric-string', $negative . '');
 	assertType("'1'", $constantInt . '');
 }
 
@@ -58,4 +58,21 @@ function concatAssignEmptyString(int $i, float $f) {
 	$s = '';
 	$s .= $f;
 	assertType('numeric-string', $s);
+}
+
+/**
+ * @param int<0, max> $positive
+ * @param int<min, 0> $negative
+ */
+function integerRangeToString($positive, $negative)
+{
+	assertType('numeric-string', (string) $positive);
+	assertType('numeric-string', (string) $negative);
+
+	if ($positive !== 0) {
+		assertType('non-falsy-string&numeric-string', (string) $positive);
+	}
+	if ($negative !== 0) {
+		assertType('non-falsy-string&numeric-string', (string) $negative);
+	}
 }


### PR DESCRIPTION
while working on https://github.com/phpstan/phpstan-src/pull/3168 I realized there is some opportunity to make this typing more precise