### PR TITLE
Use ConstantScalarTypeTrait in NullType

### DIFF
--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -11,6 +11,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Traits\ConstantScalarTypeTrait;
 use PHPStan\Type\Traits\FalseyBooleanTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonCallableTypeTrait;
@@ -23,6 +24,7 @@ use PHPStan\Type\Traits\NonRemoveableTypeTrait;
 class NullType implements ConstantScalarType
 {
 
+	use ConstantScalarTypeTrait;
 	use NonArrayTypeTrait;
 	use NonCallableTypeTrait;
 	use NonIterableTypeTrait;
@@ -72,71 +74,9 @@ class NullType implements ConstantScalarType
 		return $this;
 	}
 
-	public function accepts(Type $type, bool $strictTypes): TrinaryLogic
-	{
-		return $this->acceptsWithReason($type, $strictTypes)->result;
-	}
-
-	public function acceptsWithReason(Type $type, bool $strictTypes): AcceptsResult
-	{
-		if ($type instanceof self) {
-			return AcceptsResult::createYes();
-		}
-
-		if ($type instanceof CompoundType) {
-			return $type->isAcceptedWithReasonBy($this, $strictTypes);
-		}
-
-		return AcceptsResult::createNo();
-	}
-
-	public function isSuperTypeOf(Type $type): TrinaryLogic
-	{
-		return $this->isSuperTypeOfWithReason($type)->result;
-	}
-
-	public function isSuperTypeOfWithReason(Type $type): IsSuperTypeOfResult
-	{
-		if ($type instanceof self) {
-			return IsSuperTypeOfResult::createYes();
-		}
-
-		if ($type instanceof CompoundType) {
-			return $type->isSubTypeOfWithReason($this);
-		}
-
-		return IsSuperTypeOfResult::createNo();
-	}
-
 	public function equals(Type $type): bool
 	{
 		return $type instanceof self;
-	}
-
-	public function isSmallerThan(Type $otherType): TrinaryLogic
-	{
-		if ($otherType instanceof ConstantScalarType) {
-			return TrinaryLogic::createFromBoolean(null < $otherType->getValue());
-		}
-
-		if ($otherType instanceof CompoundType) {
-			return $otherType->isGreaterThan($this);
-		}
-
-		return TrinaryLogic::createMaybe();
-	}
-
-	public function isSmallerThanOrEqual(Type $otherType): TrinaryLogic
-	{
-		if ($otherType instanceof ConstantScalarType) {
-			return TrinaryLogic::createFromBoolean(null <= $otherType->getValue());
-		}
-
-		if ($otherType instanceof CompoundType) {
-			return $otherType->isGreaterThanOrEqual($this);
-		}
-
-		return TrinaryLogic::createMaybe();
 	}
 
 	public function describe(VerbosityLevel $level): string
@@ -228,26 +168,6 @@ class NullType implements ConstantScalarType
 	public function isNull(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
-	}
-
-	public function isConstantValue(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isConstantScalarValue(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function getConstantScalarTypes(): array
-	{
-		return [$this];
-	}
-
-	public function getConstantScalarValues(): array
-	{
-		return [$this->getValue()];
 	}
 
 	public function isTrue(): TrinaryLogic

--- a/src/Type/Traits/ConstantScalarTypeTrait.php
+++ b/src/Type/Traits/ConstantScalarTypeTrait.php
@@ -13,6 +13,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\LooseComparisonHelper;
 use PHPStan\Type\Type;
+use function get_parent_class;
 
 trait ConstantScalarTypeTrait
 {
@@ -32,7 +33,11 @@ trait ConstantScalarTypeTrait
 			return $type->isAcceptedWithReasonBy($this, $strictTypes);
 		}
 
-		return parent::acceptsWithReason($type, $strictTypes)->and(AcceptsResult::createMaybe());
+		if (get_parent_class($this) !== false) {
+			return parent::acceptsWithReason($type, $strictTypes)->and(AcceptsResult::createMaybe());
+		}
+
+		return AcceptsResult::createNo();
 	}
 
 	public function isSuperTypeOf(Type $type): TrinaryLogic
@@ -46,7 +51,7 @@ trait ConstantScalarTypeTrait
 			return IsSuperTypeOfResult::createFromBoolean($this->equals($type));
 		}
 
-		if ($type instanceof parent) {
+		if (get_parent_class($this) !== false && $type instanceof parent) {
 			return IsSuperTypeOfResult::createMaybe();
 		}
 
@@ -76,18 +81,22 @@ trait ConstantScalarTypeTrait
 			return $type->looseCompare($this, $phpVersion);
 		}
 
-		return parent::looseCompare($type, $phpVersion);
+		if (get_parent_class($this) !== false) {
+			return parent::looseCompare($type, $phpVersion);
+		}
+
+		return new BooleanType();
 	}
 
 	public function equals(Type $type): bool
 	{
-		return $type instanceof self && $this->value === $type->value;
+		return $type instanceof self && $this->getValue() === $type->getValue();
 	}
 
 	public function isSmallerThan(Type $otherType): TrinaryLogic
 	{
 		if ($otherType instanceof ConstantScalarType) {
-			return TrinaryLogic::createFromBoolean($this->value < $otherType->getValue());
+			return TrinaryLogic::createFromBoolean($this->getValue() < $otherType->getValue());
 		}
 
 		if ($otherType instanceof CompoundType) {
@@ -100,7 +109,7 @@ trait ConstantScalarTypeTrait
 	public function isSmallerThanOrEqual(Type $otherType): TrinaryLogic
 	{
 		if ($otherType instanceof ConstantScalarType) {
-			return TrinaryLogic::createFromBoolean($this->value <= $otherType->getValue());
+			return TrinaryLogic::createFromBoolean($this->getValue() <= $otherType->getValue());
 		}
 
 		if ($otherType instanceof CompoundType) {

--- a/src/Type/Traits/ConstantScalarTypeTrait.php
+++ b/src/Type/Traits/ConstantScalarTypeTrait.php
@@ -34,6 +34,7 @@ trait ConstantScalarTypeTrait
 		}
 
 		if (get_parent_class($this) !== false) {
+			// @phpstan-ignore class.noParent
 			return parent::acceptsWithReason($type, $strictTypes)->and(AcceptsResult::createMaybe());
 		}
 


### PR DESCRIPTION
Hi, I wanted to finish (https://github.com/phpstan/phpstan-src/pull/3484) and therefor following your advice on https://github.com/phpstan/phpstan-src/pull/3485#issuecomment-2376086557.

The best option I see would be to introduce
```
public function compareToScalar(
    ConstantScalarType,
    Phpversion,
    callable
)
```
in the ConstantScalarTypeTrait ; but the NullType would require the exact same logic.

So it would be helpful to use the ConstantScalarTypeTrait in the NullType.
Also, there is multiple method duplicated between both trait/class.

The only issue I found is that ConstantScalarTypeTrait sometimes rely on parent method. This can be avoided with
```
get_parent_class($this) !== false
```
checks ; but PHPStan doesn't understand such things.

Should I just ignore the static analysis error or you don't want such PR ?
Also, I didn't know if I should have targeted the 2.0.x branch for such refacto to avoid conflict on merge ; or if it's ok on 1.12.x.