### PR TITLE
TypeCombinator: Don't combine array-shapes of lists with non-lists

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1532,6 +1532,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			return $keyTypesCount === 0;
 		}
 
+		if (!$this->isList->equals($otherArray->isList)) {
+			return false;
+		}
+
 		$failOnDifferentValueType = $keyTypesCount !== $otherKeyTypesCount || $keyTypesCount < 2;
 
 		$keyTypes = $this->keyTypes;

--- a/tests/PHPStan/Analyser/nsrt/bug-1021.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-1021.php
@@ -13,7 +13,7 @@ function foobar() {
 		}
 	}
 
-	assertType('array{0?: int<1, max>, 1?: 2|3, 2?: 3}', $x);
+	assertType('array{0?: 2|3, 1?: 2|3}|array{0?: int<1, max>, 2?: 3, 1?: 2|3}|array{1, 2, 3}', $x);
 
 	if ($x) {
 	}

--- a/tests/PHPStan/Analyser/nsrt/constant-array-optional-set.php
+++ b/tests/PHPStan/Analyser/nsrt/constant-array-optional-set.php
@@ -38,15 +38,15 @@ class Foo
 		if (rand(0, 1)) {
 			$a[3] = 3;
 		}
-		assertType('array{0: 1, 1?: 2, 3?: 3}', $a);
+		assertType('array{0: 1, 1?: 2, 3: 3}|array{0: 1, 1?: 2}', $a);
 		if (rand(0, 1)) {
 			$a[] = 4;
 		}
-		assertType('array{0: 1, 1?: 2|4, 3?: 3, 4?: 4}', $a);
+		assertType('array{0: 1, 1?: 2, 3: 3, 4?: 4}|array{0: 1, 1?: 2|4, 2?: 4}', $a);
 		if (rand(0, 1)) {
 			$a[] = 5;
 		}
-		assertType('array{0: 1, 1?: 2|4|5, 3?: 3, 4?: 4|5, 5?: 5}', $a);
+		assertType('array{0: 1, 1?: 2, 3: 3, 4?: 4|5, 5?: 5}|array{0: 1, 1?: 2|4|5, 2?: 4|5, 3?: 5}', $a);
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -54,9 +54,9 @@ function doMatch(string $s): void {
 	assertType('array{}|array{0: string, 1: string, 2: string, 3: string, name?: string, 4?: string}', $matches);
 
 	if (preg_match('/(a|b)|(?:c)/', $s, $matches)) {
-		assertType('array{0: string, 1?: string}', $matches);
+		assertType('array{0: string, 1?: string}|array{string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1?: string}', $matches);
+	assertType('array{}|array{0: string, 1?: string}|array{string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz)+/', $s, $matches)) {
 		assertType('array{string, string, string, string}', $matches);
@@ -252,7 +252,7 @@ function doFoo(string $row): void
 		assertType('array{0: string, 1: string, 2?: string}', $matches);
 	}
 	if (preg_match('~^(a(b)?)?$~', $row, $matches) === 1) {
-		assertType('array{0: string, 1?: string, 2?: string}', $matches);
+		assertType('array{0: string, 1: string, 2?: string}|array{string}', $matches);
 	}
 }
 
@@ -294,7 +294,7 @@ function groupsOptional(string $size): void
 	if (preg_match('~^a\.b(c(\d+)?)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: string, 2?: string}', $matches);
+	assertType('array{0: string, 1: string, 2?: string}|array{string}', $matches);
 
 	if (preg_match('~^a\.b(c(\d+))d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -4853,8 +4853,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 			}
 		}
 		$resultType = TypeCombinator::union(...$arrays);
-		$this->assertInstanceOf(ConstantArrayType::class, $resultType);
-		$this->assertSame('array{0: string, 1?: string, 2?: string, 3?: string, 4?: string, test?: string}', $resultType->describe(VerbosityLevel::precise()));
+		$this->assertInstanceOf(UnionType::class, $resultType);
+		$this->assertSame('array{0: string, 1?: string, 2?: string, 3?: string, 4?: string, test: string}|array{0: string, 1?: string, 2?: string, 3?: string, 4?: string}', $resultType->describe(VerbosityLevel::precise()));
 	}
 
 	/**


### PR DESCRIPTION
idea is to not combine lists with non-lists array-shapes. keeping them separate yields a more precise union which later on can lead to better analysis results

motivated by the issue described in https://github.com/phpstan/phpstan/discussions/11256#discussioncomment-9917907