### PR TITLE
Fix string types sorting

### DIFF
--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -116,6 +116,10 @@ final class UnionTypeHelper
 				return self::compareStrings($a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value()));
 			}
 
+			if ($a->isString()->yes() && $b->isString()->yes()) {
+				return self::compareStrings($a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value()));
+			}
+
 			return self::compareStrings($a->describe(VerbosityLevel::typeOnly()), $b->describe(VerbosityLevel::typeOnly()));
 		});
 		return $types;

--- a/tests/PHPStan/Analyser/nsrt/string-union.php
+++ b/tests/PHPStan/Analyser/nsrt/string-union.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace StringUnion;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param literal-string $s1
+	 * @param numeric-string $s2
+	 */
+	public function sayHello(string $s1, string $s2): void
+	{
+		$a = random_int(0, 1) ? $s1 : $s2;
+		assertType('literal-string|numeric-string', $a);
+		$b = random_int(0, 1) ? $s2 : $s1;
+		assertType('literal-string|numeric-string', $b);
+	}
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1962,6 +1962,14 @@ class TypeCombinatorTest extends PHPStanTestCase
 			],
 			[
 				[
+					new IntersectionType([new StringType(), new AccessoryNumericStringType()]),
+					new IntersectionType([new StringType(), new AccessoryLiteralStringType()]),
+				],
+				UnionType::class,
+				'literal-string|numeric-string',
+			],
+			[
+				[
 					TemplateTypeFactory::create(
 						TemplateTypeScope::createWithFunction('doFoo'),
 						'T',


### PR DESCRIPTION
Needed for https://github.com/phpstan/phpstan-src/pull/3438#pullrequestreview-2305028004
or testUnion and testUnionReversed doesn't give the same result.

As seen in
https://phpstan.org/r/f9b06e12-01e6-45c2-92dc-2fcd514a5dbb
PHPStan is not consistent about union of strings.

I'm not familiar with the UnionTypeHelper method, so I'm not sure if 
```
if ($a->isString()->yes() && $b->isString()->yes()) {
				return self::compareStrings($a->describe(VerbosityLevel::value()), $b->describe(VerbosityLevel::value()));
			}
```
is the best fix or if something more generic like
```
instanceof IntersectionType
```
should be preferred.