### PR TITLE
Set normalized in BenevolentUnionType

### DIFF
--- a/src/Type/BenevolentUnionType.php
+++ b/src/Type/BenevolentUnionType.php
@@ -14,9 +14,9 @@ class BenevolentUnionType extends UnionType
 	 * @api
 	 * @param Type[] $types
 	 */
-	public function __construct(array $types)
+	public function __construct(array $types, bool $normalized = false)
 	{
-		parent::__construct($types);
+		parent::__construct($types, $normalized);
 	}
 
 	public function describe(VerbosityLevel $level): string

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -363,7 +363,7 @@ class TypeCombinator
 					return $benevolentUnionObject->withTypes($types);
 				}
 
-				return new BenevolentUnionType($types);
+				return new BenevolentUnionType($types, true);
 			}
 		}
 


### PR DESCRIPTION
Stumbled over this in UnionType and thought it should be set for BenevolentUnionType as well. I also noticed that it is not used yet. Tried early exiting in `TypeCombinator::union()` if only a normilzed union was passed, but it doesn't seem to affect performance much. Felt like a useless micro-optimization.

So this doesn't change anything really :)