### PR TITLE
Fix unassigning the last offset in a ConstantArray that is a list

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -734,7 +734,9 @@ class ConstantArrayType extends ArrayType implements ConstantType
 					$k++;
 				}
 
-				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, TrinaryLogic::createNo());
+				$wasLastOffset = TrinaryLogic::createFromBoolean($i === count($this->keyTypes) - 1);
+
+				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, $this->isList->and($wasLastOffset));
 			}
 
 			return $this;

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -122,12 +122,19 @@ class ConstantArrayTypeBuilder
 				$newAutoIndexes[] = $newAutoIndex;
 				$this->nextAutoIndexes = array_values(array_unique($newAutoIndexes));
 
+				$keyTypesCount = count($this->keyTypes);
+
 				if ($optional || $hasOptional) {
-					$this->optionalKeys[] = count($this->keyTypes) - 1;
+					$this->optionalKeys[] = $keyTypesCount - 1;
 				}
 
-				if (count($this->keyTypes) > self::ARRAY_COUNT_LIMIT) {
+				if ($keyTypesCount > self::ARRAY_COUNT_LIMIT) {
 					$this->degradeToGeneralArray = true;
+				}
+
+				if ($keyTypesCount - 1 !== $max && $this->isList->yes()) {
+					// The array is not a list any longer if there is gap in the offsets
+					$this->isList = TrinaryLogic::createNo();
 				}
 
 				return;

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
@@ -19,7 +19,7 @@ function () {
 	assertType('true', array_is_list($a));
 	unset($a[2]);
 	assertType('array{1, 2}', $a);
-	assertType('false', array_is_list($a));
+	assertType('true', array_is_list($a));
 	$a[] = 4;
 	assertType('array{0: 1, 1: 2, 3: 4}', $a);
 	assertType('false', array_is_list($a));

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -1054,4 +1054,9 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10715.php'], []);
 	}
 
+	public function testBug11718(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-11718.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-11718.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-11718.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11718;
+
+class Foo
+{
+	/**
+	 * @return list<string>
+	 */
+	public function test(string $a, string $b): array
+	{
+		$list = ['x', 'y', $a, $b];
+
+		unset($list[3]); // no error if uncommented!
+
+		return $list;
+	}
+}


### PR DESCRIPTION
Those keep being lists.

Fixes https://github.com/phpstan/phpstan/issues/11718