### PR TITLE
Fix `get_debug_type` produces wrong type for anonymous classes with parent

### DIFF
--- a/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
@@ -75,9 +75,10 @@ class GetDebugTypeFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 					$parentClass = $reflection->getParentClass();
 					$implementedInterfaces = $reflection->getImmediateInterfaces();
 					if ($parentClass !== null) {
-						$types[] = $parentClass->getName() . '@anonymous';
+						$types[] = new ConstantStringType($parentClass->getName() . '@anonymous');
 					} elseif ($implementedInterfaces !== []) {
-						$types[] = $implementedInterfaces[0]->getName() . '@anonymous';
+						$firstInterface = $implementedInterfaces[array_key_first($implementedInterfaces)];
+						$types[] = new ConstantStringType($firstInterface->getName() . '@anonymous');
 					} else {
 						$types[] = new ConstantStringType('class@anonymous');
 					}

--- a/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
+use function array_key_first;
 use function array_map;
 use function count;
 

--- a/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
@@ -37,6 +37,7 @@ class GetDebugTypeFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 
 	/**
 	 * @see https://www.php.net/manual/en/function.get-debug-type.php#refsect1-function.get-debug-type-returnvalues
+	 * @see https://github.com/php/php-src/commit/ef0e4478c51540510b67f7781ad240f5e0592ee4
 	 */
 	private static function resolveOneType(Type $type): Type
 	{
@@ -71,7 +72,15 @@ class GetDebugTypeFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 				}
 
 				if ($reflection->isAnonymous()) { // phpcs:ignore
-					$types[] = new ConstantStringType('class@anonymous');
+					$parentClass = $reflection->getParentClass();
+					$implementedInterfaces = $reflection->getImmediateInterfaces();
+					if ($parentClass !== null) {
+						$types[] = $parentClass->getName() . '@anonymous';
+					} elseif ($implementedInterfaces !== []) {
+						$types[] = $implementedInterfaces[0]->getName() . '@anonymous';
+					} else {
+						$types[] = new ConstantStringType('class@anonymous');
+					}
 				}
 			}
 

--- a/tests/PHPStan/Analyser/nsrt/get-debug-type.php
+++ b/tests/PHPStan/Analyser/nsrt/get-debug-type.php
@@ -5,6 +5,9 @@ namespace GetDebugType;
 use function PHPStan\Testing\assertType;
 
 final class A {}
+interface B {}
+interface C {}
+class D {}
 
 /**
  * @param double $d
@@ -18,6 +21,9 @@ function doFoo(bool $b, int $i, float $f, $d, $r, string $s, array $a, $intOrStr
 	$o = new \stdClass();
 	$A = new A();
 	$anonymous = new class {};
+	$anonymousImplements = new class implements B, C {};
+	$anonymousExtends = new class extends D {};
+	$anonymousExtendsImplements = new class extends D implements B, C {};
 
 	assertType("'bool'", get_debug_type($b));
 	assertType("'bool'", get_debug_type(true));
@@ -35,6 +41,9 @@ function doFoo(bool $b, int $i, float $f, $d, $r, string $s, array $a, $intOrStr
 	assertType("'int'|'string'", get_debug_type($intOrString));
 	assertType("'array'|'GetDebugType\\\\A'", get_debug_type($arrayOrObject));
 	assertType("'class@anonymous'", get_debug_type($anonymous));
+	assertType("'GetDebugType\\\\B@anonymous'", get_debug_type($anonymousImplements));
+	assertType("'GetDebugType\\\\D@anonymous'", get_debug_type($anonymousExtends));
+	assertType("'GetDebugType\\\\D@anonymous'", get_debug_type($anonymousExtendsImplements));
 }
 
 /**


### PR DESCRIPTION
Closes: https://github.com/phpstan/phpstan/issues/11562

Fix poorly documented case of `get_debug_type` where it provides more specific output in cases where the anonymous class extends another class or implements an interface.