### PR TITLE
deps: upgrade bashunit:0.18.0 for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -253,7 +253,7 @@ jobs:
         run: "patch src/Analyser/Error.php < e2e/PHPStanErrorPatch.patch"
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.17.0"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.18.0"
 
       - name: "Test"
         run: "${{ matrix.script }}"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -355,7 +355,7 @@ jobs:
         run: "composer install --no-interaction --no-progress"
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.17.0"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s e2e/ 0.18.0"
 
       - name: "Test"
         run: ${{ matrix.script }}


### PR DESCRIPTION
Upgrade to latest stable https://github.com/TypedDevs/bashunit/releases/tag/0.18.0 

Blog post with mayor changes: https://bashunit.typeddevs.com/blog/2024-10-16-release-0-18