### PR TITLE
Support non-falsy-string in RegexGroupParser

### DIFF
--- a/src/Type/Php/RegexGroupParser.php
+++ b/src/Type/Php/RegexGroupParser.php
@@ -365,7 +365,9 @@ final class RegexGroupParser
 			&& count($children) > 0
 		) {
 			$isNonEmpty = TrinaryLogic::createYes();
-			$isNonFalsy = TrinaryLogic::createYes();
+			if (!$inAlternation) {
+				$isNonFalsy = TrinaryLogic::createYes();
+			}
 		} elseif ($ast->getId() === '#quantification') {
 			[$min] = $this->getQuantificationRange($ast);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -127,7 +127,7 @@ function (string $size): void {
 	if (preg_match('/ab(\d+\s)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string}', $matches);
+	assertType('array{string, non-falsy-string}', $matches);
 };
 
 function (string $size): void {

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -92,14 +92,14 @@ function (string $size): void {
 	if (preg_match('/a(\dAB){2}b(\d){2,4}([1-5])([1-5a-z])e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, numeric-string, numeric-string, non-empty-string}', $matches);
+	assertType('array{string, non-falsy-string, numeric-string, numeric-string, non-empty-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('/ab(ab(\d)){2,4}xx([0-9][a-c])?e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, numeric-string, non-empty-string|null}', $matches);
+	assertType('array{string, non-falsy-string, numeric-string, non-falsy-string|null}', $matches);
 };
 
 function (string $size): void {

--- a/tests/PHPStan/Analyser/nsrt/bug-11311.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11311.php
@@ -120,7 +120,7 @@ function (string $size): void {
 	if (preg_match('/ab(\d\d)/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, numeric-string}', $matches);
+	assertType('array{string, non-falsy-string&numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -162,7 +162,7 @@ function (string $size): void {
 	if (preg_match('/ab(\d+\d?)e?/', $size, $matches, PREG_UNMATCHED_AS_NULL) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, numeric-string}', $matches);
+	assertType('array{string, non-falsy-string&numeric-string}', $matches);
 };
 
 function (string $s): void {
@@ -179,7 +179,7 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('/^%([0-9]*\$)?[0-9]*\.?[0-9]*([sbdeEfFgGhHouxX])$/', $s, $matches, PREG_UNMATCHED_AS_NULL) === 1) {
-		assertType("array{string, non-empty-string|null, 'b'|'d'|'E'|'e'|'F'|'f'|'G'|'g'|'H'|'h'|'o'|'s'|'u'|'X'|'x'}", $matches);
+		assertType("array{string, non-falsy-string|null, 'b'|'d'|'E'|'e'|'F'|'f'|'G'|'g'|'H'|'h'|'o'|'s'|'u'|'X'|'x'}", $matches);
 	}
 };
 

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -64,9 +64,9 @@ function doMatch(string $s): void {
 	assertType("array{}|array{string, 'foo', 'bar', non-falsy-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz)*/', $s, $matches)) {
-		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
+		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-falsy-string}", $matches);
 	}
-	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
+	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-falsy-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz)?/', $s, $matches)) {
 		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: 'baz'}", $matches);
@@ -79,9 +79,9 @@ function doMatch(string $s): void {
 	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-falsy-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2,3}/', $s, $matches)) {
-		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
+		assertType("array{string, 'foo', 'bar', non-falsy-string}", $matches);
 	}
-	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
+	assertType("array{}|array{string, 'foo', 'bar', non-falsy-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2}/', $s, $matches)) {
 		assertType("array{string, 'foo', 'bar', non-falsy-string}", $matches);
@@ -110,7 +110,7 @@ function doNamedSubpattern(string $s): void {
 	if (preg_match('/^(?<name>\S+::\S+)(?:(?<dataname> with data set (?:#\d+|"[^"]+"))\s\()?/', $s, $matches)) {
 		assertType('array{0: string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}', $matches);
 	}
-	assertType('array{0: string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}', $matches);
+	assertType('array{}|array{0: string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}', $matches);
 }
 
 function doOffsetCapture(string $s): void {
@@ -236,7 +236,7 @@ function doFoo(string $row): void
 		assertType("array{string, 'ab', 'b'}", $matches);
 	}
 	if (preg_match('~^(a(b)?)$~', $row, $matches) === 1) {
-		assertType("array{0: string, 1: non-empty-string, 2?: 'b'}", $matches);
+		assertType("array{0: string, 1: non-falsy-string, 2?: 'b'}", $matches);
 	}
 	if (preg_match('~^(a(b)?)?$~', $row, $matches) === 1) {
 		assertType("array{0: string, 1?: non-falsy-string, 2?: 'b'}", $matches);
@@ -279,7 +279,7 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1: non-empty-string, 2?: numeric-string}', $matches);
+	assertType('array{0: string, 1: non-falsy-string, 2?: numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -474,10 +474,10 @@ function bug11323(string $s): void {
 		assertType("array{string, non-falsy-string, 'a-z'}", $matches);
 	}
 	if (preg_match('{(\d+)(?i)insensitive((?x-i)case SENSITIVE here(?i:insensitive non-capturing group))}', $s, $matches)) {
-		assertType('array{string, numeric-string, non-empty-string}', $matches);
+		assertType('array{string, numeric-string, non-falsy-string}', $matches);
 	}
 	if (preg_match('{([]] [^]])}', $s, $matches)) {
-		assertType('array{string, non-empty-string}', $matches);
+		assertType('array{string, non-falsy-string}', $matches);
 	}
 	if (preg_match('{([[:digit:]])}', $s, $matches)) {
 		assertType('array{string, numeric-string}', $matches);
@@ -510,10 +510,10 @@ function bug11323(string $s): void {
 		assertType('array{string, non-empty-string, numeric-string}', $matches);
 	}
 	if (preg_match('{(\d([1-4])\d)}', $s, $matches)) {
-		assertType('array{string, numeric-string, numeric-string}', $matches);
+		assertType('array{string, non-falsy-string&numeric-string, numeric-string}', $matches);
 	}
 	if (preg_match('{(x?([1-4])\d)}', $s, $matches)) {
-		assertType('array{string, non-empty-string, numeric-string}', $matches);
+		assertType('array{string, non-falsy-string, numeric-string}', $matches);
 	}
 	if (preg_match('{([^1-4])}', $s, $matches)) {
 		assertType('array{string, non-empty-string}', $matches);

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -249,7 +249,7 @@ function doFoo2(string $row): void
 		return;
 	}
 
-	assertType("array{0: string, 1: string, branchCode: ''|numeric-string, 2: ''|numeric-string, accountNumber: numeric-string, 3: numeric-string, bankCode: numeric-string, 4: numeric-string}", $matches);
+	assertType("array{0: string, 1: string, branchCode: ''|numeric-string, 2: ''|numeric-string, accountNumber: numeric-string, 3: numeric-string, bankCode: non-falsy-string&numeric-string, 4: non-falsy-string&numeric-string}", $matches);
 }
 
 function doFoo3(string $row): void
@@ -258,7 +258,7 @@ function doFoo3(string $row): void
 		return;
 	}
 
-	assertType('array{string, non-empty-string, non-empty-string, numeric-string, numeric-string, numeric-string, numeric-string}', $matches);
+	assertType('array{string, non-falsy-string, non-falsy-string, numeric-string, numeric-string, numeric-string, numeric-string}', $matches);
 }
 
 function (string $size): void {

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -265,7 +265,7 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)(\d+)(\s+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, numeric-string, numeric-string, non-empty-string}|array{string}', $matches);
+	assertType('array{string, non-falsy-string, numeric-string, numeric-string, non-empty-string}|array{string}', $matches);
 };
 
 function (string $size): void {
@@ -328,7 +328,7 @@ function (string $size): void {
 function bug11277a(string $value): void
 {
 	if (preg_match('/^\[(.+,?)*\]$/', $value, $matches)) {
-		assertType('array{0: string, 1?: non-empty-string}', $matches);
+		assertType('array{0: string, 1?: non-falsy-string}', $matches);
 		if (count($matches) === 2) {
 			assertType('array{string, string}', $matches); // could be array{string, non-empty-string}
 		}
@@ -501,13 +501,13 @@ function bug11323(string $s): void {
 		assertType('array{string, non-falsy-string}', $matches);
 	}
 	if (preg_match('{(\d\d)}', $s, $matches)) {
-		assertType('array{string, numeric-string}', $matches);
+		assertType('array{string, non-falsy-string&numeric-string}', $matches);
 	}
 	if (preg_match('{(.(\d))}', $s, $matches)) {
 		assertType('array{string, non-falsy-string, numeric-string}', $matches);
 	}
 	if (preg_match('{((\d).)}', $s, $matches)) {
-		assertType('array{string, non-empty-string, numeric-string}', $matches);
+		assertType('array{string, non-falsy-string, numeric-string}', $matches);
 	}
 	if (preg_match('{(\d([1-4])\d)}', $s, $matches)) {
 		assertType('array{string, non-falsy-string&numeric-string, numeric-string}', $matches);

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -59,9 +59,9 @@ function doMatch(string $s): void {
 	assertType('array{}|array{0: string, 1?: non-empty-string}', $matches);
 
 	if (preg_match('/(foo)(bar)(baz)+/', $s, $matches)) {
-		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
+		assertType("array{string, 'foo', 'bar', non-falsy-string}", $matches);
 	}
-	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
+	assertType("array{}|array{string, 'foo', 'bar', non-falsy-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz)*/', $s, $matches)) {
 		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
@@ -74,9 +74,9 @@ function doMatch(string $s): void {
 	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: 'baz'}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){0,3}/', $s, $matches)) {
-		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
+		assertType("array{0: string, 1: 'foo', 2: 'bar', 3?: non-falsy-string}", $matches);
 	}
-	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-empty-string}", $matches);
+	assertType("array{}|array{0: string, 1: 'foo', 2: 'bar', 3?: non-falsy-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2,3}/', $s, $matches)) {
 		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
@@ -84,9 +84,9 @@ function doMatch(string $s): void {
 	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
 
 	if (preg_match('/(foo)(bar)(baz){2}/', $s, $matches)) {
-		assertType("array{string, 'foo', 'bar', non-empty-string}", $matches);
+		assertType("array{string, 'foo', 'bar', non-falsy-string}", $matches);
 	}
-	assertType("array{}|array{string, 'foo', 'bar', non-empty-string}", $matches);
+	assertType("array{}|array{string, 'foo', 'bar', non-falsy-string}", $matches);
 }
 
 function doNonCapturingGroup(string $s): void {
@@ -103,14 +103,14 @@ function doNamedSubpattern(string $s): void {
 	assertType('array{}|array{0: string, num: numeric-string, 1: numeric-string, 2: non-empty-string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)/', $s, $matches)) {
-		assertType('array{0: string, name: non-empty-string, 1: non-empty-string}', $matches);
+		assertType('array{0: string, name: non-falsy-string, 1: non-falsy-string}', $matches);
 	}
-	assertType('array{}|array{0: string, name: non-empty-string, 1: non-empty-string}', $matches);
+	assertType('array{}|array{0: string, name: non-falsy-string, 1: non-falsy-string}', $matches);
 
 	if (preg_match('/^(?<name>\S+::\S+)(?:(?<dataname> with data set (?:#\d+|"[^"]+"))\s\()?/', $s, $matches)) {
-		assertType('array{0: string, name: non-empty-string, 1: non-empty-string, dataname?: non-empty-string, 2?: non-empty-string}', $matches);
+		assertType('array{0: string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}', $matches);
 	}
-	assertType('array{}|array{0: string, name: non-empty-string, 1: non-empty-string, dataname?: non-empty-string, 2?: non-empty-string}', $matches);
+	assertType('array{0: string, name: non-falsy-string, 1: non-falsy-string, dataname?: non-falsy-string, 2?: non-falsy-string}', $matches);
 }
 
 function doOffsetCapture(string $s): void {
@@ -239,7 +239,7 @@ function doFoo(string $row): void
 		assertType("array{0: string, 1: non-empty-string, 2?: 'b'}", $matches);
 	}
 	if (preg_match('~^(a(b)?)?$~', $row, $matches) === 1) {
-		assertType("array{0: string, 1?: non-empty-string, 2?: 'b'}", $matches);
+		assertType("array{0: string, 1?: non-falsy-string, 2?: 'b'}", $matches);
 	}
 }
 
@@ -272,7 +272,7 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, numeric-string}|array{string}', $matches);
+	assertType('array{string, non-falsy-string, numeric-string}|array{string}', $matches);
 };
 
 function (string $size): void {
@@ -286,14 +286,14 @@ function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+)?)?d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{0: string, 1?: non-empty-string, 2?: numeric-string}', $matches);
+	assertType('array{0: string, 1?: non-falsy-string, 2?: numeric-string}', $matches);
 };
 
 function (string $size): void {
 	if (preg_match('~^a\.b(c(\d+))d~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType('array{string, non-empty-string, numeric-string}', $matches);
+	assertType('array{string, non-falsy-string, numeric-string}', $matches);
 };
 
 function (string $size): void {
@@ -321,7 +321,7 @@ function (string $size): void {
 	if (preg_match('~\{(?:(include)\\s+(?:[$]?\\w+(?<!file))\\s)|(?:(include\\s+file)\\s+(?:[$]?\\w+)\\s)|(?:(include(?:Template|(?:\\s+file)))\\s+(?:\'?.*?\.latte\'?)\\s)~', $size, $matches) !== 1) {
 		throw new InvalidArgumentException(sprintf('Invalid size "%s"', $size));
 	}
-	assertType("array{0: string, 1: 'include', 2?: non-empty-string, 3?: non-empty-string}", $matches);
+	assertType("array{0: string, 1: 'include', 2?: non-falsy-string, 3?: non-falsy-string}", $matches);
 };
 
 
@@ -338,7 +338,7 @@ function bug11277a(string $value): void
 function bug11277b(string $value): void
 {
 	if (preg_match('/^(?:(.+,?)|(x))*$/', $value, $matches)) {
-		assertType('array{0: string, 1?: non-empty-string, 2?: non-empty-string}', $matches);
+		assertType('array{0: string, 1?: non-falsy-string, 2?: non-empty-string}', $matches);
 		if (count($matches) === 2) {
 			assertType('array{string, string}', $matches); // could be array{string, non-empty-string}
 		}
@@ -441,13 +441,13 @@ function (string $s): void {
 
 function (string $s): void {
 	if (preg_match('~^((\\d{1,6})-)$~', $s, $matches) === 1) {
-		assertType("array{string, non-empty-string, numeric-string}", $matches);
+		assertType("array{string, non-falsy-string, numeric-string}", $matches);
 	}
 };
 
 function (string $s): void {
 	if (preg_match('~^((\\d{1,6}).)$~', $s, $matches) === 1) {
-		assertType("array{string, non-empty-string, numeric-string}", $matches);
+		assertType("array{string, non-falsy-string, numeric-string}", $matches);
 	}
 };
 
@@ -471,7 +471,7 @@ function bug11323(string $s): void {
 		assertType('array{string, non-empty-string, non-empty-string}', $matches);
 	}
 	if (preg_match('{([-\p{L}[\]*|\x03\a\b+?{}(?:)-]+[^[:digit:]?{}a-z0-9#-k]+)(a-z)}', $s, $matches)) {
-		assertType("array{string, non-empty-string, 'a-z'}", $matches);
+		assertType("array{string, non-falsy-string, 'a-z'}", $matches);
 	}
 	if (preg_match('{(\d+)(?i)insensitive((?x-i)case SENSITIVE here(?i:insensitive non-capturing group))}', $s, $matches)) {
 		assertType('array{string, numeric-string, non-empty-string}', $matches);
@@ -495,16 +495,16 @@ function bug11323(string $s): void {
 		assertType("array{string, ''|'a', string, non-empty-string, non-empty-string}", $matches);
 	}
 	if (preg_match('{(.\d)}', $s, $matches)) {
-		assertType('array{string, non-empty-string}', $matches);
+		assertType('array{string, non-falsy-string}', $matches);
 	}
 	if (preg_match('{(\d.)}', $s, $matches)) {
-		assertType('array{string, non-empty-string}', $matches);
+		assertType('array{string, non-falsy-string}', $matches);
 	}
 	if (preg_match('{(\d\d)}', $s, $matches)) {
 		assertType('array{string, numeric-string}', $matches);
 	}
 	if (preg_match('{(.(\d))}', $s, $matches)) {
-		assertType('array{string, non-empty-string, numeric-string}', $matches);
+		assertType('array{string, non-falsy-string, numeric-string}', $matches);
 	}
 	if (preg_match('{((\d).)}', $s, $matches)) {
 		assertType('array{string, non-empty-string, numeric-string}', $matches);
@@ -604,5 +604,11 @@ function (string $s): void {
 function (string $s): void {
 	if (preg_match('/Price: (b[ao][mn])/', $s, $matches)) {
 		assertType("array{string, 'bam'|'ban'|'bom'|'bon'}", $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('/Price: (\s{3}|0)/', $s, $matches)) {
+		assertType("array{string, non-empty-string}", $matches);
 	}
 };

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -612,3 +612,16 @@ function (string $s): void {
 		assertType("array{string, non-empty-string}", $matches);
 	}
 };
+
+function (string $s): void {
+	if (preg_match('/Price: (a|0)/', $s, $matches)) {
+		assertType("array{string, non-empty-string}", $matches);
+	}
+};
+
+function (string $s): void {
+	if (preg_match('/Price: (aa|0)/', $s, $matches)) {
+		assertType("array{string, non-empty-string}", $matches);
+	}
+};
+


### PR DESCRIPTION
we could infer `non-falsy-string` in more situtations but this one is a easy start, which make constant-array result-types of the [patterns more different](https://github.com/phpstan/phpstan/issues/11443#issuecomment-2266709936).