### PR TITLE
Fix array-shape descriptions with special chars

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1476,7 +1476,7 @@ class ConstantArrayType extends ArrayType implements ConstantType
 				if (is_string($keyDescription)) {
 					if (str_contains($keyDescription, '"')) {
 						$keyDescription = sprintf('\'%s\'', $keyDescription);
-					} elseif (str_contains($keyDescription, '\'')) {
+					} else {
 						$keyDescription = sprintf('"%s"', $keyDescription);
 					}
 				}

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Constant;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 use PHPUnit\Framework\TestCase;
@@ -160,6 +161,40 @@ class ConstantArrayTypeBuilderTest extends TestCase
 
 		$builder->setOffsetValueType($oneOrFour, new NullType());
 		$this->assertFalse($builder->isList());
+	}
+
+	public function dataQuotedOffsetNames(): iterable
+	{
+		yield [
+			'array{"count(*)": 1}',
+			new ConstantStringType('count(*)'),
+			new ConstantIntegerType(1),
+		];
+
+		yield [
+			"array{'cou\"nt(*)': 1}",
+			new ConstantStringType('cou"nt(*)'),
+			new ConstantIntegerType(1),
+		];
+
+		yield [
+			'array{"count\'ed": 1}',
+			new ConstantStringType("count'ed"),
+			new ConstantIntegerType(1),
+		];
+	}
+
+	/**
+	 * @dataProvider dataQuotedOffsetNames
+	 */
+	public function testQuotedOffsetNames(string $expectedDescription, Type $key, Type $value): void
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		$builder->setOffsetValueType($key, $value);
+
+		$array1 = $builder->getArray();
+		$this->assertInstanceOf(ConstantArrayType::class, $array1);
+		$this->assertSame($expectedDescription, $array1->describe(VerbosityLevel::precise()));
 	}
 
 }


### PR DESCRIPTION
goal is to make sure array-shapes generated via `$constantArrayType->describe(VerbosityLevel::precise())` are parsable with `TypeStringResolver`