### PR TITLE
5x Faster `IntersectionType->getEnumCases()`

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -842,7 +842,7 @@ class IntersectionType implements CompoundType
 		foreach ($this->types as $type) {
 			$oneType = [];
 			foreach ($type->getEnumCases() as $enumCase) {
-				$oneType[md5($enumCase->describe(VerbosityLevel::typeOnly()))] = $enumCase;
+				$oneType[$enumCase->getClassName() . '::' . $enumCase->getEnumCaseName()] = $enumCase;
 			}
 			$compare[] = $oneType;
 		}


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/11968

using a **reduced repro**

before this PR
```
➜  phpstan-src git:(2.0.x) ✗ hyperfine 'php bin/phpstan analyze test11968.php --debug' -i
Benchmark 1: php bin/phpstan analyze test11968.php --debug
  Time (mean ± σ):      9.262 s ±  0.039 s    [User: 9.106 s, System: 0.153 s]
  Range (min … max):    9.192 s …  9.326 s    10 runs

```

after this PR
```
➜  phpstan-src git:(2.0.x) ✗ hyperfine 'php bin/phpstan analyze test11968.php --debug' -i
Benchmark 1: php bin/phpstan analyze test11968.php --debug
  Time (mean ± σ):      1.755 s ±  0.005 s    [User: 1.636 s, System: 0.117 s]
  Range (min … max):    1.745 s …  1.762 s    10 runs

```

the full repro of https://github.com/phpstan/phpstan/issues/11968 takes still 11,5 seconds after this PR on my m4 pro (took 1min10s before)