### PR TITLE
RegexArrayShapeMatcher: Don't narrow 'J' modifier

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -34,6 +34,10 @@ use function trim;
 final class RegexGroupParser
 {
 
+	private const NOT_SUPPORTED_MODIFIERS = [
+		'J', // rare modifier too complicated to support
+	];
+
 	private static ?Parser $parser = null;
 
 	public function __construct(
@@ -67,8 +71,14 @@ final class RegexGroupParser
 			return null;
 		}
 
-		$captureOnlyNamed = false;
 		$modifiers = $this->regexExpressionHelper->getPatternModifiers($regex) ?? '';
+		foreach (self::NOT_SUPPORTED_MODIFIERS as $notSupportedModifier) {
+			if (str_contains($modifiers, $notSupportedModifier)) {
+				return null;
+			}
+		}
+
+		$captureOnlyNamed = false;
 		if ($this->phpVersion->supportsPregCaptureOnlyNamedGroups()) {
 			$captureOnlyNamed = str_contains($modifiers, 'n');
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-12126.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12126.php
@@ -1,0 +1,36 @@
+<?php // lint >= 7.4
+
+namespace Bug12126;
+
+use function PHPStan\Testing\assertType;
+
+
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		$options = ['footest', 'testfoo'];
+		$key = array_rand($options, 1);
+
+		$regex = '/foo(?P<test>test)|test(?P<test>foo)/J';
+		if (!preg_match_all($regex, $options[$key], $matches, PREG_SET_ORDER)) {
+			return;
+		}
+
+		assertType('list<array<string>>', $matches);
+		// could be assertType("list<array{0: string, test: 'foo'|'test', 1?: 'test', 2?: 'foo'}>", $matches);
+		if (!preg_match_all($regex, $options[$key], $matches, PREG_PATTERN_ORDER)) {
+			return;
+		}
+
+		assertType('array<list<string>>', $matches);
+		// could be assertType("array{0: list<string>, test: list<'foo'|'test'>, 1: list<'test'|''>, 2: list<''|'foo'>}", $matches);
+
+		if (!preg_match($regex, $options[$key], $matches)) {
+			return;
+		}
+
+		assertType('array<string>', $matches);
+		// could be assertType("array{0: list<string>, test: 'foo', 1: '', 2: 'foo'}|array{0: list<string>, test: 'test', 1: 'test', 2: ''}", $matches);
+	}
+}


### PR DESCRIPTION
I think the 'J' modifier - which I have never seen in code until today - is something we don't need to support.
adding support is not impossible, but I don't want to overcomplicate the regex analysis for such an edge case.

this PR just makes sure we don't narrow it in a wrong way.

closes https://github.com/phpstan/phpstan/issues/12126