### PR TITLE
Fixed a bug where the last value was not recognized when passing an associative array as an argument

### DIFF
--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -499,4 +499,9 @@ class InstantiationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10248.php'], []);
 	}
 
+	public function testBug11815(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-11815.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-11815.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-11815.php
@@ -1,0 +1,43 @@
+<?php // lint >= 8.2
+
+declare(strict_types = 1);
+
+class Dimensions
+{
+    public function __construct(
+        public int $width,
+        public int $height,
+    ) {
+    }
+}
+
+class StoreProcessorResult
+{
+    public function __construct(
+        public string $path,
+        public string $mimetype,
+        public Dimensions $dimensions,
+        public int $filesize,
+        public true|null $identical = null,
+     ) {
+     }
+}
+
+/**
+ * @return array{path: string, identical?: true}
+ */
+function getPath(): array
+{
+	$data = ['path' => 'some/path'];
+	if ((bool)rand(0, 1)) {
+		$data['identical'] = true;
+	}
+	return $data;
+}
+
+$data = getPath();
+$data['dimensions'] = new Dimensions(100, 100);
+$data['mimetype'] = 'image/png';
+$data['filesize'] = 123456;
+
+$dto = new StoreProcessorResult(...$data);


### PR DESCRIPTION
For optional arguments, updated the validation to treat them as non-existent when not provided.

resolve phpstan/phpstan#11815