### PR TITLE
Fix FileExcluder on windows

### DIFF
--- a/src/File/FileExcluder.php
+++ b/src/File/FileExcluder.php
@@ -50,7 +50,7 @@ final class FileExcluder
 	 * @param string[] $analyseExcludes
 	 */
 	public function __construct(
-		FileHelper $fileHelper,
+		private FileHelper $fileHelper,
 		array $analyseExcludes,
 	)
 	{
@@ -89,6 +89,8 @@ final class FileExcluder
 
 	public function isExcludedFromAnalysing(string $file): bool
 	{
+		$file = $this->fileHelper->normalizePath($file);
+
 		foreach ($this->literalAnalyseExcludes as $exclude) {
 			if (str_starts_with($file, $exclude)) {
 				return true;

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -64,7 +64,7 @@ class FileExcluderTest extends PHPStanTestCase
 			],
 			[
 				__DIR__ . '\data\parse-error.php',
-				['tests/PHPStan/File/data/*'],
+				['*/tests/PHPStan/File/data/*'],
 				true,
 			],
 			[


### PR DESCRIPTION
fixes 1 of the test errors. one remaining but I am not sure yet whether its a problem in the test or the impl.

underlying problem was

```php
<?php

var_dump(fnmatch(
	'C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\File\*',
	'C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\File/data/excluded-file.php',
	FNM_NOESCAPE | FNM_CASEFOLD
));

var_dump(fnmatch(
	'C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\File\*',
	'C:\dvl\Workspace\phpstan-src-staabm\tests\PHPStan\File\data\excluded-file.php',
	FNM_NOESCAPE | FNM_CASEFOLD
));
```

see https://3v4l.org/WAAkK