### PR TITLE
Fix `iterator_to_array` return type with generators

### DIFF
--- a/src/Type/Php/IteratorToArrayFunctionReturnTypeExtension.php
+++ b/src/Type/Php/IteratorToArrayFunctionReturnTypeExtension.php
@@ -8,7 +8,9 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use function strtolower;
 
@@ -29,7 +31,12 @@ final class IteratorToArrayFunctionReturnTypeExtension implements DynamicFunctio
 		}
 
 		$traversableType = $scope->getType($arguments[0]->value);
-		$arrayKeyType = $traversableType->getIterableKeyType();
+		$arrayKeyType = $traversableType->getIterableKeyType()->toArrayKey();
+
+		if ($arrayKeyType instanceof ErrorType) {
+			return new NeverType(true);
+		}
+
 		$isList = false;
 
 		if (isset($arguments[1])) {

--- a/tests/PHPStan/Analyser/nsrt/iterator_to_array.php
+++ b/tests/PHPStan/Analyser/nsrt/iterator_to_array.php
@@ -2,6 +2,7 @@
 
 namespace IteratorToArray;
 
+use stdClass;
 use Traversable;
 use function iterator_to_array;
 use function PHPStan\Testing\assertType;
@@ -30,5 +31,34 @@ class Foo
 	public function testNotPreservingKeys(Traversable $foo)
 	{
 		assertType('list<string>', iterator_to_array($foo, false));
+	}
+
+	public function testBehaviorOnGenerators(): void
+	{
+		$generator1 = static function (): iterable {
+			yield 0 => 1;
+			yield true => 2;
+			yield 2 => 3;
+			yield null => 4;
+		};
+		$generator2 = static function (): iterable {
+			yield 0 => 1;
+			yield 'a' => 2;
+			yield null => 3;
+			yield true => 4;
+		};
+
+		assertType('array<0|1|2|\'\', 1|2|3|4>', iterator_to_array($generator1()));
+		assertType('array<0|1|\'\'|\'a\', 1|2|3|4>', iterator_to_array($generator2()));
+	}
+
+	public function testOnGeneratorsWithIllegalKeysForArray(): void
+	{
+		$illegalGenerator = static function (): iterable {
+			yield 'a' => 'b';
+			yield new stdClass => 'c';
+		};
+
+		assertType('*NEVER*', iterator_to_array($illegalGenerator()));
 	}
 }


### PR DESCRIPTION
Generators allow any type for its keys. When passed to `iterator_to_array()`, the keys are coerced to string or int where possible. For non-scalar keys, the function throws.

Current PHPStan behaviour: https://phpstan.org/r/2489fc17-69f8-4e75-894a-48e9cb1b211f
Expected behaviours:
  - https://3v4l.org/TodlT
  - https://3v4l.org/QgQWa
  - https://3v4l.org/g2hKC