### PR TITLE
10% faster FunctionCallParametersCheck

### DIFF
--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -88,8 +88,7 @@ final class FunctionCallParametersCheck
 		$hasNamedArguments = false;
 		$hasUnpackedArgument = false;
 		$errors = [];
-		foreach ($args as $i => $arg) {
-			$type = $scope->getType($arg->value);
+		foreach ($args as $arg) {
 			if ($hasNamedArguments && $arg->unpack) {
 				$errors[] = RuleErrorBuilder::message('Named argument cannot be followed by an unpacked (...) argument.')
 					->identifier('argument.unpackAfterNamed')
@@ -113,6 +112,7 @@ final class FunctionCallParametersCheck
 				$argumentName = $arg->name->toString();
 			}
 			if ($arg->unpack) {
+				$type = $scope->getType($arg->value);
 				$arrays = $type->getConstantArrays();
 				if (count($arrays) > 0) {
 					$minKeys = null;
@@ -191,7 +191,7 @@ final class FunctionCallParametersCheck
 
 		if (!$hasNamedArguments) {
 			$invokedParametersCount = count($arguments);
-			foreach ($arguments as $i => [$argumentValue, $argumentValueType, $unpack, $argumentName]) {
+			foreach ($arguments as [$argumentValue, $argumentValueType, $unpack, $argumentName]) {
 				if ($unpack) {
 					$invokedParametersCount = max($functionParametersMinCount, $functionParametersMaxCount);
 					break;


### PR DESCRIPTION
2.0.x before this PR
```
time php bin/phpstan --debug  
79.37s user 0.92s system 99% cpu 1:20.37 total
```

2.0.x after this PR
```
time php bin/phpstan --debug  
76.22s user 0.84s system 99% cpu 1:17.13 total
```

by reducing `getType` calls:

<img width="429" alt="grafik" src="https://github.com/user-attachments/assets/dbcce8fe-6a6f-4d1a-9d78-53d23e11bb47" />

