### PR TITLE
Use `NullableTypeNode` for unions in `ConstantArrayType::toPhpDocNode`

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -13,6 +13,7 @@ use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\Callables\FunctionCallableVariant;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
@@ -1657,6 +1658,12 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			}
 			$valueType = $this->valueTypes[$i];
 
+			if ($valueType instanceof UnionType && $valueType->isNull()->maybe() && count($valueType->getTypes()) === 2) {
+				$valueTypePhpDocNode = new NullableTypeNode(TypeCombinator::removeNull($valueType)->toPhpDocNode());
+			} else {
+				$valueTypePhpDocNode = $valueType->toPhpDocNode();
+			}
+
 			/** @var ConstExprStringNode|ConstExprIntegerNode $keyNode */
 			$keyNode = $keyPhpDocNode->constExpr;
 			if ($keyNode instanceof ConstExprStringNode) {
@@ -1673,12 +1680,12 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			$items[] = new ArrayShapeItemNode(
 				$keyNode,
 				$isOptional,
-				$valueType->toPhpDocNode(),
+				$valueTypePhpDocNode,
 			);
 			$values[] = new ArrayShapeItemNode(
 				null,
 				$isOptional,
-				$valueType->toPhpDocNode(),
+				$valueTypePhpDocNode,
 			);
 		}
 

--- a/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
+++ b/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
@@ -303,6 +303,24 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 			], [2], [1]),
 			"array{0: 'foo', 1?: 'bar'}",
 		];
+
+		yield [
+			new ConstantArrayType([
+				new ConstantIntegerType(0),
+			], [
+				new UnionType([new StringType(), new NullType()]),
+			]),
+			'array{?string}',
+		];
+
+		yield [
+			new ConstantArrayType([
+				new ConstantStringType('foo'),
+			], [
+				new UnionType([new StringType(), new NullType()]),
+			]),
+			'array{foo: ?string}',
+		];
 	}
 
 	/**


### PR DESCRIPTION
Currently, `ConstantArrayType::toPhpDocNode()` produces the following code when you have an array shape with nullable string type for key `foo`:

```
array{foo: (string | null)}
```

It would be great to convert those shapes to:
```
array{foo: ?string}
```

This feels more natural, especially because PHP also has the ?string type.