### PR TITLE
RegexArrayShapeMatcher: fix regex wildcard omitted from type

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -535,13 +535,19 @@ final class RegexGroupParser
 			if (
 				$appendLiterals
 				&& $onlyLiterals !== null
-				&& (!in_array($value, ['.'], true) || $isEscaped || $inCharacterClass)
 			) {
-				if ($onlyLiterals === []) {
-					$onlyLiterals = [$value];
+				if (
+					in_array($value, ['.'], true)
+					&& !($isEscaped || $inCharacterClass)
+				) {
+					$onlyLiterals = null;
 				} else {
-					foreach ($onlyLiterals as &$literal) {
-						$literal .= $value;
+					if ($onlyLiterals === []) {
+						$onlyLiterals = [$value];
+					} else {
+						foreach ($onlyLiterals as &$literal) {
+							$literal .= $value;
+						}
 					}
 				}
 			}

--- a/tests/PHPStan/Analyser/nsrt/bug-12211.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12211.php
@@ -1,0 +1,16 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug12211;
+
+use function PHPStan\Testing\assertType;
+
+const REGEX = '((m.x))';
+
+function foo(string $text): void {
+	assert(preg_match(REGEX, $text, $match) === 1);
+	assertType('array{string, non-falsy-string}', $match);
+}
+
+


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/12211