### PR TITLE
RegexArrayShapeMatcher: fix regex alternatives in capture group are concatenated

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -446,7 +446,30 @@ final class RegexGroupParser
 		}
 
 		if ($ast->getId() === '#alternation') {
-			$inAlternation = true;
+			$newLiterals = [];
+			foreach ($children as $child) {
+				$walkResult = $this->walkGroupAst(
+					$child,
+					true,
+					$inClass,
+					$patternModifiers,
+					$walkResult->onlyLiterals([]),
+				);
+
+				if ($newLiterals === null) {
+					continue;
+				}
+
+				if (count($walkResult->getOnlyLiterals() ?? []) > 0) {
+					foreach ($walkResult->getOnlyLiterals() as $alternationLiterals) {
+						$newLiterals[] = $alternationLiterals;
+					}
+				} else {
+					$newLiterals = null;
+				}
+			}
+
+			return $walkResult->onlyLiterals($newLiterals);
 		}
 
 		// [^0-9] should not parse as numeric-string, and [^list-everything-but-numbers] is technically

--- a/tests/PHPStan/Analyser/nsrt/bug-12173.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12173.php
@@ -1,0 +1,19 @@
+<?php // lint >= 7.4
+
+namespace Bug12173;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function parse(string $string): void
+	{
+		$regex = '#.*(?<fruit>(apple|orange)).*#';
+
+		if (preg_match($regex, $string, $matches) !== 1) {
+			throw new \Exception('Invalid input');
+		}
+
+		assertType("'apple'|'orange'", $matches['fruit']);;
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12210.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12210.php
@@ -1,0 +1,27 @@
+<?php // lint >= 7.4
+
+declare(strict_types = 1);
+
+namespace Bug12210;
+
+use function PHPStan\Testing\assertType;
+
+function bug12210a(string $text): void {
+	assert(preg_match('(((sum|min|max)))', $text, $match) === 1);
+	assertType("array{string, 'max'|'min'|'sum', 'max'|'min'|'sum'}", $match);
+}
+
+function bug12210b(string $text): void {
+	assert(preg_match('(((sum|min|ma.)))', $text, $match) === 1);
+	assertType("array{string, non-empty-string, non-falsy-string}", $match);
+}
+
+function bug12210c(string $text): void {
+	assert(preg_match('(((su.|min|max)))', $text, $match) === 1);
+	assertType("array{string, non-empty-string, non-falsy-string}", $match);
+}
+
+function bug12210d(string $text): void {
+	assert(preg_match('(((sum|mi.|max)))', $text, $match) === 1);
+	assertType("array{string, non-empty-string, non-falsy-string}", $match);
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/12210
closes https://github.com/phpstan/phpstan/issues/12173