### PR TITLE
Remove incorrect doc leftover from 1.x

### DIFF
--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -64,13 +64,6 @@ interface Type
 	/** @return list<ConstantStringType> */
 	public function getConstantStrings(): array;
 
-	/**
-	 * This is like accepts() but gives reasons
-	 * why the type was not/might not be accepted in some non-intuitive scenarios.
-	 *
-	 * In PHPStan 2.0 this method will be removed and the return type of accepts()
-	 * will change to AcceptsResult.
-	 */
 	public function accepts(Type $type, bool $strictTypes): AcceptsResult;
 
 	public function isSuperTypeOf(Type $type): IsSuperTypeOfResult;


### PR DESCRIPTION
This appears to have come from a now removed function, or at least it doesn't really make sens to say to use accepts() instead of accepts() :)