### PR TITLE
Workaround bug in slevomat/coding-standard TypeNameMatchesFileName

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="PHPStan">
 	<config name="php_version" value="70400"/>
+	<arg name="basepath" value="."/>
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
 	<arg name="encoding" value="utf-8"/>


### PR DESCRIPTION
For each root namespace, the slevomat rule considers the left-most match of the given directory in the absolute path of the file. That is, for /home/user/src/phpstan-src/ the root namespace PHPStan is not assigned to /home/user/src/phpstan-src/src, but to /home/user/src, which is obviously wrong.

The bug is known as slevomat/coding-standard#1249 for a long time, but yet to be fixed. To avoid issues for developers of PHPStan, we can set a basepath of "." in the PHP CodeSniffer config, which causes paths to be evaluated relative to the current directory, avoiding false-positives in the path leading up to the phpstan-src directory.