### PR TITLE
Improve `count()` narrowing of constant arrays

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1071,10 +1071,10 @@ final class TypeSpecifier
 			}
 
 			$isSizeSuperTypeOfArraySize = $sizeType->isSuperTypeOf($type->getArraySize());
-			if ($context->truthy() && $isSizeSuperTypeOfArraySize->no()) {
+			if ($isSizeSuperTypeOfArraySize->no()) {
 				return new NeverType();
 			}
-			if ($context->falsey() && !$isSizeSuperTypeOfArraySize->yes()) {
+			if ($context->falsey() && $isSizeSuperTypeOfArraySize->maybe()) {
 				return new NeverType();
 			}
 
@@ -1123,10 +1123,10 @@ final class TypeSpecifier
 					return $valueTypesBuilder->getArray();
 				}
 
-				return $type;
+				return $context->truthy() ? $type : new NeverType();
 			}
 
-			return TypeCombinator::intersect($type, new NonEmptyArrayType());
+			return $context->truthy() ? TypeCombinator::intersect($type, new NonEmptyArrayType()) : new NeverType();
 		});
 
 		return $this->create($countFuncCall->getArgs()[0]->value, $resultType, $context, $scope)->setRootExpr($rootExpr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -272,7 +272,6 @@ final class TypeSpecifier
 			) {
 				$argType = $scope->getType($expr->right->getArgs()[0]->value);
 
-				$sizeType = null;
 				if ($leftType instanceof ConstantIntegerType) {
 					if ($orEqual) {
 						$sizeType = IntegerRangeType::createAllGreaterThanOrEqualTo($leftType->getValue());
@@ -281,6 +280,8 @@ final class TypeSpecifier
 					}
 				} elseif ($leftType instanceof IntegerRangeType) {
 					$sizeType = $leftType->shift($offset);
+				} else {
+					$sizeType = $leftType;
 				}
 
 				$specifiedTypes = $this->specifyTypesForCountFuncCall($expr->right, $argType, $sizeType, $context, $scope, $expr);
@@ -1044,103 +1045,91 @@ final class TypeSpecifier
 		return (new SpecifiedTypes([], []))->setRootExpr($expr);
 	}
 
-	private function specifyTypesForCountFuncCall(FuncCall $countFuncCall, Type $type, ?Type $sizeType, TypeSpecifierContext $context, Scope $scope, ?Expr $rootExpr): ?SpecifiedTypes
+	private function specifyTypesForCountFuncCall(
+		FuncCall $countFuncCall,
+		Type $type,
+		Type $sizeType,
+		TypeSpecifierContext $context,
+		Scope $scope,
+		Expr $rootExpr,
+	): ?SpecifiedTypes
 	{
-		if ($sizeType === null) {
+		if (count($countFuncCall->getArgs()) === 1) {
+			$isNormalCount = TrinaryLogic::createYes();
+		} else {
+			$mode = $scope->getType($countFuncCall->getArgs()[1]->value);
+			$isNormalCount = (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($type->getIterableValueType()->isArray()->negate());
+		}
+
+		if (!$isNormalCount->yes() || (!$type->isConstantArray()->yes() && !$type->isList()->yes())) {
 			return null;
 		}
 
-		if (
-			$this->isFuncCallWithNormalCount($countFuncCall, $scope)->yes()
-			&& $type->isConstantArray()->yes()
-		) {
-			$resultType = TypeTraverser::map($type, function (Type $type, callable $traverse) use ($sizeType, $context) {
-				if ($type instanceof UnionType) {
-					return $traverse($type);
-				}
-
-				$arraySize = $type->getArraySize();
-				$isSize = $sizeType->isSuperTypeOf($arraySize);
-				if ($context->truthy() && $isSize->no()) {
-					return new NeverType();
-				}
-				if ($context->falsey() && !$isSize->yes()) {
-					return new NeverType();
-				}
-
-				return $this->turnListIntoConstantArray($type, $sizeType) ?? $type;
-			});
-
-			return $this->create($countFuncCall->getArgs()[0]->value, $resultType, $context, $scope)->setRootExpr($rootExpr);
-		}
-
-		return null;
-	}
-
-	private function turnListIntoConstantArray(Type $type, Type $sizeType): ?Type
-	{
-		if (
-			$type->isList()->yes()
-			&& $sizeType instanceof ConstantIntegerType
-			&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
-		) {
-			// turn optional offsets non-optional
-			$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
-			for ($i = 0; $i < $sizeType->getValue(); $i++) {
-				$offsetType = new ConstantIntegerType($i);
-				$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
+		$resultType = TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($sizeType, $context) {
+			if ($type instanceof UnionType) {
+				return $traverse($type);
 			}
-			return $valueTypesBuilder->getArray();
-		}
 
-		if (
-			$type->isList()->yes()
-			&& $sizeType instanceof IntegerRangeType
-			&& $sizeType->getMin() !== null
-		) {
-			// turn optional offsets non-optional
-			$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
-			for ($i = 0; $i < $sizeType->getMin(); $i++) {
-				$offsetType = new ConstantIntegerType($i);
-				$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
+			$isSizeSuperTypeOfArraySize = $sizeType->isSuperTypeOf($type->getArraySize());
+			if ($context->truthy() && $isSizeSuperTypeOfArraySize->no()) {
+				return new NeverType();
 			}
-			if ($sizeType->getMax() !== null) {
-				for ($i = $sizeType->getMin(); $i < $sizeType->getMax(); $i++) {
-					$offsetType = new ConstantIntegerType($i);
-					$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType), true);
-				}
-			} elseif ($type->isConstantArray()->yes()) {
-				for ($i = $sizeType->getMin();; $i++) {
-					$offsetType = new ConstantIntegerType($i);
-					$hasOffset = $type->hasOffsetValueType($offsetType);
-					if ($hasOffset->no()) {
-						break;
+			if ($context->falsey() && !$isSizeSuperTypeOfArraySize->yes()) {
+				return new NeverType();
+			}
+
+			if ($type->isList()->yes()) {
+				if (
+					$sizeType instanceof ConstantIntegerType
+					&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
+				) {
+					// turn optional offsets non-optional
+					$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
+					for ($i = 0; $i < $sizeType->getValue(); $i++) {
+						$offsetType = new ConstantIntegerType($i);
+						$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
 					}
-					$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType), !$hasOffset->yes());
+					return $valueTypesBuilder->getArray();
 				}
-			} else {
-				return null;
+
+				if (
+					$sizeType instanceof IntegerRangeType
+					&& $sizeType->getMin() !== null
+				) {
+					// turn optional offsets non-optional
+					$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
+					for ($i = 0; $i < $sizeType->getMin(); $i++) {
+						$offsetType = new ConstantIntegerType($i);
+						$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
+					}
+					if ($sizeType->getMax() !== null) {
+						for ($i = $sizeType->getMin(); $i < $sizeType->getMax(); $i++) {
+							$offsetType = new ConstantIntegerType($i);
+							$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType), true);
+						}
+					} elseif ($type->isConstantArray()->yes()) {
+						for ($i = $sizeType->getMin();; $i++) {
+							$offsetType = new ConstantIntegerType($i);
+							$hasOffset = $type->hasOffsetValueType($offsetType);
+							if ($hasOffset->no()) {
+								break;
+							}
+							$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType), !$hasOffset->yes());
+						}
+					} else {
+						return TypeCombinator::intersect($type, new NonEmptyArrayType());
+					}
+
+					return $valueTypesBuilder->getArray();
+				}
+
+				return $type;
 			}
 
-			$arrayType = $valueTypesBuilder->getArray();
-			if ($arrayType->isIterableAtLeastOnce()->yes()) {
-				return $arrayType;
-			}
-		}
+			return TypeCombinator::intersect($type, new NonEmptyArrayType());
+		});
 
-		return null;
-	}
-
-	private function isFuncCallWithNormalCount(FuncCall $countFuncCall, Scope $scope): TrinaryLogic
-	{
-		$argType = $scope->getType($countFuncCall->getArgs()[0]->value);
-
-		if (count($countFuncCall->getArgs()) === 1) {
-			return TrinaryLogic::createYes();
-		}
-		$mode = $scope->getType($countFuncCall->getArgs()[1]->value);
-
-		return (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($argType->getIterableValueType()->isArray()->negate());
+		return $this->create($countFuncCall->getArgs()[0]->value, $resultType, $context, $scope)->setRootExpr($rootExpr);
 	}
 
 	private function specifyTypesForConstantBinaryExpression(
@@ -2177,30 +2166,15 @@ final class TypeSpecifier
 				return $specifiedTypes;
 			}
 
-			if ($context->truthy()) {
-				if ($argType->isArray()->yes()) {
-					if (
-						$argType->isConstantArray()->yes()
-						&& $rightType->isSuperTypeOf($argType->getArraySize())->no()
-					) {
-						return $this->create($unwrappedLeftExpr->getArgs()[0]->value, new NeverType(), $context, $scope)->setRootExpr($expr);
-					}
-
-					$funcTypes = $this->create($unwrappedLeftExpr, $rightType, $context, $scope)->setRootExpr($expr);
-					$isNormalCount = $this->isFuncCallWithNormalCount($unwrappedLeftExpr, $scope);
-					$constArray = $isNormalCount->yes() ? $this->turnListIntoConstantArray($argType, $rightType) : null;
-					if ($constArray !== null) {
-						return $funcTypes->unionWith(
-							$this->create($unwrappedLeftExpr->getArgs()[0]->value, $constArray, $context, $scope)->setRootExpr($expr),
-						);
-					} elseif (IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($rightType)->yes()) {
-						return $funcTypes->unionWith(
-							$this->create($unwrappedLeftExpr->getArgs()[0]->value, new NonEmptyArrayType(), $context, $scope)->setRootExpr($expr),
-						);
-					}
-
-					return $funcTypes;
+			if ($context->truthy() && $argType->isArray()->yes()) {
+				$funcTypes = $this->create($unwrappedLeftExpr, $rightType, $context, $scope)->setRootExpr($expr);
+				if (IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($rightType)->yes()) {
+					return $funcTypes->unionWith(
+						$this->create($unwrappedLeftExpr->getArgs()[0]->value, new NonEmptyArrayType(), $context, $scope)->setRootExpr($expr),
+					);
 				}
+
+				return $funcTypes;
 			}
 		}
 

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -272,22 +272,20 @@ final class TypeSpecifier
 			) {
 				$argType = $scope->getType($expr->right->getArgs()[0]->value);
 
-				if ($argType instanceof UnionType) {
-					$sizeType = null;
-					if ($leftType instanceof ConstantIntegerType) {
-						if ($orEqual) {
-							$sizeType = IntegerRangeType::createAllGreaterThanOrEqualTo($leftType->getValue());
-						} else {
-							$sizeType = IntegerRangeType::createAllGreaterThan($leftType->getValue());
-						}
-					} elseif ($leftType instanceof IntegerRangeType) {
-						$sizeType = $leftType;
+				$sizeType = null;
+				if ($leftType instanceof ConstantIntegerType) {
+					if ($orEqual) {
+						$sizeType = IntegerRangeType::createAllGreaterThanOrEqualTo($leftType->getValue());
+					} else {
+						$sizeType = IntegerRangeType::createAllGreaterThan($leftType->getValue());
 					}
+				} elseif ($leftType instanceof IntegerRangeType) {
+					$sizeType = $leftType;
+				}
 
-					$narrowed = $this->narrowUnionByArraySize($expr->right, $argType, $sizeType, $context, $scope, $expr);
-					if ($narrowed !== null) {
-						return $narrowed;
-					}
+				$specifiedTypes = $this->specifyTypesForCountFuncCall($expr->right, $argType, $sizeType, $context, $scope, $expr);
+				if ($specifiedTypes !== null) {
+					$result = $result->unionWith($specifiedTypes);
 				}
 
 				if (
@@ -1046,66 +1044,52 @@ final class TypeSpecifier
 		return (new SpecifiedTypes([], []))->setRootExpr($expr);
 	}
 
-	private function narrowUnionByArraySize(FuncCall $countFuncCall, UnionType $argType, ?Type $sizeType, TypeSpecifierContext $context, Scope $scope, ?Expr $rootExpr): ?SpecifiedTypes
+	private function specifyTypesForCountFuncCall(FuncCall $countFuncCall, Type $type, ?Type $sizeType, TypeSpecifierContext $context, Scope $scope, ?Expr $rootExpr): ?SpecifiedTypes
 	{
 		if ($sizeType === null) {
 			return null;
 		}
 
-		if (count($countFuncCall->getArgs()) === 1) {
-			$isNormalCount = TrinaryLogic::createYes();
-		} else {
-			$mode = $scope->getType($countFuncCall->getArgs()[1]->value);
-			$isNormalCount = (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($argType->getIterableValueType()->isArray()->negate());
-		}
-
 		if (
-			$isNormalCount->yes()
-			&& $argType->isConstantArray()->yes()
+			$this->isFuncCallWithNormalCount($countFuncCall, $scope)->yes()
+			&& $type->isConstantArray()->yes()
 		) {
-			$result = [];
-			foreach ($argType->getTypes() as $innerType) {
-				$arraySize = $innerType->getArraySize();
+			$resultType = TypeTraverser::map($type, function (Type $type, callable $traverse) use ($sizeType, $context) {
+				if ($type instanceof UnionType) {
+					return $traverse($type);
+				}
+
+				$arraySize = $type->getArraySize();
 				$isSize = $sizeType->isSuperTypeOf($arraySize);
 				if ($context->truthy()) {
 					if ($isSize->no()) {
-						continue;
+						return new NeverType();
 					}
 
-					$constArray = $this->turnListIntoConstantArray($countFuncCall, $innerType, $sizeType, $scope);
+					$constArray = $this->turnListIntoConstantArray($type, $sizeType);
 					if ($constArray !== null) {
-						$innerType = $constArray;
+						$type = $constArray;
 					}
 				}
 				if ($context->falsey()) {
 					if (!$isSize->yes()) {
-						continue;
+						return new NeverType();
 					}
 				}
 
-				$result[] = $innerType;
-			}
+				return $type;
+			});
 
-			return $this->create($countFuncCall->getArgs()[0]->value, TypeCombinator::union(...$result), $context, $scope)->setRootExpr($rootExpr);
+			return $this->create($countFuncCall->getArgs()[0]->value, $resultType, $context, $scope)->setRootExpr($rootExpr);
 		}
 
 		return null;
 	}
 
-	private function turnListIntoConstantArray(FuncCall $countFuncCall, Type $type, Type $sizeType, Scope $scope): ?Type
+	private function turnListIntoConstantArray(Type $type, Type $sizeType): ?Type
 	{
-		$argType = $scope->getType($countFuncCall->getArgs()[0]->value);
-
-		if (count($countFuncCall->getArgs()) === 1) {
-			$isNormalCount = TrinaryLogic::createYes();
-		} else {
-			$mode = $scope->getType($countFuncCall->getArgs()[1]->value);
-			$isNormalCount = (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($argType->getIterableValueType()->isArray()->negate());
-		}
-
 		if (
-			$isNormalCount->yes()
-			&& $type->isList()->yes()
+			$type->isList()->yes()
 			&& $sizeType instanceof ConstantIntegerType
 			&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
 		) {
@@ -1119,8 +1103,7 @@ final class TypeSpecifier
 		}
 
 		if (
-			$isNormalCount->yes()
-			&& $type->isList()->yes()
+			$type->isList()->yes()
 			&& $sizeType instanceof IntegerRangeType
 			&& $sizeType->getMin() !== null
 		) {
@@ -1155,6 +1138,18 @@ final class TypeSpecifier
 		}
 
 		return null;
+	}
+
+	private function isFuncCallWithNormalCount(FuncCall $countFuncCall, Scope $scope): TrinaryLogic
+	{
+		$argType = $scope->getType($countFuncCall->getArgs()[0]->value);
+
+		if (count($countFuncCall->getArgs()) === 1) {
+			return TrinaryLogic::createYes();
+		}
+		$mode = $scope->getType($countFuncCall->getArgs()[1]->value);
+
+		return (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($argType->getIterableValueType()->isArray()->negate());
 	}
 
 	private function specifyTypesForConstantBinaryExpression(
@@ -2186,11 +2181,9 @@ final class TypeSpecifier
 				);
 			}
 
-			if ($argType instanceof UnionType) {
-				$narrowed = $this->narrowUnionByArraySize($unwrappedLeftExpr, $argType, $rightType, $context, $scope, $expr);
-				if ($narrowed !== null) {
-					return $narrowed;
-				}
+			$specifiedTypes = $this->specifyTypesForCountFuncCall($unwrappedLeftExpr, $argType, $rightType, $context, $scope, $expr);
+			if ($specifiedTypes !== null) {
+				return $specifiedTypes;
 			}
 
 			if ($context->truthy()) {
@@ -2203,7 +2196,8 @@ final class TypeSpecifier
 					}
 
 					$funcTypes = $this->create($unwrappedLeftExpr, $rightType, $context, $scope)->setRootExpr($expr);
-					$constArray = $this->turnListIntoConstantArray($unwrappedLeftExpr, $argType, $rightType, $scope);
+					$isNormalCount = $this->isFuncCallWithNormalCount($unwrappedLeftExpr, $scope);
+					$constArray = $isNormalCount->yes() ? $this->turnListIntoConstantArray($argType, $rightType) : null;
 					if ($constArray !== null) {
 						return $funcTypes->unionWith(
 							$this->create($unwrappedLeftExpr->getArgs()[0]->value, $constArray, $context, $scope)->setRootExpr($expr),

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1061,23 +1061,28 @@ final class TypeSpecifier
 			$isNormalCount = (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($type->getIterableValueType()->isArray()->negate());
 		}
 
-		if (!$isNormalCount->yes() || (!$type->isConstantArray()->yes() && !$type->isList()->yes())) {
+		$isList = $type->isList();
+		if (
+			!$isNormalCount->yes()
+			|| (!$type->isConstantArray()->yes() && !$isList->yes())
+			|| $type->isIterableAtLeastOnce()->no() // array{} cannot be used for further narrowing
+		) {
 			return null;
 		}
 
 		$resultTypes = [];
-		$innerTypes = $type instanceof UnionType ? $type->getTypes() : [$type];
-		foreach ($innerTypes as $innerType) {
-			$isSizeSuperTypeOfArraySize = $sizeType->isSuperTypeOf($innerType->getArraySize());
+		foreach ($type->getArrays() as $arrayType) {
+			$isSizeSuperTypeOfArraySize = $sizeType->isSuperTypeOf($arrayType->getArraySize());
 			if ($isSizeSuperTypeOfArraySize->no()) {
 				continue;
 			}
+
 			if ($context->falsey() && $isSizeSuperTypeOfArraySize->maybe()) {
 				continue;
 			}
 
 			if (
-				$innerType->isList()->yes()
+				$isList->yes()
 				&& $sizeType instanceof ConstantIntegerType
 				&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
 			) {
@@ -1085,14 +1090,14 @@ final class TypeSpecifier
 				$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
 				for ($i = 0; $i < $sizeType->getValue(); $i++) {
 					$offsetType = new ConstantIntegerType($i);
-					$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType));
+					$valueTypesBuilder->setOffsetValueType($offsetType, $arrayType->getOffsetValueType($offsetType));
 				}
 				$resultTypes[] = $valueTypesBuilder->getArray();
 				continue;
 			}
 
 			if (
-				$innerType->isList()->yes()
+				$isList->yes()
 				&& $sizeType instanceof IntegerRangeType
 				&& $sizeType->getMin() !== null
 			) {
@@ -1100,24 +1105,24 @@ final class TypeSpecifier
 				$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
 				for ($i = 0; $i < $sizeType->getMin(); $i++) {
 					$offsetType = new ConstantIntegerType($i);
-					$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType));
+					$valueTypesBuilder->setOffsetValueType($offsetType, $arrayType->getOffsetValueType($offsetType));
 				}
 				if ($sizeType->getMax() !== null) {
 					for ($i = $sizeType->getMin(); $i < $sizeType->getMax(); $i++) {
 						$offsetType = new ConstantIntegerType($i);
-						$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType), true);
+						$valueTypesBuilder->setOffsetValueType($offsetType, $arrayType->getOffsetValueType($offsetType), true);
 					}
-				} elseif ($innerType->isConstantArray()->yes()) {
+				} elseif ($arrayType->isConstantArray()->yes()) {
 					for ($i = $sizeType->getMin();; $i++) {
 						$offsetType = new ConstantIntegerType($i);
-						$hasOffset = $innerType->hasOffsetValueType($offsetType);
+						$hasOffset = $arrayType->hasOffsetValueType($offsetType);
 						if ($hasOffset->no()) {
 							break;
 						}
-						$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType), !$hasOffset->yes());
+						$valueTypesBuilder->setOffsetValueType($offsetType, $arrayType->getOffsetValueType($offsetType), !$hasOffset->yes());
 					}
 				} else {
-					$resultTypes[] = TypeCombinator::intersect($innerType, new NonEmptyArrayType());
+					$resultTypes[] = TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
 					continue;
 				}
 
@@ -1125,11 +1130,7 @@ final class TypeSpecifier
 				continue;
 			}
 
-			if (!$context->truthy()) {
-				continue;
-			}
-
-			$resultTypes[] = $innerType;
+			$resultTypes[] = $arrayType;
 		}
 
 		return $this->create($countFuncCall->getArgs()[0]->value, TypeCombinator::union(...$resultTypes), $context, $scope)->setRootExpr($rootExpr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -280,7 +280,7 @@ final class TypeSpecifier
 						$sizeType = IntegerRangeType::createAllGreaterThan($leftType->getValue());
 					}
 				} elseif ($leftType instanceof IntegerRangeType) {
-					$sizeType = $leftType;
+					$sizeType = $leftType->shift($offset);
 				}
 
 				$specifiedTypes = $this->specifyTypesForCountFuncCall($expr->right, $argType, $sizeType, $context, $scope, $expr);
@@ -1061,23 +1061,14 @@ final class TypeSpecifier
 
 				$arraySize = $type->getArraySize();
 				$isSize = $sizeType->isSuperTypeOf($arraySize);
-				if ($context->truthy()) {
-					if ($isSize->no()) {
-						return new NeverType();
-					}
-
-					$constArray = $this->turnListIntoConstantArray($type, $sizeType);
-					if ($constArray !== null) {
-						$type = $constArray;
-					}
+				if ($context->truthy() && $isSize->no()) {
+					return new NeverType();
 				}
-				if ($context->falsey()) {
-					if (!$isSize->yes()) {
-						return new NeverType();
-					}
+				if ($context->falsey() && !$isSize->yes()) {
+					return new NeverType();
 				}
 
-				return $type;
+				return $this->turnListIntoConstantArray($type, $sizeType) ?? $type;
 			});
 
 			return $this->create($countFuncCall->getArgs()[0]->value, $resultType, $context, $scope)->setRootExpr($rootExpr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1065,71 +1065,74 @@ final class TypeSpecifier
 			return null;
 		}
 
-		$resultType = TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($sizeType, $context) {
-			if ($type instanceof UnionType) {
-				return $traverse($type);
-			}
-
-			$isSizeSuperTypeOfArraySize = $sizeType->isSuperTypeOf($type->getArraySize());
+		$resultTypes = [];
+		$innerTypes = $type instanceof UnionType ? $type->getTypes() : [$type];
+		foreach ($innerTypes as $innerType) {
+			$isSizeSuperTypeOfArraySize = $sizeType->isSuperTypeOf($innerType->getArraySize());
 			if ($isSizeSuperTypeOfArraySize->no()) {
-				return new NeverType();
+				continue;
 			}
 			if ($context->falsey() && $isSizeSuperTypeOfArraySize->maybe()) {
-				return new NeverType();
+				continue;
 			}
 
-			if ($type->isList()->yes()) {
-				if (
-					$sizeType instanceof ConstantIntegerType
-					&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
-				) {
-					// turn optional offsets non-optional
-					$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
-					for ($i = 0; $i < $sizeType->getValue(); $i++) {
-						$offsetType = new ConstantIntegerType($i);
-						$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
-					}
-					return $valueTypesBuilder->getArray();
+			if (
+				$innerType->isList()->yes()
+				&& $sizeType instanceof ConstantIntegerType
+				&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
+			) {
+				// turn optional offsets non-optional
+				$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
+				for ($i = 0; $i < $sizeType->getValue(); $i++) {
+					$offsetType = new ConstantIntegerType($i);
+					$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType));
 				}
-
-				if (
-					$sizeType instanceof IntegerRangeType
-					&& $sizeType->getMin() !== null
-				) {
-					// turn optional offsets non-optional
-					$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
-					for ($i = 0; $i < $sizeType->getMin(); $i++) {
-						$offsetType = new ConstantIntegerType($i);
-						$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType));
-					}
-					if ($sizeType->getMax() !== null) {
-						for ($i = $sizeType->getMin(); $i < $sizeType->getMax(); $i++) {
-							$offsetType = new ConstantIntegerType($i);
-							$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType), true);
-						}
-					} elseif ($type->isConstantArray()->yes()) {
-						for ($i = $sizeType->getMin();; $i++) {
-							$offsetType = new ConstantIntegerType($i);
-							$hasOffset = $type->hasOffsetValueType($offsetType);
-							if ($hasOffset->no()) {
-								break;
-							}
-							$valueTypesBuilder->setOffsetValueType($offsetType, $type->getOffsetValueType($offsetType), !$hasOffset->yes());
-						}
-					} else {
-						return TypeCombinator::intersect($type, new NonEmptyArrayType());
-					}
-
-					return $valueTypesBuilder->getArray();
-				}
-
-				return $context->truthy() ? $type : new NeverType();
+				$resultTypes[] = $valueTypesBuilder->getArray();
+				continue;
 			}
 
-			return $context->truthy() ? TypeCombinator::intersect($type, new NonEmptyArrayType()) : new NeverType();
-		});
+			if (
+				$innerType->isList()->yes()
+				&& $sizeType instanceof IntegerRangeType
+				&& $sizeType->getMin() !== null
+			) {
+				// turn optional offsets non-optional
+				$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();
+				for ($i = 0; $i < $sizeType->getMin(); $i++) {
+					$offsetType = new ConstantIntegerType($i);
+					$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType));
+				}
+				if ($sizeType->getMax() !== null) {
+					for ($i = $sizeType->getMin(); $i < $sizeType->getMax(); $i++) {
+						$offsetType = new ConstantIntegerType($i);
+						$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType), true);
+					}
+				} elseif ($innerType->isConstantArray()->yes()) {
+					for ($i = $sizeType->getMin();; $i++) {
+						$offsetType = new ConstantIntegerType($i);
+						$hasOffset = $innerType->hasOffsetValueType($offsetType);
+						if ($hasOffset->no()) {
+							break;
+						}
+						$valueTypesBuilder->setOffsetValueType($offsetType, $innerType->getOffsetValueType($offsetType), !$hasOffset->yes());
+					}
+				} else {
+					$resultTypes[] = TypeCombinator::intersect($innerType, new NonEmptyArrayType());
+					continue;
+				}
 
-		return $this->create($countFuncCall->getArgs()[0]->value, $resultType, $context, $scope)->setRootExpr($rootExpr);
+				$resultTypes[] = $valueTypesBuilder->getArray();
+				continue;
+			}
+
+			if (!$context->truthy()) {
+				continue;
+			}
+
+			$resultTypes[] = $innerType;
+		}
+
+		return $this->create($countFuncCall->getArgs()[0]->value, TypeCombinator::union(...$resultTypes), $context, $scope)->setRootExpr($rootExpr);
 	}
 
 	private function specifyTypesForConstantBinaryExpression(

--- a/tests/PHPStan/Analyser/nsrt/bug-4700.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-4700.php
@@ -41,9 +41,9 @@ function(array $array, int $count): void {
 	if (isset($array['e'])) $a[] = $array['e'];
 	if (count($a) > $count) {
 		assertType('int<2, 5>', count($a));
-		assertType('array{0: mixed~null, 1?: mixed~null, 2?: mixed~null, 3?: mixed~null, 4?: mixed~null}', $a);
+		assertType('list{0: mixed~null, 1: mixed~null, 2?: mixed~null, 3?: mixed~null, 4?: mixed~null}', $a);
 	} else {
-		assertType('0', count($a));
-		assertType('array{}', $a);
+		assertType('int<0, 5>', count($a)); // Could be int<0, 1>
+		assertType('array{}|array{0: mixed~null, 1?: mixed~null, 2?: mixed~null, 3?: mixed~null, 4?: mixed~null}', $a); // Could be array{}|array{0: mixed~null}
 	}
 };

--- a/tests/PHPStan/Analyser/nsrt/bug-4700.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-4700.php
@@ -40,7 +40,7 @@ function(array $array, int $count): void {
 	if (isset($array['d'])) $a[] = $array['d'];
 	if (isset($array['e'])) $a[] = $array['e'];
 	if (count($a) > $count) {
-		assertType('int<1, 5>', count($a));
+		assertType('int<2, 5>', count($a));
 		assertType('array{0: mixed~null, 1?: mixed~null, 2?: mixed~null, 3?: mixed~null, 4?: mixed~null}', $a);
 	} else {
 		assertType('0', count($a));

--- a/tests/PHPStan/Analyser/nsrt/bug11480.php
+++ b/tests/PHPStan/Analyser/nsrt/bug11480.php
@@ -84,7 +84,7 @@ class HelloWorld
 		if (count($x) >= $count) {
 			assertType("array{'xy'}|array{0: 'ab', 1?: 'xy'}", $x);
 		} else {
-			assertType("array{}|array{'xy'}|array{0: 'ab', 1?: 'xy'}", $x);
+			assertType("array{}", $x);
 		}
 		assertType("array{}|array{'xy'}|array{0: 'ab', 1?: 'xy'}", $x);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug11480.php
+++ b/tests/PHPStan/Analyser/nsrt/bug11480.php
@@ -84,7 +84,7 @@ class HelloWorld
 		if (count($x) >= $count) {
 			assertType("array{'xy'}|array{0: 'ab', 1?: 'xy'}", $x);
 		} else {
-			assertType("array{}", $x);
+			assertType("array{}|array{'xy'}|array{0: 'ab', 1?: 'xy'}", $x);
 		}
 		assertType("array{}|array{'xy'}|array{0: 'ab', 1?: 'xy'}", $x);
 	}

--- a/tests/PHPStan/Analyser/nsrt/count-type.php
+++ b/tests/PHPStan/Analyser/nsrt/count-type.php
@@ -64,6 +64,29 @@ class Foo
 		}
 	}
 
+	/** @param array{0: string, 1?: string} $arr */
+	public function doBar(array $arr): void
+	{
+		if (count($arr) <= 1) {
+			assertType('1', count($arr));
+			return;
+		}
+
+		assertType('2', count($arr));
+		assertType('array{string, string}', $arr);
+	}
+
+	/** @param array{0: string, 1?: string} $arr */
+	public function doBaz(array $arr): void
+	{
+		if (count($arr) > 1) {
+			assertType('2', count($arr));
+			assertType('array{string, string}', $arr);
+		}
+
+		assertType('1|2', count($arr));
+	}
+
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -369,7 +369,7 @@ class CountWithOptionalKeys
 		if (count($row) >= $maxThree) {
 			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
 		} else {
-			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+			assertType('list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -369,7 +369,7 @@ class CountWithOptionalKeys
 		if (count($row) >= $maxThree) {
 			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
 		} else {
-			assertType('list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
 		}
 	}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -545,6 +545,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3608.php'], []);
 	}
 
+	public function testBug3631(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-3631.php'], []);
+	}
+
 	public function testBug3920(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-3920.php'], []);

--- a/tests/PHPStan/Rules/Functions/data/bug-3631.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-3631.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3631;
+
+/**
+ * @return array<string>
+ */
+function someFunc(bool $flag): array
+{
+	$ids = [
+		['fa', 'foo', 'baz']
+	];
+
+	if ($flag) {
+		$ids[] = ['foo', 'bar', 'baz'];
+
+	}
+
+	if (count($ids) > 1) {
+		return array_intersect(...$ids);
+	}
+
+	return $ids[0];
+}
+
+var_dump(someFunc(true));
+var_dump(someFunc(false));


### PR DESCRIPTION
Generalizes the already existing solution (wow, this is way more complicated than I thought!) and uses it outside of union types as well. I kind of had to make the "isNormalCount" determination a bit more dry, which unfortunately made the diff worse..

I did do a performance comparison with `hyperfine` running `make phpstan` and didn't notice any changes, but my system is not the best.

Closes https://github.com/phpstan/phpstan/issues/12190
Closes https://github.com/phpstan/phpstan/issues/3631
