### PR TITLE
TooWidePropertyTypeRule: dont skip always-read properties

### DIFF
--- a/src/Rules/TooWideTypehints/TooWidePropertyTypeRule.php
+++ b/src/Rules/TooWideTypehints/TooWidePropertyTypeRule.php
@@ -61,9 +61,6 @@ final class TooWidePropertyTypeRule implements Rule
 				continue;
 			}
 			foreach ($this->extensionProvider->getExtensions() as $extension) {
-				if ($extension->isAlwaysRead($propertyReflection, $propertyName)) {
-					continue 2;
-				}
 				if ($extension->isAlwaysWritten($propertyReflection, $propertyName)) {
 					continue 2;
 				}


### PR DESCRIPTION
- Since this rule reports assignment issues, it is irrelevant if it is always read or not
- Found this by dropping [similar rule](https://github.com/shipmonk-rnd/phpstan-rules/pull/283) of our own and Doctrine entities are no longer reported:

```php
#[Entity]
class FooEntity 
{

    /**
     * @var array<string>|null
     */
    #[Column(type: Types::SIMPLE_ARRAY, nullable: true)]
    private ?array $zones; // null never assigned

    /**
     * @param list<string> $zones
     */
    public function __construct(
        array $zones,
    )
    {
        $this->zones = $zones;
    }

}
```