### PR TITLE
Support inferring new templated type from initial null coalesce assignment

### DIFF
--- a/src/Parser/NewAssignedToPropertyVisitor.php
+++ b/src/Parser/NewAssignedToPropertyVisitor.php
@@ -12,7 +12,7 @@ final class NewAssignedToPropertyVisitor extends NodeVisitorAbstract
 
 	public function enterNode(Node $node): ?Node
 	{
-		if ($node instanceof Node\Expr\Assign || $node instanceof Node\Expr\AssignRef) {
+		if ($node instanceof Node\Expr\Assign || $node instanceof Node\Expr\AssignRef || $node instanceof Node\Expr\AssignOp\Coalesce) {
 			if (
 				($node->var instanceof Node\Expr\PropertyFetch || $node->var instanceof Node\Expr\StaticPropertyFetch)
 				&& $node->expr instanceof Node\Expr\New_

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -651,6 +651,11 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12250(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12250.php'], []);
+	}
+
 	public function testBug11617(): void
 	{
 		$this->checkExplicitMixed = true;

--- a/tests/PHPStan/Rules/Properties/data/bug-12250.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12250.php
@@ -1,0 +1,31 @@
+<?php // lint >= 7.4
+
+namespace Bug12250;
+
+class Model {}
+
+/**
+ * @template T of object|array<mixed>
+ */
+class WeakAnalysingMap
+{
+	/** @var list<T> */
+	public array $values = [];
+}
+
+class Reference
+{
+	/** @var WeakAnalysingMap<Model> */
+	private static WeakAnalysingMap $analysingTheirModelMap;
+
+	public function createAnalysingTheirModel(): Model
+	{
+		self::$analysingTheirModelMap ??= new WeakAnalysingMap();
+
+		$theirModel = new Model();
+
+		self::$analysingTheirModelMap->values[] = $theirModel;
+
+		return end(self::$analysingTheirModelMap->values);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/12250

I made a bug report https://github.com/phpstan/phpstan/issues/12250, and this PR is fixing that.

While all the current tests are passing this PR adds a conditional assignment to NewAssignedToPropertyVisitor which only contained non conditional ones so I'm marking it as draft.