### PR TITLE
Prevent reporting `property.inInterface` error when PHP version is `8.4` or later

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,7 +116,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.3"
+          php-version: "8.4"
 
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php \
 		--exclude tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php \
 		--exclude tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php \
+		--exclude tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php \
+		--exclude tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-with-bodies.php \
+		--exclude tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php \
+		--exclude tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php \
+		--exclude tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php \
 		src tests
 
 cs:

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ lint:
 		--exclude tests/PHPStan/Rules/Classes/data/extends-readonly-class.php \
 		--exclude tests/PHPStan/Rules/Classes/data/instantiation-promoted-properties.php \
 		--exclude tests/PHPStan/Rules/Classes/data/bug-11592.php \
+		--exclude tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php \
+		--exclude tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php \
+		--exclude tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php \
 		src tests
 
 cs:

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php \
+		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php \
+		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php \
 		src tests
 
 cs:

--- a/build/collision-detector.json
+++ b/build/collision-detector.json
@@ -11,17 +11,6 @@
 		"../tests/PHPStan/Rules/Names/data/no-namespace.php",
 		"../tests/notAutoloaded",
 		"../tests/PHPStan/Rules/Functions/data/define-bug-3349.php",
-		"../tests/PHPStan/Levels/data/stubs/function.php",
-		"../tests/PHPStan/Rules/Properties/data/properties-in-interface.php",
-		"../tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php",
-		"../tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php",
-		"../tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php",
-		"../tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php",
-		"../tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-with-bodies.php",
-		"../tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php",
-		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php",
-		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php",
-		"../tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php",
-		"../tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php"
+		"../tests/PHPStan/Levels/data/stubs/function.php"
     ]
 }

--- a/build/collision-detector.json
+++ b/build/collision-detector.json
@@ -14,6 +14,11 @@
 		"../tests/PHPStan/Levels/data/stubs/function.php",
 		"../tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php",
 		"../tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php",
-		"../tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php"
-	]
+		"../tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php",
+		"../tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php",
+		"../tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-with-bodies.php",
+		"../tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php",
+		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php",
+		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php"
+    ]
 }

--- a/build/collision-detector.json
+++ b/build/collision-detector.json
@@ -12,6 +12,7 @@
 		"../tests/notAutoloaded",
 		"../tests/PHPStan/Rules/Functions/data/define-bug-3349.php",
 		"../tests/PHPStan/Levels/data/stubs/function.php",
+		"../tests/PHPStan/Rules/Properties/data/properties-in-interface.php",
 		"../tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php",
 		"../tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php",
 		"../tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php",
@@ -19,6 +20,8 @@
 		"../tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-with-bodies.php",
 		"../tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php",
 		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php",
-		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php"
+		"../tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php",
+		"../tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php",
+		"../tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php"
     ]
 }

--- a/build/collision-detector.json
+++ b/build/collision-detector.json
@@ -11,6 +11,9 @@
 		"../tests/PHPStan/Rules/Names/data/no-namespace.php",
 		"../tests/notAutoloaded",
 		"../tests/PHPStan/Rules/Functions/data/define-bug-3349.php",
-		"../tests/PHPStan/Levels/data/stubs/function.php"
+		"../tests/PHPStan/Levels/data/stubs/function.php",
+		"../tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php",
+		"../tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php",
+		"../tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php"
 	]
 }

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -96,6 +96,7 @@ rules:
 	- PHPStan\Rules\Properties\MissingReadOnlyByPhpDocPropertyAssignRule
 	- PHPStan\Rules\Properties\PropertiesInInterfaceRule
 	- PHPStan\Rules\Properties\PropertyAttributesRule
+	- PHPStan\Rules\Properties\PropertyInClassRule
 	- PHPStan\Rules\Properties\ReadOnlyPropertyRule
 	- PHPStan\Rules\Properties\ReadOnlyByPhpDocPropertyRule
 	- PHPStan\Rules\Regexp\RegularExpressionPatternRule

--- a/src/Node/ClassPropertyNode.php
+++ b/src/Node/ClassPropertyNode.php
@@ -111,6 +111,11 @@ final class ClassPropertyNode extends NodeAbstract implements VirtualNode
 		return $this->isAllowedPrivateMutation;
 	}
 
+	public function isAbstract(): bool
+	{
+		return (bool) ($this->flags & Modifiers::ABSTRACT);
+	}
+
 	public function getNativeType(): ?Type
 	{
 		return $this->type;

--- a/src/Node/ClassPropertyNode.php
+++ b/src/Node/ClassPropertyNode.php
@@ -142,4 +142,17 @@ final class ClassPropertyNode extends NodeAbstract implements VirtualNode
 		return [];
 	}
 
+	public function hasHooks(): bool
+	{
+		return $this->getHooks() !== [];
+	}
+
+	/**
+	 * @return Node\PropertyHook[]
+	 */
+	public function getHooks(): array
+	{
+		return $this->originalNode->hooks;
+	}
+
 }

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -347,6 +347,11 @@ final class PhpVersion
 		return $this->versionId >= 80200;
 	}
 
+	public function supportsPropertyHooks(): bool
+	{
+		return $this->versionId >= 80400;
+	}
+
 	public function hasDateTimeExceptions(): bool
 	{
 		return $this->versionId >= 80300;

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -32,7 +32,7 @@ final class PropertiesInInterfaceRule implements Rule
 
 		if (!$this->phpVersion->supportsPropertyHooks()) {
 			return [
-				RuleErrorBuilder::message('Interfaces may not include properties.')
+				RuleErrorBuilder::message('Interfaces cannot include properties.')
 					->nonIgnorable()
 					->identifier('property.inInterface')
 					->build(),
@@ -41,7 +41,7 @@ final class PropertiesInInterfaceRule implements Rule
 
 		if (!$node->hasHooks()) {
 			return [
-				RuleErrorBuilder::message('Interfaces may only include hooked properties.')
+				RuleErrorBuilder::message('Interfaces can only include hooked properties.')
 					->nonIgnorable()
 					->identifier('property.nonHookedInInterface')
 					->build(),
@@ -50,7 +50,7 @@ final class PropertiesInInterfaceRule implements Rule
 
 		if (!$node->isPublic()) {
 			return [
-				RuleErrorBuilder::message('Interfaces may not include non-public properties.')
+				RuleErrorBuilder::message('Interfaces cannot include non-public properties.')
 					->nonIgnorable()
 					->identifier('property.nonPublicInInterface')
 					->build(),
@@ -59,7 +59,7 @@ final class PropertiesInInterfaceRule implements Rule
 
 		if ($this->hasAnyHookBody($node)) {
 			return [
-				RuleErrorBuilder::message('Interfaces may not include property hooks with bodies.')
+				RuleErrorBuilder::message('Interfaces cannot include property hooks with bodies.')
 					->nonIgnorable()
 					->identifier('property.hookBodyInInterface')
 					->build(),

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -30,15 +30,6 @@ final class PropertiesInInterfaceRule implements Rule
 			return [];
 		}
 
-		if (!$this->phpVersion->supportsPropertyHooks() && $node->hasHooks()) {
-			return [
-				RuleErrorBuilder::message('Property hooks in interfaces are supported only on PHP 8.4 and later.')
-					->nonIgnorable()
-					->identifier('property.unsupportedHooksInInterface')
-					->build(),
-			];
-		}
-
 		if (!$this->phpVersion->supportsPropertyHooks()) {
 			return [
 				RuleErrorBuilder::message('Interfaces may not include properties.')

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -30,6 +30,15 @@ final class PropertiesInInterfaceRule implements Rule
 			return [];
 		}
 
+		if (!$this->phpVersion->supportsPropertyHooks() && $node->hasHooks()) {
+			return [
+				RuleErrorBuilder::message('Property hooks in interfaces are supported only on PHP 8.4 and later.')
+					->nonIgnorable()
+					->identifier('property.unsupportedHooksInInterface')
+					->build(),
+			];
+		}
+
 		if (!$this->phpVersion->supportsPropertyHooks()) {
 			return [
 				RuleErrorBuilder::message('Interfaces may not include properties.')

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Properties;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -13,6 +14,10 @@ use PHPStan\Rules\RuleErrorBuilder;
  */
 final class PropertiesInInterfaceRule implements Rule
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function getNodeType(): string
 	{
@@ -25,12 +30,54 @@ final class PropertiesInInterfaceRule implements Rule
 			return [];
 		}
 
-		return [
-			RuleErrorBuilder::message('Interfaces may not include properties.')
-				->nonIgnorable()
-				->identifier('property.inInterface')
-				->build(),
-		];
+		if (!$this->phpVersion->supportsPropertyHooks()) {
+			return [
+				RuleErrorBuilder::message('Interfaces may not include properties.')
+					->nonIgnorable()
+					->identifier('property.inInterface')
+					->build(),
+			];
+		}
+
+		if (!$node->hasHooks()) {
+			return [
+				RuleErrorBuilder::message('Interfaces may only include hooked properties.')
+					->nonIgnorable()
+					->identifier('property.nonHookedInInterface')
+					->build(),
+			];
+		}
+
+		if (!$node->isPublic()) {
+			return [
+				RuleErrorBuilder::message('Interfaces may not include non-public properties.')
+					->nonIgnorable()
+					->identifier('property.nonPublicInInterface')
+					->build(),
+			];
+		}
+
+		if ($this->hasAnyHookBody($node)) {
+			return [
+				RuleErrorBuilder::message('Interfaces may not include property hooks with bodies.')
+					->nonIgnorable()
+					->identifier('property.hookBodyInInterface')
+					->build(),
+			];
+		}
+
+		return [];
+	}
+
+	private function hasAnyHookBody(ClassPropertyNode $node): bool
+	{
+		foreach ($node->getHooks() as $hook) {
+			if ($hook->body !== null) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -64,17 +64,17 @@ final class PropertyInClassRule implements Rule
 							->build(),
 					];
 				}
+
+				return [];
 			}
 
-			if (!$node->isAbstract()) {
-				if ($node->hasHooks()) {
-					return [
-						RuleErrorBuilder::message('Abstract classes cannot include non-abstract hooked properties without bodies.')
-							->nonIgnorable()
-							->identifier('property.nonAbstractWithAbstractHook')
-							->build(),
-					];
-				}
+			if (!$this->doAllHooksHaveBody($node)) {
+				return [
+					RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
+						->nonIgnorable()
+						->identifier('property.hookWithoutBody')
+						->build(),
+				];
 			}
 
 			return [];

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -45,43 +45,26 @@ final class PropertyInClassRule implements Rule
 			return [];
 		}
 
-		if ($classReflection->isAbstract()) {
-			if ($node->isAbstract()) {
-				if (!$node->hasHooks()) {
-					return [
-						RuleErrorBuilder::message('Only hooked properties can be declared abstract.')
-							->nonIgnorable()
-							->identifier('property.abstractNonHooked')
-							->build(),
-					];
-				}
-
-				if (!$this->isAtLeastOneHookBodyEmpty($node)) {
-					return [
-						RuleErrorBuilder::message('Abstract properties must specify at least one abstract hook.')
-							->nonIgnorable()
-							->identifier('property.abstractWithoutAbstractHook')
-							->build(),
-					];
-				}
-
-				return [];
-			}
-
-			if (!$this->doAllHooksHaveBody($node)) {
+		if ($node->isAbstract()) {
+			if (!$node->hasHooks()) {
 				return [
-					RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
+					RuleErrorBuilder::message('Only hooked properties can be declared abstract.')
 						->nonIgnorable()
-						->identifier('property.hookWithoutBody')
+						->identifier('property.abstractNonHooked')
 						->build(),
 				];
 			}
 
-			return [];
-		}
+			if (!$this->isAtLeastOneHookBodyEmpty($node)) {
+				return [
+					RuleErrorBuilder::message('Abstract properties must specify at least one abstract hook.')
+						->nonIgnorable()
+						->identifier('property.abstractWithoutAbstractHook')
+						->build(),
+				];
+			}
 
-		if ($node->hasHooks()) {
-			if ($node->isAbstract()) {
+			if (!$classReflection->isAbstract()) {
 				return [
 					RuleErrorBuilder::message('Non-abstract classes cannot include abstract properties.')
 						->nonIgnorable()
@@ -90,14 +73,16 @@ final class PropertyInClassRule implements Rule
 				];
 			}
 
-			if (!$this->doAllHooksHaveBody($node)) {
-				return [
-					RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
-						->nonIgnorable()
-						->identifier('property.hookWithoutBody')
-						->build(),
-				];
-			}
+			return [];
+		}
+
+		if (!$this->doAllHooksHaveBody($node)) {
+			return [
+				RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
+					->nonIgnorable()
+					->identifier('property.hookWithoutBody')
+					->build(),
+			];
 		}
 
 		return [];

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -28,57 +28,76 @@ final class PropertyInClassRule implements Rule
 	{
 		$classReflection = $node->getClassReflection();
 
-		if (!$classReflection->isClass() || !$this->phpVersion->supportsPropertyHooks()) {
+		if (!$classReflection->isClass()) {
 			return [];
 		}
 
-		if (!$classReflection->isAbstract() && $node->hasHooks() && $node->isAbstract()) {
+		if (!$this->phpVersion->supportsPropertyHooks() && $node->hasHooks()) {
 			return [
-				RuleErrorBuilder::message('Classes may not include abstract hooked properties.')
+				RuleErrorBuilder::message('Property hooks in classes are supported only on PHP 8.4 and later.')
 					->nonIgnorable()
-					->identifier('property.abstractHookedInClass')
+					->identifier('property.unsupportedHooksInClass')
 					->build(),
 			];
 		}
 
-		if (!$classReflection->isAbstract() && $node->hasHooks() && !$this->doAllHooksHaveBody($node)) {
-			return [
-				RuleErrorBuilder::message('Classes may not include hooked properties without bodies.')
-					->nonIgnorable()
-					->identifier('property.hookedWithoutBodyInClass')
-					->build(),
-			];
-		}
-
-		if (!$classReflection->isAbstract()) {
+		if (!$this->phpVersion->supportsPropertyHooks()) {
 			return [];
 		}
 
-		if ($node->hasHooks() && !$node->isAbstract()) {
-			return [
-				RuleErrorBuilder::message('Abstract classes may not include non-abstract hooked properties without bodies.')
-					->nonIgnorable()
-					->identifier('property.nonAbstractHookedWithoutBodyInAbstractClass')
-					->build(),
-			];
+		if ($classReflection->isAbstract()) {
+			if ($node->isAbstract()) {
+				if (!$node->hasHooks()) {
+					return [
+						RuleErrorBuilder::message('Only hooked properties may be declared abstract.')
+							->nonIgnorable()
+							->identifier('property.nonHookedAbstractInClass')
+							->build(),
+					];
+				}
+
+				if (!$this->isAtLeastOneHookBodyEmpty($node)) {
+					return [
+						RuleErrorBuilder::message('Abstract properties must specify at least one abstract hook.')
+							->nonIgnorable()
+							->identifier('property.hookedAbstractWithBodies')
+							->build(),
+					];
+				}
+			}
+
+			if (!$node->isAbstract()) {
+				if ($node->hasHooks()) {
+					return [
+						RuleErrorBuilder::message('Abstract classes may not include non-abstract hooked properties without bodies.')
+							->nonIgnorable()
+							->identifier('property.nonAbstractHookedWithoutBodyInAbstractClass')
+							->build(),
+					];
+				}
+			}
+
+			return [];
 		}
 
-		if ($node->isAbstract() && !$node->hasHooks()) {
-			return [
-				RuleErrorBuilder::message('Only hooked properties may be declared abstract.')
-					->nonIgnorable()
-					->identifier('property.nonHookedAbstractInClass')
-					->build(),
-			];
-		}
+		if ($node->hasHooks()) {
+			if ($node->isAbstract()) {
+				return [
+					RuleErrorBuilder::message('Classes may not include abstract hooked properties.')
+						->nonIgnorable()
+						->identifier('property.abstractHookedInClass')
+						->build(),
+				];
+			}
 
-		if ($node->isAbstract() && !$this->isAtLeastOneHookBodyEmpty($node)) {
-			return [
-				RuleErrorBuilder::message('Abstract properties must specify at least one abstract hook.')
-					->nonIgnorable()
-					->identifier('property.hookedAbstractWithBodies')
-					->build(),
-			];
+			if (!$this->doAllHooksHaveBody($node)) {
+				return [
+					RuleErrorBuilder::message('Non-abstract classes may not include hooked properties without bodies.')
+						->nonIgnorable()
+						->identifier('property.hookedWithoutBodyInClass')
+						->build(),
+				];
+			}
 		}
 
 		return [];

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<ClassPropertyNode>
+ */
+final class PropertyInClassRule implements Rule
+{
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return ClassPropertyNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$classReflection = $node->getClassReflection();
+
+		if (!$classReflection->isClass() || !$this->phpVersion->supportsPropertyHooks()) {
+			return [];
+		}
+
+		if (!$classReflection->isAbstract() && $node->hasHooks() && $node->isAbstract()) {
+			return [
+				RuleErrorBuilder::message('Classes may not include abstract hooked properties.')
+					->nonIgnorable()
+					->identifier('property.abstractHookedInClass')
+					->build(),
+			];
+		}
+
+		if (!$classReflection->isAbstract() && $node->hasHooks() && !$this->doAllHooksHaveBody($node)) {
+			return [
+				RuleErrorBuilder::message('Classes may not include hooked properties without bodies.')
+					->nonIgnorable()
+					->identifier('property.hookedWithoutBodyInClass')
+					->build(),
+			];
+		}
+
+		if (!$classReflection->isAbstract()) {
+			return [];
+		}
+
+		if ($node->hasHooks() && !$node->isAbstract()) {
+			return [
+				RuleErrorBuilder::message('Abstract classes may not include non-abstract hooked properties without bodies.')
+					->nonIgnorable()
+					->identifier('property.nonAbstractHookedWithoutBodyInAbstractClass')
+					->build(),
+			];
+		}
+
+		if ($node->isAbstract() && !$node->hasHooks()) {
+			return [
+				RuleErrorBuilder::message('Only hooked properties may be declared abstract.')
+					->nonIgnorable()
+					->identifier('property.nonHookedAbstractInClass')
+					->build(),
+			];
+		}
+
+		if ($node->isAbstract() && !$this->isAtLeastOneHookBodyEmpty($node)) {
+			return [
+				RuleErrorBuilder::message('Abstract properties must specify at least one abstract hook.')
+					->nonIgnorable()
+					->identifier('property.hookedAbstractWithBodies')
+					->build(),
+			];
+		}
+
+		return [];
+	}
+
+	private function doAllHooksHaveBody(ClassPropertyNode $node): bool
+	{
+		foreach ($node->getHooks() as $hook) {
+			if ($hook->body === null) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private function isAtLeastOneHookBodyEmpty(ClassPropertyNode $node): bool
+	{
+		foreach ($node->getHooks() as $hook) {
+			if ($hook->body === null) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -32,16 +32,16 @@ final class PropertyInClassRule implements Rule
 			return [];
 		}
 
-		if (!$this->phpVersion->supportsPropertyHooks() && $node->hasHooks()) {
-			return [
-				RuleErrorBuilder::message('Property hooks in classes are supported only on PHP 8.4 and later.')
-					->nonIgnorable()
-					->identifier('property.unsupportedHooksInClass')
-					->build(),
-			];
-		}
-
 		if (!$this->phpVersion->supportsPropertyHooks()) {
+			if ($node->hasHooks()) {
+				return [
+					RuleErrorBuilder::message('Property hooks are supported only on PHP 8.4 and later.')
+						->nonIgnorable()
+						->identifier('property.hooksNotSupported')
+						->build(),
+				];
+			}
+
 			return [];
 		}
 
@@ -49,9 +49,9 @@ final class PropertyInClassRule implements Rule
 			if ($node->isAbstract()) {
 				if (!$node->hasHooks()) {
 					return [
-						RuleErrorBuilder::message('Only hooked properties may be declared abstract.')
+						RuleErrorBuilder::message('Only hooked properties can be declared abstract.')
 							->nonIgnorable()
-							->identifier('property.nonHookedAbstractInClass')
+							->identifier('property.abstractNonHooked')
 							->build(),
 					];
 				}
@@ -60,7 +60,7 @@ final class PropertyInClassRule implements Rule
 					return [
 						RuleErrorBuilder::message('Abstract properties must specify at least one abstract hook.')
 							->nonIgnorable()
-							->identifier('property.hookedAbstractWithBodies')
+							->identifier('property.abstractWithoutAbstractHook')
 							->build(),
 					];
 				}
@@ -69,9 +69,9 @@ final class PropertyInClassRule implements Rule
 			if (!$node->isAbstract()) {
 				if ($node->hasHooks()) {
 					return [
-						RuleErrorBuilder::message('Abstract classes may not include non-abstract hooked properties without bodies.')
+						RuleErrorBuilder::message('Abstract classes cannot include non-abstract hooked properties without bodies.')
 							->nonIgnorable()
-							->identifier('property.nonAbstractHookedWithoutBodyInAbstractClass')
+							->identifier('property.nonAbstractWithAbstractHook')
 							->build(),
 					];
 				}
@@ -83,18 +83,18 @@ final class PropertyInClassRule implements Rule
 		if ($node->hasHooks()) {
 			if ($node->isAbstract()) {
 				return [
-					RuleErrorBuilder::message('Classes may not include abstract hooked properties.')
+					RuleErrorBuilder::message('Non-abstract classes cannot include abstract properties.')
 						->nonIgnorable()
-						->identifier('property.abstractHookedInClass')
+						->identifier('property.abstract')
 						->build(),
 				];
 			}
 
 			if (!$this->doAllHooksHaveBody($node)) {
 				return [
-					RuleErrorBuilder::message('Non-abstract classes may not include hooked properties without bodies.')
+					RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
 						->nonIgnorable()
-						->identifier('property.hookedWithoutBodyInClass')
+						->identifier('property.hookWithoutBody')
 						->build(),
 				];
 			}

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -23,6 +23,9 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 		if (PHP_VERSION_ID >= 80400) {
 			$this->markTestSkipped('Test requires PHP 8.3 or earlier.');
 		}
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Property hooks cause syntax error on PHP 7.4');
+		}
 
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
@@ -44,6 +47,9 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 	{
 		if (PHP_VERSION_ID >= 80400) {
 			$this->markTestSkipped('Test requires PHP 8.3 or earlier.');
+		}
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Property hooks cause syntax error on PHP 7.4');
 		}
 
 		$this->analyse([__DIR__ . '/data/property-hooks-in-interface.php'], [

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -2,8 +2,10 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<PropertiesInInterfaceRule>
@@ -11,13 +13,17 @@ use PHPStan\Testing\RuleTestCase;
 class PropertiesInInterfaceRuleTest extends RuleTestCase
 {
 
+	private int $phpVersion = PHP_VERSION_ID;
+
 	protected function getRule(): Rule
 	{
-		return new PropertiesInInterfaceRule();
+		return new PropertiesInInterfaceRule(new PhpVersion($this->phpVersion));
 	}
 
-	public function testRule(): void
+	public function testPhp83AndPropertiesInInterface(): void
 	{
+		$this->phpVersion = 80300;
+
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
 				'Interfaces may not include properties.',
@@ -26,6 +32,70 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 			[
 				'Interfaces may not include properties.',
 				9,
+			],
+		]);
+	}
+
+	public function testPhp83AndPropertyHooksInInterface(): void
+	{
+		$this->phpVersion = 80300;
+
+		$this->analyse([__DIR__ . '/data/property-hooks-in-interface.php'], [
+			[
+				'Interfaces may not include properties.',
+				7,
+			],
+			[
+				'Interfaces may not include properties.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndPropertiesInInterface(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
+			[
+				'Interfaces may only include hooked properties.',
+				7,
+			],
+			[
+				'Interfaces may only include hooked properties.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndNonPublicPropertyHooksInInterface(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/property-hooks-visibility-in-interface.php'], [
+			[
+				'Interfaces may not include non-public properties.',
+				7,
+			],
+			[
+				'Interfaces may not include non-public properties.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndPropertyHooksWithBodiesInInterface(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/property-hooks-bodies-in-interface.php'], [
+			[
+				'Interfaces may not include property hooks with bodies.',
+				7,
+			],
+			[
+				'Interfaces may not include property hooks with bodies.',
+				13,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -13,32 +13,38 @@ use const PHP_VERSION_ID;
 class PropertiesInInterfaceRuleTest extends RuleTestCase
 {
 
-	private int $phpVersion = PHP_VERSION_ID;
-
 	protected function getRule(): Rule
 	{
-		return new PropertiesInInterfaceRule(new PhpVersion($this->phpVersion));
+		return new PropertiesInInterfaceRule(new PhpVersion(PHP_VERSION_ID));
 	}
 
 	public function testPhp83AndPropertiesInInterface(): void
 	{
-		$this->phpVersion = 80300;
+		if (PHP_VERSION_ID >= 80400) {
+			$this->markTestSkipped('Test requires PHP 8.3 or earlier.');
+		}
 
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
-				'Interfaces may not include properties.',
+				'Property hooks in interfaces are supported only on PHP 8.4 and later.',
 				7,
 			],
 			[
 				'Interfaces may not include properties.',
 				9,
 			],
+			[
+				'Interfaces may not include properties.',
+				11,
+			],
 		]);
 	}
 
 	public function testPhp83AndPropertyHooksInInterface(): void
 	{
-		$this->phpVersion = 80300;
+		if (PHP_VERSION_ID >= 80400) {
+			$this->markTestSkipped('Test requires PHP 8.3 or earlier.');
+		}
 
 		$this->analyse([__DIR__ . '/data/property-hooks-in-interface.php'], [
 			[
@@ -54,23 +60,27 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 	public function testPhp84AndPropertiesInInterface(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
 				'Interfaces may only include hooked properties.',
-				7,
+				9,
 			],
 			[
 				'Interfaces may only include hooked properties.',
-				9,
+				11,
 			],
 		]);
 	}
 
 	public function testPhp84AndNonPublicPropertyHooksInInterface(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/property-hooks-visibility-in-interface.php'], [
 			[
@@ -86,7 +96,9 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 	public function testPhp84AndPropertyHooksWithBodiesInInterface(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/property-hooks-bodies-in-interface.php'], [
 			[

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -29,7 +29,7 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
-				'Property hooks in interfaces are supported only on PHP 8.4 and later.',
+				'Interfaces may not include properties.',
 				7,
 			],
 			[

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -29,15 +29,15 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
-				'Interfaces may not include properties.',
+				'Interfaces cannot include properties.',
 				7,
 			],
 			[
-				'Interfaces may not include properties.',
+				'Interfaces cannot include properties.',
 				9,
 			],
 			[
-				'Interfaces may not include properties.',
+				'Interfaces cannot include properties.',
 				11,
 			],
 		]);
@@ -54,11 +54,11 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/property-hooks-in-interface.php'], [
 			[
-				'Interfaces may not include properties.',
+				'Interfaces cannot include properties.',
 				7,
 			],
 			[
-				'Interfaces may not include properties.',
+				'Interfaces cannot include properties.',
 				9,
 			],
 		]);
@@ -72,11 +72,11 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/properties-in-interface.php'], [
 			[
-				'Interfaces may only include hooked properties.',
+				'Interfaces can only include hooked properties.',
 				9,
 			],
 			[
-				'Interfaces may only include hooked properties.',
+				'Interfaces can only include hooked properties.',
 				11,
 			],
 		]);
@@ -90,11 +90,11 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/property-hooks-visibility-in-interface.php'], [
 			[
-				'Interfaces may not include non-public properties.',
+				'Interfaces cannot include non-public properties.',
 				7,
 			],
 			[
-				'Interfaces may not include non-public properties.',
+				'Interfaces cannot include non-public properties.',
 				9,
 			],
 		]);
@@ -108,11 +108,11 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/property-hooks-bodies-in-interface.php'], [
 			[
-				'Interfaces may not include property hooks with bodies.',
+				'Interfaces cannot include property hooks with bodies.',
 				7,
 			],
 			[
-				'Interfaces may not include property hooks with bodies.',
+				'Interfaces cannot include property hooks with bodies.',
 				13,
 			],
 		]);

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -23,6 +23,9 @@ class PropertyInClassRuleTest extends RuleTestCase
 		if (PHP_VERSION_ID >= 80400) {
 			$this->markTestSkipped('Test requires PHP 8.3 or earlier.');
 		}
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Property hooks cause syntax error on PHP 7.4');
+		}
 
 		$this->analyse([__DIR__ . '/data/hooked-properties-in-class.php'], [
 			[

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -29,7 +29,7 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/hooked-properties-in-class.php'], [
 			[
-				'Property hooks in classes are supported only on PHP 8.4 and later.',
+				'Property hooks are supported only on PHP 8.4 and later.',
 				7,
 			],
 		]);
@@ -43,11 +43,11 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/hooked-properties-without-bodies-in-class.php'], [
 			[
-				'Non-abstract classes may not include hooked properties without bodies.',
+				'Non-abstract properties cannot include hooks without bodies.',
 				7,
 			],
 			[
-				'Non-abstract classes may not include hooked properties without bodies.',
+				'Non-abstract properties cannot include hooks without bodies.',
 				9,
 			],
 		]);
@@ -61,11 +61,11 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-class.php'], [
 			[
-				'Non-abstract classes may not include hooked properties without bodies.',
+				'Non-abstract properties cannot include hooks without bodies.',
 				7,
 			],
 			[
-				'Non-abstract classes may not include hooked properties without bodies.',
+				'Non-abstract properties cannot include hooks without bodies.',
 				9,
 			],
 		]);
@@ -79,11 +79,11 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/abstract-hooked-properties-in-class.php'], [
 			[
-				'Classes may not include abstract hooked properties.',
+				'Non-abstract classes cannot include abstract properties.',
 				7,
 			],
 			[
-				'Classes may not include abstract hooked properties.',
+				'Non-abstract classes cannot include abstract properties.',
 				9,
 			],
 		]);
@@ -97,11 +97,11 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-abstract-class.php'], [
 			[
-				'Abstract classes may not include non-abstract hooked properties without bodies.',
+				'Abstract classes cannot include non-abstract hooked properties without bodies.',
 				7,
 			],
 			[
-				'Abstract classes may not include non-abstract hooked properties without bodies.',
+				'Abstract classes cannot include non-abstract hooked properties without bodies.',
 				9,
 			],
 		]);
@@ -115,11 +115,11 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/abstract-non-hooked-properties-in-abstract-class.php'], [
 			[
-				'Only hooked properties may be declared abstract.',
+				'Only hooked properties can be declared abstract.',
 				7,
 			],
 			[
-				'Only hooked properties may be declared abstract.',
+				'Only hooked properties can be declared abstract.',
 				9,
 			],
 		]);

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -97,12 +97,16 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-abstract-class.php'], [
 			[
-				'Abstract classes cannot include non-abstract hooked properties without bodies.',
+				'Non-abstract properties cannot include hooks without bodies.',
 				7,
 			],
 			[
-				'Abstract classes cannot include non-abstract hooked properties without bodies.',
+				'Non-abstract properties cannot include hooks without bodies.',
 				9,
+			],
+			[
+				'Non-abstract properties cannot include hooks without bodies.',
+				25,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -13,24 +13,56 @@ use const PHP_VERSION_ID;
 class PropertyInClassRuleTest extends RuleTestCase
 {
 
-	private int $phpVersion = PHP_VERSION_ID;
-
 	protected function getRule(): Rule
 	{
-		return new PropertyInClassRule(new PhpVersion($this->phpVersion));
+		return new PropertyInClassRule(new PhpVersion(PHP_VERSION_ID));
+	}
+
+	public function testPhpLessThan84AndHookedPropertiesInClass(): void
+	{
+		if (PHP_VERSION_ID >= 80400) {
+			$this->markTestSkipped('Test requires PHP 8.3 or earlier.');
+		}
+
+		$this->analyse([__DIR__ . '/data/hooked-properties-in-class.php'], [
+			[
+				'Property hooks in classes are supported only on PHP 8.4 and later.',
+				7,
+			],
+		]);
+	}
+
+	public function testPhp84AndHookedPropertiesWithoutBodiesInClass(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
+
+		$this->analyse([__DIR__ . '/data/hooked-properties-without-bodies-in-class.php'], [
+			[
+				'Non-abstract classes may not include hooked properties without bodies.',
+				7,
+			],
+			[
+				'Non-abstract classes may not include hooked properties without bodies.',
+				9,
+			],
+		]);
 	}
 
 	public function testPhp84AndNonAbstractHookedPropertiesInClass(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-class.php'], [
 			[
-				'Classes may not include hooked properties without bodies.',
+				'Non-abstract classes may not include hooked properties without bodies.',
 				7,
 			],
 			[
-				'Classes may not include hooked properties without bodies.',
+				'Non-abstract classes may not include hooked properties without bodies.',
 				9,
 			],
 		]);
@@ -38,7 +70,9 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 	public function testPhp84AndAbstractHookedPropertiesInClass(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/abstract-hooked-properties-in-class.php'], [
 			[
@@ -54,7 +88,9 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 	public function testPhp84AndNonAbstractHookedPropertiesInAbstractClass(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-abstract-class.php'], [
 			[
@@ -70,7 +106,9 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 	public function testPhp84AndAbstractNonHookedPropertiesInAbstractClass(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/abstract-non-hooked-properties-in-abstract-class.php'], [
 			[
@@ -86,7 +124,9 @@ class PropertyInClassRuleTest extends RuleTestCase
 
 	public function testPhp84AndAbstractHookedPropertiesWithBodies(): void
 	{
-		$this->phpVersion = 80400;
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
 
 		$this->analyse([__DIR__ . '/data/abstract-hooked-properties-with-bodies.php'], [
 			[

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Properties;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<PropertyInClassRule>
+ */
+class PropertyInClassRuleTest extends RuleTestCase
+{
+
+	private int $phpVersion = PHP_VERSION_ID;
+
+	protected function getRule(): Rule
+	{
+		return new PropertyInClassRule(new PhpVersion($this->phpVersion));
+	}
+
+	public function testPhp84AndNonAbstractHookedPropertiesInClass(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-class.php'], [
+			[
+				'Classes may not include hooked properties without bodies.',
+				7,
+			],
+			[
+				'Classes may not include hooked properties without bodies.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndAbstractHookedPropertiesInClass(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/abstract-hooked-properties-in-class.php'], [
+			[
+				'Classes may not include abstract hooked properties.',
+				7,
+			],
+			[
+				'Classes may not include abstract hooked properties.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndNonAbstractHookedPropertiesInAbstractClass(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/non-abstract-hooked-properties-in-abstract-class.php'], [
+			[
+				'Abstract classes may not include non-abstract hooked properties without bodies.',
+				7,
+			],
+			[
+				'Abstract classes may not include non-abstract hooked properties without bodies.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndAbstractNonHookedPropertiesInAbstractClass(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/abstract-non-hooked-properties-in-abstract-class.php'], [
+			[
+				'Only hooked properties may be declared abstract.',
+				7,
+			],
+			[
+				'Only hooked properties may be declared abstract.',
+				9,
+			],
+		]);
+	}
+
+	public function testPhp84AndAbstractHookedPropertiesWithBodies(): void
+	{
+		$this->phpVersion = 80400;
+
+		$this->analyse([__DIR__ . '/data/abstract-hooked-properties-with-bodies.php'], [
+			[
+				'Abstract properties must specify at least one abstract hook.',
+				7,
+			],
+			[
+				'Abstract properties must specify at least one abstract hook.',
+				12,
+			],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace NonAbstractHookedPropertiesInAbstractClass;
+namespace AbstractHookedPropertiesInClass;
 
 class AbstractPerson
 {

--- a/tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-in-class.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace NonAbstractHookedPropertiesInAbstractClass;
+
+class AbstractPerson
+{
+	public abstract string $name { get; set; }
+
+	public abstract string $lastName { get; set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-with-bodies.php
+++ b/tests/PHPStan/Rules/Properties/data/abstract-hooked-properties-with-bodies.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace AbstractHookedPropertiesWithBodies;
+
+abstract class AbstractPerson
+{
+	public abstract string $name {
+		get => $this->name;
+		set => $this->name = $value;
+	}
+
+	public abstract string $lastName {
+		get => $this->lastName;
+		set => $this->lastName = $value;
+	}
+
+	public abstract string $middleName {
+		get => $this->name;
+		set;
+	}
+
+	public abstract string $familyName {
+		get;
+		set;
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php
+++ b/tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace NonAbstractHookedPropertiesInAbstractClass;
+
+abstract class AbstractPerson
+{
+	public abstract string $name;
+
+	public abstract string $lastName;
+}

--- a/tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php
+++ b/tests/PHPStan/Rules/Properties/data/abstract-non-hooked-properties-in-abstract-class.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace NonAbstractHookedPropertiesInAbstractClass;
+namespace AbstractNonHookedPropertiesInAbstractClass;
 
 abstract class AbstractPerson
 {

--- a/tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace NonAbstractHookedPropertiesInClass;
+
+class Person
+{
+	public string $name {
+		get => $this->name;
+		set => $this->name = $value;
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace NonAbstractHookedPropertiesInClass;
+namespace HookedPropertiesInClass;
 
 class Person
 {

--- a/tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace HookedPropertiesWithoutBodiesInClass;
+
+class AbstractPerson
+{
+	public string $name { get; set; }
+
+	public string $lastName { get; set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php
+++ b/tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace NonAbstractHookedPropertiesInAbstractClass;
+
+abstract class AbstractPerson
+{
+	public string $name { get; set; }
+
+	public string $lastName { get; set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php
+++ b/tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-abstract-class.php
@@ -8,3 +8,28 @@ abstract class AbstractPerson
 
 	public string $lastName { get; set; }
 }
+
+abstract class Foo
+{
+
+	public string $name {
+		get {
+
+		}
+
+		set {
+
+		}
+	}
+
+	public string $name2 {
+		get;
+
+		set {
+
+		}
+	}
+
+	public string $name3;
+
+}

--- a/tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace NonAbstractHookedPropertiesInClass;
+
+class Person
+{
+	public string $name { get; set; }
+
+	public string $lastName { get; set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/properties-in-interface.php
+++ b/tests/PHPStan/Rules/Properties/data/properties-in-interface.php
@@ -4,6 +4,8 @@ namespace PropertiesInInterface;
 
 interface HelloWorld
 {
+	public string $name { get; }
+
     public \DateTimeInterface $dateTime;
 
     public static \Closure $callable;

--- a/tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php
+++ b/tests/PHPStan/Rules/Properties/data/property-hooks-bodies-in-interface.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooksBodiesInInterface;
+
+interface HelloWorld
+{
+	public string $firstName {
+		get {
+			return 'Foo';
+		}
+	}
+
+	public string $lastName {
+		set {
+			echo 'I will eventually be set to ' . $value;
+		}
+	}
+
+	public string $middleName { get; set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php
+++ b/tests/PHPStan/Rules/Properties/data/property-hooks-in-interface.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooksInInterface;
+
+interface HelloWorld
+{
+	public string $firstName { get; }
+
+	public string $lastName { get; set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php
+++ b/tests/PHPStan/Rules/Properties/data/property-hooks-visibility-in-interface.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace PropertyHooksVisibilityInInterface;
+
+interface HelloWorld
+{
+	private string $firstName { get; }
+
+	protected string $lastName { get; set; }
+
+	public string $fullName { get; set; }
+}


### PR DESCRIPTION
After reading Ondrej's tweet and playing with PHPStan `2.0` on PHP `8.4`, I've found out it reports the `property.inInterface` error and it is non-ignorable. My first thought was to allow ignoring this error, but I've ended up not reporting this issue at all once the PHP version is `8.4` or later. 