### PR TITLE
RegexArrayShapeMatcher - Fix PREG_UNMATCHED_AS_NULL with top level alternation

### DIFF
--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -170,7 +170,7 @@ final class RegexArrayShapeMatcher
 						$beforeCurrentCombo = false;
 					} elseif ($beforeCurrentCombo && !$group->resetsGroupCounter()) {
 						$group->forceNonOptional();
-					} elseif ($group->getAlternationId() === $onlyTopLevelAlternationId) {
+					} elseif ($group->getAlternationId() === $onlyTopLevelAlternationId && !$this->containsUnmatchedAsNull($flags ?? 0)) {
 						unset($comboList[$groupId]);
 					}
 				}
@@ -191,7 +191,7 @@ final class RegexArrayShapeMatcher
 				}
 			}
 
-			if ($isOptionalAlternation) {
+			if ($isOptionalAlternation && !$this->containsUnmatchedAsNull($flags ?? 0)) {
 				$combiTypes[] = new ConstantArrayType([new ConstantIntegerType(0)], [new StringType()], [0], [], true);
 			}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -65,3 +65,17 @@ $}x', $url, $matches, PREG_UNMATCHED_AS_NULL)) {
 		assertType('array{string, string|null, string|null, string, string}', $matches);
 	}
 }
+
+class UnmatchedAsNullWithTopLevelAlternation {
+	function doFoo(string $s): void {
+		if (preg_match('/Price: (?:(£)|(€))\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+			assertType('array{string, string|null, string|null}', $matches); // could be array{0: string, 1: null, 2: string}|array{0: string, 1: string, 2: null}
+		}
+	}
+
+	function doBar(string $s): void {
+		if (preg_match('/Price: (?:(£)|(€))?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+			assertType('array{string, string|null, string|null}', $matches);
+		}
+	}
+}


### PR DESCRIPTION
this `PREG_UNMATCHED_AS_NULL` thing really affects all kind of types :-)