### PR TITLE
RegexArrayShapeMatcher - Fix optional groups with PREG_UNMATCHED_AS_NULL

### DIFF
--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -121,10 +121,13 @@ final class RegexArrayShapeMatcher
 				$flags ?? 0,
 			);
 
-			return TypeCombinator::union(
-				new ConstantArrayType([new ConstantIntegerType(0)], [new StringType()], [0], [], true),
-				$combiType,
-			);
+			if (!$this->containsUnmatchedAsNull($flags ?? 0)) {
+				$combiType = TypeCombinator::union(
+					new ConstantArrayType([new ConstantIntegerType(0)], [new StringType()], [0], [], true),
+					$combiType,
+				);
+			}
+			return $combiType;
 		} elseif (
 			$wasMatched->yes()
 			&& $onlyTopLevelAlternationId !== null

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -19,3 +19,12 @@ function doUnmatchedAsNull(string $s): void {
 	assertType('array{}|array{0: string, 1?: string, 2?: string, 3?: string}', $matches);
 }
 
+// see https://3v4l.org/VeDob#veol
+function unmatchedAsNullWithOptionalGroup(string $s): void {
+	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		assertType('array{0: string, 1?: string}', $matches);
+	} else {
+		assertType('array{}', $matches);
+	}
+	assertType('array{}|array{0: string, 1?: string}', $matches);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -17,3 +17,15 @@ function doUnmatchedAsNull(string $s): void {
 	}
 	assertType('array{}|array{string, string|null, string|null, string|null}', $matches);
 }
+
+// see https://3v4l.org/VeDob
+function unmatchedAsNullWithOptionalGroup(string $s): void {
+	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		// with PREG_UNMATCHED_AS_NULL the offset 1 will always exist. It is correct that it's nullable because it's optional though
+		assertType('array{string, string|null}', $matches);
+	} else {
+		assertType('array{}', $matches);
+	}
+	assertType('array{}|array{string, string|null}', $matches);
+}
+

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -93,10 +93,9 @@ function doNonCapturingGroup(string $s): void {
 
 function doNamedSubpattern(string $s): void {
 	if (preg_match('/\w-(?P<num>\d+)-(\w)/', $s, $matches)) {
-		// could be assertType('array{0: string, num: string, 1: string, 2: string, 3: string}', $matches);
-		assertType('array<string>', $matches);
+		assertType('array{0: string, num: string, 1: string, 2: string}', $matches);
 	}
-	assertType('array<string>', $matches);
+	assertType('array{}|array{0: string, num: string, 1: string, 2: string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)/', $s, $matches)) {
 		assertType('array{0: string, name: string, 1: string}', $matches);

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -353,17 +353,6 @@ function bug11277b(string $value): void
 	}
 }
 
-// see https://3v4l.org/VeDob
-function unmatchedAsNullWithOptionalGroup(string $s): void {
-	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		// with PREG_UNMATCHED_AS_NULL the offset 1 will always exist. It is correct that it's nullable because it's optional though
-		assertType('array{string, string|null}', $matches);
-	} else {
-		assertType('array{}', $matches);
-	}
-	assertType('array{}|array{string, string|null}', $matches);
-}
-
 // https://www.pcre.org/current/doc/html/pcre2pattern.html#dupgroupnumber
 // https://3v4l.org/09qdT
 function bug11291(string $s): void {

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -353,6 +353,17 @@ function bug11277b(string $value): void
 	}
 }
 
+// see https://3v4l.org/VeDob
+function unmatchedAsNullWithOptionalGroup(string $s): void {
+	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		// with PREG_UNMATCHED_AS_NULL the offset 1 will always exist. It is correct that it's nullable because it's optional though
+		assertType('array{string, string|null}', $matches);
+	} else {
+		assertType('array{}', $matches);
+	}
+	assertType('array{}|array{string, string|null}', $matches);
+}
+
 // https://www.pcre.org/current/doc/html/pcre2pattern.html#dupgroupnumber
 // https://3v4l.org/09qdT
 function bug11291(string $s): void {

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -93,9 +93,10 @@ function doNonCapturingGroup(string $s): void {
 
 function doNamedSubpattern(string $s): void {
 	if (preg_match('/\w-(?P<num>\d+)-(\w)/', $s, $matches)) {
-		assertType('array{0: string, num: string, 1: string, 2: string}', $matches);
+		// could be assertType('array{0: string, num: string, 1: string, 2: string, 3: string}', $matches);
+		assertType('array<string>', $matches);
 	}
-	assertType('array{}|array{0: string, num: string, 1: string, 2: string}', $matches);
+	assertType('array<string>', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)/', $s, $matches)) {
 		assertType('array{0: string, name: string, 1: string}', $matches);
@@ -364,9 +365,8 @@ function bug11291(string $s): void {
 	assertType('array{}|array{0: string, 1: string, 2?: string, 3?: string}', $matches);
 }
 
-function bug11323a(string $s): void
-{
-	if (preg_match('/Price: (?P<currency>£|€)\d+/', $s, $matches)) {
+function unmatchedAsNullWithMandatoryGroup(string $s): void {
+	if (preg_match('/Price: (?<currency>£|€)\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 		assertType('array{0: string, currency: string, 1: string}', $matches);
 	} else {
 		assertType('array{}', $matches);
@@ -374,12 +374,3 @@ function bug11323a(string $s): void
 	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
 }
 
-function bug11323b(string $s): void
-{
-	if (preg_match('/Price: (?<currency>£|€)\d+/', $s, $matches)) {
-		assertType('array{0: string, currency: string, 1: string}', $matches);
-	} else {
-		assertType('array{}', $matches);
-	}
-	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
-}

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -365,6 +365,26 @@ function bug11291(string $s): void {
 	assertType('array{}|array{0: string, 1: string, 2?: string, 3?: string}', $matches);
 }
 
+function bug11323a(string $s): void
+{
+	if (preg_match('/Price: (?P<currency>£|€)\d+/', $s, $matches)) {
+		assertType('array{0: string, currency: string, 1: string}', $matches);
+	} else {
+		assertType('array{}', $matches);
+	}
+	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
+}
+
+function bug11323b(string $s): void
+{
+	if (preg_match('/Price: (?<currency>£|€)\d+/', $s, $matches)) {
+		assertType('array{0: string, currency: string, 1: string}', $matches);
+	} else {
+		assertType('array{}', $matches);
+	}
+	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
+}
+
 function unmatchedAsNullWithMandatoryGroup(string $s): void {
 	if (preg_match('/Price: (?<currency>£|€)\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 		assertType('array{0: string, currency: string, 1: string}', $matches);


### PR DESCRIPTION
as discussed in https://github.com/composer/pcre/pull/29#discussion_r1674205666 - as usual `PREG_UNMATCHED_AS_NULL` depends on php-version for optional groups.

//cc @Seldaek 