### PR TITLE
Add basic type narrowing in the loose equality with the empty string

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1611,7 +1611,7 @@ final class TypeSpecifier
 	}
 
 	/**
-	 * @return array{Expr, ConstantScalarType}|null
+	 * @return array{Expr, ConstantScalarType, Type}|null
 	 */
 	private function findTypeExpressionsFromBinaryOperation(Scope $scope, Node\Expr\BinaryOp $binaryOperation): ?array
 	{
@@ -1633,13 +1633,13 @@ final class TypeSpecifier
 			&& !$rightExpr instanceof ConstFetch
 			&& !$rightExpr instanceof ClassConstFetch
 		) {
-			return [$binaryOperation->right, $leftType];
+			return [$binaryOperation->right, $leftType, $rightType];
 		} elseif (
 			$rightType instanceof ConstantScalarType
 			&& !$leftExpr instanceof ConstFetch
 			&& !$leftExpr instanceof ClassConstFetch
 		) {
-			return [$binaryOperation->left, $rightType];
+			return [$binaryOperation->left, $rightType, $leftType];
 		}
 
 		return null;
@@ -1950,6 +1950,7 @@ final class TypeSpecifier
 		if ($expressions !== null) {
 			$exprNode = $expressions[0];
 			$constantType = $expressions[1];
+			$otherType = $expressions[2];
 
 			if (!$context->null() && $constantType->getValue() === null) {
 				$trueTypes = [
@@ -1979,6 +1980,30 @@ final class TypeSpecifier
 					$context->true() ? TypeSpecifierContext::createTruthy() : TypeSpecifierContext::createTruthy()->negate(),
 					$rootExpr,
 				);
+			}
+
+			if (!$context->null() && $constantType->getValue() === 0 && !$otherType->isInteger()->yes()) {
+				/* There is a difference between php 7.x and 8.x on the equality
+				 * behavior between zero and the empty string, so to be conservative
+				 * we leave it untouched regardless of the language version */
+				if ($context->true()) {
+					$trueTypes = [
+						new NullType(),
+						new ConstantBooleanType(false),
+						new ConstantIntegerType(0),
+						new ConstantFloatType(0.0),
+						new StringType(),
+					];
+				} else {
+					$trueTypes = [
+						new NullType(),
+						new ConstantBooleanType(false),
+						new ConstantIntegerType(0),
+						new ConstantFloatType(0.0),
+						new ConstantStringType('0'),
+					];
+				}
+				return $this->create($exprNode, new UnionType($trueTypes), $context, false, $scope, $rootExpr);
 			}
 
 			if (!$context->null() && $constantType->getValue() === '') {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1982,7 +1982,7 @@ final class TypeSpecifier
 				);
 			}
 
-			if (!$context->null() && $constantType->getValue() === 0 && !$otherType->isInteger()->yes()) {
+			if (!$context->null() && $constantType->getValue() === 0 && !$otherType->isInteger()->yes() && !$otherType->isBoolean()->yes()) {
 				/* There is a difference between php 7.x and 8.x on the equality
 				 * behavior between zero and the empty string, so to be conservative
 				 * we leave it untouched regardless of the language version */
@@ -2121,11 +2121,13 @@ final class TypeSpecifier
 
 	public function resolveIdentical(Expr\BinaryOp\Identical $expr, Scope $scope, TypeSpecifierContext $context, ?Expr $rootExpr): SpecifiedTypes
 	{
+		// Normalize to: fn() === expr
 		$leftExpr = $expr->left;
 		$rightExpr = $expr->right;
 		if ($rightExpr instanceof FuncCall && !$leftExpr instanceof FuncCall) {
 			[$leftExpr, $rightExpr] = [$rightExpr, $leftExpr];
 		}
+
 		$unwrappedLeftExpr = $leftExpr;
 		if ($leftExpr instanceof AlwaysRememberedExpr) {
 			$unwrappedLeftExpr = $leftExpr->getExpr();
@@ -2134,8 +2136,10 @@ final class TypeSpecifier
 		if ($rightExpr instanceof AlwaysRememberedExpr) {
 			$unwrappedRightExpr = $rightExpr->getExpr();
 		}
+
 		$rightType = $scope->getType($rightExpr);
 
+		// (count($a) === $b)
 		if (
 			!$context->null()
 			&& $unwrappedLeftExpr instanceof FuncCall
@@ -2200,6 +2204,7 @@ final class TypeSpecifier
 			}
 		}
 
+		// strlen($a) === $b
 		if (
 			!$context->null()
 			&& $unwrappedLeftExpr instanceof FuncCall
@@ -2236,6 +2241,7 @@ final class TypeSpecifier
 			}
 		}
 
+		// preg_match($a) === $b
 		if (
 			$context->true()
 			&& $unwrappedLeftExpr instanceof FuncCall
@@ -2251,6 +2257,7 @@ final class TypeSpecifier
 			);
 		}
 
+		// get_class($a) === 'Foo'
 		if (
 			$context->true()
 			&& $unwrappedLeftExpr instanceof FuncCall
@@ -2270,6 +2277,7 @@ final class TypeSpecifier
 			}
 		}
 
+		// get_class($a) === 'Foo'
 		if (
 			$context->truthy()
 			&& $unwrappedLeftExpr instanceof FuncCall
@@ -2350,6 +2358,7 @@ final class TypeSpecifier
 			}
 		}
 
+		// $a::class === 'Foo'
 		if (
 			$context->true() &&
 			$unwrappedLeftExpr instanceof ClassConstFetch &&
@@ -2372,6 +2381,8 @@ final class TypeSpecifier
 		}
 
 		$leftType = $scope->getType($leftExpr);
+
+		// 'Foo' === $a::class
 		if (
 			$context->true() &&
 			$unwrappedRightExpr instanceof ClassConstFetch &&
@@ -2417,7 +2428,11 @@ final class TypeSpecifier
 		$types = null;
 		if (
 			count($leftType->getFiniteTypes()) === 1
-			|| ($context->true() && $leftType->isConstantValue()->yes() && !$rightType->equals($leftType) && $rightType->isSuperTypeOf($leftType)->yes())
+			|| (
+				$context->true()
+				&& $leftType->isConstantValue()->yes()
+				&& !$rightType->equals($leftType)
+				&& $rightType->isSuperTypeOf($leftType)->yes())
 		) {
 			$types = $this->create(
 				$rightExpr,
@@ -2440,7 +2455,12 @@ final class TypeSpecifier
 		}
 		if (
 			count($rightType->getFiniteTypes()) === 1
-			|| ($context->true() && $rightType->isConstantValue()->yes() && !$leftType->equals($rightType) && $leftType->isSuperTypeOf($rightType)->yes())
+			|| (
+				$context->true()
+				&& $rightType->isConstantValue()->yes()
+				&& !$leftType->equals($rightType)
+				&& $leftType->isSuperTypeOf($rightType)->yes()
+			)
 		) {
 			$leftTypes = $this->create(
 				$leftExpr,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -43,6 +43,7 @@ use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
@@ -1949,7 +1950,20 @@ final class TypeSpecifier
 		if ($expressions !== null) {
 			$exprNode = $expressions[0];
 			$constantType = $expressions[1];
-			if (!$context->null() && ($constantType->getValue() === false || $constantType->getValue() === null)) {
+
+			if (!$context->null() && $constantType->getValue() === null) {
+				$trueTypes = [
+					new NullType(),
+					new ConstantBooleanType(false),
+					new ConstantIntegerType(0),
+					new ConstantFloatType(0.0),
+					new ConstantStringType(''),
+					new ConstantArrayType([], []),
+				];
+				return $this->create($exprNode, new UnionType($trueTypes), $context, false, $scope, $rootExpr);
+			}
+
+			if (!$context->null() && $constantType->getValue() === false) {
 				return $this->specifyTypesInCondition(
 					$scope,
 					$exprNode,
@@ -1965,6 +1979,28 @@ final class TypeSpecifier
 					$context->true() ? TypeSpecifierContext::createTruthy() : TypeSpecifierContext::createTruthy()->negate(),
 					$rootExpr,
 				);
+			}
+
+			if (!$context->null() && $constantType->getValue() === '') {
+				/* There is a difference between php 7.x and 8.x on the equality
+				 * behavior between zero and the empty string, so to be conservative
+				 * we leave it untouched regardless of the language version */
+				if ($context->true()) {
+					$trueTypes = [
+						new NullType(),
+						new ConstantBooleanType(false),
+						new ConstantIntegerType(0),
+						new ConstantFloatType(0.0),
+						new ConstantStringType(''),
+					];
+				} else {
+					$trueTypes = [
+						new NullType(),
+						new ConstantBooleanType(false),
+						new ConstantStringType(''),
+					];
+				}
+				return $this->create($exprNode, new UnionType($trueTypes), $context, false, $scope, $rootExpr);
 			}
 
 			if (

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -477,8 +477,8 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Variable('foo'),
 					new Expr\ConstFetch(new Name('null')),
 				),
-				['$foo' => self::SURE_NOT_TRUTHY],
-				['$foo' => self::SURE_NOT_FALSEY],
+				['$foo' => '0|0.0|\'\'|array{}|false|null'],
+				['$foo' => '~0|0.0|\'\'|array{}|false|null'],
 			],
 			[
 				new Expr\BinaryOp\Identical(

--- a/tests/PHPStan/Analyser/nsrt/equal-narrow.php
+++ b/tests/PHPStan/Analyser/nsrt/equal-narrow.php
@@ -59,6 +59,12 @@ function doFalse($x, $y, $z): void
 		assertType("0|0.0|''|'0'|array{}|false|null", $x);
 	}
 
+	if (!$x) {
+		assertType("0|0.0|''|'0'|array{}|false|null", $x);
+	} else {
+		assertType("1|'x'|object|true", $x);
+	}
+
 	if ($y == false) {
 		assertType("0|''|'0'|null", $y);
 	} else {
@@ -88,6 +94,12 @@ function doTrue($x, $y, $z): void
 		assertType("0|0.0|''|'0'|array{}|false|null", $x);
 	} else {
 		assertType("1|'x'|object|true", $x);
+	}
+
+	if ($x) {
+		assertType("1|'x'|object|true", $x);
+	} else {
+		assertType("0|0.0|''|'0'|array{}|false|null", $x);
 	}
 
 	if ($y == true) {

--- a/tests/PHPStan/Analyser/nsrt/equal-narrow.php
+++ b/tests/PHPStan/Analyser/nsrt/equal-narrow.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+// phpcs:disable SlevomatCodingStandard.ControlStructures.DisallowYodaComparison.DisallowedYodaComparison
+// phpcs:disable SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator
+// phpcs:disable SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedNotEqualOperator
+// phpcs:disable Squiz.Functions.GlobalFunction.Found
+// phpcs:disable Squiz.Strings.DoubleQuoteUsage.NotRequired
+
+namespace EqualTypeNarrowing;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param 0|0.0|1|''|'0'|'x'|array{}|bool|object|null $x
+ * @param int|string|null $y
+ * @param mixed $z
+ */
+function doNull($x, $y, $z): void
+{
+	if ($x == null) {
+		assertType("0|0.0|''|array{}|false|null", $x);
+	} else {
+		assertType("1|'0'|'x'|object|true", $x);
+	}
+	if (null != $x) {
+		assertType("1|'0'|'x'|object|true", $x);
+	} else {
+		assertType("0|0.0|''|array{}|false|null", $x);
+	}
+
+	if ($y == null) {
+		assertType("0|''|null", $y);
+	} else {
+		assertType("int<min, -1>|int<1, max>|non-empty-string", $y);
+	}
+
+	if ($z == null) {
+		assertType("0|0.0|''|array{}|false|null", $z);
+	} else {
+		assertType("mixed~0|0.0|''|array{}|false|null", $z);
+	}
+}
+
+/**
+ * @param 0|0.0|1|''|'0'|'x'|array{}|bool|object|null $x
+ * @param int|string|null $y
+ * @param mixed $z
+ */
+function doFalse($x, $y, $z): void
+{
+	if ($x == false) {
+		assertType("0|0.0|''|'0'|array{}|false|null", $x);
+	} else {
+		assertType("1|'x'|object|true", $x);
+	}
+	if (false != $x) {
+		assertType("1|'x'|object|true", $x);
+	} else {
+		assertType("0|0.0|''|'0'|array{}|false|null", $x);
+	}
+
+	if ($y == false) {
+		assertType("0|''|'0'|null", $y);
+	} else {
+		assertType("int<min, -1>|int<1, max>|non-falsy-string", $y);
+	}
+
+	if ($z == false) {
+		assertType("0|0.0|''|'0'|array{}|false|null", $z);
+	} else {
+		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $z);
+	}
+}
+
+/**
+ * @param 0|0.0|1|''|'0'|'x'|array{}|bool|object|null $x
+ * @param int|string|null $y
+ * @param mixed $z
+ */
+function doTrue($x, $y, $z): void
+{
+	if ($x == true) {
+		assertType("1|'x'|object|true", $x);
+	} else {
+		assertType("0|0.0|''|'0'|array{}|false|null", $x);
+	}
+	if (true != $x) {
+		assertType("0|0.0|''|'0'|array{}|false|null", $x);
+	} else {
+		assertType("1|'x'|object|true", $x);
+	}
+
+	if ($y == true) {
+		assertType("int<min, -1>|int<1, max>|non-falsy-string", $y);
+	} else {
+		assertType("0|''|'0'|null", $y);
+	}
+
+	if ($z == true) {
+		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $z);
+	} else {
+		assertType("0|0.0|''|'0'|array{}|false|null", $z);
+	}
+}
+
+/**
+ * @param 0|0.0|1|''|'0'|'x'|array{}|bool|object|null $x
+ * @param int|string|null $y
+ * @param mixed $z
+ */
+function doEmptyString($x, $y, $z): void
+{
+	// PHP 7.x/8.x compatibility: Keep zero in both cases
+	if ($x == '') {
+		assertType("0|0.0|''|false|null", $x);
+	} else {
+		assertType("0|0.0|1|'0'|'x'|array{}|object|true", $x);
+	}
+	if ('' != $x) {
+		assertType("0|0.0|1|'0'|'x'|array{}|object|true", $x);
+	} else {
+		assertType("0|0.0|''|false|null", $x);
+	}
+
+	if ($y == '') {
+		assertType("0|''|null", $y);
+	} else {
+		assertType("int|non-empty-string", $y);
+	}
+
+	if ($z == '') {
+		assertType("0|0.0|''|false|null", $z);
+	} else {
+		assertType("mixed~''|false|null", $z);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/equal-narrow.php
+++ b/tests/PHPStan/Analyser/nsrt/equal-narrow.php
@@ -37,7 +37,7 @@ function doNull($x, $y, $z): void
 	if ($z == null) {
 		assertType("0|0.0|''|array{}|false|null", $z);
 	} else {
-		assertType("mixed~0|0.0|''|array{}|false|null", $z);
+		assertType("mixed~(0|0.0|''|array{}|false|null)", $z);
 	}
 }
 
@@ -74,7 +74,7 @@ function doFalse($x, $y, $z): void
 	if ($z == false) {
 		assertType("0|0.0|''|'0'|array{}|false|null", $z);
 	} else {
-		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $z);
+		assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $z);
 	}
 }
 
@@ -109,7 +109,7 @@ function doTrue($x, $y, $z): void
 	}
 
 	if ($z == true) {
-		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $z);
+		assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $z);
 	} else {
 		assertType("0|0.0|''|'0'|array{}|false|null", $z);
 	}
@@ -143,6 +143,6 @@ function doEmptyString($x, $y, $z): void
 	if ($z == '') {
 		assertType("0|0.0|''|false|null", $z);
 	} else {
-		assertType("mixed~''|false|null", $z);
+		assertType("mixed~(''|false|null)", $z);
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/equal-narrow.php
+++ b/tests/PHPStan/Analyser/nsrt/equal-narrow.php
@@ -120,6 +120,38 @@ function doTrue($x, $y, $z): void
  * @param int|string|null $y
  * @param mixed $z
  */
+function doZero($x, $y, $z): void
+{
+	// PHP 7.x/8.x compatibility: Keep zero in both cases
+	if ($x == 0) {
+		assertType("0|0.0|''|'0'|'x'|false|null", $x);
+	} else {
+		assertType("1|''|'x'|array{}|object|true", $x);
+	}
+	if (0 != $x) {
+		assertType("1|''|'x'|array{}|object|true", $x);
+	} else {
+		assertType("0|0.0|''|'0'|'x'|false|null", $x);
+	}
+
+	if ($y == 0) {
+		assertType("0|string|null", $y);
+	} else {
+		assertType("int<min, -1>|int<1, max>|string", $y);
+	}
+
+	if ($z == 0) {
+		assertType("0|0.0|string|false|null", $z);
+	} else {
+		assertType("mixed~(0|0.0|'0'|false|null)", $z);
+	}
+}
+
+/**
+ * @param 0|0.0|1|''|'0'|'x'|array{}|bool|object|null $x
+ * @param int|string|null $y
+ * @param mixed $z
+ */
 function doEmptyString($x, $y, $z): void
 {
 	// PHP 7.x/8.x compatibility: Keep zero in both cases

--- a/tests/PHPStan/Analyser/nsrt/integer-range-types.php
+++ b/tests/PHPStan/Analyser/nsrt/integer-range-types.php
@@ -449,7 +449,7 @@ class X {
 
 function subtract($m) {
 	if ($m != 0) {
-		assertType("mixed", $m); // could be "mixed~0|0.0|''|'0'|array{}|false|null"
+		assertType("mixed~(0|0.0|'0'|false|null)", $m); // could be "mixed~(0|0.0|''|'0'|false|null)"
 		assertType('int', (int) $m);
 	}
 	if ($m !== 0) {

--- a/tests/PHPStan/Analyser/nsrt/narrow-cast.php
+++ b/tests/PHPStan/Analyser/nsrt/narrow-cast.php
@@ -33,7 +33,7 @@ function castString($x, string $s, bool $b) {
 	if ((string) $x) {
 		assertType('int<-5, 5>', $x);
 	} else {
-		assertType('int<-5, 5>', $x);
+		assertType('0', $x);
 	}
 
 	if ((string) $b) {

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string.php
@@ -422,8 +422,8 @@ class MoreNonEmptyStringFunctions
 			assertType('non-falsy-string', (string) $m);
 		}
 		if ($m != '') {
-			assertType("mixed", $m);
-			assertType('string', (string) $m);
+			assertType("mixed~(''|false|null)", $m);
+			assertType('non-empty-string', (string) $m);
 		}
 		if ($m !== '') {
 			assertType("mixed~''", $m);

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -135,6 +135,10 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 				'Elseif condition is always false.',
 				28,
 			],
+			[
+				'Elseif condition is always false.',
+				36,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/bug-11674.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-11674.php
@@ -10,7 +10,7 @@ class Test {
 		if ((int) $this->param) {
 			echo 1;
 		} elseif ($this->param) {
-			echo 2;
+			echo 2; // might be "0"
 		}
 	}
 
@@ -18,7 +18,7 @@ class Test {
 		if ((float) $this->param) {
 			echo 1;
 		} elseif ($this->param) {
-			echo 2;
+			echo 2; // might be "0"
 		}
 	}
 
@@ -26,7 +26,7 @@ class Test {
 		if ((bool) $this->param) {
 			echo 1;
 		} elseif ($this->param) {
-			echo 2;
+			echo 2; // not possible
 		}
 	}
 
@@ -34,7 +34,7 @@ class Test {
 		if ((string) $this->param) {
 			echo 1;
 		} elseif ($this->param) {
-			echo 2;
+			echo 2; // not possible
 		}
 	}
 }


### PR DESCRIPTION
As promised a [long time ago](https://github.com/phpstan/phpstan/issues/7668#issuecomment-1191379214), I submit my first real attempt to narrow the type after `if ($a != "") ...`

This is by no means a complete analysis of the loose equality operator, but it should be sound. The discrepancy between php 7.x and 8.x are handled by preserving the two offending types (integer and float zero) in the type for both the true and false context.

I have the feeling that the definitive solution would be to replace `Type::looseCompare()` with `Type::looseIntersectWith()`, which should solve all the loose comparison problems. Do you think it would be something worth pursuing?

If in the meanwhile you think this PR is acceptable, it would solve a lot of problems in my codebase.
