### PR TITLE
Use native PHPDocs for `Rule` and `RuleTestCase`

### DIFF
--- a/src/Rules/Rule.php
+++ b/src/Rules/Rule.php
@@ -20,18 +20,18 @@ use PHPStan\Analyser\Scope;
  * Learn more: https://phpstan.org/developing-extensions/rules
  *
  * @api
- * @phpstan-template TNodeType of Node
+ * @template TNodeType of Node
  */
 interface Rule
 {
 
 	/**
-	 * @phpstan-return class-string<TNodeType>
+	 * @return class-string<TNodeType>
 	 */
 	public function getNodeType(): string;
 
 	/**
-	 * @phpstan-param TNodeType $node
+	 * @param TNodeType $node
 	 * @return (string|RuleError)[] errors
 	 */
 	public function processNode(Node $node, Scope $scope): array;

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -45,7 +45,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 	private ?Analyser $analyser = null;
 
 	/**
-	 * @phpstan-return TRule
+	 * @return TRule
 	 */
 	abstract protected function getRule(): Rule;
 


### PR DESCRIPTION
I'm using intelephense in VS Code and it cannot understand the `@phpstan-` annotated PHPDocs. However, it understands the native PHPDocs, including the generics related. This PR uses those PHPDocs for `Rule` and `RuleTestCase` for better IDE completion on vscode.

Proof:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/75b8d241-0ded-44ed-90d8-21ffd6b44a14">
