### PR TITLE
Refacto LooseComparisonHelper

### DIFF
--- a/src/Type/LooseComparisonHelper.php
+++ b/src/Type/LooseComparisonHelper.php
@@ -8,7 +8,21 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 final class LooseComparisonHelper
 {
 
+	/**
+	 * @deprecated Use getConstantScalarValuesForComparison instead
+	 */
 	public static function compareConstantScalars(ConstantScalarType $leftType, ConstantScalarType $rightType, PhpVersion $phpVersion): BooleanType
+	{
+		[$leftValue, $rightValue] = self::getConstantScalarValuesForComparison($leftType, $rightType, $phpVersion);
+
+		// @phpstan-ignore equal.notAllowed
+		return new ConstantBooleanType($leftValue == $rightValue); // phpcs:ignore
+	}
+
+	/**
+	 * @return array{scalar|null, scalar|null}
+	 */
+	public static function getConstantScalarValuesForComparison(ConstantScalarType $leftType, ConstantScalarType $rightType, PhpVersion $phpVersion): array
 	{
 		if ($phpVersion->castsNumbersToStringsOnLooseComparison()) {
 			$isNumber = new UnionType([
@@ -17,34 +31,27 @@ final class LooseComparisonHelper
 			]);
 
 			if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $isNumber->isSuperTypeOf($rightType)->yes()) {
-				$stringValue = (string) $rightType->getValue();
-				return new ConstantBooleanType($stringValue === $leftType->getValue());
+				return [$leftType->getValue(), (string) $rightType->getValue()];
 			}
 			if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $isNumber->isSuperTypeOf($leftType)->yes()) {
-				$stringValue = (string) $leftType->getValue();
-				return new ConstantBooleanType($stringValue === $rightType->getValue());
+				return [(string) $leftType->getValue(), $rightType->getValue()];
 			}
 		} else {
 			if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $rightType->isFloat()->yes()) {
-				$numericPart = (float) $leftType->getValue();
-				return new ConstantBooleanType($numericPart === $rightType->getValue());
+				return [(float) $leftType->getValue(), $rightType->getValue()];
 			}
 			if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $leftType->isFloat()->yes()) {
-				$numericPart = (float) $rightType->getValue();
-				return new ConstantBooleanType($numericPart === $leftType->getValue());
+				return [$leftType->getValue(), (float) $rightType->getValue()];
 			}
 			if ($leftType->isString()->yes() && $leftType->isNumericString()->no() && $rightType->isInteger()->yes()) {
-				$numericPart = (int) $leftType->getValue();
-				return new ConstantBooleanType($numericPart === $rightType->getValue());
+				return [(int) $leftType->getValue(), $rightType->getValue()];
 			}
 			if ($rightType->isString()->yes() && $rightType->isNumericString()->no() && $leftType->isInteger()->yes()) {
-				$numericPart = (int) $rightType->getValue();
-				return new ConstantBooleanType($numericPart === $leftType->getValue());
+				return [$leftType->getValue(), (int) $rightType->getValue()];
 			}
 		}
 
-		// @phpstan-ignore equal.notAllowed
-		return new ConstantBooleanType($leftType->getValue() == $rightType->getValue()); // phpcs:ignore
+		return [$leftType->getValue(), $rightType->getValue()];
 	}
 
 }

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -328,7 +328,10 @@ class NullType implements ConstantScalarType
 	public function looseCompare(Type $type, PhpVersion $phpVersion): BooleanType
 	{
 		if ($type instanceof ConstantScalarType) {
-			return LooseComparisonHelper::compareConstantScalars($this, $type, $phpVersion);
+			[$leftValue, $rightValue] = LooseComparisonHelper::getConstantScalarValuesForComparison($this, $type, $phpVersion);
+
+			// @phpstan-ignore equal.notAllowed
+			return new ConstantBooleanType($leftValue == $rightValue); // phpcs:ignore
 		}
 
 		if ($type->isConstantArray()->yes() && $type->isIterableAtLeastOnce()->no()) {

--- a/src/Type/Traits/ConstantScalarTypeTrait.php
+++ b/src/Type/Traits/ConstantScalarTypeTrait.php
@@ -58,7 +58,10 @@ trait ConstantScalarTypeTrait
 		}
 
 		if ($type instanceof ConstantScalarType) {
-			return LooseComparisonHelper::compareConstantScalars($this, $type, $phpVersion);
+			[$leftValue, $rightValue] = LooseComparisonHelper::getConstantScalarValuesForComparison($this, $type, $phpVersion);
+
+			// @phpstan-ignore equal.alwaysTrue, equal.notAllowed
+			return new ConstantBooleanType($leftValue == $rightValue); // phpcs:ignore
 		}
 
 		if ($type->isConstantArray()->yes() && $type->isIterableAtLeastOnce()->no()) {


### PR DESCRIPTION
I'll use the logic from LooseComparisonHelper in https://github.com/phpstan/phpstan-src/pull/3484

After the refacto, `compareConstantScalars` doesn't seems so useful and we could have the pattern
```
[$leftValue, $rightValue] = LooseComparisonHelper::getConstantScalarValuesForComparison($this, $type, $phpVersion);
```
and then do the `==`, `<` or `<=` comparison.

Still to avoid BC break, I deprecate the method `compareConstantScalars` in 1.12.x to remove it in 2.0.x.

cc @staabm since you wrote this code.