### PR TITLE
Respect asserts and throws on pure functions that return void

### DIFF
--- a/src/Rules/Pure/FunctionPurityCheck.php
+++ b/src/Rules/Pure/FunctionPurityCheck.php
@@ -59,7 +59,13 @@ final class FunctionPurityCheck
 				))->identifier(sprintf('pure%s.parameterByRef', $identifier))->build();
 			}
 
-			if ($returnType->isVoid()->yes() && !$isConstructor) {
+			$throwType = $functionReflection->getThrowType();
+			if (
+				$returnType->isVoid()->yes()
+				&& !$isConstructor
+				&& ($throwType === null || $throwType->isVoid()->yes())
+				&& $functionReflection->getAsserts()->getAll() === []
+			) {
 				$errors[] = RuleErrorBuilder::message(sprintf(
 					'%s is marked as pure but returns void.',
 					$functionDescription,

--- a/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
@@ -167,4 +167,14 @@ class PureFunctionRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12224(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12224.php'], [
+			[
+				'Function PHPStan\Rules\Pure\data\pureWithThrowsVoid() is marked as pure but returns void.',
+				18,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Pure/PureMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureMethodRuleTest.php
@@ -212,4 +212,12 @@ class PureMethodRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12048.php'], []);
 	}
 
+	public function testBug12224(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-12224.php'], [
+			['Method PHPStan\Rules\Pure\data\A::pureWithThrowsVoid() is marked as pure but returns void.', 47],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Pure/data/bug-12224.php
+++ b/tests/PHPStan/Rules/Pure/data/bug-12224.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Pure\data;
+
+/**
+ * @phpstan-pure
+ * @throws \Exception
+ */
+function pureWithThrows(): void
+{
+	throw new \Exception();
+}
+
+/**
+ * @phpstan-pure
+ * @throws void
+ */
+function pureWithThrowsVoid(): void
+{
+}
+
+/**
+ * @phpstan-pure
+ * @phpstan-assert int $a
+ */
+function pureWithAssert(mixed $a): void
+{
+	if (!is_int($a)) {
+		throw new \Exception();
+	}
+}
+
+class A {
+	/**
+	 * @phpstan-pure
+	 * @throws \Exception
+	 */
+	public function pureWithThrows(): void
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @phpstan-pure
+	 * @throws void
+	 */
+	public function pureWithThrowsVoid(): void
+	{
+	}
+
+	/**
+	 * @phpstan-pure
+	 * @phpstan-assert int $a
+	 */
+	public function pureWithAssert(mixed $a): void
+	{
+		if (!is_int($a)) {
+			throw new \Exception();
+		}
+	}
+}
+
+class B {
+	/**
+	 * @phpstan-pure
+	 * @throws \Exception
+	 */
+	public static function pureWithThrows(): void
+	{
+		throw new \Exception();
+	}
+
+	/**
+	 * @phpstan-pure
+	 * @throws \Exception
+	 */
+	public static function pureWithThrowsVoid(): void
+	{
+	}
+
+	/**
+	 * @phpstan-pure
+	 * @phpstan-assert int $a
+	 */
+	public static function pureWithAssert(mixed $a): void
+	{
+		if (!is_int($a)) {
+			throw new \Exception();
+		}
+	}
+}


### PR DESCRIPTION
Fixes some of the problems from https://github.com/phpstan/phpstan/issues/12224

This should now be fixed: https://phpstan.org/r/852dd5b6-e76c-41ed-a0fb-7b1a46b0900f

