### PR TITLE
Fix array_is_list call after unset 

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -734,7 +734,9 @@ class ConstantArrayType extends ArrayType implements ConstantType
 					$k++;
 				}
 
-				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, TrinaryLogic::createNo());
+				$isList = $this->isList()->and(TrinaryLogic::createFromBoolean($i === count($this->keyTypes) - 1));
+
+				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, $isList);
 			}
 
 			return $this;

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -109,6 +109,9 @@ class ConstantArrayTypeBuilder
 				}
 
 				$max = max($this->nextAutoIndexes);
+				if ($max !== count($this->keyTypes)) {
+					$this->isList = TrinaryLogic::createNo();
+				}
 
 				$this->keyTypes[] = new ConstantIntegerType($max);
 				$this->valueTypes[] = $valueType;

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
@@ -19,7 +19,7 @@ function () {
 	assertType('true', array_is_list($a));
 	unset($a[2]);
 	assertType('array{1, 2}', $a);
-	assertType('false', array_is_list($a));
+	assertType('true', array_is_list($a));
 	$a[] = 4;
 	assertType('array{0: 1, 1: 2, 3: 4}', $a);
 	assertType('false', array_is_list($a));

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
@@ -23,4 +23,7 @@ function () {
 	$a[] = 4;
 	assertType('array{0: 1, 1: 2, 3: 4}', $a);
 	assertType('false', array_is_list($a));
+	unset($a[3]);
+	assertType('array{0: 1, 1: 2}', $a);
+	assertType('true', array_is_list($a));
 };


### PR DESCRIPTION
Extracted from https://github.com/phpstan/phpstan-src/pull/3381

It may be surprising but the code
```
$a = [1, 2, 3];
unset($a[2]);

var_dump(array_is_list($a));
```
display `TRUE`.

As shown in the example https://3v4l.org/0HFeL

So I updated `ConstantArrayType::unsetOffsetType()`
and `ConstantArrayTypeBuilder::setOffsetValueType()`

Edit: But I feel like this bugfix might not enough like shown by the latest added test https://github.com/phpstan/phpstan-src/pull/3400/commits/61b61607386c2e8707b2cbc889479b8689f122f8
=> See https://3v4l.org/XX2fU for the PHP behavior.

So maybe the fix should be done differently