### PR TITLE
Support # comments in regex

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -23,6 +23,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function in_array;
 use function is_int;
+use function preg_replace;
 use function rtrim;
 use function sscanf;
 use function str_contains;
@@ -64,18 +65,26 @@ final class RegexGroupParser
 			return null;
 		}
 
-		$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);
-		try {
-			$ast = self::$parser->parse($rawRegex);
-		} catch (Exception) {
-			return null;
-		}
-
 		$modifiers = $this->regexExpressionHelper->getPatternModifiers($regex) ?? '';
 		foreach (self::NOT_SUPPORTED_MODIFIERS as $notSupportedModifier) {
 			if (str_contains($modifiers, $notSupportedModifier)) {
 				return null;
 			}
+		}
+
+		// The regex engine ignores everything after the (?# until the first closing parenthesis
+		$regex = preg_replace('/\(\?#[^)]*\)/', '', $regex) ?? '';
+
+		if (str_contains($modifiers, 'x')) {
+			// in freespacing mode the # character starts a comment and runs until the end of the line
+			$regex = preg_replace('/#.*/', '', $regex) ?? '';
+		}
+
+		$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);
+		try {
+			$ast = self::$parser->parse($rawRegex);
+		} catch (Exception) {
+			return null;
 		}
 
 		$captureOnlyNamed = false;

--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -72,12 +72,9 @@ final class RegexGroupParser
 			}
 		}
 
-		// The regex engine ignores everything after the (?# until the first closing parenthesis
-		$regex = preg_replace('/\(\?#[^)]*\)/', '', $regex) ?? '';
-
 		if (str_contains($modifiers, 'x')) {
 			// in freespacing mode the # character starts a comment and runs until the end of the line
-			$regex = preg_replace('/#.*/', '', $regex) ?? '';
+			$regex = preg_replace('/[^?]#.*/', '', $regex) ?? '';
 		}
 
 		$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);

--- a/tests/PHPStan/Analyser/nsrt/bug-12242.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12242.php
@@ -15,3 +15,18 @@ function foo(string $str): void
 		assertType('array{string, string}', $match);
 	}
 }
+
+function bar(string $str): void
+{
+	$regexp = '/^
+            (\w+)        # column type [1]
+            [\(]         # (
+                ?([\d,]*)  # size or size, precision [2]
+            [\)]         # )
+            ?\s*         # whitespace
+            (\w*)        # extra description (UNSIGNED, CHARACTER SET, ...) [3]
+        $/x';
+	if (preg_match($regexp, $str, $matches)) {
+		assertType('array{string, non-empty-string, string, string}', $matches);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12242.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12242.php
@@ -1,0 +1,17 @@
+<?php // lint >= 7.4
+
+namespace Bug12242;
+
+use function PHPStan\Testing\assertType;
+
+function foo(string $str): void
+{
+	$regexp = '/
+		# (
+		([\d,]*)
+		# )
+	/x';
+	if (preg_match($regexp, $str, $match)) {
+		assertType('array{string, string}', $match);
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/12242

see https://www.regular-expressions.info/freespacing.html#freecomment

will look into whitespace normalization for the `x`-modifer in a separate PR