### PR TITLE
Allow asserting array offset certainty

### DIFF
--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -906,7 +906,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		$this->assertTrue(
 			$expectedCertainty->equals($certainty),
 			sprintf(
-				'Certainty of variable $%s is %s, expected %s',
+				'Certainty of %s is %s, expected %s',
 				$variableName,
 				$certainty->describe(),
 				$expectedCertainty->describe(),

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -255,7 +255,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 				$variableName = $args[2];
 
 				if ($expectedCertainty->equals($actualCertainty) !== true) {
-					$failures[] = sprintf("Certainty of variable \$%s on line %d:\nExpected: %s\nActual:   %s\n", $variableName, $args[3], $expectedCertainty->describe(), $actualCertainty->describe());
+					$failures[] = sprintf("Certainty of %s on line %d:\nExpected: %s\nActual:   %s\n", $variableName, $args[3], $expectedCertainty->describe(), $actualCertainty->describe());
 				}
 			}
 		}

--- a/tests/PHPStan/Analyser/nsrt/assert-variable-certainty-on-array.php
+++ b/tests/PHPStan/Analyser/nsrt/assert-variable-certainty-on-array.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AssertVariableCertaintyOnArray;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+
+class Foo
+{
+	/**
+	 * @param array{firstName: string, lastName?: string, sub: array{other: string}} $context
+	 */
+	public function __invoke(array $context) : void
+	{
+		assertVariableCertainty(TrinaryLogic::createYes(), $context['firstName']);
+		assertVariableCertainty(TrinaryLogic::createYes(), $context['sub']);
+		assertVariableCertainty(TrinaryLogic::createYes(), $context['sub']['other']);
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $context['lastName']);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $context['nonexistent']['somethingElse']);
+
+		assertVariableCertainty(TrinaryLogic::createNo(), $context['sub']['nonexistent']);
+		assertVariableCertainty(TrinaryLogic::createNo(), $context['email']);
+	}
+
+}

--- a/tests/PHPStan/Rules/Debug/FileAssertRuleTest.php
+++ b/tests/PHPStan/Rules/Debug/FileAssertRuleTest.php
@@ -32,12 +32,16 @@ class FileAssertRuleTest extends RuleTestCase
 				37,
 			],
 			[
-				'Expected variable certainty Yes, actual: No',
+				'Expected variable $b certainty Yes, actual: No',
 				45,
 			],
 			[
-				'Expected variable certainty Maybe, actual: No',
+				'Expected variable $b certainty Maybe, actual: No',
 				46,
+			],
+			[
+				"Expected offset 'firstName' certainty No, actual: Yes",
+				65,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Debug/data/file-asserts.php
+++ b/tests/PHPStan/Rules/Debug/data/file-asserts.php
@@ -46,4 +46,23 @@ class Foo
 		assertVariableCertainty(TrinaryLogic::createMaybe(), $b);
 	}
 
+	/**
+	 * @param array{firstName: string, lastName?: string, sub: array{other: string}} $context
+	 */
+	public function arrayOffset(array $context) : void
+	{
+		assertVariableCertainty(TrinaryLogic::createYes(), $context['firstName']);
+		assertVariableCertainty(TrinaryLogic::createYes(), $context['sub']);
+		assertVariableCertainty(TrinaryLogic::createYes(), $context['sub']['other']);
+
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $context['lastName']);
+		assertVariableCertainty(TrinaryLogic::createMaybe(), $context['nonexistent']['somethingElse']);
+
+		assertVariableCertainty(TrinaryLogic::createNo(), $context['sub']['nonexistent']);
+		assertVariableCertainty(TrinaryLogic::createNo(), $context['email']);
+
+		// Deliberate error:
+		assertVariableCertainty(TrinaryLogic::createNo(), $context['firstName']);
+	}
+
 }

--- a/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
+++ b/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Testing;
 
 use PHPStan\File\FileHelper;
 use PHPUnit\Framework\AssertionFailedError;
+use function array_values;
 use function sprintf;
 
 final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
@@ -88,6 +89,16 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 		$this->expectExceptionMessage($errorMessage);
 
 		$this->gatherAssertTypes($filePath);
+	}
+
+	public function testVariableOrOffsetDescription(): void
+	{
+		$filePath = __DIR__ . '/data/assert-certainty-variable-or-offset.php';
+
+		[$variableAssert, $offsetAssert] = array_values($this->gatherAssertTypes($filePath));
+
+		$this->assertSame('variable $context', $variableAssert[4]);
+		$this->assertSame("offset 'email'", $offsetAssert[4]);
 	}
 
 }

--- a/tests/PHPStan/Testing/data/assert-certainty-variable-or-offset.php
+++ b/tests/PHPStan/Testing/data/assert-certainty-variable-or-offset.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AssertCertaintyVariableOrOffset;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertVariableCertainty;
+
+/**
+ * @param array{} $context
+ */
+function someMethod(array $context) : void
+{
+	assertVariableCertainty(TrinaryLogic::createNo(), $context);
+	assertVariableCertainty(TrinaryLogic::createYes(), $context['email']);
+}


### PR DESCRIPTION
This makes it possible to do this:

```php
/**
 * @param array{firstName: string, lastName?: string} $context
 */
public function arrayOffset(array $context) : void
{
    assertVariableCertainty(TrinaryLogic::createYes(), $context['firstName']);
    assertVariableCertainty(TrinaryLogic::createMaybe(), $context['lastName']);
    assertVariableCertainty(TrinaryLogic::createNo(), $context['email']);
}
```

