### PR TITLE
ContainerFactory::clearOldContainers check only ctime, not atime

### DIFF
--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -218,9 +218,6 @@ class ContainerFactory
 			if ($path === false) {
 				continue;
 			}
-			if ($containerFile->getATime() > $twoDaysAgo) {
-				continue;
-			}
 			if ($containerFile->getCTime() > $twoDaysAgo) {
 				continue;
 			}


### PR DESCRIPTION
- When cache is pulled from some storage (e.g. S3), it gets recent atimes and this does not work. That causes unwanted cache swelling.
- Ref: https://x.com/janedbal/status/1825450878708462024