### PR TITLE
Reflection `getAttributes` returns `list`

### DIFF
--- a/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
@@ -5,10 +5,11 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\MixedType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 use ReflectionAttribute;
 use function count;
@@ -42,7 +43,7 @@ final class ReflectionGetAttributesMethodReturnTypeExtension implements DynamicM
 		$argType = $scope->getType($methodCall->getArgs()[0]->value);
 		$classType = $argType->getClassStringObjectType();
 
-		return new ArrayType(new MixedType(), new GenericObjectType(ReflectionAttribute::class, [$classType]));
+		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new GenericObjectType(ReflectionAttribute::class, [$classType])));
 	}
 
 }

--- a/stubs/ReflectionClass.stub
+++ b/stubs/ReflectionClass.stub
@@ -42,7 +42,7 @@ class ReflectionClass
 	public function newInstanceWithoutConstructor();
 
     /**
-     * @return array<ReflectionAttribute<object>>
+     * @return list<ReflectionAttribute<object>>
      */
     public function getAttributes(?string $name = null, int $flags = 0)
     {

--- a/stubs/ReflectionClassConstant.stub
+++ b/stubs/ReflectionClassConstant.stub
@@ -3,7 +3,7 @@
 class ReflectionClassConstant
 {
     /**
-     * @return array<ReflectionAttribute<object>>
+     * @return list<ReflectionAttribute<object>>
      */
     public function getAttributes(?string $name = null, int $flags = 0)
     {

--- a/stubs/ReflectionFunctionAbstract.stub
+++ b/stubs/ReflectionFunctionAbstract.stub
@@ -9,7 +9,7 @@ abstract class ReflectionFunctionAbstract
 	public function getFileName () {}
 
     /**
-     * @return array<ReflectionAttribute<object>>
+     * @return list<ReflectionAttribute<object>>
      */
     public function getAttributes(?string $name = null, int $flags = 0)
     {

--- a/stubs/ReflectionParameter.stub
+++ b/stubs/ReflectionParameter.stub
@@ -3,7 +3,7 @@
 class ReflectionParameter
 {
     /**
-     * @return array<ReflectionAttribute<object>>
+     * @return list<ReflectionAttribute<object>>
      */
     public function getAttributes(?string $name = null, int $flags = 0)
     {

--- a/stubs/ReflectionProperty.stub
+++ b/stubs/ReflectionProperty.stub
@@ -3,7 +3,7 @@
 class ReflectionProperty
 {
     /**
-     * @return array<ReflectionAttribute<object>>
+     * @return list<ReflectionAttribute<object>>
      */
     public function getAttributes(?string $name = null, int $flags = 0)
     {

--- a/tests/PHPStan/Analyser/nsrt/reflectionclass-issue-5511-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/reflectionclass-issue-5511-php8.php
@@ -36,38 +36,38 @@ function testGetAttributes(
 	$classStr = $reflectionClass->getAttributes($str);
 	$classNonsense = $reflectionClass->getAttributes("some random string");
 
-	assertType('array<ReflectionAttribute<object>>', $classAll);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $classAbc1);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $classAbc2);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $classGCN);
-	assertType('array<ReflectionAttribute<object>>', $classCN);
-	assertType('array<ReflectionAttribute<object>>', $classStr);
-	assertType('array<ReflectionAttribute<*ERROR*>>', $classNonsense);
+	assertType('list<ReflectionAttribute<object>>', $classAll);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $classAbc1);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $classAbc2);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $classGCN);
+	assertType('list<ReflectionAttribute<object>>', $classCN);
+	assertType('list<ReflectionAttribute<object>>', $classStr);
+	assertType('list<ReflectionAttribute<*ERROR*>>', $classNonsense);
 
 	$methodAll = $reflectionMethod->getAttributes();
 	$methodAbc = $reflectionMethod->getAttributes(Abc::class);
-	assertType('array<ReflectionAttribute<object>>', $methodAll);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $methodAbc);
+	assertType('list<ReflectionAttribute<object>>', $methodAll);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $methodAbc);
 
 	$paramAll = $reflectionParameter->getAttributes();
 	$paramAbc = $reflectionParameter->getAttributes(Abc::class);
-	assertType('array<ReflectionAttribute<object>>', $paramAll);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $paramAbc);
+	assertType('list<ReflectionAttribute<object>>', $paramAll);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $paramAbc);
 
 	$propAll = $reflectionProperty->getAttributes();
 	$propAbc = $reflectionProperty->getAttributes(Abc::class);
-	assertType('array<ReflectionAttribute<object>>', $propAll);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $propAbc);
+	assertType('list<ReflectionAttribute<object>>', $propAll);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $propAbc);
 
 	$constAll = $reflectionClassConstant->getAttributes();
 	$constAbc = $reflectionClassConstant->getAttributes(Abc::class);
-	assertType('array<ReflectionAttribute<object>>', $constAll);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $constAbc);
+	assertType('list<ReflectionAttribute<object>>', $constAll);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $constAbc);
 
 	$funcAll = $reflectionFunction->getAttributes();
 	$funcAbc = $reflectionFunction->getAttributes(Abc::class);
-	assertType('array<ReflectionAttribute<object>>', $funcAll);
-	assertType('array<ReflectionAttribute<Issue5511\Abc>>', $funcAbc);
+	assertType('list<ReflectionAttribute<object>>', $funcAll);
+	assertType('list<ReflectionAttribute<Issue5511\Abc>>', $funcAbc);
 }
 
 /**


### PR DESCRIPTION
constructed attributes returned by `ReflectionX->getAttributes()` are always added with the next array indices:
* https://github.com/php/php-src/blob/85cf4a39d744ab4a30a0815ac61b347b8d155f94/ext/reflection/php_reflection.c#L1193-L1194
* https://github.com/php/php-src/blob/85cf4a39d744ab4a30a0815ac61b347b8d155f94/ext/reflection/php_reflection.c#L1225-L1226

So the return type should be `list<...>` instead of `array<mixed,,...>`.