### PR TITLE
RegexArrayShapeMatcher - trailling groups are not optional when PREG_UNMATCHED_AS_NULL

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -311,7 +311,7 @@ class PhpVersion
 
 	public function supportsPregUnmatchedAsNull(): bool
 	{
-		// while PREG_UNMATCHED_AS_NULL is defined in php-src since 7.2.x it starts working like described in the report with 7.4.x
+		// while PREG_UNMATCHED_AS_NULL is defined in php-src since 7.2.x it starts working as expected with 7.4.x
 		// https://3v4l.org/v3HE4
 		return $this->versionId >= 70400;
 	}

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -309,6 +309,13 @@ class PhpVersion
 		return $this->versionId >= 80200;
 	}
 
+	public function supportsPregUnmatchedAsNull(): bool
+	{
+		// while PREG_UNMATCHED_AS_NULL is defined in php-src since 7.2.x it starts working like described in the report with 7.4.x
+		// https://3v4l.org/v3HE4
+		return $this->versionId >= 70400;
+	}
+
 	public function hasDateTimeExceptions(): bool
 	{
 		return $this->versionId >= 80300;

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -1,0 +1,12 @@
+<?php // lint < 7.4
+
+namespace Bug11311;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', '12.5', $matches, PREG_UNMATCHED_AS_NULL)) {
+        // on PHP < 7.4, unmatched-as-null does not return null values; see https://3v4l.org/v3HE4
+		assertType('array{0: string, major: string, 1: string, minor: string, 2: string, patch?: string, 3?: string}', $matches);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -4,8 +4,8 @@ namespace Bug11311;
 
 use function PHPStan\Testing\assertType;
 
-function doFoo() {
-	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', '12.5', $matches, PREG_UNMATCHED_AS_NULL)) {
+function doFoo(string $s) {
+	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
         // on PHP < 7.4, unmatched-as-null does not return null values; see https://3v4l.org/v3HE4
 		assertType('array{0: string, major: string, 1: string, minor: string, 2: string, patch?: string, 3?: string}', $matches);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -4,9 +4,18 @@ namespace Bug11311;
 
 use function PHPStan\Testing\assertType;
 
+// on PHP < 7.4, unmatched-as-null does not return null values; see https://3v4l.org/v3HE4
+
 function doFoo(string $s) {
 	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-        // on PHP < 7.4, unmatched-as-null does not return null values; see https://3v4l.org/v3HE4
 		assertType('array{0: string, major: string, 1: string, minor: string, 2: string, patch?: string, 3?: string}', $matches);
 	}
 }
+
+function doUnmatchedAsNull(string $s): void {
+	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		assertType('array{0: string, 1?: string, 2?: string, 3?: string}', $matches);
+	}
+	assertType('array{}|array{0: string, 1?: string, 2?: string, 3?: string}', $matches);
+}
+

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -1,6 +1,6 @@
 <?php // lint < 7.4
 
-namespace Bug11311;
+namespace Bug11311Php72;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -7,7 +7,7 @@ use function PHPStan\Testing\assertType;
 function doFoo(string $s) {
 	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 
-		assertType('array{0: string, major: string|null, 1: string|null, minor: string|null, 2: string|null, patch: string|null, 3: string|null}', $matches);
+		assertType('array{0: string, major: string, 1: string, minor: string, 2: string, patch: string|null, 3: string|null}', $matches);
 	}
 }
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -10,3 +10,10 @@ function doFoo(string $s) {
 		assertType('array{0: string, major: string|null, 1: string|null, minor: string|null, 2: string|null, patch: string|null, 3: string|null}', $matches);
 	}
 }
+
+function doUnmatchedAsNull(string $s): void {
+	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		assertType('array{string, string|null, string|null, string|null}', $matches);
+	}
+	assertType('array{}|array{string, string|null, string|null, string|null}', $matches);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -4,8 +4,8 @@ namespace Bug11311;
 
 use function PHPStan\Testing\assertType;
 
-function doFoo() {
-	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', '12.5', $matches, PREG_UNMATCHED_AS_NULL)) {
+function doFoo(string $s) {
+	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 
 		assertType('array{0: string, major: string|null, 1: string|null, minor: string|null, 2: string|null, patch: string|null, 3: string|null}', $matches);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -1,0 +1,12 @@
+<?php // lint >= 7.4
+
+namespace Bug11311;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', '12.5', $matches, PREG_UNMATCHED_AS_NULL)) {
+
+		assertType('array{0: string, major: string|null, 1: string|null, minor: string|null, 2: string|null, patch: string|null, 3: string|null}', $matches);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -116,13 +116,6 @@ function doOffsetCapture(string $s): void {
 	assertType('array{}|array{array{string, int<0, max>}, array{string, int<0, max>}, array{string, int<0, max>}, array{string, int<0, max>}}', $matches);
 }
 
-function doUnmatchedAsNull(string $s): void {
-	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, 1?: string|null, 2?: string|null, 3?: string|null}', $matches);
-	}
-	assertType('array{}|array{0: string, 1?: string|null, 2?: string|null, 3?: string|null}', $matches);
-}
-
 function doUnknownFlags(string $s, int $flags): void {
 	if (preg_match('/(foo)(bar)(baz)/xyz', $s, $matches, $flags)) {
 		assertType('array<array{string|null, int<-1, max>}|string|null>', $matches);


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11311