### PR TITLE
Fix ErrorType after ArrayDimFetch

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -651,6 +651,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function getOffsetValueType(Type $offsetType): Type
 	{
+		if (count($this->keyTypes) === 0) {
+			return new ErrorType();
+		}
+
 		$offsetType = $offsetType->toArrayKey();
 		$matchingValueTypes = [];
 		$all = true;
@@ -674,10 +678,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		if ($all) {
-			if (count($this->keyTypes) === 0) {
-				return new ErrorType();
-			}
-
 			return $this->getIterableValueType();
 		}
 
@@ -691,10 +691,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		if ($maybeAll) {
-			if (count($this->keyTypes) === 0) {
-				return new ErrorType();
-			}
-
 			return $this->getIterableValueType();
 		}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -654,9 +654,19 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		$offsetType = $offsetType->toArrayKey();
 		$matchingValueTypes = [];
 		$all = true;
+		$maybeAll = true;
 		foreach ($this->keyTypes as $i => $keyType) {
 			if ($keyType->isSuperTypeOf($offsetType)->no()) {
 				$all = false;
+
+				if (
+					$keyType instanceof ConstantIntegerType
+					&& !$offsetType->isString()->no()
+					&& $offsetType->isConstantScalarValue()->no()
+				) {
+					continue;
+				}
+				$maybeAll = false;
 				continue;
 			}
 
@@ -678,6 +688,14 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			}
 
 			return $type;
+		}
+
+		if ($maybeAll) {
+			if (count($this->keyTypes) === 0) {
+				return new ErrorType();
+			}
+
+			return $this->getIterableValueType();
 		}
 
 		return new ErrorType(); // undefined offset

--- a/tests/PHPStan/Rules/Variables/data/bug-10577.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-10577.php
@@ -20,10 +20,22 @@ class HelloWorld
 			throw new \RuntimeException();
 		}
 
+		assertType("non-empty-string", $value);
+		assertType("'Test1'|'Test2'", self::MAP[$value]);
+
 		$value = self::MAP[$value] ?? $value;
 
+		assertType("non-empty-string", $value);
 		assertType("'Test1'|'Test2'", self::MAP[$value]);
 
 		// ...
+	}
+
+	public function validateNumericString(string $value): void
+	{
+		if (!is_numeric($value)) return;
+
+		assertType("numeric-string", $value);
+		assertType("'Test1'|'Test2'", self::MAP[$value]);
 	}
 }


### PR DESCRIPTION
another try at fixing `ErrorType`s which showed up in https://github.com/phpstan/phpstan-src/pull/3453#issuecomment-2360493603

before this PR: https://phpstan.org/r/1eacbfc8-49e2-4b6e-ba01-ef56aa2b8f56

I got to this point with inspiration from https://github.com/phpstan/phpstan-src/commit/2fb66328fdd7119922ce4579f8951ee776320ef6 which added support for maybe-has-offset for constant arrays.
I took the same condition to make sure `getOffsetValueType()` will not return `ErrorType` for this path when `hasOffsetValueType` returns `Maybe`.

----

Goal is, to get a green build in https://github.com/phpstan/phpstan-src/pull/3453


---- 

1st commit is the actual fix
2nd commit is a refactor to de-duplicate logic