### PR TITLE
Get rid of unnecessary `instanceof self` in `ConstantArrayType`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -882,7 +882,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantArrayType is error\-prone and deprecated\. Use Type\:\:getConstantArrays\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 7
+			count: 5
 			path: src/Type/Constant/ConstantArrayType.php
 
 		-

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -51,7 +51,6 @@ use function array_map;
 use function array_merge;
 use function array_pop;
 use function array_push;
-use function array_reverse;
 use function array_slice;
 use function array_unique;
 use function array_values;
@@ -241,7 +240,7 @@ class ConstantArrayType implements Type
 			}
 
 			$array = $builder->getArray();
-			if (!$array instanceof ConstantArrayType) {
+			if (!$array instanceof self) {
 				throw new ShouldNotHappenException();
 			}
 
@@ -857,14 +856,16 @@ class ConstantArrayType implements Type
 
 	public function reverseArray(TrinaryLogic $preserveKeys): Type
 	{
-		$keyTypesReversed = array_reverse($this->keyTypes, true);
-		$keyTypes = array_values($keyTypesReversed);
-		$keyTypesReversedKeys = array_keys($keyTypesReversed);
-		$optionalKeys = array_map(static fn (int $optionalKey): int => $keyTypesReversedKeys[$optionalKey], $this->optionalKeys);
+		$builder = ConstantArrayTypeBuilder::createEmpty();
 
-		$reversed = new self($keyTypes, array_reverse($this->valueTypes), $this->nextAutoIndexes, $optionalKeys, TrinaryLogic::createNo());
+		for ($i = count($this->keyTypes) - 1; $i >= 0; $i--) {
+			$offsetType = $preserveKeys->yes() || $this->keyTypes[$i]->isInteger()->no()
+				? $this->keyTypes[$i]
+				: null;
+			$builder->setOffsetValueType($offsetType, $this->valueTypes[$i], $this->isOptionalKey($i));
+		}
 
-		return $preserveKeys->yes() ? $reversed : $reversed->reindex();
+		return $builder->getArray();
 	}
 
 	public function searchArray(Type $needleType): Type
@@ -993,15 +994,14 @@ class ConstantArrayType implements Type
 				$isOptional = true;
 			}
 
-			$builder->setOffsetValueType($this->keyTypes[$i], $this->valueTypes[$i], $isOptional);
+			$offsetType = $preserveKeys->yes() || $this->keyTypes[$i]->isInteger()->no()
+				? $this->keyTypes[$i]
+				: null;
+
+			$builder->setOffsetValueType($offsetType, $this->valueTypes[$i], $isOptional);
 		}
 
-		$slice = $builder->getArray();
-		if (!$slice instanceof self) {
-			throw new ShouldNotHappenException();
-		}
-
-		return $preserveKeys->yes() ? $slice : $slice->reindex();
+		return $builder->getArray();
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic
@@ -1147,7 +1147,7 @@ class ConstantArrayType implements Type
 	}
 
 	/** @param positive-int $length */
-	private function removeFirstElements(int $length, bool $reindex = true): self
+	private function removeFirstElements(int $length, bool $reindex = true): Type
 	{
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 
@@ -1174,30 +1174,7 @@ class ConstantArrayType implements Type
 			$builder->setOffsetValueType($keyType, $valueType, $isOptional);
 		}
 
-		$array = $builder->getArray();
-		if (!$array instanceof self) {
-			throw new ShouldNotHappenException();
-		}
-
-		return $array;
-	}
-
-	private function reindex(): self
-	{
-		$keyTypes = [];
-		$autoIndex = 0;
-
-		foreach ($this->keyTypes as $keyType) {
-			if (!$keyType instanceof ConstantIntegerType) {
-				$keyTypes[] = $keyType;
-				continue;
-			}
-
-			$keyTypes[] = new ConstantIntegerType($autoIndex);
-			$autoIndex++;
-		}
-
-		return new self($keyTypes, $this->valueTypes, [$autoIndex], $this->optionalKeys, TrinaryLogic::createYes());
+		return $builder->getArray();
 	}
 
 	public function toBoolean(): BooleanType


### PR DESCRIPTION
Gets rid of now unnecessary `instanceof self` in `ConstantArrayType`  by slightly improving `sliceArray()` which made it possible to remove `reindex()` completely :)

Contains changes of https://github.com/phpstan/phpstan-src/pull/3406 and should be merged after that one came into 2.0.x. Should apply cleanly, if not I can update it of course.