### PR TITLE
Add null to array_map(null, $a, $b)

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/array_map_multiple.php
+++ b/tests/PHPStan/Analyser/nsrt/array_map_multiple.php
@@ -29,8 +29,12 @@ class Foo
 		assertType('non-empty-array<int, array{1|2|3, 4|5|6}>', array_map(null, [1, 2, 3], [4, 5, 6]));
 
 		assertType('non-empty-array<string, int>', array_map(null, $array));
-		assertType('non-empty-array<int, array{int|null, int|null}>', array_map(null, $array, $array));
+		assertType('non-empty-array<int, array{int, int}>', array_map(null, $array, $array));
+		assertType('non-empty-array<int, array{int, int, int}>', array_map(null, $array, $array, $array));
 		assertType('non-empty-array<int, array{int|null, bool|null}>', array_map(null, $array, $other));
+
+		assertType('array{1}|array{true}', array_map(null, rand() ? [1] : [true]));
+		assertType('array{1}|array{true, false}', array_map(null, rand() ? [1] : [true, false]));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/array_map_multiple.php
+++ b/tests/PHPStan/Analyser/nsrt/array_map_multiple.php
@@ -29,8 +29,8 @@ class Foo
 		assertType('non-empty-array<int, array{1|2|3, 4|5|6}>', array_map(null, [1, 2, 3], [4, 5, 6]));
 
 		assertType('non-empty-array<string, int>', array_map(null, $array));
-		assertType('non-empty-array<int, array{int, int}>', array_map(null, $array, $array));
-		assertType('non-empty-array<int, array{int, bool}>', array_map(null, $array, $other));
+		assertType('non-empty-array<int, array{int|null, int|null}>', array_map(null, $array, $array));
+		assertType('non-empty-array<int, array{int|null, bool|null}>', array_map(null, $array, $other));
 	}
 
 }


### PR DESCRIPTION
Fixes: https://3v4l.org/QKHrt (https://phpstan.org/r/357b09e6-80b7-4c50-97db-35995ff4cb67)

Unfortunately, since it depends on values of multiple variables at the same time (which may be correlated), there will be false positives like this:

```php
if (rand()) {
	$a = [1];
	$b = [2];
} else {
	$a = [1, 2];
	$b = [3, 4];
}

array_map(null, $a, $b);
```

But I guess it's better to be safe than sorry. I at least added support for `array_map(null, $a, $a)`.