### PR TITLE
Improve return type of token_name() and PhpToken::getTokenName()

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -12606,7 +12606,7 @@ return [
 'timezone_version_get' => ['string'],
 'tmpfile' => ['__benevolent<resource|false>'],
 'token_get_all' => ['list<string|array{0:int,1:string,2:int}>', 'source'=>'string', 'flags='=>'int'],
-'token_name' => ['non-empty-string', 'type'=>'int'],
+'token_name' => ['non-falsy-string', 'type'=>'int'],
 'TokyoTyrant::__construct' => ['void', 'host='=>'string', 'port='=>'int', 'options='=>'array'],
 'TokyoTyrant::add' => ['int|float', 'key'=>'string', 'increment'=>'float', 'type='=>'int'],
 'TokyoTyrant::connect' => ['TokyoTyrant', 'host'=>'string', 'port='=>'int', 'options='=>'array'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -91,7 +91,7 @@ return [
 		'PhpToken::tokenize' => ['list<PhpToken>', 'code'=>'string', 'flags='=>'int'],
 		'PhpToken::is' => ['bool', 'kind'=>'string|int|string[]|int[]'],
 		'PhpToken::isIgnorable' => ['bool'],
-		'PhpToken::getTokenName' => ['string'],
+		'PhpToken::getTokenName' => ['non-falsy-string'],
 		'preg_match_all' => ['0|positive-int|false', 'pattern'=>'string', 'subject'=>'string', '&w_subpatterns='=>'array', 'flags='=>'int', 'offset='=>'int'],
 		'proc_get_status' => ['array{command: string, pid: int, running: bool, signaled: bool, stopped: bool, exitcode: int, termsig: int, stopsig: int}', 'process'=>'resource'],
 		'set_error_handler' => ['?callable', 'callback'=>'null|callable(int,string,string,int):bool', 'error_types='=>'int'],


### PR DESCRIPTION
The return value of [`token_name()`](https://www.php.net/token_name) and [`PhpToken::getTokenName()`](https://www.php.net/manual/phptoken.gettokenname.php) is neither `''` nor `'0'`, so they can be typed more precisely.

refs https://github.com/phpstan/phpstan/issues/11808, https://github.com/phpstan/phpstan-src/pull/3540