### PR TITLE
Add extended reasons tips to param out errors

### DIFF
--- a/src/Rules/Variables/ParameterOutAssignedTypeRule.php
+++ b/src/Rules/Variables/ParameterOutAssignedTypeRule.php
@@ -108,10 +108,15 @@ class ParameterOutAssignedTypeRule implements Rule
 			$functionDescription,
 			$outType->describe($verbosityLevel),
 			$assignedExprType->describe($verbosityLevel),
-		))->identifier(sprintf('%s.type', $isParamOutType ? 'paramOut' : 'parameterByRef'));
+		))->identifier($isParamOutType ? 'paramOut.type' : 'parameterByRef.type');
+
+		$accepts = $outType->acceptsWithReason($assignedExprType, true);
+		if (!$accepts->result->yes()) {
+			$errorBuilder->acceptsReasonsTip($accepts->reasons);
+		}
 
 		if (!$isParamOutType) {
-			$errorBuilder->tip('You can change the parameter out type with @param-out PHPDoc tag.');
+			$errorBuilder->addTip('You can change the parameter out type with @param-out PHPDoc tag.');
 		}
 
 		return [

--- a/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
@@ -37,6 +37,7 @@ class ParameterOutAssignedTypeRuleTest extends RuleTestCase
 			[
 				'Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBaz() expects list<int>, array<0|int<2, max>, int> given.',
 				38,
+				'array<0|int<2, max>, int> might not be a list.',
 			],
 			[
 				'Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBaz2() expects list<int>, non-empty-list<\'str\'|int> given.',
@@ -45,6 +46,8 @@ class ParameterOutAssignedTypeRuleTest extends RuleTestCase
 			[
 				'Parameter &$p @param-out type of method ParameterOutAssignedType\Foo::doBaz3() expects list<list<int>>, array<int<0, max>, array<int<0, max>, int>> given.',
 				56,
+				'• array<int<0, max>, int> might not be a list.' . "\n" .
+				'• array<int<0, max>, array<int<0, max>, int>> might not be a list.',
 			],
 			[
 				'Parameter &$p by-ref type of method ParameterOutAssignedType\Foo::doNoParamOut() expects string, int given.',


### PR DESCRIPTION
This adds the very useful tips on complex types also to param-out.

Please carefully review the correctness, I assume that isSuperTypeOf and acceptsWithReason are equivalent.

Also not sure how to set the strictness parameter, as it is a param-out it should not be affected by the strict types declare.

Before:
```
 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   case2.php
 ------ ----------------------------------------------------------------------------------------------------------------------------
  8      Parameter &$foo by-ref type of function foo() expects array{a: int, b: int, c: string}, array{a: int, b: int, c: 5} given.
           parameterByRef.type
          You can change the parameter out type with @param-out PHPDoc tag.
 ------ ----------------------------------------------------------------------------------------------------------------------------
```

After:
```
 ------ ----------------------------------------------------------------------------------------------------------------------------
  Line   case2.php
 ------ ----------------------------------------------------------------------------------------------------------------------------
  8      Parameter &$foo by-ref type of function foo() expects array{a: int, b: int, c: string}, array{a: int, b: int, c: 5} given.
           parameterByRef.type
          Offset 'c' (string) does not accept type int.
          You can change the parameter out type with @param-out PHPDoc tag.
 ------ ----------------------------------------------------------------------------------------------------------------------------
```
