### PR TITLE
Improve curl_init() return type analysis

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -327,4 +327,12 @@ class PhpVersion
 		return $this->versionId >= 80300;
 	}
 
+	public function isCurloptUrlCheckingFileSchemeWithOpenBasedir(): bool
+	{
+		// Before PHP 8.0, when setting CURLOPT_URL, an unparsable URL or a file:// scheme would fail if open_basedir is used
+		// https://github.com/php/php-src/blob/php-7.4.33/ext/curl/interface.c#L139-L158
+		// https://github.com/php/php-src/blob/php-8.0.0/ext/curl/interface.c#L128-L130
+		return $this->versionId < 80000;
+	}
+
 }

--- a/src/Type/Php/CurlInitReturnTypeExtension.php
+++ b/src/Type/Php/CurlInitReturnTypeExtension.php
@@ -81,7 +81,7 @@ class CurlInitReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 			// https://github.com/php/php-src/blob/php-8.0.0/ext/curl/interface.c#L104-L107
 			return new NeverType();
 		}
-		if ($this->phpVersion->getVersionId() < 80000) {
+		if ($this->phpVersion->isCurloptUrlCheckingFileSchemeWithOpenBasedir()) {
 			// Before PHP 8.0 an unparsable URL or a file:// scheme would fail if open_basedir is used
 			// Since we can't detect open_basedir properly, we'll always consider a failure possible if these
 			//   conditions are given

--- a/src/Type/Php/CurlInitReturnTypeExtension.php
+++ b/src/Type/Php/CurlInitReturnTypeExtension.php
@@ -4,16 +4,31 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
+use function is_string;
+use function parse_url;
+use function str_contains;
+use function strcasecmp;
+use function strlen;
 
 class CurlInitReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	/** @see https://github.com/curl/curl/blob/curl-8_9_1/lib/urldata.h#L135 */
+	private const CURL_MAX_INPUT_LENGTH = 8000000;
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -26,10 +41,49 @@ class CurlInitReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 		Scope $scope,
 	): Type
 	{
-		$argsCount = count($functionCall->getArgs());
+		$args = $functionCall->getArgs();
+		$argsCount = count($args);
 		$returnType = ParametersAcceptorSelector::selectSingle($functionReflection->getVariants())->getReturnType();
+		$notFalseReturnType = TypeCombinator::remove($returnType, new ConstantBooleanType(false));
 		if ($argsCount === 0) {
-			return TypeCombinator::remove($returnType, new ConstantBooleanType(false));
+			return $notFalseReturnType;
+		}
+
+		$urlArgType = $scope->getType($args[0]->value);
+		if ($urlArgType->isNull()->yes()) {
+			return $notFalseReturnType;
+		}
+		if ($urlArgType->isString()->yes()) {
+			$urlArgValue = $urlArgType->getConstantScalarValues()[0] ?? null;
+			if ($urlArgValue !== null) {
+				if (!is_string($urlArgValue)) {
+					throw new ShouldNotHappenException();
+				}
+				if (str_contains($urlArgValue, "\0")) {
+					if (!$this->phpVersion->throwsValueErrorForInternalFunctions()) {
+						// https://github.com/php/php-src/blob/php-7.4.33/ext/curl/interface.c#L112-L115
+						return new ConstantBooleanType(false);
+					}
+					// https://github.com/php/php-src/blob/php-8.0.0/ext/curl/interface.c#L104-L107
+					return new NeverType();
+				}
+				if ($this->phpVersion->getVersionId() < 80000) {
+					// Before PHP 8.0 an unparsable URL or a file:// scheme would fail if open_basedir is used
+					// Since we can't detect open_basedir properly, we'll always consider a failure possible if these
+					//   conditions are given
+					// https://github.com/php/php-src/blob/php-7.4.33/ext/curl/interface.c#L139-L158
+					$parsedUrlArg = parse_url($urlArgValue);
+					if ($parsedUrlArg === false || (isset($parsedUrlArg['scheme']) && strcasecmp($parsedUrlArg['scheme'], 'file') === 0)) {
+						return $returnType;
+					}
+				}
+				if (strlen($urlArgValue) > self::CURL_MAX_INPUT_LENGTH) {
+					// Since libcurl 7.65.0 this would always fail, but no current PHP version requires it at the moment
+					// https://github.com/curl/curl/commit/5fc28510a4664f46459d9a40187d81cc08571e60
+					return $returnType;
+				}
+				return $notFalseReturnType;
+			}
 		}
 
 		return $returnType;

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -3088,6 +3088,42 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'curl_init($string)',
 			],
 			[
+				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
+				'curl_init(null)',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
+				'curl_init(\'https://phpstan.org\')',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
+				"curl_init('\0')",
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
+				"curl_init('https://phpstan.org\0')",
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
+				'curl_init(\'\')',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle',
+				'curl_init(\':\')',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle',
+				'curl_init(\'file://host/text.txt\')',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle',
+				'curl_init(\'FIle://host/text.txt\')',
+			],
+			[
+				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
+				'curl_init(\'host/text.txt\')',
+			],
+			[
 				'string',
 				'sprintf($string, $string, 1)',
 			],

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -3080,50 +3080,6 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_key_exists(\'foo\', $generalArray)',
 			],
 			[
-				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
-				'curl_init()',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle|false',
-				'curl_init($string)',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
-				'curl_init(null)',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
-				'curl_init(\'https://phpstan.org\')',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
-				"curl_init('\0')",
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'false' : '*NEVER*',
-				"curl_init('https://phpstan.org\0')",
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
-				'curl_init(\'\')',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle',
-				'curl_init(\':\')',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle',
-				'curl_init(\'file://host/text.txt\')',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource|false' : 'CurlHandle',
-				'curl_init(\'FIle://host/text.txt\')',
-			],
-			[
-				PHP_VERSION_ID < 80000 ? 'resource' : 'CurlHandle',
-				'curl_init(\'host/text.txt\')',
-			],
-			[
 				'string',
 				'sprintf($string, $string, 1)',
 			],

--- a/tests/PHPStan/Type/Php/CurlInitReturnTypeExtensionTest.php
+++ b/tests/PHPStan/Type/Php/CurlInitReturnTypeExtensionTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use const PHP_VERSION_ID;
+
+class CurlInitReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		if (PHP_VERSION_ID < 80000) {
+			yield from self::gatherAssertTypes(__DIR__ . '/data/curl-init-php-7.php');
+		} else {
+			yield from self::gatherAssertTypes(__DIR__ . '/data/curl-init-php-8.php');
+		}
+	}
+
+	/**
+	 * @dataProvider dataFileAsserts
+	 */
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		mixed ...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+}

--- a/tests/PHPStan/Type/Php/data/curl-init-php-7.php
+++ b/tests/PHPStan/Type/Php/data/curl-init-php-7.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace CurlInitReturnTypeExtensionTestPhp7;
+
+use function PHPStan\Testing\assertType;
+
+function (string $unknownString) {
+	assertType('resource', curl_init());
+	assertType('resource', curl_init('https://phpstan.org'));
+	assertType('resource|false', curl_init($unknownString));
+	assertType('resource', curl_init(null));
+	assertType('resource', curl_init(''));
+	assertType('resource|false', curl_init(':'));
+	assertType('resource|false', curl_init('file://host/text.txt'));
+	assertType('resource|false', curl_init('FIle://host/text.txt'));
+	assertType('resource', curl_init('host/text.txt'));
+	assertType('false', curl_init("\0"));
+	assertType('false', curl_init("https://phpstan.org\0"));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = null;
+	assertType('resource', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'https://phpstan.org/try';
+	assertType('resource', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = "\0";
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = "https://phpstan.org\0";
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = $unknownString;
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = ':';
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'file://host/text.txt';
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'FIle://host/text.txt';
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'host/text.txt';
+	assertType('resource', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'file://host/text.txt';
+	if (rand(0,1)) $url = null;
+	assertType('resource|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = null;
+	if (rand(0,1)) $url = $unknownString;
+	assertType('resource|false', curl_init($url));
+};

--- a/tests/PHPStan/Type/Php/data/curl-init-php-8.php
+++ b/tests/PHPStan/Type/Php/data/curl-init-php-8.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace CurlInitReturnTypeExtensionTestPhp8;
+
+use function PHPStan\Testing\assertType;
+
+function (string $unknownString) {
+	assertType('CurlHandle', curl_init());
+	assertType('CurlHandle', curl_init('https://phpstan.org'));
+	assertType('CurlHandle|false', curl_init($unknownString));
+	assertType('CurlHandle', curl_init(null));
+	assertType('CurlHandle', curl_init(''));
+	assertType('CurlHandle', curl_init(':'));
+	assertType('CurlHandle', curl_init('file://host/text.txt'));
+	assertType('CurlHandle', curl_init('FIle://host/text.txt'));
+	assertType('CurlHandle', curl_init('host/text.txt'));
+	assertType('*NEVER*', curl_init("\0"));
+	assertType('*NEVER*', curl_init("https://phpstan.org\0"));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = null;
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'https://phpstan.org/try';
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = "\0";
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = "https://phpstan.org\0";
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = $unknownString;
+	assertType('CurlHandle|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url .= $unknownString;
+	assertType('CurlHandle|false', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = ':';
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'file://host/text.txt';
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'FIle://host/text.txt';
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'host/text.txt';
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = 'file://host/text.txt';
+	if (rand(0,1)) $url = null;
+	assertType('CurlHandle', curl_init($url));
+
+	$url = 'https://phpstan.org';
+	if (rand(0,1)) $url = null;
+	if (rand(0,1)) $url = $unknownString;
+	assertType('CurlHandle|false', curl_init($url));
+};


### PR DESCRIPTION
I got annoyed by the failing e2e/php8 test (https://github.com/phpstan/phpstan/blob/1.12.x/e2e/php8/test.php#L11, https://phpstan.org/r/32a5c25f-c266-4c04-9bf1-2ec0562397d8), so I wanted to resolve it by restoring the expected issue there. (But only now do I notice that this doesn't help that at all - I completely misunderstood the issue there :P)

Following, https://github.com/phpstan/phpstan/issues/1274, https://github.com/phpstan/phpstan/issues/1465, https://github.com/phpstan/phpstan/pull/1484 I looked into `curl_init()` a bit more.

Here's my analysis: (with verified behavior across all latest PHP minor versions and libcurl 7.10.5 + 8.9.1)
One important point to start with, if we presume that `curl_init()` without arguments never returns `false`, we generally ignore initialization errors or the case where curl fails to allocate more memory.
- `curl_init()` with a string argument will only return false if it fails to set `CURLOPT_URL` with it
  https://github.com/php/php-src/blob/php-8.4.0beta3/ext/curl/interface.c#L1154-L1159
- On PHP >= 8.0 Setting `CURLOPT_URL` will fail with a value error on the PHP side if the URL contains a null byte
  https://github.com/php/php-src/blob/php-8.4.0beta3/ext/curl/interface.c#L139
  https://github.com/php/php-src/blob/php-8.0.30/ext/curl/interface.c#L104-L107
- On PHP < 8.0 Setting `CURLOPT_URL` will fail with a warning (`false` return) on the PHP side if the URL contains a null byte
  https://github.com/php/php-src/blob/php-7.4.33/ext/curl/interface.c#L112-L115
  But, if open_basedir is enabled, it will also fail when the URL is invalid or uses the `file` scheme
  https://github.com/php/php-src/blob/php-7.4.33/ext/curl/interface.c#L146-L155
- On the side of libcurl, setting the URL option will only fail if the input exceeds a relatively high limit, but only since version 7.65.0 (https://github.com/curl/curl/commit/5fc28510a4664f46459d9a40187d81cc08571e60)
  https://github.com/curl/curl/blob/curl-8_9_1/lib/setopt.c#L3256
  https://github.com/curl/curl/blob/curl-8_9_1/lib/setopt.c#L1470
  https://github.com/curl/curl/blob/curl-8_9_1/lib/setopt.c#L70-L71