### PR TITLE
Fix ImpossibleCheckTypeFunctionCallRule for `is_subclass_of` and `is_a`

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -38,9 +38,6 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		}
 
 		$functionName = (string) $node->name;
-		if (in_array(strtolower($functionName), ['is_a', 'is_subclass_of'], true)) {
-			return [];
-		}
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
 		if ($isAlways === null) {
 			return [];

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -7,9 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function in_array;
 use function sprintf;
-use function strtolower;
 
 /**
  * @implements Rule<Node\Expr\FuncCall>

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use function in_array;
 use function sprintf;
 use function strtolower;
 
@@ -37,7 +38,7 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		}
 
 		$functionName = (string) $node->name;
-		if (strtolower($functionName) === 'is_a') {
+		if (in_array(strtolower($functionName), ['is_a', 'is_subclass_of'], true)) {
 			return [];
 		}
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);

--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\TypeCombinator;
-
 use function count;
 use function strtolower;
 

--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -53,14 +53,17 @@ final class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifying
 		$superType = $allowString
 			? TypeCombinator::union(new ObjectWithoutClassType(), new ClassStringType())
 			: new ObjectWithoutClassType();
+
+		$resultType = $this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, true);
+
 		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
-		if ($superType->isSuperTypeOf($objectOrClassType)->yes() && !$classType->isClassStringType()->yes()) {
+		if ($resultType->equals($superType) && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
 			return new SpecifiedTypes([], []);
 		}
 
 		return $this->typeSpecifier->create(
 			$node->getArgs()[0]->value,
-			$this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, true),
+			$resultType,
 			$context,
 			false,
 			$scope,

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -13,11 +13,8 @@ use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\Generic\GenericClassStringType;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\UnionType;
-
 use function count;
 use function strtolower;
 

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -54,14 +54,17 @@ final class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeS
 		$superType = $allowString
 			? TypeCombinator::union(new ObjectWithoutClassType(), new ClassStringType())
 			: new ObjectWithoutClassType();
+
+		$resultType = $this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, false);
+
 		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
-		if ($superType->isSuperTypeOf($objectOrClassType)->yes() && !$classType->isClassStringType()->yes()) {
+		if ($resultType->equals($superType) && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
 			return new SpecifiedTypes([], []);
 		}
 
 		return $this->typeSpecifier->create(
 			$node->getArgs()[0]->value,
-			$this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, false),
+			$resultType,
 			$context,
 			false,
 			$scope,

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -9,9 +9,15 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+
 use function count;
 use function strtolower;
 
@@ -45,6 +51,14 @@ final class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeS
 
 		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
 		if ($objectOrClassType instanceof GenericClassStringType && $classType instanceof GenericClassStringType) {
+			return new SpecifiedTypes([], []);
+		}
+
+		$superType = $allowString
+			? TypeCombinator::union(new ObjectWithoutClassType(), new ClassStringType())
+			: new ObjectWithoutClassType();
+		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
+		if ($superType->isSuperTypeOf($objectOrClassType)->yes() && !$classType->isClassStringType()->yes()) {
 			return new SpecifiedTypes([], []);
 		}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -1133,9 +1133,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Variable('stringOrNull')),
 					new Arg(new Expr\ConstFetch(new Name('false'))),
 				]),
-				[
-					'$object' => 'object',
-				],
+				[],
 				[],
 			],
 			[

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -492,16 +492,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
-		$this->analyse([__DIR__ . '/data/bug-6305.php'], [
-			[
-				'Call to function is_subclass_of() with Bug6305\B and \'Bug6305\\\A\' will always evaluate to true.',
-				11,
-			],
-			[
-				'Call to function is_subclass_of() with Bug6305\B and \'Bug6305\\\B\' will always evaluate to false.',
-				14,
-			],
-		]);
+		$this->analyse([__DIR__ . '/data/bug-6305.php'], []);
 	}
 
 	public function testBug6698(): void
@@ -1099,6 +1090,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/always-true-preg-match.php'], []);
+	}
+
+	public function testBug3979(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-3979.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -492,7 +492,16 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 	{
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
-		$this->analyse([__DIR__ . '/data/bug-6305.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-6305.php'], [
+			[
+				'Call to function is_subclass_of() with Bug6305\B and \'Bug6305\\\A\' will always evaluate to true.',
+				11,
+			],
+			[
+				'Call to function is_subclass_of() with Bug6305\B and \'Bug6305\\\B\' will always evaluate to false.',
+				14,
+			],
+		]);
 	}
 
 	public function testBug6698(): void

--- a/tests/PHPStan/Rules/Comparison/data/bug-3979.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3979.php
@@ -20,3 +20,15 @@ function check_class($value, $class_type): bool
 
 var_dump(check_class("B", "A")); // true
 var_dump(check_class("C", "A")); // false
+
+/**
+ * @param class-string $value
+ * @param string $class_type
+ */
+function check_class2($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-3979.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3979.php
@@ -80,3 +80,51 @@ function check_class6($value, $class_type): bool
 	}
 	return false;
 }
+
+/**
+ * @param object $value
+ * @param class-string $class_type
+ */
+function check_class7($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param class-string $class_type
+ */
+function check_class8($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string $value
+ * @param class-string $class_type
+ */
+function check_class9($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string $value
+ * @param class-string $class_type
+ */
+function check_class10($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-3979.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3979.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Bug3979;
+
+class A { }
+class B extends A { }
+class C { }
+
+/**
+ * @param mixed $value
+ * @param string $class_type
+ */
+function check_class($value, $class_type): bool
+{
+	if (!is_string($value) || !class_exists($value) ||
+		($class_type && !is_subclass_of($value, $class_type)))
+		return false;
+	return true;
+}
+
+var_dump(check_class("B", "A")); // true
+var_dump(check_class("C", "A")); // false

--- a/tests/PHPStan/Rules/Comparison/data/bug-3979.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3979.php
@@ -32,3 +32,51 @@ function check_class2($value, $class_type): bool
 	}
 	return false;
 }
+
+/**
+ * @param class-string|object $value
+ * @param string $class_type
+ */
+function check_class3($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string|object $value
+ * @param string $class_type
+ */
+function check_class4($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param string $class_type
+ */
+function check_class5($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param string $class_type
+ */
+function check_class6($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/3979
which can be simplified to https://phpstan.org/r/ef72a996-8fbe-4a4e-831f-4d78c542ad19

I'm not sure there is a better (easy ?) fix for this issue. `is_subclass_of($string, $bar)` specify the type of `$string` to class-string when true, but it doesn't mean that the call is useless if the param is already a class-string.

I discovered there was an exclusion of `is_a` in the `ImpossibleCheckTypeFunctionCallRule` (maybe for the same reason)
so I think it could be the same for `is_subclass_of` since the behavior is similar.
