### PR TITLE
Make ArrayFindArgVisitor supports array_any() and array_all()

### DIFF
--- a/src/Parser/ArrayFindArgVisitor.php
+++ b/src/Parser/ArrayFindArgVisitor.php
@@ -15,7 +15,7 @@ final class ArrayFindArgVisitor extends NodeVisitorAbstract
 	{
 		if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
 			$functionName = $node->name->toLowerString();
-			if (in_array($functionName, ['array_find', 'array_find_key'], true)) {
+			if (in_array($functionName, ['array_all', 'array_any', 'array_find', 'array_find_key'], true)) {
 				$args = $node->getRawArgs();
 				if (isset($args[0])) {
 					$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -903,11 +903,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			],
 			[
 				'Parameter #2 $callback of function array_find expects callable(mixed, int|string): bool, Closure(string, array): false given.',
-				49,
+				52,
 			],
 			[
 				'Parameter #2 $callback of function array_find expects callable(mixed, int|string): bool, Closure(string, int): array{} given.',
-				52,
+				55,
 			],
 		]);
 	}
@@ -929,11 +929,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			],
 			[
 				'Parameter #2 $callback of function array_find_key expects callable(mixed, int|string): bool, Closure(string, array): false given.',
-				49,
+				52,
 			],
 			[
 				'Parameter #2 $callback of function array_find_key expects callable(mixed, int|string): bool, Closure(string, int): array{} given.',
-				52,
+				55,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -888,6 +888,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 	public function testArrayAllCallback(): void
 	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test skipped on lower version than 8.4 (needs array_all function)');
+		}
+
 		$this->analyse([__DIR__ . '/data/array_all.php'], [
 			[
 				'Parameter #2 $callback of function array_all expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(string, int): bool given.',
@@ -914,6 +918,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 	public function testArrayAnyCallback(): void
 	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test skipped on lower version than 8.4 (needs array_any function)');
+		}
+
 		$this->analyse([__DIR__ . '/data/array_any.php'], [
 			[
 				'Parameter #2 $callback of function array_any expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(string, int): bool given.',

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -886,6 +886,58 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/array_filter_callback.php'], $errors);
 	}
 
+	public function testArrayAllCallback(): void
+	{
+		$this->analyse([__DIR__ . '/data/array_all.php'], [
+			[
+				'Parameter #2 $callback of function array_all expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(string, int): bool given.',
+				22,
+			],
+			[
+				'Parameter #2 $callback of function array_all expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(string, int): bool given.',
+				30,
+			],
+			[
+				'Parameter #2 $callback of function array_all expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(int, string): (\'bar\'|\'foo\') given.',
+				36,
+			],
+			[
+				'Parameter #2 $callback of function array_all expects callable(mixed, int|string): bool, Closure(string, array): false given.',
+				52,
+			],
+			[
+				'Parameter #2 $callback of function array_all expects callable(mixed, int|string): bool, Closure(string, int): array{} given.',
+				55,
+			],
+		]);
+	}
+
+	public function testArrayAnyCallback(): void
+	{
+		$this->analyse([__DIR__ . '/data/array_any.php'], [
+			[
+				'Parameter #2 $callback of function array_any expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(string, int): bool given.',
+				22,
+			],
+			[
+				'Parameter #2 $callback of function array_any expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(string, int): bool given.',
+				30,
+			],
+			[
+				'Parameter #2 $callback of function array_any expects callable(1|2, \'bar\'|\'foo\'): bool, Closure(int, string): (\'bar\'|\'foo\') given.',
+				36,
+			],
+			[
+				'Parameter #2 $callback of function array_any expects callable(mixed, int|string): bool, Closure(string, array): false given.',
+				52,
+			],
+			[
+				'Parameter #2 $callback of function array_any expects callable(mixed, int|string): bool, Closure(string, int): array{} given.',
+				55,
+			],
+		]);
+	}
+
 	public function testArrayFindCallback(): void
 	{
 		$this->analyse([__DIR__ . '/data/array_find.php'], [

--- a/tests/PHPStan/Rules/Functions/data/array_all.php
+++ b/tests/PHPStan/Rules/Functions/data/array_all.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1); // lint >= 8.4
+
+// ok
+array_all(
+	['foo' => 1, 'bar' => 2],
+	function($value, $key) {
+		return $key === 0;
+	}
+);
+
+// ok
+array_all(
+	['foo' => 1, 'bar' => 2],
+	function(int $value, string $key) {
+		return $key === 0;
+	}
+);
+
+// bad parameters
+array_all(
+	['foo' => 1, 'bar' => 2],
+	function(string $value, int $key): bool {
+		return $key === 0;
+	}
+);
+
+// bad parameters
+array_all(
+	['foo' => 1, 'bar' => 2],
+	fn (string $item, int $key) => $key === 0,
+);
+
+// bad return type
+array_all(
+	['foo' => 1, 'bar' => 2],
+	function(int $value, string $key) {
+		return $key;
+	},
+);
+
+if (is_array($array)) {
+	// ok
+	array_all($array, fn ($value, $key) => $key === 0);
+
+	// ok
+	array_all($array, fn (string $value, int $key) => $key === 0);
+
+	// ok
+	array_all($array, fn (string $value) => $value === 'foo');
+
+	// bad parameters
+	array_all($array, fn (string $item, array $key) => $key === 0);
+
+	// bad return type
+	array_all($array, fn (string $value, int $key): array => []);
+}

--- a/tests/PHPStan/Rules/Functions/data/array_any.php
+++ b/tests/PHPStan/Rules/Functions/data/array_any.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1); // lint >= 8.4
+
+// ok
+array_any(
+	['foo' => 1, 'bar' => 2],
+	function($value, $key) {
+		return $key === 0;
+	}
+);
+
+// ok
+array_any(
+	['foo' => 1, 'bar' => 2],
+	function(int $value, string $key) {
+		return $key === 0;
+	}
+);
+
+// bad parameters
+array_any(
+	['foo' => 1, 'bar' => 2],
+	function(string $value, int $key): bool {
+		return $key === 0;
+	}
+);
+
+// bad parameters
+array_any(
+	['foo' => 1, 'bar' => 2],
+	fn (string $item, int $key) => $key === 0,
+);
+
+// bad return type
+array_any(
+	['foo' => 1, 'bar' => 2],
+	function(int $value, string $key) {
+		return $key;
+	},
+);
+
+if (is_array($array)) {
+	// ok
+	array_any($array, fn ($value, $key) => $key === 0);
+
+	// ok
+	array_any($array, fn (string $value, int $key) => $key === 0);
+
+	// ok
+	array_any($array, fn (string $value) => $value === 'foo');
+
+	// bad parameters
+	array_any($array, fn (string $item, array $key) => $key === 0);
+
+	// bad return type
+	array_any($array, fn (string $value, int $key): array => []);
+}

--- a/tests/PHPStan/Rules/Functions/data/array_find.php
+++ b/tests/PHPStan/Rules/Functions/data/array_find.php
@@ -45,6 +45,9 @@ if (is_array($array)) {
 	// ok
 	array_find($array, fn (string $value, int $key) => $key === 0);
 
+	// ok
+	array_find($array, fn (string $value) => $key === 0);
+
 	// bad parameters
 	array_find($array, fn (string $item, array $key) => $key === 0);
 

--- a/tests/PHPStan/Rules/Functions/data/array_find_key.php
+++ b/tests/PHPStan/Rules/Functions/data/array_find_key.php
@@ -45,6 +45,9 @@ if (is_array($array)) {
 	// ok
 	array_find_key($array, fn (string $value, int $key) => $key === 0);
 
+	// ok
+	array_find_key($array, fn (string $value) => $value === 'foo');
+
 	// bad parameters
 	array_find_key($array, fn (string $item, array $key) => $key === 0);
 


### PR DESCRIPTION
After https://github.com/phpstan/phpstan-src/pull/3518 was merged, I remembered that these functions could be supported as well.