### PR TITLE
implement ClosureType::getReferencedTemplateTypes()

### DIFF
--- a/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodSignatureVarianceRuleTest.php
@@ -234,4 +234,14 @@ class MethodSignatureVarianceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10609(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10609.php'], [
+			[
+				'Template type A is declared as covariant, but occurs in contravariant position in parameter fn of method Bug10609\Collection::tap().',
+				13,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Generics/data/bug-10609.php
+++ b/tests/PHPStan/Rules/Generics/data/bug-10609.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bug10609;
+
+/**
+ * @template-covariant A
+ */
+final class Collection
+{
+	/**
+	 * @param \Closure(A): A $fn
+	 */
+	public function tap(mixed $fn): void
+	{
+	}
+}


### PR DESCRIPTION
closes phpstan/phpstan#10609