### PR TITLE
Allow gitlab ci to be detected

### DIFF
--- a/src/Command/ErrorFormatter/CiDetectedErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CiDetectedErrorFormatter.php
@@ -17,6 +17,7 @@ class CiDetectedErrorFormatter implements ErrorFormatter
 	public function __construct(
 		private GithubErrorFormatter $githubErrorFormatter,
 		private TeamcityErrorFormatter $teamcityErrorFormatter,
+		private GitlabErrorFormatter $gitlabErrorFormatter,
 	)
 	{
 	}
@@ -31,6 +32,8 @@ class CiDetectedErrorFormatter implements ErrorFormatter
 				return $this->githubErrorFormatter->formatErrors($analysisResult, $output);
 			} elseif ($ci->getCiName() === CiDetector::CI_TEAMCITY) {
 				return $this->teamcityErrorFormatter->formatErrors($analysisResult, $output);
+			} elseif ($ci->getCiName() === CiDetector::CI_GITLAB) {
+				return $this->gitlabErrorFormatter->formatErrors($analysisResult, $output);
 			}
 		} catch (CiNotDetectedException) {
 			// pass

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command;
 use PHPStan\Analyser\ResultCache\ResultCacheClearer;
 use PHPStan\Command\ErrorFormatter\CiDetectedErrorFormatter;
 use PHPStan\Command\ErrorFormatter\GithubErrorFormatter;
+use PHPStan\Command\ErrorFormatter\GitlabErrorFormatter;
 use PHPStan\Command\ErrorFormatter\TableErrorFormatter;
 use PHPStan\Command\ErrorFormatter\TeamcityErrorFormatter;
 use PHPStan\Command\Symfony\SymfonyOutput;
@@ -74,6 +75,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 			new CiDetectedErrorFormatter(
 				new GithubErrorFormatter($relativePathHelper),
 				new TeamcityErrorFormatter($relativePathHelper),
+				new GitlabErrorFormatter($relativePathHelper),
 			),
 			false,
 			null,

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -325,6 +325,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			new CiDetectedErrorFormatter(
 				new GithubErrorFormatter($relativePathHelper),
 				new TeamcityErrorFormatter($relativePathHelper),
+				new GitlabErrorFormatter($relativePathHelper),
 			),
 			false,
 			$editorUrl,


### PR DESCRIPTION
Gitlab CI wasn't being detected by the `CiDetectedErrorFormatter`. This MR allows detection so that the `CiDetectedErrorFormatter` can be used for gitlab as well.