### PR TITLE
Narrow string on strlen() == and === comparison with integer-range

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/count-type.php
+++ b/tests/PHPStan/Analyser/nsrt/count-type.php
@@ -18,4 +18,50 @@ class Foo
 		assertType('int<1, max>', sizeof($nonEmpty));
 	}
 
+	/**
+	 * @param int<3,5> $range
+	 * @param int<0,5> $maybeZero
+	 * @param int<-10,-5> $negative
+	 */
+	public function doFooBar(
+		array $arr,
+		int $range,
+		int $maybeZero,
+		int $negative
+	)
+	{
+		if (count($arr) == $range) {
+			assertType('non-empty-array', $arr);
+		} else {
+			assertType('array', $arr);
+		}
+		if (count($arr) === $range) {
+			assertType('non-empty-array', $arr);
+		} else {
+			assertType('array', $arr);
+		}
+
+		if (count($arr) == $maybeZero) {
+			assertType('array', $arr);
+		} else {
+			assertType('non-empty-array', $arr);
+		}
+		if (count($arr) === $maybeZero) {
+			assertType('array', $arr);
+		} else {
+			assertType('non-empty-array', $arr);
+		}
+
+		if (count($arr) == $negative) {
+			assertType('*NEVER*', $arr);
+		} else {
+			assertType('array', $arr);
+		}
+		if (count($arr) === $negative) {
+			assertType('*NEVER*', $arr);
+		} else {
+			assertType('array', $arr);
+		}
+	}
+
 }

--- a/tests/PHPStan/Analyser/nsrt/strlen-int-range.php
+++ b/tests/PHPStan/Analyser/nsrt/strlen-int-range.php
@@ -9,9 +9,11 @@ use function PHPStan\Testing\assertType;
  * @param int<2, 3> $twoOrThree
  * @param int<2, max> $twoOrMore
  * @param int<min, 3> $maxThree
- * @param int<10, 11> $tenOrEleven
+ * @param 10|11 $tenOrEleven
+ * @param 0|11 $zeroOrEleven
+ * @param int<-10,-5> $negative
  */
-function doFoo(string $s, $zeroToThree, $twoOrThree, $twoOrMore, int $maxThree, $tenOrEleven): void
+function doFoo(string $s, $zeroToThree, $twoOrThree, $twoOrMore, int $maxThree, $tenOrEleven, $zeroOrEleven, int $negative): void
 {
 	if (strlen($s) >= $zeroToThree) {
 		assertType('string', $s);
@@ -50,5 +52,64 @@ function doFoo(string $s, $zeroToThree, $twoOrThree, $twoOrMore, int $maxThree, 
 
 	if (strlen($s) > $tenOrEleven) {
 		assertType('non-falsy-string', $s);
+	}
+
+	if (strlen($s) == $zeroToThree) {
+		assertType('string', $s);
+	}
+	if (strlen($s) === $zeroToThree) {
+		assertType('string', $s);
+	}
+
+	if (strlen($s) == $twoOrThree) {
+		assertType('non-falsy-string', $s);
+	}
+	if (strlen($s) === $twoOrThree) {
+		assertType('non-falsy-string', $s);
+	}
+
+	if (strlen($s) == $oneOrMore) {
+		assertType('string', $s); // could be non-empty-string
+	}
+	if (strlen($s) === $oneOrMore) {
+		assertType('string', $s); // could be non-empty-string
+	}
+
+	if (strlen($s) == $tenOrEleven) {
+		assertType('non-falsy-string', $s);
+	}
+	if (strlen($s) === $tenOrEleven) {
+		assertType('non-falsy-string', $s);
+	}
+	if ($tenOrEleven == strlen($s)) {
+		assertType('non-falsy-string', $s);
+	}
+	if ($tenOrEleven === strlen($s)) {
+		assertType('non-falsy-string', $s);
+	}
+
+	if (strlen($s) == $maxThree) {
+		assertType('string', $s);
+	}
+	if (strlen($s) === $maxThree) {
+		assertType('string', $s);
+	}
+
+	if (strlen($s) == $zeroOrEleven) {
+		assertType('string', $s);
+	}
+	if (strlen($s) === $zeroOrEleven) {
+		assertType('string', $s);
+	}
+
+	if (strlen($s) == $negative) {
+		assertType('*NEVER*', $s);
+	} else {
+		assertType('string', $s);
+	}
+	if (strlen($s) === $negative) {
+		assertType('*NEVER*', $s);
+	} else {
+		assertType('string', $s);
 	}
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11548

----

after implementing I realized this also makes `count($arr) == integer-range` narrow to `non-empty-array`