### PR TITLE
Added regression test

### DIFF
--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -798,4 +798,16 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7863(): void
+	{
+		$this->checkImplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-7863.php'], [
+			[
+				'Binary operation "+" between mixed and array results in an error.',
+				10,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/bug-7863.php
+++ b/tests/PHPStan/Rules/Operators/data/bug-7863.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bug7863;
+
+function ($mixed, array $arr) {
+	if (is_array($mixed)) {
+		return;
+	}
+	// mixed~array + array
+	$x = $mixed + $arr;
+};


### PR DESCRIPTION
the error I have expected in https://github.com/phpstan/phpstan/issues/7863 was already there. we did not see it though, because it's hidden behind `checkImplicitMixed`.

closes https://github.com/phpstan/phpstan/issues/7863