### PR TITLE
TypeSpecifier: Narrow `(int) $expr` like `$expr != 0`

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -196,15 +196,17 @@ final class TypeSpecifier
 				$context,
 				$rootExpr,
 			);
-		} elseif ($expr instanceof Expr\Cast\String_) {
+		} elseif (
+			$expr instanceof Expr\Cast\String_
+			|| $expr instanceof Expr\Cast\Int_
+			|| $expr instanceof Expr\Cast\Bool_
+		) {
 			return $this->specifyTypesInCondition(
 				$scope,
 				new Node\Expr\BinaryOp\NotEqual($expr->expr, new ConstFetch(new Name\FullyQualified('false'))),
 				$context,
 				$rootExpr,
 			);
-		} elseif ($expr instanceof Expr\Cast\Bool_) {
-			return $this->resolveEqual(new Expr\BinaryOp\Equal($expr->expr, new ConstFetch(new Name\FullyQualified('true'))), $scope, $context, $rootExpr);
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Equal) {
 			return $this->resolveEqual($expr, $scope, $context, $rootExpr);
 		} elseif ($expr instanceof Node\Expr\BinaryOp\NotEqual) {

--- a/tests/PHPStan/Analyser/nsrt/narrow-cast.php
+++ b/tests/PHPStan/Analyser/nsrt/narrow-cast.php
@@ -48,3 +48,24 @@ function castString($x, string $s, bool $b) {
 		assertType('string', $s);
 	}
 }
+
+/** @param int<-5, 5> $x */
+function castInt($x, string $s, bool $b) {
+    if ((int) $x) {
+        assertType('int<-5, -1>|int<1, 5>', $x);
+    } else {
+        assertType('0', $x);
+    }
+
+    if ((int) $b) {
+        assertType('true', $b);
+    } else {
+        assertType('false', $b);
+    }
+
+    if ((int) strpos($s, 'xy')) {
+        assertType('non-falsy-string', $s);
+    } else {
+        assertType('string', $s);
+    }
+}


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan-src/pull/3380#discussion_r1740085169