### PR TITLE
Lazier return in `UnionType->isSuperTypeOfWithReason()` (~40% faster)

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -253,11 +253,7 @@ class UnionType implements CompoundType
 			}
 			$results[] = $result;
 		}
-
 		$result = IsSuperTypeOfResult::createNo()->or(...$results);
-		if ($result->yes()) {
-			return $result;
-		}
 
 		if ($otherType instanceof TemplateUnionType) {
 			return $result->or($otherType->isSubTypeOfWithReason($this));

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -245,7 +245,16 @@ class UnionType implements CompoundType
 			return $otherType->isSubTypeOfWithReason($this);
 		}
 
-		$result = IsSuperTypeOfResult::createNo()->or(...array_map(static fn (Type $innerType) => $innerType->isSuperTypeOfWithReason($otherType), $this->types));
+		$results = [];
+		foreach ($this->types as $innerType) {
+			$result = $innerType->isSuperTypeOfWithReason($otherType);
+			if ($result->yes()) {
+				return $result;
+			}
+			$results[] = $result;
+		}
+
+		$result = IsSuperTypeOfResult::createNo()->or(...$results);
 		if ($result->yes()) {
 			return $result;
 		}


### PR DESCRIPTION
slow profile before this PR of https://github.com/phpstan/phpstan/issues/12159#issuecomment-2508567762 with https://github.com/phpstan/phpstan-src/commit/14d2bed182eb17346fd457f2c798301b17c42856

<img width="482" alt="grafik" src="https://github.com/user-attachments/assets/6fcefa82-000b-4e4f-87de-f95dd3b789b0">

---

this PR:
```
➜  phpstan-src git:(lazy-or-1x) ✗ hyperfine 'php bin/phpstan analyze test.php --debug' -i
Benchmark 1: php bin/phpstan analyze test.php --debug
  Time (mean ± σ):      5.175 s ±  0.028 s    [User: 5.041 s, System: 0.131 s]
  Range (min … max):    5.137 s …  5.218 s    10 runs

```

with 1.12.x on https://github.com/phpstan/phpstan-src/commit/8d67d7a7617fcc3fb88dc5544f281d288ad696f4
```
➜  phpstan-src git:(1.12.x) ✗ hyperfine 'php bin/phpstan analyze test.php --debug' -i
Benchmark 1: php bin/phpstan analyze test.php --debug
  Time (mean ± σ):      8.579 s ±  0.080 s    [User: 8.424 s, System: 0.148 s]
  Range (min … max):    8.493 s …  8.727 s    10 runs

```