### PR TITLE
Remove incorrect CURLOPT_ACCEPT_ENCODING alias

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -919,7 +919,6 @@ final class ParametersAcceptorSelector
 		}
 
 		$nullableStringConstants = [
-			'CURLOPT_ACCEPT_ENCODING',
 			'CURLOPT_CUSTOMREQUEST',
 			'CURLOPT_DNS_INTERFACE',
 			'CURLOPT_DNS_LOCAL_IP4',
@@ -1032,7 +1031,7 @@ final class ParametersAcceptorSelector
 
 		$stringConstants = [
 			'CURLOPT_COOKIEFILE',
-			'CURLOPT_ENCODING',
+			'CURLOPT_ENCODING', // Alias: CURLOPT_ACCEPT_ENCODING
 			'CURLOPT_PRE_PROXY',
 			'CURLOPT_PRIVATE',
 			'CURLOPT_PROXY',

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1321,40 +1321,48 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				18,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects bool, int given.',
+				'Parameter #3 $value of function curl_setopt expects string, int given.',
+				19,
+			],
+			[
+				'Parameter #3 $value of function curl_setopt expects string, int given.',
 				20,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects bool, string given.',
-				21,
+				'Parameter #3 $value of function curl_setopt expects bool, int given.',
+				22,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects int, string given.',
+				'Parameter #3 $value of function curl_setopt expects bool, string given.',
 				23,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects array, string given.',
+				'Parameter #3 $value of function curl_setopt expects int, string given.',
 				25,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects resource, string given.',
+				'Parameter #3 $value of function curl_setopt expects array, string given.',
 				27,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects array|string, int given.',
+				'Parameter #3 $value of function curl_setopt expects resource, string given.',
 				29,
 			],
 			[
-				'Parameter #3 $value of function curl_setopt expects non-empty-string, \'\' given.',
+				'Parameter #3 $value of function curl_setopt expects array|string, int given.',
 				31,
 			],
 			[
+				'Parameter #3 $value of function curl_setopt expects non-empty-string, \'\' given.',
+				33,
+			],
+			[
 				'Parameter #3 $value of function curl_setopt expects non-empty-string|null, \'\' given.',
-				32,
+				34,
 			],
 			[
 				'Parameter #3 $value of function curl_setopt expects array<int, string>, array<string, string> given.',
-				75,
+				77,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1354,7 +1354,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 			],
 			[
 				'Parameter #3 $value of function curl_setopt expects array<int, string>, array<string, string> given.',
-				73,
+				75,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -16,6 +16,8 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_URL, $i);
 		curl_setopt($curl, CURLOPT_HTTPHEADER, $i);
 		curl_setopt($curl, CURLOPT_ABSTRACT_UNIX_SOCKET, null);
+		curl_setopt($curl, CURLOPT_ENCODING, $i);
+		curl_setopt($curl, CURLOPT_ACCEPT_ENCODING, $i);
 		// expecting bool
 		curl_setopt($curl, CURLOPT_AUTOREFERER, $i);
 		curl_setopt($curl, CURLOPT_RETURNTRANSFER, $s);

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -62,6 +62,8 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_PRE_PROXY, '');
 		curl_setopt($curl, CURLOPT_PROXY, '');
 		curl_setopt($curl, CURLOPT_PRIVATE, '');
+		curl_setopt($curl, CURLOPT_ENCODING, '');
+		curl_setopt($curl, CURLOPT_ACCEPT_ENCODING, '');
 	}
 
 	public function bug9263() {


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/12171

```
> CURLOPT_ACCEPT_ENCODING === CURLOPT_ENCODING
= true
```