### PR TITLE
add callback types for array_uintersect etc

### DIFF
--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -201,8 +201,11 @@ final class TypehintHelper
 			}
 
 			if (
-				(!$phpDocType instanceof NeverType || ($type instanceof MixedType && !$type->isExplicitMixed()))
-				&& $type->isSuperTypeOf(TemplateTypeHelper::resolveToBounds($phpDocType))->yes()
+				($type->isCallable()->yes() && $phpDocType->isCallable()->yes())
+				|| (
+					(!$phpDocType instanceof NeverType || ($type instanceof MixedType && !$type->isExplicitMixed()))
+					&& $type->isSuperTypeOf(TemplateTypeHelper::resolveToBounds($phpDocType))->yes()
+				)
 			) {
 				$resultType = $phpDocType;
 			} else {

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -58,17 +58,19 @@ function uksort(array &$array, callable $callback): bool
 }
 
 /**
- * @template T of mixed
+ * @template TV of mixed
+ * @template TK of mixed
  *
- * @param array<T> $one
- * @param array<T> $two
- * @param callable(T, T): int $three
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int $three
+ * @return array<TK, TV>
  */
 function array_udiff(
     array $one,
     array $two,
     callable $three
-): int {}
+): array {}
 
 /**
  * @param array<array-key, mixed> $value

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -77,7 +77,7 @@ function array_udiff(
 function array_is_list(array $value): bool {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -92,7 +92,7 @@ function array_diff_uassoc(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -107,7 +107,7 @@ function array_diff_ukey(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -122,7 +122,7 @@ function array_intersect_uassoc(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -138,7 +138,7 @@ function array_intersect_ukey(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -154,7 +154,7 @@ function array_udiff_assoc(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -171,7 +171,7 @@ function array_udiff_uassoc(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -186,7 +186,7 @@ function array_uintersect_assoc(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one
@@ -203,7 +203,7 @@ function array_uintersect_uassoc(
 ): array {}
 
 /**
- * @template TK of mixed
+ * @template TK of array-key
  * @template TV of mixed
  *
  * @param array<TK, TV> $one

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -75,3 +75,144 @@ function array_udiff(
  * @return ($value is __always-list ? true : false)
  */
 function array_is_list(array $value): bool {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_diff_uassoc(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_diff_ukey(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_intersect_uassoc(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TK, TK): int<-1, 1> $three
+ *
+ * @return array<TK, TV>
+ */
+function array_intersect_ukey(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ *
+ * @return array<TK, TV>
+ */
+function array_udiff_assoc(
+    array $one,
+    array $two,
+    callable $three
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TK, TK): int<-1, 1> $four
+ * @return array<TK, TV>
+ */
+function array_udiff_uassoc(
+    array $one,
+    array $two,
+    callable $three,
+    callable $four
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_uintersect_assoc(
+    array $one,
+    array $two,
+    callable $three,
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TK, TK): int<-1, 1> $four
+ * @return array<TK, TV>
+ */
+function array_uintersect_uassoc(
+    array $one,
+    array $two,
+    callable $three,
+    callable $four
+): array {}
+
+/**
+ * @template TK of mixed
+ * @template TV of mixed
+ *
+ * @param array<TK, TV> $one
+ * @param array<TK, TV> $two
+ * @param callable(TV, TV): int<-1, 1> $three
+ * @return array<TK, TV>
+ */
+function array_uintersect(
+    array $one,
+    array $two,
+    callable $three,
+): array {}

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -82,7 +82,7 @@ function array_is_list(array $value): bool {}
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TK, TK): int<-1, 1> $three
+ * @param callable(TK, TK): int $three
  * @return array<TK, TV>
  */
 function array_diff_uassoc(
@@ -97,7 +97,7 @@ function array_diff_uassoc(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TK, TK): int<-1, 1> $three
+ * @param callable(TK, TK): int $three
  * @return array<TK, TV>
  */
 function array_diff_ukey(
@@ -112,7 +112,7 @@ function array_diff_ukey(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TK, TK): int<-1, 1> $three
+ * @param callable(TK, TK): int $three
  * @return array<TK, TV>
  */
 function array_intersect_uassoc(
@@ -127,7 +127,7 @@ function array_intersect_uassoc(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TK, TK): int<-1, 1> $three
+ * @param callable(TK, TK): int $three
  *
  * @return array<TK, TV>
  */
@@ -143,7 +143,7 @@ function array_intersect_ukey(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TV, TV): int $three
  *
  * @return array<TK, TV>
  */
@@ -159,8 +159,8 @@ function array_udiff_assoc(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TV, TV): int<-1, 1> $three
- * @param callable(TK, TK): int<-1, 1> $four
+ * @param callable(TV, TV): int $three
+ * @param callable(TK, TK): int $four
  * @return array<TK, TV>
  */
 function array_udiff_uassoc(
@@ -176,7 +176,7 @@ function array_udiff_uassoc(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TV, TV): int $three
  * @return array<TK, TV>
  */
 function array_uintersect_assoc(
@@ -191,8 +191,8 @@ function array_uintersect_assoc(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TV, TV): int<-1, 1> $three
- * @param callable(TK, TK): int<-1, 1> $four
+ * @param callable(TV, TV): int $three
+ * @param callable(TK, TK): int $four
  * @return array<TK, TV>
  */
 function array_uintersect_uassoc(
@@ -208,7 +208,7 @@ function array_uintersect_uassoc(
  *
  * @param array<TK, TV> $one
  * @param array<TK, TV> $two
- * @param callable(TV, TV): int<-1, 1> $three
+ * @param callable(TV, TV): int $three
  * @return array<TK, TV>
  */
 function array_uintersect(

--- a/tests/PHPStan/Analyser/nsrt/array_diff_intersect_callbacks.php
+++ b/tests/PHPStan/Analyser/nsrt/array_diff_intersect_callbacks.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayDiffIntersectCallbacks;
+
+use function PHPStan\Testing\assertType;
+
+array_diff_uassoc(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('0|1', $a);
+		assertType('0|1', $b);
+
+		return 0;
+	},
+);
+
+array_diff_ukey(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('0|1', $a);
+		assertType('0|1', $b);
+
+		return 0;
+	},
+);
+
+array_intersect_uassoc(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('0|1', $a);
+		assertType('0|1', $b);
+
+		return 0;
+	},
+);
+
+array_intersect_ukey(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('0|1', $a);
+		assertType('0|1', $b);
+
+		return 0;
+	},
+);
+
+array_udiff(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('1|2|3|4', $a);
+		assertType('1|2|3|4', $b);
+
+		return 0;
+	},
+);
+
+array_udiff_assoc(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('1|2|3|4', $a);
+		assertType('1|2|3|4', $b);
+
+		return 0;
+	},
+);
+
+array_udiff_uassoc(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('1|2|3|4', $a);
+		assertType('1|2|3|4', $b);
+
+		return 0;
+	},
+	static function ($a, $b) {
+		assertType('0|1', $a);
+		assertType('0|1', $b);
+
+		return 0;
+	},
+);
+
+array_uintersect(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('1|2|3|4', $a);
+		assertType('1|2|3|4', $b);
+
+		return 0;
+	},
+);
+
+array_uintersect_assoc(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('1|2|3|4', $a);
+		assertType('1|2|3|4', $b);
+
+		return 0;
+	},
+);
+
+array_uintersect_uassoc(
+	[1, 2],
+	[3, 4],
+	static function ($a, $b) {
+		assertType('1|2|3|4', $a);
+		assertType('1|2|3|4', $b);
+
+		return 0;
+	},
+	static function ($a, $b) {
+		assertType('0|1', $a);
+		assertType('0|1', $b);
+
+		return 0;
+	},
+);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1844,11 +1844,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_diff_uassoc.php'], [
 			[
-				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1859,11 +1859,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_diff_ukey.php'], [
 			[
-				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1874,11 +1874,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_intersect_uassoc.php'], [
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1889,11 +1889,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_intersect_ukey.php'], [
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1904,34 +1904,34 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_udiff_assoc.php'], [
 			[
-				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2, 1|2): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2|3|4|5, 1|2|3|4|5): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
 	}
 
-	public function testArrayUdiffUsssoc(): void
+	public function testArrayUdiffUasssoc(): void
 	{
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_udiff_uassoc.php'], [
 			[
-				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				28,
 			],
 			[
-				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				31,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				39,
 			],
 			[
-				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				42,
 			],
 		]);
@@ -1942,11 +1942,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_uintersect_assoc.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(1|2|3|4, 1|2|3|4): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1957,19 +1957,19 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_uintersect_uassoc.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				28,
 			],
 			[
-				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				31,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				39,
 			],
 			[
-				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				42,
 			],
 		]);
@@ -1980,11 +1980,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_uintersect.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4, 1|2|3|4): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -642,11 +642,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				14,
 			],
 			[
-				'Parameter #1 $arr1 of function array_udiff expects array<string>, null given.',
+				'Parameter #1 $arr1 of function array_udiff expects array<(int&TK)|(string&TK), string>, null given.',
 				20,
 			],
 			[
-				'Parameter #2 $arr2 of function array_udiff expects array<string>, null given.',
+				'Parameter #2 $arr2 of function array_udiff expects array<(int&TK)|(string&TK), string>, null given.',
 				21,
 			],
 			[

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1839,6 +1839,157 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/count-array-shift.php'], $errors);
 	}
 
+	public function testArrayDiffUassoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_diff_uassoc.php'], [
+			[
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayDiffUkey(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_diff_ukey.php'], [
+			[
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayIntersectUassoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_intersect_uassoc.php'], [
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayIntersectUkey(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_intersect_ukey.php'], [
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayUdiffAssoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_udiff_assoc.php'], [
+			[
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayUdiffUsssoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_udiff_uassoc.php'], [
+			[
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				28,
+			],
+			[
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				31,
+			],
+			[
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				39,
+			],
+			[
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				42,
+			],
+		]);
+	}
+
+	public function testArrayUintersectAssoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_uintersect_assoc.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
+	public function testArrayUintersectUassoc(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_uintersect_uassoc.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				28,
+			],
+			[
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				31,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				39,
+			],
+			[
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				42,
+			],
+		]);
+	}
+
+	public function testArrayUintersect(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/array_uintersect.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(string, string): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				22,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(int, int): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				30,
+			],
+		]);
+	}
+
 	public function testNoNamedArguments(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1990,6 +1990,13 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7707(): void
+	{
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-7707.php'], []);
+	}
+
 	public function testNoNamedArguments(): void
 	{
 		if (PHP_VERSION_ID < 80000) {

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1844,11 +1844,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_diff_uassoc.php'], [
 			[
-				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_diff_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1859,11 +1859,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_diff_ukey.php'], [
 			[
-				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_diff_ukey expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1874,11 +1874,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_intersect_uassoc.php'], [
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1889,11 +1889,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_intersect_ukey.php'], [
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_compare_func of function array_intersect_ukey expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1904,11 +1904,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_udiff_assoc.php'], [
 			[
-				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2, 1|2): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2, 1|2): int, Closure(string, string): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2|3|4|5, 1|2|3|4|5): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $key_comp_func of function array_udiff_assoc expects callable(1|2|3|4|5, 1|2|3|4|5): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1919,19 +1919,19 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_udiff_uassoc.php'], [
 			[
-				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				28,
 			],
 			[
-				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				31,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_comp_func of function array_udiff_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int, Closure(string, string): int<-1, 1> given.',
 				39,
 			],
 			[
-				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #4 $key_comp_func of function array_udiff_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.',
 				42,
 			],
 		]);
@@ -1942,11 +1942,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_uintersect_assoc.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(1|2|3|4, 1|2|3|4): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_assoc expects callable(1|2|3|4, 1|2|3|4): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);
@@ -1957,19 +1957,19 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_uintersect_uassoc.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				28,
 			],
 			[
-				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				31,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect_uassoc expects callable(1|2|3|4|5, 1|2|3|4|5): int, Closure(string, string): int<-1, 1> given.',
 				39,
 			],
 			[
-				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #4 $key_compare_func of function array_uintersect_uassoc expects callable(0|1|2|3, 0|1|2|3): int, Closure(string, string): int<-1, 1> given.',
 				42,
 			],
 		]);
@@ -1980,11 +1980,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->checkExplicitMixed = true;
 		$this->analyse([__DIR__ . '/data/array_uintersect.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int<-1, 1>, Closure(int, int): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(\'a\'|\'b\'|\'c\'|\'d\', \'a\'|\'b\'|\'c\'|\'d\'): int, Closure(int, int): int<-1, 1> given.',
 				22,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4, 1|2|3|4): int<-1, 1>, Closure(string, string): int<-1, 1> given.',
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4, 1|2|3|4): int, Closure(string, string): int<-1, 1> given.',
 				30,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/data/array_diff_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_diff_uassoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_diff_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_diff_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_diff_uassoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayDiffUassoc;
 
 array_diff_uassoc(
 	['a' => 1, 'b' => 2],

--- a/tests/PHPStan/Rules/Functions/data/array_diff_ukey.php
+++ b/tests/PHPStan/Rules/Functions/data/array_diff_ukey.php
@@ -1,0 +1,33 @@
+<?php
+
+array_diff_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_diff_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_diff_ukey.php
+++ b/tests/PHPStan/Rules/Functions/data/array_diff_ukey.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayDiffUkey;
 
 array_diff_ukey(
 	['a' => 1, 'b' => 2],

--- a/tests/PHPStan/Rules/Functions/data/array_intersect_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_intersect_uassoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_intersect_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_uassoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_intersect_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_intersect_uassoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayIntersectUassoc;
 
 array_intersect_uassoc(
 	['a' => 1, 'b' => 2],

--- a/tests/PHPStan/Rules/Functions/data/array_intersect_ukey.php
+++ b/tests/PHPStan/Rules/Functions/data/array_intersect_ukey.php
@@ -1,0 +1,33 @@
+<?php
+
+array_intersect_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_ukey(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_intersect_ukey(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_intersect_ukey.php
+++ b/tests/PHPStan/Rules/Functions/data/array_intersect_ukey.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayIntersectUkey;
 
 array_intersect_ukey(
 	['a' => 1, 'b' => 2],

--- a/tests/PHPStan/Rules/Functions/data/array_udiff_assoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff_assoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_udiff_assoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_assoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_assoc(
+	['a' => 1, 'b' => 2],
+	['c' => 1, 'd' => 2],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_assoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_udiff_assoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff_assoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayUdiffAssoc;
 
 array_udiff_assoc(
 	['a' => 1, 'b' => 2],

--- a/tests/PHPStan/Rules/Functions/data/array_udiff_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff_uassoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayUDiffUassoc;
 
 array_udiff_uassoc(
 	['a' => 'a', 'b' => 'b'],

--- a/tests/PHPStan/Rules/Functions/data/array_udiff_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff_uassoc.php
@@ -1,0 +1,45 @@
+<?php
+
+array_udiff_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+);
+
+array_udiff_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_udiff_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayUintersect;
 
 array_uintersect(
 	['a', 'b'],

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect.php
@@ -1,0 +1,33 @@
+<?php
+
+array_uintersect(
+	['a', 'b'],
+	['c', 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect(
+	['a', 'b'],
+	['c', 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect_assoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect_assoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayUintersectAssoc;
 
 array_uintersect_assoc(
 	['a' => 'a', 'b' => 'b'],

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect_assoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect_assoc.php
@@ -1,0 +1,33 @@
+<?php
+
+array_uintersect_assoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_assoc(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_assoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_assoc(
+	[1, 2, 3],
+	[1, 2, 3, 4],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect_uassoc.php
@@ -1,0 +1,45 @@
+<?php
+
+array_uintersect_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+);
+
+array_uintersect_uassoc(
+	['a' => 'a', 'b' => 'b'],
+	['c' => 'c', 'd' => 'd'],
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	},
+	static function (int $a, int $b): int {
+		return $a <=> $b;
+	}
+);
+
+array_uintersect_uassoc(
+	[1, 2, 3],
+	[1, 2, 4, 5],
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	},
+	static function (string $a, string $b): int {
+		return $a <=> $b;
+	}
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect_uassoc.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect_uassoc.php
@@ -1,4 +1,4 @@
-<?php
+<?php namespace ParamsArrayUIntersectUassoc;
 
 array_uintersect_uassoc(
 	['a' => 'a', 'b' => 'b'],

--- a/tests/PHPStan/Rules/Functions/data/bug-7707.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-7707.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7707;
+
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		var_dump(array_diff_uassoc(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// keys comparison
+			static function (string $a, string $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_diff_ukey(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// keys comparison
+			static function (string $a, string $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_intersect_uassoc(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// keys comparison
+			static function (string $a, string $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_intersect_ukey(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// keys comparison
+			static function (string $a, string $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_udiff_assoc(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// values comparison
+			static function (int $a, int $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_udiff_uassoc(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// values comparison
+			static function (int $a, int $b): int {
+				return $a <=> $b;
+			},
+			// keys comparison
+			static function (string $a, string $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_uintersect_assoc(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// values comparison
+			static function (int $a, int $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_uintersect_uassoc(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// values comparison
+			static function (int $a, int $b): int {
+				return $a <=> $b;
+			},
+			// keys comparison
+			static function (string $a, string $b): int {
+				return $a <=> $b;
+			}
+		));
+
+		var_dump(array_uintersect(
+			['a' => 1, 'b' => 2],
+			['c' => 1, 'd' => 2],
+			// values comparison
+			static function (int $a, int $b): int {
+				return $a <=> $b;
+			}
+		));
+	}
+}


### PR DESCRIPTION
This is a fixed version of https://github.com/phpstan/phpstan-src/pull/1571 (`TK of array-key` as you requested).
Fixes https://github.com/phpstan/phpstan/issues/7707

Unfortunately, it doesn't cover all variants due to the limitations of the stubs and the weird interface of the functions. E.g.

```
var_dump(array_uintersect(
	['a' => 1, 'b' => 2],
	['c' => 1, 'd' => 2],
	['c' => 1, 'd' => 2],
	['c' => 1, 'd' => 2],
	// values comparison
	static function (int $a, int $b): int {
		return $a <=> $b;
	}
));
```

results in:

```
Parameter #5 ...$rest of function array_uintersect expects array|(callable(mixed, mixed): int), Closure(int, int): int<-1, 1> given.
    💡 • Type #2 from the union: Type int of parameter #1 $a of passed callable needs to be same or wider than parameter type mixed of accepting callable.
• Type #2 from the union: Type int of parameter #2 $b of passed callable needs to be same or wider than parameter type mixed of accepting callable.
```

But at least it's a step in the right direction.