### PR TITLE
Ease debugging BaselineNeonErrorFormatterIntegrationTest

### DIFF
--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
@@ -69,9 +69,9 @@ class BaselineNeonErrorFormatterIntegrationTest extends TestCase
 			throw new ShouldNotHappenException();
 		}
 		chdir(__DIR__ . '/../../../..');
-		exec(sprintf('%s %s clear-result-cache %s', escapeshellarg(PHP_BINARY), 'bin/phpstan', $configFile !== null ? '--configuration ' . escapeshellarg($configFile) : ''), $clearResultCacheOutputLines, $clearResultCacheExitCode);
+		exec(sprintf('%s %s clear-result-cache %s', escapeshellarg(PHP_BINARY), 'bin/phpstan', $configFile !== null ? '--configuration ' . escapeshellarg($configFile) : '') . ' 2>&1', $clearResultCacheOutputLines, $clearResultCacheExitCode);
 		if ($clearResultCacheExitCode !== 0) {
-			throw new ShouldNotHappenException('Could not clear result cache.');
+			throw new ShouldNotHappenException('Could not clear result cache:' . "\n" . implode("\n", $clearResultCacheOutputLines));
 		}
 
 		exec(sprintf('%s %s analyse --no-progress --error-format=%s --level=7 %s %s%s', escapeshellarg(PHP_BINARY), 'bin/phpstan', $errorFormatter, $configFile !== null ? '--configuration ' . escapeshellarg($configFile) : '', escapeshellarg($analysedPath), $baselineFile !== null ? ' --generate-baseline ' . escapeshellarg($baselineFile) : ''), $outputLines);

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
@@ -69,7 +69,7 @@ class BaselineNeonErrorFormatterIntegrationTest extends TestCase
 			throw new ShouldNotHappenException();
 		}
 		chdir(__DIR__ . '/../../../..');
-		exec(sprintf('%s %s clear-result-cache %s', escapeshellarg(PHP_BINARY), 'bin/phpstan', $configFile !== null ? '--configuration ' . escapeshellarg($configFile) : '') . ' 2>&1', $clearResultCacheOutputLines, $clearResultCacheExitCode);
+		exec(sprintf('%s %s clear-result-cache %s 2>&1', escapeshellarg(PHP_BINARY), 'bin/phpstan', $configFile !== null ? '--configuration ' . escapeshellarg($configFile) : ''), $clearResultCacheOutputLines, $clearResultCacheExitCode);
 		if ($clearResultCacheExitCode !== 0) {
 			throw new ShouldNotHappenException('Could not clear result cache:' . "\n" . implode("\n", $clearResultCacheOutputLines));
 		}


### PR DESCRIPTION
I see this test fail more often on PRs lately with output like:

```
php vendor/bin/paratest --runner WrapperRunner --no-coverage --group exec
ParaTest v6.6.3 upon PHPUnit 9.6.20 by Sebastian Bergmann and contributors.

............................E...                                 32 / 32 (100%)

Time: 00:35.534, Memory: 80.00 MB

There was 1 error:

1) PHPStan\Command\ErrorFormatter\BaselineNeonErrorFormatterIntegrationTest::testRunUnixFileWithWindowsBaseline
PHPStan\ShouldNotHappenException: Could not clear result cache.

D:\a\phpstan-src\phpstan-src\tests\PHPStan\Command\ErrorFormatter\BaselineNeonErrorFormatterIntegrationTest.php:74
D:\a\phpstan-src\phpstan-src\tests\PHPStan\Command\ErrorFormatter\BaselineNeonErrorFormatterIntegrationTest.php:54

FAILURES!
Tests: 32, Assertions: 82, Errors: 1.
make: *** [Makefile:9: tests-integration] Error 2
```

lets see whether we can get a more meaningful output which might help to fix the underlying problem