### PR TITLE
Use native PHPDocs wherever possible

### DIFF
--- a/src/Collectors/Collector.php
+++ b/src/Collectors/Collector.php
@@ -20,19 +20,19 @@ use PHPStan\Analyser\Scope;
  * Learn more: https://phpstan.org/developing-extensions/collectors
  *
  * @api
- * @phpstan-template-covariant TNodeType of Node
- * @phpstan-template-covariant TValue
+ * @template-covariant TNodeType of Node
+ * @template-covariant TValue
  */
 interface Collector
 {
 
 	/**
-	 * @phpstan-return class-string<TNodeType>
+	 * @return class-string<TNodeType>
 	 */
 	public function getNodeType(): string;
 
 	/**
-	 * @phpstan-param TNodeType $node
+	 * @param TNodeType $node
 	 * @return TValue|null Collected data
 	 */
 	public function processNode(Node $node, Scope $scope);

--- a/src/Collectors/Registry.php
+++ b/src/Collectors/Registry.php
@@ -27,10 +27,8 @@ final class Registry
 
 	/**
 	 * @template TNodeType of Node
-	 * @phpstan-param class-string<TNodeType> $nodeType
-	 * @param Node $nodeType
-	 * @phpstan-return array<Collector<TNodeType, mixed>>
-	 * @return Collector[]
+	 * @param class-string<TNodeType> $nodeType
+	 * @return array<Collector<TNodeType, mixed>>
 	 */
 	public function getCollectors(string $nodeType): array
 	{
@@ -48,8 +46,7 @@ final class Registry
 		}
 
 		/**
-		 * @phpstan-var array<Collector<TNodeType, mixed>> $selectedCollectors
-		 * @var Collector[] $selectedCollectors
+		 * @var array<Collector<TNodeType, mixed>> $selectedCollectors
 		 */
 		$selectedCollectors = $this->cache[$nodeType];
 

--- a/src/DependencyInjection/Container.php
+++ b/src/DependencyInjection/Container.php
@@ -14,10 +14,9 @@ interface Container
 	public function getService(string $serviceName);
 
 	/**
-	 * @phpstan-template T of object
-	 * @phpstan-param class-string<T> $className
-	 * @phpstan-return T
-	 * @return mixed
+	 * @template T of object
+	 * @param class-string<T> $className
+	 * @return T
 	 */
 	public function getByType(string $className);
 

--- a/src/DependencyInjection/Nette/NetteContainer.php
+++ b/src/DependencyInjection/Nette/NetteContainer.php
@@ -32,10 +32,9 @@ final class NetteContainer implements Container
 	}
 
 	/**
-	 * @phpstan-template T of object
-	 * @phpstan-param class-string<T> $className
-	 * @phpstan-return T
-	 * @return mixed
+	 * @template T of object
+	 * @param class-string<T> $className
+	 * @return T
 	 */
 	public function getByType(string $className)
 	{

--- a/src/Rules/DirectRegistry.php
+++ b/src/Rules/DirectRegistry.php
@@ -30,10 +30,8 @@ class DirectRegistry implements Registry
 
 	/**
 	 * @template TNodeType of Node
-	 * @phpstan-param class-string<TNodeType> $nodeType
-	 * @param Node $nodeType
-	 * @phpstan-return array<Rule<TNodeType>>
-	 * @return Rule[]
+	 * @param class-string<TNodeType> $nodeType
+	 * @return array<Rule<TNodeType>>
 	 */
 	public function getRules(string $nodeType): array
 	{
@@ -51,8 +49,7 @@ class DirectRegistry implements Registry
 		}
 
 		/**
-		 * @phpstan-var array<Rule<TNodeType>> $selectedRules
-		 * @var Rule[] $selectedRules
+		 * @var array<Rule<TNodeType>> $selectedRules
 		 */
 		$selectedRules = $this->cache[$nodeType];
 

--- a/src/Rules/LazyRegistry.php
+++ b/src/Rules/LazyRegistry.php
@@ -24,10 +24,8 @@ final class LazyRegistry implements Registry
 
 	/**
 	 * @template TNodeType of Node
-	 * @phpstan-param class-string<TNodeType> $nodeType
-	 * @param Node $nodeType
-	 * @phpstan-return array<Rule<TNodeType>>
-	 * @return Rule[]
+	 * @param class-string<TNodeType> $nodeType
+	 * @return array<Rule<TNodeType>>
 	 */
 	public function getRules(string $nodeType): array
 	{
@@ -46,8 +44,7 @@ final class LazyRegistry implements Registry
 		}
 
 		/**
-		 * @phpstan-var array<Rule<TNodeType>> $selectedRules
-		 * @var Rule[] $selectedRules
+		 * @var array<Rule<TNodeType>> $selectedRules
 		 */
 		$selectedRules = $this->cache[$nodeType];
 

--- a/src/Rules/Registry.php
+++ b/src/Rules/Registry.php
@@ -9,10 +9,8 @@ interface Registry
 
 	/**
 	 * @template TNodeType of Node
-	 * @phpstan-param class-string<TNodeType> $nodeType
-	 * @param Node $nodeType
-	 * @phpstan-return array<Rule<TNodeType>>
-	 * @return Rule[]
+	 * @param class-string<TNodeType> $nodeType
+	 * @return array<Rule<TNodeType>>
 	 */
 	public function getRules(string $nodeType): array;
 

--- a/stubs/bleedingEdge/Rule.stub
+++ b/stubs/bleedingEdge/Rule.stub
@@ -7,18 +7,18 @@ use PHPStan\Analyser\Scope;
 
 /**
  * @api
- * @phpstan-template TNodeType of Node
+ * @template TNodeType of Node
  */
 interface Rule
 {
 
 	/**
-	 * @phpstan-return class-string<TNodeType>
+	 * @return class-string<TNodeType>
 	 */
 	public function getNodeType(): string;
 
 	/**
-	 * @phpstan-param TNodeType $node
+	 * @param TNodeType $node
 	 * @return list<IdentifierRuleError>
 	 */
 	public function processNode(Node $node, Scope $scope): array;


### PR DESCRIPTION
Follow up PR to #3698 

Replaced the phpdocs only in `src/` and `stubs/`.