### PR TITLE
add generic types for array_values

### DIFF
--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -17,6 +17,14 @@ function array_reduce(
 ) {}
 
 /**
+ * @template T of mixed
+ *
+ * @param array<T> $array
+ * @return ($array is non-empty-array ? non-empty-list<T> : list<T>)
+ */
+function array_values(array $array): array {}
+
+/**
  * @template TKey as (int|string)
  * @template T
  * @template TArray as array<TKey,T>

--- a/tests/PHPStan/Analyser/nsrt/array_values.php
+++ b/tests/PHPStan/Analyser/nsrt/array_values.php
@@ -37,4 +37,12 @@ class HelloWorld
 		);
 		assertType("array{0?: 'a'|'b'|'c', 1?: 'b'|'c', 2?: 'c'}", array_values($numbers));
 	}
+
+	/**
+	 * @param array<string, non-empty-array<string, int>> $a
+	 */
+	public function arrayMap(array $a): void
+	{
+		assertType('array<string, non-empty-list<int>>', array_map(array_values(...), $a));
+	}
 }


### PR DESCRIPTION
Fixes: https://phpstan.org/r/0865ef07-67b3-47a7-9747-2b34554c57f3

[Phpstorm-stubs](https://github.com/JetBrains/phpstorm-stubs/blob/63db92ae3d59bb746cda2ff6bc6f2949473a5ca3/standard/standard_9.php#L101) don't have a generic type for `array_values` (and they wouldn't have the conditional return type anyway).