### PR TITLE
TypeSpecifier: Narrow `(string) $expr` like `$expr != ''`

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -196,6 +196,13 @@ final class TypeSpecifier
 				$context,
 				$rootExpr,
 			);
+		} elseif ($expr instanceof Expr\Cast\String_) {
+			return $this->specifyTypesInCondition(
+				$scope,
+				new Node\Expr\BinaryOp\NotEqual($expr->expr, new ConstFetch(new Name\FullyQualified('false'))),
+				$context,
+				$rootExpr,
+			);
 		} elseif ($expr instanceof Expr\Cast\Bool_) {
 			return $this->resolveEqual(new Expr\BinaryOp\Equal($expr->expr, new ConstFetch(new Name\FullyQualified('true'))), $scope, $context, $rootExpr);
 		} elseif ($expr instanceof Node\Expr\BinaryOp\Equal) {

--- a/tests/PHPStan/Analyser/nsrt/narrow-bool-cast.php
+++ b/tests/PHPStan/Analyser/nsrt/narrow-bool-cast.php
@@ -27,3 +27,24 @@ function doFoo(string $x, array $arr): void {
 	}
 	assertType('array{}|array{string}', $matches);
 }
+
+/** @param int<-5, 5> $x */
+function castString($x, string $s, bool $b) {
+	if ((string) $x) {
+		assertType('int<-5, -1>|int<1, 5>', $x);
+	} else {
+		assertType('0', $x);
+	}
+
+	if ((string) $b) {
+		assertType('true', $b);
+	} else {
+		assertType('false', $b);
+	}
+
+	if ((string) strrchr($s, 'xy')) {
+		assertType('string', $s); // could be non-empty-string
+	} else {
+		assertType('string', $s);
+	}
+}


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan-src/pull/3380#discussion_r1740085169