### PR TITLE
Implement ArrayColumnRule

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -5,6 +5,7 @@ parameters:
 		explicitMixedInUnknownGenericNew: true
 		explicitMixedForGlobalVariables: true
 		explicitMixedViaIsArray: true
+		arrayColumn: true
 		arrayFilter: true
 		arrayUnpacking: true
 		arrayValues: true

--- a/conf/config.level5.neon
+++ b/conf/config.level5.neon
@@ -6,6 +6,8 @@ parameters:
 	checkArgumentsPassedByReference: true
 
 conditionalTags:
+	PHPStan\Rules\Functions\ArrayColumnRule:
+		phpstan.rules.rule: %featureToggles.arrayColumn%
 	PHPStan\Rules\Functions\ArrayFilterRule:
 		phpstan.rules.rule: %featureToggles.arrayFilter%
 	PHPStan\Rules\Functions\ArrayValuesRule:
@@ -56,3 +58,9 @@ services:
 		class: PHPStan\Rules\Functions\ImplodeParameterCastableToStringRule
 	-
 		class: PHPStan\Rules\Functions\SortParameterCastableToStringRule
+
+	-
+		class: PHPStan\Rules\Functions\ArrayColumnRule
+		arguments:
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+			treatPhpDocTypesAsCertainTip: %tips.treatPhpDocTypesAsCertain%

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -39,6 +39,7 @@ parameters:
 		explicitMixedInUnknownGenericNew: false
 		explicitMixedForGlobalVariables: false
 		explicitMixedViaIsArray: false
+		arrayColumn: false
 		arrayFilter: false
 		arrayUnpacking: false
 		arrayValues: false
@@ -1191,6 +1192,9 @@ services:
 		class: PHPStan\Type\Php\ArrayColumnFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
+
+	-
+		class: PHPStan\Type\Php\ArrayColumnHelper
 
 	-
 		class: PHPStan\Type\Php\ArrayCombineFunctionReturnTypeExtension

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -34,6 +34,7 @@ parametersSchema:
 		explicitMixedInUnknownGenericNew: bool(),
 		explicitMixedForGlobalVariables: bool(),
 		explicitMixedViaIsArray: bool(),
+		arrayColumn: bool(),
 		arrayFilter: bool(),
 		arrayUnpacking: bool(),
 		arrayValues: bool(),

--- a/src/Rules/Functions/ArrayColumnRule.php
+++ b/src/Rules/Functions/ArrayColumnRule.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Php\ArrayColumnHelper;
+use PHPStan\Type\VerbosityLevel;
+use function count;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\FuncCall>
+ */
+final class ArrayColumnRule implements Rule
+{
+
+	public function __construct(
+		private readonly ReflectionProvider $reflectionProvider,
+		private readonly bool $treatPhpDocTypesAsCertain,
+		private readonly bool $treatPhpDocTypesAsCertainTip,
+		private readonly ArrayColumnHelper $arrayColumnHelper,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!($node->name instanceof Node\Name)) {
+			return [];
+		}
+
+		$args = $node->getArgs();
+		if (count($args) < 2) {
+			return [];
+		}
+
+		if (!$this->reflectionProvider->hasFunction($node->name, $scope)) {
+			return [];
+		}
+
+		$functionReflection = $this->reflectionProvider->getFunction($node->name, $scope);
+		if ($functionReflection->getName() !== 'array_column') {
+			return [];
+		}
+
+		$indexKeyType = null;
+		if ($this->treatPhpDocTypesAsCertain) {
+			$arrayType = $scope->getType($args[0]->value);
+			$columnKeyType = $scope->getType($args[1]->value);
+			if (count($args) >= 3) {
+				$indexKeyType = $scope->getType($args[2]->value);
+			}
+		} else {
+			$arrayType = $scope->getNativeType($args[0]->value);
+			$columnKeyType = $scope->getNativeType($args[1]->value);
+			if (count($args) >= 3) {
+				$indexKeyType = $scope->getNativeType($args[2]->value);
+			}
+		}
+
+		$errors = [];
+		if ($columnKeyType->isNull()->no()) {
+			[$returnValueType] = $this->arrayColumnHelper->getReturnValueType($arrayType, $columnKeyType, $scope);
+			if ($returnValueType instanceof NeverType) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf(
+					'Cannot access column %s on %s.',
+					$columnKeyType->describe(VerbosityLevel::value()),
+					$arrayType->getIterableValueType()->describe(VerbosityLevel::value()),
+				))->identifier('arrayColumn.column');
+
+				if ($this->treatPhpDocTypesAsCertainTip) {
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
+				}
+
+				$errors[] = $errorBuilder->build();
+			}
+		}
+
+		if ($indexKeyType !== null && $indexKeyType->isNull()->no()) {
+			$returnIndexType = $this->arrayColumnHelper->getReturnIndexType($arrayType, $indexKeyType, $scope);
+			if ($returnIndexType instanceof NeverType) {
+				$errorBuilder = RuleErrorBuilder::message(sprintf(
+					'Cannot access column %s on %s.',
+					$indexKeyType->describe(VerbosityLevel::value()),
+					$arrayType->getIterableValueType()->describe(VerbosityLevel::value()),
+				))->identifier('arrayColumn.index');
+
+				if ($this->treatPhpDocTypesAsCertainTip) {
+					$errorBuilder->treatPhpDocTypesAsCertainTip();
+				}
+
+				$errors[] = $errorBuilder->build();
+			}
+		}
+
+		return $errors;
+	}
+
+}

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -4,27 +4,17 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\ShouldNotHappenException;
-use PHPStan\TrinaryLogic;
-use PHPStan\Type\Accessory\AccessoryArrayListType;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\IntegerType;
-use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use function count;
 
 final class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 
-	public function __construct(private PhpVersion $phpVersion)
+	public function __construct(
+		private ArrayColumnHelper $arrayColumnHelper,
+	)
 	{
 	}
 
@@ -46,167 +36,13 @@ final class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionRet
 
 		$constantArrayTypes = $arrayType->getConstantArrays();
 		if (count($constantArrayTypes) === 1) {
-			$type = $this->handleConstantArray($constantArrayTypes[0], $columnType, $indexType, $scope);
+			$type = $this->arrayColumnHelper->handleConstantArray($constantArrayTypes[0], $columnType, $indexType, $scope);
 			if ($type !== null) {
 				return $type;
 			}
 		}
 
-		return $this->handleAnyArray($arrayType, $columnType, $indexType, $scope);
-	}
-
-	private function handleAnyArray(Type $arrayType, Type $columnType, ?Type $indexType, Scope $scope): Type
-	{
-		$iterableAtLeastOnce = $arrayType->isIterableAtLeastOnce();
-		if ($iterableAtLeastOnce->no()) {
-			return new ConstantArrayType([], []);
-		}
-
-		$iterableValueType = $arrayType->getIterableValueType();
-		$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
-
-		if ($returnValueType === null) {
-			$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, true);
-			$iterableAtLeastOnce = TrinaryLogic::createMaybe();
-			if ($returnValueType === null) {
-				throw new ShouldNotHappenException();
-			}
-		}
-
-		if ($returnValueType instanceof NeverType) {
-			return new ConstantArrayType([], []);
-		}
-
-		if ($indexType !== null) {
-			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
-			if ($type !== null) {
-				$returnKeyType = $type;
-			} else {
-				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
-				if ($type !== null) {
-					$returnKeyType = TypeCombinator::union($type, new IntegerType());
-				} else {
-					$returnKeyType = new IntegerType();
-				}
-			}
-		} else {
-			$returnKeyType = new IntegerType();
-		}
-
-		$returnType = new ArrayType($this->castToArrayKeyType($returnKeyType), $returnValueType);
-
-		if ($iterableAtLeastOnce->yes()) {
-			$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
-		}
-		if ($indexType === null) {
-			$returnType = AccessoryArrayListType::intersectWith($returnType);
-		}
-
-		return $returnType;
-	}
-
-	private function handleConstantArray(ConstantArrayType $arrayType, Type $columnType, ?Type $indexType, Scope $scope): ?Type
-	{
-		$builder = ConstantArrayTypeBuilder::createEmpty();
-
-		foreach ($arrayType->getValueTypes() as $i => $iterableValueType) {
-			$valueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
-			if ($valueType === null) {
-				return null;
-			}
-			if ($valueType instanceof NeverType) {
-				continue;
-			}
-
-			if ($indexType !== null) {
-				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
-				if ($type !== null) {
-					$keyType = $type;
-				} else {
-					$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
-					if ($type !== null) {
-						$keyType = TypeCombinator::union($type, new IntegerType());
-					} else {
-						$keyType = null;
-					}
-				}
-			} else {
-				$keyType = null;
-			}
-
-			if ($keyType !== null) {
-				$keyType = $this->castToArrayKeyType($keyType);
-			}
-			$builder->setOffsetValueType($keyType, $valueType, $arrayType->isOptionalKey($i));
-		}
-
-		return $builder->getArray();
-	}
-
-	private function getOffsetOrProperty(Type $type, Type $offsetOrProperty, Scope $scope, bool $allowMaybe): ?Type
-	{
-		$offsetIsNull = $offsetOrProperty->isNull();
-		if ($offsetIsNull->yes()) {
-			return $type;
-		}
-
-		$returnTypes = [];
-
-		if ($offsetIsNull->maybe()) {
-			$returnTypes[] = $type;
-		}
-
-		if (!$type->canAccessProperties()->no()) {
-			$propertyTypes = $offsetOrProperty->getConstantStrings();
-			if ($propertyTypes === []) {
-				return new MixedType();
-			}
-			foreach ($propertyTypes as $propertyType) {
-				$propertyName = $propertyType->getValue();
-				$hasProperty = $type->hasProperty($propertyName);
-				if ($hasProperty->maybe()) {
-					return $allowMaybe ? new MixedType() : null;
-				}
-				if (!$hasProperty->yes()) {
-					continue;
-				}
-
-				$returnTypes[] = $type->getProperty($propertyName, $scope)->getReadableType();
-			}
-		}
-
-		if ($type->isOffsetAccessible()->yes()) {
-			$hasOffset = $type->hasOffsetValueType($offsetOrProperty);
-			if (!$allowMaybe && $hasOffset->maybe()) {
-				return null;
-			}
-			if (!$hasOffset->no()) {
-				$returnTypes[] = $type->getOffsetValueType($offsetOrProperty);
-			}
-		}
-
-		if ($returnTypes === []) {
-			return new NeverType();
-		}
-
-		return TypeCombinator::union(...$returnTypes);
-	}
-
-	private function castToArrayKeyType(Type $type): Type
-	{
-		$isArray = $type->isArray();
-		if ($isArray->yes()) {
-			return $this->phpVersion->throwsTypeErrorForInternalFunctions() ? new NeverType() : new IntegerType();
-		}
-		if ($isArray->no()) {
-			return $type->toArrayKey();
-		}
-		$withoutArrayType = TypeCombinator::remove($type, new ArrayType(new MixedType(), new MixedType()));
-		$keyType = $withoutArrayType->toArrayKey();
-		if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
-			return $keyType;
-		}
-		return TypeCombinator::union($keyType, new IntegerType());
+		return $this->arrayColumnHelper->handleAnyArray($arrayType, $columnType, $indexType, $scope);
 	}
 
 }

--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -50,6 +50,27 @@ final class ArrayColumnHelper
 		return [$returnValueType, $iterableAtLeastOnce];
 	}
 
+	public function getReturnIndexType(Type $arrayType, ?Type $indexType, Scope $scope): Type
+	{
+		if ($indexType !== null) {
+			$iterableValueType = $arrayType->getIterableValueType();
+
+			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
+			if ($type !== null) {
+				return $type;
+			}
+
+			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
+			if ($type !== null) {
+				return TypeCombinator::union($type, new IntegerType());
+			}
+
+			return new IntegerType();
+		}
+
+		return new IntegerType();
+	}
+
 	public function handleAnyArray(Type $arrayType, Type $columnType, ?Type $indexType, Scope $scope): Type
 	{
 		[$returnValueType, $iterableAtLeastOnce] = $this->getReturnValueType($arrayType, $columnType, $scope);
@@ -57,24 +78,7 @@ final class ArrayColumnHelper
 			return new ConstantArrayType([], []);
 		}
 
-		if ($indexType !== null) {
-			$iterableValueType = $arrayType->getIterableValueType();
-
-			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
-			if ($type !== null) {
-				$returnKeyType = $type;
-			} else {
-				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
-				if ($type !== null) {
-					$returnKeyType = TypeCombinator::union($type, new IntegerType());
-				} else {
-					$returnKeyType = new IntegerType();
-				}
-			}
-		} else {
-			$returnKeyType = new IntegerType();
-		}
-
+		$returnKeyType = $this->getReturnIndexType($arrayType, $indexType, $scope);
 		$returnType = new ArrayType($this->castToArrayKeyType($returnKeyType), $returnValueType);
 
 		if ($iterableAtLeastOnce->yes()) {

--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -26,11 +26,14 @@ final class ArrayColumnHelper
 	{
 	}
 
-	public function handleAnyArray(Type $arrayType, Type $columnType, ?Type $indexType, Scope $scope): Type
+	/**
+	 * @return array{Type, TrinaryLogic}
+	 */
+	public function getReturnValueType(Type $arrayType, Type $columnType, Scope $scope): array
 	{
 		$iterableAtLeastOnce = $arrayType->isIterableAtLeastOnce();
 		if ($iterableAtLeastOnce->no()) {
-			return new ConstantArrayType([], []);
+			return [new NeverType(), $iterableAtLeastOnce];
 		}
 
 		$iterableValueType = $arrayType->getIterableValueType();
@@ -44,11 +47,19 @@ final class ArrayColumnHelper
 			}
 		}
 
+		return [$returnValueType, $iterableAtLeastOnce];
+	}
+
+	public function handleAnyArray(Type $arrayType, Type $columnType, ?Type $indexType, Scope $scope): Type
+	{
+		[$returnValueType, $iterableAtLeastOnce] = $this->getReturnValueType($arrayType, $columnType, $scope);
 		if ($returnValueType instanceof NeverType) {
 			return new ConstantArrayType([], []);
 		}
 
 		if ($indexType !== null) {
+			$iterableValueType = $arrayType->getIterableValueType();
+
 			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
 			if ($type !== null) {
 				$returnKeyType = $type;

--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -1,0 +1,183 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class ArrayColumnHelper
+{
+
+	public function __construct(
+		private PhpVersion $phpVersion,
+	)
+	{
+	}
+
+	public function handleAnyArray(Type $arrayType, Type $columnType, ?Type $indexType, Scope $scope): Type
+	{
+		$iterableAtLeastOnce = $arrayType->isIterableAtLeastOnce();
+		if ($iterableAtLeastOnce->no()) {
+			return new ConstantArrayType([], []);
+		}
+
+		$iterableValueType = $arrayType->getIterableValueType();
+		$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
+
+		if ($returnValueType === null) {
+			$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, true);
+			$iterableAtLeastOnce = TrinaryLogic::createMaybe();
+			if ($returnValueType === null) {
+				throw new ShouldNotHappenException();
+			}
+		}
+
+		if ($returnValueType instanceof NeverType) {
+			return new ConstantArrayType([], []);
+		}
+
+		if ($indexType !== null) {
+			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
+			if ($type !== null) {
+				$returnKeyType = $type;
+			} else {
+				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
+				if ($type !== null) {
+					$returnKeyType = TypeCombinator::union($type, new IntegerType());
+				} else {
+					$returnKeyType = new IntegerType();
+				}
+			}
+		} else {
+			$returnKeyType = new IntegerType();
+		}
+
+		$returnType = new ArrayType($this->castToArrayKeyType($returnKeyType), $returnValueType);
+
+		if ($iterableAtLeastOnce->yes()) {
+			$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
+		}
+		if ($indexType === null) {
+			$returnType = AccessoryArrayListType::intersectWith($returnType);
+		}
+
+		return $returnType;
+	}
+
+	public function handleConstantArray(ConstantArrayType $arrayType, Type $columnType, ?Type $indexType, Scope $scope): ?Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+
+		foreach ($arrayType->getValueTypes() as $i => $iterableValueType) {
+			$valueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
+			if ($valueType === null) {
+				return null;
+			}
+			if ($valueType instanceof NeverType) {
+				continue;
+			}
+
+			if ($indexType !== null) {
+				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
+				if ($type !== null) {
+					$keyType = $type;
+				} else {
+					$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
+					if ($type !== null) {
+						$keyType = TypeCombinator::union($type, new IntegerType());
+					} else {
+						$keyType = null;
+					}
+				}
+			} else {
+				$keyType = null;
+			}
+
+			if ($keyType !== null) {
+				$keyType = $this->castToArrayKeyType($keyType);
+			}
+			$builder->setOffsetValueType($keyType, $valueType, $arrayType->isOptionalKey($i));
+		}
+
+		return $builder->getArray();
+	}
+
+	private function getOffsetOrProperty(Type $type, Type $offsetOrProperty, Scope $scope, bool $allowMaybe): ?Type
+	{
+		$offsetIsNull = $offsetOrProperty->isNull();
+		if ($offsetIsNull->yes()) {
+			return $type;
+		}
+
+		$returnTypes = [];
+
+		if ($offsetIsNull->maybe()) {
+			$returnTypes[] = $type;
+		}
+
+		if (!$type->canAccessProperties()->no()) {
+			$propertyTypes = $offsetOrProperty->getConstantStrings();
+			if ($propertyTypes === []) {
+				return new MixedType();
+			}
+			foreach ($propertyTypes as $propertyType) {
+				$propertyName = $propertyType->getValue();
+				$hasProperty = $type->hasProperty($propertyName);
+				if ($hasProperty->maybe()) {
+					return $allowMaybe ? new MixedType() : null;
+				}
+				if (!$hasProperty->yes()) {
+					continue;
+				}
+
+				$returnTypes[] = $type->getProperty($propertyName, $scope)->getReadableType();
+			}
+		}
+
+		if ($type->isOffsetAccessible()->yes()) {
+			$hasOffset = $type->hasOffsetValueType($offsetOrProperty);
+			if (!$allowMaybe && $hasOffset->maybe()) {
+				return null;
+			}
+			if (!$hasOffset->no()) {
+				$returnTypes[] = $type->getOffsetValueType($offsetOrProperty);
+			}
+		}
+
+		if ($returnTypes === []) {
+			return new NeverType();
+		}
+
+		return TypeCombinator::union(...$returnTypes);
+	}
+
+	private function castToArrayKeyType(Type $type): Type
+	{
+		$isArray = $type->isArray();
+		if ($isArray->yes()) {
+			return $this->phpVersion->throwsTypeErrorForInternalFunctions() ? new NeverType() : new IntegerType();
+		}
+		if ($isArray->no()) {
+			return $type->toArrayKey();
+		}
+		$withoutArrayType = TypeCombinator::remove($type, new ArrayType(new MixedType(), new MixedType()));
+		$keyType = $withoutArrayType->toArrayKey();
+		if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
+			return $keyType;
+		}
+		return TypeCombinator::union($keyType, new IntegerType());
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/ArrayColumnRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrayColumnRuleTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Php\ArrayColumnHelper;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<ArrayColumnRule>
+ */
+class ArrayColumnRuleTest extends RuleTestCase
+{
+
+	private bool $treatPhpDocTypesAsCertain = true;
+
+	protected function getRule(): Rule
+	{
+		return new ArrayColumnRule(
+			$this->createReflectionProvider(),
+			$this->treatPhpDocTypesAsCertain,
+			true,
+			self::getContainer()->getByType(ArrayColumnHelper::class),
+		);
+	}
+
+	public function testFile(): void
+	{
+		$expectedErrors = [];
+
+		$this->analyse([__DIR__ . '/../../Analyser/nsrt/array-column-php7.php'], $expectedErrors);
+	}
+
+	public function testFilePhp82(): void
+	{
+		if (PHP_VERSION_ID < 80200) {
+			$this->markTestSkipped('Test requires PHP 8.2');
+		}
+
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$expectedErrors = [
+			[
+				"Cannot access column 'column' on *NEVER*.",
+				30,
+				$tipText,
+			],
+			[
+				"Cannot access column 'column' on *NEVER*.",
+				31,
+				$tipText,
+			],
+			[
+				"Cannot access column 'key' on *NEVER*.",
+				31,
+				$tipText,
+			],
+			[
+				"Cannot access column 'key' on *NEVER*.",
+				32,
+				$tipText,
+			],
+			[
+				"Cannot access column 'foo' on array{column: string, key: string}.",
+				76,
+				$tipText,
+			],
+			[
+				"Cannot access column 'foo' on array{column: string, key: string}.",
+				77,
+				$tipText,
+			],
+			[
+				"Cannot access column 'nodeName' on ArrayColumn82\Foo.",
+				216,
+				$tipText,
+			],
+			[
+				"Cannot access column 'nodeName' on ArrayColumn82\Foo.",
+				217,
+				$tipText,
+			],
+			[
+				"Cannot access column 'tagName' on ArrayColumn82\Foo.",
+				217,
+				$tipText,
+			],
+		];
+
+		$this->analyse([__DIR__ . '/../../Analyser/nsrt/array-column-php82.php'], $expectedErrors);
+	}
+
+	public function testBug5101(): void
+	{
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+
+		// in PHP < 8.2 dynamic properties can exist any time
+		$expectedErrors = [];
+		if (PHP_VERSION_ID >= 80200) {
+			$expectedErrors = [
+				[
+					"Cannot access column 'y' on Bug5101\FinalFooBar.",
+					22,
+					$tipText,
+				],
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-5101.php'], $expectedErrors);
+	}
+
+	public function testBug12188(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1');
+		}
+
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$expectedErrors = [
+			[
+				"Cannot access column 'value' on Bug12188\Foo::A|Bug12188\Foo::B.",
+				14,
+				$tipText,
+			],
+		];
+
+		$this->analyse([__DIR__ . '/data/bug-12188.php'], $expectedErrors);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-12188.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-12188.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug12188;
+
+enum Foo
+{
+	case A;
+	case B;
+}
+
+function doFoo() {
+	$arr = [Foo::A, Foo::B];
+
+	var_dump(array_column($arr, 'value'));
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-5101.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-5101.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1); // lint >= 7.4
+
+namespace Bug5101;
+
+class FooBar
+{
+	public $x;
+}
+
+final class FinalFooBar
+{
+	public $x;
+}
+
+/** @param array<FooBar> $arrClass */
+function doFoo(array $arrClass) {
+	$arrFinalClass = [new FinalFooBar()];
+
+	var_dump(array_column($arrClass, 'x'));
+	var_dump(array_column($arrClass, 'y'));
+	var_dump(array_column($arrFinalClass, 'x'));
+	var_dump(array_column($arrFinalClass, 'y'));
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/5101
closes https://github.com/phpstan/phpstan/issues/12188

ArrayColumnRule re-uses the logic from the `array_column` return type extension and reports problems when the logic implies the result will be a never-type.

there are more open problems with `array_column` and I would approach those after this PR got merged