### PR TITLE
Support `@readonly` PHPDoc on the class as alternative to `@immutable`

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -1238,7 +1238,7 @@ class ClassReflection
 	{
 		if ($this->isImmutable === null) {
 			$resolvedPhpDoc = $this->getResolvedPhpDoc();
-			$this->isImmutable = $resolvedPhpDoc !== null && $resolvedPhpDoc->isImmutable();
+			$this->isImmutable = $resolvedPhpDoc !== null && ($resolvedPhpDoc->isImmutable() || $resolvedPhpDoc->isReadOnly());
 
 			$parentClass = $this->getParentClass();
 			if ($parentClass !== null && !$this->isImmutable) {

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -160,4 +160,22 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/feature-7648.php'], []);
 	}
 
+	public function testFeature11775(): void
+	{
+		if (PHP_VERSION_ID < 70400) {
+			$this->markTestSkipped('Test requires PHP 7.4.');
+		}
+
+		$this->analyse([__DIR__ . '/data/feature-11775.php'], [
+			[
+				'@readonly property Feature11775\FooImmutable::$i is assigned outside of the constructor.',
+				22,
+			],
+			[
+				'@readonly property Feature11775\FooReadonly::$i is assigned outside of the constructor.',
+				43,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/feature-11775.php
+++ b/tests/PHPStan/Rules/Properties/data/feature-11775.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Feature11775;
+
+/** @immutable */
+class FooImmutable
+{
+	private int $i;
+
+	public function __construct(int $i)
+	{
+		$this->i = $i;
+	}
+
+	public function getId(): int
+	{
+		return $this->i;
+	}
+
+	public function setId(): void
+	{
+		$this->i = 5;
+	}
+}
+
+/** @readonly */
+class FooReadonly
+{
+	private int $i;
+
+	public function __construct(int $i)
+	{
+		$this->i = $i;
+	}
+
+	public function getId(): int
+	{
+		return $this->i;
+	}
+
+	public function setId(): void
+	{
+		$this->i = 5;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/11775
Docs PR: https://github.com/phpstan/phpstan/pull/11783

I decided to directly adapt `ClassReflection::isImmutable()` because there is already `ClassReflection::isReadonly()` for native readonly and that would clash. An alternative would be to add a new `ClassReflection::isReadonlyPhpDoc()` or so, but I dislike that isImmutable is also PHPDoc only and it then feels somewhat inconsistent / even more complicated :)

the rules are still, as before, only enabled with the `readOnlyByPhpDoc` feature toggle.