### PR TITLE
feat: add TypeCombinator::removeTruthy method

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1341,4 +1341,9 @@ class TypeCombinator
 		return self::remove($type, StaticTypeFactory::falsey());
 	}
 
+	public static function removeTruthy(Type $type): Type
+	{
+		return self::remove($type, StaticTypeFactory::truthy());
+	}
+
 }


### PR DESCRIPTION
This PR adds `TypeCombinator::removeTruthy` method.

Did not add tests because the `remove` method already have tests that covers this case.