### PR TITLE
Avoid using AlwaysRememberedExpr when match expression condition is a `BinaryOperation`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3509,6 +3509,9 @@ class MutatingScope implements Scope
 		if ($expr->cond instanceof AlwaysRememberedExpr) {
 			return $this;
 		}
+		if ($expr->cond instanceof BinaryOp) {
+			return $this;
+		}
 
 		$type = $this->getType($expr->cond);
 		$nativeType = $this->getNativeType($expr->cond);

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -543,4 +543,13 @@ class MatchExpressionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-unhandled-true-with-complex-condition.php'], []);
 	}
 
+	public function testBug11246(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-11246.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-11246.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-11246.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug11246;
+
+$var = 0;
+foreach ([1, 2, 3, 4, 5] as $index) {
+	$var++;
+
+	match ($var % 5) {
+		1 => 'c27ba0',
+		2 => '5b9bd5',
+		3 => 'ed7d31',
+		4 => 'ffc000',
+		default => '674ea7',
+	};
+}


### PR DESCRIPTION
Fix https://github.com/phpstan/phpstan/issues/11246