### PR TITLE
Add regression test for array self-append

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -981,6 +981,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug6948(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6948.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug7963(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7963.php');

--- a/tests/PHPStan/Analyser/data/bug-6948.php
+++ b/tests/PHPStan/Analyser/data/bug-6948.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace Bug6948;
+
+$row = [1];
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}
+if (rand()) {
+	$row[] = $row;
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/6948

This is using the example that @staabm used in that issue as well. If I double the cases it gets just a tiny bit slower, but not much. it seems to be linear instead of exponential now. I can add cases until at some point xdebug starts detecting endless recursions, but that's another issue I guess 😁 so I think the original case of "exponential slowdown" has really been properly fixed.

For the record as already mentioned, this was somewhere massively improved between these commits: https://github.com/phpstan/phpstan-src/commit/a07996a9cad15c0c6e6e8fd57338236734a5c0dd, https://github.com/phpstan/phpstan-src/commit/1a0099dc61674ff1eb0ef8d68c90011f2206a64b, https://github.com/phpstan/phpstan-src/commit/53a15542683e5e0fd4e8f32cb9e94290edb7c39c, https://github.com/phpstan/phpstan-src/commit/537c12c0c3f14371ceaf59051fc5445339857a97, https://github.com/phpstan/phpstan-src/commit/c04555b9387dea448a5649348546e9629063dda8, https://github.com/phpstan/phpstan-src/commit/4dfbe16ed9cdf0808027f3bcbdb26980ec39df3f

https://github.com/phpstan/phpstan-src/commit/c04555b9387dea448a5649348546e9629063dda8 stood out via git bisect and improved it initially, which surprised me, but reverting it on 1.12.x does not bring the issue back, so the situation is somewhat more complex I suppose and there might be something else later that also fixes or improves this in combination.