### PR TITLE
InternalError is part of `@api`

### DIFF
--- a/src/Analyser/InternalError.php
+++ b/src/Analyser/InternalError.php
@@ -9,6 +9,7 @@ use function array_map;
 use function array_unshift;
 
 /**
+ * @api
  * @phpstan-type Trace = list<array{file: string|null, line: int|null}>
  */
 class InternalError implements JsonSerializable


### PR DESCRIPTION
My custom formatter is outputting internal errors. I'm getting `Calling PHPStan\Analyser\InternalError::getMessage() is not covered by backward compatibility promise.`. I believe this should be part of public api.