### PR TITLE
Narrow explode return to constant arrays for small positive limits

### DIFF
--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -11,7 +11,9 @@ use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerRangeType;
@@ -24,9 +26,12 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function count;
+use const PHP_INT_MAX;
 
 final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	private const CONST_ARRAY_LIMIT = 8;
 
 	public function __construct(private PhpVersion $phpVersion)
 	{
@@ -73,11 +78,21 @@ final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunction
 		}
 
 		$returnType = TypeCombinator::intersect(new ArrayType(new IntegerType(), $returnValueType), new AccessoryArrayListType());
-		if (
-			!isset($args[2])
-			|| IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($scope->getType($args[2]->value))->yes()
-		) {
-			$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
+		$limitType = isset($args[2]) ? $scope->getType($args[2]->value) : new ConstantIntegerType(PHP_INT_MAX);
+		if (IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($limitType)->yes()) {
+			$constantScalarTypes = $limitType->getConstantScalarTypes();
+			if (count($constantScalarTypes) === 1 && IntegerRangeType::fromInterval(0, self::CONST_ARRAY_LIMIT)->isSuperTypeOf($limitType)->yes()) {
+				$limit = (int) $constantScalarTypes[0]->getValue() ?: 1; // 0 is treated as 1
+
+				$builder = ConstantArrayTypeBuilder::createEmpty();
+				for ($i = 0; $i < $limit; $i++) {
+					$builder->setOffsetValueType(null, $returnValueType, $i !== 0);
+				}
+
+				$returnType = $builder->getArray();
+			} else {
+				$returnType = TypeCombinator::intersect($returnType, new NonEmptyArrayType());
+			}
 		}
 
 		if (!$this->phpVersion->throwsValueErrorForInternalFunctions() && $isEmptyString->maybe()) {

--- a/tests/PHPStan/Analyser/nsrt/bug-3961-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3961-php8.php
@@ -12,8 +12,8 @@ class Foo
 		assertType('non-empty-list<string>', explode('.', $v));
 		assertType('*NEVER*', explode('', $v));
 		assertType('list<string>', explode('.', $v, -2));
-		assertType('non-empty-list<string>', explode('.', $v, 0));
-		assertType('non-empty-list<string>', explode('.', $v, 1));
+		assertType('array{string}', explode('.', $v, 0));
+		assertType('array{string}', explode('.', $v, 1));
 		assertType('non-empty-list<string>', explode($d, $v));
 		assertType('non-empty-list<string>', explode($m, $v));
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-3961.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3961.php
@@ -12,8 +12,8 @@ class Foo
 		assertType('non-empty-list<string>', explode('.', $v));
 		assertType('false', explode('', $v));
 		assertType('list<string>', explode('.', $v, -2));
-		assertType('non-empty-list<string>', explode('.', $v, 0));
-		assertType('non-empty-list<string>', explode('.', $v, 1));
+		assertType('array{string}', explode('.', $v, 0));
+		assertType('array{string}', explode('.', $v, 1));
 		assertType('non-empty-list<string>|false', explode($d, $v));
 		assertType('(non-empty-list<string>|false)', explode($m, $v));
 	}

--- a/tests/PHPStan/Analyser/nsrt/explode-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/explode-php7.php
@@ -1,0 +1,34 @@
+<?php // lint < 8.0
+
+namespace ExplodePhp7;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param non-empty-string $nonEmptyString
+	 */
+	public function constantArrays(string $string, string $nonEmptyString): void
+	{
+		$strings = explode(',', $string, 0);
+		assertType('array{string}', $strings);
+
+		$strings = explode(',', $string, 2);
+		assertType('array{0: string, 1?: string}', $strings);
+
+		$strings = explode(rand(0, 1) ? '' : ',', $string, 2);
+		assertType('array{0: string, 1?: string}|false', $strings);
+
+		$strings = explode(',', $string, 16);
+		assertType('non-empty-list<string>', $strings);
+
+		$strings = explode(',', $nonEmptyString, 2);
+		assertType('array{0: string, 1?: string}', $strings);
+
+		$strings = explode(',', $nonEmptyString, 16);
+		assertType('non-empty-list<string>', $strings);
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/explode-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/explode-php8.php
@@ -1,0 +1,34 @@
+<?php // lint >= 8.0
+
+namespace ExplodePhp8;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param non-empty-string $nonEmptyString
+	 */
+	public function constantArrays(string $string, string $nonEmptyString): void
+	{
+		$strings = explode(',', $string, 0);
+		assertType('array{string}', $strings);
+
+		$strings = explode(',', $string, 2);
+		assertType('array{0: string, 1?: string}', $strings);
+
+		$strings = explode(rand(0, 1) ? '' : ',', $string, 2);
+		assertType('array{0: string, 1?: string}', $strings);
+
+		$strings = explode(',', $string, 16);
+		assertType('non-empty-list<string>', $strings);
+
+		$strings = explode(',', $nonEmptyString, 2);
+		assertType('array{0: string, 1?: string}', $strings);
+
+		$strings = explode(',', $nonEmptyString, 16);
+		assertType('non-empty-list<string>', $strings);
+	}
+
+}


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan/discussions/12187

kept this simple and only handle a single constant limit on purpose for now

Needs https://github.com/phpstan/phpstan-src/pull/3709 first