### PR TITLE
Do not truncate offset key

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -327,7 +327,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			$acceptsValue = $valueType->acceptsWithReason($otherValueType, $strictTypes)->decorateReasons(
 				static fn (string $reason) => sprintf(
 					'Offset %s (%s) does not accept type %s: %s',
-					$keyType->describe(VerbosityLevel::value()),
+					$keyType->describe(VerbosityLevel::precise()),
 					$valueType->describe($verbosity),
 					$otherValueType->describe($verbosity),
 					$reason,
@@ -337,7 +337,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				$acceptsValue = new AcceptsResult($acceptsValue->result, [
 					sprintf(
 						'Offset %s (%s) does not accept type %s.',
-						$keyType->describe(VerbosityLevel::value()),
+						$keyType->describe(VerbosityLevel::precise()),
 						$valueType->describe($verbosity),
 						$otherValueType->describe($verbosity),
 					),


### PR DESCRIPTION
When you have an array with long key names, it becomes hard / impossible to see which one errors:

> 💡 Offset 'lockedPersonalizati…' (F\Q\C\N) does not accept type F\Q\C\N|null.

I think it would be better to be precise here.

@ondrejmirtes curious if you agree 😊 