### PR TITLE
Allow multiple error formatters

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -2174,3 +2174,9 @@ services:
 		class: PHPStan\Command\ErrorFormatter\TeamcityErrorFormatter
 		arguments:
 			relativePathHelper: @simpleRelativePathHelper
+
+	errorFormatter.multiple:
+		class: PHPStan\Command\ErrorFormatter\ChainErrorFormatter
+		arguments:
+			formatters:
+				- @errorFormatter.table

--- a/src/Command/ErrorFormatter/ChainErrorFormatter.php
+++ b/src/Command/ErrorFormatter/ChainErrorFormatter.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+
+/**
+ * @api
+ */
+final class ChainErrorFormatter implements ErrorFormatter
+{
+
+	/**
+	 * @param list<ErrorFormatter> $formatters
+	 */
+	public function __construct(
+		private array $formatters,
+	)
+	{
+	}
+
+	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+	{
+		foreach ($this->formatters as $errorFormatter) {
+			$errorFormatter->formatErrors($analysisResult, $output);
+		}
+
+		return $analysisResult->hasErrors() ? 1 : 0;
+	}
+
+}

--- a/src/Command/ErrorFormatter/GitlabErrorFormatter.php
+++ b/src/Command/ErrorFormatter/GitlabErrorFormatter.php
@@ -6,6 +6,7 @@ use Nette\Utils\Json;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
 use PHPStan\File\RelativePathHelper;
+use function file_put_contents;
 use function hash;
 use function implode;
 
@@ -15,7 +16,10 @@ use function implode;
 final class GitlabErrorFormatter implements ErrorFormatter
 {
 
-	public function __construct(private RelativePathHelper $relativePathHelper)
+	public function __construct(
+		private RelativePathHelper $relativePathHelper,
+		private ?string $fileLocation = null,
+	)
 	{
 	}
 
@@ -64,7 +68,11 @@ final class GitlabErrorFormatter implements ErrorFormatter
 
 		$json = Json::encode($errorsArray, Json::PRETTY);
 
-		$output->writeRaw($json);
+		if ($this->fileLocation !== null) {
+			file_put_contents($this->fileLocation, $json);
+		} else {
+			$output->writeRaw($json);
+		}
 
 		return $analysisResult->hasErrors() ? 1 : 0;
 	}


### PR DESCRIPTION
This MR introduces the `errorFormatter.multiple` (name pending). It allows a user to specify multiple output formats.

In a CI environment, you sometimes want to output to multiple tools, and a table output for the logs.
Currently that is only possible by composing multiple error formatters in your own code. When you have multiple projects with the same set up, you either need a package, or duplicated code.

In your config you could specify the following, which mean you'll use both the table and gitlab output when running PHPStan with the flag `--error-format multiple`.

```yaml
services:
    errorFormatter.multiple:
        arguments:
            formatters:
                - @errorFormatter.table
                - @errorFormatter.gitlab
```

The second commit introduces a new parameter for the gitlab output, to allow redirecting this to a file, instead of the stdout.
This means that we can have both a table output in the logs, and a gitlab output written to a file. 

I have not added this paramter to other formatters like the JSON one, as i'm unsure if this is the way to go.

With the gitlab option one could then the following configuration to output the needed json for gitlab, and still have a table output.

```yaml
services:
    errorFormatter.gitlab:
        arguments:
            fileLocation: %currentWorkingDirectory%/phpstan.json
    errorFormatter.multiple:
        arguments:
            formatters:
                - @errorFormatter.table
                - @errorFormatter.gitlab
```

Another option would be change the error-format flag to allow multiple error formatters. I think this way gives users more freedom as they can specify the `multiple` as their default error formatter in the configuration.