### PR TITLE
Report unparseable regexp when compilable

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -63,5 +63,6 @@ parameters:
 		explicitThrow: true
 		absentTypeChecks: true
 		requireFileExists: true
+		reportUnparsedRegexpWhenCompilable: true
 	stubFiles:
 		- ../stubs/bleedingEdge/Rule.stub

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -294,6 +294,8 @@ services:
 
 	-
 		class: PHPStan\Rules\Regexp\RegularExpressionPatternRule
+		arguments:
+			reportUnparsedRegexpWhenCompilable: %featureToggles.reportUnparsedRegexpWhenCompilable%
 		tags:
 			- phpstan.rules.rule
 

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -95,6 +95,7 @@ parameters:
 		validatePregQuote: false
 		noImplicitWildcard: false
 		requireFileExists: false
+		reportUnparsedRegexpWhenCompilable: false
 		narrowPregMatches: true
 		tooWidePropertyType: false
 		explicitThrow: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -94,6 +94,7 @@ parametersSchema:
 		explicitThrow: bool()
 		absentTypeChecks: bool()
 		requireFileExists: bool()
+		reportUnparsedRegexpWhenCompilable: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()

--- a/src/Rules/Regexp/RegularExpressionPatternRule.php
+++ b/src/Rules/Regexp/RegularExpressionPatternRule.php
@@ -55,12 +55,14 @@ final class RegularExpressionPatternRule implements Rule
 
 			$errorMessage = $this->validatePatternByParserGrammar($pattern);
 
-			if ($errorMessage !== null && $this->reportUnparsedRegexpWhenCompilable) {
-				$errors[] = RuleErrorBuilder::message(sprintf('Regex pattern cannot be parsed: %s', $errorMessage))
-					->identifier('regexp.pattern')
-					->tip(sprintf('Please open an issue for your regex pattern at %s', 'https://github.com/phpstan/phpstan/issues'))
-					->build();
+			if ($errorMessage === null || !$this->reportUnparsedRegexpWhenCompilable) {
+				continue;
 			}
+
+			$errors[] = RuleErrorBuilder::message(sprintf('Regex pattern cannot be parsed: %s', $errorMessage))
+				->identifier('regexp.pattern')
+				->tip(sprintf('Please open an issue for your regex pattern at %s', 'https://github.com/phpstan/phpstan/issues'))
+				->build();
 		}
 
 		return $errors;

--- a/src/Rules/Regexp/RegularExpressionPatternRule.php
+++ b/src/Rules/Regexp/RegularExpressionPatternRule.php
@@ -59,9 +59,9 @@ final class RegularExpressionPatternRule implements Rule
 				continue;
 			}
 
-			$errors[] = RuleErrorBuilder::message(sprintf('Regex pattern cannot be parsed: %s', $errorMessage))
+			$errors[] = RuleErrorBuilder::message(sprintf('Regex pattern cannot be parsed by PHPStan: %s', $errorMessage))
 				->identifier('regexp.pattern')
-				->tip(sprintf('Please open an issue for your regex pattern at %s', 'https://github.com/phpstan/phpstan/issues'))
+				->tip(sprintf('Please identify minimal reproducible pattern and report it at %s', 'https://github.com/phpstan/phpstan/issues'))
 				->build();
 		}
 

--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -525,11 +525,11 @@ final class RegexGroupParser
 
 		if (
 			in_array($token, [
-				'literal', 'escaped_end_class',
+				'literal',
 				// literal "-" in front/back of a character class like '[-a-z]' or '[abc-]', not forming a range
 				'range',
 				// literal "[" or "]" inside character classes '[[]' or '[]]'
-				'class_', '_class_literal',
+				'class_', '_class',
 			], true)
 		) {
 			if (str_contains($patternModifiers, 'x') && trim($value) === '') {
@@ -544,7 +544,6 @@ final class RegexGroupParser
 
 			if (
 				$appendLiterals
-				&& in_array($token, ['literal', 'range', 'class_', '_class_literal'], true)
 				&& $onlyLiterals !== null
 				&& (!in_array($value, ['.'], true) || $isEscaped || $inCharacterClass)
 			) {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1410,11 +1410,9 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11292.php');
 		$this->assertCount(1, $errors);
-		$this->assertSame(str_replace('\x7f-\xff|$', "\x7f-\xff]|$", <<<'EOD'
-			Regex pattern cannot be parsed: Unrecognized token "\" at line 1 and column 1:
-			\b(https?://)?(?:([^]\\\x00-\x20\"(),:-<>[\x7f-\xff]{1,64})(:[^]\\\x00-\x20\"(),:-<>[\x7f-\xff]{1,64})?@)?((?:[-a-zA-Z0-9\x7f-\xff]{1,63}\.)+[a-zA-Z\x7f-\xff][-a-zA-Z0-9\x7f-\xff]{1,62})((:[0-9]{1,5})?(/[!$-/0-9:;=@_~':;!a-zA-Z\x7f-\xff]*?)?(\?[!$-/0-9:;=@_':;!a-zA-Z\x7f-\xff]+?)?(#[!$-/0-9?:;=@_':;!a-zA-Z\x7f-\xff]+?)?)(?=[)'?.!,;:]*([^-_#$+.!*%'(),;/?:@~=&a-zA-Z0-9\x7f-\xff|$))
-			↑
-			EOD), $errors[0]->getMessage());
+		$this->assertSame(str_replace('\x7f-\xff|$', "\x7f-\xff]|$", 'Regex pattern cannot be parsed: Unrecognized token "\\" at line 1 and column 1:
+\\b(https?://)?(?:([^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})(:[^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})?@)?((?:[-a-zA-Z0-9\\x7f-\\xff]{1,63}\\.)+[a-zA-Z\\x7f-\\xff][-a-zA-Z0-9\\x7f-\\xff]{1,62})((:[0-9]{1,5})?(/[!$-/0-9:;=@_~\':;!a-zA-Z\\x7f-\\xff]*?)?(\\?[!$-/0-9:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?(#[!$-/0-9?:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?)(?=[)\'?.!,;:]*([^-_#$+.!*%\'(),;/?:@~=&a-zA-Z0-9\\x7f-\\xff|$))
+↑'), $errors[0]->getMessage());
 	}
 
 	public function testBug11297(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -14,6 +14,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use function extension_loaded;
 use function restore_error_handler;
 use function sprintf;
+use function str_replace;
 use const PHP_VERSION_ID;
 
 class AnalyserIntegrationTest extends PHPStanTestCase
@@ -1408,7 +1409,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug11292(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11292.php');
-		$this->assertNoErrors($errors);
+		$this->assertCount(1, $errors);
+		$this->assertSame(str_replace('\x7f-\xff|$', "\x7f-\xff]|$", <<<'EOD'
+			Regex pattern cannot be parsed: Unrecognized token "\" at line 1 and column 1:
+			\b(https?://)?(?:([^]\\\x00-\x20\"(),:-<>[\x7f-\xff]{1,64})(:[^]\\\x00-\x20\"(),:-<>[\x7f-\xff]{1,64})?@)?((?:[-a-zA-Z0-9\x7f-\xff]{1,63}\.)+[a-zA-Z\x7f-\xff][-a-zA-Z0-9\x7f-\xff]{1,62})((:[0-9]{1,5})?(/[!$-/0-9:;=@_~':;!a-zA-Z\x7f-\xff]*?)?(\?[!$-/0-9:;=@_':;!a-zA-Z\x7f-\xff]+?)?(#[!$-/0-9?:;=@_':;!a-zA-Z\x7f-\xff]+?)?)(?=[)'?.!,;:]*([^-_#$+.!*%'(),;/?:@~=&a-zA-Z0-9\x7f-\xff|$))
+			↑
+			EOD), $errors[0]->getMessage());
 	}
 
 	public function testBug11297(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1410,7 +1410,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11292.php');
 		$this->assertCount(1, $errors);
-		$this->assertSame(str_replace('\x7f-\xff|$', "\x7f-\xff]|$", 'Regex pattern cannot be parsed: Unrecognized token "\\" at line 1 and column 1:
+		$this->assertSame(str_replace('\x7f-\xff|$', "\x7f-\xff]|$", 'Regex pattern cannot be parsed by PHPStan: Unrecognized token "\\" at line 1 and column 1:
 \\b(https?://)?(?:([^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})(:[^]\\\\\\x00-\\x20\\"(),:-<>[\\x7f-\\xff]{1,64})?@)?((?:[-a-zA-Z0-9\\x7f-\\xff]{1,63}\\.)+[a-zA-Z\\x7f-\\xff][-a-zA-Z0-9\\x7f-\\xff]{1,62})((:[0-9]{1,5})?(/[!$-/0-9:;=@_~\':;!a-zA-Z\\x7f-\\xff]*?)?(\\?[!$-/0-9:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?(#[!$-/0-9?:;=@_\':;!a-zA-Z\\x7f-\\xff]+?)?)(?=[)\'?.!,;:]*([^-_#$+.!*%\'(),;/?:@~=&a-zA-Z0-9\\x7f-\\xff|$))
 ↑'), $errors[0]->getMessage());
 	}

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -467,6 +467,9 @@ function bug11323(string $s): void {
 	if (preg_match('{([-\p{L}[\]*|\x03\a\b+?{}(?:)-]+[^[:digit:]?{}a-z0-9#-k]+)(a-z)}', $s, $matches)) {
 		assertType("array{string, non-falsy-string, 'a-z'}", $matches);
 	}
+	if (preg_match('{(\d+)(?i)insensitive((?xs-i)case SENSITIVE here.+and dot matches new lines)}', $s, $matches)) {
+		assertType('array{string, numeric-string, non-falsy-string}', $matches);
+	}
 	if (preg_match('{(\d+)(?i)insensitive((?x-i)case SENSITIVE here(?i:insensitive non-capturing group))}', $s, $matches)) {
 		assertType('array{string, numeric-string, non-falsy-string}', $matches);
 	}
@@ -776,5 +779,123 @@ function testLtrimDelimiter (string $string): void {
 
 	if (preg_match('  /(x)/', $string, $matches)) {
 		assertType("array{string, 'x'}", $matches);
+	}
+}
+
+function testUnescapeBackslash (string $string): void {
+	if (preg_match(<<<'EOD'
+		~(\[)~
+		EOD, $string, $matches)) {
+		assertType("array{string, '['}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\d)~
+		EOD, $string, $matches)) {
+		assertType("array{string, numeric-string}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\\d)~
+		EOD, $string, $matches)) {
+		assertType("array{string, '\\\d'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\\\d)~
+		EOD, $string, $matches)) {
+		assertType("array{string, non-falsy-string}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\\\\d)~
+		EOD, $string, $matches)) {
+		assertType("array{string, '\\\\\\\d'}", $matches);
+	}
+}
+
+function testEscapedDelimiter (string $string): void {
+	if (preg_match(<<<'EOD'
+		/(\/)/
+		EOD, $string, $matches)) {
+		assertType("array{string, '/'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\~)~
+		EOD, $string, $matches)) {
+		assertType("array{string, '~'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\[2])~
+		EOD, $string, $matches)) {
+		assertType("array{string, '[2]'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		[(\[2\])]
+		EOD, $string, $matches)) {
+		assertType("array{string, '[2]'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~(\{2})~
+		EOD, $string, $matches)) {
+		assertType("array{string, '{2}'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		{(\{2\})}
+		EOD, $string, $matches)) {
+		assertType("array{string, '{2}'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~([a\]])~
+		EOD, $string, $matches)) {
+		assertType("array{string, ']'|'a'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~([a[])~
+		EOD, $string, $matches)) {
+		assertType("array{string, '['|'a'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~([a\]b])~
+		EOD, $string, $matches)) {
+		assertType("array{string, ']'|'a'|'b'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~([a[b])~
+		EOD, $string, $matches)) {
+		assertType("array{string, '['|'a'|'b'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		~([a\[b])~
+		EOD, $string, $matches)) {
+		assertType("array{string, '['|'a'|'b'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		[([a\[b])]
+		EOD, $string, $matches)) {
+		assertType("array{string, '['|'a'|'b'}", $matches);
+	}
+
+	if (preg_match(<<<'EOD'
+		{(x\\\{)|(y\\\\\})}
+		EOD, $string, $matches)) {
+		assertType("array{string, '', 'y\\\\\\\}'}|array{string, 'x\\\{'}", $matches);
+	}
+}
+
+function bugUnescapedDashAfterRange (string $string): void {
+	if (preg_match('/([0-1-y])/', $string, $matches)) {
+		assertType("array{string, non-empty-string}", $matches);
 	}
 }

--- a/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
+++ b/tests/PHPStan/Rules/Regexp/RegularExpressionPatternRuleTest.php
@@ -18,6 +18,7 @@ class RegularExpressionPatternRuleTest extends RuleTestCase
 	{
 		return new RegularExpressionPatternRule(
 			self::getContainer()->getByType(RegexExpressionHelper::class),
+			true,
 		);
 	}
 


### PR DESCRIPTION
needs https://github.com/phpstan/phpstan-src/pull/3488 to be merged first

Figuring out regexes that are not parsed by PHPStan grammar is hard. Let's help developers and they can help us.

With good reports PHPStan grammar can be improved quickly so all PCRE patterns are supported by PHPStan parser.