### PR TITLE
Use current PHP version in CallToFunctionParametersRuleTest

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -28,7 +28,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$broker = $this->createReflectionProvider();
 		return new CallToFunctionParametersRule(
 			$broker,
-			new FunctionCallParametersCheck(new RuleLevelHelper($broker, true, false, true, $this->checkExplicitMixed, $this->checkImplicitMixed, true, false), new NullsafeCheck(), new PhpVersion(80000), new UnresolvableTypeHelper(), new PropertyReflectionFinder(), true, true, true, true, true),
+			new FunctionCallParametersCheck(new RuleLevelHelper($broker, true, false, true, $this->checkExplicitMixed, $this->checkImplicitMixed, true, false), new NullsafeCheck(), new PhpVersion(PHP_VERSION_ID), new UnresolvableTypeHelper(), new PropertyReflectionFinder(), true, true, true, true, true),
 		);
 	}
 
@@ -481,6 +481,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 
 	public function testNamedArguments(): void
 	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
 		$errors = [
 			[
 				'Missing parameter $j (int) in call to function FunctionNamedArguments\foo.',
@@ -495,12 +499,6 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				14,
 			],
 		];
-		if (PHP_VERSION_ID < 80000) {
-			$errors[] = [
-				'Missing parameter $arr1 (array) in call to function array_merge.',
-				14,
-			];
-		}
 
 		require_once __DIR__ . '/data/named-arguments-define.php';
 		$this->analyse([__DIR__ . '/data/named-arguments.php'], $errors);


### PR DESCRIPTION
Working on something in `FunctionCallParametersCheck` which is tested via `CallToFunctionParametersRuleTest` but realised that the PHP version was hard-coded to 8.0 which is blocking me there. Also: bigger range of tests over multiple PHP versions, yay :) in general there seem to be many rules where similar things could be done.

Unfortunately this causes a small conflict in 2.0.x apparently.

UPDATE: Markus made me aware of https://github.com/phpstan/phpstan-src/pull/3662 and I adapted the named arguments test to be skipped exactly the same way to avoid troubles there.