### PR TITLE
Implement SocketCreateReturnTypeExtension

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1830,6 +1830,16 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
+		class: PHPStan\Type\Php\SocketObjectReturnTypeFunctionExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
+		class: PHPStan\Type\Php\AddressInfoObjectReturnTypeFunctionExtension
+		tags:
+			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
 		class: PHPStan\Type\Php\StrSplitFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/Php/PhpVersions.php
+++ b/src/Php/PhpVersions.php
@@ -33,6 +33,11 @@ final class PhpVersions
 		return IntegerRangeType::fromInterval(80000, null)->isSuperTypeOf($this->phpVersions)->result;
 	}
 
+	public function socketFunctionsUseObject(): TrinaryLogic
+	{
+		return IntegerRangeType::fromInterval(80000, null)->isSuperTypeOf($this->phpVersions)->result;
+	}
+
 	public function supportsNamedArguments(): TrinaryLogic
 	{
 		return IntegerRangeType::fromInterval(80000, null)->isSuperTypeOf($this->phpVersions)->result;

--- a/src/Type/Php/AddressInfoObjectReturnTypeFunctionExtension.php
+++ b/src/Type/Php/AddressInfoObjectReturnTypeFunctionExtension.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ResourceType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use function in_array;
+
+final class AddressInfoObjectReturnTypeFunctionExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	private const FUNCTIONS = [
+		'socket_addrinfo_lookup',
+	];
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), self::FUNCTIONS, true);
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+	{
+		if ($scope->getPhpVersion()->socketFunctionsUseObject()->yes()) {
+			return new UnionType([new ConstantBooleanType(false), new ArrayType(new MixedType(), new ObjectType('\\AddressInfo'))]);
+		}
+
+		if ($scope->getPhpVersion()->socketFunctionsUseObject()->no()) {
+			return new UnionType([new ConstantBooleanType(false), new ArrayType(new MixedType(), new ResourceType())]);
+		}
+
+		return null;
+	}
+
+}

--- a/src/Type/Php/SocketObjectReturnTypeFunctionExtension.php
+++ b/src/Type/Php/SocketObjectReturnTypeFunctionExtension.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ResourceType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use function in_array;
+
+final class SocketObjectReturnTypeFunctionExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	private const FUNCTIONS = [
+		'socket_accept',
+		'socket_addrinfo_bind',
+		'socket_addrinfo_connect',
+		'socket_create',
+		'socket_create_listen',
+		'socket_import_stream',
+		'socket_wsaprotocol_info_import',
+	];
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), self::FUNCTIONS, true);
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+	{
+		if ($scope->getPhpVersion()->socketFunctionsUseObject()->yes()) {
+			return new UnionType([new ConstantBooleanType(false), new ObjectType('\\Socket')]);
+		}
+
+		if ($scope->getPhpVersion()->socketFunctionsUseObject()->no()) {
+			return new UnionType([new ConstantBooleanType(false), new ResourceType()]);
+		}
+
+		return null;
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/socket-create.php
+++ b/tests/PHPStan/Analyser/nsrt/socket-create.php
@@ -1,0 +1,32 @@
+<?php // lint >= 7.4
+
+declare(strict_types=1);
+
+namespace SocketCreate;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function createSocket(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			assertType('resource|false', socket_create(AF_INET, SOCK_DGRAM, SOL_UDP));
+		}
+
+		if (PHP_VERSION_ID >= 80000) {
+			assertType('\Socket|false', socket_create(AF_INET, SOCK_DGRAM, SOL_UDP));
+		}
+	}
+
+	public function addrinfo($host): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			assertType('array<resource>|false', socket_addrinfo_lookup($host));
+		}
+
+		if (PHP_VERSION_ID >= 80000) {
+			assertType('array<\AddressInfo>|false', socket_addrinfo_lookup($host));
+		}
+	}
+}


### PR DESCRIPTION
php-version dependent `socket_create` handling to ease writing cross php version code

refs https://github.com/phpstan/phpstan/discussions/4212

see https://php.watch/versions/8.0/sockets-sockets-addressinfo