### PR TITLE
issue-bot: subshell is eating the exit code

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -163,7 +163,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "$(./console.php evaluate)" >> $GITHUB_STEP_SUMMARY
+        run: ./console.php evaluate >> $GITHUB_STEP_SUMMARY
 
       - name: "Evaluate results - push"
         working-directory: "issue-bot"
@@ -172,4 +172,4 @@ jobs:
           GITHUB_PAT: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           PHPSTAN_SRC_COMMIT_BEFORE: ${{ github.event.before }}
           PHPSTAN_SRC_COMMIT_AFTER: ${{ github.event.after }}
-        run: echo "$(./console.php evaluate --post-comments)" >> $GITHUB_STEP_SUMMARY
+        run: ./console.php evaluate --post-comments >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
we want the github action to fail [in case of non zero exit status](https://github.com/phpstan/phpstan-src/blob/c1fc05398165ee36fa984879668371368e040b49/issue-bot/src/Console/EvaluateCommand.php#L163)

repro

```
➜  phpstan-src git:(1.11.x) echo "$(exit 1)" 

➜  phpstan-src git:(1.11.x) echo $?
0
```