### PR TITLE
Expose Output::isDecorated and Output::isVeryVerbose

### DIFF
--- a/src/Command/Output.php
+++ b/src/Command/Output.php
@@ -16,6 +16,8 @@ interface Output
 
 	public function isVerbose(): bool;
 
+	public function isVeryVerbose(): bool;
+
 	public function isDebug(): bool;
 
 	public function isDecorated(): bool;

--- a/src/Command/Output.php
+++ b/src/Command/Output.php
@@ -18,4 +18,6 @@ interface Output
 
 	public function isDebug(): bool;
 
+	public function isDecorated(): bool;
+
 }

--- a/src/Command/Symfony/SymfonyOutput.php
+++ b/src/Command/Symfony/SymfonyOutput.php
@@ -49,4 +49,9 @@ final class SymfonyOutput implements Output
 		return $this->symfonyOutput->isDebug();
 	}
 
+	public function isDecorated(): bool
+	{
+		return $this->symfonyOutput->isDecorated();
+	}
+
 }

--- a/src/Command/Symfony/SymfonyOutput.php
+++ b/src/Command/Symfony/SymfonyOutput.php
@@ -44,6 +44,11 @@ final class SymfonyOutput implements Output
 		return $this->symfonyOutput->isVerbose();
 	}
 
+	public function isVeryVerbose(): bool
+	{
+		return $this->symfonyOutput->isVeryVerbose();
+	}
+
 	public function isDebug(): bool
 	{
 		return $this->symfonyOutput->isDebug();

--- a/src/Rules/Api/BcUncoveredInterface.php
+++ b/src/Rules/Api/BcUncoveredInterface.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Api;
 
 use PHPStan\Analyser\Scope;
+use PHPStan\Command\Output;
 use PHPStan\Reflection\Callables\CallableParametersAcceptor;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Reflection\ExtendedPropertyReflection;
@@ -39,6 +40,7 @@ final class BcUncoveredInterface
 		NonIgnorableRuleError::class,
 		RuleError::class,
 		TipRuleError::class,
+		Output::class,
 	];
 
 }


### PR DESCRIPTION
This can be used by an ErrorFormatter to determine if `--ansi` or `--no-ansi` was used.

A use case can be to toggle rendering of colors or hyperlinks.

When ansi is not enabled, one might want to render a link differently.

Needed for https://github.com/TicketSwap/phpstan-error-formatter