### PR TITLE
Remove sha256 definition

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -10448,8 +10448,6 @@ return [
 'settype' => ['bool', '&rw_var'=>'mixed', 'type'=>'string'],
 'sha1' => ['non-falsy-string&lowercase-string', 'str'=>'string', 'raw_output='=>'bool'],
 'sha1_file' => ['(non-falsy-string&lowercase-string)|false', 'filename'=>'string', 'raw_output='=>'bool'],
-'sha256' => ['string', 'str'=>'string', 'raw_output='=>'bool'],
-'sha256_file' => ['string', 'filename'=>'string', 'raw_output='=>'bool'],
 'shapefileObj::__construct' => ['void', 'filename'=>'string', 'type'=>'int'],
 'shapefileObj::addPoint' => ['int', 'point'=>'pointObj'],
 'shapefileObj::addShape' => ['int', 'shape'=>'shapeObj'],


### PR DESCRIPTION
Cf https://github.com/phpstan/phpstan/issues/12048#issuecomment-2496156102 message 
and https://onlinephp.io/c/37b9d0 example, I feel like this function doesn't exists.

That would explain why there is none in PHPStorm stubs.

I'm opened to counter-example.