### PR TITLE
Bleeding edge: stricter ++/-- operator check

### DIFF
--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -205,6 +205,7 @@ services:
 		tags:
 			- phpstan.rules.rule
 		arguments:
+			bleedingEdge: %featureToggles.bleedingEdge%
 			checkThisOnly: %checkThisOnly%
 
 	-

--- a/tests/PHPStan/Rules/Operators/InvalidIncDecOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidIncDecOperationRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Operators;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
 
 /**
@@ -11,9 +12,17 @@ use PHPStan\Testing\RuleTestCase;
 class InvalidIncDecOperationRuleTest extends RuleTestCase
 {
 
+	private bool $checkExplicitMixed = false;
+
+	private bool $checkImplicitMixed = false;
+
 	protected function getRule(): Rule
 	{
-		return new InvalidIncDecOperationRule(false);
+		return new InvalidIncDecOperationRule(
+			new RuleLevelHelper($this->createReflectionProvider(), true, false, true, $this->checkExplicitMixed, $this->checkImplicitMixed, true, false),
+			true,
+			false,
+		);
 	}
 
 	public function testRule(): void
@@ -30,6 +39,108 @@ class InvalidIncDecOperationRuleTest extends RuleTestCase
 			[
 				'Cannot use ++ on stdClass.',
 				17,
+			],
+			[
+				'Cannot use ++ on InvalidIncDec\\ClassWithToString.',
+				19,
+			],
+			[
+				'Cannot use -- on InvalidIncDec\\ClassWithToString.',
+				21,
+			],
+			[
+				'Cannot use ++ on array{}.',
+				23,
+			],
+			[
+				'Cannot use -- on array{}.',
+				25,
+			],
+			[
+				'Cannot use ++ on resource.',
+				28,
+			],
+			[
+				'Cannot use -- on resource.',
+				32,
+			],
+		]);
+	}
+
+	public function testMixed(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkImplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/invalid-inc-dec-mixed.php'], [
+			[
+				'Cannot use ++ on T of mixed.',
+				12,
+			],
+			[
+				'Cannot use ++ on T of mixed.',
+				14,
+			],
+			[
+				'Cannot use -- on T of mixed.',
+				16,
+			],
+			[
+				'Cannot use -- on T of mixed.',
+				18,
+			],
+			[
+				'Cannot use ++ on mixed.',
+				24,
+			],
+			[
+				'Cannot use ++ on mixed.',
+				26,
+			],
+			[
+				'Cannot use -- on mixed.',
+				28,
+			],
+			[
+				'Cannot use -- on mixed.',
+				30,
+			],
+			[
+				'Cannot use ++ on mixed.',
+				36,
+			],
+			[
+				'Cannot use ++ on mixed.',
+				38,
+			],
+			[
+				'Cannot use -- on mixed.',
+				40,
+			],
+			[
+				'Cannot use -- on mixed.',
+				42,
+			],
+		]);
+	}
+
+	public function testUnion(): void
+	{
+		$this->analyse([__DIR__ . '/data/invalid-inc-dec-union.php'], [
+			[
+				'Cannot use ++ on array|bool|float|int|object|string|null.',
+				24,
+			],
+			[
+				'Cannot use -- on array|bool|float|int|object|string|null.',
+				26,
+			],
+			[
+				'Cannot use ++ on (array|object).',
+				29,
+			],
+			[
+				'Cannot use -- on (array|object).',
+				31,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Operators/data/invalid-inc-dec-mixed.php
+++ b/tests/PHPStan/Rules/Operators/data/invalid-inc-dec-mixed.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace InvalidIncDecMixed;
+
+/**
+ * @template T
+ * @param T $a
+ */
+function genericMixed(mixed $a): void
+{
+	$b = $a;
+	var_dump(++$b);
+	$b = $a;
+	var_dump($b++);
+	$b = $a;
+	var_dump(--$b);
+	$b = $a;
+	var_dump($b--);
+}
+
+function explicitMixed(mixed $a): void
+{
+	$b = $a;
+	var_dump(++$b);
+	$b = $a;
+	var_dump($b++);
+	$b = $a;
+	var_dump(--$b);
+	$b = $a;
+	var_dump($b--);
+}
+
+function implicitMixed($a): void
+{
+	$b = $a;
+	var_dump(++$b);
+	$b = $a;
+	var_dump($b++);
+	$b = $a;
+	var_dump(--$b);
+	$b = $a;
+	var_dump($b--);
+}

--- a/tests/PHPStan/Rules/Operators/data/invalid-inc-dec-union.php
+++ b/tests/PHPStan/Rules/Operators/data/invalid-inc-dec-union.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace InvalidIncDecUnion;
+
+/**
+ * @param __benevolent<scalar|null|array|object> $benevolentUnion
+ * @param string|int|float|bool|null $okUnion
+ * @param scalar|null|array|object $union
+ * @param __benevolent<array|object> $badBenevolentUnion
+ */
+function foo($benevolentUnion, $okUnion, $union, $badBenevolentUnion): void
+{
+	$a = $benevolentUnion;
+	$a++;
+	$a = $benevolentUnion;
+	--$a;
+
+	$a = $okUnion;
+	$a++;
+	$a = $okUnion;
+	--$a;
+
+	$a = $union;
+	$a++;
+	$a = $union;
+	--$a;
+
+	$a = $badBenevolentUnion;
+	$a++;
+	$a = $badBenevolentUnion;
+	--$a;
+}

--- a/tests/PHPStan/Rules/Operators/data/invalid-inc-dec.php
+++ b/tests/PHPStan/Rules/Operators/data/invalid-inc-dec.php
@@ -2,7 +2,7 @@
 
 namespace InvalidIncDec;
 
-function ($a, int $i, ?float $j, string $str, \stdClass $std) {
+function ($a, int $i, ?float $j, string $str, \stdClass $std, \SimpleXMLElement $simpleXMLElement) {
 	$a++;
 
 	$b = [1];
@@ -15,4 +15,41 @@ function ($a, int $i, ?float $j, string $str, \stdClass $std) {
 	$j++;
 	$str++;
 	$std++;
+	$classWithToString = new ClassWithToString();
+	$classWithToString++;
+	$classWithToString = new ClassWithToString();
+	--$classWithToString;
+	$arr = [];
+	$arr++;
+	$arr = [];
+	--$arr;
+
+	if (($f = fopen('php://stdin', 'r')) !== false) {
+		$f++;
+	}
+
+	if (($f = fopen('php://stdin', 'r')) !== false) {
+		--$f;
+	}
+
+	$bool = true;
+	$bool++;
+	$bool = false;
+	--$bool;
+	$null = null;
+	$null++;
+	$null = null;
+	--$null;
+	$a = $simpleXMLElement;
+	$a++;
+	$a = $simpleXMLElement;
+	--$a;
 };
+
+class ClassWithToString
+{
+	public function __toString(): string
+	{
+		return 'foo';
+	}
+}


### PR DESCRIPTION
The goal of this PR was to check mixed in `++`/`--`, but while I was at it I also fixed several other cases which were not previously reported (pretty much the same as the binary/unary operator PRs).

Current behavior: https://phpstan.org/r/974fc0d6-90ba-4b72-8d83-edff03ac3482