### PR TITLE
Remove shortArraySyntax definiton on Printer::construct()

### DIFF
--- a/src/Node/Printer/Printer.php
+++ b/src/Node/Printer/Printer.php
@@ -24,12 +24,6 @@ use function sprintf;
  */
 final class Printer extends Standard
 {
-
-	public function __construct()
-	{
-		parent::__construct(['shortArraySyntax' => true]);
-	}
-
 	protected function pPHPStan_Node_TypeExpr(TypeExpr $expr): string // phpcs:ignore
 	{
 		return sprintf('__phpstanType(%s)', $expr->getExprType()->describe(VerbosityLevel::precise()));


### PR DESCRIPTION
It seems already short array syntax by default