### PR TITLE
Get rid of unnecessary `instanceof self` in `ConstantArrayType`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -882,7 +882,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantArrayType is error\-prone and deprecated\. Use Type\:\:getConstantArrays\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 7
+			count: 5
 			path: src/Type/Constant/ConstantArrayType.php
 
 		-


### PR DESCRIPTION
Another try of https://github.com/phpstan/phpstan-src/pull/3542 which was reverted. Since the precondition  https://github.com/phpstan/phpstan-src/pull/3406 was merged we can't see the array_reverse changes anymore in the diff.

Sorry for having that in there in the first place, I was impatient.

This removes `ConstantArrayType::reindex()` which was a bad design decision from my side from the beginning.