### PR TITLE
Retain list type when assigning to offset 1 of non-empty-list

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -760,7 +760,7 @@ class IntersectionType implements CompoundType
 		$result = $this->intersectTypes(static fn (Type $type): Type => $type->setOffsetValueType($offsetType, $valueType, $unionValues));
 
 		if ($offsetType !== null && $this->isList()->yes() && $this->isIterableAtLeastOnce()->yes() && (new ConstantIntegerType(1))->isSuperTypeOf($offsetType)->yes()) {
-			$result = TypeCombinator::intersect($result, new AccessoryArrayListType());
+			$result = AccessoryArrayListType::intersectWith($result);
 		}
 
 		return $result;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -756,7 +756,14 @@ class IntersectionType implements CompoundType
 				);
 			});
 		}
-		return $this->intersectTypes(static fn (Type $type): Type => $type->setOffsetValueType($offsetType, $valueType, $unionValues));
+
+		$result = $this->intersectTypes(static fn (Type $type): Type => $type->setOffsetValueType($offsetType, $valueType, $unionValues));
+
+		if ($offsetType !== null && $this->isList()->yes() && $this->isIterableAtLeastOnce()->yes() && (new ConstantIntegerType(1))->isSuperTypeOf($offsetType)->yes()) {
+			$result = TypeCombinator::intersect($result, new AccessoryArrayListType());
+		}
+
+		return $result;
 	}
 
 	public function setExistingOffsetValueType(Type $offsetType, Type $valueType): Type

--- a/tests/PHPStan/Analyser/nsrt/list-type.php
+++ b/tests/PHPStan/Analyser/nsrt/list-type.php
@@ -106,4 +106,29 @@ class Foo
 		assertType('array<int<0, 1>|int<3, max>, int>', $list);
 	}
 
+	/** @param list<int> $list */
+	public function testSetOffsetExplicitlyWithoutGap(array $list): void
+	{
+		assertType('list<int>', $list);
+		$list[0] = 17;
+		assertType('non-empty-list<int>&hasOffsetValue(0, 17)', $list);
+		$list[1] = 19;
+		assertType('non-empty-list<int>&hasOffsetValue(0, 17)&hasOffsetValue(1, 19)', $list);
+		$list[0] = 21;
+		assertType('non-empty-list<int>&hasOffsetValue(0, 21)&hasOffsetValue(1, 19)', $list);
+
+		$list[2] = 23;
+		assertType('non-empty-array<int<0, max>, int>&hasOffsetValue(0, 21)&hasOffsetValue(1, 19)&hasOffsetValue(2, 23)', $list);
+	}
+
+	/** @param list<int> $list */
+	public function testSetOffsetExplicitlyWithGap(array $list): void
+	{
+		assertType('list<int>', $list);
+		$list[0] = 17;
+		assertType('non-empty-list<int>&hasOffsetValue(0, 17)', $list);
+		$list[2] = 21;
+		assertType('non-empty-array<int<0, max>, int>&hasOffsetValue(0, 17)&hasOffsetValue(2, 21)', $list);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -695,7 +695,13 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 	public function testBug12131(): void
 	{
 		$this->checkExplicitMixed = true;
-		$this->analyse([__DIR__ . '/data/bug-12131.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-12131.php'], [
+			[
+				'Property Bug12131\Test::$array (non-empty-list<int>) does not accept non-empty-array<int<0, max>, int>.',
+				29,
+				'non-empty-array<int<0, max>, int> might not be a list.',
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -692,4 +692,10 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12131(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-12131.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-12131.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12131.php
@@ -23,7 +23,9 @@ class Test
 	{
 		$this->array[1] = 1;
 	}
-}
 
-$a = new Test();
-$a->setAtOne();
+	public function setAtTwo(): void
+	{
+		$this->array[2] = 1;
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-12131.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12131.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Bug12131;
+
+class Test
+{
+	/**
+	 * @var non-empty-list<int>
+	 */
+	public array $array;
+
+	public function __construct()
+	{
+		$this->array = array_fill(0, 10, 1);
+	}
+
+	public function setAtZero(): void
+	{
+		$this->array[0] = 1;
+	}
+
+	public function setAtOne(): void
+	{
+		$this->array[1] = 1;
+	}
+}
+
+$a = new Test();
+$a->setAtOne();


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/12131

I don't think we can detect this edge case inside `Type::setOffsetValueType()` because we need info of 2 different accessory types, right? Is `IntersectionType` the best place then I suppose?