### PR TITLE
curl_multi_getcontent() can return null

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -1497,7 +1497,7 @@ return [
 'curl_multi_close' => ['void', 'mh'=>'resource'],
 'curl_multi_errno' => ['int', 'mh'=>'resource'],
 'curl_multi_exec' => ['int', 'mh'=>'resource', '&w_still_running'=>'int'],
-'curl_multi_getcontent' => ['string', 'ch'=>'resource'],
+'curl_multi_getcontent' => ['string|null', 'ch'=>'resource'],
 'curl_multi_info_read' => ['array|false', 'mh'=>'resource', '&w_msgs_in_queue='=>'int'],
 'curl_multi_init' => ['resource'],
 'curl_multi_remove_handle' => ['int', 'mh'=>'resource', 'ch'=>'resource'],


### PR DESCRIPTION
fixes

PHP 7.x 
> Call to function is_string() with string will always evaluate to true.


https://phpstan.org/r/bef8ccfb-a36f-4bc6-9884-f5627583859a
https://www.php.net/curl_multi_getcontent