### PR TITLE
Prevent warning in range() on php 7.x

### DIFF
--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -68,7 +68,7 @@ final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 					}
 
 					try {
-						$rangeValues = range($startConstant->getValue(), $endConstant->getValue(), $stepConstant->getValue());
+						$rangeValues = @range($startConstant->getValue(), $endConstant->getValue(), $stepConstant->getValue());
 					} catch (ValueError) {
 						continue;
 					}

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5686,6 +5686,10 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'range(2, 5, 2)',
 			],
 			[
+				'array{2, 0}',
+				"range(2, '', 2)",
+			],
+			[
 				PHP_VERSION_ID < 80300 ? 'array{2.0, 3.0, 4.0, 5.0}' : 'array{2, 3, 4, 5}',
 				'range(2, 5, 1.0)',
 			],


### PR DESCRIPTION
given invalid parameters the `range()` function can emit warnings, as I recently experienced in https://github.com/phpstan/phpstan-src/pull/3419

see https://3v4l.org/nYbAo

there are a few cases which only emit warnings
see https://www.php.net/manual/en/function.range.php

<img width="1058" alt="grafik" src="https://github.com/user-attachments/assets/394fdb17-0bed-4155-9db3-93eb03bdefee">
