### PR TITLE
fix: check for existence of second arg in CountCharsFunctionDynamicReturnTypeExtension

### DIFF
--- a/src/Type/Php/CountCharsFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/CountCharsFunctionDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
@@ -35,11 +36,13 @@ final class CountCharsFunctionDynamicReturnTypeExtension implements DynamicFunct
 		Scope $scope,
 	): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+
+		if (count($args) < 1) {
 			return null;
 		}
 
-		$modeType = $scope->getType($functionCall->getArgs()[1]->value);
+		$modeType = count($args) === 2 ? $scope->getType($args[1]->value) : new ConstantIntegerType(0);
 
 		if (IntegerRangeType::fromInterval(0, 2)->isSuperTypeOf($modeType)->yes()) {
 			$arrayType = new ArrayType(new IntegerType(), new IntegerType());

--- a/tests/PHPStan/Analyser/nsrt/count-chars-7.4.php
+++ b/tests/PHPStan/Analyser/nsrt/count-chars-7.4.php
@@ -8,6 +8,7 @@ class X {
 	const ABC = 'abcdef';
 
 	function doFoo(): void {
+		assertType('array<int, int>|false', count_chars(self::ABC));
 		assertType('array<int, int>|false', count_chars(self::ABC, 0));
 		assertType('array<int, int>|false', count_chars(self::ABC, 1));
 		assertType('array<int, int>|false', count_chars(self::ABC, 2));

--- a/tests/PHPStan/Analyser/nsrt/count-chars-8.0.php
+++ b/tests/PHPStan/Analyser/nsrt/count-chars-8.0.php
@@ -8,6 +8,7 @@ class Y {
 	const ABC = 'abcdef';
 
 	function doFoo(): void {
+		assertType('array<int, int>', count_chars(self::ABC));
 		assertType('array<int, int>', count_chars(self::ABC, 0));
 		assertType('array<int, int>', count_chars(self::ABC, 1));
 		assertType('array<int, int>', count_chars(self::ABC, 2));


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/11994