### PR TITLE
RoundFunctionReturnTypeExtension supports types with ConstantScalar

### DIFF
--- a/src/Type/Php/RoundFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RoundFunctionReturnTypeExtension.php
@@ -151,10 +151,9 @@ final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 				$precisionArg = $args[1]->value;
 				$precisionType = $scope->getType($precisionArg);
 				$precisions = $precisionType->getConstantScalarValues();
-				if (count($precisions) !== 1) {
+				if (count($precisions) !== 1 || !is_int($precisions[0])) {
 					return null;
 				}
-
 				$precision = $precisions[0];
 			} else {
 				$precision = 0;
@@ -168,7 +167,7 @@ final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 			$modeType = $scope->getType($modeArg);
 			$mode = $modeType->getConstantScalarValues();
 
-			if (count($mode) === 1) {
+			if (count($mode) === 1 && is_int($mode[0])) {
 				return static fn ($name) => round($name, $precision, $mode[0]);
 			}
 		}

--- a/src/Type/Php/RoundFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RoundFunctionReturnTypeExtension.php
@@ -29,6 +29,10 @@ use function in_array;
 use function is_float;
 use function is_int;
 use function round;
+use const PHP_ROUND_HALF_DOWN;
+use const PHP_ROUND_HALF_EVEN;
+use const PHP_ROUND_HALF_ODD;
+use const PHP_ROUND_HALF_UP;
 
 final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -146,7 +150,7 @@ final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 					$modeType = $scope->getType($modeArg);
 					$mode = $modeType->getConstantScalarValues();
 
-					if (count($mode) === 1 && is_int($mode[0])) {
+					if (count($mode) === 1 && in_array($mode[0], [PHP_ROUND_HALF_UP, PHP_ROUND_HALF_DOWN, PHP_ROUND_HALF_EVEN, PHP_ROUND_HALF_ODD], true)) {
 						$proc = static fn ($name) => round($name, $precision, $mode[0]);
 					}
 				}

--- a/src/Type/Php/RoundFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RoundFunctionReturnTypeExtension.php
@@ -21,7 +21,6 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use function array_map;
 use function ceil;
 use function count;
 use function floor;
@@ -107,7 +106,6 @@ final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 				// PHP 8 fatals if the parameter is not an integer or float.
 				return new NeverType(true);
 			}
-
 		} elseif ($firstArgType->isArray()->yes()) {
 			// PHP 7 returns false if the parameter is an array.
 			return new ConstantBooleanType(false);
@@ -174,7 +172,7 @@ final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 
 		if (count($returnValueTypes) >= 1) {
-			return TypeCombinator::union(...array_map(static fn ($l) => $l, $returnValueTypes));
+			return TypeCombinator::union(...$returnValueTypes);
 		}
 
 		return null;

--- a/tests/PHPStan/Analyser/nsrt/round-php8-strict-types.php
+++ b/tests/PHPStan/Analyser/nsrt/round-php8-strict-types.php
@@ -12,8 +12,8 @@ if (rand(0, 1)) {
 }
 
 // Round
-assertType('float', round(123));
-assertType('float', round(123.456));
+assertType('123.0', round(123));
+assertType('123.0', round(123.456));
 assertType('float', round($_GET['foo'] / 60));
 assertType('*NEVER*', round('123'));
 assertType('*NEVER*', round('123.456'));
@@ -29,8 +29,8 @@ assertType('*NEVER*', round());
 assertType('float', round($_GET['foo']));
 
 // Ceil
-assertType('float', ceil(123));
-assertType('float', ceil(123.456));
+assertType('123.0', ceil(123));
+assertType('124.0', ceil(123.456));
 assertType('float', ceil($_GET['foo'] / 60));
 assertType('*NEVER*', ceil('123'));
 assertType('*NEVER*', ceil('123.456'));
@@ -46,8 +46,8 @@ assertType('*NEVER*', ceil());
 assertType('float', ceil($_GET['foo']));
 
 // Floor
-assertType('float', floor(123));
-assertType('float', floor(123.456));
+assertType('123.0', floor(123));
+assertType('123.0', floor(123.456));
 assertType('float', floor($_GET['foo'] / 60));
 assertType('*NEVER*', floor('123'));
 assertType('*NEVER*', floor('123.456'));
@@ -61,3 +61,87 @@ assertType('*NEVER*', floor(array()));
 assertType('*NEVER*', floor(array(123)));
 assertType('*NEVER*', floor());
 assertType('float', floor($_GET['foo']));
+
+/**
+ * @param 1.11|2.22 $floatUnionA
+ * @param 1.5|2.5 $floatUnionB
+ * @param 1.1|2.2|5.5|6.6 $floatUnionC
+ */
+function constant(float $floatUnionA, float $floatUnionB, float $floatUnionC)
+{
+	assertType('3.0', round(3.4));
+	assertType('4.0', round(3.5));
+	assertType('4.0', round(3.6));
+	assertType('4.0', round(3.6, 0));
+	assertType('5.05', round(5.045, 2));
+	assertType('5.06', round(5.055, 2));
+	assertType('300.0', round(345, -2));
+	assertType('0.0', round(345, -3));
+	assertType('700.0', round(678, -2));
+	assertType('1000.0', round(678, -3));
+
+	assertType('1.1|2.2', round($floatUnionA, 1));
+	assertType('1.1|2.2', round($floatUnionA, 1, PHP_ROUND_HALF_UP));
+	assertType('1.0|2.0', round($floatUnionA, mode: PHP_ROUND_HALF_UP));
+	assertType('2.0|3.0', round($floatUnionB, mode: PHP_ROUND_HALF_UP));
+	assertType('1.0|2.0', round($floatUnionB, mode: PHP_ROUND_HALF_DOWN));
+	assertType('1.0|2.0|5.0|6.0', floor($floatUnionC));
+
+	$number = 135.79;
+	assertType('135.79', round($number, 3));
+	assertType('135.79', round($number, 2));
+	assertType('135.8', round($number, 1));
+	assertType('136.0', round($number, 0));
+	assertType('140.0', round($number, -1));
+	assertType('100.0', round($number, -2));
+	assertType('0.0', round($number, -3));
+
+	// Rounding modes with 9.5
+	assertType('10.0', round(9.5, 0, PHP_ROUND_HALF_UP));
+	assertType('9.0', round(9.5, 0, PHP_ROUND_HALF_DOWN));
+	assertType('10.0', round(9.5, 0, PHP_ROUND_HALF_EVEN));
+	assertType('9.0', round(9.5, 0, PHP_ROUND_HALF_ODD));
+
+	// Rounding modes with 8.5
+	assertType('9.0', round(8.5, 0, PHP_ROUND_HALF_UP));
+	assertType('8.0', round(8.5, 0, PHP_ROUND_HALF_DOWN));
+	assertType('8.0', round(8.5, 0, PHP_ROUND_HALF_EVEN));
+	assertType('9.0', round(8.5, 0, PHP_ROUND_HALF_ODD));
+
+	// Using PHP_ROUND_HALF_UP with 1 decimal digit precision
+	assertType('1.6', round( 1.55, 1, PHP_ROUND_HALF_UP));
+	assertType('-1.6', round(-1.55, 1, PHP_ROUND_HALF_UP));
+
+	// Using PHP_ROUND_HALF_DOWN with 1 decimal digit precision
+	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_DOWN));
+	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_DOWN));
+
+	// Using PHP_ROUND_HALF_EVEN with 1 decimal digit precision
+	assertType('1.6', round( 1.55, 1, PHP_ROUND_HALF_EVEN));
+	assertType('-1.6', round(-1.55, 1, PHP_ROUND_HALF_EVEN));
+
+	// Using PHP_ROUND_HALF_ODD with 1 decimal digit precision
+	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_ODD));
+	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_ODD));
+}
+
+/**
+ * @param 1.11|2.22 $floatUnion
+ * @param 2|3 $precisionUnion
+ * @param 2|4 $modeUnion
+ * @param 1|'2.5' $IntOrNumStr
+ * @param 1.11|'2.22' $floatOrNumStr
+ */
+function notConstant(float $floatUnion, float $precisionUnion, float $modeUnion, $IntOrNumStr, $floatOrNumStr)
+{
+	assertType('float', round($floatUnion, $precisionUnion, PHP_ROUND_HALF_UP));
+	assertType('float', round($floatUnion, 0, $modeUnion));
+
+	assertType('float', round($IntOrNumStr));
+	assertType('float', round($IntOrNumStr, mode: PHP_ROUND_HALF_UP));
+	assertType('float', round($IntOrNumStr, mode: PHP_ROUND_HALF_DOWN));
+
+	assertType('float', round($floatOrNumStr));
+	assertType('float', round($floatOrNumStr, mode: PHP_ROUND_HALF_UP));
+	assertType('float', round($floatOrNumStr, mode: PHP_ROUND_HALF_DOWN));
+}

--- a/tests/PHPStan/Analyser/nsrt/round-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/round-php8.php
@@ -59,3 +59,42 @@ assertType('*NEVER*', floor(array()));
 assertType('*NEVER*', floor(array(123)));
 assertType('*NEVER*', floor());
 assertType('float', floor($_GET['foo']));
+
+/**
+ * @param 1.1|2.2|5.5|6.6 $n
+ */
+function f(float $n): void
+{
+	assertType('1.0|2.0|5.0|6.0', floor($n));
+}
+
+
+/**
+ * @param 1.11|2.22 $n
+ * @param 2|3 $m
+ * @param 2|4 $p
+ * @param 1.5|2.5 $q
+ */
+function g(float $n,float $m ,float $p , float $q): void
+{
+	assertType('1.1|2.2', round($n,1));
+	assertType('1.1|2.2', round($n,1,PHP_ROUND_HALF_UP));
+	assertType('float', round($n,$m,PHP_ROUND_HALF_UP));
+	assertType('float', round($n,0,$p));
+	assertType('1.1|2.2', round($n,1));
+	assertType('1.0|2.0', round($n,mode:PHP_ROUND_HALF_UP));
+	assertType('2.0|3.0', round($q,mode:PHP_ROUND_HALF_UP));
+	assertType('1.0|2.0', round($q,mode:PHP_ROUND_HALF_DOWN));
+
+//	assertType(3,round(3.4));
+//	assertType(4,round(3.5));
+//	assertType(4,round(3.6));
+//	assertType(4.round(3.6, 0));
+//	assertType(5.05.round(5.045, 2));
+//	assertType(5.06round(5.055, 2));
+//	assertType(round(300,345, -2));
+//	assertType(round(0,345, -3));
+//	assertType(round(700,678, -2));
+//	assertType(round(1000,678, -3));
+//	assertType('float', round($n,2,3));
+}

--- a/tests/PHPStan/Analyser/nsrt/round-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/round-php8.php
@@ -10,8 +10,8 @@ if (rand(0, 1)) {
 }
 
 // Round
-assertType('float', round(123));
-assertType('float', round(123.456));
+assertType('123.0', round(123));
+assertType('123.0', round(123.456));
 assertType('float', round($_GET['foo'] / 60));
 assertType('float', round('123'));
 assertType('float', round('123.456'));
@@ -27,8 +27,8 @@ assertType('*NEVER*', round());
 assertType('float', round($_GET['foo']));
 
 // Ceil
-assertType('float', ceil(123));
-assertType('float', ceil(123.456));
+assertType('123.0', ceil(123));
+assertType('124.0', ceil(123.456));
 assertType('float', ceil($_GET['foo'] / 60));
 assertType('float', ceil('123'));
 assertType('float', ceil('123.456'));
@@ -44,8 +44,8 @@ assertType('*NEVER*', ceil());
 assertType('float', ceil($_GET['foo']));
 
 // Floor
-assertType('float', floor(123));
-assertType('float', floor(123.456));
+assertType('123.0', floor(123));
+assertType('123.0', floor(123.456));
 assertType('float', floor($_GET['foo'] / 60));
 assertType('float', floor('123'));
 assertType('float', floor('123.456'));
@@ -86,15 +86,51 @@ function g(float $n,float $m ,float $p , float $q): void
 	assertType('2.0|3.0', round($q,mode:PHP_ROUND_HALF_UP));
 	assertType('1.0|2.0', round($q,mode:PHP_ROUND_HALF_DOWN));
 
-//	assertType(3,round(3.4));
-//	assertType(4,round(3.5));
-//	assertType(4,round(3.6));
-//	assertType(4.round(3.6, 0));
-//	assertType(5.05.round(5.045, 2));
-//	assertType(5.06round(5.055, 2));
-//	assertType(round(300,345, -2));
-//	assertType(round(0,345, -3));
-//	assertType(round(700,678, -2));
-//	assertType(round(1000,678, -3));
-//	assertType('float', round($n,2,3));
+	assertType('3.0', round(3.4));
+	assertType('4.0', round(3.5));
+	assertType('4.0', round(3.6));
+	assertType('4.0', round(3.6, 0));
+	assertType('5.05', round(5.045, 2));
+	assertType('5.06', round(5.055, 2));
+	assertType('300.0', round(345, -2));
+	assertType('0.0', round(345, -3));
+	assertType('700.0', round(678, -2));
+	assertType('1000.0', round(678, -3));
+
+	$number = 135.79;
+	assertType('135.79', round($number, 3));
+	assertType('135.79', round($number, 2));
+	assertType('135.8', round($number, 1));
+	assertType('136.0', round($number, 0));
+	assertType('140.0', round($number, -1));
+	assertType('100.0', round($number, -2));
+	assertType('0.0', round($number, -3));
+
+	// Rounding modes with 9.5
+	assertType('10.0', round(9.5, 0, PHP_ROUND_HALF_UP));
+	assertType('9.0', round(9.5, 0, PHP_ROUND_HALF_DOWN));
+	assertType('10.0', round(9.5, 0, PHP_ROUND_HALF_EVEN));
+	assertType('9.0', round(9.5, 0, PHP_ROUND_HALF_ODD));
+
+	// Rounding modes with 8.5
+	assertType('9.0', round(8.5, 0, PHP_ROUND_HALF_UP));
+	assertType('8.0', round(8.5, 0, PHP_ROUND_HALF_DOWN));
+	assertType('8.0', round(8.5, 0, PHP_ROUND_HALF_EVEN));
+	assertType('9.0', round(8.5, 0, PHP_ROUND_HALF_ODD));
+
+	// Using PHP_ROUND_HALF_UP with 1 decimal digit precision
+	assertType('1.6', round( 1.55, 1, PHP_ROUND_HALF_UP));
+	assertType('-1.6', round(-1.55, 1, PHP_ROUND_HALF_UP));
+
+	// Using PHP_ROUND_HALF_DOWN with 1 decimal digit precision
+	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_DOWN));
+	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_DOWN));
+
+	// Using PHP_ROUND_HALF_EVEN with 1 decimal digit precision
+	assertType('1.6', round( 1.55, 1, PHP_ROUND_HALF_EVEN));
+	assertType('-1.6', round(-1.55, 1, PHP_ROUND_HALF_EVEN));
+
+	// Using PHP_ROUND_HALF_ODD with 1 decimal digit precision
+	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_ODD));
+	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_ODD));
 }

--- a/tests/PHPStan/Analyser/nsrt/round-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/round-php8.php
@@ -61,31 +61,12 @@ assertType('*NEVER*', floor());
 assertType('float', floor($_GET['foo']));
 
 /**
- * @param 1.1|2.2|5.5|6.6 $n
+ * @param 1.11|2.22 $floatUnionA
+ * @param 1.5|2.5 $floatUnionB
+ * @param 1.1|2.2|5.5|6.6 $floatUnionC
  */
-function f(float $n): void
+function constant(float $floatUnionA, float $floatUnionB, float $floatUnionC)
 {
-	assertType('1.0|2.0|5.0|6.0', floor($n));
-}
-
-
-/**
- * @param 1.11|2.22 $n
- * @param 2|3 $m
- * @param 2|4 $p
- * @param 1.5|2.5 $q
- */
-function g(float $n,float $m ,float $p , float $q): void
-{
-	assertType('1.1|2.2', round($n,1));
-	assertType('1.1|2.2', round($n,1,PHP_ROUND_HALF_UP));
-	assertType('float', round($n,$m,PHP_ROUND_HALF_UP));
-	assertType('float', round($n,0,$p));
-	assertType('1.1|2.2', round($n,1));
-	assertType('1.0|2.0', round($n,mode:PHP_ROUND_HALF_UP));
-	assertType('2.0|3.0', round($q,mode:PHP_ROUND_HALF_UP));
-	assertType('1.0|2.0', round($q,mode:PHP_ROUND_HALF_DOWN));
-
 	assertType('3.0', round(3.4));
 	assertType('4.0', round(3.5));
 	assertType('4.0', round(3.6));
@@ -96,6 +77,13 @@ function g(float $n,float $m ,float $p , float $q): void
 	assertType('0.0', round(345, -3));
 	assertType('700.0', round(678, -2));
 	assertType('1000.0', round(678, -3));
+
+	assertType('1.1|2.2', round($floatUnionA, 1));
+	assertType('1.1|2.2', round($floatUnionA, 1, PHP_ROUND_HALF_UP));
+	assertType('1.0|2.0', round($floatUnionA, mode: PHP_ROUND_HALF_UP));
+	assertType('2.0|3.0', round($floatUnionB, mode: PHP_ROUND_HALF_UP));
+	assertType('1.0|2.0', round($floatUnionB, mode: PHP_ROUND_HALF_DOWN));
+	assertType('1.0|2.0|5.0|6.0', floor($floatUnionC));
 
 	$number = 135.79;
 	assertType('135.79', round($number, 3));
@@ -133,4 +121,25 @@ function g(float $n,float $m ,float $p , float $q): void
 	// Using PHP_ROUND_HALF_ODD with 1 decimal digit precision
 	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_ODD));
 	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_ODD));
+}
+
+/**
+ * @param 1.11|2.22 $floatUnion
+ * @param 2|3 $precisionUnion
+ * @param 2|4 $modeUnion
+ * @param 1|'2.5' $IntOrNumStr
+ * @param 1.11|'2.22' $floatOrNumStr
+ */
+function notConstant(float $floatUnion, float $precisionUnion, float $modeUnion, $IntOrNumStr, $floatOrNumStr)
+{
+	assertType('float', round($floatUnion, $precisionUnion, PHP_ROUND_HALF_UP));
+	assertType('float', round($floatUnion, 0, $modeUnion));
+
+	assertType('float', round($IntOrNumStr));
+	assertType('float', round($IntOrNumStr, mode: PHP_ROUND_HALF_UP));
+	assertType('float', round($IntOrNumStr, mode: PHP_ROUND_HALF_DOWN));
+
+	assertType('float', round($floatOrNumStr));
+	assertType('float', round($floatOrNumStr, mode: PHP_ROUND_HALF_UP));
+	assertType('float', round($floatOrNumStr, mode: PHP_ROUND_HALF_DOWN));
 }

--- a/tests/PHPStan/Analyser/nsrt/round.php
+++ b/tests/PHPStan/Analyser/nsrt/round.php
@@ -10,8 +10,8 @@ if (rand(0, 1)) {
 }
 
 // Round
-assertType('float', round(123));
-assertType('float', round(123.456));
+assertType('123.0', round(123));
+assertType('123.0', round(123.456));
 assertType('float', round($_GET['foo'] / 60));
 assertType('float', round('123'));
 assertType('float', round('123.456'));
@@ -27,8 +27,8 @@ assertType('null', round());
 assertType('(float|false)', round($_GET['foo']));
 
 // Ceil
-assertType('float', ceil(123));
-assertType('float', ceil(123.456));
+assertType('123.0', ceil(123));
+assertType('124.0', ceil(123.456));
 assertType('float', ceil($_GET['foo'] / 60));
 assertType('float', ceil('123'));
 assertType('float', ceil('123.456'));
@@ -44,8 +44,8 @@ assertType('null', ceil());
 assertType('(float|false)', ceil($_GET['foo']));
 
 // Floor
-assertType('float', floor(123));
-assertType('float', floor(123.456));
+assertType('123.0', floor(123));
+assertType('123.0', floor(123.456));
 assertType('float', floor($_GET['foo'] / 60));
 assertType('float', floor('123'));
 assertType('float', floor('123.456'));
@@ -59,3 +59,79 @@ assertType('false', floor(array()));
 assertType('false', floor(array(123)));
 assertType('null', floor());
 assertType('(float|false)', floor($_GET['foo']));
+
+/**
+ * @param 1.11|2.22 $floatUnionA
+ * @param 1.5|2.5 $floatUnionB
+ * @param 1.1|2.2|5.5|6.6 $floatUnionC
+ */
+function constant(float $floatUnionA, float $floatUnionB, float $floatUnionC)
+{
+	assertType('3.0', round(3.4));
+	assertType('4.0', round(3.5));
+	assertType('4.0', round(3.6));
+	assertType('4.0', round(3.6, 0));
+	assertType('5.05', round(5.045, 2));
+	assertType('5.06', round(5.055, 2));
+	assertType('300.0', round(345, -2));
+	assertType('0.0', round(345, -3));
+	assertType('700.0', round(678, -2));
+	assertType('1000.0', round(678, -3));
+
+	assertType('1.1|2.2', round($floatUnionA, 1));
+	assertType('1.1|2.2', round($floatUnionA, 1, PHP_ROUND_HALF_UP));
+	assertType('1.0|2.0|5.0|6.0', floor($floatUnionC));
+
+	$number = 135.79;
+	assertType('135.79', round($number, 3));
+	assertType('135.79', round($number, 2));
+	assertType('135.8', round($number, 1));
+	assertType('136.0', round($number, 0));
+	assertType('140.0', round($number, -1));
+	assertType('100.0', round($number, -2));
+	assertType('0.0', round($number, -3));
+
+	// Rounding modes with 9.5
+	assertType('10.0', round(9.5, 0, PHP_ROUND_HALF_UP));
+	assertType('9.0', round(9.5, 0, PHP_ROUND_HALF_DOWN));
+	assertType('10.0', round(9.5, 0, PHP_ROUND_HALF_EVEN));
+	assertType('9.0', round(9.5, 0, PHP_ROUND_HALF_ODD));
+
+	// Rounding modes with 8.5
+	assertType('9.0', round(8.5, 0, PHP_ROUND_HALF_UP));
+	assertType('8.0', round(8.5, 0, PHP_ROUND_HALF_DOWN));
+	assertType('8.0', round(8.5, 0, PHP_ROUND_HALF_EVEN));
+	assertType('9.0', round(8.5, 0, PHP_ROUND_HALF_ODD));
+
+	// Using PHP_ROUND_HALF_UP with 1 decimal digit precision
+	assertType('1.6', round( 1.55, 1, PHP_ROUND_HALF_UP));
+	assertType('-1.6', round(-1.55, 1, PHP_ROUND_HALF_UP));
+
+	// Using PHP_ROUND_HALF_DOWN with 1 decimal digit precision
+	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_DOWN));
+	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_DOWN));
+
+	// Using PHP_ROUND_HALF_EVEN with 1 decimal digit precision
+	assertType('1.6', round( 1.55, 1, PHP_ROUND_HALF_EVEN));
+	assertType('-1.6', round(-1.55, 1, PHP_ROUND_HALF_EVEN));
+
+	// Using PHP_ROUND_HALF_ODD with 1 decimal digit precision
+	assertType('1.5', round( 1.55, 1, PHP_ROUND_HALF_ODD));
+	assertType('-1.5', round(-1.55, 1, PHP_ROUND_HALF_ODD));
+}
+
+/**
+ * @param 1.11|2.22 $floatUnion
+ * @param 2|3 $precisionUnion
+ * @param 2|4 $modeUnion
+ * @param 1|'2.5' $IntOrNumStr
+ * @param 1.11|'2.22' $floatOrNumStr
+ */
+function notConstant(float $floatUnion, float $precisionUnion, float $modeUnion, $IntOrNumStr, $floatOrNumStr)
+{
+	assertType('float', round($floatUnion, $precisionUnion, PHP_ROUND_HALF_UP));
+	assertType('float', round($floatUnion, 0, $modeUnion));
+
+	assertType('float', round($IntOrNumStr));
+	assertType('float', round($floatOrNumStr));
+}


### PR DESCRIPTION
Returns a constant when `$num` parameter and option of the round function are constants.

In this case , the conventional type is returned.
- `$num` parameter is a numeric string.
- `$num` parameter union contains a numeric string.
- `round()` option is not a constant.