### PR TITLE
Enhance offset access by defining various access modes, and restrict which ones are available for DOM classes

### DIFF
--- a/src/Type/AccessOffsetMode.php
+++ b/src/Type/AccessOffsetMode.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PHPStan\Type;
+
+enum AccessOffsetMode
+{
+	case Exist;
+	case Read;
+	case Write;
+	case ReadWrite;
+	case Unset;
+	case Append;
+	case IncrementDecrement;
+	case Fetch; // By reference fetch
+}

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantFloatType;
@@ -130,7 +131,7 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -27,6 +28,7 @@ use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -42,6 +44,7 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGenericTypeTrait;
 	use NonRemoveableTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -119,11 +122,6 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -26,6 +27,7 @@ use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -41,6 +43,7 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGenericTypeTrait;
 	use NonRemoveableTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -115,11 +118,6 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -26,6 +27,7 @@ use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
@@ -43,6 +45,7 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGenericTypeTrait;
 	use UndecidedBooleanTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -121,11 +124,6 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -26,6 +27,7 @@ use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\TruthyBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
@@ -43,6 +45,7 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGenericTypeTrait;
 	use NonRemoveableTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -124,12 +127,6 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 	{
 		return TrinaryLogic::createYes();
 	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
 		return $offsetType->isInteger()->and(TrinaryLogic::createMaybe());

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -25,6 +26,7 @@ use PHPStan\Type\Traits\NonCallableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
@@ -42,6 +44,7 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 	use UndecidedBooleanTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGenericTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -124,11 +127,6 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
@@ -26,6 +27,7 @@ use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
@@ -41,6 +43,7 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGenericTypeTrait;
 	use NonRemoveableTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -115,11 +118,6 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\Type\CallbackUnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
@@ -111,7 +112,7 @@ class HasMethodType implements AccessoryType, CompoundType
 		return sprintf('hasMethod(%s)', $this->methodName);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
 	}

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -130,7 +131,7 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -8,6 +8,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -142,7 +143,7 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\TrivialParametersAcceptor;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
@@ -106,7 +107,7 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return sprintf('hasProperty(%s)', $this->propertyName);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
 	}

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantFloatType;
@@ -128,7 +129,7 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantFloatType;
@@ -124,7 +125,7 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/BooleanType.php
+++ b/src/Type/BooleanType.php
@@ -101,8 +101,9 @@ class BooleanType implements Type
 		return new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(1)]);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
+		// TODO Should this be NO?
 		return TrinaryLogic::createYes();
 	}
 

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -321,7 +321,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		return new ErrorType();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
 	}

--- a/src/Type/ClosureType.php
+++ b/src/Type/ClosureType.php
@@ -269,7 +269,7 @@ class ClosureType implements TypeWithClassName, CallableParametersAcceptor
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -143,7 +143,7 @@ class FloatType implements Type
 		return new IntegerType();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -97,7 +97,7 @@ class IntegerType implements Type
 		return $this;
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -724,9 +724,9 @@ class IntersectionType implements CompoundType
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessible());
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
-		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessLegal());
+		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessLegal($mode));
 	}
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -234,7 +234,7 @@ class IterableType implements CompoundType
 		return new ErrorType();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
 	}

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -651,7 +651,7 @@ class MixedType implements CompoundType, SubtractableType
 		return TrinaryLogic::createMaybe();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {
 			if ($this->subtractedType->isSuperTypeOf(new ObjectWithoutClassType())->yes()) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -243,7 +243,7 @@ class NeverType implements CompoundType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/NonexistentParentClassType.php
+++ b/src/Type/NonexistentParentClassType.php
@@ -157,7 +157,7 @@ class NonexistentParentClassType implements Type
 		return new ErrorType();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}

--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -171,7 +171,7 @@ class NullType implements ConstantScalarType
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -420,7 +420,7 @@ class ObjectShapeType implements Type
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
 	}

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1101,8 +1101,9 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
+		// TODO Narrow down NodeList/Map types
 		return $this->isOffsetAccessible();
 	}
 

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -134,7 +134,7 @@ class ObjectWithoutClassType implements SubtractableType
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();
 	}

--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -91,8 +91,9 @@ class ResourceType implements Type
 		return new ErrorType();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
+		// TODO Should be NO?
 		return TrinaryLogic::createYes();
 	}
 

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -366,9 +366,9 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->isOffsetAccessible();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
-		return $this->getStaticObjectType()->isOffsetAccessLegal();
+		return $this->getStaticObjectType()->isOffsetAccessLegal($mode);
 	}
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic

--- a/src/Type/StrictMixedType.php
+++ b/src/Type/StrictMixedType.php
@@ -310,7 +310,7 @@ class StrictMixedType implements CompoundType
 		return TrinaryLogic::createNo();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();
 	}

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -18,6 +18,7 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\NonIterableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
+use PHPStan\Type\Traits\StringTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use function count;
@@ -35,6 +36,7 @@ class StringType implements Type
 	use UndecidedComparisonTypeTrait;
 	use NonGenericTypeTrait;
 	use NonGeneralizableTypeTrait;
+	use StringTypeTrait;
 
 	/** @api */
 	public function __construct()
@@ -52,11 +54,6 @@ class StringType implements Type
 	}
 
 	public function isOffsetAccessible(): TrinaryLogic
-	{
-		return TrinaryLogic::createYes();
-	}
-
-	public function isOffsetAccessLegal(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Traits/ArrayTypeTrait.php
+++ b/src/Type/Traits/ArrayTypeTrait.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Traits;
 
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -34,7 +35,7 @@ trait ArrayTypeTrait
 		return TrinaryLogic::createYes();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\Type\UnresolvedMethodPrototypeReflection;
 use PHPStan\Reflection\Type\UnresolvedPropertyPrototypeReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
+use PHPStan\Type\AccessOffsetMode;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CompoundType;
 use PHPStan\Type\Generic\TemplateTypeMap;
@@ -218,9 +219,9 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->isOffsetAccessible();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
-		return $this->resolve()->isOffsetAccessLegal();
+		return $this->resolve()->isOffsetAccessLegal($mode);
 	}
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic

--- a/src/Type/Traits/StringTypeTrait.php
+++ b/src/Type/Traits/StringTypeTrait.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\AccessOffsetMode;
+
+trait StringTypeTrait
+{
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
+	{
+		return match ($mode) {
+			AccessOffsetMode::Exist, AccessOffsetMode::Read, AccessOffsetMode::Write => TrinaryLogic::createYes(),
+			default => TrinaryLogic::createNo(),
+		};
+	}
+
+}

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -129,7 +129,7 @@ interface Type
 
 	public function isOffsetAccessible(): TrinaryLogic;
 
-	public function isOffsetAccessLegal(): TrinaryLogic;
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic;
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic;
 

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -684,9 +684,9 @@ class UnionType implements CompoundType
 		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessible());
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
-		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessLegal());
+		return $this->unionResults(static fn (Type $type): TrinaryLogic => $type->isOffsetAccessLegal($mode));
 	}
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic

--- a/src/Type/VoidType.php
+++ b/src/Type/VoidType.php
@@ -119,7 +119,7 @@ class VoidType implements Type
 		return new ErrorType();
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
+	public function isOffsetAccessLegal(AccessOffsetMode $mode): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();
 	}

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -1097,7 +1097,8 @@ class MixedTypeTest extends PHPStanTestCase
 	public function testSubstractedIsOffsetLegal(MixedType $mixedType, Type $typeToSubtract, TrinaryLogic $expectedResult): void
 	{
 		$subtracted = $mixedType->subtract($typeToSubtract);
-		$actualResult = $subtracted->isOffsetAccessLegal();
+		// TODO Propagate Access Mode?
+		$actualResult = $subtracted->isOffsetAccessLegal(AccessOffsetMode::Read);
 
 		$this->assertSame(
 			$expectedResult->describe(),


### PR DESCRIPTION
This is very W.I.P. and I think this is the correct way to fix it, but I don't know if I should update `Type::isOffsetAccessible()` to pass in the `$mode` parameter or not.

This would fix https://github.com/phpstan/phpstan/issues/12235 and do preliminary work to support https://wiki.php.net/rfc/container-offset-behaviour if/when it lands.