### PR TITLE
Fix ConstantArrayType::isCallable

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -482,7 +482,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				if (!$phpVersion->supportsCallableInstanceMethods()) {
 					$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
 					if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
-						$has = $has->and(TrinaryLogic::createNo());
+						$has = TrinaryLogic::createNo();
 					}
 				} elseif ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
 					$has = $has->and(TrinaryLogic::createMaybe());

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -458,7 +458,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function isCallable(): TrinaryLogic
 	{
-		$typeAndMethods = $this->findTypeAndMethodNames(false);
+		$typeAndMethods = $this->findTypeAndMethodNames();
 		if ($typeAndMethods === []) {
 			return TrinaryLogic::createNo();
 		}
@@ -468,7 +468,19 @@ class ConstantArrayType extends ArrayType implements ConstantType
 			$typeAndMethods,
 		);
 
-		return TrinaryLogic::extremeIdentity(...$results);
+		$isCallable = TrinaryLogic::createYes()->and(...$results);
+		if ($isCallable->yes()) {
+			$callableArray = $this->getClassOrObjectAndMethods();
+			if ($callableArray !== []) {
+				[$classOrObject, $methods] = $callableArray;
+
+				if (count($methods->getConstantStrings()) !== count($typeAndMethods)) {
+					return TrinaryLogic::createMaybe();
+				}
+			}
+		}
+
+		return $isCallable;
 	}
 
 	public function getCallableParametersAcceptors(ClassMemberAccessAnswerer $scope): array
@@ -561,7 +573,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 	}
 
 	/** @return ConstantArrayTypeAndMethod[] */
-	public function findTypeAndMethodNames(bool $atLeastMaybe = true): array
+	public function findTypeAndMethodNames(): array
 	{
 		$callableArray = $this->getClassOrObjectAndMethods();
 		if ($callableArray === []) {
@@ -582,21 +594,25 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		$phpVersion = PhpVersionStaticAccessor::getInstance();
 		foreach ($methods->getConstantStrings() as $method) {
 			$has = $type->hasMethod($method->getValue());
+			if ($has->no()) {
+				continue;
+			}
 
-			if ($has->yes()) {
-				if (BleedingEdgeToggle::isBleedingEdge() && !$phpVersion->supportsCallableInstanceMethods()) {
-					$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
-					if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
-						$has = TrinaryLogic::createNo();
-					}
-				} elseif ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
-					$has = $has->and(TrinaryLogic::createMaybe());
+			if (
+				BleedingEdgeToggle::isBleedingEdge()
+				&& $has->yes()
+				&& !$phpVersion->supportsCallableInstanceMethods()
+			) {
+				$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
+				if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
+					continue;
 				}
 			}
 
-			if ($atLeastMaybe && $has->no()) {
-				continue;
+			if ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
+				$has = $has->and(TrinaryLogic::createMaybe());
 			}
+
 			$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);
 		}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -458,41 +458,17 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function isCallable(): TrinaryLogic
 	{
-		$callableArray = $this->getClassOrObjectAndMethods();
-		if ($callableArray === []) {
+		$typeAndMethods = $this->findTypeAndMethodNames();
+		if ($typeAndMethods === []) {
 			return TrinaryLogic::createNo();
 		}
 
-		[$classOrObject, $methods] = $callableArray;
-		if (count($methods->getConstantStrings()) === 0) {
-			return TrinaryLogic::createMaybe();
-		}
+		$results = array_map(
+			static fn (ConstantArrayTypeAndMethod $typeAndMethod): TrinaryLogic => $typeAndMethod->getCertainty(),
+			$typeAndMethods,
+		);
 
-		$type = $classOrObject->getObjectTypeOrClassStringObjectType();
-		if (!$type->isObject()->yes()) {
-			return TrinaryLogic::createMaybe();
-		}
-
-		$hasMethodTrinary = [];
-		$phpVersion = PhpVersionStaticAccessor::getInstance();
-		foreach ($methods->getConstantStrings() as $method) {
-			$has = $type->hasMethod($method->getValue());
-
-			if ($has->yes()) {
-				if (!$phpVersion->supportsCallableInstanceMethods()) {
-					$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
-					if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
-						$has = TrinaryLogic::createNo();
-					}
-				} elseif ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
-					$has = $has->and(TrinaryLogic::createMaybe());
-				}
-			}
-
-			$hasMethodTrinary[] = $has;
-		}
-
-		return TrinaryLogic::extremeIdentity(...$hasMethodTrinary);
+		return TrinaryLogic::extremeIdentity(...$results);
 	}
 
 	public function getCallableParametersAcceptors(ClassMemberAccessAnswerer $scope): array
@@ -606,23 +582,16 @@ class ConstantArrayType extends ArrayType implements ConstantType
 		$phpVersion = PhpVersionStaticAccessor::getInstance();
 		foreach ($methods->getConstantStrings() as $method) {
 			$has = $type->hasMethod($method->getValue());
-			if ($has->no()) {
-				continue;
-			}
 
-			if (
-				BleedingEdgeToggle::isBleedingEdge()
-				&& $has->yes()
-				&& !$phpVersion->supportsCallableInstanceMethods()
-			) {
-				$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
-				if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
-					continue;
+			if ($has->yes()) {
+				if (BleedingEdgeToggle::isBleedingEdge() && !$phpVersion->supportsCallableInstanceMethods()) {
+					$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
+					if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
+						$has = TrinaryLogic::createNo();
+					}
+				} elseif ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
+					$has = $has->and(TrinaryLogic::createMaybe());
 				}
-			}
-
-			if ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
-				$has = $has->and(TrinaryLogic::createMaybe());
 			}
 
 			$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -594,9 +594,10 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				}
 			}
 
-			if (!$atLeastMaybe || !$has->no()) {
-				$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);
+			if ($atLeastMaybe && $has->no()) {
+				continue;
 			}
+			$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);
 		}
 
 		return $typeAndMethods;

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -458,17 +458,41 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function isCallable(): TrinaryLogic
 	{
-		$typeAndMethods = $this->findTypeAndMethodNames();
-		if ($typeAndMethods === []) {
+		$callableArray = $this->getClassOrObjectAndMethods();
+		if ($callableArray === []) {
 			return TrinaryLogic::createNo();
 		}
 
-		$results = array_map(
-			static fn (ConstantArrayTypeAndMethod $typeAndMethod): TrinaryLogic => $typeAndMethod->getCertainty(),
-			$typeAndMethods,
-		);
+		[$classOrObject, $methods] = $callableArray;
+		if (count($methods->getConstantStrings()) === 0) {
+			return TrinaryLogic::createMaybe();
+		}
 
-		return TrinaryLogic::createYes()->and(...$results);
+		$type = $classOrObject->getObjectTypeOrClassStringObjectType();
+		if (!$type->isObject()->yes()) {
+			return TrinaryLogic::createMaybe();
+		}
+
+		$hasMethodTrinary = [];
+		$phpVersion = PhpVersionStaticAccessor::getInstance();
+		foreach ($methods->getConstantStrings() as $method) {
+			$has = $type->hasMethod($method->getValue());
+
+			if ($has->yes()) {
+				if (!$phpVersion->supportsCallableInstanceMethods()) {
+					$methodReflection = $type->getMethod($method->getValue(), new OutOfClassScope());
+					if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
+						$has = $has->and(TrinaryLogic::createNo());
+					}
+				} elseif ($this->isOptionalKey(0) || $this->isOptionalKey(1)) {
+					$has = $has->and(TrinaryLogic::createMaybe());
+				}
+			}
+
+			$hasMethodTrinary[] = $has;
+		}
+
+		return TrinaryLogic::extremeIdentity(...$hasMethodTrinary);
 	}
 
 	public function getCallableParametersAcceptors(ClassMemberAccessAnswerer $scope): array

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -458,7 +458,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 
 	public function isCallable(): TrinaryLogic
 	{
-		$typeAndMethods = $this->findTypeAndMethodNames();
+		$typeAndMethods = $this->findTypeAndMethodNames(false);
 		if ($typeAndMethods === []) {
 			return TrinaryLogic::createNo();
 		}
@@ -561,7 +561,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 	}
 
 	/** @return ConstantArrayTypeAndMethod[] */
-	public function findTypeAndMethodNames(): array
+	public function findTypeAndMethodNames(bool $atLeastMaybe = true): array
 	{
 		$callableArray = $this->getClassOrObjectAndMethods();
 		if ($callableArray === []) {
@@ -594,7 +594,9 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				}
 			}
 
-			$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);
+			if (!$atLeastMaybe || !$has->no()) {
+				$typeAndMethods[] = ConstantArrayTypeAndMethod::createConcrete($type, $method->getValue(), $has);
+			}
 		}
 
 		return $typeAndMethods;

--- a/src/Type/Constant/ConstantArrayTypeAndMethod.php
+++ b/src/Type/Constant/ConstantArrayTypeAndMethod.php
@@ -27,9 +27,6 @@ class ConstantArrayTypeAndMethod
 		TrinaryLogic $certainty,
 	): self
 	{
-		if ($certainty->no()) {
-			throw new ShouldNotHappenException();
-		}
 		return new self($type, $method, $certainty);
 	}
 

--- a/src/Type/Constant/ConstantArrayTypeAndMethod.php
+++ b/src/Type/Constant/ConstantArrayTypeAndMethod.php
@@ -27,6 +27,9 @@ class ConstantArrayTypeAndMethod
 		TrinaryLogic $certainty,
 	): self
 	{
+		if ($certainty->no()) {
+			throw new ShouldNotHappenException();
+		}
 		return new self($type, $method, $certainty);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1102,4 +1102,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/always-true-preg-match.php'], []);
 	}
 
+	public function testBug12063(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-12063.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-12063.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-12063.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1); // lint >= 7.4
+
+namespace Bug12063;
+
+use BadFunctionCallException;
+
+final class View
+{
+	public function existingMethod(): void
+	{
+	}
+}
+
+final class TwigExtension
+{
+	private View $viewFunctions;
+
+	public function __construct(View $viewFunctions)
+	{
+		$this->viewFunctions = $viewFunctions;
+	}
+
+	public function iterateFunctions(): void
+	{
+		$functionMappings = [
+			'i_exist' => 'existingMethod',
+			'i_dont_exist' => 'nonExistingMethod'
+		];
+
+		$functions = [];
+		foreach ($functionMappings as $nameFrom => $nameTo) {
+			$callable = [$this->viewFunctions, $nameTo];
+			if (!is_callable($callable)) {
+				throw new BadFunctionCallException("Function $nameTo does not exist in view functions");
+			}
+		}
+	}
+}


### PR DESCRIPTION
I basically copied the logic `findTypeAndMethodNames` with the following changes:
- I kept the methods with `no` as result of `$type->hasMethod($method->getValue())`
- I ended up with an `TrinaryLogic::extremIdentity`

Closes https://github.com/phpstan/phpstan/issues/12063