### PR TITLE
Use the correct type for final constants

### DIFF
--- a/src/Reflection/ClassConstantReflection.php
+++ b/src/Reflection/ClassConstantReflection.php
@@ -28,6 +28,7 @@ class ClassConstantReflection implements ConstantReflection
 		private ?string $deprecatedDescription,
 		private bool $isDeprecated,
 		private bool $isInternal,
+		private bool $isFinal,
 	)
 	{
 	}
@@ -124,7 +125,7 @@ class ClassConstantReflection implements ConstantReflection
 
 	public function isFinal(): bool
 	{
-		return $this->reflection->isFinal();
+		return $this->isFinal || $this->reflection->isFinal();
 	}
 
 	public function isDeprecated(): TrinaryLogic

--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -1080,6 +1080,7 @@ class ClassReflection
 			$deprecatedDescription = $resolvedPhpDoc->getDeprecatedTag() !== null ? $resolvedPhpDoc->getDeprecatedTag()->getMessage() : null;
 			$isDeprecated = $resolvedPhpDoc->isDeprecated();
 			$isInternal = $resolvedPhpDoc->isInternal();
+			$isFinal = $resolvedPhpDoc->isFinal();
 			$varTags = $resolvedPhpDoc->getVarTags();
 			if (isset($varTags[0]) && count($varTags) === 1) {
 				$phpDocType = $varTags[0]->getType();
@@ -1101,6 +1102,7 @@ class ClassReflection
 				$deprecatedDescription,
 				$isDeprecated,
 				$isInternal,
+				$isFinal,
 			);
 		}
 		return $this->constants[$name];

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1987,6 +1987,7 @@ final class InitializerExprTypeResolver
 			$constantReflection = $constantClassReflection->getConstant($constantName);
 			if (
 				!$constantClassReflection->isFinal()
+				&& !$constantReflection->isFinal()
 				&& !$constantReflection->hasPhpDocType()
 				&& !$constantReflection->hasNativeType()
 			) {

--- a/tests/PHPStan/Analyser/nsrt/class-constant-types.php
+++ b/tests/PHPStan/Analyser/nsrt/class-constant-types.php
@@ -15,6 +15,9 @@ class Foo
 	/** @var string */
 	private const PRIVATE_TYPE = 'foo';
 
+	/** @final */
+	const FINAL_TYPE = 'zoo';
+
 	public function doFoo()
 	{
 		assertType('1', self::NO_TYPE);
@@ -28,6 +31,10 @@ class Foo
 		assertType('\'foo\'', self::PRIVATE_TYPE);
 		assertType('string', static::PRIVATE_TYPE);
 		assertType('string', $this::PRIVATE_TYPE);
+
+		assertType('\'zoo\'', self::FINAL_TYPE);
+		assertType('\'zoo\'', static::FINAL_TYPE);
+		assertType('\'zoo\'', $this::FINAL_TYPE);
 	}
 
 }


### PR DESCRIPTION
Trying to tame the new level 10.. I want to access class constants as `$var::CONST`, but rightfully so they are of mixed type as they could be overridden...

Accept a `@final` annotation (or the actual native final for php 8.3) to return the correct type.