### PR TITLE
More precise sprintf() format-arg based return type

### DIFF
--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -189,14 +189,14 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 			return null;
 		}
 
-		try {
-			$dummyValues = array_fill(0, $valuesCount, '');
-			if ($dummyValues === false) { // @phpstan-ignore identical.alwaysFalse PHP7.2 compat
-				return null;
-			}
+		$dummyValues = array_fill(0, $valuesCount, '');
+		if ($dummyValues === false) { // @phpstan-ignore identical.alwaysFalse (PHP7.2 compat)
+			return null;
+		}
 
+		try {
 			$formatted = @vsprintf($format, $dummyValues);
-			if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse PHP7.2 compat
+			if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse (PHP7.2 compat)
 				return null;
 			}
 			return new ConstantStringType($formatted);

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -37,8 +37,6 @@ use function vsprintf;
 class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 
-	private const MAX_INTERPOLATION_RETRIES = 5;
-
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
 		return in_array($functionReflection->getName(), ['sprintf', 'vsprintf'], true);
@@ -165,6 +163,9 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		return $returnType;
 	}
 
+	/**
+	 * Detect constant strings in the format which neither depend on placeholders nor on given value arguments.
+	 */
 	private function getFormatConstantParts(
 		string $format,
 		FunctionReflection $functionReflection,
@@ -196,8 +197,6 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 				return null;
 			}
 			return new ConstantStringType($formatted);
-		} catch (ArgumentCountError) {
-			return null;
 		} catch (Throwable) {
 			return null;
 		}

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -152,7 +152,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 			try {
 				$formatted = @sprintf($format, ...$dummyValues);
-				if ($formatted === false) { // PHP 7.x
+				if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse PHP 7.x only
 					continue;
 				}
 				return new ConstantStringType($formatted);

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -79,7 +79,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		foreach ($formatStrings as $constantString) {
 			$constantParts = $this->getFormatConstantParts($constantString->getValue());
 			if ($constantParts !== null) {
-				if ($constantParts->isNonFalsyString()->yes()) { // phpcs:ignore
+				if ($constantParts->isNonFalsyString()->yes()) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
 					// keep all bool flags as is
 				} elseif ($constantParts->isNonEmptyString()->yes()) {
 					$allPatternsNonFalsy = false;

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -38,12 +38,6 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 	private const MAX_INTERPOLATION_RETRIES = 5;
 
-	public function __construct(
-		private PhpVersion $phpVersion,
-	)
-	{
-	}
-
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
 		return in_array($functionReflection->getName(), ['sprintf', 'vsprintf'], true);

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -80,10 +80,9 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 			$constantParts = $this->getFormatConstantParts($constantString->getValue());
 			if ($constantParts !== null) {
 				if ($constantParts->isNonFalsyString()->yes()) {
-					$allPatternsNonFalsy = $allPatternsNonFalsy && true;
+					// keep all bool flags as is
 				} elseif ($constantParts->isNonEmptyString()->yes()) {
 					$allPatternsNonFalsy = false;
-					$allPatternsNonEmpty = $allPatternsNonEmpty && true;
 				} else {
 					$allPatternsNonEmpty = false;
 					$allPatternsNonFalsy = false;

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -190,8 +190,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		try {
-			$dummyValues = array_fill(0, $valuesCount, '');
-			$formatted = @sprintf($format, ...$dummyValues);
+			$formatted = @vsprintf($format, array_fill(0, $valuesCount, ''));
 			if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse
 				return null;
 			}

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -70,7 +70,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 			&& $formatType->isNonEmptyString()->yes()
 			&& $scope->getType($args[1]->value)->isNonEmptyString()->yes()
 		) {
-			$isNonEmpty = $isNonEmpty->or(TrinaryLogic::createYes());
+			$isNonEmpty = TrinaryLogic::createYes();
 		}
 
 		$singlePlaceholderEarlyReturn = null;

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -74,14 +74,23 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		$singlePlaceholderEarlyReturn = null;
+		$allPatternsNonEmpty = count($formatStrings) !== 0;
+		$allPatternsNonFalsy = count($formatStrings) !== 0;
 		foreach ($formatStrings as $constantString) {
 			$constantParts = $this->getFormatConstantParts($constantString->getValue());
 			if ($constantParts !== null) {
 				if ($constantParts->isNonFalsyString()->yes()) {
-					$isNonFalsy = $isNonFalsy->or(TrinaryLogic::createYes());
+					$allPatternsNonFalsy = $allPatternsNonFalsy && true;
 				} elseif ($constantParts->isNonEmptyString()->yes()) {
-					$isNonEmpty = $isNonEmpty->or(TrinaryLogic::createYes());
+					$allPatternsNonFalsy = false;
+					$allPatternsNonEmpty = $allPatternsNonEmpty && true;
+				} else {
+					$allPatternsNonEmpty = false;
+					$allPatternsNonFalsy = false;
 				}
+			} else {
+				$allPatternsNonEmpty = false;
+				$allPatternsNonFalsy = false;
 			}
 
 			// The printf format is %[argnum$][flags][width][.precision]
@@ -124,6 +133,13 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 		if ($singlePlaceholderEarlyReturn !== null) {
 			return $singlePlaceholderEarlyReturn;
+		}
+
+		if ($allPatternsNonFalsy) {
+			$isNonFalsy = TrinaryLogic::createYes();
+		}
+		if ($allPatternsNonEmpty) {
+			$isNonEmpty = TrinaryLogic::createYes();
 		}
 
 		if ($isNonFalsy->yes()) {

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -180,10 +180,10 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 			return null;
 		}
 
-		$dummyValues = array_fill(0, $valuesCount, '');
-		if ($dummyValues === []) {
+		if ($valuesCount <= 0) {
 			return null;
 		}
+		$dummyValues = array_fill(0, $valuesCount, '');
 
 		try {
 			$formatted = @vsprintf($format, $dummyValues);

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -79,7 +79,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		foreach ($formatStrings as $constantString) {
 			$constantParts = $this->getFormatConstantParts($constantString->getValue());
 			if ($constantParts !== null) {
-				if ($constantParts->isNonFalsyString()->yes()) {
+				if ($constantParts->isNonFalsyString()->yes()) { // phpcs:ignore
 					// keep all bool flags as is
 				} elseif ($constantParts->isNonEmptyString()->yes()) {
 					$allPatternsNonFalsy = false;

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -7,7 +7,6 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\CombinationsHelper;
-use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\TrinaryLogic;

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -96,7 +96,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 				$allPatternsNonFalsy = false;
 			}
 
-			// The printf format is %[argnum$][flags][width][.precision]
+			// The printf format is %[argnum$][flags][width][.precision]specifier.
 			if (preg_match('/^%([0-9]*\$)?[0-9]*\.?[0-9]*([sbdeEfFgGhHouxX])$/', $constantString->getValue(), $matches) === 1) {
 				if ($matches[1] !== '') {
 					// invalid positional argument

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Type\Php;
 
-use ArgumentCountError;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -190,8 +190,13 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		try {
-			$formatted = @vsprintf($format, array_fill(0, $valuesCount, ''));
-			if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse
+			$dummyValues = array_fill(0, $valuesCount, '');
+			if ($dummyValues === false) { // @phpstan-ignore identical.alwaysFalse PHP7.2 compat
+				return null;
+			}
+
+			$formatted = @vsprintf($format, $dummyValues);
+			if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse PHP7.2 compat
 				return null;
 			}
 			return new ConstantStringType($formatted);

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -190,7 +190,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		$dummyValues = array_fill(0, $valuesCount, '');
-		if ($dummyValues === false) { // @phpstan-ignore identical.alwaysFalse (PHP7.2 compat)
+		if ($dummyValues === []) {
 			return null;
 		}
 

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -152,7 +152,7 @@ class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 			try {
 				$formatted = @sprintf($format, ...$dummyValues);
-				if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse PHP 7.x only
+				if ($formatted === false) { // @phpstan-ignore identical.alwaysFalse
 					continue;
 				}
 				return new ConstantStringType($formatted);

--- a/tests/PHPStan/Analyser/nsrt/bug-7387.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7387.php
@@ -88,7 +88,7 @@ class HelloWorld
 		assertType('numeric-string', vsprintf("%4d", explode('-', '1988-8-1')));
 		assertType('numeric-string', vsprintf("%4d", $array));
 		assertType('numeric-string', vsprintf("%4d", ['123']));
-		assertType('non-falsy-string', vsprintf("%s", ['123']));
+		assertType('string', vsprintf("%s", ['123'])); // could be '123'
 		// too many arguments.. php silently allows it
 		assertType('numeric-string', vsprintf("%4d", ['123', '456']));
 	}

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string.php
@@ -386,4 +386,22 @@ class MoreNonEmptyStringFunctions
 		assertType('string', str_repeat($s, $i));
 	}
 
+	function multiplesPrintfFormats(string $s) {
+		$maybeNonEmpty = '%s';
+		$maybeNonFalsy = '%s';
+		$nonEmpty = '%s0';
+		$nonFalsy = '%sAA';
+
+		if (rand(0,1)) {
+			$maybeNonEmpty = '%s0';
+			$maybeNonFalsy = '%sAA';
+			$nonEmpty = '0%s';
+			$nonFalsy = 'AA%s';
+		}
+
+		assertType('string', sprintf($maybeNonEmpty, $s));
+		assertType('string', sprintf($maybeNonFalsy, $s));
+		assertType('non-empty-string', sprintf($nonEmpty, $s));
+		assertType('non-falsy-string', sprintf($nonFalsy, $s));
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string.php
@@ -363,7 +363,7 @@ class MoreNonEmptyStringFunctions
 
 		assertType('non-empty-string', sprintf("%s0%s", $s, $s));
 		assertType('non-empty-string', sprintf("%s0%s%s%s%s", $s, $s, $s, $s, $s));
-		assertType('string', sprintf("%s0%s%s%s%s%s", $s, $s, $s, $s, $s, $s)); // max interpolation limit reached
+		assertType('non-empty-string', sprintf("%s0%s%s%s%s%s", $s, $s, $s, $s, $s, $s));
 
 		assertType('0', strlen(''));
 		assertType('5', strlen('hallo'));

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string.php
@@ -303,9 +303,10 @@ class MoreNonEmptyStringFunctions
 
 	/**
 	 * @param non-empty-string $nonEmpty
+	 * @param non-falsy-string $nonFalsy
 	 * @param '1'|'2'|'5'|'10' $constUnion
 	 */
-	public function doFoo(string $s, string $nonEmpty, int $i, bool $bool, $constUnion)
+	public function doFoo(string $s, string $nonEmpty, string $nonFalsy, int $i, bool $bool, $constUnion)
 	{
 		assertType('string', addslashes($s));
 		assertType('non-empty-string', addslashes($nonEmpty));
@@ -350,8 +351,19 @@ class MoreNonEmptyStringFunctions
 
 		assertType('string', sprintf($s));
 		assertType('string', sprintf($nonEmpty));
+		assertType('string', sprintf($s, $nonEmpty));
+		assertType('string', sprintf($nonEmpty, $s));
+		assertType('string', sprintf($s, $nonFalsy));
+		assertType('string', sprintf($nonFalsy, $s));
+		assertType('non-empty-string', sprintf($nonEmpty, $nonEmpty));
+		assertType('non-empty-string', sprintf($nonEmpty, $nonFalsy));
+		assertType('non-empty-string', sprintf($nonFalsy, $nonEmpty));
 		assertType('string', vsprintf($s, []));
 		assertType('string', vsprintf($nonEmpty, []));
+
+		assertType('non-empty-string', sprintf("%s0%s", $s, $s));
+		assertType('non-empty-string', sprintf("%s0%s%s%s%s", $s, $s, $s, $s, $s));
+		assertType('string', sprintf("%s0%s%s%s%s%s", $s, $s, $s, $s, $s, $s)); // max interpolation limit reached
 
 		assertType('0', strlen(''));
 		assertType('5', strlen('hallo'));

--- a/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
@@ -107,12 +107,16 @@ class Foo {
 		assertType('string', sprintf($nonFalsey));
 		assertType("'foo'", sprintf('foo'));
 		assertType("string", sprintf(...$arr));
-		assertType("non-falsy-string", sprintf('%s', ...$arr)); // should be 'string'
+		assertType("string", sprintf('%s', ...$arr));
 		assertType('string', vsprintf($nonFalsey, []));
 		assertType('string', vsprintf($nonFalsey, []));
 		assertType("non-falsy-string", vsprintf('foo', [])); // should be 'foo'
-		assertType("non-falsy-string", vsprintf('%s', ...$arr)); // should be 'string'
+		assertType("string", vsprintf('%s', ...$arr));
 		assertType("string", vsprintf(...$arr));
+
+		assertType('non-falsy-string', sprintf("%sAA%s", $s, $s));
+		assertType('non-falsy-string', sprintf("%sAA%s%s%s%s", $s, $s, $s, $s, $s));
+		assertType('string', sprintf("%sAA%s%s%s%s%s", $s, $s, $s, $s, $s, $s)); // max interpolation limit reached
 
 		assertType('int<1, max>', strlen($nonFalsey));
 

--- a/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
@@ -108,9 +108,12 @@ class Foo {
 		assertType("'foo'", sprintf('foo'));
 		assertType("string", sprintf(...$arr));
 		assertType("string", sprintf('%s', ...$arr));
+
+		// empty array only works as long as no placeholder in the pattern
 		assertType('string', vsprintf($nonFalsey, []));
 		assertType('string', vsprintf($nonFalsey, []));
-		assertType("non-falsy-string", vsprintf('foo', [])); // should be 'foo'
+		assertType("string", vsprintf('foo', []));
+
 		assertType("string", vsprintf('%s', ...$arr));
 		assertType("string", vsprintf(...$arr));
 		assertType('non-falsy-string', vsprintf('%sAA%s', [$s, $s]));

--- a/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
@@ -113,10 +113,13 @@ class Foo {
 		assertType("non-falsy-string", vsprintf('foo', [])); // should be 'foo'
 		assertType("string", vsprintf('%s', ...$arr));
 		assertType("string", vsprintf(...$arr));
+		assertType('non-falsy-string', vsprintf('%sAA%s', [$s, $s]));
+		assertType('non-falsy-string', vsprintf('%d%d', [$s, $s])); // could be non-falsy-string&numeric-string
 
 		assertType('non-falsy-string', sprintf("%sAA%s", $s, $s));
+		assertType('non-falsy-string', sprintf("%d%d", $s, $s)); // could be non-falsy-string&numeric-string
 		assertType('non-falsy-string', sprintf("%sAA%s%s%s%s", $s, $s, $s, $s, $s));
-		assertType('string', sprintf("%sAA%s%s%s%s%s", $s, $s, $s, $s, $s, $s)); // max interpolation limit reached
+		assertType('non-falsy-string', sprintf("%sAA%s%s%s%s%s", $s, $s, $s, $s, $s, $s));
 
 		assertType('int<1, max>', strlen($nonFalsey));
 

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1052,4 +1052,10 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10697.php'], []);
 	}
 
+	public function testBug10493(): void
+	{
+		$this->checkAlwaysTrueStrictComparison = true;
+		$this->analyse([__DIR__ . '/data/bug-10493.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-10493.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-10493.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.1
+
+namespace Bug10493;
+
+class Foo
+{
+	public function __construct(
+		private readonly ?string $old,
+		private readonly ?string $new,
+	)
+	{
+	}
+
+	public function foo(): ?string
+	{
+		$return = sprintf('%s%s', $this->old, $this->new);
+
+		if ($return === '') {
+			return null;
+		}
+
+		return $return;
+	}
+}


### PR DESCRIPTION
extracted from https://github.com/phpstan/phpstan-src/pull/3168

closes https://github.com/phpstan/phpstan/issues/11248
closes https://github.com/phpstan/phpstan/issues/10493

the previous format-type based logic was too optimistic regarding types and false-positively created too precise types in some cases.