### PR TITLE
Use precise Verbosity level for getArgumentsDescription

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeHelper.php
@@ -343,7 +343,7 @@ final class ImpossibleCheckTypeHelper
 			return '';
 		}
 
-		$descriptions = array_map(fn (Arg $arg): string => ($this->treatPhpDocTypesAsCertain ? $scope->getType($arg->value) : $scope->getNativeType($arg->value))->describe(VerbosityLevel::value()), $args);
+		$descriptions = array_map(fn (Arg $arg): string => ($this->treatPhpDocTypesAsCertain ? $scope->getType($arg->value) : $scope->getNativeType($arg->value))->describe(VerbosityLevel::precise()), $args);
 
 		if (count($descriptions) < 3) {
 			return sprintf(' with %s', implode(' and ', $descriptions));

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -146,15 +146,15 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					367,
 				],
 				[
-					'Call to function is_string() with mixed will always evaluate to false.',
+					'Call to function is_string() with mixed~string will always evaluate to false.',
 					561,
 				],
 				[
-					'Call to function is_callable() with mixed will always evaluate to false.',
+					'Call to function is_callable() with mixed~callable() will always evaluate to false.',
 					572,
 				],
 				[
-					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExists\' and \'testWithStringFirst…\' will always evaluate to true.',
+					'Call to function method_exists() with \'CheckTypeFunctionCall\\\\MethodExists\' and \'testWithStringFirstArgument\' will always evaluate to true.',
 					586,
 				],
 				[
@@ -330,11 +330,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 					367,
 				],
 				[
-					'Call to function is_string() with mixed will always evaluate to false.',
+					'Call to function is_string() with mixed~string will always evaluate to false.',
 					561,
 				],
 				[
-					'Call to function is_callable() with mixed will always evaluate to false.',
+					'Call to function is_callable() with mixed~callable() will always evaluate to false.',
 					572,
 				],
 				[
@@ -1100,6 +1100,18 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/always-true-preg-match.php'], []);
+	}
+
+	public function testBug11799(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-11799.php'], [
+			[
+				"Call to function in_array() with arguments lowercase-string, array{'publishDate', 'approvedAt', 'allowedValues'} and true will always evaluate to false.",
+				11,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-11799.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-11799.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11799;
+
+function getSomeInput(): string { return random_bytes(100); }
+
+function getSortBy(): string
+{
+	$sortBy = mb_strtolower(getSomeInput());
+
+	if (! in_array($sortBy, ['publishDate', 'approvedAt', 'allowedValues'], true)) {
+		// Do something
+	}
+
+	return $sortBy;
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/11799

At first I discover the issue for `lowercase-string` and feel like the message could be improved for other situation like
```
Call to function is_string() with mixed will always evaluate to false.
```
which could explain that string is not in the mixed type, and become 
```
Call to function is_string() with mixed~string will always evaluate to false.
```
but maybe it's voluntary...

So currently I dunno:
- If we consider there is no issue, and `Call to function in_array() with arguments string, array{'publishDate', 'approvedAt', 'allowedValues'} and true will always evaluate to false.` is an OK message. Then I can close both the PR and the issue
- If this PR is OK to be merged
- If this PR should be done on 2.0 since it's kinda a BC break
- If we consider the behavior should only be fixed for lowercase-string (how ? I assume this fix is harder)
- If the fix should be somewhere else... (Maybe in 2.0 the Verbosity of lowercase-string should become value)

Your call @ondrejmirtes 