### PR TITLE
Change iptcparse return type

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5627,7 +5627,7 @@ return [
 'InvalidArgumentException::getTraceAsString' => ['string'],
 'ip2long' => ['int|false', 'ip_address'=>'string'],
 'iptcembed' => ['string|bool', 'iptcdata'=>'string', 'jpeg_file_name'=>'string', 'spool='=>'int'],
-'iptcparse' => ['array<string,array<string>>|false', 'iptcdata'=>'string'],
+'iptcparse' => ['array<string,list<string>>|false', 'iptcdata'=>'string'],
 'is_a' => ['bool', 'object_or_string'=>'object|string', 'class_name'=>'string', 'allow_string='=>'bool'],
 'is_array' => ['bool', 'var'=>'mixed'],
 'is_bool' => ['bool', 'var'=>'mixed'],


### PR DESCRIPTION
the inner arrays are always lists, see https://github.com/php/php-src/blob/e035a957237a7c17aa3dc2810d86333c93654c11/ext/standard/iptc.c#L365