### PR TITLE
Add hint as to what might be wrong when invalid identifiers are used

### DIFF
--- a/src/Rules/RuleErrorBuilder.php
+++ b/src/Rules/RuleErrorBuilder.php
@@ -221,7 +221,7 @@ class RuleErrorBuilder
 	public function identifier(string $identifier): self
 	{
 		if (!Error::validateIdentifier($identifier)) {
-			throw new ShouldNotHappenException(sprintf('Invalid identifier: %s', $identifier));
+			throw new ShouldNotHappenException(sprintf('Invalid identifier: %s, error identifiers must match /%s/', $identifier, Error::PATTERN_IDENTIFIER));
 		}
 
 		$this->properties['identifier'] = $identifier;


### PR DESCRIPTION
Went on a wild goose hunt to figure out if I needed to register my new identifier somewhere to make it valid before ultimately realizing I used `foo_bar` and that's not legal 🤦🏻‍♂️ 