### PR TITLE
Faster ObjectType->getEnumCases() type substraction

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1250,7 +1250,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			}
 		}
 
-		return self::$enumCases[$cacheKey] = array_values($cases);
+		return self::$enumCases[$cacheKey] = $cases;
 	}
 
 	public function isCallable(): TrinaryLogic

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1229,21 +1229,24 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 		$className = $classReflection->getName();
 
-		$cases = [];
-		foreach ($classReflection->getEnumCases() as $enumCase) {
-			$cases[] = new EnumCaseObjectType($className, $enumCase->getName(), $classReflection);
-		}
-
 		if ($this->subtractedType !== null) {
-			$subtracedEnumCases = $this->subtractedType->getEnumCases();
-			foreach ($cases as $i => $case) {
-				$caseName = $case->getEnumCaseName();
-				foreach ($subtracedEnumCases as $subtracedCase) {
-					if ($caseName === $subtracedCase->getEnumCaseName()) {
-						unset($cases[$i]);
-						continue 2;
-					}
+			$subtracedEnumCaseNames = [];
+
+			foreach ($this->subtractedType->getEnumCases() as $subtracedCase) {
+				$subtracedEnumCaseNames[$subtracedCase->getEnumCaseName()] = true;
+			}
+
+			$cases = [];
+			foreach ($classReflection->getEnumCases() as $enumCase) {
+				if (array_key_exists($enumCase->getName(), $subtracedEnumCaseNames)) {
+					continue;
 				}
+				$cases[] = new EnumCaseObjectType($className, $enumCase->getName(), $classReflection);
+			}
+		} else {
+			$cases = [];
+			foreach ($classReflection->getEnumCases() as $enumCase) {
+				$cases[] = new EnumCaseObjectType($className, $enumCase->getName(), $classReflection);
 			}
 		}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1232,8 +1232,8 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		if ($this->subtractedType !== null) {
 			$subtracedEnumCaseNames = [];
 
-			foreach ($this->subtractedType->getEnumCases() as $subtracedCase) {
-				$subtracedEnumCaseNames[$subtracedCase->getEnumCaseName()] = true;
+			foreach ($this->subtractedType->getEnumCases() as $subtractedCase) {
+				$subtracedEnumCaseNames[$subtractedCase->getEnumCaseName()] = true;
 			}
 
 			$cases = [];


### PR DESCRIPTION
turns a nested loop into 2 subsequent loops.

----

repro of https://github.com/phpstan/phpstan/issues/11263

before this PR ([c6b961d](https://github.com/phpstan/phpstan-src/commit/c6b961da8cdf6cc12bd0affb2c42da5348074906))
```
time php bin/phpstan analyze slow.php --debug
 8.52s user 0.14s system 99% cpu 8.732 total
time php bin/phpstan analyze slow.php --debug
 8.44s user 0.15s system 99% cpu 8.624 total
```

after this PR
```
time php bin/phpstan analyze slow.php --debug
 7.83s user 0.14s system 99% cpu 8.010 total
time php bin/phpstan analyze slow.php --debug
 7.80s user 0.14s system 99% cpu 7.979 total
```