### PR TITLE
Normalize path in TypeInferenceTestCase

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -302,13 +302,12 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		$finder->followLinks();
 		$files = [];
 
-		$fileHelper = new FileHelper($directory);
 		foreach ($finder->files()->name('*.php')->in($directory) as $fileInfo) {
 			$path = $fileInfo->getPathname();
 			if (self::isFileLintSkipped($path)) {
 				continue;
 			}
-			$files[] = $fileHelper->normalizePath($path);
+			$files[] = $path;
 		}
 
 		return $files;

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -301,12 +301,14 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		$finder = new Finder();
 		$finder->followLinks();
 		$files = [];
+
+		$fileHelper = new FileHelper($directory);
 		foreach ($finder->files()->name('*.php')->in($directory) as $fileInfo) {
 			$path = $fileInfo->getPathname();
 			if (self::isFileLintSkipped($path)) {
 				continue;
 			}
-			$files[] = $path;
+			$files[] = $fileHelper->normalizePath($path);
 		}
 
 		return $files;

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -301,7 +301,6 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		$finder = new Finder();
 		$finder->followLinks();
 		$files = [];
-
 		foreach ($finder->files()->name('*.php')->in($directory) as $fileInfo) {
 			$path = $fileInfo->getPathname();
 			if (self::isFileLintSkipped($path)) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use EnumTypeAssertions\Foo;
+use PHPStan\File\FileHelper;
 use PHPStan\Testing\TypeInferenceTestCase;
 use stdClass;
 use function array_shift;
@@ -209,7 +210,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		$base = dirname(__DIR__, 3) . '/';
 		$baseLength = strlen($base);
 
+		$fileHelper = new FileHelper($base);
 		foreach (self::findTestFiles() as $file) {
+			$file = $fileHelper->normalizePath($file);
+
 			$testName = $file;
 			if (str_starts_with($file, $base)) {
 				$testName = substr($file, $baseLength);


### PR DESCRIPTION
since https://github.com/phpstan/phpstan-src/pull/3440 I get mixed directory separators in test-failure reporting:

```
There were 3 failures:

1) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser/nsrt\bug-4207.php" ('C:\dvl\Workspace\phpstan-src-...07.php')
Failed assertions in C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\nsrt\bug-4207.php:

...

2) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser/nsrt\bug-11692.php" ('C:\dvl\Workspace\phpstan-src-...92.php')
Failed assertions in C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\nsrt\bug-11692.php:

...
```

see the mix of `\` and `/` in the data set names.

---

this PR normalizes the separator so we get now:
```
There were 3 failures:

1) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\nsrt\bug-11692.php" ('C:\dvl\Workspace\phpstan-src-...92.php')
Failed assertions in C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\nsrt\bug-11692.php:

...

C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\NodeScopeResolverTest.php:257

2) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\nsrt\range-int-range.php" ('C:\dvl\Workspace\phpstan-src-...ge.php')
Failed assertions in C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\Analyser\nsrt\range-int-range.php:

...
```