### PR TITLE
Make array/object keys quote aware

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -9,6 +9,7 @@ use PHPStan\Internal\CombinationsHelper;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\QuoteAwareConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
@@ -1666,6 +1667,8 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				$value = $keyNode->value;
 				if (self::isValidIdentifier($value)) {
 					$keyNode = new IdentifierTypeNode($value);
+				} else {
+					$keyNode = new QuoteAwareConstExprStringNode($value, QuoteAwareConstExprStringNode::SINGLE_QUOTED);
 				}
 			}
 

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type;
 use PHPStan\Analyser\OutOfClassScope;
 use PHPStan\Broker\Broker;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\QuoteAwareConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ObjectShapeItemNode;
@@ -519,6 +520,8 @@ class ObjectShapeType implements Type
 
 				/** @var ConstExprStringNode $keyNode */
 				$keyNode = $keyPhpDocNode->constExpr;
+
+				$keyNode = new QuoteAwareConstExprStringNode($keyNode->value, QuoteAwareConstExprStringNode::SINGLE_QUOTED);
 			}
 			$items[] = new ObjectShapeItemNode(
 				$keyNode,


### PR DESCRIPTION
Fixes phpstan/phpdoc-parser#251

Needs tests, let's see where. 