### PR TITLE
Enabling constructor check for class-string variables

### DIFF
--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -16,11 +16,16 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\TemplateGenericObjectType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\VerbosityLevel;
 use function array_map;
 use function array_merge;
 use function count;
 use function sprintf;
+use function str_starts_with;
 use function strtolower;
 
 /**
@@ -244,6 +249,21 @@ final class InstantiationRule implements Rule
 		}
 
 		$type = $scope->getType($node->class);
+
+		if (str_starts_with($type->describe(VerbosityLevel::precise()), 'class-string')) {
+			$classStringObjectType = $type->getClassStringObjectType();
+
+			if (
+				!$classStringObjectType instanceof StaticType
+				&& !$classStringObjectType instanceof CompoundType
+				&& !$classStringObjectType instanceof TemplateGenericObjectType
+			) {
+				return array_map(
+					static fn (string $name): array => [$name, true],
+					$classStringObjectType->getObjectClassNames(),
+				);
+			}
+		}
 
 		return array_merge(
 			array_map(

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -253,7 +253,7 @@ final class InstantiationRule implements Rule
 				static fn (ClassReflection $classReflection): bool => !$classReflection->isAbstract() && !$classReflection->isInterface(),
 			);
 
-			if (0 < count($concretes)) {
+			if (count($concretes) > 0) {
 				return array_map(
 					static fn (ClassReflection $classReflection): array => [$classReflection->getName(), true],
 					$concretes,

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\SprintfHelper;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -17,13 +18,11 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\VerbosityLevel;
 use function array_filter;
 use function array_map;
 use function array_merge;
 use function count;
 use function sprintf;
-use function str_starts_with;
 use function strtolower;
 
 /**
@@ -248,16 +247,18 @@ final class InstantiationRule implements Rule
 
 		$type = $scope->getType($node->class);
 
-		if (str_starts_with($type->describe(VerbosityLevel::precise()), 'class-string')) {
-			$classStringObjectType = $type->getClassStringObjectType();
-
-			return array_map(
-				static fn (string $name): array => [$name, true],
-				array_filter($classStringObjectType->getObjectClassNames(), function (string $name): bool {
-					$reflectionClass = $this->reflectionProvider->getClass($name);
-					return !$reflectionClass->isAbstract() && !$reflectionClass->isInterface();
-				}),
+		if ($type->isClassString()->yes()) {
+			$concretes = array_filter(
+				$type->getClassStringObjectType()->getObjectClassReflections(),
+				static fn (ClassReflection $classReflection): bool => !$classReflection->isAbstract() && !$classReflection->isInterface(),
 			);
+
+			if (0 < count($concretes)) {
+				return array_map(
+					static fn (ClassReflection $classReflection): array => [$classReflection->getName(), true],
+					$concretes,
+				);
+			}
 		}
 
 		return array_merge(

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -16,11 +16,9 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\Generic\TemplateGenericObjectType;
-use PHPStan\Type\StaticType;
 use PHPStan\Type\VerbosityLevel;
+use function array_filter;
 use function array_map;
 use function array_merge;
 use function count;
@@ -253,16 +251,13 @@ final class InstantiationRule implements Rule
 		if (str_starts_with($type->describe(VerbosityLevel::precise()), 'class-string')) {
 			$classStringObjectType = $type->getClassStringObjectType();
 
-			if (
-				!$classStringObjectType instanceof StaticType
-				&& !$classStringObjectType instanceof CompoundType
-				&& !$classStringObjectType instanceof TemplateGenericObjectType
-			) {
-				return array_map(
-					static fn (string $name): array => [$name, true],
-					$classStringObjectType->getObjectClassNames(),
-				);
-			}
+			return array_map(
+				static fn (string $name): array => [$name, true],
+				array_filter($classStringObjectType->getObjectClassNames(), function (string $name): bool {
+					$reflectionClass = $this->reflectionProvider->getClass($name);
+					return !$reflectionClass->isAbstract() && !$reflectionClass->isInterface();
+				}),
+			);
 		}
 
 		return array_merge(

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -509,27 +509,39 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/class-string.php'], [
 			[
 				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
-				26,
+				65,
 			],
 			[
 				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
-				27,
+				66,
 			],
 			[
 				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
-				28,
+				67,
+			],
+			[
+				'Parameter #1 $i of class ClassString\C constructor expects int, string given.',
+				75,
+			],
+			[
+				'Parameter #1 $i of class ClassString\C constructor expects int, string given.',
+				76,
+			],
+			[
+				'Parameter #1 $i of class ClassString\C constructor expects int, string given.',
+				77,
 			],
 			[
 				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
-				31,
+				85,
 			],
 			[
 				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
-				32,
+				86,
 			],
 			[
 				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
-				34,
+				87,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -504,4 +504,34 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11815.php'], []);
 	}
 
+	public function testClassString(): void
+	{
+		$this->analyse([__DIR__ . '/data/class-string.php'], [
+			[
+				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
+				26,
+			],
+			[
+				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
+				27,
+			],
+			[
+				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
+				28,
+			],
+			[
+				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
+				31,
+			],
+			[
+				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
+				32,
+			],
+			[
+				'Parameter #1 $i of class ClassString\A constructor expects int, string given.',
+				34,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/class-string.php
+++ b/tests/PHPStan/Rules/Classes/data/class-string.php
@@ -1,0 +1,34 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace ClassString;
+
+class A
+{
+    public function __construct(public int $i)
+    {
+    }
+}
+
+class HelloWorld
+{
+    /**
+     * @return class-string<A>
+     */
+    public static function sayHelloBug(): string
+    {
+        return A::class;
+    }
+}
+
+$classString = HelloWorld::sayHelloBug();
+$bug = new (HelloWorld::sayHelloBug())('O_O');
+$bug = new ($classString)('O_O');
+$bug = new $classString('O_O');
+
+$className = A::class;
+$ok = new ($className)('O_O');
+$ok = new $className('O_O');
+
+$ok = new A('O_O');

--- a/tests/PHPStan/Rules/Classes/data/class-string.php
+++ b/tests/PHPStan/Rules/Classes/data/class-string.php
@@ -11,24 +11,77 @@ class A
     }
 }
 
-class HelloWorld
+abstract class B
+{
+    public function __construct(public int $i)
+    {
+    }
+}
+
+class C extends B
+{
+}
+
+interface D
+{
+}
+
+class Foo
 {
     /**
      * @return class-string<A>
      */
-    public static function sayHelloBug(): string
+    public static function returnClassStringA(): string
     {
         return A::class;
     }
+
+    /**
+     * @return class-string<B>
+     */
+    public static function returnClassStringB(): string
+    {
+        return B::class;
+    }
+
+    /**
+     * @return class-string<C>
+     */
+    public static function returnClassStringC(): string
+    {
+        return C::class;
+    }
+
+    /**
+     * @return class-string<D>
+     */
+    public static function returnClassStringD(): string
+    {
+        return D::class;
+    }
 }
 
-$classString = HelloWorld::sayHelloBug();
-$bug = new (HelloWorld::sayHelloBug())('O_O');
-$bug = new ($classString)('O_O');
-$bug = new $classString('O_O');
+$classString = Foo::returnClassStringA();
+$error = new (Foo::returnClassStringA())('O_O');
+$error = new ($classString)('O_O');
+$error = new $classString('O_O');
+
+$classString = Foo::returnClassStringB();
+$ok = new (Foo::returnClassStringB())('O_O');
+$ok = new ($classString)('O_O');
+$ok = new $classString('O_O');
+
+$classString = Foo::returnClassStringC();
+$error = new (Foo::returnClassStringC())('O_O');
+$error = new ($classString)('O_O');
+$error = new $classString('O_O');
+
+$classString = Foo::returnClassStringD();
+$ok = new (Foo::returnClassStringD())('O_O');
+$ok = new ($classString)('O_O');
+$ok = new $classString('O_O');
 
 $className = A::class;
-$ok = new ($className)('O_O');
-$ok = new $className('O_O');
-
-$ok = new A('O_O');
+$error = new ($className)('O_O');
+$error = new $className('O_O');
+$error = new A('O_O');


### PR DESCRIPTION
Changed to check constructor arguments when creating an instance from a variable containing a class-string.
Skip checking if T in class-string<T> is abstract or interface.

resolve phpstan/phpstan#12010

