### PR TITLE
Don't report "is always true/false" for conditionally defined variables

### DIFF
--- a/src/Rules/Comparison/ConstantConditionRuleHelper.php
+++ b/src/Rules/Comparison/ConstantConditionRuleHelper.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\BooleanType;
+use function is_string;
 
 final class ConstantConditionRuleHelper
 {
@@ -18,7 +19,7 @@ final class ConstantConditionRuleHelper
 	{
 	}
 
-	public function shouldSkip(Scope $scope, Expr $expr): bool
+	private function shouldSkip(Scope $scope, Expr $expr): bool
 	{
 		if (
 			$expr instanceof Expr\BinaryOp\Equal
@@ -55,6 +56,14 @@ final class ConstantConditionRuleHelper
 			if ($isAlways !== null) {
 				return true;
 			}
+		}
+
+		if (
+			$expr instanceof Expr\Variable
+			&& is_string($expr->name)
+			&& !$scope->hasVariableType($expr->name)->yes()
+		) {
+			return true;
 		}
 
 		return false;

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -173,4 +173,10 @@ class IfConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4912.php'], []);
 	}
 
+	public function testBug6830(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-6830.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-6830.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-6830.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug6830;
+
+function test(bool $do): void
+{
+
+	if ($do) {
+
+		$x = 9999;
+	}
+
+	foreach ([1, 2, 3] as $whatever) {
+
+		if ($do) {
+
+			if ($x) {
+
+				$x = 123;
+			}
+		}
+	}
+}
+
+
+


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/6830