### PR TITLE
Fix item-type in list to constant-array conversion with count()

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -991,7 +991,7 @@ class TypeSpecifier
 		return null;
 	}
 
-	private function turnListIntoConstantArray(FuncCall $countFuncCall, Type $listOrArray, Type $sizeType, Scope $scope): ?Type
+	private function turnListIntoConstantArray(FuncCall $countFuncCall, Type $type, Type $sizeType, Scope $scope): ?Type
 	{
 		$argType = $scope->getType($countFuncCall->getArgs()[0]->value);
 
@@ -1004,15 +1004,15 @@ class TypeSpecifier
 
 		if (
 			$isNormalCount->yes()
+			&& $type->isList()->yes()
 			&& $sizeType instanceof ConstantIntegerType
-			&& $listOrArray->isList()->yes()
 			&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
 		) {
 			// turn optional offsets non-optional
 			$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
 			for ($i = 0; $i < $sizeType->getValue(); $i++) {
 				$offsetType = new ConstantIntegerType($i);
-				$valueTypesBuilder->setOffsetValueType($offsetType, $listOrArray->getOffsetValueType($offsetType));
+				$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
 			}
 			return $valueTypesBuilder->getArray();
 		}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -971,7 +971,7 @@ class TypeSpecifier
 						continue;
 					}
 
-					if ($sizeType instanceof ConstantIntegerType && $innerType->isList()->yes()) {
+					if ($sizeType instanceof ConstantIntegerType && $innerType->isList()->yes() && $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
 						// turn optional offsets non-optional
 						$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
 						for ($i = 0; $i < $sizeType->getValue(); $i++) {
@@ -1060,6 +1060,14 @@ class TypeSpecifier
 				}
 
 				if ($argType->isArray()->yes()) {
+					if (
+						$context->truthy()
+						&& $argType->isConstantArray()->yes()
+						&& $constantType->isSuperTypeOf($argType->getArraySize())->no()
+					) {
+						return $this->create($exprNode->getArgs()[0]->value, new NeverType(), $context, false, $scope, $rootExpr);
+					}
+
 					if (count($exprNode->getArgs()) === 1) {
 						$isNormalCount = TrinaryLogic::createYes();
 					} else {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1060,9 +1060,9 @@ class TypeSpecifier
 					$funcTypes = $this->create($exprNode, $constantType, $context, false, $scope, $rootExpr);
 					if ($isNormalCount->yes() && $argType->isList()->yes() && $context->truthy() && $constantType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
 						$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
-						$itemType = $argType->getIterableValueType();
 						for ($i = 0; $i < $constantType->getValue(); $i++) {
-							$valueTypesBuilder->setOffsetValueType(new ConstantIntegerType($i), $itemType);
+							$offsetType = new ConstantIntegerType($i);
+							$valueTypesBuilder->setOffsetValueType($offsetType, $argType->getOffsetValueType($offsetType));
 						}
 						$valueTypes = $this->create($exprNode->getArgs()[0]->value, $valueTypesBuilder->getArray(), $context, false, $scope, $rootExpr);
 					} else {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -970,6 +970,16 @@ class TypeSpecifier
 					if ($isSize->no()) {
 						continue;
 					}
+
+					if ($sizeType instanceof ConstantIntegerType && $innerType->isList()->yes()) {
+						// turn optional offsets non-optional
+						$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
+						for ($i = 0; $i < $sizeType->getValue(); $i++) {
+							$offsetType = new ConstantIntegerType($i);
+							$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType));
+						}
+						$innerType = $valueTypesBuilder->getArray();
+					}
 				}
 				if ($context->falsey()) {
 					if (!$isSize->yes()) {
@@ -1059,6 +1069,7 @@ class TypeSpecifier
 
 					$funcTypes = $this->create($exprNode, $constantType, $context, false, $scope, $rootExpr);
 					if ($isNormalCount->yes() && $argType->isList()->yes() && $context->truthy() && $constantType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+						// turn optional offsets non-optional
 						$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
 						for ($i = 0; $i < $constantType->getValue(); $i++) {
 							$offsetType = new ConstantIntegerType($i);

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -216,3 +216,17 @@ function countCountable(CountableFoo $x, int $mode)
 	}
 	assertType('ListCount\CountableFoo', $x);
 }
+
+class CountWithOptionalKeys
+{
+	/**
+	 * @param array{mixed}|array{0: mixed, 1?: string|null} $row
+	 */
+	protected function testOptionalKeys(array $row): void
+	{
+		if (count($row) === 2) {
+			assertType('array{mixed, string|null}', $row);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -220,12 +220,32 @@ function countCountable(CountableFoo $x, int $mode)
 class CountWithOptionalKeys
 {
 	/**
-	 * @param array{mixed}|array{0: mixed, 1?: string|null} $row
+	 * @param array{0: mixed, 1?: string|null} $row
 	 */
 	protected function testOptionalKeys(array $row): void
 	{
+		if (count($row) === 0) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 1) {
+			assertType('array{mixed}', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
 		if (count($row) === 2) {
 			assertType('array{mixed, string|null}', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 3) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -249,4 +249,34 @@ class CountWithOptionalKeys
 		}
 	}
 
+	/**
+	 * @param array{mixed}|array{0: mixed, 1?: string|null} $row
+	 */
+	protected function testOptionalKeysInUnion(array $row): void
+	{
+		if (count($row) === 0) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 1) {
+			assertType('array{mixed}', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 2) {
+			assertType('array{mixed, string|null}', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 3) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+	}
+
 }

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -279,4 +279,34 @@ class CountWithOptionalKeys
 		}
 	}
 
+	/**
+	 * @param array{string}|array{0: mixed, 1?: string|null} $row
+	 */
+	protected function testOptionalKeysInTaggedUnion(array $row): void
+	{
+		if (count($row) === 0) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 1) {
+			assertType('array{mixed}', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 2) {
+			assertType('array{mixed, string|null}', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+
+		if (count($row) === 3) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: mixed, 1?: string|null}', $row);
+		}
+	}
+
 }

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -222,7 +222,7 @@ class CountWithOptionalKeys
 	/**
 	 * @param array{0: mixed, 1?: string|null} $row
 	 */
-	protected function testOptionalKeys(array $row): void
+	protected function testOptionalKeys($row): void
 	{
 		if (count($row) === 0) {
 			assertType('*NEVER*', $row);
@@ -252,7 +252,7 @@ class CountWithOptionalKeys
 	/**
 	 * @param array{mixed}|array{0: mixed, 1?: string|null} $row
 	 */
-	protected function testOptionalKeysInUnion(array $row): void
+	protected function testOptionalKeysInUnion($row): void
 	{
 		if (count($row) === 0) {
 			assertType('*NEVER*', $row);
@@ -280,32 +280,32 @@ class CountWithOptionalKeys
 	}
 
 	/**
-	 * @param array{string}|array{0: mixed, 1?: string|null} $row
+	 * @param array{string}|array{0: int, 1?: string|null} $row
 	 */
-	protected function testOptionalKeysInTaggedUnion(array $row): void
+	protected function testOptionalKeysInTaggedUnion($row): void
 	{
 		if (count($row) === 0) {
 			assertType('*NEVER*', $row);
 		} else {
-			assertType('array{0: mixed, 1?: string|null}', $row);
+			assertType('array{0: int, 1?: string|null}|array{string}', $row);
 		}
 
 		if (count($row) === 1) {
-			assertType('array{mixed}', $row);
+			assertType('array{0: int, 1?: string|null}|array{string}', $row);
 		} else {
-			assertType('array{0: mixed, 1?: string|null}', $row);
+			assertType('array{0: int, 1?: string|null}', $row);
 		}
 
 		if (count($row) === 2) {
-			assertType('array{mixed, string|null}', $row);
+			assertType('array{int, string|null}', $row);
 		} else {
-			assertType('array{0: mixed, 1?: string|null}', $row);
+			assertType('array{0: int, 1?: string|null}|array{string}', $row);
 		}
 
 		if (count($row) === 3) {
 			assertType('*NEVER*', $row);
 		} else {
-			assertType('array{0: mixed, 1?: string|null}', $row);
+			assertType('array{0: int, 1?: string|null}|array{string}', $row);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -282,7 +282,7 @@ class CountWithOptionalKeys
 	/**
 	 * @param array{string}|array{0: int, 1?: string|null} $row
 	 */
-	protected function testOptionalKeysInTaggedUnion($row): void
+	protected function testOptionalKeysInListsOfTaggedUnion($row): void
 	{
 		if (count($row) === 0) {
 			assertType('*NEVER*', $row);
@@ -306,6 +306,36 @@ class CountWithOptionalKeys
 			assertType('*NEVER*', $row);
 		} else {
 			assertType('array{0: int, 1?: string|null}|array{string}', $row);
+		}
+	}
+
+	/**
+	 * @param array{string}|array{0: int, 3?: string|null} $row
+	 */
+	protected function testOptionalKeysInUnionArray($row): void
+	{
+		if (count($row) === 0) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: int, 3?: string|null}|array{string}', $row);
+		}
+
+		if (count($row) === 1) {
+			assertType('array{0: int, 3?: string|null}|array{string}', $row);
+		} else {
+			assertType('array{0: int, 3?: string|null}', $row);
+		}
+
+		if (count($row) === 2) {
+			assertType('array{0: int, 3?: string|null}', $row);
+		} else {
+			assertType('array{0: int, 3?: string|null}|array{string}', $row);
+		}
+
+		if (count($row) === 3) {
+			assertType('*NEVER*', $row);
+		} else {
+			assertType('array{0: int, 3?: string|null}|array{string}', $row);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -330,7 +330,7 @@ function bug11277a(string $value): void
 	if (preg_match('/^\[(.+,?)*\]$/', $value, $matches)) {
 		assertType('array{0: string, 1?: non-empty-string}', $matches);
 		if (count($matches) === 2) {
-			assertType('array{string, string}', $matches); // could be array{string, non-empty-string}
+			assertType('array{string, non-empty-string}', $matches);
 		}
 	}
 }


### PR DESCRIPTION
before this PR we were loosing precision in this process as item-types were kind of generalized before.

I guess the original implementation was done before `Type->getOffsetValueType()` was a thing.