### PR TITLE
Support `for` endless loops

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1194,8 +1194,10 @@ final class NodeScopeResolver
 
 			if ($alwaysIterates) {
 				$isAlwaysTerminating = count($finalScopeResult->getExitPointsByType(Break_::class)) === 0;
+			} elseif ($isIterableAtLeastOnce) {
+				$isAlwaysTerminating = $finalScopeResult->isAlwaysTerminating();
 			} else {
-				$isAlwaysTerminating = $isIterableAtLeastOnce && $finalScopeResult->isAlwaysTerminating();
+				$isAlwaysTerminating = false;
 			}
 			$condScope = $condResult->getFalseyScope();
 			if (!$isIterableAtLeastOnce) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1414,8 +1414,10 @@ final class NodeScopeResolver
 
 			if ($alwaysIterates) {
 				$isAlwaysTerminating = count($finalScopeResult->getExitPointsByType(Break_::class)) === 0;
+			} elseif ($isIterableAtLeastOnce->yes()) {
+				$isAlwaysTerminating = $finalScopeResult->isAlwaysTerminating();
 			} else {
-				$isAlwaysTerminating = false; // $finalScopeResult->isAlwaysTerminating() && $isAlwaysIterable
+				$isAlwaysTerminating = false;
 			}
 
 			return new StatementResult(

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1314,7 +1314,6 @@ final class NodeScopeResolver
 			}
 
 			$bodyScope = $initScope;
-			$alwaysIterates = $stmt->cond === [] && $context->isTopLevel();
 			$isIterableAtLeastOnce = TrinaryLogic::createYes();
 			$lastCondExpr = $stmt->cond[count($stmt->cond) - 1] ?? null;
 			foreach ($stmt->cond as $condExpr) {
@@ -1385,7 +1384,10 @@ final class NodeScopeResolver
 				$loopScope = $this->processExprNode($stmt, $loopExpr, $loopScope, $nodeCallback, ExpressionContext::createTopLevel())->getScope();
 			}
 			$finalScope = $finalScope->generalizeWith($loopScope);
+
+			$alwaysIterates = TrinaryLogic::createFromBoolean($context->isTopLevel());
 			if ($lastCondExpr !== null) {
+				$alwaysIterates = $alwaysIterates->and($finalScope->getType($lastCondExpr)->toBoolean()->isTrue());
 				$finalScope = $finalScope->filterByFalseyValue($lastCondExpr);
 			}
 
@@ -1412,7 +1414,7 @@ final class NodeScopeResolver
 				}
 			}
 
-			if ($alwaysIterates) {
+			if ($alwaysIterates->yes()) {
 				$isAlwaysTerminating = count($finalScopeResult->getExitPointsByType(Break_::class)) === 0;
 			} elseif ($isIterableAtLeastOnce->yes()) {
 				$isAlwaysTerminating = $finalScopeResult->isAlwaysTerminating();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1194,10 +1194,8 @@ final class NodeScopeResolver
 
 			if ($alwaysIterates) {
 				$isAlwaysTerminating = count($finalScopeResult->getExitPointsByType(Break_::class)) === 0;
-			} elseif ($isIterableAtLeastOnce) {
-				$isAlwaysTerminating = $finalScopeResult->isAlwaysTerminating();
 			} else {
-				$isAlwaysTerminating = false;
+				$isAlwaysTerminating = $isIterableAtLeastOnce && $finalScopeResult->isAlwaysTerminating();
 			}
 			$condScope = $condResult->getFalseyScope();
 			if (!$isIterableAtLeastOnce) {
@@ -1314,6 +1312,7 @@ final class NodeScopeResolver
 			}
 
 			$bodyScope = $initScope;
+			$alwaysIterates = $stmt->cond === [] && $context->isTopLevel();
 			$isIterableAtLeastOnce = TrinaryLogic::createYes();
 			$lastCondExpr = $stmt->cond[count($stmt->cond) - 1] ?? null;
 			foreach ($stmt->cond as $condExpr) {
@@ -1411,10 +1410,16 @@ final class NodeScopeResolver
 				}
 			}
 
+			if ($alwaysIterates) {
+				$isAlwaysTerminating = count($finalScopeResult->getExitPointsByType(Break_::class)) === 0;
+			} else {
+				$isAlwaysTerminating = false; // $finalScopeResult->isAlwaysTerminating() && $isAlwaysIterable
+			}
+
 			return new StatementResult(
 				$finalScope,
 				$finalScopeResult->hasYield() || $hasYield,
-				false/* $finalScopeResult->isAlwaysTerminating() && $isAlwaysIterable*/,
+				$isAlwaysTerminating,
 				$finalScopeResult->getExitPointsForOuterLoop(),
 				array_merge($throwPoints, $finalScopeResult->getThrowPoints()),
 				array_merge($impurePoints, $finalScopeResult->getImpurePoints()),

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -243,7 +243,7 @@ class StatementResultTest extends PHPStanTestCase
 			],
 			[
 				'for ($i = 0; $i < 10; $i++) { return; }',
-				false, // will be true with range types
+				true,
 			],
 			[
 				'for ($i = 0; $i < 0; $i++) { return; }',

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -174,6 +174,18 @@ class StatementResultTest extends PHPStanTestCase
 				false,
 			],
 			[
+				'for (;;) { }',
+				true,
+			],
+			[
+				'for (;;) { return; }',
+				true,
+			],
+			[
+				'for (;;) { break; }',
+				false,
+			],
+			[
 				'do { } while (doFoo());',
 				false,
 			],

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -174,6 +174,50 @@ class StatementResultTest extends PHPStanTestCase
 				false,
 			],
 			[
+				'while (true) { exit; }',
+				true,
+			],
+			[
+				'while (true) { while (true) { } }',
+				true,
+			],
+			[
+				'while (true) { while (true) { return; } }',
+				true,
+			],
+			[
+				'while (true) { while (true) { break; } }',
+				true,
+			],
+			[
+				'while (true) { while (true) { exit; } }',
+				true,
+			],
+			[
+				'while (true) { while (true) { break 2; } }',
+				false,
+			],
+			[
+				'while (true) { while ($x) { } }',
+				true,
+			],
+			[
+				'while (true) { while ($x) { return; } }',
+				true,
+			],
+			[
+				'while (true) { while ($x) { break; } }',
+				true,
+			],
+			[
+				'while (true) { while ($x) { exit; } }',
+				true,
+			],
+			[
+				'while (true) { while ($x) { break 2; } }',
+				false,
+			],
+			[
 				'for (;;) { }',
 				true,
 			],
@@ -183,6 +227,50 @@ class StatementResultTest extends PHPStanTestCase
 			],
 			[
 				'for (;;) { break; }',
+				false,
+			],
+			[
+				'for (;;) { exit; }',
+				true,
+			],
+			[
+				'for (;;) { for (;;) { } }',
+				true,
+			],
+			[
+				'for (;;) { for (;;) { return; } }',
+				true,
+			],
+			[
+				'for (;;) { for (;;) { break; }	}',
+				true,
+			],
+			[
+				'for (;;) { for (;;) { exit; } }',
+				true,
+			],
+			[
+				'for (;;) { for (;;) { break 2; } }',
+				false,
+			],
+			[
+				'for (;;) { for ($i = 0; $i< 5; $i++) { } }',
+				true,
+			],
+			[
+				'for (;;) { for ($i = 0; $i< 5; $i++) { return; } }',
+				true,
+			],
+			[
+				'for (;;) { for ($i = 0; $i< 5; $i++) { break; } }',
+				true,
+			],
+			[
+				'for (;;) { for ($i = 0; $i< 5; $i++) { exit; } }',
+				true,
+			],
+			[
+				'for (;;) { for ($i = 0; $i< 5; $i++) { break 2; } }',
 				false,
 			],
 			[

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -274,6 +274,30 @@ class StatementResultTest extends PHPStanTestCase
 				false,
 			],
 			[
+				'for ($i = 0; $i < 5;) { }',
+				true,
+			],
+			[
+				'for ($i = 0; $i < 5; $i--) { }',
+				true,
+			],
+			[
+				'for (; 0, 1;) { }',
+				true,
+			],
+			[
+				'for (; 1, 0;) { }',
+				false,
+			],
+			[
+				'for (; "", "a";) { }',
+				true,
+			],
+			[
+				'for (; "a", "";) { }',
+				false,
+			],
+			[
 				'do { } while (doFoo());',
 				false,
 			],

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -109,12 +109,12 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 					140,
 				],
 				[
-					'Strict comparison using !== between StrictComparison\Foo|null and 1 will always evaluate to true.',
-					154,
+					'Strict comparison using === between non-empty-array and null will always evaluate to false.',
+					150,
 				],
 				[
-					'Strict comparison using === between non-empty-array and null will always evaluate to false.',
-					164,
+					'Strict comparison using !== between StrictComparison\Foo|null and 1 will always evaluate to true.',
+					161,
 				],
 				[
 					'Strict comparison using !== between StrictComparison\Node|null and false will always evaluate to true.',
@@ -352,7 +352,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 				],
 				[
 					'Strict comparison using === between non-empty-array and null will always evaluate to false.',
-					164,
+					150,
 				],
 				[
 					'Strict comparison using === between 1 and 2 will always evaluate to false.',

--- a/tests/PHPStan/Rules/Comparison/data/strict-comparison.php
+++ b/tests/PHPStan/Rules/Comparison/data/strict-comparison.php
@@ -146,6 +146,13 @@ class Foo
 
 	public function forWithTypeChange()
 	{
+		for (; $val = $this->returnArray();) {
+			if ($val === null) {
+
+			}
+			$val = null;
+		}
+
 		$foo = null;
 		for (;;) {
 			if ($foo !== null) {
@@ -158,13 +165,6 @@ class Foo
 			if (something()) {
 				$foo = new self();
 			}
-		}
-
-		for (; $val = $this->returnArray();) {
-			if ($val === null) {
-
-			}
-			$val = null;
 		}
 	}
 

--- a/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
+++ b/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
@@ -325,10 +325,22 @@ class MissingReturnRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9309.php'], []);
 	}
 
+	public function testBug6807(): void
+	{
+		$this->checkExplicitMixedMissingReturn = true;
+		$this->analyse([__DIR__ . '/data/bug-6807.php'], []);
+	}
+
 	public function testBug8463(): void
 	{
 		$this->checkExplicitMixedMissingReturn = true;
 		$this->analyse([__DIR__ . '/data/bug-8463.php'], []);
+	}
+
+	public function testBug9374(): void
+	{
+		$this->checkExplicitMixedMissingReturn = true;
+		$this->analyse([__DIR__ . '/data/bug-9374.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
+++ b/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
@@ -325,4 +325,10 @@ class MissingReturnRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9309.php'], []);
 	}
 
+	public function testBug8463(): void
+	{
+		$this->checkExplicitMixedMissingReturn = true;
+		$this->analyse([__DIR__ . '/data/bug-8463.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Missing/data/bug-6807.php
+++ b/tests/PHPStan/Rules/Missing/data/bug-6807.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6807;
+
+/** @return int */
+function test()
+{
+	for ($attempts = 0; ; $attempts++)
+	{
+		if ($attempts > 5)
+			throw new Exception();
+
+		if (rand() == 1)
+			return 5;
+	}
+}

--- a/tests/PHPStan/Rules/Missing/data/bug-8463.php
+++ b/tests/PHPStan/Rules/Missing/data/bug-8463.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug8463;
+
+function f1() : int
+{
+	while(true)
+	{
+		if(rand() === rand())
+		{
+			return 1;
+		}
+	}
+}
+
+
+function f2() : int
+{
+	for(;;)
+	{
+		if(rand() === rand())
+		{
+			return 1;
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Missing/data/bug-9374.php
+++ b/tests/PHPStan/Rules/Missing/data/bug-9374.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9374;
+
+function bar(): string {
+	for ($i = 0; ; ++$i)
+		return "";
+}

--- a/tests/PHPStan/Rules/Variables/data/defined-variables-anonymous-function-use.php
+++ b/tests/PHPStan/Rules/Variables/data/defined-variables-anonymous-function-use.php
@@ -14,7 +14,7 @@ if (foo()) {
 	$onlyInIf = 1;
 }
 
-for ($forI = 0; $forI < 10, $anotherVariableFromForCond = 1; $forI++, $forJ = $forI) {
+for ($forI = 0; $anotherVariableFromForCond = 1, $forI < 10; $forI++, $forJ = $forI) {
 
 }
 

--- a/tests/PHPStan/Rules/Variables/data/defined-variables.php
+++ b/tests/PHPStan/Rules/Variables/data/defined-variables.php
@@ -243,7 +243,7 @@ function () {
 
 	}
 
-	for ($forI = 0; $forI < 10, $forK = 5; $forI++, $forK++, $forJ = $forI) {
+	for ($forI = 0; $forK = 5, $forI < 10; $forI++, $forK++, $forJ = $forI) {
 		echo $forI;
 	}
 
@@ -322,7 +322,7 @@ function () {
 	include($fileB='includeB.php');
 	echo $fileB;
 
-	for ($forLoopVariableInit = 0; $forLoopVariableInit < 5; $forLoopVariableInit = $forLoopVariable, $anotherForLoopVariable = 1) {
+	for ($forLoopVariableInit = 0; $forLoopVariableInit < 5 && rand(0, 1); $forLoopVariableInit = $forLoopVariable, $anotherForLoopVariable = 1) {
 		$forLoopVariable = 2;
 	}
 	echo $anotherForLoopVariable;
@@ -357,7 +357,7 @@ function () {
 
 	}
 
-	for (; $forVariableUsedAndThenDefined && $forVariableUsedAndThenDefined = 1;) {
+	for (; $forVariableUsedAndThenDefined && $forVariableUsedAndThenDefined = 1 && rand(0, 1);) {
 
 	}
 

--- a/tests/e2e/baseline.neon
+++ b/tests/e2e/baseline.neon
@@ -156,6 +156,11 @@ parameters:
 			path: PHP-Parser/lib/PhpParser/ParserAbstract.php
 
 		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: PHP-Parser/lib/PhpParser/ParserAbstract.php
+
+		-
 			message: "#^Variable \\$action might not be defined\\.$#"
 			count: 1
 			path: PHP-Parser/lib/PhpParser/ParserAbstract.php


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6807
Closes https://github.com/phpstan/phpstan/issues/8463
Closes https://github.com/phpstan/phpstan/issues/9374

analogue to `while`.  contains also a slight simplification in the setting of `$isAlwaysTerminating` for `while` loops to keep this more in sync.

I had to switch the 2 test blocks in `tests/PHPStan/Rules/Comparison/data/strict-comparison.php` because the first one would be never exiting endless loop after this change, which would make the second one dead code and not testing anything useful any more.