### PR TITLE
Support literal strings in RegexGroupParser

### DIFF
--- a/src/Type/Php/RegexGroupParser.php
+++ b/src/Type/Php/RegexGroupParser.php
@@ -113,12 +113,12 @@ final class RegexGroupParser
 		array &$groupCombinations,
 		array &$markVerbs,
 		bool $captureOnlyNamed,
-		bool $repeatedMoreThenOnce,
+		bool $repeatedMoreThanOnce,
 	): void
 	{
 		$group = null;
 		if ($ast->getId() === '#capturing') {
-			$maybeConstant = !$repeatedMoreThenOnce;
+			$maybeConstant = !$repeatedMoreThanOnce;
 			if ($parentGroup !== null && $parentGroup->resetsGroupCounter()) {
 				$maybeConstant = false;
 			}
@@ -133,7 +133,7 @@ final class RegexGroupParser
 			);
 			$parentGroup = $group;
 		} elseif ($ast->getId() === '#namedcapturing') {
-			$maybeConstant = !$repeatedMoreThenOnce;
+			$maybeConstant = !$repeatedMoreThanOnce;
 			if ($parentGroup !== null && $parentGroup->resetsGroupCounter()) {
 				$maybeConstant = false;
 			}
@@ -175,7 +175,7 @@ final class RegexGroupParser
 			}
 
 			if ($max === null || $max > 1) {
-				$repeatedMoreThenOnce = true;
+				$repeatedMoreThanOnce = true;
 			}
 		}
 
@@ -217,7 +217,7 @@ final class RegexGroupParser
 				$groupCombinations,
 				$markVerbs,
 				$captureOnlyNamed,
-				$repeatedMoreThenOnce,
+				$repeatedMoreThanOnce,
 			);
 
 			if ($ast->getId() !== '#alternation') {

--- a/src/Type/Php/RegexGroupParser.php
+++ b/src/Type/Php/RegexGroupParser.php
@@ -344,8 +344,6 @@ final class RegexGroupParser
 			}
 		} elseif (!in_array($ast->getId(), ['#capturing', '#namedcapturing'], true)) {
 			$onlyLiterals = null;
-		} else {
-			$x = 1;
 		}
 
 		// [^0-9] should not parse as numeric-string, and [^list-everything-but-numbers] is technically

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -22,9 +22,9 @@ function doUnmatchedAsNull(string $s): void {
 // see https://3v4l.org/VeDob#veol
 function unmatchedAsNullWithOptionalGroup(string $s): void {
 	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType("array{0: string, 1?: 'foo', 2?: 'bar', 3?: 'baz'}", $matches);
+		assertType("array{0: string, 1?: non-empty-string}", $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType("array{}|array{0: string, 1?: 'foo', 2?: 'bar', 3?: 'baz'}", $matches);
+	assertType("array{}|array{0: string, 1?: non-empty-string}", $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311-php72.php
@@ -14,17 +14,17 @@ function doFoo(string $s) {
 
 function doUnmatchedAsNull(string $s): void {
 	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
+		assertType("array{0: string, 1?: 'foo', 2?: 'bar', 3?: 'baz'}", $matches);
 	}
-	assertType('array{}|array{0: string, 1?: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1?: 'foo', 2?: 'bar', 3?: 'baz'}", $matches);
 }
 
 // see https://3v4l.org/VeDob#veol
 function unmatchedAsNullWithOptionalGroup(string $s): void {
 	if (preg_match('/Price: (£|€)?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{0: string, 1?: non-empty-string}', $matches);
+		assertType("array{0: string, 1?: 'foo', 2?: 'bar', 3?: 'baz'}", $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, 1?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1?: 'foo', 2?: 'bar', 3?: 'baz'}", $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -14,9 +14,9 @@ function doFoo(string $s) {
 
 function doUnmatchedAsNull(string $s): void {
 	if (preg_match('/(foo)?(bar)?(baz)?/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{string, non-empty-string|null, non-empty-string|null, non-empty-string|null}', $matches);
+		assertType("array{string, 'foo'|null, 'bar'|null, 'baz'|null}", $matches);
 	}
-	assertType('array{}|array{string, non-empty-string|null, non-empty-string|null, non-empty-string|null}', $matches);
+	assertType("array{}|array{string, 'foo'|null, 'bar'|null, 'baz'|null}", $matches);
 }
 
 // see https://3v4l.org/VeDob
@@ -70,13 +70,13 @@ $}x', $url, $matches, PREG_UNMATCHED_AS_NULL)) {
 class UnmatchedAsNullWithTopLevelAlternation {
 	function doFoo(string $s): void {
 		if (preg_match('/Price: (?:(£)|(€))\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-			assertType('array{string, non-empty-string|null, non-empty-string|null}', $matches); // could be array{0: string, 1: null, 2: non-empty-string}|array{0: string, 1: non-empty-string, 2: null}
+			assertType("array{string, '£'|null, '€'|null}", $matches); // could be tagged union
 		}
 	}
 
 	function doBar(string $s): void {
 		if (preg_match('/Price: (?:(£)|(€))?\d+/', $s, $matches, PREG_UNMATCHED_AS_NULL)) {
-			assertType('array{string, non-empty-string|null, non-empty-string|null}', $matches);
+			assertType("array{string, '£'|null, '€'|null}", $matches); // could be tagged union
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug11384.php
+++ b/tests/PHPStan/Analyser/nsrt/bug11384.php
@@ -14,7 +14,7 @@ class HelloWorld
 	public function sayHello(string $s): void
 	{
 		if (preg_match('{(' . Bar::VAL . ')}', $s, $m)) {
-			assertType('array{string, numeric-string}', $m);
+			assertType("array{string, '3'}", $m);
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_all_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_all_shapes.php
@@ -71,65 +71,65 @@ function (string $size): void {
 
 function (string $size): void {
 	preg_match_all('/a(b)(\d+)?/', $size, $matches, PREG_SET_ORDER);
-	assertType("list<array{0: string, 1: non-empty-string, 2?: numeric-string}>", $matches);
+	assertType("list<array{0: string, 1: 'b', 2?: numeric-string}>", $matches);
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches)) {
-		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<string>, 2: list<string>}", $matches);
+		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<''|'ab'>, 2: list<''|'ab'>}", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_UNMATCHED_AS_NULL)) {
-		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<non-empty-string|null>, 2: list<non-empty-string|null>}", $matches);
+		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<'ab'|null>, 2: list<'ab'|null>}", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_SET_ORDER)) {
-		assertType("list<array{0: string, num: numeric-string, 1: numeric-string, suffix?: non-empty-string, 2?: non-empty-string}>", $matches);
+		assertType("list<array{0: string, num: numeric-string, 1: numeric-string, suffix?: 'ab', 2?: 'ab'}>", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_PATTERN_ORDER)) {
-		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<string>, 2: list<string>}", $matches);
+		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<''|'ab'>, 2: list<''|'ab'>}", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_UNMATCHED_AS_NULL|PREG_SET_ORDER)) {
-		assertType("list<array{0: string, num: numeric-string, 1: numeric-string, suffix: non-empty-string|null, 2: non-empty-string|null}>", $matches);
+		assertType("list<array{0: string, num: numeric-string, 1: numeric-string, suffix: 'ab'|null, 2: 'ab'|null}>", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_UNMATCHED_AS_NULL|PREG_PATTERN_ORDER)) {
-		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<non-empty-string|null>, 2: list<non-empty-string|null>}", $matches);
+		assertType("array{0: list<string>, num: list<numeric-string>, 1: list<numeric-string>, suffix: list<'ab'|null>, 2: list<'ab'|null>}", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_SET_ORDER|PREG_OFFSET_CAPTURE)) {
-		assertType("list<array{0: array{string, int<0, max>}, num: array{numeric-string, int<0, max>}, 1: array{numeric-string, int<0, max>}, suffix?: array{non-empty-string, int<0, max>}, 2?: array{non-empty-string, int<0, max>}}>", $matches);
+		assertType("list<array{0: array{string, int<0, max>}, num: array{numeric-string, int<0, max>}, 1: array{numeric-string, int<0, max>}, suffix?: array{'ab', int<0, max>}, 2?: array{'ab', int<0, max>}}>", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_PATTERN_ORDER|PREG_OFFSET_CAPTURE)) {
-		assertType("array{0: list<array{string, int<0, max>}>, num: list<array{numeric-string, int<0, max>}>, 1: list<array{numeric-string, int<0, max>}>, suffix: list<''|array{non-empty-string, int<0, max>}>, 2: list<''|array{non-empty-string, int<0, max>}>}", $matches);
+		assertType("array{0: list<array{string, int<0, max>}>, num: list<array{numeric-string, int<0, max>}>, 1: list<array{numeric-string, int<0, max>}>, suffix: list<''|array{'ab', int<0, max>}>, 2: list<''|array{'ab', int<0, max>}>}", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_UNMATCHED_AS_NULL|PREG_SET_ORDER|PREG_OFFSET_CAPTURE)) {
-		assertType("list<array{0: array{string|null, int<-1, max>}, num: array{numeric-string|null, int<-1, max>}, 1: array{numeric-string|null, int<-1, max>}, suffix: array{non-empty-string|null, int<-1, max>}, 2: array{non-empty-string|null, int<-1, max>}}>", $matches);
+		assertType("list<array{0: array{string|null, int<-1, max>}, num: array{numeric-string|null, int<-1, max>}, 1: array{numeric-string|null, int<-1, max>}, suffix: array{'ab'|null, int<-1, max>}, 2: array{'ab'|null, int<-1, max>}}>", $matches);
 	}
 };
 
 function (string $size): void {
 	if (preg_match_all('/ab(?P<num>\d+)(?P<suffix>ab)?/', $size, $matches, PREG_UNMATCHED_AS_NULL|PREG_PATTERN_ORDER|PREG_OFFSET_CAPTURE)) {
-		assertType("array{0: list<array{string|null, int<-1, max>}>, num: list<array{numeric-string|null, int<-1, max>}>, 1: list<array{numeric-string|null, int<-1, max>}>, suffix: list<array{non-empty-string|null, int<-1, max>}>, 2: list<array{non-empty-string|null, int<-1, max>}>}", $matches);
+		assertType("array{0: list<array{string|null, int<-1, max>}>, num: list<array{numeric-string|null, int<-1, max>}>, 1: list<array{numeric-string|null, int<-1, max>}>, suffix: list<array{'ab'|null, int<-1, max>}>, 2: list<array{'ab'|null, int<-1, max>}>}", $matches);
 	}
 };

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -44,9 +44,9 @@ function doMatch(string $s): void {
 	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
 
 	if (preg_match('/(a)(?<name>b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, name: string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'a', name: string, 2: string, 3: 'c', 4?: 'd'}", $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, name: string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'a', name: string, 2: string, 3: 'c', 4?: 'd'}", $matches);
 
 	if (preg_match('/(a)(b)*(c)(?<name>d)*/', $s, $matches)) {
 		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
@@ -233,13 +233,13 @@ function testUnionPattern(string $s): void
 function doFoo(string $row): void
 {
 	if (preg_match('~^(a(b))$~', $row, $matches) === 1) {
-		assertType('array{string, non-empty-string, non-empty-string}', $matches);
+		assertType("array{string, non-empty-string, 'b'}", $matches);
 	}
 	if (preg_match('~^(a(b)?)$~', $row, $matches) === 1) {
 		assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
 	}
 	if (preg_match('~^(a(b)?)?$~', $row, $matches) === 1) {
-		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
+		assertType("array{0: string, 1?: non-empty-string, 2?: 'b'}", $matches);
 	}
 }
 
@@ -390,11 +390,11 @@ function unmatchedAsNullWithMandatoryGroup(string $s): void {
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote('xxx') . '(z)}', $s, $matches)) {
-		assertType('array{string, non-empty-string}', $matches);
+		assertType("array{string, 'z'}", $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string}', $matches);
+	assertType("array{}|array{string, 'z'}", $matches);
 };
 
 function (string $s): void {
@@ -417,11 +417,11 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote($s) . '(z)' . preg_quote($s) . '(?:abc)(def)?}', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'z', 2?: non-empty-string", $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'z', 2?: non-empty-string}", $matches);
 };
 
 function (string $s, $mixed): void {
@@ -546,3 +546,15 @@ class Bug11376
 		}
 	}
 }
+
+function (string $s): void {
+	if (rand(0,1)) {
+		$p = '/Price: (£)(abc)/i';
+	} else {
+		$p = '/Price: (\d)(b)/i';
+	}
+
+	if (preg_match($p, $s, $matches)) {
+		assertType("array{string, '£', 'abc'}|array{string, numeric-string, 'b'}", $matches);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -39,19 +39,19 @@ function doMatch(string $s): void {
 	assertType('array{}|array{string, non-empty-string}', $matches);
 
 	if (preg_match('/(a)(b)*(c)(d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'a', 2: string, 3: 'c', 4?: non-empty-string}", $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, 4?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'a', 2: string, 3: 'c', 4?: non-empty-string}", $matches);
 
 	if (preg_match('/(a)(?<name>b)*(c)(d)*/', $s, $matches)) {
-		assertType("array{0: string, 1: 'a', name: string, 2: string, 3: 'c', 4?: 'd'}", $matches);
+		assertType("array{0: string, 1: 'a', name: string, 2: string, 3: 'c', 4?: non-empty-string}", $matches);
 	}
-	assertType("array{}|array{0: string, 1: 'a', name: string, 2: string, 3: 'c', 4?: 'd'}", $matches);
+	assertType("array{}|array{0: string, 1: 'a', name: string, 2: string, 3: 'c', 4?: non-empty-string}", $matches);
 
 	if (preg_match('/(a)(b)*(c)(?<name>d)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'a', 2: string, 3: 'c', name?: non-empty-string, 4?: non-empty-string}", $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: string, 3: non-empty-string, name?: non-empty-string, 4?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'a', 2: string, 3: 'c', name?: non-empty-string, 4?: non-empty-string}", $matches);
 
 	if (preg_match('/(a|b)|(?:c)/', $s, $matches)) {
 		assertType('array{0: string, 1?: non-empty-string}', $matches);
@@ -59,34 +59,34 @@ function doMatch(string $s): void {
 	assertType('array{}|array{0: string, 1?: non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz)+/', $s, $matches)) {
-		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
 	}
-	assertType('array{}|array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz)*/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz)?/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: 'baz'}", $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: 'baz'}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){0,3}/', $s, $matches)) {
-		assertType('array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
 	}
-	assertType('array{}|array{0: string, 1: non-empty-string, 2: non-empty-string, 3?: non-empty-string}', $matches);
+	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2,3}/', $s, $matches)) {
-		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
 	}
-	assertType('array{}|array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2}/', $s, $matches)) {
-		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
 	}
-	assertType('array{}|array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
 }
 
 function doNonCapturingGroup(string $s): void {
@@ -115,9 +115,9 @@ function doNamedSubpattern(string $s): void {
 
 function doOffsetCapture(string $s): void {
 	if (preg_match('/(foo)(bar)(baz)/', $s, $matches, PREG_OFFSET_CAPTURE)) {
-		assertType('array{array{string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}}', $matches);
+		assertType("array{array{string, int<0, max>}, array{'foo', int<0, max>}, array{'bar', int<0, max>}, array{'baz', int<0, max>}}", $matches);
 	}
-	assertType('array{}|array{array{string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}, array{non-empty-string, int<0, max>}}', $matches);
+	assertType("array{}|array{array{string, int<0, max>}, array{'foo', int<0, max>}, array{'bar', int<0, max>}, array{'baz', int<0, max>}}", $matches);
 }
 
 function doUnknownFlags(string $s, int $flags): void {
@@ -233,10 +233,10 @@ function testUnionPattern(string $s): void
 function doFoo(string $row): void
 {
 	if (preg_match('~^(a(b))$~', $row, $matches) === 1) {
-		assertType("array{string, non-empty-string, 'b'}", $matches);
+		assertType("array{string, 'ab', 'b'}", $matches);
 	}
 	if (preg_match('~^(a(b)?)$~', $row, $matches) === 1) {
-		assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string}', $matches);
+		assertType("array{0: string, 1: non-empty-string, 2?: 'b'}", $matches);
 	}
 	if (preg_match('~^(a(b)?)?$~', $row, $matches) === 1) {
 		assertType("array{0: string, 1?: non-empty-string, 2?: 'b'}", $matches);
@@ -300,7 +300,7 @@ function (string $size): void {
 	if (preg_match('~^a\.(b)?(c)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
+	assertType("array{0: string, 1?: 'b', 2?: 'c'}", $matches);
 };
 
 function (string $size): void {
@@ -321,7 +321,7 @@ function (string $size): void {
 	if (preg_match('~\{(?:(include)\\s+(?:[$]?\\w+(?<!file))\\s)|(?:(include\\s+file)\\s+(?:[$]?\\w+)\\s)|(?:(include(?:Template|(?:\\s+file)))\\s+(?:\'?.*?\.latte\'?)\\s)~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string, 2?: non-empty-string, 3?: non-empty-string}', $matches);
+	assertType("array{0: string, 1: 'include', 2?: non-empty-string, 3?: non-empty-string}", $matches);
 };
 
 
@@ -399,11 +399,11 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote($s) . '(z)}', $s, $matches)) {
-		assertType('array{string, non-empty-string}', $matches);
+		assertType("array{string, 'z'}", $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType('array{}|array{string, non-empty-string}', $matches);
+	assertType("array{}|array{string, 'z'}", $matches);
 };
 
 function (string $s): void {
@@ -417,11 +417,11 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('{' . preg_quote($s) . '(z)' . preg_quote($s) . '(?:abc)(def)?}', $s, $matches)) {
-		assertType("array{0: string, 1: 'z', 2?: non-empty-string", $matches);
+		assertType("array{0: string, 1: 'z', 2?: 'def'}", $matches);
 	} else {
 		assertType('array{}', $matches);
 	}
-	assertType("array{}|array{0: string, 1: 'z', 2?: non-empty-string}", $matches);
+	assertType("array{}|array{0: string, 1: 'z', 2?: 'def'}", $matches);
 };
 
 function (string $s, $mixed): void {
@@ -471,7 +471,7 @@ function bug11323(string $s): void {
 		assertType('array{string, non-empty-string, non-empty-string}', $matches);
 	}
 	if (preg_match('{([-\p{L}[\]*|\x03\a\b+?{}(?:)-]+[^[:digit:]?{}a-z0-9#-k]+)(a-z)}', $s, $matches)) {
-		assertType('array{string, non-empty-string, non-empty-string}', $matches);
+		assertType("array{string, non-empty-string, 'a-z'}", $matches);
 	}
 	if (preg_match('{(\d+)(?i)insensitive((?x-i)case SENSITIVE here(?i:insensitive non-capturing group))}', $s, $matches)) {
 		assertType('array{string, numeric-string, non-empty-string}', $matches);
@@ -492,7 +492,7 @@ function bug11323(string $s): void {
 		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 	}
 	if (preg_match('{(a)??(b)*+(c++)(d)+?}', $s, $matches)) {
-		assertType('array{string, string, string, non-empty-string, non-empty-string}', $matches);
+		assertType("array{string, string, string, non-empty-string, 'd'}", $matches);
 	}
 	if (preg_match('{(.\d)}', $s, $matches)) {
 		assertType('array{string, non-empty-string}', $matches);
@@ -519,7 +519,7 @@ function bug11323(string $s): void {
 		assertType('array{string, non-empty-string}', $matches);
 	}
 	if (preg_match("{([\r\n]+)(\n)([\n])}", $s, $matches)) {
-		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
+		assertType('array{string, non-empty-string, "\n", non-empty-string}', $matches);
 	}
 	if (preg_match('/foo(*:first)|bar(*:second)([x])/', $s, $matches)) {
 		assertType("array{0: string, 1?: non-empty-string, MARK?: 'first'|'second'}", $matches);

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -492,7 +492,7 @@ function bug11323(string $s): void {
 		assertType('array{string, non-empty-string, non-empty-string, non-empty-string}', $matches);
 	}
 	if (preg_match('{(a)??(b)*+(c++)(d)+?}', $s, $matches)) {
-		assertType("array{string, string, string, non-empty-string, 'd'}", $matches);
+		assertType("array{string, ''|'a', string, non-empty-string, non-empty-string}", $matches);
 	}
 	if (preg_match('{(.\d)}', $s, $matches)) {
 		assertType('array{string, non-empty-string}', $matches);

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -558,3 +558,15 @@ function (string $s): void {
 		assertType("array{string, '£', 'abc'}|array{string, numeric-string, 'b'}", $matches);
 	}
 };
+
+function (string $s): void {
+	if (rand(0,1)) {
+		$p = '/Price: (£)/i';
+	} else {
+		$p = '/Price: (£|(\d)|(x))/i';
+	}
+
+	if (preg_match($p, $s, $matches)) {
+		assertType("array{0: string, 1: non-empty-string, 2?: numeric-string, 3?: 'x'}", $matches);
+	}
+};

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php80.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes_php80.php
@@ -7,9 +7,9 @@ use function PHPStan\Testing\assertType;
 function doOffsetCaptureWithUnmatchedNull(string $s): void {
 	// see https://3v4l.org/07rBO#v8.2.9
 	if (preg_match('/(foo)(bar)(baz)/', $s, $matches, PREG_OFFSET_CAPTURE|PREG_UNMATCHED_AS_NULL)) {
-		assertType('array{array{string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}}', $matches);
+		assertType("array{array{string|null, int<-1, max>}, array{'foo'|null, int<-1, max>}, array{'bar'|null, int<-1, max>}, array{'baz'|null, int<-1, max>}}", $matches);
 	}
-	assertType('array{}|array{array{string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}}', $matches);
+	assertType("array{}|array{array{string|null, int<-1, max>}, array{'foo'|null, int<-1, max>}, array{'bar'|null, int<-1, max>}, array{'baz'|null, int<-1, max>}}", $matches);
 }
 
 function doNonAutoCapturingModifier(string $s): void {

--- a/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_replace_callback_shapes.php
@@ -8,7 +8,7 @@ function (string $s): void {
 	preg_replace_callback(
 		'/(foo)?(bar)?(baz)?/',
 		function ($matches) {
-			assertType('array{string, non-empty-string|null, non-empty-string|null, non-empty-string|null}', $matches);
+			assertType("array{string, 'foo'|null, 'bar'|null, 'baz'|null}", $matches);
 			return '';
 		},
 		$s,
@@ -22,7 +22,7 @@ function (string $s): void {
 	preg_replace_callback(
 		'/(foo)?(bar)?(baz)?/',
 		function ($matches) {
-			assertType('array{0: array{string, int<0, max>}, 1?: array{non-empty-string, int<0, max>}, 2?: array{non-empty-string, int<0, max>}, 3?: array{non-empty-string, int<0, max>}}', $matches);
+			assertType("array{0: array{string, int<0, max>}, 1?: array{'foo', int<0, max>}, 2?: array{'bar', int<0, max>}, 3?: array{'baz', int<0, max>}}", $matches);
 			return '';
 		},
 		$s,
@@ -36,7 +36,7 @@ function (string $s): void {
 	preg_replace_callback(
 		'/(foo)?(bar)?(baz)?/',
 		function ($matches) {
-			assertType('array{array{string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}, array{non-empty-string|null, int<-1, max>}}', $matches);
+			assertType("array{array{string|null, int<-1, max>}, array{'foo'|null, int<-1, max>}, array{'bar'|null, int<-1, max>}, array{'baz'|null, int<-1, max>}}", $matches);
 			return '';
 		},
 		$s,


### PR DESCRIPTION
by detecting static string literals in the regex pattern, we make constant-array result-types of the [patterns more different](https://github.com/phpstan/phpstan/issues/11443#issuecomment-2266709936).
this helps the TypeCombinator to produce tagged unions more often, which can result in more precise overall types.

first step into the direction described in https://github.com/phpstan/phpstan/issues/11443#issuecomment-2266700800