### PR TITLE
Bleeding edge - Precise array shape for preg_replace_callback() $matches

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -295,6 +295,8 @@ conditionalTags:
 		phpstan.typeSpecifier.functionTypeSpecifyingExtension: %featureToggles.narrowPregMatches%
 	PHPStan\Type\Php\PregMatchParameterOutTypeExtension:
 		phpstan.functionParameterOutTypeExtension: %featureToggles.narrowPregMatches%
+	PHPStan\Type\Php\PregMatchCallbackClosureTypeExtension:
+		phpstan.functionParameterClosureTypeExtension: %featureToggles.narrowPregMatches%
 
 services:
 	-
@@ -1496,6 +1498,9 @@ services:
 
 	-
 		class: PHPStan\Type\Php\PregMatchParameterOutTypeExtension
+
+	-
+		class: PHPStan\Type\Php\PregMatchCallbackClosureTypeExtension
 
 	-
 		class: PHPStan\Type\Php\RegexArrayShapeMatcher

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -295,7 +295,7 @@ conditionalTags:
 		phpstan.typeSpecifier.functionTypeSpecifyingExtension: %featureToggles.narrowPregMatches%
 	PHPStan\Type\Php\PregMatchParameterOutTypeExtension:
 		phpstan.functionParameterOutTypeExtension: %featureToggles.narrowPregMatches%
-	PHPStan\Type\Php\PregMatchCallbackClosureTypeExtension:
+	PHPStan\Type\Php\PregReplaceCallbackClosureTypeExtension:
 		phpstan.functionParameterClosureTypeExtension: %featureToggles.narrowPregMatches%
 
 services:
@@ -1500,7 +1500,7 @@ services:
 		class: PHPStan\Type\Php\PregMatchParameterOutTypeExtension
 
 	-
-		class: PHPStan\Type\Php\PregMatchCallbackClosureTypeExtension
+		class: PHPStan\Type\Php\PregReplaceCallbackClosureTypeExtension
 
 	-
 		class: PHPStan\Type\Php\RegexArrayShapeMatcher

--- a/src/Type/Php/PregMatchCallbackClosureTypeExtension.php
+++ b/src/Type/Php/PregMatchCallbackClosureTypeExtension.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\Native\NativeParameterReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\FunctionParameterClosureTypeExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+final class PregMatchCallbackClosureTypeExtension implements FunctionParameterClosureTypeExtension
+{
+
+	public function __construct(
+		private RegexArrayShapeMatcher $regexShapeMatcher,
+	)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool
+	{
+		return $functionReflection->getName() === 'preg_replace_callback' && $parameter->getName() === 'callback';
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		$args = $functionCall->getArgs();
+		$patternArg = $args[0] ?? null;
+		$flagsArg = $args[5] ?? null;
+
+		if (
+			$patternArg === null
+		) {
+			return null;
+		}
+
+		$flagsType = null;
+		if ($flagsArg !== null) {
+			$flagsType = $scope->getType($flagsArg->value);
+		}
+
+		$matchesType = $this->regexShapeMatcher->matchExpr($patternArg->value, $flagsType, TrinaryLogic::createYes(), $scope);
+		if ($matchesType === null) {
+			return null;
+		}
+
+		return new ClosureType(
+			[
+				new NativeParameterReflection($parameter->getName(), $parameter->isOptional(), $matchesType, $parameter->passedByReference(), $parameter->isVariadic(), $parameter->getDefaultValue()),
+			],
+			new StringType(),
+		);
+	}
+
+}

--- a/src/Type/Php/PregReplaceCallbackClosureTypeExtension.php
+++ b/src/Type/Php/PregReplaceCallbackClosureTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\FunctionParameterClosureTypeExtension;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 
-final class PregMatchCallbackClosureTypeExtension implements FunctionParameterClosureTypeExtension
+final class PregReplaceCallbackClosureTypeExtension implements FunctionParameterClosureTypeExtension
 {
 
 	public function __construct(

--- a/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes-php72.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PregReplaceCallbackMatchShapes72;
+
+use function PHPStan\Testing\assertType;
+
+function (string $s): void {
+	preg_replace_callback(
+		'|<p>(\s*)\w|',
+		function ($matches) {
+			assertType('array{string, string}', $matches);
+			return '';
+		},
+		$s
+	);
+};
+
+// The flags parameter was added in PHP 7.4

--- a/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes-php72.php
@@ -6,6 +6,17 @@ use function PHPStan\Testing\assertType;
 
 function (string $s): void {
 	preg_replace_callback(
+		$s,
+		function ($matches) {
+			assertType('array<int|string, string>', $matches);
+			return '';
+		},
+		$s
+	);
+};
+
+function (string $s): void {
+	preg_replace_callback(
 		'|<p>(\s*)\w|',
 		function ($matches) {
 			assertType('array{string, string}', $matches);

--- a/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
@@ -1,19 +1,8 @@
-<?php
+<?php // lint >= 7.4
 
 namespace PregReplaceCallbackMatchShapes;
 
 use function PHPStan\Testing\assertType;
-
-function (string $s): void {
-	preg_replace_callback(
-		'|<p>(\s*)\w|',
-		function ($matches) {
-			assertType('array{string, string}', $matches);
-			return '';
-		},
-		$s
-	);
-};
 
 function (string $s): void {
 	preg_replace_callback(

--- a/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace PregReplaceCallbackMatchShapes;
+
+use function PHPStan\Testing\assertType;
+
+function (string $s): void {
+	preg_replace_callback(
+		'|<p>(\s*)\w|',
+		function ($matches) {
+			assertType('array{string, string}', $matches);
+			return '';
+		},
+		$s
+	);
+};
+
+function (string $s): void {
+	preg_replace_callback(
+		'/(foo)?(bar)?(baz)?/',
+		function ($matches) {
+			assertType('array{string, non-empty-string|null, non-empty-string|null, non-empty-string|null}', $matches);
+			return '';
+		},
+		$s,
+		-1,
+		$count,
+		PREG_UNMATCHED_AS_NULL
+	);
+};
+
+function (string $s): void {
+	preg_replace_callback(
+		'/(foo)?(bar)?(baz)?/',
+		function ($matches) {
+			assertType('array{0: array{string, int<0, max>}, 1?: array{non-empty-string, int<0, max>}, 2?: array{non-empty-string, int<0, max>}, 3?: array{non-empty-string, int<0, max>}}', $matches);
+			return '';
+		},
+		$s,
+		-1,
+		$count,
+		PREG_OFFSET_CAPTURE
+	);
+};
+
+function (string $s): void {
+	preg_replace_callback(
+		'/(foo)?(bar)?(baz)?/',
+		function ($matches) {
+			assertType('array{array{string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}}', $matches);
+			return '';
+		},
+		$s,
+		-1,
+		$count,
+		PREG_OFFSET_CAPTURE|PREG_UNMATCHED_AS_NULL
+	);
+};


### PR DESCRIPTION
will do `preg_replace_callback_array` in a separate PR