### PR TITLE
Scope->getPhpVersion() allows array via phpVersion NEON config

### DIFF
--- a/src/Analyser/DirectInternalScopeFactory.php
+++ b/src/Analyser/DirectInternalScopeFactory.php
@@ -19,6 +19,9 @@ use PHPStan\Rules\Properties\PropertyReflectionFinder;
 final class DirectInternalScopeFactory implements InternalScopeFactory
 {
 
+	/**
+	 * @param int|array{min: int, max: int}|null $configPhpVersion
+	 */
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
@@ -31,6 +34,7 @@ final class DirectInternalScopeFactory implements InternalScopeFactory
 		private NodeScopeResolver $nodeScopeResolver,
 		private RicherScopeGetTypeHelper $richerScopeGetTypeHelper,
 		private PhpVersion $phpVersion,
+		private int|array|null $configPhpVersion,
 		private ConstantResolver $constantResolver,
 	)
 	{
@@ -78,6 +82,7 @@ final class DirectInternalScopeFactory implements InternalScopeFactory
 			$this->constantResolver,
 			$context,
 			$this->phpVersion,
+			$this->configPhpVersion,
 			$declareStrictTypes,
 			$function,
 			$namespace,

--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -67,6 +67,7 @@ final class LazyInternalScopeFactory implements InternalScopeFactory
 			$this->container->getByType(ConstantResolver::class),
 			$context,
 			$this->container->getByType(PhpVersion::class),
+			$this->container->getParameter('phpVersion'),
 			$declareStrictTypes,
 			$function,
 			$namespace,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -144,6 +144,7 @@ use function explode;
 use function get_class;
 use function implode;
 use function in_array;
+use function is_array;
 use function is_bool;
 use function is_numeric;
 use function is_string;
@@ -184,6 +185,7 @@ final class MutatingScope implements Scope
 	private static int $resolveClosureTypeDepth = 0;
 
 	/**
+	 * @param int|array{min: int, max: int}|null $configPhpVersion
 	 * @param array<string, ExpressionTypeHolder> $expressionTypes
 	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
 	 * @param list<string> $inClosureBindScopeClasses
@@ -207,6 +209,7 @@ final class MutatingScope implements Scope
 		private ConstantResolver $constantResolver,
 		private ScopeContext $context,
 		private PhpVersion $phpVersion,
+		private int|array|null $configPhpVersion,
 		private bool $declareStrictTypes = false,
 		private PhpFunctionFromParserNodeReflection|null $function = null,
 		?string $namespace = null,
@@ -5726,6 +5729,9 @@ final class MutatingScope implements Scope
 	{
 		$versionExpr = new ConstFetch(new Name('PHP_VERSION_ID'));
 		if (!$this->hasExpressionType($versionExpr)->yes()) {
+			if (is_array($this->configPhpVersion)) {
+				return new PhpVersions(IntegerRangeType::fromInterval($this->configPhpVersion['min'], $this->configPhpVersion['max']));
+			}
 			return new PhpVersions(new ConstantIntegerType($this->phpVersion->getVersionId()));
 		}
 

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -163,6 +163,7 @@ abstract class PHPStanTestCase extends TestCase
 				$container->getByType(NodeScopeResolver::class),
 				new RicherScopeGetTypeHelper($initializerExprTypeResolver),
 				$container->getByType(PhpVersion::class),
+				$container->getParameter('phpVersion'),
 				$constantResolver,
 			),
 		);

--- a/tests/PHPStan/Rules/Methods/FinalPrivateMethodRuleConfigPhpTest.php
+++ b/tests/PHPStan/Rules/Methods/FinalPrivateMethodRuleConfigPhpTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/** @extends RuleTestCase<FinalPrivateMethodRule> */
+class FinalPrivateMethodRuleConfigPhpTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new FinalPrivateMethodRule();
+	}
+
+	public function testRulePhpVersions(): void
+	{
+		$this->analyse([__DIR__ . '/data/final-private-method-config-phpversion.php'], [
+			[
+				'Private method FinalPrivateMethodConfigPhpVersions\PhpVersionViaNEONConfg::foo() cannot be final as it is never overridden by other classes.',
+				8,
+			],
+		]);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/data/final-private-php-version.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Rules/Methods/data/final-private-method-config-phpversion.php
+++ b/tests/PHPStan/Rules/Methods/data/final-private-method-config-phpversion.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace FinalPrivateMethodConfigPhpVersions;
+
+class PhpVersionViaNEONConfg
+{
+
+	final private function foo(): void
+	{
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/final-private-php-version.neon
+++ b/tests/PHPStan/Rules/Methods/data/final-private-php-version.neon
@@ -1,0 +1,4 @@
+parameters:
+    phpVersion:
+        min: 80100
+        max: 80499


### PR DESCRIPTION
> We can afford to start reading min/max values from the phpVersion config.

refs https://github.com/phpstan/phpstan-src/pull/3642#discussion_r1855167754