### PR TITLE
Remove null-return on preg_replace() with valid patterns

### DIFF
--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -7426,11 +7426,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$expectedArray',
 			],
 			[
-				'array{a: string, b: string}|null',
+				'array{a?: string, b?: string}',
 				'$expectedArray2',
 			],
 			[
-				'array{a: string, b: string}|null',
+				'array{a?: string, b?: string}',
 				'$anotherExpectedArray',
 			],
 			[
@@ -7450,7 +7450,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$anotherExpectedArrayOrString',
 			],
 			[
-				'array{a: string, b: string}|null',
+				'array{a?: string, b?: string}',
 				'preg_replace_callback_array($callbacks, $array)',
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/bug-11547.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11547.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Bug11547;
+
+use function PHPStan\Testing\assertType;
+
+function foo(string $s)
+{
+	$r = preg_replace('/^a/', 'b', $s);
+	assertType('string|null', $r);
+	return $r;
+}
+
+function foobar(string $s, string $pattern)
+{
+	$r = preg_replace($pattern, 'b', $s);
+	assertType('string|null', $r);
+	return $r;
+}
+
+/**
+ * @param array{a: string, b:string} $arr
+ */
+function bar(array $arr): array
+{
+	$r = preg_replace('/^a/', 'x', $arr);
+	assertType('array{a?: string, b?: string}', $r);
+	return $r;
+}
+
+/**
+ * @param array{a: string, b:string} $arr
+ */
+function barbar($arr, string $pattern)
+{
+	$r = preg_replace($pattern, 'b', $arr);
+	assertType('array{a?: string, b?: string}', $r);
+	return $r;
+}
+
+// see https://github.com/phpstan/phpstan/issues/11547#issuecomment-2307156443
+// see https://3v4l.org/c70bG
+function validPatternWithEmptyResult(string $s, array $arr) {
+	$r = preg_replace('/(\D+)*[12]/', 'x', $s);
+	assertType('string|null', $r);
+
+	$r = preg_replace('/(\D+)*[12]/', 'x', $arr);
+	assertType('array', $r);
+}
+
+
+/**
+ * @return string
+ */
+function fooCallback(string $s)
+{
+	$r = preg_replace_callback('/^a/', function ($matches) {
+		return strtolower($matches[0]);
+	}, $s);
+	assertType('string|null', $r);
+	return $r;
+}


### PR DESCRIPTION
~Remove null-return on preg_replace() with valid patterns~
~Return benevolent union from preg_replace()~

closes https://github.com/phpstan/phpstan/issues/11547

requires https://github.com/phpstan/phpstan-src/pull/3339