### PR TITLE
ConstantArrayType: fix returned ConstantArrayTypeAndMethod

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -483,6 +483,7 @@ class ConstantArrayType implements Type
 			}
 
 			$method = $typeAndMethodName->getType()
+				->getObjectTypeOrClassStringObjectType()
 				->getMethod($typeAndMethodName->getMethod(), $scope);
 
 			if (!$scope->canCallMethod($method)) {
@@ -567,7 +568,7 @@ class ConstantArrayType implements Type
 				$has = $has->and(TrinaryLogic::createMaybe());
 			}
 
-			$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);
+			$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($classOrObject, $method->getValue(), $has);
 		}
 
 		return $typeAndMethods;

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -1051,4 +1051,34 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 		$this->assertSame($expectedType->getNextAutoIndexes(), $actualType->getNextAutoIndexes());
 	}
 
+	public function testFindTypeAndMethodNames(): void
+	{
+		$classStringArray = new ConstantArrayType([
+			new ConstantIntegerType(0),
+			new ConstantIntegerType(1),
+		], [
+			new ConstantStringType(Closure::class, true),
+			new ConstantStringType('bind'),
+		]);
+		$objectArray = new ConstantArrayType([
+			new ConstantIntegerType(0),
+			new ConstantIntegerType(1),
+		], [
+			new ObjectType(Closure::class, null, $this->createReflectionProvider()->getClass(Closure::class)),
+			new ConstantStringType('bind'),
+		]);
+
+		$classStringResult = $classStringArray->findTypeAndMethodNames();
+		$objectResult = $objectArray->findTypeAndMethodNames();
+
+		$this->assertCount(1, $classStringResult);
+		$this->assertCount(1, $objectResult);
+		$this->assertInstanceOf(ConstantStringType::class, $classStringResult[0]->getType());
+		$this->assertInstanceOf(ObjectType::class, $objectResult[0]->getType());
+		$this->assertSame('bind', $classStringResult[0]->getMethod());
+		$this->assertSame('bind', $objectResult[0]->getMethod());
+		$this->assertSame(TrinaryLogic::createYes(), $classStringResult[0]->getCertainty());
+		$this->assertSame(TrinaryLogic::createYes(), $objectResult[0]->getCertainty());
+	}
+
 }


### PR DESCRIPTION
With this, we can recognize those cases:

```php

class Parnt
{
	public function __construct()
	{
		array_map([self::class, 'method1'], [1]); // calls Parnt::method1
		array_map([$this, 'method1'], [1]); // calls Child::method1
	}

	public function method1(): void {
	    echo 'parent';
	}
	
}

class Child extends Parnt
{
	public function __construct()
	{
		parent::__construct();
	}

	public function method1(): void {
	    echo 'child';
	}
	
}

new Child();
```