### PR TITLE
Add `Type::sliceArray()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -794,7 +794,7 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\Constant\\\\ConstantArrayType is error\\-prone and deprecated\\. Use Type\\:\\:getConstantArrays\\(\\) instead\\.$#"
-			count: 8
+			count: 10
 			path: src/Type/Constant/ConstantArrayType.php
 
 		-

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -247,6 +247,19 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		if ($preserveKeys->no()) {
+			return $this;
+		}
+
+		if ((new ConstantIntegerType(0))->isSuperTypeOf($offsetType)->yes()) {
+			return $this;
+		}
+
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -14,6 +14,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -27,6 +28,7 @@ use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
@@ -262,6 +264,20 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 	public function shuffleArray(): Type
 	{
 		return new NonEmptyArrayType();
+	}
+
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		if (
+			$this->offsetType->isSuperTypeOf($offsetType)->yes()
+			&& ($lengthType->isNull()->yes() || IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($lengthType)->yes())
+		) {
+			return $preserveKeys->yes()
+				? TypeCombinator::intersect($this, new NonEmptyArrayType())
+				: new NonEmptyArrayType();
+		}
+
+		return new MixedType();
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -224,6 +224,18 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		if (
+			(new ConstantIntegerType(0))->isSuperTypeOf($offsetType)->yes()
+			&& ($lengthType->isNull()->yes() || IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($lengthType)->yes())
+		) {
+			return $this;
+		}
+
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -220,6 +220,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -591,6 +591,11 @@ class ArrayType implements Type
 		return AccessoryArrayListType::intersectWith(new self(new IntegerType(), $this->itemType));
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return $this;
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe()->and($this->itemType->isString());

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -31,6 +31,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ConstantType;
+use PHPStan\Type\ConstantTypeHelper;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\TemplateTypeMap;
@@ -39,6 +40,7 @@ use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
@@ -812,7 +814,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 				$keyTypesCount = count($this->keyTypes);
 				for ($i = 0; $i < $keyTypesCount; $i += $length) {
-					$chunk = $this->slice($i, $length, true);
+					$chunk = $this->sliceArray(new ConstantIntegerType($i), new ConstantIntegerType($length), TrinaryLogic::createYes());
 					$builder->setOffsetValueType(null, $preserveKeys->yes() ? $chunk : $chunk->getValuesArray());
 				}
 
@@ -882,7 +884,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $this->removeLastElements(1);
 	}
 
-	private function reverseConstantArray(TrinaryLogic $preserveKeys): self
+	public function reverseArray(TrinaryLogic $preserveKeys): Type
 	{
 		$keyTypesReversed = array_reverse($this->keyTypes, true);
 		$keyTypes = array_values($keyTypesReversed);
@@ -892,11 +894,6 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		$reversed = new self($keyTypes, array_reverse($this->valueTypes), $this->nextAutoIndexes, $optionalKeys, TrinaryLogic::createNo());
 
 		return $preserveKeys->yes() ? $reversed : $reversed->reindex();
-	}
-
-	public function reverseArray(TrinaryLogic $preserveKeys): Type
-	{
-		return $this->reverseConstantArray($preserveKeys);
 	}
 
 	public function searchArray(Type $needleType): Type
@@ -955,6 +952,85 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		}
 
 		return $generalizedArray;
+	}
+
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		$keyTypesCount = count($this->keyTypes);
+		if ($keyTypesCount === 0) {
+			return $this;
+		}
+
+		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : 0;
+		$length = $lengthType instanceof ConstantIntegerType ? $lengthType->getValue() : $keyTypesCount;
+
+		if ($length < 0) {
+			// Negative lengths prevent access to the most right n elements
+			return $this->removeLastElements($length * -1)
+				->sliceArray($offsetType, new NullType(), $preserveKeys);
+		}
+
+		if ($keyTypesCount + $offset <= 0) {
+			// A negative offset cannot reach left outside the array
+			$offset = 0;
+		}
+
+		if ($offset < 0) {
+			/*
+			 * Transforms the problem with the negative offset in one with a positive offset using array reversion.
+			 * The reason is belows handling of optional keys which works only from left to right.
+			 *
+			 * e.g.
+			 * array{a: 0, b: 1, c: 2, d: 3, e: 4}
+			 * with offset -4 and length 2 (which would be sliced to array{b: 1, c: 2})
+			 *
+			 * is transformed via reversion to
+			 *
+			 * array{e: 4, d: 3, c: 2, b: 1, a: 0}
+			 * with offset 2 and length 2 (which will be sliced to array{c: 2, b: 1} and then reversed again)
+			 */
+			$offset *= -1;
+			$reversedLength = min($length, $offset);
+			$reversedOffset = $offset - $reversedLength;
+			return $this->reverseArray(TrinaryLogic::createYes())
+				->sliceArray(new ConstantIntegerType($reversedOffset), new ConstantIntegerType($reversedLength), $preserveKeys)
+				->reverseArray(TrinaryLogic::createYes());
+		}
+
+		if ($offset > 0) {
+			return $this->removeFirstElements($offset, false)
+				->sliceArray(new ConstantIntegerType(0), $lengthType, $preserveKeys);
+		}
+
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		$nonOptionalElementsCount = 0;
+		$hasOptional = false;
+		for ($i = 0; $nonOptionalElementsCount < $length && $i < $keyTypesCount; $i++) {
+			$isOptional = $this->isOptionalKey($i);
+			if (!$isOptional) {
+				$nonOptionalElementsCount++;
+			} else {
+				$hasOptional = true;
+			}
+
+			$isLastElement = $nonOptionalElementsCount >= $length || $i + 1 >= $keyTypesCount;
+			if ($isLastElement && $length < $keyTypesCount && $hasOptional) {
+				// If the slice is not full yet, but has at least one optional key
+				// the last non-optional element is going to be optional.
+				// Otherwise, it would not fit into the slice if previous non-optional keys are there.
+				$isOptional = true;
+			}
+
+			$builder->setOffsetValueType($this->keyTypes[$i], $this->valueTypes[$i], $isOptional);
+		}
+
+		$slice = $builder->getArray();
+		if (!$slice instanceof self) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $preserveKeys->yes() ? $slice : $slice->reindex();
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic
@@ -1147,87 +1223,30 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		return $array;
 	}
 
+	/** @deprecated Use sliceArray() instead */
 	public function slice(int $offset, ?int $limit, bool $preserveKeys = false): self
 	{
-		$keyTypesCount = count($this->keyTypes);
-		if ($keyTypesCount === 0) {
-			return $this;
-		}
-
-		$limit ??= $keyTypesCount;
-		if ($limit < 0) {
-			// Negative limits prevent access to the most right n elements
-			return $this->removeLastElements($limit * -1)
-				->slice($offset, null, $preserveKeys);
-		}
-
-		if ($keyTypesCount + $offset <= 0) {
-			// A negative offset cannot reach left outside the array
-			$offset = 0;
-		}
-
-		if ($offset < 0) {
-			/*
-			 * Transforms the problem with the negative offset in one with a positive offset using array reversion.
-			 * The reason is belows handling of optional keys which works only from left to right.
-			 *
-			 * e.g.
-			 * array{a: 0, b: 1, c: 2, d: 3, e: 4}
-			 * with offset -4 and limit 2 (which would be sliced to array{b: 1, c: 2})
-			 *
-			 * is transformed via reversion to
-			 *
-			 * array{e: 4, d: 3, c: 2, b: 1, a: 0}
-			 * with offset 2 and limit 2 (which will be sliced to array{c: 2, b: 1} and then reversed again)
-			 */
-			$offset *= -1;
-			$reversedLimit = min($limit, $offset);
-			$reversedOffset = $offset - $reversedLimit;
-			return $this->reverseConstantArray(TrinaryLogic::createYes())
-				->slice($reversedOffset, $reversedLimit, $preserveKeys)
-				->reverseConstantArray(TrinaryLogic::createYes());
-		}
-
-		if ($offset > 0) {
-			return $this->removeFirstElements($offset, false)
-				->slice(0, $limit, $preserveKeys);
-		}
-
-		$builder = ConstantArrayTypeBuilder::createEmpty();
-
-		$nonOptionalElementsCount = 0;
-		$hasOptional = false;
-		for ($i = 0; $nonOptionalElementsCount < $limit && $i < $keyTypesCount; $i++) {
-			$isOptional = $this->isOptionalKey($i);
-			if (!$isOptional) {
-				$nonOptionalElementsCount++;
-			} else {
-				$hasOptional = true;
-			}
-
-			$isLastElement = $nonOptionalElementsCount >= $limit || $i + 1 >= $keyTypesCount;
-			if ($isLastElement && $limit < $keyTypesCount && $hasOptional) {
-				// If the slice is not full yet, but has at least one optional key
-				// the last non-optional element is going to be optional.
-				// Otherwise, it would not fit into the slice if previous non-optional keys are there.
-				$isOptional = true;
-			}
-
-			$builder->setOffsetValueType($this->keyTypes[$i], $this->valueTypes[$i], $isOptional);
-		}
-
-		$slice = $builder->getArray();
-		if (!$slice instanceof self) {
+		$array = $this->sliceArray(
+			ConstantTypeHelper::getTypeFromValue($offset),
+			ConstantTypeHelper::getTypeFromValue($limit),
+			TrinaryLogic::createFromBoolean($preserveKeys),
+		);
+		if (!$array instanceof self) {
 			throw new ShouldNotHappenException();
 		}
 
-		return $preserveKeys ? $slice : $slice->reindex();
+		return $array;
 	}
 
 	/** @deprecated Use reverseArray() instead */
 	public function reverse(bool $preserveKeys = false): self
 	{
-		return $this->reverseConstantArray(TrinaryLogic::createFromBoolean($preserveKeys));
+		$array = $this->reverseArray(TrinaryLogic::createFromBoolean($preserveKeys));
+		if (!$array instanceof self) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $array;
 	}
 
 	/**

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -780,6 +780,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->shuffleArray());
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->sliceArray($offsetType, $lengthType, $preserveKeys));
+	}
+
 	public function getEnumCases(): array
 	{
 		$compare = [];

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -274,6 +274,15 @@ class MixedType implements CompoundType, SubtractableType
 		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new MixedType($this->isExplicitMixed)));
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -341,6 +341,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return new NeverType();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -39,11 +39,9 @@ final class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionRetu
 
 		$offsetType = $scope->getType($args[1]->value);
 		$lengthType = isset($args[2]) ? $scope->getType($args[2]->value) : new NullType();
-
 		$preserveKeysType = isset($args[3]) ? $scope->getType($args[3]->value) : new ConstantBooleanType(false);
-		$preserveKeys = (new ConstantBooleanType(true))->isSuperTypeOf($preserveKeysType);
 
-		return $arrayType->sliceArray($offsetType, $lengthType, $preserveKeys);
+		return $arrayType->sliceArray($offsetType, $lengthType, $preserveKeysType->isTrue());
 	}
 
 }

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -460,6 +460,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->shuffleArray();
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return $this->getStaticObjectType()->sliceArray($offsetType, $lengthType, $preserveKeys);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -307,6 +307,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->shuffleArray();
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return $this->resolve()->sliceArray($offsetType, $lengthType, $preserveKeys);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -94,4 +94,9 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -94,4 +94,9 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -169,6 +169,8 @@ interface Type
 
 	public function shuffleArray(): Type;
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type;
+
 	/**
 	 * @return list<EnumCaseObjectType>
 	 */

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -751,6 +751,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->shuffleArray());
 	}
 
+	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->sliceArray($offsetType, $lengthType, $preserveKeys));
+	}
+
 	public function getEnumCases(): array
 	{
 		return $this->pickFromTypes(

--- a/tests/PHPStan/Analyser/nsrt/array-slice.php
+++ b/tests/PHPStan/Analyser/nsrt/array-slice.php
@@ -89,4 +89,17 @@ class Foo
 		assertType('array{a: 0}', array_slice($arr, -3, 1));
 	}
 
+
+	public function offsets(array $arr): void
+	{
+		if (array_key_exists(1, $arr)) {
+			assertType('non-empty-array', array_slice($arr, 1, null, false));
+			assertType('hasOffset(1)&non-empty-array', array_slice($arr, 1, null, true));
+		}
+		if (array_key_exists(1, $arr) && $arr[1] === 'foo') {
+			assertType('non-empty-array', array_slice($arr, 1, null, false));
+			assertType("hasOffsetValue(1, 'foo')&non-empty-array", array_slice($arr, 1, null, true));
+		}
+	}
+
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-10721.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10721.php
@@ -68,10 +68,10 @@ final class HandpickedWordlistProvider
 		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 3)); // could be non-empty-array
 		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 3));
 
-		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 3, true));
+		assertType("array<0|1, 'zib'|'zib 2'>", array_slice($list, -1, 3, true));
 		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 3, true));
-		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 1, 3, true)); // could be non-empty-array
-		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 2, 3, true));
+		assertType("array<0|1, 'zib'|'zib 2'>", array_slice($list, 1, 3, true)); // could be non-empty-array
+		assertType("array<0|1, 'zib'|'zib 2'>", array_slice($list, 2, 3, true));
 
 		assertType("array<0|1, 'zib'|'zib 2'>&list", array_slice($list, -1, 3, false));
 		assertType("non-empty-array<0|1, 'zib'|'zib 2'>&list", array_slice($list, 0, 3, false));


### PR DESCRIPTION
Improves type specification edge cases slightly, but there is more potential which I definitely don't want to get into here (e.g. currently `$offsetType` and `$lengthType` are only used for constant arrays if they are of type `ConstantIntegerType`).

The test change is correct I believe, those array slices might not be lists, see [3v4l.org/hAv10](https://3v4l.org/hAv10)

I dislike the 2 new `instanceof self` checks, but they are only for BC and can be removed / will not be there in 2.0