### PR TITLE
ClassReflection: resolve missing template type to its default rather than bound

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -1374,7 +1374,7 @@ class ClassReflection
 				if ($type instanceof ErrorType) {
 					$templateType = $templateTypeMap->getType($name);
 					if ($templateType !== null) {
-						return TemplateTypeHelper::resolveToBounds($templateType);
+						return TemplateTypeHelper::resolveToDefaults($templateType);
 					}
 				}
 

--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -68,6 +68,17 @@ final class TemplateTypeHelper
 		});
 	}
 
+	public static function resolveToDefaults(Type $type): Type
+	{
+		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
+			if ($type instanceof TemplateType) {
+				return $traverse($type->getDefault() ?? $type->getBound());
+			}
+
+			return $traverse($type);
+		});
+	}
+
 	public static function resolveToBounds(Type $type): Type
 	{
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {

--- a/src/Type/GenericTypeVariableResolver.php
+++ b/src/Type/GenericTypeVariableResolver.php
@@ -44,7 +44,7 @@ class GenericTypeVariableResolver
 				return new MixedType(false);
 			}
 
-			return $bound;
+			return TemplateTypeHelper::resolveToDefaults($templateType);
 		}
 
 		return $type;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -841,7 +841,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 				return new MixedType(false);
 			}
 
-			return $bound;
+			return TemplateTypeHelper::resolveToDefaults($templateType);
 		}
 
 		return $type;

--- a/tests/PHPStan/Analyser/nsrt/bug-11899.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11899.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bug11899;
+
+use function PHPStan\Testing\assertType;
+
+abstract class Test {}
+
+interface InvertedQuestions {}
+
+class SomeTest extends Test implements InvertedQuestions {}
+
+/**
+ * @template TTestType = Test
+ * @property-read ?TTestType $test
+ */
+class UserTest {
+	public function __get() : mixed {
+		return new SomeTest();
+	}
+}
+
+function acceptUserTest1(UserTest $ut) : void {
+	assertType('Bug11899\\UserTest', $ut);
+	assertType('Bug11899\\Test|null', $ut->test);
+}
+
+/**
+ * @param UserTest<InvertedQuestions> $ut
+ */
+function acceptUserTest2(UserTest $ut) : void {
+	assertType('Bug11899\\UserTest<Bug11899\\InvertedQuestions>', $ut);
+	assertType('Bug11899\\InvertedQuestions|null', $ut->test);
+}


### PR DESCRIPTION
closes phpstan/phpstan#11899 