### PR TITLE
Fix sprintf() inference for constant values with format-width in pattern

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-7387.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7387.php
@@ -57,6 +57,7 @@ class HelloWorld
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $posInt));
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $negInt));
 		assertType('numeric-string', sprintf('%2$14s', $mixed, $intRange));
+		assertType("non-falsy-string", sprintf('%2$14s', $mixed, '1'));
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $nonZeroIntRange));
 
 		assertType('numeric-string', sprintf('%2$.14F', $mixed, $i));

--- a/tests/PHPStan/Analyser/nsrt/bug-7387.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7387.php
@@ -57,9 +57,14 @@ class HelloWorld
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $posInt));
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $negInt));
 		assertType('numeric-string', sprintf('%2$14s', $mixed, $intRange));
-		assertType("non-falsy-string", sprintf('%2$14s', $mixed, '1'));
-		assertType("'1'", sprintf('%2$s', $mixed, '1'));
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $nonZeroIntRange));
+
+		assertType("non-falsy-string", sprintf('%2$14s', $mixed, 1));
+		assertType("non-falsy-string", sprintf('%2$14s', $mixed, '1'));
+		assertType("non-falsy-string", sprintf('%2$14s', $mixed, 'abc'));
+		assertType("'1'", sprintf('%2$s', $mixed, 1));
+		assertType("'1'", sprintf('%2$s', $mixed, '1'));
+		assertType("'abc'", sprintf('%2$s', $mixed, 'abc'));
 
 		assertType('numeric-string', sprintf('%2$.14F', $mixed, $i));
 		assertType('numeric-string', sprintf('%2$.14F', $mixed, $f));

--- a/tests/PHPStan/Analyser/nsrt/bug-7387.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7387.php
@@ -58,6 +58,7 @@ class HelloWorld
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $negInt));
 		assertType('numeric-string', sprintf('%2$14s', $mixed, $intRange));
 		assertType("non-falsy-string", sprintf('%2$14s', $mixed, '1'));
+		assertType("'1'", sprintf('%2$s', $mixed, '1'));
 		assertType('non-falsy-string&numeric-string', sprintf('%2$14s', $mixed, $nonZeroIntRange));
 
 		assertType('numeric-string', sprintf('%2$.14F', $mixed, $i));


### PR DESCRIPTION
we should not infer constant strings 1:1 when sprintf expects a format-width which can add padding characters and what-not.

---

fixes wrong constant value inference
https://phpstan.org/r/ea3080f4-f032-4f2f-8f3b-c5c0f0062da0
https://3v4l.org/HI0pE


We could make this more precise but I fixed only what is blocking https://github.com/phpstan/phpstan-src/pull/3475