### PR TITLE
Prevent out-of-memory errors while regex array shape inference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,8 @@
 			],
 			"hoa/compiler": [
 				"patches/HoaException.patch",
-				"patches/Rule.patch"
+				"patches/Rule.patch",
+				"patches/Lexer.patch"
 			],
 			"hoa/consistency": [
 				"patches/Consistency.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "518cef83d930fabedc701ab1b60bebb4",
+    "content-hash": "00228dc36c9773581897d929dd4511ec",
     "packages": [
         {
             "name": "clue/ndjson-react",

--- a/patches/Lexer.patch
+++ b/patches/Lexer.patch
@@ -1,0 +1,12 @@
+diff --git a/Llk/Lexer.php b/Llk/Lexer.php
+index 6851367..b8acf98 100644
+--- a/Llk/Lexer.php
++++ b/Llk/Lexer.php
+@@ -281,7 +281,7 @@ class Lexer
+             $offset
+         );
+
+-        if (0 === $preg) {
++        if (0 === $preg || $preg === false) {
+             return null;
+         }

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1399,6 +1399,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11283.php');
 		$this->assertNoErrors($errors);
 	}
+	
+	public function testBug11292(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11292.php');
+		$this->assertNoErrors($errors);
+	}
 
 	/**
 	 * @param string[]|null $allAnalysedFiles

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1399,7 +1399,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11283.php');
 		$this->assertNoErrors($errors);
 	}
-	
+
 	public function testBug11292(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11292.php');

--- a/tests/PHPStan/Analyser/data/bug-11292.php
+++ b/tests/PHPStan/Analyser/data/bug-11292.php
@@ -2,10 +2,12 @@
 
 namespace Bug11292;
 
+use function PHPStan\Testing\assertType;
+
 function (string $s): void {
 	$nonUrl = "[^-_#$+.!*%'(),;/?:@~=&a-zA-Z0-9\x7f-\xff]";
 	$pattern = '{\\b(https?://)?(?:([^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})(:[^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})?@)?((?:[-a-zA-Z0-9\\x7f-\\xff]{1,63}\\.)+[a-zA-Z\\x7f-\\xff][-a-zA-Z0-9\\x7f-\\xff]{1,62})((:[0-9]{1,5})?(/[!$-/0-9:;=@_~\':;!a-zA-Z\\x7f-\\xff]*?)?(\\?[!$-/0-9:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?(#[!$-/0-9?:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?)(?=[)\'?.!,;:]*(' . $nonUrl . '|$))}';
 	if (preg_match($pattern, $s, $matches, PREG_OFFSET_CAPTURE, 0)) {
-
+		assertType('array<array{string, int<-1, max>}>', $matches);
 	}
 };

--- a/tests/PHPStan/Analyser/data/bug-11292.php
+++ b/tests/PHPStan/Analyser/data/bug-11292.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11292;
+
+function (string $s): void {
+	$nonUrl = "[^-_#$+.!*%'(),;/?:@~=&a-zA-Z0-9\x7f-\xff]";
+	$pattern = '{\\b(https?://)?(?:([^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})(:[^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})?@)?((?:[-a-zA-Z0-9\\x7f-\\xff]{1,63}\\.)+[a-zA-Z\\x7f-\\xff][-a-zA-Z0-9\\x7f-\\xff]{1,62})((:[0-9]{1,5})?(/[!$-/0-9:;=@_~\':;!a-zA-Z\\x7f-\\xff]*?)?(\\?[!$-/0-9:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?(#[!$-/0-9?:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?)(?=[)\'?.!,;:]*(' . $nonUrl . '|$))}';
+	if (preg_match($pattern, $s, $matches, PREG_OFFSET_CAPTURE, 0)) {
+
+	}
+};


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11292

before this PR the following snippet..

```php
<?php

require 'vendor/autoload.php';

// 1. Read the grammar.
$grammar  = new Hoa\File\Read('hoa://Library/Regex/Grammar.pp');

// 2. Load the compiler.
$compiler = Hoa\Compiler\Llk\Llk::load($grammar);

$nonUrl = "[^\x7f-\xff]";
$pattern = '{(' . $nonUrl . ')}';


// 3. Lex, parse and produce the AST.
$ast      = $compiler->parse($pattern);

// 4. Dump the result.
$dump     = new Hoa\Compiler\Visitor\Dump();
echo $dump->visit($ast);
```

.. mistakenly detected a non-parseable regex string as a lexeme, because errors in `preg_match` were not reported back properly in https://github.com/staabm/HoaCompiler/blob/c620f44deff0b4c2d0c27560a3b0f5e7e376e001/Llk/Lexer.php#L275-L302

this in turn lead to a wall of warnings like

```
Warning: Undefined array key 0 in /Users/staabm/workspace/phpstan-src/vendor/hoa/compiler/Llk/Lexer.php on line 288
PHP Warning:  Undefined array key 0 in /Users/staabm/workspace/phpstan-src/vendor/hoa/compiler/Llk/Lexer.php on line 299

Warning: Undefined array key 0 in /Users/staabm/workspace/phpstan-src/vendor/hoa/compiler/Llk/Lexer.php on line 299
PHP Warning:  Undefined array key 0 in /Users/staabm/workspace/phpstan-src/vendor/hoa/compiler/Llk/Lexer.php on line 300
```

and the lexer running into a infinite loop