### PR TITLE
Makefile: Disable xdebug in dev tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 build: cs tests phpstan
 
 tests:
-	php vendor/bin/paratest --runner WrapperRunner --no-coverage
+	XDEBUG_MODE=off php vendor/bin/paratest --runner WrapperRunner --no-coverage
 
 tests-integration:
 	php vendor/bin/paratest --runner WrapperRunner --no-coverage --group exec
@@ -18,7 +18,7 @@ tests-golden-reflection:
 	php vendor/bin/paratest --runner WrapperRunner --no-coverage tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
 
 lint:
-	php vendor/bin/parallel-lint --colors \
+	XDEBUG_MODE=off php vendor/bin/parallel-lint --colors \
 		--exclude tests/PHPStan/Analyser/data \
 		--exclude tests/PHPStan/Analyser/nsrt \
 		--exclude tests/PHPStan/Rules/Methods/data \
@@ -80,10 +80,10 @@ lint:
 		src tests
 
 cs:
-	composer install --working-dir build-cs && php build-cs/vendor/bin/phpcs
+	composer install --working-dir build-cs && XDEBUG_MODE=off php build-cs/vendor/bin/phpcs
 
 cs-fix:
-	php build-cs/vendor/bin/phpcbf
+	XDEBUG_MODE=off php build-cs/vendor/bin/phpcbf
 
 phpstan:
 	php bin/phpstan clear-result-cache -q && php -d memory_limit=448M bin/phpstan


### PR DESCRIPTION
when working locally often-times xdebug is loaded which slows down some `make` tasks.

lets prepend `XDEBUG_MODE=off` to disable xdebug for commands often used and for the tools that do not already auto-disabling restarts on their own.

`make cs-fix` with this PR (xdebug loaded):
`Time: 32.12 secs; Memory: 156.5MB`

`make cs-fix` before this PR (xdebug loaded):
`Time: 1 mins, 9.14 secs; Memory: 156.5MB`