### PR TITLE
Add support for internal classes that overload offset access

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -67,7 +67,19 @@ class ObjectType implements TypeWithClassName, SubtractableType
 	use UndecidedComparisonTypeTrait;
 	use NonGeneralizableTypeTrait;
 
-	private const EXTRA_OFFSET_CLASSES = ['SimpleXMLElement', 'DOMNodeList', 'Threaded'];
+	private const EXTRA_OFFSET_CLASSES = [
+		'DOMNamedNodeMap', // Only read and existence
+		'Dom\NamedNodeMap', // Only read and existence
+		'DOMNodeList', // Only read and existence
+		'Dom\NodeList', // Only read and existence
+		'Dom\HTMLCollection', // Only read and existence
+		'Dom\DtdNamedNodeMap', // Only read and existence
+		'PDORow', // Only read and existence
+		'ResourceBundle', // Only read
+		'FFI\CData', // Very funky and weird
+		'SimpleXMLElement',
+		'Threaded',
+	];
 
 	private ?Type $subtractedType;
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -898,4 +898,14 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-2634.php'], []);
 	}
 
+	public function testInternalClassesWithOverloadedOffsetAccess(): void
+	{
+		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access.php'], []);
+	}
+
+	public function testInternalClassesWithOverloadedOffsetAccessInvalid(): void
+	{
+		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-invalid.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -905,8 +905,8 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	public function testInternalClassesWithOverloadedOffsetAccess84(): void
 	{
-		if (version_compare(PHP_VERSION, '8.4.0', '<')) {
-			$this->markTestSkipped('Test requires PHP version 8.4.');
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
 		}
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-php84.php'], []);
 	}
@@ -918,8 +918,8 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	public function testInternalClassesWithOverloadedOffsetAccessInvalid84(): void
 	{
-		if (version_compare(PHP_VERSION, '8.4.0', '<')) {
-			$this->markTestSkipped('Test requires PHP version 8.4.');
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
 		}
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-invalid-php84.php'], []);
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -919,7 +919,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	public function testInternalClassesWithOverloadedOffsetAccessInvalid84(): void
 	{
 		if (PHP_VERSION_ID < 80400) {
-			$this->markTestSkipped('Test requires PHP 8.1.');
+			$this->markTestSkipped('Test requires PHP 8.4.');
 		}
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-invalid-php84.php'], []);
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -905,6 +905,9 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	public function testInternalClassesWithOverloadedOffsetAccess84(): void
 	{
+		if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+			$this->markTestSkipped('Test requires PHP version 8.4.');
+		}
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-php84.php'], []);
 	}
 
@@ -915,6 +918,9 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 
 	public function testInternalClassesWithOverloadedOffsetAccessInvalid84(): void
 	{
+		if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+			$this->markTestSkipped('Test requires PHP version 8.4.');
+		}
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-invalid-php84.php'], []);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -906,7 +906,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	public function testInternalClassesWithOverloadedOffsetAccess84(): void
 	{
 		if (PHP_VERSION_ID < 80400) {
-			$this->markTestSkipped('Test requires PHP 8.1.');
+			$this->markTestSkipped('Test requires PHP 8.4.');
 		}
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-php84.php'], []);
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -903,9 +903,19 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access.php'], []);
 	}
 
+	public function testInternalClassesWithOverloadedOffsetAccess84(): void
+	{
+		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-php84.php'], []);
+	}
+
 	public function testInternalClassesWithOverloadedOffsetAccessInvalid(): void
 	{
 		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-invalid.php'], []);
+	}
+
+	public function testInternalClassesWithOverloadedOffsetAccessInvalid84(): void
+	{
+		$this->analyse([__DIR__ . '/data/internal-classes-overload-offset-access-invalid-php84.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-invalid-php84.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-invalid-php84.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.4
+<?php
 /**
  * All of these offset accesses are invalid
  * ++ and -- are also disallowed in general are they operate "by ref"

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-invalid-php84.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-invalid-php84.php
@@ -1,9 +1,9 @@
-<?php
+<?php // lint >= 8.4
 /**
  * All of these offset accesses are invalid
  * ++ and -- are also disallowed in general are they operate "by ref"
  */
-namespace InternalClassesOverloadOffsetAccessInvalid;
+namespace InternalClassesOverloadOffsetAccessInvalid\Php84;
 
 function test1(\DOMNamedNodeMap $v): void
 {
@@ -15,7 +15,47 @@ function test1(\DOMNamedNodeMap $v): void
 	var_dump($r1);
 }
 
+function test2(\Dom\NamedNodeMap $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
 function test3(\DOMNodeList $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test4(\Dom\NodeList $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test5(\Dom\HTMLCollection $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test6(\Dom\DtdNamedNodeMap $v): void
 {
 	$v[] = 'append';
 	$v[0] = 'update';
@@ -49,4 +89,3 @@ function test8(\ResourceBundle $v): void
 	var_dump($v['name']);
 	var_dump($v[0]);
 }
-

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-invalid.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-invalid.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * All of these offset accesses are invalid
+ * ++ and -- are also disallowed in general are they operate "by ref"
+ */
+namespace InternalClassesOverloadOffsetAccessInvalid;
+
+function test1(\DOMNamedNodeMap $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test2(\Dom\NamedNodeMap $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test3(\DOMNodeList $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test4(\Dom\NodeList $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test5(\Dom\HTMLCollection $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test6(\Dom\DtdNamedNodeMap $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test7(\PDORow $v): void
+{
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+}
+
+function test8(\ResourceBundle $v): void
+{
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+	$v[] = 'append';
+	$v[0] = 'update';
+	$v[0] .= ' and again';
+	$r1 = &$v[0];
+	unset($v[0]);
+	var_dump($r1);
+	var_dump($v['name']);
+	var_dump($v[0]);
+}
+

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-php84.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-php84.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.4
+<?php
 
 namespace InternalClassesOverloadOffsetAccess\Php84;
 

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-php84.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access-php84.php
@@ -1,0 +1,74 @@
+<?php // lint >= 8.4
+
+namespace InternalClassesOverloadOffsetAccess\Php84;
+
+function test1(\DOMNamedNodeMap $v): void
+{
+	if ($v['attribute_name']) {
+		var_dump($v['attribute_name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test2(\Dom\NamedNodeMap $v): void
+{
+	if ($v['attribute_name']) {
+		var_dump($v['attribute_name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test3(\DOMNodeList $v): void
+{
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test4(\Dom\NodeList $v): void
+{
+	//var_dump($v['attribute_name']);
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test5(\Dom\HTMLCollection $v): void
+{
+	if ($v['name']) {
+		var_dump($v['name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test6(\Dom\DtdNamedNodeMap $v): void
+{
+	if ($v['name']) {
+		var_dump($v['name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test7(\PDORow $v): void
+{
+	if ($v['name']) {
+		var_dump($v['name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test8(\ResourceBundle $v): void
+{
+	var_dump($v['name']);
+	var_dump($v[0]);
+}

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace InternalClassesOverloadOffsetAccess;
+
+function test1(\DOMNamedNodeMap $v): void
+{
+	if ($v['attribute_name']) {
+		var_dump($v['attribute_name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test2(\Dom\NamedNodeMap $v): void
+{
+	if ($v['attribute_name']) {
+		var_dump($v['attribute_name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test3(\DOMNodeList $v): void
+{
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test4(\Dom\NodeList $v): void
+{
+	//var_dump($v['attribute_name']);
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test5(\Dom\HTMLCollection $v): void
+{
+	if ($v['name']) {
+		var_dump($v['name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test6(\Dom\DtdNamedNodeMap $v): void
+{
+	if ($v['name']) {
+		var_dump($v['name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test7(\PDORow $v): void
+{
+	if ($v['name']) {
+		var_dump($v['name']);
+	}
+	if ($v[0]) {
+		var_dump($v[0]);
+	}
+}
+
+function test8(\ResourceBundle $v): void
+{
+	var_dump($v['name']);
+	var_dump($v[0]);
+}
+

--- a/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access.php
+++ b/tests/PHPStan/Rules/Arrays/data/internal-classes-overload-offset-access.php
@@ -12,46 +12,8 @@ function test1(\DOMNamedNodeMap $v): void
 	}
 }
 
-function test2(\Dom\NamedNodeMap $v): void
-{
-	if ($v['attribute_name']) {
-		var_dump($v['attribute_name']);
-	}
-	if ($v[0]) {
-		var_dump($v[0]);
-	}
-}
-
 function test3(\DOMNodeList $v): void
 {
-	if ($v[0]) {
-		var_dump($v[0]);
-	}
-}
-
-function test4(\Dom\NodeList $v): void
-{
-	//var_dump($v['attribute_name']);
-	if ($v[0]) {
-		var_dump($v[0]);
-	}
-}
-
-function test5(\Dom\HTMLCollection $v): void
-{
-	if ($v['name']) {
-		var_dump($v['name']);
-	}
-	if ($v[0]) {
-		var_dump($v[0]);
-	}
-}
-
-function test6(\Dom\DtdNamedNodeMap $v): void
-{
-	if ($v['name']) {
-		var_dump($v['name']);
-	}
 	if ($v[0]) {
 		var_dump($v[0]);
 	}


### PR DESCRIPTION
Quick fix for https://github.com/phpstan/phpstan/issues/12235 as `DOMNodeList` already doesn't complain about incorrect writes it makes sense to have the same behaviour for the other internal classes until PHPStan uses the access mode of the offset.