### PR TITLE
TypeSpecifier - understand \Composer\Pcre\Preg::match() == 1 same way as === 1

### DIFF
--- a/build/composer-dependency-analyser.php
+++ b/build/composer-dependency-analyser.php
@@ -37,4 +37,5 @@ return $config
 	->ignoreUnknownClasses([
 		'JetBrains\PhpStorm\Pure', // not present on composer's classmap
 		'PHPStan\ExtensionInstaller\GeneratedConfig', // generated
+		'Composer\Pcre\Preg', // reverse dependency on composer/pcre
 	]);

--- a/build/composer-dependency-analyser.php
+++ b/build/composer-dependency-analyser.php
@@ -33,9 +33,9 @@ return $config
 	)
 	->ignoreErrorsOnPackage('phpunit/phpunit', [ErrorType::DEV_DEPENDENCY_IN_PROD]) // prepared test tooling
 	->ignoreErrorsOnPackage('jetbrains/phpstorm-stubs', [ErrorType::PROD_DEPENDENCY_ONLY_IN_DEV]) // there is no direct usage, but we need newer version then required by ondrejmirtes/BetterReflection
+	->ignoreErrorsOnPackage('composer/pcre', [ErrorType::SHADOW_DEPENDENCY]) // reverse dependency on composer/pcre to support https://github.com/composer/pcre/pull/24
 	->ignoreErrorsOnPath(__DIR__ . '/../tests', [ErrorType::UNKNOWN_CLASS, ErrorType::UNKNOWN_FUNCTION]) // to be able to test invalid symbols
 	->ignoreUnknownClasses([
 		'JetBrains\PhpStorm\Pure', // not present on composer's classmap
 		'PHPStan\ExtensionInstaller\GeneratedConfig', // generated
-		'Composer\Pcre\Preg', // reverse dependency on composer/pcre
 	]);


### PR DESCRIPTION
required for composer/pcre type narrowing analog
- https://github.com/phpstan/phpstan-src/commit/328fcb91de1605c1a578e45d72f20952b3312501
- https://github.com/phpstan/phpstan-src/commit/d842380a1f07014d045dd42d6ccd4204a85e688a

required for https://github.com/composer/pcre/pull/24#discussion_r1648827531 to [cover the `==1` and `===1` testcases](https://github.com/composer/pcre/pull/24/files#diff-8f259a63a4ab66c0f035859cea17176b75144dfb4c81db9981e04b66168edc4cR32-R50)