### PR TITLE
Improve Vsprintf inference

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-7387.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7387.php
@@ -110,7 +110,7 @@ class HelloWorld
 		assertType('numeric-string', vsprintf("%4d", explode('-', '1988-8-1')));
 		assertType('numeric-string', vsprintf("%4d", $array));
 		assertType('numeric-string', vsprintf("%4d", ['123']));
-		assertType('string', vsprintf("%s", ['123'])); // could be '123'
+		assertType('non-empty-string', vsprintf("%s", ['123'])); // could be '123'
 		// too many arguments.. php silently allows it
 		assertType('numeric-string', vsprintf("%4d", ['123', '456']));
 	}

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string.php
@@ -364,6 +364,13 @@ class MoreNonEmptyStringFunctions
 		assertType('non-empty-string', sprintf($nonFalsy, $nonFalsy, $nonFalsy));
 		assertType('string', vsprintf($s, []));
 		assertType('string', vsprintf($nonEmpty, []));
+		assertType('non-empty-string', vsprintf($nonEmpty, [$nonEmpty]));
+		assertType('non-empty-string', vsprintf($nonEmpty, [$nonEmpty, $nonEmpty]));
+		assertType('non-empty-string', vsprintf($nonEmpty, [$nonFalsy, $nonFalsy]));
+		assertType('non-empty-string', vsprintf($nonFalsy, [$nonEmpty]));
+		assertType('non-empty-string', vsprintf($nonFalsy, [$nonEmpty, $nonEmpty]));
+		assertType('non-empty-string', vsprintf($nonFalsy, [$nonFalsy, $nonEmpty]));
+		assertType('non-empty-string', vsprintf($nonFalsy, [$nonFalsy, $nonFalsy]));
 
 		assertType('non-empty-string', sprintf("%s0%s", $s, $s));
 		assertType('non-empty-string', sprintf("%s0%s%s%s%s", $s, $s, $s, $s, $s));


### PR DESCRIPTION
The same logic done for `sprintf` could be done for `vsprintf`.
Instead of a foreach on every values, I just need to check the iterableValueType. 

I refacto to a method `allValuesSatisfies`, because I have in mind to re-use this method to check if every values are lowercase-string.

cc @staabm if you wanna review, since you seemed to work multiple times on this dynamicReturnTypeExtension.