### PR TITLE
Apply the stricter signatures for php 8.0 after the basic ones

### DIFF
--- a/resources/functionMap_php80delta_bleedingEdge.php
+++ b/resources/functionMap_php80delta_bleedingEdge.php
@@ -5,7 +5,7 @@ return [
 		'error_log' => ['bool', 'message'=>'string', 'message_type='=>'0|1|3|4', 'destination='=>'string', 'extra_headers='=>'string'],
 		'filter_input' => ['mixed', 'type'=>'INPUT_GET|INPUT_POST|INPUT_COOKIE|INPUT_SERVER|INPUT_ENV', 'variable_name'=>'string', 'filter='=>'int', 'options='=>'array|int'],
 		'filter_input_array' => ['array|false|null', 'type'=>'INPUT_GET|INPUT_POST|INPUT_COOKIE|INPUT_SERVER|INPUT_ENV', 'definition='=>'int|array', 'add_empty='=>'bool'],
-		'hash_hkdf' => ['non-empty-string', 'algo'=>'non-falsy-string', 'key'=>'string', 'length='=>'0|positive-int', 'info='=>'string', 'salt='=>'string'],
+		'hash_hkdf' => ['non-falsy-string', 'algo'=>'non-falsy-string', 'key'=>'string', 'length='=>'0|positive-int', 'info='=>'string', 'salt='=>'string'],
 		'hash_pbkdf2' => ['non-empty-string', 'algo'=>'non-falsy-string', 'password'=>'string', 'salt'=>'string', 'iterations'=>'positive-int', 'length='=>'0|positive-int', 'raw_output='=>'bool'],
 		'imagecreate' => ['__benevolent<GdImage|false>', 'width'=>'int<1, max>', 'height'=>'int<1, max>'],
 		'imagecreatetruecolor' => ['__benevolent<GdImage|false>', 'width'=>'int<1, max>', 'height'=>'int<1, max>'],

--- a/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/FunctionSignatureMapProvider.php
@@ -190,15 +190,6 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 			}
 
 			$signatureMap = $this->computeSignatureMap($signatureMap, $stricterFunctionMap);
-
-			if ($this->phpVersion->getVersionId() >= 80000) {
-				$php80StricterFunctionMapDelta = require __DIR__ . '/../../../resources/functionMap_php80delta_bleedingEdge.php';
-				if (!is_array($php80StricterFunctionMapDelta)) {
-					throw new ShouldNotHappenException('Signature map could not be loaded.');
-				}
-
-				$signatureMap = $this->computeSignatureMap($signatureMap, $php80StricterFunctionMapDelta);
-			}
 		}
 
 		if ($this->phpVersion->getVersionId() >= 70400) {
@@ -217,6 +208,15 @@ class FunctionSignatureMapProvider implements SignatureMapProvider
 			}
 
 			$signatureMap = $this->computeSignatureMap($signatureMap, $php80MapDelta);
+
+			if ($this->stricterFunctionMap) {
+				$php80StricterFunctionMapDelta = require __DIR__ . '/../../../resources/functionMap_php80delta_bleedingEdge.php';
+				if (!is_array($php80StricterFunctionMapDelta)) {
+					throw new ShouldNotHappenException('Signature map could not be loaded.');
+				}
+
+				$signatureMap = $this->computeSignatureMap($signatureMap, $php80StricterFunctionMapDelta);
+			}
 		}
 
 		if ($this->phpVersion->getVersionId() >= 80100) {


### PR DESCRIPTION
This change is required to make the stricter map effective.
