### PR TITLE
Implement TypeSpecifierComparisonContext

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -2081,10 +2081,7 @@ final class TypeSpecifier
 				return $this->specifyTypesInCondition($scope, new Expr\BinaryOp\Identical($expr->left, $expr->right), $context, $rootExpr);
 			}
 
-			if (
-				$context->true()
-				&& $exprNode instanceof Expr\CallLike
-			) {
+			if ($exprNode instanceof Expr\CallLike) {
 				$specifiedTypes = $this->specifyWithComparisonAwareTypeSpecifyingExtensions(
 					$expr,
 					$exprNode,
@@ -2188,8 +2185,7 @@ final class TypeSpecifier
 		$rightType = $scope->getType($rightExpr);
 
 		if (
-			$context->true()
-			&& $unwrappedLeftExpr instanceof FuncCall
+			$unwrappedLeftExpr instanceof FuncCall
 			&& $unwrappedLeftExpr->name instanceof Name
 		) {
 			$specifiedTypes = $this->specifyWithComparisonAwareTypeSpecifyingExtensions(

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -38,6 +38,7 @@ use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
+use PHPStan\Type\ComparisonAwareTypeSpecifyingExtension;
 use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -2005,6 +2006,47 @@ final class TypeSpecifier
 		return array_merge(...$extensionsForClass);
 	}
 
+	private function specifyWithComparisonAwareTypeSpecifyingExtensions(
+		Expr\BinaryOp $binaryOp,
+		Expr $callExpr,
+		Expr\CallLike $callLike,
+		Type $comparisonType,
+		Scope $scope,
+		TypeSpecifierContext $context,
+		?Expr $rootExpr,
+	): ?SpecifiedTypes
+	{
+		if ($callLike instanceof FuncCall && $callLike->name instanceof Name) {
+			if (!$this->reflectionProvider->hasFunction($callLike->name, $scope)) {
+				return null;
+			}
+			$functionReflection = $this->reflectionProvider->getFunction($callLike->name, $scope);
+
+			$comparisonContext = TypeSpecifierContext::createComparison(
+				new TypeSpecifierComparisonContext(
+					$binaryOp,
+					$callExpr,
+					$comparisonType,
+					$context,
+					$rootExpr,
+				),
+			);
+			foreach ($this->getFunctionTypeSpecifyingExtensions() as $extension) {
+				if (!$extension instanceof ComparisonAwareTypeSpecifyingExtension) {
+					continue;
+				}
+
+				if (!$extension->isFunctionSupported($functionReflection, $callLike, $comparisonContext)) {
+					continue;
+				}
+
+				return $extension->specifyTypes($functionReflection, $callLike, $scope, $comparisonContext);
+			}
+		}
+
+		return null;
+	}
+
 	public function resolveEqual(Expr\BinaryOp\Equal $expr, Scope $scope, TypeSpecifierContext $context, ?Expr $rootExpr): SpecifiedTypes
 	{
 		$expressions = $this->findTypeExpressionsFromBinaryOperation($scope, $expr);
@@ -2041,12 +2083,20 @@ final class TypeSpecifier
 
 			if (
 				$context->true()
-				&& $exprNode instanceof FuncCall
-				&& $exprNode->name instanceof Name
-				&& $exprNode->name->toLowerString() === 'preg_match'
-				&& (new ConstantIntegerType(1))->isSuperTypeOf($constantType)->yes()
+				&& $exprNode instanceof Expr\CallLike
 			) {
-				return $this->specifyTypesInCondition($scope, new Expr\BinaryOp\Identical($expr->left, $expr->right), $context, $rootExpr);
+				$specifiedTypes = $this->specifyWithComparisonAwareTypeSpecifyingExtensions(
+					$expr,
+					$exprNode,
+					$exprNode,
+					$constantType,
+					$scope,
+					$context,
+					$rootExpr,
+				);
+				if ($specifiedTypes !== null) {
+					return $specifiedTypes;
+				}
 			}
 		}
 
@@ -2141,15 +2191,19 @@ final class TypeSpecifier
 			$context->true()
 			&& $unwrappedLeftExpr instanceof FuncCall
 			&& $unwrappedLeftExpr->name instanceof Name
-			&& $unwrappedLeftExpr->name->toLowerString() === 'preg_match'
-			&& (new ConstantIntegerType(1))->isSuperTypeOf($rightType)->yes()
 		) {
-			return $this->specifyTypesInCondition(
-				$scope,
+			$specifiedTypes = $this->specifyWithComparisonAwareTypeSpecifyingExtensions(
+				$expr,
 				$leftExpr,
+				$unwrappedLeftExpr,
+				$rightType,
+				$scope,
 				$context,
 				$rootExpr,
 			);
+			if ($specifiedTypes !== null) {
+				return $specifiedTypes;
+			}
 		}
 
 		if (

--- a/src/Analyser/TypeSpecifierComparisonContext.php
+++ b/src/Analyser/TypeSpecifierComparisonContext.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp;
+use PHPStan\Type\Type;
+
+/** @api */
+final class TypeSpecifierComparisonContext
+{
+
+	public function __construct(
+		private BinaryOp $binaryOp,
+		private Expr $callExpr,
+		private Type $comparisonType,
+		private TypeSpecifierContext $context,
+		private ?Expr $rootExpr,
+	)
+	{
+	}
+
+	public function getBinaryOp(): BinaryOp
+	{
+		return $this->binaryOp;
+	}
+
+	public function getCallExpr(): Expr
+	{
+		return $this->callExpr;
+	}
+
+	public function getComparisonType(): Type
+	{
+		return $this->comparisonType;
+	}
+
+	public function getTypeSpecifierContext(): TypeSpecifierContext
+	{
+		return $this->context;
+	}
+
+	public function getRootExpr(): ?Expr
+	{
+		return $this->rootExpr;
+	}
+
+}

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -32,8 +32,14 @@ class TypeSpecifierContext
 
 	private static function create(?int $value, ?TypeSpecifierComparisonContext $comparisonContext = null): self
 	{
-		self::$registry[$value] ??= new self($value, $comparisonContext);
-		return self::$registry[$value];
+		if ($value !== self::CONTEXT_COMPARISON) {
+			self::$registry[$value] ??= new self($value, $comparisonContext);
+			return self::$registry[$value];
+		}
+
+		// each comparison context contains context dependent properties
+		// and therefore cannot be cached/re-used
+		return new self($value, $comparisonContext);
 	}
 
 	public static function createTrue(): self

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -17,18 +17,22 @@ class TypeSpecifierContext
 	public const CONTEXT_FALSE = 0b0100;
 	public const CONTEXT_FALSEY_BUT_NOT_FALSE = 0b1000;
 	public const CONTEXT_FALSEY = self::CONTEXT_FALSE | self::CONTEXT_FALSEY_BUT_NOT_FALSE;
-	public const CONTEXT_BITMASK = 0b1111;
+	public const CONTEXT_COMPARISON = 0b10000;
+	public const CONTEXT_BITMASK = 0b01111;
 
 	/** @var self[] */
 	private static array $registry;
 
-	private function __construct(private ?int $value)
+	private function __construct(
+		private ?int $value,
+		private ?TypeSpecifierComparisonContext $comparisonContext,
+	)
 	{
 	}
 
-	private static function create(?int $value): self
+	private static function create(?int $value, ?TypeSpecifierComparisonContext $comparisonContext = null): self
 	{
-		self::$registry[$value] ??= new self($value);
+		self::$registry[$value] ??= new self($value, $comparisonContext);
 		return self::$registry[$value];
 	}
 
@@ -50,6 +54,11 @@ class TypeSpecifierContext
 	public static function createFalsey(): self
 	{
 		return self::create(self::CONTEXT_FALSEY);
+	}
+
+	public static function createComparison(TypeSpecifierComparisonContext $comparisonContext): self
+	{
+		return self::create(self::CONTEXT_COMPARISON, $comparisonContext);
 	}
 
 	public static function createNull(): self
@@ -88,6 +97,11 @@ class TypeSpecifierContext
 	public function null(): bool
 	{
 		return $this->value === null;
+	}
+
+	public function comparison(): ?TypeSpecifierComparisonContext
+	{
+		return $this->comparisonContext;
 	}
 
 }

--- a/src/Type/ComparisonAwareTypeSpecifyingExtension.php
+++ b/src/Type/ComparisonAwareTypeSpecifyingExtension.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+/**
+ * This is the marker interface *TypeSpecifyingExtension might implement to specify types for comparisons.
+ *
+ * Use it in your already registered type specifying extension.
+ *
+ * Learn more: https://phpstan.org/developing-extensions/type-specifying-extensions
+ *
+ * @api
+ *
+ */
+interface ComparisonAwareTypeSpecifyingExtension
+{
+
+}


### PR DESCRIPTION
implement a POC for idea from https://github.com/phpstan/phpstan-src/pull/3178#issuecomment-2184949350

goal is to allow type-specifying extensions to narrow types of comparisons even in non true/truethy/false/falsey context, but e.g. from comparison against constant values.

similar as https://github.com/phpstan/phpstan-src/commit/d842380a1f07014d045dd42d6ccd4204a85e688a hardcoded it for `preg_match` but this time with support for extensions.
we need it for https://github.com/composer/pcre/pull/24/files#diff-8f259a63a4ab66c0f035859cea17176b75144dfb4c81db9981e04b66168edc4cR32-R50

this is an alternative implementation for https://github.com/phpstan/phpstan-src/pull/3178 and does not yet handle everything (MethodCall, StaticCall etc.).