### PR TITLE
`Doctrine\ORM\EntityManager` could be overridden in analyzing

### DIFF
--- a/tests/PHPStan/Rules/Exceptions/data/catch-with-unthrown-exception-stubs.php
+++ b/tests/PHPStan/Rules/Exceptions/data/catch-with-unthrown-exception-stubs.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace Doctrine\ORM {
-	class EntityManager
+	class EntityManagerPHPStanAlias
 	{
 
 		public function transactional(callable $cb): void {
@@ -20,11 +20,11 @@ namespace MyFunction {
 namespace CatchWithUnthrownExceptionStubs
 {
 
-	use Doctrine\ORM\EntityManager;
+	use Doctrine\ORM\EntityManagerPHPStanAlias;
 
 	class Foo
 	{
-		public function doFoo(EntityManager $em): void
+		public function doFoo(EntityManagerPHPStanAlias $em): void
 		{
 			try {
 				$em->transactional(function () {

--- a/tests/PHPStan/Rules/Exceptions/data/catch-with-unthrown-exception-stubs.stub
+++ b/tests/PHPStan/Rules/Exceptions/data/catch-with-unthrown-exception-stubs.stub
@@ -1,7 +1,7 @@
 <?php
 
 namespace Doctrine\ORM {
-	class EntityManager
+	class EntityManagerPHPStanAlias
 	{
 
 		/**


### PR DESCRIPTION
I tried out phpstan-src directly to look into some potential changes. While doing so I faced a crash in the doctrine plugin code when analyzing a project which worked fine with the phpstan phar variant.
It turned out to happen because a file of a test `catch-with-unthrown-exception-stubs.php` registers in the autoloader as `Doctrine\ORM\EntityManager` and overrides the real class. The file was added just in March, yet I wondered why it did not affect other developers. Maybe because the doctrine plugin was not used.

I just picked a slightly different name for the EntityManager class. It does not matter for the test to do its job.