### PR TITLE
ArrayShapeMatcher - Don't optimize alternations with optional-groups for tagged-unions

### DIFF
--- a/src/Type/Php/RegexArrayShapeMatcher.php
+++ b/src/Type/Php/RegexArrayShapeMatcher.php
@@ -280,6 +280,10 @@ final class RegexArrayShapeMatcher
 				return null;
 			}
 
+			if ($captureGroup->inOptionalQuantification()) {
+				return null;
+			}
+
 			if ($alternation === null) {
 				$alternation = $captureGroup->getAlternation();
 			} elseif ($alternation->getId() !== $captureGroup->getAlternation()->getId()) {

--- a/src/Type/Regex/RegexCapturingGroup.php
+++ b/src/Type/Regex/RegexCapturingGroup.php
@@ -82,6 +82,11 @@ final class RegexCapturingGroup
 			|| $this->parent !== null && $this->parent->isOptional();
 	}
 
+	public function inOptionalQuantification(): bool
+	{
+		return $this->inOptionalQuantification;
+	}
+
 	public function inOptionalAlternation(): bool
 	{
 		if (!$this->inAlternation()) {

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -753,3 +753,11 @@ function bug11622 (string $expression): void {
 		assertType("array{string, string}", $matches);
 	}
 }
+
+function bug11604 (string $string): void {
+	if (! preg_match('/(XX)|(YY)?ZZ/', $string, $matches)) {
+		return;
+	}
+
+	assertType("array{0: string, 1?: ''|'XX', 2?: 'YY'}", $matches);
+}

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -760,4 +760,5 @@ function bug11604 (string $string): void {
 	}
 
 	assertType("array{0: string, 1?: ''|'XX', 2?: 'YY'}", $matches);
+	// could be array{string, '', 'YY'}|array{string, 'XX'}|array{string}
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -762,3 +762,9 @@ function bug11604 (string $string): void {
 	assertType("array{0: string, 1?: ''|'XX', 2?: 'YY'}", $matches);
 	// could be array{string, '', 'YY'}|array{string, 'XX'}|array{string}
 }
+
+function bug11604b (string $string): void {
+	if (preg_match('/(XX)|(YY)?(ZZ)/', $string, $matches)) {
+		assertType("array{0: string, 1?: ''|'XX', 2?: ''|'YY', 3?: 'ZZ'}", $matches);
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11604