### PR TITLE
RegexArrayShapeMatcher - More precise non-empty-string and numeric-string

### DIFF
--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -655,6 +655,11 @@ final class RegexArrayShapeMatcher
 			return $node->getValueValue();
 		}
 
+		// literal "-" outside of a character class like '~^((\\d{1,6})-)$~'
+		if ($node->getId() === 'token' && $node->getValueToken() === 'range') {
+			return $node->getValueValue();
+		}
+
 		return null;
 	}
 

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -556,14 +556,15 @@ final class RegexArrayShapeMatcher
 		if ($accessories !== []) {
 			return new IntersectionType([
 				new StringType(),
-				...$accessories
+				...$accessories,
 			]);
 		}
 
 		return new StringType();
 	}
 
-	private function walkGroupAst(TreeNode $ast, TrinaryLogic &$isNonEmpty, TrinaryLogic &$isNumeric, bool &$inOptionalQuantification): void {
+	private function walkGroupAst(TreeNode $ast, TrinaryLogic &$isNonEmpty, TrinaryLogic &$isNumeric, bool &$inOptionalQuantification): void
+	{
 		$children = $ast->getChildren();
 
 		if (
@@ -592,7 +593,7 @@ final class RegexArrayShapeMatcher
 			}
 
 			if ($ast->getValueToken() === 'character_type') {
-				if ('\d' === $ast->getValueValue()) {
+				if ($ast->getValueValue() === '\d') {
 					if ($isNumeric->maybe()) {
 						$isNumeric = TrinaryLogic::createYes();
 					}
@@ -609,7 +610,7 @@ final class RegexArrayShapeMatcher
 		if ($ast->getId() === '#range') {
 			if ($isNumeric->maybe()) {
 				$allNumeric = true;
-				foreach($children as $child) {
+				foreach ($children as $child) {
 					$literalValue = $this->getLiteralValue($child);
 
 					if ($literalValue === null) {
@@ -632,12 +633,12 @@ final class RegexArrayShapeMatcher
 			}
 		}
 
-		foreach($children as $child) {
+		foreach ($children as $child) {
 			$this->walkGroupAst(
 				$child,
 				$isNonEmpty,
 				$isNumeric,
-				$inOptionalQuantification
+				$inOptionalQuantification,
 			);
 		}
 	}

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -551,9 +551,7 @@ final class RegexArrayShapeMatcher
 		$accessories = [];
 		if ($isNumeric->yes()) {
 			$accessories[] = new AccessoryNumericStringType();
-		}
-
-		if ($isNonEmpty->yes()) {
+		} elseif ($isNonEmpty->yes()) {
 			$accessories[] = new AccessoryNonEmptyStringType();
 		}
 

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -588,7 +588,7 @@ final class RegexArrayShapeMatcher
 
 		if ($ast->getId() === 'token') {
 			$literalValue = $this->getLiteralValue($ast);
-			if ($literalValue !== null && !Strings::match($literalValue, '/^\d+$/')) {
+			if ($literalValue !== null && Strings::match($literalValue, '/^\d+$/') === null) {
 				$isNumeric = TrinaryLogic::createNo();
 			}
 
@@ -609,7 +609,7 @@ final class RegexArrayShapeMatcher
 
 		if ($ast->getId() === '#range') {
 			if ($isNumeric->maybe()) {
-				$allNumeric = true;
+				$allNumeric = null;
 				foreach ($children as $child) {
 					$literalValue = $this->getLiteralValue($child);
 
@@ -617,13 +617,15 @@ final class RegexArrayShapeMatcher
 						break;
 					}
 
-					if (!Strings::match($literalValue, '/^\d+$/')) {
+					if (Strings::match($literalValue, '/^\d+$/') === null) {
 						$allNumeric = false;
 						break;
 					}
+
+					$allNumeric = true;
 				}
 
-				if ($allNumeric) {
+				if ($allNumeric === true) {
 					$isNumeric = TrinaryLogic::createYes();
 				}
 			}

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -588,8 +588,14 @@ final class RegexArrayShapeMatcher
 
 		if ($ast->getId() === 'token') {
 			$literalValue = $this->getLiteralValue($ast);
-			if ($literalValue !== null && Strings::match($literalValue, '/^\d+$/') === null) {
-				$isNumeric = TrinaryLogic::createNo();
+			if ($literalValue !== null) {
+				if (Strings::match($literalValue, '/^\d+$/') === null) {
+					$isNumeric = TrinaryLogic::createNo();
+				}
+
+				if (!$inOptionalQuantification) {
+					$isNonEmpty = TrinaryLogic::createYes();
+				}
 			}
 
 			if ($ast->getValueToken() === 'character_type') {
@@ -600,10 +606,10 @@ final class RegexArrayShapeMatcher
 				} else {
 					$isNumeric = TrinaryLogic::createNo();
 				}
-			}
 
-			if (!$inOptionalQuantification) {
-				$isNonEmpty = TrinaryLogic::createYes();
+				if (!$inOptionalQuantification) {
+					$isNonEmpty = TrinaryLogic::createYes();
+				}
 			}
 		}
 

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -549,6 +549,12 @@ final class RegexArrayShapeMatcher
 	{
 		$children = $group->getChildren();
 
+		// remove capturing group name
+		if ($group->getId() === '#namedcapturing') {
+			$children = [$children[1]];
+		}
+
+		// #quantification is not relevant for the type of the group
 		if (count($children) === 1 && $children[0]->getId() === '#quantification') {
 			$quantification = $children[0];
 			if (count($quantification->getChildren()) === 2) {

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -611,7 +611,7 @@ final class RegexArrayShapeMatcher
 			}
 		}
 
-		if ($ast->getId() === '#range') {
+		if ($ast->getId() === '#range' || $ast->getId() === '#class') {
 			if ($isNumeric->maybe()) {
 				$allNumeric = null;
 				foreach ($children as $child) {

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -558,10 +558,8 @@ final class RegexArrayShapeMatcher
 		}
 
 		if ($accessories !== []) {
-			return new IntersectionType([
-				new StringType(),
-				...$accessories,
-			]);
+			$accessories[] = new StringType();
+			return new IntersectionType($accessories);
 		}
 
 		return new StringType();

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -549,6 +549,13 @@ final class RegexArrayShapeMatcher
 	{
 		$children = $group->getChildren();
 
+		if (count($children) === 1 && $children[0]->getId() === '#quantification') {
+			$quantification = $children[0];
+			if (count($quantification->getChildren()) === 2) {
+				$children = [$quantification->getChildren()[0]];
+			}
+		}
+
 		if (
 			count($children) === 1
 			&& $children[0]->getId() === 'token'

--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -298,6 +298,10 @@ final class RegexArrayShapeMatcher
 				}
 			}
 
+			if (!$optional && $captureGroup->isOptional() && !$this->containsUnmatchedAsNull($flags)) {
+				$groupValueType = TypeCombinator::union($groupValueType, new ConstantStringType(''));
+			}
+
 			if ($captureGroup->isNamed()) {
 				$builder->setOffsetValueType(
 					$this->getKeyType($captureGroup->getName()),

--- a/src/Type/Php/RegexCapturingGroup.php
+++ b/src/Type/Php/RegexCapturingGroup.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Type\Php;
 
+use PHPStan\Type\Type;
+
 class RegexCapturingGroup
 {
 
@@ -13,6 +15,7 @@ class RegexCapturingGroup
 		private ?int $alternationId,
 		private bool $inOptionalQuantification,
 		private RegexCapturingGroup|RegexNonCapturingGroup|null $parent,
+		private Type $type,
 	)
 	{
 	}
@@ -90,6 +93,11 @@ class RegexCapturingGroup
 	public function getName(): ?string
 	{
 		return $this->name;
+	}
+
+	public function getType(): Type
+	{
+		return $this->type;
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -8,23 +8,23 @@ use function PHPStan\Testing\assertType;
 
 function doFoo(string $s) {
 	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, major: string, 1: string, minor: string, 2: string, patch?: string, 3?: string}', $matches);
+		assertType('array{0: string, major: numeric-string, 1: numeric-string, minor: numeric-string, 2: numeric-string, patch?: numeric-string, 3?: numeric-string}', $matches);
 	}
 }
 
 function doUnmatchedAsNull(string $s): void {
 	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, 1?: string, 2?: string, 3?: string}', $matches);
+		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1?: string, 2?: string, 3?: string}', $matches);
+	assertType('array{}|array{0: string, 1?: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
 }
 
 // see https://3v4l.org/VeDob#veol
 function unmatchedAsNullWithOptionalGroup(string $s): void {
 	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, 1?: string}', $matches);
+		assertType('array{0: string, 1?: non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, 1?: string}', $matches);
+	assertType('array{}|array{0: string, 1?: non-empty-string}', $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -7,7 +7,7 @@ use function PHPStan\Testing\assertType;
 function doFoo(string $s) {
 	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 
-		assertType('array{0: string, major: non-empty-string&numeric-string, 1: non-empty-string&numeric-string, minor: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, patch: (non-empty-string&numeric-string)|null, 3: (non-empty-string&numeric-string)|null}', $matches);
+		assertType('array{0: string, major: numeric-string, 1: numeric-string, minor: numeric-string, 2: numeric-string, patch: numeric-string|null, 3: numeric-string|null}', $matches);
 	}
 }
 
@@ -84,42 +84,42 @@ function (string $size): void {
 	if (preg_match('/ab(\d){2,4}xx([0-9])?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string&numeric-string, (non-empty-string&numeric-string)|null}', $matches);
+	assertType('array{string, numeric-string, numeric-string|null}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/a(\dAB){2}b(\d){2,4}([1-5])([1-5a-z])e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string}', $matches);
+	assertType('array{string, non-empty-string, numeric-string, numeric-string, non-empty-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string|null}', $matches);
+	assertType('array{string, non-empty-string, numeric-string, non-empty-string|null}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/ab(\d+)e(\d?)/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string&numeric-string, numeric-string}', $matches);
+	assertType('array{string, numeric-string, numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/ab(?P<num>\d+)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string}', $matches);
+	assertType('array{0: string, num: numeric-string, 1: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/ab(\d\d)/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string&numeric-string}', $matches);
+	assertType('array{string, numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -161,12 +161,12 @@ function (string $size): void {
 	if (preg_match('/ab(\d+\d?)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string&numeric-string}', $matches);
+	assertType('array{string, numeric-string}', $matches);
 };
 
 function (string $s): void {
 	if (preg_match('/Price: ([2-5])/i', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{string, non-empty-string&numeric-string}', $matches);
+		assertType('array{string, numeric-string}', $matches);
 	}
 };
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -98,7 +98,7 @@ function (string $size): void {
 	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string, 2: non-empty-string&numeric-string, 3?: non-empty-string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string|null}', $matches);
 };
 
 function (string $size): void {
@@ -154,7 +154,7 @@ function (string $size): void {
 	if (preg_match('/ab(\S)?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: non-empty-string}', $matches);
+	assertType('array{string, non-empty-string|null}', $matches);
 };
 
 function (string $size): void {

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -79,3 +79,105 @@ class UnmatchedAsNullWithTopLevelAlternation {
 		}
 	}
 }
+
+function (string $size): void {
+	if (preg_match('/ab(\d){2,4}xx([0-9])?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string&numeric-string, (non-empty-string&numeric-string)|null}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/a(\dAB){2}b(\d){2,4}([1-5])([1-5a-z])e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, 1: non-empty-string, 2: non-empty-string&numeric-string, 3?: non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d+)e(\d?)/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string&numeric-string, numeric-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(?P<num>\d+)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d\d)/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string&numeric-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d+\s)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\s)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\S)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\S?)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\S)?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, 1?: non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d+\d?)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string&numeric-string}', $matches);
+};
+
+function (string $s): void {
+	if (preg_match('/Price: ([2-5])/i', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		assertType('array{string, non-empty-string&numeric-string}', $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('/Price: ([2-5A-Z])/i', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
+		assertType('array{string, non-empty-string}', $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('/^%([0-9]*\$)?[0-9]*\.?[0-9]*([sbdeEfFgGhHouxX])$/', $s, $matches, PREG_UNMATCHED_AS_NULL) === 1) {
+		assertType('array{string, non-empty-string|null, non-empty-string}', $matches);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -7,26 +7,26 @@ use function PHPStan\Testing\assertType;
 function doFoo(string $s) {
 	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 
-		assertType('array{0: string, major: numeric-string, 1: numeric-string, minor: numeric-string, 2: numeric-string, patch: numeric-string|null, 3: numeric-string|null}', $matches);
+		assertType('array{0: string, major: non-empty-string&numeric-string, 1: non-empty-string&numeric-string, minor: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, patch: (non-empty-string&numeric-string)|null, 3: (non-empty-string&numeric-string)|null}', $matches);
 	}
 }
 
 function doUnmatchedAsNull(string $s): void {
 	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{string, string|null, string|null, string|null}', $matches);
+		assertType('array{string, non-empty-string|null, non-empty-string|null, non-empty-string|null}', $matches);
 	}
-	assertType('array{}|array{string, string|null, string|null, string|null}', $matches);
+	assertType('array{}|array{string, non-empty-string|null, non-empty-string|null, non-empty-string|null}', $matches);
 }
 
 // see https://3v4l.org/VeDob
 function unmatchedAsNullWithOptionalGroup(string $s): void {
 	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 		// with PREG_UNMATCHED_AS_NULL the offset 1 will always exist. It is correct that it's nullable because it's optional though
-		assertType('array{string, string|null}', $matches);
+		assertType('array{string, non-empty-string|null}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, string|null}', $matches);
+	assertType('array{}|array{string, non-empty-string|null}', $matches);
 }
 
 function bug11331a(string $url):void {
@@ -36,7 +36,7 @@ function bug11331a(string $url):void {
 		(?<a>.+)
 	)?
 	(?<b>.+)}mix', $url, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, a: string|null, 1: string|null, b: string, 2: string}', $matches);
+		assertType('array{0: string, a: non-empty-string|null, 1: non-empty-string|null, b: non-empty-string, 2: non-empty-string}', $matches);
 	}
 }
 
@@ -46,7 +46,7 @@ function bug11331b(string $url):void {
 		(?<a>.+)
 	)?
 	(?<b>.+)?}mix', $url, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, a: string|null, 1: string|null, b: string|null, 2: string|null}', $matches);
+		assertType('array{0: string, a: non-empty-string|null, 1: non-empty-string|null, b: non-empty-string|null, 2: non-empty-string|null}', $matches);
 	}
 }
 
@@ -62,20 +62,20 @@ function bug11331c(string $url):void {
 	([^/]+?)
 	(?:\.git|/)?
 $}x', $url, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{string, string|null, string|null, string, string}', $matches);
+		assertType('array{string, non-empty-string|null, non-empty-string|null, non-empty-string, non-empty-string}', $matches);
 	}
 }
 
 class UnmatchedAsNullWithTopLevelAlternation {
 	function doFoo(string $s): void {
 		if (preg_match('/Price: (?:(£)|(€))\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-			assertType('array{string, string|null, string|null}', $matches); // could be array{0: string, 1: null, 2: string}|array{0: string, 1: string, 2: null}
+			assertType('array{string, non-empty-string|null, non-empty-string|null}', $matches); // could be array{0: string, 1: null, 2: string}|array{0: string, 1: string, 2: null}
 		}
 	}
 
 	function doBar(string $s): void {
 		if (preg_match('/Price: (?:(£)|(€))?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-			assertType('array{string, string|null, string|null}', $matches);
+			assertType('array{string, non-empty-string|null, non-empty-string|null}', $matches);
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -181,3 +181,9 @@ function (string $s): void {
 		assertType('array{string, non-empty-string|null, non-empty-string}', $matches);
 	}
 };
+
+function (string $s): void {
+	if (preg_match('/(?<whitespace>\s*)(?<value>.*)/', $s, $matches, PREG_UNMATCHED_AS_NULL) === 1) {
+		assertType('array{0: string, whitespace: string, 1: string, value: string, 2: string}', $matches);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -69,7 +69,7 @@ $}x', $url, $matches, PREG_UNMATCHED_AS_NULL)) {
 class UnmatchedAsNullWithTopLevelAlternation {
 	function doFoo(string $s): void {
 		if (preg_match('/Price: (?:(£)|(€))\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-			assertType('array{string, non-empty-string|null, non-empty-string|null}', $matches); // could be array{0: string, 1: null, 2: string}|array{0: string, 1: string, 2: null}
+			assertType('array{string, non-empty-string|null, non-empty-string|null}', $matches); // could be array{0: string, 1: null, 2: non-empty-string}|array{0: string, 1: non-empty-string, 2: null}
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -7,7 +7,7 @@ use function PHPStan\Testing\assertType;
 function doFoo(string $s) {
 	if (1 === preg_match('/(?<major>\d+)\.(?<minor>\d+)(?:\.(?<patch>\d+))?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
 
-		assertType('array{0: string, major: string, 1: string, minor: string, 2: string, patch: string|null, 3: string|null}', $matches);
+		assertType('array{0: string, major: numeric-string, 1: numeric-string, minor: numeric-string, 2: numeric-string, patch: numeric-string|null, 3: numeric-string|null}', $matches);
 	}
 }
 

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -448,3 +448,15 @@ function (string $s): void {
 		assertType('array{string, string, non-empty-string}', $matches);
 	}
 };
+
+function (string $s): void {
+	if (preg_match('~^((\\d{1,6})-)$~', $s, $matches) === 1) {
+		assertType("array{string, non-empty-string, non-empty-string&numeric-string}", $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('~^((\\d{1,6}).)$~', $s, $matches) === 1) {
+		assertType("array{string, non-empty-string, non-empty-string&numeric-string}", $matches);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -12,112 +12,112 @@ function doMatch(string $s): void {
 	assertType('array{}|array{string}', $matches);
 
 	if (preg_match('/Price: (£|€)\d+/', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/Price: (£|€)(\d+)/i', $s, $matches)) {
-		assertType('array{string, string, numeric-string}', $matches);
+		assertType('array{string, non-empty-string, non-empty-string&numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, string, numeric-string}', $matches);
+	assertType('array{}|array{string, non-empty-string, non-empty-string&numeric-string}', $matches);
 
 	if (preg_match('  /Price: (£|€)\d+/ i u', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('(Price: (£|€))i', $s, $matches)) {
-		assertType('array{string, string, string}', $matches);
+		assertType('array{string, non-empty-string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string, non-empty-string}', $matches);
 
 	if (preg_match('_foo(.)\_i_i', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/(a)(b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2: string, 3: string, 4?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2: string, 3: string, 4?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a)(?<name>b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: string, name: string, 2: string, 3: string, 4?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, name: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, name: string, 2: string, 3: string, 4?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, name: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a)(b)*(c)(?<name>d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2: string, 3: string, name?: string, 4?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2: string, 3: string, name?: string, 4?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a|b)|(?:c)/', $s, $matches)) {
-		assertType('array{0: string, 1?: string}', $matches);
+		assertType('array{0: string, 1?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1?: string}', $matches);
+	assertType('array{}|array{0: string, 1?: non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz)+/', $s, $matches)) {
-		assertType('array{string, string, string, string}', $matches);
+		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string, string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz)*/', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2: string, 3?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2: string, 3?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz)?/', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2: string, 3?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2: string, 3?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz){0,3}/', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2: string, 3?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2: string, 3?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2,3}/', $s, $matches)) {
-		assertType('array{string, string, string, string}', $matches);
+		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string, string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2}/', $s, $matches)) {
-		assertType('array{string, string, string, string}', $matches);
+		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string, string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 }
 
 function doNonCapturingGroup(string $s): void {
 	if (preg_match('/Price: (?:£|€)(\d+)/', $s, $matches)) {
-		assertType('array{string, numeric-string}', $matches);
+		assertType('array{string, non-empty-string&numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, numeric-string}', $matches);
+	assertType('array{}|array{string, non-empty-string&numeric-string}', $matches);
 }
 
 function doNamedSubpattern(string $s): void {
 	if (preg_match('/\w-(?P<num>\d+)-(\w)/', $s, $matches)) {
-		assertType('array{0: string, num: numeric-string, 1: numeric-string, 2: string}', $matches);
+		assertType('array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string, 2: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, num: numeric-string, 1: numeric-string, 2: string}', $matches);
+	assertType('array{}|array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string, 2: non-empty-string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)/', $s, $matches)) {
-		assertType('array{0: string, name: string, 1: string}', $matches);
+		assertType('array{0: string, name: non-empty-string, 1: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, name: string, 1: string}', $matches);
+	assertType('array{}|array{0: string, name: non-empty-string, 1: non-empty-string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)(?:(?<dataname> with data set (?:#\d+|"[^"]+"))\s\()?/', $s, $matches)) {
-		assertType('array{0: string, name: string, 1: string, dataname?: string, 2?: string}', $matches);
+		assertType('array{0: string, name: non-empty-string, 1: non-empty-string, dataname?: non-empty-string, 2?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, name: string, 1: string, dataname?: string, 2?: string}', $matches);
+	assertType('array{}|array{0: string, name: non-empty-string, 1: non-empty-string, dataname?: non-empty-string, 2?: non-empty-string}', $matches);
 }
 
 function doOffsetCapture(string $s): void {
 	if (preg_match('/(foo)(bar)(baz)/', $s, $matches, PREG_OFFSET_CAPTURE)) {
-		assertType('array{array{string, int<0, max>}, array{string, int<0, max>}, array{string, int<0, max>}, array{string, int<0, max>}}', $matches);
+		assertType('array{array{string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}}', $matches);
 	}
-	assertType('array{}|array{array{string, int<0, max>}, array{string, int<0, max>}, array{string, int<0, max>}, array{string, int<0, max>}}', $matches);
+	assertType('array{}|array{array{string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}}', $matches);
 }
 
 function doUnknownFlags(string $s, int $flags): void {
@@ -154,14 +154,14 @@ function doMultipleConsecutiveCaptureGroupsWithSameNameWithModifier(string $s): 
 // https://github.com/hoaproject/Regex/issues/31
 function hoaBug31(string $s): void {
 	if (preg_match('/([\w-])/', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/\w-(\d+)-(\w)/', $s, $matches)) {
-		assertType('array{string, numeric-string, string}', $matches);
+		assertType('array{string, non-empty-string&numeric-string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, numeric-string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string&numeric-string, non-empty-string}', $matches);
 }
 
 // https://github.com/phpstan/phpstan/issues/10855#issuecomment-2044323638
@@ -235,21 +235,21 @@ function testUnionPattern(string $s): void
 		$pattern = '/Price: (\d+)(\d+)(\d+)/';
 	}
 	if (preg_match($pattern, $s, $matches)) {
-		assertType('array{string, numeric-string, numeric-string, numeric-string}|array{string, numeric-string}', $matches);
+		assertType('array{string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string}|array{string, non-empty-string&numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, numeric-string, numeric-string, numeric-string}|array{string, numeric-string}', $matches);
+	assertType('array{}|array{string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string}|array{string, non-empty-string&numeric-string}', $matches);
 }
 
 function doFoo(string $row): void
 {
 	if (preg_match('~^(a(b))$~', $row, $matches) === 1) {
-		assertType('array{string, string, string}', $matches);
+		assertType('array{string, non-empty-string, non-empty-string}', $matches);
 	}
 	if (preg_match('~^(a(b)?)$~', $row, $matches) === 1) {
-		assertType('array{0: string, 1: string, 2?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
 	}
 	if (preg_match('~^(a(b)?)?$~', $row, $matches) === 1) {
-		assertType('array{0: string, 1?: string, 2?: string}', $matches);
+		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
 	}
 }
 
@@ -268,21 +268,21 @@ function doFoo3(string $row): void
 		return;
 	}
 
-	assertType('array{string, string, string, numeric-string, numeric-string, numeric-string, numeric-string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string}', $matches);
 }
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)(\d+)(\s+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, numeric-string, numeric-string, string}|array{string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string}|array{string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, numeric-string}|array{string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string&numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
@@ -296,7 +296,7 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: string, 2?: numeric-string}', $matches);
+	assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string&numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -310,37 +310,37 @@ function (string $size): void {
 	if (preg_match('~^a\.(b)?(c)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: string, 2?: string}', $matches);
+	assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^(?:(\\d+)x(\\d+)|(\\d+)|x(\\d+))$~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: numeric-string, 2: numeric-string, 3?: numeric-string, 4?: numeric-string}', $matches);
+	assertType('array{0: string, 1: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, 3?: non-empty-string&numeric-string, 4?: non-empty-string&numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^(?:(\\d+)x(\\d+)|(\\d+)|x(\\d+))?$~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: numeric-string, 2: numeric-string, 3?: numeric-string, 4?: numeric-string}|array{string}', $matches);
+	assertType('array{0: string, 1: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, 3?: non-empty-string&numeric-string, 4?: non-empty-string&numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~\{(?:(include)\\s+(?:[$]?\\w+(?<!file))\\s)|(?:(include\\s+file)\\s+(?:[$]?\\w+)\\s)|(?:(include(?:Template|(?:\\s+file)))\\s+(?:\'?.*?\.latte\'?)\\s)~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: string, 2?: string, 3?: string}', $matches);
+	assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
 };
 
 
 function bug11277a(string $value): void
 {
 	if (preg_match('/^\[(.+,?)*\]$/', $value, $matches)) {
-		assertType('array{0: string, 1?: string}', $matches);
+		assertType('array{0: string, 1?: non-empty-string}', $matches);
 		if (count($matches) === 2) {
-			assertType('array{string, string}', $matches);
+			assertType('array{string, non-empty-string}', $matches);
 		}
 	}
 }
@@ -348,12 +348,12 @@ function bug11277a(string $value): void
 function bug11277b(string $value): void
 {
 	if (preg_match('/^(?:(.+,?)|(x))*$/', $value, $matches)) {
-		assertType('array{0: string, 1?: string, 2?: string}', $matches);
+		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
 		if (count($matches) === 2) {
-			assertType('array{string, string}', $matches);
+			assertType('array{string, non-empty-string}', $matches);
 		}
 		if (count($matches) === 3) {
-			assertType('array{string, string, string}', $matches);
+			assertType('array{string, non-empty-string, non-empty-string}', $matches);
 		}
 	}
 }
@@ -362,17 +362,17 @@ function bug11277b(string $value): void
 // https://3v4l.org/09qdT
 function bug11291(string $s): void {
 	if (preg_match('/(?|(a)|(b)(c)|(d)(e)(f))/', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2?: string, 3?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2?: string, 3?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
 }
 
 function bug11323a(string $s): void
 {
 	if (preg_match('/Price: (?P<currency>£|€)\d+/', $s, $matches)) {
-		assertType('array{0: string, currency: string, 1: string}', $matches);
+		assertType('array{0: string, currency: non-empty-string, 1: non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
@@ -382,56 +382,56 @@ function bug11323a(string $s): void
 function bug11323b(string $s): void
 {
 	if (preg_match('/Price: (?<currency>£|€)\d+/', $s, $matches)) {
-		assertType('array{0: string, currency: string, 1: string}', $matches);
+		assertType('array{0: string, currency: non-empty-string, 1: non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
+	assertType('array{}|array{0: string, currency: non-empty-string, 1: non-empty-string}', $matches);
 }
 
 function unmatchedAsNullWithMandatoryGroup(string $s): void {
 	if (preg_match('/Price: (?<currency>£|€)\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, currency: string, 1: string}', $matches);
+		assertType('array{0: string, currency: non-empty-string, 1: non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
+	assertType('array{}|array{0: string, currency: non-empty-string, 1: non-empty-string}', $matches);
 }
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote('xxx') . '(z)}', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string}', $matches);
 };
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote($s) . '(z)}', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, non-empty-string}', $matches);
 };
 
 function (string $s): void {
 	if (preg_match('/' . preg_quote($s, '/') . '(\d)/', $s, $matches)) {
-		assertType('array{string, numeric-string}', $matches);
+		assertType('array{string, non-empty-string&numeric-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, numeric-string}', $matches);
+	assertType('array{}|array{string, non-empty-string&numeric-string}', $matches);
 };
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote($s) . '(z)' . preg_quote($s) . '(?:abc)(def)?}', $s, $matches)) {
-		assertType('array{0: string, 1: string, 2?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, 2?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
 };
 
 function (string $s, $mixed): void {
@@ -447,7 +447,7 @@ function (string $size): void {
 	if (preg_match('/ab(\d){2,4}xx([0-9])?e?/', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: numeric-string, 2?: numeric-string}', $matches);
+	assertType('array{0: string, 1: non-empty-string&numeric-string, 2?: non-empty-string}', $matches);
 };
 
 function (string $size): void {
@@ -468,7 +468,7 @@ function (string $size): void {
 	if (preg_match('/ab(\d+)e(\d?)/', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, numeric-string, numeric-string}', $matches);
+	assertType('array{string, non-empty-string&numeric-string, numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -476,4 +476,65 @@ function (string $size): void {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
 	assertType('array{0: string, num: numeric-string, 1: numeric-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d\d)/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string&numeric-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d+\s)e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\s)e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\S)e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\S?)e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\S)?e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, 1?: non-empty-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d+\d?)e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, non-empty-string&numeric-string}', $matches);
+};
+
+function (string $s): void {
+	if (preg_match('/Price: ([2-5])/i', $s, $matches)) {
+		assertType('array{string, non-empty-string&numeric-string}', $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('/Price: ([2-5A-Z])/i', $s, $matches)) {
+		assertType('array{string, non-empty-string}', $matches);
+	}
 };

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -98,9 +98,9 @@ function doNonCapturingGroup(string $s): void {
 
 function doNamedSubpattern(string $s): void {
 	if (preg_match('/\w-(?P<num>\d+)-(\w)/', $s, $matches)) {
-		assertType('array{0: string, num: string, 1: string, 2: string}', $matches);
+		assertType('array{0: string, num: numeric-string, 1: numeric-string, 2: string}', $matches);
 	}
-	assertType('array{}|array{0: string, num: string, 1: string, 2: string}', $matches);
+	assertType('array{}|array{0: string, num: numeric-string, 1: numeric-string, 2: string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)/', $s, $matches)) {
 		assertType('array{0: string, name: string, 1: string}', $matches);
@@ -259,7 +259,7 @@ function doFoo2(string $row): void
 		return;
 	}
 
-	assertType('array{0: string, 1: string, branchCode: string, 2: string, accountNumber: string, 3: string, bankCode: string, 4: string}', $matches);
+	assertType('array{0: string, 1: string, branchCode: numeric-string, 2: numeric-string, accountNumber: numeric-string, 3: numeric-string, bankCode: numeric-string, 4: numeric-string}', $matches);
 }
 
 function doFoo3(string $row): void

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -340,7 +340,7 @@ function bug11277a(string $value): void
 	if (preg_match('/^\[(.+,?)*\]$/', $value, $matches)) {
 		assertType('array{0: string, 1?: non-empty-string}', $matches);
 		if (count($matches) === 2) {
-			assertType('array{string, non-empty-string}', $matches);
+			assertType('array{string, string}', $matches); // could be array{string, non-empty-string}
 		}
 	}
 }
@@ -350,10 +350,10 @@ function bug11277b(string $value): void
 	if (preg_match('/^(?:(.+,?)|(x))*$/', $value, $matches)) {
 		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
 		if (count($matches) === 2) {
-			assertType('array{string, non-empty-string}', $matches);
+			assertType('array{string, string}', $matches); // could be array{string, non-empty-string}
 		}
 		if (count($matches) === 3) {
-			assertType('array{string, non-empty-string, non-empty-string}', $matches);
+			assertType('array{string, string, string}', $matches); // could be array{string, non-empty-string, non-empty-string}
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -460,3 +460,15 @@ function (string $s): void {
 		assertType("array{string, non-empty-string, non-empty-string&numeric-string}", $matches);
 	}
 };
+
+function (string $s): void {
+	if (preg_match('~^([157])$~', $s, $matches) === 1) {
+		assertType("array{string, non-empty-string&numeric-string}", $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('~^([157XY])$~', $s, $matches) === 1) {
+		assertType("array{string, non-empty-string}", $matches);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -418,11 +418,11 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('/' . preg_quote($s, '/') . '(\d)/', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, numeric-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, numeric-string}', $matches);
 };
 
 function (string $s): void {
@@ -441,4 +441,25 @@ function (string $s, $mixed): void {
 		assertType('array{}', $matches);
 	}
 	assertType('array<string>', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d){2,4}xx([0-9])?e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, 1: numeric-string, 2?: numeric-string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/a(\dAB){2}b(\d){2,4}([1-5])([1-5a-z])e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, string, numeric-string, numeric-string, string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, 1: string, 2: numeric-string, 3?: string}', $matches);
 };

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -259,7 +259,7 @@ function doFoo2(string $row): void
 		return;
 	}
 
-	assertType('array{0: string, 1: string, branchCode: numeric-string, 2: numeric-string, accountNumber: numeric-string, 3: numeric-string, bankCode: numeric-string, 4: numeric-string}', $matches);
+	assertType('array{0: string, 1: non-empty-string&numeric-string, branchCode: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, accountNumber: non-empty-string&numeric-string, 3: non-empty-string&numeric-string, bankCode: non-empty-string&numeric-string, 4: non-empty-string&numeric-string}', $matches);
 }
 
 function doFoo3(string $row): void
@@ -289,7 +289,7 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: string, 2?: numeric-string}', $matches);
+	assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string&numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -303,7 +303,7 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, numeric-string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string&numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -376,7 +376,7 @@ function bug11323a(string $s): void
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, currency: string, 1: string}', $matches);
+	assertType('array{}|array{0: string, currency: non-empty-string, 1: non-empty-string}', $matches);
 }
 
 function bug11323b(string $s): void
@@ -447,21 +447,21 @@ function (string $size): void {
 	if (preg_match('/ab(\d){2,4}xx([0-9])?e?/', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string&numeric-string, 2?: non-empty-string}', $matches);
+	assertType('array{0: string, 1: non-empty-string&numeric-string, 2?: non-empty-string&numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/a(\dAB){2}b(\d){2,4}([1-5])([1-5a-z])e?/', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, numeric-string, numeric-string, string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: string, 2: numeric-string, 3?: string}', $matches);
+	assertType('array{0: string, 1: non-empty-string, 2: non-empty-string&numeric-string, 3?: non-empty-string}', $matches);
 };
 
 function (string $size): void {
@@ -475,7 +475,7 @@ function (string $size): void {
 	if (preg_match('/ab(?P<num>\d+)e?/', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, num: numeric-string, 1: numeric-string}', $matches);
+	assertType('array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string}', $matches);
 };
 
 function (string $size): void {

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -39,19 +39,19 @@ function doMatch(string $s): void {
 	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/(a)(b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: string}', $matches);
 
 	if (preg_match('/(a)(?<name>b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, name: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, name: string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, name: non-empty-string, 2: non-empty-string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, name: string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a)(b)*(c)(?<name>d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a|b)|(?:c)/', $s, $matches)) {
 		assertType('array{0: string, 1?: non-empty-string}', $matches);
@@ -259,7 +259,7 @@ function doFoo2(string $row): void
 		return;
 	}
 
-	assertType('array{0: string, 1: non-empty-string&numeric-string, branchCode: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, accountNumber: non-empty-string&numeric-string, 3: non-empty-string&numeric-string, bankCode: non-empty-string&numeric-string, 4: non-empty-string&numeric-string}', $matches);
+	assertType("array{0: string, 1: ''|(non-empty-string&numeric-string), branchCode: ''|(non-empty-string&numeric-string), 2: ''|(non-empty-string&numeric-string), accountNumber: non-empty-string&numeric-string, 3: non-empty-string&numeric-string, bankCode: non-empty-string&numeric-string, 4: non-empty-string&numeric-string}", $matches);
 }
 
 function doFoo3(string $row): void
@@ -443,98 +443,8 @@ function (string $s, $mixed): void {
 	assertType('array<string>', $matches);
 };
 
-function (string $size): void {
-	if (preg_match('/ab(\d){2,4}xx([0-9])?e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{0: string, 1: non-empty-string&numeric-string, 2?: non-empty-string&numeric-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/a(\dAB){2}b(\d){2,4}([1-5])([1-5a-z])e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{0: string, 1: non-empty-string, 2: non-empty-string&numeric-string, 3?: non-empty-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\d+)e(\d?)/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string&numeric-string, numeric-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(?P<num>\d+)e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\d\d)/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string&numeric-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\d+\s)e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\s)e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\S)e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\S?)e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\S)?e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{0: string, 1?: non-empty-string}', $matches);
-};
-
-function (string $size): void {
-	if (preg_match('/ab(\d+\d?)e?/', $size, $matches) !== 1) {
-		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
-	}
-	assertType('array{string, non-empty-string&numeric-string}', $matches);
-};
-
 function (string $s): void {
-	if (preg_match('/Price: ([2-5])/i', $s, $matches)) {
-		assertType('array{string, non-empty-string&numeric-string}', $matches);
-	}
-};
-
-function (string $s): void {
-	if (preg_match('/Price: ([2-5A-Z])/i', $s, $matches)) {
-		assertType('array{string, non-empty-string}', $matches);
+	if (preg_match('/^%([0-9]*\$)?[0-9]*\.?[0-9]*([sbdeEfFgGhHouxX])$/', $s, $matches) === 1) {
+		assertType('array{string, string, non-empty-string}', $matches);
 	}
 };

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -39,9 +39,9 @@ function doMatch(string $s): void {
 	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/(a)(b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: string}', $matches);
+		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a)(?<name>b)*(c)(d)*/', $s, $matches)) {
 		assertType('array{0: string, 1: non-empty-string, name: string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
@@ -259,7 +259,7 @@ function doFoo2(string $row): void
 		return;
 	}
 
-	assertType("array{0: string, 1: ''|(non-empty-string&numeric-string), branchCode: ''|(non-empty-string&numeric-string), 2: ''|(non-empty-string&numeric-string), accountNumber: non-empty-string&numeric-string, 3: non-empty-string&numeric-string, bankCode: non-empty-string&numeric-string, 4: non-empty-string&numeric-string}", $matches);
+	assertType("array{0: string, 1: string, branchCode: ''|(non-empty-string&numeric-string), 2: ''|(non-empty-string&numeric-string), accountNumber: non-empty-string&numeric-string, 3: non-empty-string&numeric-string, bankCode: non-empty-string&numeric-string, 4: non-empty-string&numeric-string}", $matches);
 }
 
 function doFoo3(string $row): void

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -19,9 +19,9 @@ function doMatch(string $s): void {
 	assertType('array{}|array{string, string}', $matches);
 
 	if (preg_match('/Price: (£|€)(\d+)/i', $s, $matches)) {
-		assertType('array{string, string, string}', $matches);
+		assertType('array{string, string, numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, string, string}', $matches);
+	assertType('array{}|array{string, string, numeric-string}', $matches);
 
 	if (preg_match('  /Price: (£|€)\d+/ i u', $s, $matches)) {
 		assertType('array{string, string}', $matches);
@@ -91,9 +91,9 @@ function doMatch(string $s): void {
 
 function doNonCapturingGroup(string $s): void {
 	if (preg_match('/Price: (?:£|€)(\d+)/', $s, $matches)) {
-		assertType('array{string, string}', $matches);
+		assertType('array{string, numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, numeric-string}', $matches);
 }
 
 function doNamedSubpattern(string $s): void {
@@ -159,9 +159,9 @@ function hoaBug31(string $s): void {
 	assertType('array{}|array{string, string}', $matches);
 
 	if (preg_match('/\w-(\d+)-(\w)/', $s, $matches)) {
-		assertType('array{string, string, string}', $matches);
+		assertType('array{string, numeric-string, string}', $matches);
 	}
-	assertType('array{}|array{string, string, string}', $matches);
+	assertType('array{}|array{string, numeric-string, string}', $matches);
 }
 
 // https://github.com/phpstan/phpstan/issues/10855#issuecomment-2044323638
@@ -235,9 +235,9 @@ function testUnionPattern(string $s): void
 		$pattern = '/Price: (\d+)(\d+)(\d+)/';
 	}
 	if (preg_match($pattern, $s, $matches)) {
-		assertType('array{string, string, string, string}|array{string, string}', $matches);
+		assertType('array{string, numeric-string, numeric-string, numeric-string}|array{string, numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, string, string, string}|array{string, string}', $matches);
+	assertType('array{}|array{string, numeric-string, numeric-string, numeric-string}|array{string, numeric-string}', $matches);
 }
 
 function doFoo(string $row): void
@@ -268,42 +268,42 @@ function doFoo3(string $row): void
 		return;
 	}
 
-	assertType('array{string, string, string, string, string, string, string}', $matches);
+	assertType('array{string, string, string, numeric-string, numeric-string, numeric-string, numeric-string}', $matches);
 }
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)(\d+)(\s+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, string, string, string}|array{string}', $matches);
+	assertType('array{string, string, numeric-string, numeric-string, string}|array{string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, string}|array{string}', $matches);
+	assertType('array{string, string, numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: string, 2?: string}', $matches);
+	assertType('array{0: string, 1: string, 2?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: string, 2?: string}', $matches);
+	assertType('array{0: string, 1?: string, 2?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, string, string}', $matches);
+	assertType('array{string, string, numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -317,14 +317,14 @@ function (string $size): void {
 	if (preg_match('~^(?:(\\d+)x(\\d+)|(\\d+)|x(\\d+))$~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: string, 2: string, 3?: string, 4?: string}', $matches);
+	assertType('array{0: string, 1: numeric-string, 2: numeric-string, 3?: numeric-string, 4?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^(?:(\\d+)x(\\d+)|(\\d+)|x(\\d+))?$~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: string, 2: string, 3?: string, 4?: string}|array{string}', $matches);
+	assertType('array{0: string, 1: numeric-string, 2: numeric-string, 3?: numeric-string, 4?: numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
@@ -462,4 +462,11 @@ function (string $size): void {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
 	assertType('array{0: string, 1: string, 2: numeric-string, 3?: string}', $matches);
+};
+
+function (string $size): void {
+	if (preg_match('/ab(\d+)e(\d?)/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{string, numeric-string, numeric-string}', $matches);
 };

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -19,9 +19,9 @@ function doMatch(string $s): void {
 	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/Price: (£|€)(\d+)/i', $s, $matches)) {
-		assertType('array{string, non-empty-string, non-empty-string&numeric-string}', $matches);
+		assertType('array{string, non-empty-string, numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string, non-empty-string&numeric-string}', $matches);
+	assertType('array{}|array{string, non-empty-string, numeric-string}', $matches);
 
 	if (preg_match('  /Price: (£|€)\d+/ i u', $s, $matches)) {
 		assertType('array{string, non-empty-string}', $matches);
@@ -91,16 +91,16 @@ function doMatch(string $s): void {
 
 function doNonCapturingGroup(string $s): void {
 	if (preg_match('/Price: (?:£|€)(\d+)/', $s, $matches)) {
-		assertType('array{string, non-empty-string&numeric-string}', $matches);
+		assertType('array{string, numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string&numeric-string}', $matches);
+	assertType('array{}|array{string, numeric-string}', $matches);
 }
 
 function doNamedSubpattern(string $s): void {
 	if (preg_match('/\w-(?P<num>\d+)-(\w)/', $s, $matches)) {
-		assertType('array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string, 2: non-empty-string}', $matches);
+		assertType('array{0: string, num: numeric-string, 1: numeric-string, 2: non-empty-string}', $matches);
 	}
-	assertType('array{}|array{0: string, num: non-empty-string&numeric-string, 1: non-empty-string&numeric-string, 2: non-empty-string}', $matches);
+	assertType('array{}|array{0: string, num: numeric-string, 1: numeric-string, 2: non-empty-string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)/', $s, $matches)) {
 		assertType('array{0: string, name: non-empty-string, 1: non-empty-string}', $matches);
@@ -159,9 +159,9 @@ function hoaBug31(string $s): void {
 	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/\w-(\d+)-(\w)/', $s, $matches)) {
-		assertType('array{string, non-empty-string&numeric-string, non-empty-string}', $matches);
+		assertType('array{string, numeric-string, non-empty-string}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string&numeric-string, non-empty-string}', $matches);
+	assertType('array{}|array{string, numeric-string, non-empty-string}', $matches);
 }
 
 // https://github.com/phpstan/phpstan/issues/10855#issuecomment-2044323638
@@ -235,9 +235,9 @@ function testUnionPattern(string $s): void
 		$pattern = '/Price: (\d+)(\d+)(\d+)/';
 	}
 	if (preg_match($pattern, $s, $matches)) {
-		assertType('array{string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string}|array{string, non-empty-string&numeric-string}', $matches);
+		assertType('array{string, numeric-string, numeric-string, numeric-string}|array{string, numeric-string}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string}|array{string, non-empty-string&numeric-string}', $matches);
+	assertType('array{}|array{string, numeric-string, numeric-string, numeric-string}|array{string, numeric-string}', $matches);
 }
 
 function doFoo(string $row): void
@@ -259,7 +259,7 @@ function doFoo2(string $row): void
 		return;
 	}
 
-	assertType("array{0: string, 1: string, branchCode: ''|(non-empty-string&numeric-string), 2: ''|(non-empty-string&numeric-string), accountNumber: non-empty-string&numeric-string, 3: non-empty-string&numeric-string, bankCode: non-empty-string&numeric-string, 4: non-empty-string&numeric-string}", $matches);
+	assertType("array{0: string, 1: string, branchCode: ''|numeric-string, 2: ''|numeric-string, accountNumber: numeric-string, 3: numeric-string, bankCode: numeric-string, 4: numeric-string}", $matches);
 }
 
 function doFoo3(string $row): void
@@ -268,42 +268,42 @@ function doFoo3(string $row): void
 		return;
 	}
 
-	assertType('array{string, non-empty-string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string&numeric-string}', $matches);
+	assertType('array{string, non-empty-string, non-empty-string, numeric-string, numeric-string, numeric-string, numeric-string}', $matches);
 }
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)(\d+)(\s+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, non-empty-string&numeric-string, non-empty-string&numeric-string, non-empty-string}|array{string}', $matches);
+	assertType('array{string, non-empty-string, numeric-string, numeric-string, non-empty-string}|array{string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, non-empty-string&numeric-string}|array{string}', $matches);
+	assertType('array{string, non-empty-string, numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string&numeric-string}', $matches);
+	assertType('array{0: string, 1: non-empty-string, 2?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string&numeric-string}', $matches);
+	assertType('array{0: string, 1?: non-empty-string, 2?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, non-empty-string&numeric-string}', $matches);
+	assertType('array{string, non-empty-string, numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -317,14 +317,14 @@ function (string $size): void {
 	if (preg_match('~^(?:(\\d+)x(\\d+)|(\\d+)|x(\\d+))$~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, 3?: non-empty-string&numeric-string, 4?: non-empty-string&numeric-string}', $matches);
+	assertType('array{0: string, 1: numeric-string, 2: numeric-string, 3?: numeric-string, 4?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^(?:(\\d+)x(\\d+)|(\\d+)|x(\\d+))?$~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string&numeric-string, 2: non-empty-string&numeric-string, 3?: non-empty-string&numeric-string, 4?: non-empty-string&numeric-string}|array{string}', $matches);
+	assertType('array{0: string, 1: numeric-string, 2: numeric-string, 3?: numeric-string, 4?: numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
@@ -418,11 +418,11 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('/' . preg_quote($s, '/') . '(\d)/', $s, $matches)) {
-		assertType('array{string, non-empty-string&numeric-string}', $matches);
+		assertType('array{string, numeric-string}', $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string&numeric-string}', $matches);
+	assertType('array{}|array{string, numeric-string}', $matches);
 };
 
 function (string $s): void {
@@ -451,19 +451,19 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('~^((\\d{1,6})-)$~', $s, $matches) === 1) {
-		assertType("array{string, non-empty-string, non-empty-string&numeric-string}", $matches);
+		assertType("array{string, non-empty-string, numeric-string}", $matches);
 	}
 };
 
 function (string $s): void {
 	if (preg_match('~^((\\d{1,6}).)$~', $s, $matches) === 1) {
-		assertType("array{string, non-empty-string, non-empty-string&numeric-string}", $matches);
+		assertType("array{string, non-empty-string, numeric-string}", $matches);
 	}
 };
 
 function (string $s): void {
 	if (preg_match('~^([157])$~', $s, $matches) === 1) {
-		assertType("array{string, non-empty-string&numeric-string}", $matches);
+		assertType("array{string, numeric-string}", $matches);
 	}
 };
 

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -470,3 +470,10 @@ function (string $size): void {
 	}
 	assertType('array{string, numeric-string, numeric-string}', $matches);
 };
+
+function (string $size): void {
+	if (preg_match('/ab(?P<num>\d+)e?/', $size, $matches) !== 1) {
+		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
+	}
+	assertType('array{0: string, num: numeric-string, 1: numeric-string}', $matches);
+};

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php80.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php80.php
@@ -7,7 +7,7 @@ use function PHPStan\Testing\assertType;
 function doOffsetCaptureWithUnmatchedNull(string $s): void {
 	// see https://3v4l.org/07rBO#v8.2.9
 	if (preg_match('/(foo)(bar)(baz)/', $s, $matches, PREG_OFFSET_CAPTURE|PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{array{string|null, int<-1, max>}, array{string|null, int<-1, max>}, array{string|null, int<-1, max>}, array{string|null, int<-1, max>}}', $matches);
+		assertType('array{array{string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}}', $matches);
 	}
-	assertType('array{}|array{array{string|null, int<-1, max>}, array{string|null, int<-1, max>}, array{string|null, int<-1, max>}, array{string|null, int<-1, max>}}', $matches);
+	assertType('array{}|array{array{string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}}', $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
@@ -8,12 +8,12 @@ use function PHPStan\Testing\assertType;
 // https://php.watch/versions/8.2/preg-n-no-capture-modifier
 function doNonAutoCapturingFlag(string $s): void {
 	if (preg_match('/(\d+)/n', $s, $matches)) {
-		assertType('array{string, numeric-string}', $matches); // should be 'array{string}'
+		assertType('array{string, non-empty-string&numeric-string}', $matches); // should be 'array{string}'
 	}
-	assertType('array{}|array{string, numeric-string}', $matches);
+	assertType('array{}|array{string, non-empty-string&numeric-string}', $matches);
 
 	if (preg_match('/(\d+)(?P<num>\d+)/n', $s, $matches)) {
-		assertType('array{0: string, 1: numeric-string, num: numeric-string, 2: numeric-string}', $matches);
+		assertType('array{0: string, 1: non-empty-string&numeric-string, num: non-empty-string&numeric-string, 2: non-empty-string&numeric-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: numeric-string, num: numeric-string, 2: numeric-string}', $matches);
+	assertType('array{}|array{0: string, 1: non-empty-string&numeric-string, num: non-empty-string&numeric-string, 2: non-empty-string&numeric-string}', $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
@@ -8,12 +8,12 @@ use function PHPStan\Testing\assertType;
 // https://php.watch/versions/8.2/preg-n-no-capture-modifier
 function doNonAutoCapturingFlag(string $s): void {
 	if (preg_match('/(\d+)/n', $s, $matches)) {
-		assertType('array{string, non-empty-string&numeric-string}', $matches); // should be 'array{string}'
+		assertType('array{string, numeric-string}', $matches); // should be 'array{string}'
 	}
-	assertType('array{}|array{string, non-empty-string&numeric-string}', $matches);
+	assertType('array{}|array{string, numeric-string}', $matches);
 
 	if (preg_match('/(\d+)(?P<num>\d+)/n', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string&numeric-string, num: non-empty-string&numeric-string, 2: non-empty-string&numeric-string}', $matches);
+		assertType('array{0: string, 1: numeric-string, num: numeric-string, 2: numeric-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string&numeric-string, num: non-empty-string&numeric-string, 2: non-empty-string&numeric-string}', $matches);
+	assertType('array{}|array{0: string, 1: numeric-string, num: numeric-string, 2: numeric-string}', $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
@@ -13,7 +13,7 @@ function doNonAutoCapturingFlag(string $s): void {
 	assertType('array{}|array{string, numeric-string}', $matches);
 
 	if (preg_match('/(\d+)(?P<num>\d+)/n', $s, $matches)) {
-		assertType('array{0: string, 1: numeric-string, num: string, 2: string}', $matches);
+		assertType('array{0: string, 1: numeric-string, num: numeric-string, 2: numeric-string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: numeric-string, num: string, 2: string}', $matches);
+	assertType('array{}|array{0: string, 1: numeric-string, num: numeric-string, 2: numeric-string}', $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php82.php
@@ -8,12 +8,12 @@ use function PHPStan\Testing\assertType;
 // https://php.watch/versions/8.2/preg-n-no-capture-modifier
 function doNonAutoCapturingFlag(string $s): void {
 	if (preg_match('/(\d+)/n', $s, $matches)) {
-		assertType('array{string, string}', $matches); // should be 'array{string}'
+		assertType('array{string, numeric-string}', $matches); // should be 'array{string}'
 	}
-	assertType('array{}|array{string, string}', $matches);
+	assertType('array{}|array{string, numeric-string}', $matches);
 
 	if (preg_match('/(\d+)(?P<num>\d+)/n', $s, $matches)) {
-		assertType('array{0: string, 1: string, num: string, 2: string}', $matches);
+		assertType('array{0: string, 1: numeric-string, num: string, 2: string}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: string, num: string, 2: string}', $matches);
+	assertType('array{}|array{0: string, 1: numeric-string, num: string, 2: string}', $matches);
 }


### PR DESCRIPTION
based on the regex ast we try to detect more precise string types, like non-empty-string and numeric-string.

I intentionally left out constant-string types for now to reduce complexity and learn from real world use-cases in the wild.