### PR TITLE
Fix substracted union type describe

### DIFF
--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -29,7 +29,6 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
@@ -440,7 +439,7 @@ class MixedType implements CompoundType, SubtractableType
 			function () use ($level): string {
 				$description = 'mixed';
 				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
+					$description .= $this->subtractedType instanceof UnionType
 						? sprintf('~(%s)', $this->subtractedType->describe($level))
 						: sprintf('~%s', $this->subtractedType->describe($level));
 				}
@@ -450,7 +449,7 @@ class MixedType implements CompoundType, SubtractableType
 			function () use ($level): string {
 				$description = 'mixed';
 				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
+					$description .= $this->subtractedType instanceof UnionType
 						? sprintf('~(%s)', $this->subtractedType->describe($level))
 						: sprintf('~%s', $this->subtractedType->describe($level));
 				}

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -32,6 +32,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
+use PHPStan\Type\UnionType;
 use function sprintf;
 
 /** @api */
@@ -438,7 +439,9 @@ class MixedType implements CompoundType, SubtractableType
 			function () use ($level): string {
 				$description = 'mixed';
 				if ($this->subtractedType !== null) {
-					$description .= sprintf('~%s', $this->subtractedType->describe($level));
+					$description .= $this->subtractedType instanceof UnionType
+						? sprintf('~(%s)', $this->subtractedType->describe($level))
+						: sprintf('~%s', $this->subtractedType->describe($level));
 				}
 
 				return $description;
@@ -446,7 +449,9 @@ class MixedType implements CompoundType, SubtractableType
 			function () use ($level): string {
 				$description = 'mixed';
 				if ($this->subtractedType !== null) {
-					$description .= sprintf('~%s', $this->subtractedType->describe($level));
+					$description .= $this->subtractedType instanceof UnionType
+						? sprintf('~(%s)', $this->subtractedType->describe($level))
+						: sprintf('~%s', $this->subtractedType->describe($level));
 				}
 
 				if ($this->isExplicitMixed) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -32,7 +32,6 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
-use PHPStan\Type\UnionType;
 use function sprintf;
 
 /** @api */

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -29,6 +29,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
@@ -439,7 +440,7 @@ class MixedType implements CompoundType, SubtractableType
 			function () use ($level): string {
 				$description = 'mixed';
 				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType
+					$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
 						? sprintf('~(%s)', $this->subtractedType->describe($level))
 						: sprintf('~%s', $this->subtractedType->describe($level));
 				}
@@ -449,7 +450,7 @@ class MixedType implements CompoundType, SubtractableType
 			function () use ($level): string {
 				$description = 'mixed';
 				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType
+					$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
 						? sprintf('~(%s)', $this->subtractedType->describe($level))
 						: sprintf('~%s', $this->subtractedType->describe($level));
 				}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -42,7 +42,6 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
@@ -489,7 +488,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		$preciseWithSubtracted = function () use ($level): string {
 			$description = $this->className;
 			if ($this->subtractedType !== null) {
-				$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
+				$description .= $this->subtractedType instanceof UnionType
 					? sprintf('~(%s)', $this->subtractedType->describe($level))
 					: sprintf('~%s', $this->subtractedType->describe($level));
 			}
@@ -542,7 +541,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		if ($this->subtractedType !== null) {
-			$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
+			$description .= $this->subtractedType instanceof UnionType
 				? sprintf('~(%s)', $this->subtractedType->describe(VerbosityLevel::cache()))
 				: sprintf('~%s', $this->subtractedType->describe(VerbosityLevel::cache()));
 		}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -47,6 +47,7 @@ use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
+use PHPStan\Type\UnionType;
 use Throwable;
 use Traversable;
 use function array_key_exists;
@@ -487,7 +488,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		$preciseWithSubtracted = function () use ($level): string {
 			$description = $this->className;
 			if ($this->subtractedType !== null) {
-				$description .= sprintf('~%s', $this->subtractedType->describe($level));
+				$description .= $this->subtractedType instanceof UnionType
+					? sprintf('~(%s)', $this->subtractedType->describe($level))
+					: sprintf('~%s', $this->subtractedType->describe($level));
 			}
 
 			return $description;
@@ -538,7 +541,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		if ($this->subtractedType !== null) {
-			$description .= sprintf('~%s', $this->subtractedType->describe(VerbosityLevel::cache()));
+			$description .= $this->subtractedType instanceof UnionType
+				? sprintf('~(%s)', $this->subtractedType->describe(VerbosityLevel::cache()))
+				: sprintf('~%s', $this->subtractedType->describe(VerbosityLevel::cache()));
 		}
 
 		$reflection = $this->classReflection;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -47,7 +47,6 @@ use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
-use PHPStan\Type\UnionType;
 use Throwable;
 use Traversable;
 use function array_key_exists;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -42,6 +42,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
@@ -488,7 +489,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		$preciseWithSubtracted = function () use ($level): string {
 			$description = $this->className;
 			if ($this->subtractedType !== null) {
-				$description .= $this->subtractedType instanceof UnionType
+				$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
 					? sprintf('~(%s)', $this->subtractedType->describe($level))
 					: sprintf('~%s', $this->subtractedType->describe($level));
 			}
@@ -541,7 +542,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		}
 
 		if ($this->subtractedType !== null) {
-			$description .= $this->subtractedType instanceof UnionType
+			$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
 				? sprintf('~(%s)', $this->subtractedType->describe(VerbosityLevel::cache()))
 				: sprintf('~%s', $this->subtractedType->describe(VerbosityLevel::cache()));
 		}

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
@@ -134,7 +133,7 @@ class ObjectWithoutClassType implements SubtractableType
 			function () use ($level): string {
 				$description = 'object';
 				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
+					$description .= $this->subtractedType instanceof UnionType
 						? sprintf('~(%s)', $this->subtractedType->describe($level))
 						: sprintf('~%s', $this->subtractedType->describe($level));
 				}

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -9,6 +9,7 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
+use PHPStan\Type\UnionType;
 use function sprintf;
 
 /** @api */
@@ -132,7 +133,9 @@ class ObjectWithoutClassType implements SubtractableType
 			function () use ($level): string {
 				$description = 'object';
 				if ($this->subtractedType !== null) {
-					$description .= sprintf('~%s', $this->subtractedType->describe($level));
+					$description .= $this->subtractedType instanceof UnionType
+						? sprintf('~(%s)', $this->subtractedType->describe($level))
+						: sprintf('~%s', $this->subtractedType->describe($level));
 				}
 
 				return $description;

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -9,7 +9,6 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
-use PHPStan\Type\UnionType;
 use function sprintf;
 
 /** @api */

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\IntersectionType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
@@ -133,7 +134,7 @@ class ObjectWithoutClassType implements SubtractableType
 			function () use ($level): string {
 				$description = 'object';
 				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType
+					$description .= $this->subtractedType instanceof UnionType || $this->subtractedType instanceof IntersectionType
 						? sprintf('~(%s)', $this->subtractedType->describe($level))
 						: sprintf('~%s', $this->subtractedType->describe($level));
 				}

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -44,7 +44,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 {
 
 	private const FALSEY_TYPE_DESCRIPTION = '0|0.0|\'\'|\'0\'|array{}|false|null';
-	private const TRUTHY_TYPE_DESCRIPTION = 'mixed~' . self::FALSEY_TYPE_DESCRIPTION;
+	private const TRUTHY_TYPE_DESCRIPTION = 'mixed~(' . self::FALSEY_TYPE_DESCRIPTION . ')';
 	private const SURE_NOT_FALSEY = '~' . self::FALSEY_TYPE_DESCRIPTION;
 	private const SURE_NOT_TRUTHY = '~' . self::TRUTHY_TYPE_DESCRIPTION;
 
@@ -819,10 +819,10 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new LNumber(3),
 				),
 				[
-					'$n' => 'mixed~int<3, max>|true',
+					'$n' => 'mixed~(int<3, max>|true)',
 				],
 				[
-					'$n' => 'mixed~0.0|int<min, 2>|false|null',
+					'$n' => 'mixed~(0.0|int<min, 2>|false|null)',
 				],
 			],
 			[
@@ -831,10 +831,10 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new LNumber(PHP_INT_MIN),
 				),
 				[
-					'$n' => 'mixed~int<' . PHP_INT_MIN . ', max>|true',
+					'$n' => 'mixed~(int<' . PHP_INT_MIN . ', max>|true)',
 				],
 				[
-					'$n' => 'mixed~0.0|false|null',
+					'$n' => 'mixed~(0.0|false|null)',
 				],
 			],
 			[
@@ -843,7 +843,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new LNumber(PHP_INT_MAX),
 				),
 				[
-					'$n' => 'mixed~0.0|bool|int<min, ' . PHP_INT_MAX . '>|null',
+					'$n' => 'mixed~(0.0|bool|int<min, ' . PHP_INT_MAX . '>|null)',
 				],
 				[
 					'$n' => 'mixed',
@@ -858,7 +858,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$n' => 'mixed~int<' . (PHP_INT_MIN + 1) . ', max>',
 				],
 				[
-					'$n' => 'mixed~0.0|bool|int<min, ' . PHP_INT_MIN . '>|null',
+					'$n' => 'mixed~(0.0|bool|int<min, ' . PHP_INT_MIN . '>|null)',
 				],
 			],
 			[
@@ -867,10 +867,10 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new LNumber(PHP_INT_MAX),
 				),
 				[
-					'$n' => 'mixed~0.0|int<min, ' . (PHP_INT_MAX - 1) . '>|false|null',
+					'$n' => 'mixed~(0.0|int<min, ' . (PHP_INT_MAX - 1) . '>|false|null)',
 				],
 				[
-					'$n' => 'mixed~int<' . PHP_INT_MAX . ', max>|true',
+					'$n' => 'mixed~(int<' . PHP_INT_MAX . ', max>|true)',
 				],
 			],
 			[
@@ -885,10 +885,10 @@ class TypeSpecifierTest extends PHPStanTestCase
 					),
 				),
 				[
-					'$n' => 'mixed~0.0|int<min, 2>|int<6, max>|false|null',
+					'$n' => 'mixed~(0.0|int<min, 2>|int<6, max>|false|null)',
 				],
 				[
-					'$n' => 'mixed~int<3, 5>|true',
+					'$n' => 'mixed~(int<3, 5>|true)',
 				],
 			],
 			[
@@ -1190,7 +1190,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => 'mixed~non-empty-string & ~null'],
+				['$a' => 'mixed~(non-empty-string) & ~null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1204,7 +1204,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => 'mixed~non-empty-string & ~null'],
+				['$a' => 'mixed~(non-empty-string) & ~null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1218,7 +1218,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-array|null'],
-				['$a' => 'mixed~non-empty-array & ~null'],
+				['$a' => 'mixed~(non-empty-array) & ~null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanAnd(
@@ -1250,7 +1250,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 				),
 				[
 					'$foo' => 'non-empty-array',
-					'count($foo)' => 'mixed~0.0|int<min, 1>|false|null',
+					'count($foo)' => 'mixed~(0.0|int<min, 1>|false|null)',
 				],
 				[],
 			],
@@ -1287,7 +1287,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'strlen($foo)' => '~0',
 				],
 				[
-					'$foo' => 'mixed~non-empty-string',
+					'$foo' => 'mixed~(non-empty-string)',
 				],
 			],
 			[

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -1190,7 +1190,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => 'mixed~(non-empty-string) & ~null'],
+				['$a' => 'mixed~non-empty-string & ~null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1204,7 +1204,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-string|null'],
-				['$a' => 'mixed~(non-empty-string) & ~null'],
+				['$a' => 'mixed~non-empty-string & ~null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanOr(
@@ -1218,7 +1218,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Identical(new Expr\ConstFetch(new Name('null')), new Variable('a')),
 				),
 				['$a' => 'non-empty-array|null'],
-				['$a' => 'mixed~(non-empty-array) & ~null'],
+				['$a' => 'mixed~non-empty-array & ~null'],
 			],
 			[
 				new Expr\BinaryOp\BooleanAnd(
@@ -1287,7 +1287,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'strlen($foo)' => '~0',
 				],
 				[
-					'$foo' => 'mixed~(non-empty-string)',
+					'$foo' => 'mixed~non-empty-string',
 				],
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-type-specifying.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-type-specifying.php
@@ -16,7 +16,7 @@ function foo2($foo) {
 	if (array_is_list($foo)) {
 		assertType('list<mixed>', $foo);
 	} else {
-		assertType('mixed~list<mixed>', $foo);
+		assertType('mixed~(list<mixed>)', $foo);
 	}
 }
 

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-type-specifying.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-type-specifying.php
@@ -16,7 +16,7 @@ function foo2($foo) {
 	if (array_is_list($foo)) {
 		assertType('list<mixed>', $foo);
 	} else {
-		assertType('mixed~(list<mixed>)', $foo);
+		assertType('mixed~list<mixed>', $foo);
 	}
 }
 

--- a/tests/PHPStan/Analyser/nsrt/assert-empty.php
+++ b/tests/PHPStan/Analyser/nsrt/assert-empty.php
@@ -25,5 +25,5 @@ function ($var) {
 
 function ($var) {
 	assertNotEmpty($var);
-	assertType("mixed~0|0.0|''|'0'|array{}|false|null", $var);
+	assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $var);
 };

--- a/tests/PHPStan/Analyser/nsrt/bug-10189.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10189.php
@@ -20,7 +20,7 @@ function file_managed_file_save_upload(): array {
 	}
 	assertType('non-empty-array|Bug10189\SomeInterface', $files);
 	$files = array_filter($files);
-	assertType("array<mixed~0|0.0|''|'0'|array{}|false|null>", $files);
+	assertType("array<mixed~(0|0.0|''|'0'|array{}|false|null)>", $files);
 
 	return empty($files) ? [] : [1,2];
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-3991.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3991.php
@@ -26,7 +26,7 @@ class Foo
 			assertType('array{}|null', $config);
 			$config = new \stdClass();
 		} elseif (! (is_array($config) || $config instanceof \stdClass)) {
-			assertNativeType('mixed~0|0.0|\'\'|\'0\'|array{}|stdClass|false|null', $config);
+			assertNativeType('mixed~(0|0.0|\'\'|\'0\'|array{}|stdClass|false|null)', $config);
 			assertType('*NEVER*', $config);
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-3993.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3993.php
@@ -13,7 +13,7 @@ class Foo
 			return;
 		}
 
-		assertType('mixed~array{}|null', $arguments);
+		assertType('mixed~(array{}|null)', $arguments);
 
 		array_shift($arguments);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-4117.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-4117.php
@@ -32,7 +32,7 @@ class GenericList implements IteratorAggregate
 		$item = $this->items[$key] ?? null;
 		assertType('T of mixed~null (class Bug4117Types\GenericList, argument)|null', $item);
 		if ($item) {
-			assertType("T of mixed~0|0.0|''|'0'|array{}|false|null (class Bug4117Types\GenericList, argument)", $item);
+			assertType("T of mixed~(0|0.0|''|'0'|array{}|false|null) (class Bug4117Types\GenericList, argument)", $item);
 		} else {
 			assertType("(array{}&T of mixed~null (class Bug4117Types\GenericList, argument))|(0.0&T of mixed~null (class Bug4117Types\GenericList, argument))|(0&T of mixed~null (class Bug4117Types\GenericList, argument))|(''&T of mixed~null (class Bug4117Types\GenericList, argument))|('0'&T of mixed~null (class Bug4117Types\GenericList, argument))|(T of mixed~null (class Bug4117Types\GenericList, argument)&false)|null", $item);
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-7176.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7176.php
@@ -25,7 +25,7 @@ function test(Suit $x): string {
 		assertType('Bug7176Types\Suit::Spades', $x);
 		return 'DOES NOT WORK';
 	}
-	assertType('Bug7176Types\Suit~Bug7176Types\Suit::Clubs|Bug7176Types\Suit::Spades', $x);
+	assertType('Bug7176Types\Suit~(Bug7176Types\Suit::Clubs|Bug7176Types\Suit::Spades)', $x);
 
 	return match ($x) {
 		Suit::Hearts => 'a',

--- a/tests/PHPStan/Analyser/nsrt/bug-pr-339.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-pr-339.php
@@ -17,14 +17,14 @@ if ($a || $c) {
 	assertType('mixed', $a);
 	assertType('mixed', $c);
 	if ($a) {
-		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $a);
+		assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $a);
 		assertType('mixed', $c);
 		assertVariableCertainty(TrinaryLogic::createYes(), $a);
 	}
 
 	if ($c) {
 		assertType('mixed', $a);
-		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $c);
+		assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $c);
 		assertVariableCertainty(TrinaryLogic::createYes(), $c);
 	}
 } else {

--- a/tests/PHPStan/Analyser/nsrt/callsite-cast-narrowing.php
+++ b/tests/PHPStan/Analyser/nsrt/callsite-cast-narrowing.php
@@ -15,7 +15,7 @@ class HelloWorld
 		if (ctype_digit((string) $mixed)) {
 			assertType('int<0, max>|numeric-string|true', $mixed);
 		} else {
-			assertType('mixed~int<0, max>|numeric-string|true', $mixed);
+			assertType('mixed~(int<0, max>|numeric-string|true)', $mixed);
 		}
 		assertType('mixed', $mixed);
 

--- a/tests/PHPStan/Analyser/nsrt/composer-array-bug.php
+++ b/tests/PHPStan/Analyser/nsrt/composer-array-bug.php
@@ -51,7 +51,7 @@ class Foo
 				unset($this->config['authors']);
 				assertType("array<mixed~'authors', mixed>", $this->config);
 			} else {
-				assertType("array&hasOffsetValue('authors', mixed~0|0.0|''|'0'|array{}|false|null)", $this->config);
+				assertType("array&hasOffsetValue('authors', mixed~(0|0.0|''|'0'|array{}|false|null))", $this->config);
 			}
 
 			assertType('array', $this->config);

--- a/tests/PHPStan/Analyser/nsrt/composer-non-empty-array-after-unset.php
+++ b/tests/PHPStan/Analyser/nsrt/composer-non-empty-array-after-unset.php
@@ -13,7 +13,7 @@ class Foo
 	public function doFoo()
 	{
 		if (!empty($this->config['authors'])) {
-			assertType("mixed~0|0.0|''|'0'|array{}|false|null", $this->config['authors']);
+			assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $this->config['authors']);
 			foreach ($this->config['authors'] as $key => $author) {
 				assertType("mixed", $this->config['authors']);
 				if (!is_array($author)) {

--- a/tests/PHPStan/Analyser/nsrt/ctype-digit.php
+++ b/tests/PHPStan/Analyser/nsrt/ctype-digit.php
@@ -20,7 +20,7 @@ class Foo
 		if (is_int($foo) && ctype_digit($foo)) {
 			assertType('int<48, 57>|int<256, max>', $foo);
 		} else {
-			assertType('mixed~int<48, 57>|int<256, max>', $foo);
+			assertType('mixed~(int<48, 57>|int<256, max>)', $foo);
 		}
 
 		if (ctype_digit($foo)) {
@@ -28,6 +28,6 @@ class Foo
 			return;
 		}
 
-		assertType('mixed~int<48, 57>|int<256, max>', $foo); // not all numeric strings are covered by ctype_digit
+		assertType('mixed~(int<48, 57>|int<256, max>)', $foo); // not all numeric strings are covered by ctype_digit
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/more-types.php
+++ b/tests/PHPStan/Analyser/nsrt/more-types.php
@@ -38,7 +38,7 @@ class Foo
 		assertType('literal-string&non-empty-string', $nonEmptyLiteralString);
 		assertType('float|int<min, -1>|int<1, max>|non-falsy-string|true', $nonEmptyScalar);
 		assertType("0|0.0|''|'0'|false", $emptyScalar);
-		assertType("mixed~0|0.0|''|'0'|array{}|false|null", $nonEmptyMixed);
+		assertType("mixed~(0|0.0|''|'0'|array{}|false|null)", $nonEmptyMixed);
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/this-subtractable.php
+++ b/tests/PHPStan/Analyser/nsrt/this-subtractable.php
@@ -12,7 +12,7 @@ class Foo
 		assertType('$this(ThisSubtractable\Foo)', $this);
 
 		if (!$this instanceof Bar && !$this instanceof Baz) {
-			assertType('$this(ThisSubtractable\Foo~ThisSubtractable\Bar|ThisSubtractable\Baz)', $this);
+			assertType('$this(ThisSubtractable\Foo~(ThisSubtractable\Bar|ThisSubtractable\Baz))', $this);
 		} else {
 			assertType('($this(ThisSubtractable\Foo)&ThisSubtractable\Bar)|($this(ThisSubtractable\Foo)&ThisSubtractable\Baz)', $this);
 		}
@@ -26,7 +26,7 @@ class Foo
 		assertType('static(ThisSubtractable\Foo)', $s);
 
 		if (!$s instanceof Bar && !$s instanceof Baz) {
-			assertType('static(ThisSubtractable\Foo~ThisSubtractable\Bar|ThisSubtractable\Baz)', $s);
+			assertType('static(ThisSubtractable\Foo~(ThisSubtractable\Bar|ThisSubtractable\Baz))', $s);
 		} else {
 			assertType('(static(ThisSubtractable\Foo)&ThisSubtractable\Bar)|(static(ThisSubtractable\Foo)&ThisSubtractable\Baz)', $s);
 		}
@@ -52,7 +52,7 @@ class Foo
 		assertType('ThisSubtractable\Foo', $s);
 
 		if (!$s instanceof Bar && !$s instanceof Baz) {
-			assertType('ThisSubtractable\Foo~ThisSubtractable\Bar|ThisSubtractable\Baz', $s);
+			assertType('ThisSubtractable\Foo~(ThisSubtractable\Bar|ThisSubtractable\Baz)', $s);
 		} else {
 			assertType('ThisSubtractable\Bar|ThisSubtractable\Baz', $s);
 		}
@@ -70,12 +70,12 @@ class Foo
 		assertType('ThisSubtractable\Foo&hasMethod(test123)', $s);
 
 		if (!$s instanceof Bar && !$s instanceof Baz) {
-			assertType('ThisSubtractable\Foo~ThisSubtractable\Bar|ThisSubtractable\Baz&hasMethod(test123)', $s);
+			assertType('ThisSubtractable\Foo~(ThisSubtractable\Bar|ThisSubtractable\Baz)&hasMethod(test123)', $s);
 		} else {
 			assertType('(ThisSubtractable\Bar&hasMethod(test123))|(ThisSubtractable\Baz&hasMethod(test123))', $s);
 		}
 
-		assertType('(ThisSubtractable\Bar&hasMethod(test123))|(ThisSubtractable\Baz&hasMethod(test123))|(ThisSubtractable\Foo~ThisSubtractable\Bar|ThisSubtractable\Baz&hasMethod(test123))', $s);
+		assertType('(ThisSubtractable\Bar&hasMethod(test123))|(ThisSubtractable\Baz&hasMethod(test123))|(ThisSubtractable\Foo~(ThisSubtractable\Bar|ThisSubtractable\Baz)&hasMethod(test123))', $s);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/throw-points/try-catch.php
+++ b/tests/PHPStan/Analyser/nsrt/throw-points/try-catch.php
@@ -76,7 +76,7 @@ function (): void {
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $baz);
 		assertType('1|2', $baz);
 	} catch (\Throwable $e) {
-		assertType('Throwable~InvalidArgumentException|RuntimeException', $e);
+		assertType('Throwable~(InvalidArgumentException|RuntimeException)', $e);
 		assertVariableCertainty(TrinaryLogic::createNo(), $foo);
 		assertVariableCertainty(TrinaryLogic::createYes(), $bar);
 		assertVariableCertainty(TrinaryLogic::createNo(), $baz);

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1886,7 +1886,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 					StaticTypeFactory::truthy(),
 				],
 				MixedType::class,
-				'mixed~0|0.0|\'\'|\'0\'|array{}|false|null=implicit',
+				'mixed~(0|0.0|\'\'|\'0\'|array{}|false|null)=implicit',
 			],
 			[
 				[
@@ -3325,7 +3325,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 					new MixedType(false, new IntegerType()),
 				],
 				MixedType::class,
-				'mixed~int|string=implicit',
+				'mixed~(int|string)=implicit',
 			],
 			[
 				[
@@ -4494,7 +4494,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				StaticTypeFactory::truthy(),
 				StaticTypeFactory::falsey(),
 				MixedType::class,
-				'mixed~0|0.0|\'\'|\'0\'|array{}|false|null',
+				'mixed~(0|0.0|\'\'|\'0\'|array{}|false|null)',
 			],
 			[
 				StaticTypeFactory::falsey(),
@@ -4670,7 +4670,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new MixedType(false, new IntegerType()),
 				new StringType(),
 				MixedType::class,
-				'mixed~int|string',
+				'mixed~(int|string)',
 			],
 			[
 				new MixedType(false),
@@ -4706,7 +4706,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				new ObjectType('Exception', new ObjectType('InvalidArgumentException')),
 				new ObjectType('LengthException'),
 				ObjectType::class,
-				'Exception~InvalidArgumentException|LengthException',
+				'Exception~(InvalidArgumentException|LengthException)',
 			],
 			[
 				new ObjectType('Exception'),


### PR DESCRIPTION
fix https://github.com/phpstan/phpstan/issues/10227

`(a~b)|c` === `a~b|c` !== `a~(b|c)`