### PR TITLE
Fix `for` endless loop detection

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -1369,7 +1369,10 @@ final class NodeScopeResolver
 			}
 
 			$bodyScope = $bodyScope->mergeWith($initScope);
+
+			$alwaysIterates = TrinaryLogic::createFromBoolean($context->isTopLevel());
 			if ($lastCondExpr !== null) {
+				$alwaysIterates = $alwaysIterates->and($bodyScope->getType($lastCondExpr)->toBoolean()->isTrue());
 				$bodyScope = $this->processExprNode($stmt, $lastCondExpr, $bodyScope, $nodeCallback, ExpressionContext::createDeep())->getTruthyScope();
 			}
 
@@ -1385,9 +1388,7 @@ final class NodeScopeResolver
 			}
 			$finalScope = $finalScope->generalizeWith($loopScope);
 
-			$alwaysIterates = TrinaryLogic::createFromBoolean($context->isTopLevel());
 			if ($lastCondExpr !== null) {
-				$alwaysIterates = $alwaysIterates->and($finalScope->getType($lastCondExpr)->toBoolean()->isTrue());
 				$finalScope = $finalScope->filterByFalseyValue($lastCondExpr);
 			}
 

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -298,6 +298,14 @@ class StatementResultTest extends PHPStanTestCase
 				false,
 			],
 			[
+				'for ($c = (0x80 | 0x40); $c & 0x80; $c = $c << 1) { }',
+				false,
+			],
+			[
+				'for ($i = 0; $i < 10; $i++) { $i = 5; }',
+				true,
+			],
+			[
 				'do { } while (doFoo());',
 				false,
 			],

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -224,4 +224,10 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11179.php'], []);
 	}
 
+	public function testBug11992(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-11992.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/data/bug-11992.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-11992.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11992;
+
+// valid
+function exampleA(): void {
+	$bc = 0;
+	for ($i = 0; $i < 3; ++$i) {
+		$bc++;
+	}
+	printf("bc: %d\n", $bc);
+}
+
+// not valid? Why? this is deterministic even from a static standpoint
+function exampleB(): void {
+	$bc = 0;
+	for ($c = (0x80 | 0x40); $c & 0x80; $c = $c << 1) {
+		$bc++;
+	}
+	printf("bc: %d\n", $bc);
+}
+
+// invalid because valid() is theoretically infinite?
+function exampleC(): void {
+	for (
+		$it = new \DirectoryIterator('/tmp');
+		$it->valid();
+		$it->next()
+	) {
+		printf("name: %s\n", $it->getFilename());
+	}
+	printf("done\n");
+}
+
+exampleA();
+exampleB();
+exampleC();


### PR DESCRIPTION
Doing this in the generalized finalScope which includes an already filtered bodyScope is too late and causes false-positives.

Fixes https://github.com/phpstan/phpstan/issues/11992
Improves endless loop detection as in cases like https://github.com/phpstan/phpstan/issues/736
And most likely it fixes what was mentioned in the discussion https://github.com/phpstan/phpstan/discussions/11986 too

Follow-up for https://github.com/phpstan/phpstan-src/pull/3573