### PR TITLE
Faster `MutatingScope->getNodeKey()`

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -710,15 +710,16 @@ final class MutatingScope implements Scope
 	{
 		$key = $this->exprPrinter->printExpr($node);
 
+		$attributes = $node->getAttributes();
 		if (
 			$node instanceof Node\FunctionLike
-			&& $node->hasAttribute(ArrayMapArgVisitor::ATTRIBUTE_NAME)
-			&& $node->hasAttribute('startFilePos')
+			&& (($attributes[ArrayMapArgVisitor::ATTRIBUTE_NAME] ?? null) !== null)
+			&& (($attributes['startFilePos'] ?? null) !== null)
 		) {
-			$key .= '/*' . $node->getAttribute('startFilePos') . '*/';
+			$key .= '/*' . $attributes['startFilePos'] . '*/';
 		}
 
-		if ($node->getAttribute(self::KEEP_VOID_ATTRIBUTE_NAME) === true) {
+		if (($attributes[self::KEEP_VOID_ATTRIBUTE_NAME] ?? null) === true) {
 			$key .= '/*' . self::KEEP_VOID_ATTRIBUTE_NAME . '*/';
 		}
 


### PR DESCRIPTION
we call `getNodeKey()` several million times in most profiles

after
```
➜  phpstan-src git:(2.0.x) ✗ hyperfine 'php bin/phpstan analyze --debug src/Rules' -i
Benchmark 1: php bin/phpstan analyze --debug src/Rules
  Time (mean ± σ):     14.899 s ±  0.110 s    [User: 14.583 s, System: 0.310 s]
  Range (min … max):   14.667 s … 15.006 s    10 runs
 ```

before 
```
➜  phpstan-src git:(2.0.x) ✗ hyperfine 'php bin/phpstan analyze --debug src/Rules' -i
Benchmark 1: php bin/phpstan analyze --debug src/Rules
  Time (mean ± σ):     14.980 s ±  0.148 s    [User: 14.645 s, System: 0.316 s]
  Range (min … max):   14.844 s … 15.332 s    10 runs
```
