### PR TITLE
ShouldNotHappenException extends LogicException

### DIFF
--- a/src/ShouldNotHappenException.php
+++ b/src/ShouldNotHappenException.php
@@ -2,9 +2,9 @@
 
 namespace PHPStan;
 
-use Exception;
+use LogicException;
 
-final class ShouldNotHappenException extends Exception
+final class ShouldNotHappenException extends LogicException
 {
 
 	/** @api */


### PR DESCRIPTION
before this PR PHPStorm false-postively reporting missing handling of ShouldNotHappenExceptions

<img width="772" alt="grafik" src="https://github.com/user-attachments/assets/f9476565-0cc2-473a-a100-42dc7c64024c">

----

LogicException

> Exception that represents error in the program logic. This kind of exception should lead directly to a fix in your code. 

see https://www.php.net/LogicException
