### PR TITLE
RegularExpressionPatternRuleTest: utilize preg_match() array shape tests

### DIFF
--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -305,10 +305,13 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 			],
 		];
 
-		yield [
-			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php80.php',
-			[],
-		];
+		if (PHP_VERSION_ID >= 80000) {
+			yield [
+				__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php80.php',
+				[],
+			];
+		}
+
 		if (PHP_VERSION_ID >= 80200) {
 			yield [
 				__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php82.php',

--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -309,10 +309,12 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php80.php',
 			[],
 		];
-		yield [
-			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php82.php',
-			[],
-		];
+		if (PHP_VERSION_ID >= 80200) {
+			yield [
+				__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php82.php',
+				[],
+			];
+		}
 
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_replace_callback_shapes.php',

--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -277,6 +277,7 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 	}
 
 	/**
+	 * @param list<array{0: string, 1: int, 2?: string|null}> $errors
 	 * @dataProvider dataArrayShapePatterns
 	 */
 	public function testArrayShapePatterns(string $file, array $errors): void

--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -293,14 +293,6 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 			__DIR__ . '/../../Analyser/nsrt/preg_match_all_shapes.php',
 			[],
 		];
-		yield [
-			__DIR__ . '/../../Analyser/nsrt/preg_match_php7.php',
-			[],
-		];
-		yield [
-			__DIR__ . '/../../Analyser/nsrt/preg_match_php8.php',
-			[],
-		];
 
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes.php',

--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -276,4 +276,59 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 		);
 	}
 
+	/**
+	 * @dataProvider dataArrayShapePatterns
+	 */
+	public function testArrayShapePatterns(string $file, array $errors): void
+	{
+		$this->analyse(
+			[$file],
+			$errors
+		);
+	}
+
+	public function dataArrayShapePatterns(): iterable
+	{
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_match_all_shapes.php',
+			[]
+		];
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_match_php7.php',
+			[]
+		];
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_match_php8.php',
+			[]
+		];
+
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes.php',
+			[
+				[
+					"Regex pattern is invalid: Unknown modifier 'y' in pattern: /(foo)(bar)(baz)/xyz",
+					124
+				]
+			]
+		];
+
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php80.php',
+			[]
+		];
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php82.php',
+			[]
+		];
+
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_replace_callback_shapes.php',
+			[]
+		];
+		yield [
+			__DIR__ . '/../../Analyser/nsrt/preg_replace_callback_shapes-php72.php',
+			[]
+		];
+	}
+
 }

--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -283,7 +283,7 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 	{
 		$this->analyse(
 			[$file],
-			$errors
+			$errors,
 		);
 	}
 
@@ -291,15 +291,15 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 	{
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_match_all_shapes.php',
-			[]
+			[],
 		];
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_match_php7.php',
-			[]
+			[],
 		];
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_match_php8.php',
-			[]
+			[],
 		];
 
 		yield [
@@ -307,27 +307,27 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 			[
 				[
 					"Regex pattern is invalid: Unknown modifier 'y' in pattern: /(foo)(bar)(baz)/xyz",
-					124
-				]
-			]
+					124,
+				],
+			],
 		];
 
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php80.php',
-			[]
+			[],
 		];
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_match_shapes_php82.php',
-			[]
+			[],
 		];
 
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_replace_callback_shapes.php',
-			[]
+			[],
 		];
 		yield [
 			__DIR__ . '/../../Analyser/nsrt/preg_replace_callback_shapes-php72.php',
-			[]
+			[],
 		];
 	}
 


### PR DESCRIPTION
utilize the huge amount of regular expressions and variants to test RegularExpressionPatternRule