### PR TITLE
Allow reinitialization of a readonly property in `__clone` since PHP8.3

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -327,4 +327,9 @@ class PhpVersion
 		return $this->versionId >= 80300;
 	}
 
+	public function supportsReadonlyPropertyReinitializationOnClone(): bool
+	{
+		return $this->versionId >= 80300;
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -162,11 +162,23 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 			$this->markTestSkipped('Test requires PHP 8.1.');
 		}
 
-		$errors = [];
 		if (PHP_VERSION_ID < 80300) {
-			$errors[] = [
-				'Readonly property Bug11495\HelloWorld::$foo is assigned outside of the constructor.',
-				17,
+			$errors = [
+				[
+					'Readonly property Bug11495\HelloWorld::$foo is assigned outside of the constructor.',
+					17,
+				],
+				[
+					'Readonly property Bug11495\HelloWorld::$foo is assigned outside of the constructor.',
+					20,
+				],
+			];
+		} else {
+			$errors = [
+				[
+					'Readonly property Bug11495\HelloWorld::$foo is not assigned on $this.',
+					20,
+				],
 			];
 		}
 

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -23,6 +24,7 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 					'ReadonlyPropertyAssign\\TestCase::setUp',
 				],
 			),
+			new PhpVersion(PHP_VERSION_ID),
 		);
 	}
 
@@ -152,6 +154,23 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 				16,
 			],
 		]);
+	}
+
+	public function testBug11495(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$errors = [];
+		if (PHP_VERSION_ID < 80300) {
+			$errors[] = [
+				'Readonly property Bug11495\HelloWorld::$foo is assigned outside of the constructor.',
+				17,
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-11495.php'], $errors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-11495.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-11495.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.1
+declare(strict_types = 1);
+
+namespace Bug11495;
+
+class HelloWorld
+{
+	private readonly string $foo;
+
+	public function __construct()
+	{
+		$this->foo = 'bar';
+	}
+
+	public function __clone()
+	{
+		$this->foo = 'baz';
+	}
+
+	public function getFoo(): string
+	{
+		return $this->foo;
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-11495.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-11495.php
@@ -15,6 +15,9 @@ class HelloWorld
 	public function __clone()
 	{
 		$this->foo = 'baz';
+
+		$s = new self();
+		$s->foo = 'baz';
 	}
 
 	public function getFoo(): string


### PR DESCRIPTION
Closes phpstan/phpstan#11495