### PR TITLE
Add non regression test for bug 6642

### DIFF
--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -231,4 +231,10 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6467.php'], []);
 	}
 
+	public function testBug6642(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-6642.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-6642.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6642.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6642;
+
+$i = 0;
+foreach([1,2,3] as $n){
+	$bool = $i++ < 3;
+	if($bool){
+	}
+}


### PR DESCRIPTION
I saw in https://github.com/phpstan/phpstan/discussions/11623 that the issue https://github.com/phpstan/phpstan/issues/6642 is referenced but not closed.

I assume you'd like a non regression test so I added one.

Closes https://github.com/phpstan/phpstan/issues/6642