### PR TITLE
Prevent resolving conditional types in callable param/return types

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-11472.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11472.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug11472;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @phpstan-return ($maybeFoo is 'foo' ? true : false)
+ */
+function isFoo(mixed $maybeFoo): bool
+{
+	return $maybeFoo === 'foo';
+}
+
+function (): void {
+	assertType('true', isFoo('foo'));
+	assertType('true', isFoo(...)('foo'));
+};


### PR DESCRIPTION
Unresolvable conditional types should not be forcibly resolved in callable param/return types because they generally depend on calling that callable.

Fix phpstan/phpstan#11472.