### PR TITLE
Update PhpStorm stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"hoa/compiler": "3.17.08.08",
 		"hoa/exception": "^1.0",
 		"hoa/file": "1.17.07.11",
-		"jetbrains/phpstorm-stubs": "dev-master#bdc8acd7c04c0c87197849c7cdd27e44b67b56c7",
+		"jetbrains/phpstorm-stubs": "dev-master#5686f9ceebde3d9338bea53b78d70ebde5fb5710",
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.1.4",
 		"nette/neon": "3.3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8e13e2eb99acb0933ff8956a498ffe4",
+    "content-hash": "8d65a8ad1ba3923e57e72376e8dfefed",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -1434,19 +1434,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "bdc8acd7c04c0c87197849c7cdd27e44b67b56c7"
+                "reference": "5686f9ceebde3d9338bea53b78d70ebde5fb5710"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/bdc8acd7c04c0c87197849c7cdd27e44b67b56c7",
-                "reference": "bdc8acd7c04c0c87197849c7cdd27e44b67b56c7",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/5686f9ceebde3d9338bea53b78d70ebde5fb5710",
+                "reference": "5686f9ceebde3d9338bea53b78d70ebde5fb5710",
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "v3.46.0",
-                "nikic/php-parser": "v5.0.0",
-                "phpdocumentor/reflection-docblock": "5.3.0",
-                "phpunit/phpunit": "10.5.5"
+                "friendsofphp/php-cs-fixer": "v3.61.1",
+                "nikic/php-parser": "v5.1.0",
+                "phpdocumentor/reflection-docblock": "5.4.1",
+                "phpunit/phpunit": "11.3.0"
             },
             "default-branch": true,
             "type": "library",
@@ -1474,7 +1474,7 @@
             "support": {
                 "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
             },
-            "time": "2024-07-05T11:52:49+00:00"
+            "time": "2024-07-24T19:11:43+00:00"
         },
         {
             "name": "nette/bootstrap",

--- a/src/Rules/Methods/CallToConstructorStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToConstructorStatementWithoutSideEffectsRule.php
@@ -8,6 +8,8 @@ use PHPStan\Node\NoopExpressionNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\NeverType;
+
 use function sprintf;
 
 /**
@@ -59,6 +61,11 @@ final class CallToConstructorStatementWithoutSideEffectsRule implements Rule
 		}
 
 		$constructor = $classReflection->getConstructor();
+		$methodResult = $scope->getType($instantiation);
+		if ($methodResult instanceof NeverType && $methodResult->isExplicit()) {
+			return [];
+		}
+
 		return [
 			RuleErrorBuilder::message(sprintf(
 				'Call to %s::%s() on a separate line has no effect.',

--- a/src/Rules/Methods/CallToConstructorStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToConstructorStatementWithoutSideEffectsRule.php
@@ -9,7 +9,6 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\NeverType;
-
 use function sprintf;
 
 /**

--- a/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
@@ -10,7 +10,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use function sprintf;
 

--- a/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Methods;
 use PhpParser\Node;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\NoopExpressionNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
@@ -14,7 +15,7 @@ use PHPStan\Type\Type;
 use function sprintf;
 
 /**
- * @implements Rule<Node\Stmt\Expression>
+ * @implements Rule<NoopExpressionNode>
  */
 final class CallToMethodStatementWithoutSideEffectsRule implements Rule
 {
@@ -25,18 +26,18 @@ final class CallToMethodStatementWithoutSideEffectsRule implements Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Stmt\Expression::class;
+		return NoopExpressionNode::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if ($node->expr instanceof Node\Expr\NullsafeMethodCall) {
-			$scope = $scope->filterByTruthyValue(new Node\Expr\BinaryOp\NotIdentical($node->expr->var, new Node\Expr\ConstFetch(new Node\Name('null'))));
-		} elseif (!$node->expr instanceof Node\Expr\MethodCall) {
+		$methodCall = $node->getOriginalExpr();
+		if ($methodCall instanceof Node\Expr\NullsafeMethodCall) {
+			$scope = $scope->filterByTruthyValue(new Node\Expr\BinaryOp\NotIdentical($methodCall->var, new Node\Expr\ConstFetch(new Node\Name('null'))));
+		} elseif (!$methodCall instanceof Node\Expr\MethodCall) {
 			return [];
 		}
 
-		$methodCall = $node->expr;
 		if (!$methodCall->name instanceof Node\Identifier) {
 			return [];
 		}
@@ -61,8 +62,8 @@ final class CallToMethodStatementWithoutSideEffectsRule implements Rule
 		}
 
 		$method = $calledOnType->getMethod($methodName, $scope);
-		if ($method->hasSideEffects()->no() || $node->expr->isFirstClassCallable()) {
-			if (!$node->expr->isFirstClassCallable()) {
+		if ($method->hasSideEffects()->no() || $methodCall->isFirstClassCallable()) {
+			if (!$methodCall->isFirstClassCallable()) {
 				$throwsType = $method->getThrowType();
 				if ($throwsType !== null && !$throwsType->isVoid()->yes()) {
 					return [];

--- a/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
@@ -10,6 +10,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use function sprintf;
 
@@ -57,6 +58,11 @@ final class CallToMethodStatementWithoutSideEffectsRule implements Rule
 		}
 
 		if (!$calledOnType->hasMethod($methodName)->yes()) {
+			return [];
+		}
+
+		$methodResult = $scope->getType($methodCall);
+		if ($methodResult instanceof NeverType && $methodResult->isExplicit()) {
 			return [];
 		}
 

--- a/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToMethodStatementWithoutSideEffectsRule.php
@@ -62,30 +62,15 @@ final class CallToMethodStatementWithoutSideEffectsRule implements Rule
 		}
 
 		$method = $calledOnType->getMethod($methodName, $scope);
-		if ($method->hasSideEffects()->no() || $methodCall->isFirstClassCallable()) {
-			if (!$methodCall->isFirstClassCallable()) {
-				$throwsType = $method->getThrowType();
-				if ($throwsType !== null && !$throwsType->isVoid()->yes()) {
-					return [];
-				}
-			}
 
-			$methodResult = $scope->getType($methodCall);
-			if ($methodResult instanceof NeverType && $methodResult->isExplicit()) {
-				return [];
-			}
-
-			return [
-				RuleErrorBuilder::message(sprintf(
-					'Call to %s %s::%s() on a separate line has no effect.',
-					$method->isStatic() ? 'static method' : 'method',
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-				))->identifier('method.resultUnused')->build(),
-			];
-		}
-
-		return [];
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Call to %s %s::%s() on a separate line has no effect.',
+				$method->isStatic() ? 'static method' : 'method',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName(),
+			))->identifier('method.resultUnused')->build(),
+		];
 	}
 
 }

--- a/src/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRule.php
@@ -11,6 +11,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use function sprintf;
@@ -81,6 +82,11 @@ final class CallToStaticMethodStatementWithoutSideEffectsRule implements Rule
 				|| strtolower($method->getName()) === strtolower($method->getDeclaringClass()->getName())
 			)
 		) {
+			return [];
+		}
+
+		$methodResult = $scope->getType($staticCall);
+		if ($methodResult instanceof NeverType && $methodResult->isExplicit()) {
 			return [];
 		}
 

--- a/src/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRule.php
+++ b/src/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRule.php
@@ -5,19 +5,19 @@ namespace PHPStan\Rules\Methods;
 use PhpParser\Node;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\NoopExpressionNode;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use function sprintf;
 use function strtolower;
 
 /**
- * @implements Rule<Node\Stmt\Expression>
+ * @implements Rule<NoopExpressionNode>
  */
 final class CallToStaticMethodStatementWithoutSideEffectsRule implements Rule
 {
@@ -31,16 +31,16 @@ final class CallToStaticMethodStatementWithoutSideEffectsRule implements Rule
 
 	public function getNodeType(): string
 	{
-		return Node\Stmt\Expression::class;
+		return NoopExpressionNode::class;
 	}
 
 	public function processNode(Node $node, Scope $scope): array
 	{
-		if (!$node->expr instanceof Node\Expr\StaticCall) {
+		$staticCall = $node->getOriginalExpr();
+		if (!$staticCall instanceof Node\Expr\StaticCall) {
 			return [];
 		}
 
-		$staticCall = $node->expr;
 		if (!$staticCall->name instanceof Node\Identifier) {
 			return [];
 		}
@@ -84,30 +84,14 @@ final class CallToStaticMethodStatementWithoutSideEffectsRule implements Rule
 			return [];
 		}
 
-		if ($method->hasSideEffects()->no() || $node->expr->isFirstClassCallable()) {
-			if (!$node->expr->isFirstClassCallable()) {
-				$throwsType = $method->getThrowType();
-				if ($throwsType !== null && !$throwsType->isVoid()->yes()) {
-					return [];
-				}
-			}
-
-			$methodResult = $scope->getType($staticCall);
-			if ($methodResult instanceof NeverType && $methodResult->isExplicit()) {
-				return [];
-			}
-
-			return [
-				RuleErrorBuilder::message(sprintf(
-					'Call to %s %s::%s() on a separate line has no effect.',
-					$method->isStatic() ? 'static method' : 'method',
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-				))->identifier('staticMethod.resultUnused')->build(),
-			];
-		}
-
-		return [];
+		return [
+			RuleErrorBuilder::message(sprintf(
+				'Call to %s %s::%s() on a separate line has no effect.',
+				$method->isStatic() ? 'static method' : 'method',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName(),
+			))->identifier('staticMethod.resultUnused')->build(),
+		];
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
@@ -21,10 +21,6 @@ class CallToMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects.php'], [
 			[
-				'Call to method DateTimeImmutable::modify() on a separate line has no effect.',
-				15,
-			],
-			[
 				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
 				16,
 			],

--- a/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
@@ -21,6 +21,10 @@ class CallToMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects.php'], [
 			[
+				'Call to method DateTimeImmutable::modify() on a separate line has no effect.',
+				15,
+			],
+			[
 				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
 				16,
 			],

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
@@ -29,10 +29,6 @@ class CallToStaticMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 				12,
 			],
 			[
-				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
-				13,
-			],
-			[
 				'Call to method DateTime::format() on a separate line has no effect.',
 				23,
 			],


### PR DESCRIPTION
Hi @ondrejmirtes, 

I tried to work on the update https://github.com/phpstan/phpstan-src/pull/3334

First I thought some DynamicMethodThrowTypeExtension was needed but it seems like it is correctly implemented since your PR https://github.com/phpstan/phpstan-src/commit/aa7989f5839ce3196cd5b874284f6efe49c62e24

But the issue is the fact that currently CallToMethodStatementWithoutSideEffectsRule
Does not seems to use those dynamicExtension but rely on `$method->getThrowType()` instead 
which seems to only rely on the phpdoc of the method.

An example can be found with https://phpstan.org/r/b071a436-7779-47de-816e-d520f4d70bdd, even if the dynamicThrowTypeExtension exists (and say there is no exception with 2 params https://github.com/phpstan/phpstan-src/blob/1.12.x/src/Type/Php/DsMapDynamicMethodThrowTypeExtension.php).

I see 3 solutions:
- This is done by design, so I ignore the "error" like in this PR
- There is an available method to use or something easy to implement instead of `$method->getThrowType()`, and I'll be happy to update the PR with it. (but which one ?)
- It's more complex and we ignore the error until then

I'll be happy to try working on this, but so far I have trouble to see if I need to play with the ThrowPoint things or just duplicate the use of DynamicMethodThrowTypeExtension....