### PR TITLE
Move result cache output from debug to very verbose mode

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -287,7 +287,7 @@ final class ResultCacheManager
 		$filesToAnalyse = array_unique($filesToAnalyse);
 		$filesToAnalyseCount = count($filesToAnalyse);
 
-		if ($output->isVerbose()) {
+		if ($output->isVeryVerbose()) {
 			$elapsed = microtime(true) - $startTime;
 			$elapsedString = $elapsed > 5
 				? sprintf(' in %f seconds', round($elapsed, 1))

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -412,20 +412,20 @@ final class ResultCacheManager
 		}
 		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, ?array $dependencies, array $exportedNodes, array $projectExtensionFiles) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): bool {
 			if ($onlyFiles) {
-				if ($output->isDebug()) {
+				if ($output->isVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because only files were passed as analysed paths.');
 				}
 				return false;
 			}
 			if ($dependencies === null) {
-				if ($output->isDebug()) {
+				if ($output->isVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of error in dependencies.');
 				}
 				return false;
 			}
 
 			if (count($internalErrors) > 0) {
-				if ($output->isDebug()) {
+				if ($output->isVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of internal errors.');
 				}
 				return false;
@@ -437,7 +437,7 @@ final class ResultCacheManager
 						continue;
 					}
 
-					if ($output->isDebug()) {
+					if ($output->isVerbose()) {
 						$output->writeLineFormatted(sprintf('Result cache was not saved because of non-ignorable exception: %s', $error->getMessage()));
 					}
 
@@ -447,7 +447,7 @@ final class ResultCacheManager
 
 			$this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $exportedNodes, $projectExtensionFiles, $meta);
 
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted('Result cache is saved.');
 			}
 
@@ -463,7 +463,7 @@ final class ResultCacheManager
 				}
 				$saved = $doSave($freshErrorsByFile, $freshLocallyIgnoredErrorsByFile, $analyserResult->getLinesToIgnore(), $analyserResult->getUnmatchedLineIgnores(), $freshCollectedDataByFile, $analyserResult->getDependencies(), $analyserResult->getExportedNodes(), $projectExtensionFiles);
 			} else {
-				if ($output->isDebug()) {
+				if ($output->isVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because it was not requested.');
 				}
 			}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -159,7 +159,7 @@ final class ResultCacheManager
 				continue;
 			}
 			if (!is_file($extensionFile)) {
-				if ($output->isVerbose()) {
+				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted(sprintf('Result cache not used because extension file %s was not found.', $extensionFile));
 				}
 				return new ResultCache($allAnalysedFiles, true, time(), $meta, [], [], [], [], [], [], [], []);
@@ -169,7 +169,7 @@ final class ResultCacheManager
 				continue;
 			}
 
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted(sprintf('Result cache not used because extension file %s hash does not match.', $extensionFile));
 			}
 
@@ -437,7 +437,7 @@ final class ResultCacheManager
 						continue;
 					}
 
-					if ($output->isVerbose()) {
+					if ($output->isVeryVerbose()) {
 						$output->writeLineFormatted(sprintf('Result cache was not saved because of non-ignorable exception: %s', $error->getMessage()));
 					}
 

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -92,13 +92,13 @@ final class ResultCacheManager
 	{
 		$startTime = microtime(true);
 		if ($debug) {
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache not used because of debug mode.');
 			}
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], [], [], [], [], []);
 		}
 		if ($onlyFiles) {
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache not used because only files were passed as analysed paths.');
 			}
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], [], [], [], [], []);
@@ -106,7 +106,7 @@ final class ResultCacheManager
 
 		$cacheFilePath = $this->cacheFilePath;
 		if (!is_file($cacheFilePath)) {
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache not used because the cache file does not exist.');
 			}
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], [], [], [], [], []);
@@ -115,7 +115,7 @@ final class ResultCacheManager
 		try {
 			$data = require $cacheFilePath;
 		} catch (Throwable $e) {
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted(sprintf('Result cache not used because an error occurred while loading the cache file: %s', $e->getMessage()));
 			}
 
@@ -126,7 +126,7 @@ final class ResultCacheManager
 
 		if (!is_array($data)) {
 			@unlink($cacheFilePath);
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache not used because the cache file is corrupted.');
 			}
 
@@ -135,7 +135,7 @@ final class ResultCacheManager
 
 		$meta = $this->getMeta($allAnalysedFiles, $projectConfigArray);
 		if ($this->isMetaDifferent($data['meta'], $meta)) {
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$diffs = $this->getMetaKeyDifferences($data['meta'], $meta);
 				$output->writeLineFormatted('Result cache not used because the metadata do not match: ' . implode(', ', $diffs));
 			}
@@ -143,7 +143,7 @@ final class ResultCacheManager
 		}
 
 		if (time() - $data['lastFullAnalysisTime'] >= 60 * 60 * 24 * 7) {
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache not used because it\'s more than 7 days since last full analysis.');
 			}
 			// run full analysis if the result cache is older than 7 days
@@ -412,20 +412,20 @@ final class ResultCacheManager
 		}
 		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, ?array $dependencies, array $exportedNodes, array $projectExtensionFiles) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): bool {
 			if ($onlyFiles) {
-				if ($output->isVerbose()) {
+				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because only files were passed as analysed paths.');
 				}
 				return false;
 			}
 			if ($dependencies === null) {
-				if ($output->isVerbose()) {
+				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of error in dependencies.');
 				}
 				return false;
 			}
 
 			if (count($internalErrors) > 0) {
-				if ($output->isVerbose()) {
+				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because of internal errors.');
 				}
 				return false;
@@ -447,7 +447,7 @@ final class ResultCacheManager
 
 			$this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $exportedNodes, $projectExtensionFiles, $meta);
 
-			if ($output->isVerbose()) {
+			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache is saved.');
 			}
 
@@ -463,7 +463,7 @@ final class ResultCacheManager
 				}
 				$saved = $doSave($freshErrorsByFile, $freshLocallyIgnoredErrorsByFile, $analyserResult->getLinesToIgnore(), $analyserResult->getUnmatchedLineIgnores(), $freshCollectedDataByFile, $analyserResult->getDependencies(), $analyserResult->getExportedNodes(), $projectExtensionFiles);
 			} else {
-				if ($output->isVerbose()) {
+				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because it was not requested.');
 				}
 			}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -92,13 +92,13 @@ final class ResultCacheManager
 	{
 		$startTime = microtime(true);
 		if ($debug) {
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted('Result cache not used because of debug mode.');
 			}
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], [], [], [], [], []);
 		}
 		if ($onlyFiles) {
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted('Result cache not used because only files were passed as analysed paths.');
 			}
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], [], [], [], [], []);
@@ -106,7 +106,7 @@ final class ResultCacheManager
 
 		$cacheFilePath = $this->cacheFilePath;
 		if (!is_file($cacheFilePath)) {
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted('Result cache not used because the cache file does not exist.');
 			}
 			return new ResultCache($allAnalysedFiles, true, time(), $this->getMeta($allAnalysedFiles, $projectConfigArray), [], [], [], [], [], [], [], []);
@@ -115,7 +115,7 @@ final class ResultCacheManager
 		try {
 			$data = require $cacheFilePath;
 		} catch (Throwable $e) {
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted(sprintf('Result cache not used because an error occurred while loading the cache file: %s', $e->getMessage()));
 			}
 
@@ -126,7 +126,7 @@ final class ResultCacheManager
 
 		if (!is_array($data)) {
 			@unlink($cacheFilePath);
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted('Result cache not used because the cache file is corrupted.');
 			}
 
@@ -135,7 +135,7 @@ final class ResultCacheManager
 
 		$meta = $this->getMeta($allAnalysedFiles, $projectConfigArray);
 		if ($this->isMetaDifferent($data['meta'], $meta)) {
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$diffs = $this->getMetaKeyDifferences($data['meta'], $meta);
 				$output->writeLineFormatted('Result cache not used because the metadata do not match: ' . implode(', ', $diffs));
 			}
@@ -143,7 +143,7 @@ final class ResultCacheManager
 		}
 
 		if (time() - $data['lastFullAnalysisTime'] >= 60 * 60 * 24 * 7) {
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted('Result cache not used because it\'s more than 7 days since last full analysis.');
 			}
 			// run full analysis if the result cache is older than 7 days
@@ -159,7 +159,7 @@ final class ResultCacheManager
 				continue;
 			}
 			if (!is_file($extensionFile)) {
-				if ($output->isDebug()) {
+				if ($output->isVerbose()) {
 					$output->writeLineFormatted(sprintf('Result cache not used because extension file %s was not found.', $extensionFile));
 				}
 				return new ResultCache($allAnalysedFiles, true, time(), $meta, [], [], [], [], [], [], [], []);
@@ -169,7 +169,7 @@ final class ResultCacheManager
 				continue;
 			}
 
-			if ($output->isDebug()) {
+			if ($output->isVerbose()) {
 				$output->writeLineFormatted(sprintf('Result cache not used because extension file %s hash does not match.', $extensionFile));
 			}
 
@@ -287,7 +287,7 @@ final class ResultCacheManager
 		$filesToAnalyse = array_unique($filesToAnalyse);
 		$filesToAnalyseCount = count($filesToAnalyse);
 
-		if ($output->isDebug()) {
+		if ($output->isVerbose()) {
 			$elapsed = microtime(true) - $startTime;
 			$elapsedString = $elapsed > 5
 				? sprintf(' in %f seconds', round($elapsed, 1))

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -60,7 +60,7 @@ final class AnalyseApplication
 			$collectedData = [];
 			$savedResultCache = false;
 			$memoryUsageBytes = memory_get_peak_usage(true);
-			if ($errorOutput->isDebug()) {
+			if ($errorOutput->isVerbose()) {
 				$errorOutput->writeLineFormatted('Result cache was not saved because of ignoredErrorHelperResult errors.');
 			}
 			$changedProjectExtensionFilesOutsideOfAnalysedPaths = [];

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -60,7 +60,7 @@ final class AnalyseApplication
 			$collectedData = [];
 			$savedResultCache = false;
 			$memoryUsageBytes = memory_get_peak_usage(true);
-			if ($errorOutput->isVerbose()) {
+			if ($errorOutput->isVeryVerbose()) {
 				$errorOutput->writeLineFormatted('Result cache was not saved because of ignoredErrorHelperResult errors.');
 			}
 			$changedProjectExtensionFilesOutsideOfAnalysedPaths = [];


### PR DESCRIPTION
Since there are more and more `DiagnoseExtensions` with spammy output being added, we are switching from `-vvv` to `-vv` mode. But I think result cache info is still pretty important even when debug mode is not enabled, so I changed it.