### PR TITLE
Improve `preg_split()` function ReturnType

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -9081,7 +9081,7 @@ return [
 'preg_replace' => ['string|array|null', 'regex'=>'string|array', 'replace'=>'string|array', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
 'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable(array<int|string, string>):string', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
 'preg_replace_callback_array' => ['string|array|null', 'pattern'=>'array<string,callable>', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
-'preg_split' => ['list<string>|false', 'pattern'=>'string', 'subject'=>'string', 'limit='=>'?int', 'flags='=>'int'],
+'preg_split' => ['__benevolent<list<string>|list<array{string, int<0, max>}>|false>', 'pattern'=>'string', 'subject'=>'string', 'limit='=>'?int', 'flags='=>'int'],
 'prev' => ['mixed', '&rw_array_arg'=>'array|object'],
 'print_r' => ['string|true', 'var'=>'mixed', 'return='=>'bool'],
 'printf' => ['int', 'format'=>'string', '...values='=>'__stringAndStringable|int|float|null|bool'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -9081,7 +9081,7 @@ return [
 'preg_replace' => ['string|array|null', 'regex'=>'string|array', 'replace'=>'string|array', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
 'preg_replace_callback' => ['string|array|null', 'regex'=>'string|array', 'callback'=>'callable(array<int|string, string>):string', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
 'preg_replace_callback_array' => ['string|array|null', 'pattern'=>'array<string,callable>', 'subject'=>'string|array', 'limit='=>'int', '&w_count='=>'int'],
-'preg_split' => ['__benevolent<list<string>|list<array{string, int<0, max>}>|false>', 'pattern'=>'string', 'subject'=>'string', 'limit='=>'?int', 'flags='=>'int'],
+'preg_split' => ['list<string>|list<array{string, int<0, max>}>|false', 'pattern'=>'string', 'subject'=>'string', 'limit='=>'?int', 'flags='=>'int'],
 'prev' => ['mixed', '&rw_array_arg'=>'array|object'],
 'print_r' => ['string|true', 'var'=>'mixed', 'return='=>'bool'],
 'printf' => ['int', 'format'=>'string', '...values='=>'__stringAndStringable|int|float|null|bool'],

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -10,9 +10,12 @@ use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BitwiseFlagHelper;
 use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
@@ -36,9 +39,28 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		$flagsArg = $functionCall->getArgs()[3] ?? null;
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
+			return null;
+		}
+		$patternArg = $args[0];
+		$subjectArg = $args[1];
+		$limitArg = $args[2] ?? null;
+		$flagArg = $args[3] ?? null;
+		$patternType = $scope->getType($patternArg->value);
+		$patternConstantTypes = $patternType->getConstantStrings();
+		$subjectType = $scope->getType($subjectArg->value);
+		$subjectConstantTypes = $subjectType->getConstantStrings();
 
-		if ($flagsArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagsArg->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE')->yes()) {
+		if (
+			count($patternConstantTypes) > 0 &&
+			@preg_match($patternConstantTypes[0]->getValue(), "") === false
+		) {
+
+			return new ErrorType();
+		}
+
+		if ($subjectArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($subjectArg->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE')->yes()) {
 			$type = new ArrayType(
 				new IntegerType(),
 				new ConstantArrayType([new ConstantIntegerType(0), new ConstantIntegerType(1)], [new StringType(), IntegerRangeType::fromInterval(0, null)], [2], [], TrinaryLogic::createYes()),
@@ -46,7 +68,50 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			return TypeCombinator::union(TypeCombinator::intersect($type, new AccessoryArrayListType()), new ConstantBooleanType(false));
 		}
 
-		return null;
-	}
+		if ($limitArg === null) {
+			$limits = [-1];
+		} else {
+			$limitType = $scope->getType($limitArg->value);
+			$limits = $limitType->getConstantScalarValues();
+		}
 
+		if ($flagArg === null) {
+			$flags = [0];
+		} else {
+			$flagType = $scope->getType($flagArg->value);
+			$flags = $flagType->getConstantScalarValues();
+		}
+
+		if (count($patternConstantTypes) === 0 || count($subjectConstantTypes) === 0 || count($flags) === 0) {
+			return null;
+		}
+
+		$resultTypes = [];
+		foreach ($patternConstantTypes as $patternConstantType) {
+			foreach ($subjectConstantTypes as $subjectConstantType) {
+				foreach ($flags as $flag) {
+					foreach ($limits as $limit) {
+						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), $limit, $flag);
+						if ($result !== false) {
+							$constantArray = ConstantArrayTypeBuilder::createEmpty();
+							foreach ($result as $key => $value) {
+								assert(is_int($key));
+								if (is_array($value)) {
+									$valueConstantArray = ConstantArrayTypeBuilder::createEmpty();
+									$valueConstantArray->setOffsetValueType(new ConstantIntegerType(0), new ConstantStringType($value[0]));
+									$valueConstantArray->setOffsetValueType(new ConstantIntegerType(1), new ConstantIntegerType($value[1]));
+									$valueType = $valueConstantArray->getArray();
+								} else {
+									$valueType = new ConstantStringType($value);
+								}
+								$constantArray->setOffsetValueType(new ConstantIntegerType($key), $valueType);
+							}
+							$resultTypes[] = $constantArray->getArray();
+						}
+					}
+				}
+			}
+		}
+		return TypeCombinator::union(...$resultTypes);
+	}
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -94,27 +94,38 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			}
 
 			$capturedArrayType = new ConstantArrayType(
-				[
-					new ConstantIntegerType(0),
-					new ConstantIntegerType(1)], [$stringType, IntegerRangeType::fromInterval(0, null)
-				],
+				[new ConstantIntegerType(0), new ConstantIntegerType(1)], [$stringType, IntegerRangeType::fromInterval(0, null)],
 				[2],
 				[],
 				TrinaryLogic::createYes()
 			);
+
 			$valueType = $stringType;
 			if ($flagArg !== null) {
 				$flagState = $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE');
 				if ($flagState->yes()) {
-					return TypeUtils::toBenevolentUnion(
-						TypeCombinator::union(
-							TypeCombinator::intersect(
-								new ArrayType(new IntegerType(), $capturedArrayType),
-								new AccessoryArrayListType()
-							),
-							new ConstantBooleanType(false)
-						)
-					);
+					if ($subjectType->isNonEmptyString()->yes()) {
+						return TypeUtils::toBenevolentUnion(
+							TypeCombinator::union(
+								TypeCombinator::intersect(
+									new ArrayType(new IntegerType(), $capturedArrayType),
+									new NonEmptyArrayType(),
+									new AccessoryArrayListType(),
+								),
+								new ConstantBooleanType(false)
+							)
+						);
+					} else {
+						return TypeUtils::toBenevolentUnion(
+							TypeCombinator::union(
+								TypeCombinator::intersect(
+									new ArrayType(new IntegerType(), $capturedArrayType),
+									new AccessoryArrayListType(),
+								),
+								new ConstantBooleanType(false)
+							)
+						);
+					}
 				}
 				if ($flagState->maybe()) {
 					$valueType = TypeCombinator::union(new StringType(), $capturedArrayType);

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -94,7 +94,6 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			}
 		}
 
-
 		if (count($patternConstantTypes) === 0 || count($subjectConstantTypes) === 0) {
 			$returnNonEmptyStrings = $flagArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_NO_EMPTY')->yes();
 			if ($returnNonEmptyStrings) {
@@ -127,7 +126,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 						$capturedArrayListType = TypeCombinator::intersect($capturedArrayListType, new NonEmptyArrayType());
 					}
 
-					return TypeUtils::toBenevolentUnion(TypeCombinator::union($capturedArrayListType, new ConstantBooleanType(false)));
+					return TypeCombinator::union($capturedArrayListType, new ConstantBooleanType(false));
 				}
 				if ($flagState->maybe()) {
 					$returnInternalValueType = TypeCombinator::union(new StringType(), $capturedArrayType);
@@ -142,7 +141,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				);
 			}
 
-			return TypeUtils::toBenevolentUnion(TypeCombinator::union($returnListType, new ConstantBooleanType(false)));
+			return TypeCombinator::union($returnListType, new ConstantBooleanType(false));
 		}
 
 		$resultTypes = [];

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -98,7 +98,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				[$returnStringType, IntegerRangeType::fromInterval(0, null)],
 				[2],
 				[],
-				TrinaryLogic::createYes()
+				TrinaryLogic::createYes(),
 			);
 
 			$returnInternalValueType = $returnStringType;

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -68,19 +68,32 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			return new ErrorType();
 		}
 
+		$limits = [];
 		if ($limitArg === null) {
 			$limits = [-1];
 		} else {
 			$limitType = $scope->getType($limitArg->value);
-			$limits = $limitType->getConstantScalarValues();
+			foreach ($limitType->getConstantScalarValues() as $limit) {
+				if (!is_int($limit)) {
+					return new ErrorType();
+				}
+				$limits[] = $limit;
+			}
 		}
 
+		$flags = [];
 		if ($flagArg === null) {
 			$flags = [0];
 		} else {
 			$flagType = $scope->getType($flagArg->value);
-			$flags = $flagType->getConstantScalarValues();
+			foreach ($flagType->getConstantScalarValues() as $flag) {
+				if (!is_int($flag)) {
+					return new ErrorType();
+				}
+				$flags[] = $flag;
+			}
 		}
+
 
 		if (count($patternConstantTypes) === 0 || count($subjectConstantTypes) === 0) {
 			$returnNonEmptyStrings = $flagArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_NO_EMPTY')->yes();
@@ -136,13 +149,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		foreach ($patternConstantTypes as $patternConstantType) {
 			foreach ($subjectConstantTypes as $subjectConstantType) {
 				foreach ($limits as $limit) {
-					if (!is_int($limit)) {
-						return null;
-					}
 					foreach ($flags as $flag) {
-						if (!is_int($flag)) {
-							return null;
-						}
 						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), $limit, $flag);
 						if ($result === false) {
 							continue;

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\Php;
 
@@ -87,14 +87,15 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			if ($returnNonEmptyStrings) {
 				$returnStringType = TypeCombinator::intersect(
 					new StringType(),
-					new AccessoryNonEmptyStringType()
+					new AccessoryNonEmptyStringType(),
 				);
 			} else {
 				$returnStringType = new StringType();
 			}
 
 			$capturedArrayType = new ConstantArrayType(
-				[new ConstantIntegerType(0), new ConstantIntegerType(1)], [$returnStringType, IntegerRangeType::fromInterval(0, null)],
+				[new ConstantIntegerType(0), new ConstantIntegerType(1)],
+				[$returnStringType, IntegerRangeType::fromInterval(0, null)],
 				[2],
 				[],
 				TrinaryLogic::createYes()
@@ -113,9 +114,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 						$capturedArrayListType = TypeCombinator::intersect($capturedArrayListType, new NonEmptyArrayType());
 					}
 
-					return TypeUtils::toBenevolentUnion(
-						TypeCombinator::union($capturedArrayListType, new ConstantBooleanType(false))
-					);
+					return TypeUtils::toBenevolentUnion(TypeCombinator::union($capturedArrayListType, new ConstantBooleanType(false)));
 				}
 				if ($flagState->maybe()) {
 					$returnInternalValueType = TypeCombinator::union(new StringType(), $capturedArrayType);
@@ -130,12 +129,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				);
 			}
 
-			return TypeUtils::toBenevolentUnion(
-				TypeCombinator::union(
-					$returnListType,
-					new ConstantBooleanType(false)
-				)
-			);
+			return TypeUtils::toBenevolentUnion(TypeCombinator::union($returnListType, new ConstantBooleanType(false)));
 		}
 
 		$resultTypes = [];
@@ -150,22 +144,23 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 							return null;
 						}
 						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), $limit, $flag);
-						if ($result !== false) {
-							$constantArray = ConstantArrayTypeBuilder::createEmpty();
-							foreach ($result as $key => $value) {
-								if (is_array($value)) {
-									$valueConstantArray = ConstantArrayTypeBuilder::createEmpty();
-									$valueConstantArray->setOffsetValueType(new ConstantIntegerType(0), new ConstantStringType($value[0]));
-									$valueConstantArray->setOffsetValueType(new ConstantIntegerType(1), new ConstantIntegerType($value[1]));
-									$returnInternalValueType = $valueConstantArray->getArray();
-								} else {
-									$returnInternalValueType = new ConstantStringType($value);
-								}
-								$constantArray->setOffsetValueType(new ConstantIntegerType($key), $returnInternalValueType);
-							}
-
-							$resultTypes[] = $constantArray->getArray();
+						if ($result === false) {
+							continue;
 						}
+						$constantArray = ConstantArrayTypeBuilder::createEmpty();
+						foreach ($result as $key => $value) {
+							if (is_array($value)) {
+								$valueConstantArray = ConstantArrayTypeBuilder::createEmpty();
+								$valueConstantArray->setOffsetValueType(new ConstantIntegerType(0), new ConstantStringType($value[0]));
+								$valueConstantArray->setOffsetValueType(new ConstantIntegerType(1), new ConstantIntegerType($value[1]));
+								$returnInternalValueType = $valueConstantArray->getArray();
+							} else {
+								$returnInternalValueType = new ConstantStringType($value);
+							}
+							$constantArray->setOffsetValueType(new ConstantIntegerType($key), $returnInternalValueType);
+						}
+
+						$resultTypes[] = $constantArray->getArray();
 					}
 				}
 			}
@@ -173,4 +168,5 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 		return TypeCombinator::union(...$resultTypes);
 	}
+
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -24,7 +24,6 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeUtils;
 use function count;
 use function is_array;
 use function is_int;

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -63,7 +63,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 		if (
 			count($patternConstantTypes) > 0
-			&& @preg_match($patternConstantTypes[0]->getValue(), "") === false
+			&& @preg_match($patternConstantTypes[0]->getValue(), '') === false
 		) {
 			return new ErrorType();
 		}

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -104,28 +104,18 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			if ($flagArg !== null) {
 				$flagState = $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE');
 				if ($flagState->yes()) {
+					$arrayType = TypeCombinator::intersect(
+						new ArrayType(new IntegerType(), $capturedArrayType),
+						new AccessoryArrayListType(),
+					);
+
 					if ($subjectType->isNonEmptyString()->yes()) {
-						return TypeUtils::toBenevolentUnion(
-							TypeCombinator::union(
-								TypeCombinator::intersect(
-									new ArrayType(new IntegerType(), $capturedArrayType),
-									new NonEmptyArrayType(),
-									new AccessoryArrayListType(),
-								),
-								new ConstantBooleanType(false)
-							)
-						);
-					} else {
-						return TypeUtils::toBenevolentUnion(
-							TypeCombinator::union(
-								TypeCombinator::intersect(
-									new ArrayType(new IntegerType(), $capturedArrayType),
-									new AccessoryArrayListType(),
-								),
-								new ConstantBooleanType(false)
-							)
-						);
+						$arrayType = TypeCombinator::intersect($arrayType, new NonEmptyArrayType());
 					}
+
+					return TypeUtils::toBenevolentUnion(
+						TypeCombinator::union($arrayType, new ConstantBooleanType(false))
+					);
 				}
 				if ($flagState->maybe()) {
 					$valueType = TypeCombinator::union(new StringType(), $capturedArrayType);

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -142,12 +142,17 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		foreach ($patternConstantTypes as $patternConstantType) {
 			foreach ($subjectConstantTypes as $subjectConstantType) {
 				foreach ($limits as $limit) {
+					if (!is_int($limit)) {
+						return null;
+					}
 					foreach ($flags as $flag) {
+						if (!is_int($flag)) {
+							return null;
+						}
 						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), $limit, $flag);
 						if ($result !== false) {
 							$constantArray = ConstantArrayTypeBuilder::createEmpty();
 							foreach ($result as $key => $value) {
-								assert(is_int($key));
 								if (is_array($value)) {
 									$valueConstantArray = ConstantArrayTypeBuilder::createEmpty();
 									$valueConstantArray->setOffsetValueType(new ConstantIntegerType(0), new ConstantStringType($value[0]));

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -157,9 +157,6 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				foreach ($limits as $limit) {
 					foreach ($flags as $flag) {
 						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), (int) $limit, (int) $flag);
-						if ($result === false) {
-							return new ErrorType();
-						}
 						$constantArray = ConstantArrayTypeBuilder::createEmpty();
 						foreach ($result as $key => $value) {
 							if (is_array($value)) {
@@ -178,7 +175,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				}
 			}
 		}
-
+		$resultTypes[] = new ConstantBooleanType(false);
 		return TypeCombinator::union(...$resultTypes);
 	}
 

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -29,12 +29,12 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function is_array;
 use function is_int;
+use function is_numeric;
 use function preg_split;
 use function strtolower;
 
 final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
-
 	public function __construct(
 		private BitwiseFlagHelper $bitwiseFlagAnalyser,
 	)
@@ -156,7 +156,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			foreach ($subjectConstantTypes as $subjectConstantType) {
 				foreach ($limits as $limit) {
 					foreach ($flags as $flag) {
-						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), (int)$limit, (int)$flag);
+						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), (int) $limit, (int) $flag);
 						if ($result === false) {
 							return new ErrorType();
 						}
@@ -178,16 +178,16 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				}
 			}
 		}
-
 		return TypeCombinator::union(...$resultTypes);
+
 	}
 
 	/**
 	 * @param ConstantStringType[] $patternConstantArray
 	 * @param ConstantStringType[] $subjectConstantArray
-	 * @return bool
 	 */
-	private function isPatternOrSubjectEmpty(array $patternConstantArray, array $subjectConstantArray): bool {
+	private function isPatternOrSubjectEmpty(array $patternConstantArray, array $subjectConstantArray): bool
+	{
 		return count($patternConstantArray) === 0 || count($subjectConstantArray) === 0;
 	}
 
@@ -195,7 +195,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 	{
 		try {
 			Strings::match('', $pattern);
-		} catch (RegexpException $e) {
+		} catch (RegexpException) {
 			return false;
 		}
 		return true;

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -26,6 +26,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use function count;
 use function is_array;
 use function is_int;
@@ -113,13 +114,16 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				$returnStringType = new StringType();
 			}
 
-			$capturedArrayType = new ConstantArrayType(
-				[new ConstantIntegerType(0), new ConstantIntegerType(1)],
-				[$returnStringType, IntegerRangeType::fromInterval(0, null)],
-				[2],
-				[],
-				TrinaryLogic::createYes(),
+			$arrayTypeBuilder = ConstantArrayTypeBuilder::createEmpty();
+			$arrayTypeBuilder->setOffsetValueType(
+				new ConstantIntegerType(0),
+				$returnStringType
 			);
+			$arrayTypeBuilder->setOffsetValueType(
+				new ConstantIntegerType(1),
+				IntegerRangeType::fromInterval(0, null)
+			);
+			$capturedArrayType = $arrayTypeBuilder->getArray();
 
 			$returnInternalValueType = $returnStringType;
 			if ($capturesOffset !== null) {
@@ -203,7 +207,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 	private function isIntOrStringValue(Type $type): bool
 	{
-		return $type->isInteger()->yes() || $type->isString()->yes() || $type->isConstantScalarValue()->yes();
+		return (new UnionType([new IntegerType(), new StringType()]))->isSuperTypeOf($type)->yes();
 	}
 
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -7,13 +7,11 @@ use Nette\Utils\Strings;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BitwiseFlagHelper;
-use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -117,11 +115,11 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			$arrayTypeBuilder = ConstantArrayTypeBuilder::createEmpty();
 			$arrayTypeBuilder->setOffsetValueType(
 				new ConstantIntegerType(0),
-				$returnStringType
+				$returnStringType,
 			);
 			$arrayTypeBuilder->setOffsetValueType(
 				new ConstantIntegerType(1),
-				IntegerRangeType::fromInterval(0, null)
+				IntegerRangeType::fromInterval(0, null),
 			);
 			$capturedArrayType = $arrayTypeBuilder->getArray();
 

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -60,9 +60,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$patternConstantTypes = $patternType->getConstantStrings();
 		if (count($patternConstantTypes) > 0) {
 			foreach ($patternConstantTypes as $patternConstantType) {
-				try {
-					Strings::match('', $patternConstantType->getValue());
-				} catch (RegexpException $e) {
+				if ($this->isValidPattern($patternConstantType->getValue()) === false) {
 					return new ErrorType();
 				}
 			}
@@ -191,5 +189,15 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 	 */
 	private function isPatternOrSubjectEmpty(array $patternConstantArray, array $subjectConstantArray): bool {
 		return count($patternConstantArray) === 0 || count($subjectConstantArray) === 0;
+	}
+
+	private function isValidPattern(string $pattern): bool
+	{
+		try {
+			Strings::match('', $pattern);
+		} catch (RegexpException $e) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -157,6 +157,9 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				foreach ($limits as $limit) {
 					foreach ($flags as $flag) {
 						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), (int) $limit, (int) $flag);
+						if ($result === false) {
+							return new ErrorType();
+						}
 						$constantArray = ConstantArrayTypeBuilder::createEmpty();
 						foreach ($result as $key => $value) {
 							if (is_array($value)) {

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -35,6 +35,7 @@ use function strtolower;
 
 final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
 	public function __construct(
 		private BitwiseFlagHelper $bitwiseFlagAnalyser,
 	)
@@ -179,7 +180,6 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			}
 		}
 		return TypeCombinator::union(...$resultTypes);
-
 	}
 
 	/**
@@ -200,4 +200,5 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 		return true;
 	}
+
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Type\Php;
 
+use Nette\Utils\RegexpException;
+use Nette\Utils\Strings;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
@@ -27,7 +29,6 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function is_array;
 use function is_int;
-use function preg_match;
 use function preg_split;
 use function strtolower;
 
@@ -57,23 +58,29 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$flagArg = $args[3] ?? null;
 		$patternType = $scope->getType($patternArg->value);
 		$patternConstantTypes = $patternType->getConstantStrings();
+		if (count($patternConstantTypes) > 0) {
+			foreach ($patternConstantTypes as $patternConstantType) {
+				try {
+					Strings::match('', $patternConstantType->getValue());
+				} catch (RegexpException $e) {
+					return new ErrorType();
+				}
+			}
+		}
+
 		$subjectType = $scope->getType($subjectArg->value);
 		$subjectConstantTypes = $subjectType->getConstantStrings();
-
-		if (
-			count($patternConstantTypes) > 0
-			&& @preg_match($patternConstantTypes[0]->getValue(), '') === false
-		) {
-			return new ErrorType();
-		}
 
 		$limits = [];
 		if ($limitArg === null) {
 			$limits = [-1];
 		} else {
 			$limitType = $scope->getType($limitArg->value);
+			if (!$limitType->isInteger()->yes() && !$limitType->isString()->yes()) {
+				return new ErrorType();
+			}
 			foreach ($limitType->getConstantScalarValues() as $limit) {
-				if (!is_int($limit)) {
+				if (!is_int($limit) && !is_numeric($limit)) {
 					return new ErrorType();
 				}
 				$limits[] = $limit;
@@ -85,15 +92,18 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			$flags = [0];
 		} else {
 			$flagType = $scope->getType($flagArg->value);
+			if (!$flagType->isInteger()->yes() && !$flagType->isString()->yes()) {
+				return new ErrorType();
+			}
 			foreach ($flagType->getConstantScalarValues() as $flag) {
-				if (!is_int($flag)) {
+				if (!is_int($flag) && !is_numeric($flag)) {
 					return new ErrorType();
 				}
 				$flags[] = $flag;
 			}
 		}
 
-		if (count($patternConstantTypes) === 0 || count($subjectConstantTypes) === 0) {
+		if ($this->isPatternOrSubjectEmpty($patternConstantTypes, $subjectConstantTypes)) {
 			$returnNonEmptyStrings = $flagArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_NO_EMPTY')->yes();
 			if ($returnNonEmptyStrings) {
 				$returnStringType = TypeCombinator::intersect(
@@ -148,9 +158,9 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			foreach ($subjectConstantTypes as $subjectConstantType) {
 				foreach ($limits as $limit) {
 					foreach ($flags as $flag) {
-						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), $limit, $flag);
+						$result = @preg_split($patternConstantType->getValue(), $subjectConstantType->getValue(), (int)$limit, (int)$flag);
 						if ($result === false) {
-							continue;
+							return new ErrorType();
 						}
 						$constantArray = ConstantArrayTypeBuilder::createEmpty();
 						foreach ($result as $key => $value) {
@@ -174,4 +184,12 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		return TypeCombinator::union(...$resultTypes);
 	}
 
+	/**
+	 * @param ConstantStringType[] $patternConstantArray
+	 * @param ConstantStringType[] $subjectConstantArray
+	 * @return bool
+	 */
+	private function isPatternOrSubjectEmpty(array $patternConstantArray, array $subjectConstantArray): bool {
+		return count($patternConstantArray) === 0 || count($subjectConstantArray) === 0;
+	}
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -205,4 +205,5 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 	{
 		return $type->isInteger()->yes() || $type->isString()->yes() || $type->isConstantScalarValue()->yes();
 	}
+
 }

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -37,7 +37,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 {
 
 	public function __construct(
-		private BitwiseFlagHelper $bitwiseFlagAnalyser,
+		private readonly BitwiseFlagHelper $bitwiseFlagAnalyser,
 	)
 	{
 	}
@@ -56,7 +56,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		$patternArg = $args[0];
 		$subjectArg = $args[1];
 		$limitArg = $args[2] ?? null;
-		$flagArg = $args[3] ?? null;
+		$capturesOffset = $args[3] ?? null;
 		$patternType = $scope->getType($patternArg->value);
 		$patternConstantTypes = $patternType->getConstantStrings();
 		if (count($patternConstantTypes) > 0) {
@@ -75,7 +75,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			$limits = [-1];
 		} else {
 			$limitType = $scope->getType($limitArg->value);
-			if (!$limitType->isInteger()->yes() && !$limitType->isString()->yes()) {
+			if (!$this->isIntOrStringValue($limitType)) {
 				return new ErrorType();
 			}
 			foreach ($limitType->getConstantScalarValues() as $limit) {
@@ -87,11 +87,11 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		$flags = [];
-		if ($flagArg === null) {
+		if ($capturesOffset === null) {
 			$flags = [0];
 		} else {
-			$flagType = $scope->getType($flagArg->value);
-			if (!$flagType->isInteger()->yes() && !$flagType->isString()->yes()) {
+			$flagType = $scope->getType($capturesOffset->value);
+			if (!$this->isIntOrStringValue($flagType)) {
 				return new ErrorType();
 			}
 			foreach ($flagType->getConstantScalarValues() as $flag) {
@@ -103,8 +103,8 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		if ($this->isPatternOrSubjectEmpty($patternConstantTypes, $subjectConstantTypes)) {
-			$returnNonEmptyStrings = $flagArg !== null && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_NO_EMPTY')->yes();
-			if ($returnNonEmptyStrings) {
+			if ($capturesOffset !== null
+				&& $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($capturesOffset->value, $scope, 'PREG_SPLIT_NO_EMPTY')->yes()) {
 				$returnStringType = TypeCombinator::intersect(
 					new StringType(),
 					new AccessoryNonEmptyStringType(),
@@ -122,8 +122,8 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 			);
 
 			$returnInternalValueType = $returnStringType;
-			if ($flagArg !== null) {
-				$flagState = $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($flagArg->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE');
+			if ($capturesOffset !== null) {
+				$flagState = $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($capturesOffset->value, $scope, 'PREG_SPLIT_OFFSET_CAPTURE');
 				if ($flagState->yes()) {
 					$capturedArrayListType = TypeCombinator::intersect(
 						new ArrayType(new IntegerType(), $capturedArrayType),
@@ -133,7 +133,6 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 					if ($subjectType->isNonEmptyString()->yes()) {
 						$capturedArrayListType = TypeCombinator::intersect($capturedArrayListType, new NonEmptyArrayType());
 					}
-
 					return TypeCombinator::union($capturedArrayListType, new ConstantBooleanType(false));
 				}
 				if ($flagState->maybe()) {
@@ -179,6 +178,7 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 				}
 			}
 		}
+
 		return TypeCombinator::union(...$resultTypes);
 	}
 
@@ -201,4 +201,8 @@ final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturn
 		return true;
 	}
 
+	private function isIntOrStringValue(Type $type): bool
+	{
+		return $type->isInteger()->yes() || $type->isString()->yes() || $type->isConstantScalarValue()->yes();
+	}
 }

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use function extension_loaded;
 use function restore_error_handler;
+use function sprintf;
 use const PHP_VERSION_ID;
 
 class AnalyserIntegrationTest extends PHPStanTestCase
@@ -885,11 +886,6 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7500.php');
 		$this->assertNoErrors($errors);
 	}
-
-
-	/**
-	 *
-	 */
 
 	public function testBug7554(): void
 	{

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -841,11 +841,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testUnresolvableParameter(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/unresolvable-parameter.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Method UnresolvableParameter\Collection::pipeInto() has parameter $class with no type specified.', $errors[0]->getMessage());
-		$this->assertSame(30, $errors[0]->getLine());
-		$this->assertSame('PHPDoc tag @param for parameter $class contains unresolvable type.', $errors[1]->getMessage());
+		$this->assertCount(3, $errors);
+		$this->assertSame('Parameter #2 $array of function array_map expects array, list<string>|false given.', $errors[0]->getMessage());
+		$this->assertSame(18, $errors[0]->getLine());
+		$this->assertSame('Method UnresolvableParameter\Collection::pipeInto() has parameter $class with no type specified.', $errors[1]->getMessage());
 		$this->assertSame(30, $errors[1]->getLine());
+		$this->assertSame('PHPDoc tag @param for parameter $class contains unresolvable type.', $errors[2]->getMessage());
+		$this->assertSame(30, $errors[2]->getLine());
 	}
 
 	public function testBug7248(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -890,13 +890,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug7554(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7554.php');
-		$this->assertCount(2, $errors);
-
-		$this->assertSame(sprintf('Parameter #1 $%s of function count expects array|Countable, list<array<int, int<0, max>|string>>|false given.', PHP_VERSION_ID < 80000 ? 'var' : 'value'), $errors[0]->getMessage());
-		$this->assertSame(26, $errors[0]->getLine());
-
-		$this->assertSame('Cannot access offset int<1, max> on list<array{string, int<0, max>}>|false.', $errors[1]->getMessage());
-		$this->assertSame(27, $errors[1]->getLine());
+		$this->assertCount(0, $errors);
 	}
 
 	public function testBug7637(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -895,7 +895,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame(sprintf('Parameter #1 $%s of function count expects array|Countable, list<array<int, int<0, max>|string>>|false given.', PHP_VERSION_ID < 80000 ? 'var' : 'value'), $errors[0]->getMessage());
 		$this->assertSame(26, $errors[0]->getLine());
 
-		$this->assertSame('Cannot access offset int<1, max> on list<array{string, int<0, max>}>|false.', $errors[1]->getMessage());
+		$this->assertSame('Cannot access offset int<1, max> on list<array{non-empty-string, int<0, max>}>|false.', $errors[1]->getMessage());
 		$this->assertSame(27, $errors[1]->getLine());
 	}
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -886,10 +886,21 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+
+	/**
+	 *
+	 */
+
 	public function testBug7554(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7554.php');
-		$this->assertCount(0, $errors);
+		$this->assertCount(2, $errors);
+
+		$this->assertSame(sprintf('Parameter #1 $%s of function count expects array|Countable, list<array<int, int<0, max>|string>>|false given.', PHP_VERSION_ID < 80000 ? 'var' : 'value'), $errors[0]->getMessage());
+		$this->assertSame(26, $errors[0]->getLine());
+
+		$this->assertSame('Cannot access offset int<1, max> on list<array{string, int<0, max>}>|false.', $errors[1]->getMessage());
+		$this->assertSame(27, $errors[1]->getLine());
 	}
 
 	public function testBug7637(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -842,13 +842,11 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testUnresolvableParameter(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/unresolvable-parameter.php');
-		$this->assertCount(3, $errors);
-		$this->assertSame('Parameter #2 $array of function array_map expects array, list<string>|false given.', $errors[0]->getMessage());
-		$this->assertSame(18, $errors[0]->getLine());
-		$this->assertSame('Method UnresolvableParameter\Collection::pipeInto() has parameter $class with no type specified.', $errors[1]->getMessage());
+		$this->assertCount(2, $errors);
+		$this->assertSame('Method UnresolvableParameter\Collection::pipeInto() has parameter $class with no type specified.', $errors[0]->getMessage());
+		$this->assertSame(30, $errors[0]->getLine());
+		$this->assertSame('PHPDoc tag @param for parameter $class contains unresolvable type.', $errors[1]->getMessage());
 		$this->assertSame(30, $errors[1]->getLine());
-		$this->assertSame('PHPDoc tag @param for parameter $class contains unresolvable type.', $errors[2]->getMessage());
-		$this->assertSame(30, $errors[2]->getLine());
 	}
 
 	public function testBug7248(): void

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -13,7 +13,6 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use function extension_loaded;
 use function restore_error_handler;
-use function sprintf;
 use const PHP_VERSION_ID;
 
 class AnalyserIntegrationTest extends PHPStanTestCase

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -11,6 +11,7 @@ class HelloWorld
 		assertType('*ERROR*', preg_split('/[0-9a]', '1-2-3'));
 		assertType("array{''}", preg_split('/-/', ''));
 		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{'1', '-', '2', '-', '3'}", preg_split('/ *(-) */', '1- 2-3', -1, PREG_SPLIT_DELIM_CAPTURE));
 		assertType("array{array{'', 0}}", preg_split('/-/', '', -1, PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
@@ -39,6 +40,8 @@ class HelloWorld
 		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, -1, $flags));
 		assertType('(list<non-empty-string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
 		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("(list<string>|false)", preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE));
+		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -6,6 +6,41 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
+	public function doFoo()
+	{
+		assertType('*ERROR*', preg_split('/[0-9a]', '1-2-3'));
+		assertType("array{''}", preg_split('/-/', ''));
+		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{array{'', 0}}", preg_split('/-/', '', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{'1', '3'}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+	}
+
+	/**
+	 * @param non-empty-string $nonEmptySubject
+	 */
+	public function doWithVariables(string $pattern, string $subject, string $nonEmptySubject, int $offset, int $flags): void
+	{
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, $offset, $flags));
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $subject, $offset, $flags));
+
+		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $nonEmptySubject, $offset, $flags));
+		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split("//", $nonEmptySubject, $offset, $flags));
+
+		assertType('(non-empty-list<string>|false)', preg_split("//", $nonEmptySubject));
+
+		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, -1, $flags));
+		assertType('(list<non-empty-string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
+		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
+	}
+
 	/**
 	 * @param string $pattern
 	 * @param string $subject
@@ -35,35 +70,5 @@ class HelloWorld
 		}
 
 		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, $flags));
-	}
-
-	public function doFoo()
-	{
-		assertType('*ERROR*', preg_split('/[0-9a]', '1-2-3'));
-		assertType("array{''}", preg_split('/-/', ''));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{'1', '3'}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-	}
-
-	/**
-	 * @param non-empty-string $nonEmptySubject
-	 */
-	public function doWithVariables(string $pattern, string $subject, string $nonEmptySubject, int $offset, int $flags): void
-	{
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, $offset, $flags));
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $subject, $offset, $flags));
-
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $nonEmptySubject, $offset, $flags));
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $nonEmptySubject, $offset, $flags));
-
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, -1, $flags));
-		assertType('(list<non-empty-string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
-		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -8,10 +8,25 @@ class HelloWorld
 {
 	public function doFoo()
 	{
-		assertType('list<string>|false', preg_split('/-/', '1-2-3'));
-		assertType('list<string>|false', preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType('list<array{string, int<0, max>}>|false', preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('list<array{string, int<0, max>}>|false', preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		$aaa = '/[0-9a]';
+		assertType('*ERROR*', preg_split($aaa, '1-2-3'));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{'1', '3'}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+	}
+
+	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void
+	{
+		assertType('(list<string>|false)', preg_split($pattern, $subject, $offset, $flags));
+		assertType('(list<string>|false)', preg_split("//", $subject, $offset, $flags));
+		assertType('(list<string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
+		assertType('(list<string>|false)', preg_split($pattern, $subject, -1, $flags));
+		assertType('(list<string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
+		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
 	}
 
 	/**
@@ -24,10 +39,10 @@ class HelloWorld
 	 */
 	public static function splitWithOffset($pattern, $subject, $limit = -1, $flags = 0)
 	{
-		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, $flags | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags));
+		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $limit, $flags | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags));
 
-		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags | PREG_SPLIT_NO_EMPTY));
+		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags | PREG_SPLIT_NO_EMPTY));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -23,18 +23,10 @@ class HelloWorld
 		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
 	}
 
-	/**
-	 * @param non-empty-string $nonEmptySubject
-	 */
-	public function doWithVariables(string $pattern, string $subject, string $nonEmptySubject, int $offset, int $flags): void
+	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void
 	{
 		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, $offset, $flags));
 		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $subject, $offset, $flags));
-
-		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $nonEmptySubject, $offset, $flags));
-		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split("//", $nonEmptySubject, $offset, $flags));
-
-		assertType('(non-empty-list<string>|false)', preg_split("//", $nonEmptySubject));
 
 		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
 		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, -1, $flags));
@@ -42,6 +34,24 @@ class HelloWorld
 		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("(list<string>|false)", preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE));
 		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
+	}
+
+	/**
+	 * @param non-empty-string $nonEmptySubject
+	 */
+	public function doWithNonEmptySubject(string $pattern, string $nonEmptySubject, int $offset, int $flags): void
+	{
+		assertType('(non-empty-list<string>|false)', preg_split("//", $nonEmptySubject));
+
+		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $nonEmptySubject, $offset, $flags));
+		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split("//", $nonEmptySubject, $offset, $flags));
+
+		assertType('(non-empty-list<array{string, int<0, max>}>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('(non-empty-list<non-empty-string>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY));
+		assertType('(non-empty-list<string>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_DELIM_CAPTURE));
+		assertType('(non-empty-list<array{string, int<0, max>}>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('(non-empty-list<array{non-empty-string, int<0, max>}>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('(non-empty-list<non-empty-string>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -6,29 +6,6 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
-	public function doFoo()
-	{
-		$aaa = '/[0-9a]';
-		assertType('*ERROR*', preg_split($aaa, '1-2-3'));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{'1', '3'}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-	}
-
-	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void
-	{
-		assertType('(list<string>|false)', preg_split($pattern, $subject, $offset, $flags));
-		assertType('(list<string>|false)', preg_split("//", $subject, $offset, $flags));
-		assertType('(list<string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
-		assertType('(list<string>|false)', preg_split($pattern, $subject, -1, $flags));
-		assertType('(list<string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
-		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
-	}
-
 	/**
 	 * @param string $pattern
 	 * @param string $subject
@@ -39,10 +16,9 @@ class HelloWorld
 	 */
 	public static function splitWithOffset($pattern, $subject, $limit = -1, $flags = 0)
 	{
-		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $limit, $flags | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags));
-
-		assertType('list<array{string, int<0, max>}>', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags | PREG_SPLIT_NO_EMPTY));
+		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, $flags | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags));
+		assertType('(list<array{non-empty-string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags | PREG_SPLIT_NO_EMPTY));
 	}
 
 	/**
@@ -50,13 +26,44 @@ class HelloWorld
 	 * @param string $subject
 	 * @param int $limit
 	 */
-	public static function dynamicFlags($pattern, $subject, $limit = -1) {
+	public static function dynamicFlags($pattern, $subject, $limit = -1)
+	{
 		$flags = PREG_SPLIT_OFFSET_CAPTURE;
 
 		if ($subject === '1-2-3') {
 			$flags |= PREG_SPLIT_NO_EMPTY;
 		}
 
-		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, $flags));
+		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, $flags));
+	}
+
+	public function doFoo()
+	{
+		assertType('*ERROR*', preg_split('/[0-9a]', '1-2-3'));
+		assertType("array{''}", preg_split('/-/', ''));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{'1', '3'}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+	}
+
+	/**
+	 * @param non-empty-string $nonEmptySubject
+	 */
+	public function doWithVariables(string $pattern, string $subject, string $nonEmptySubject, int $offset, int $flags): void
+	{
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, $offset, $flags));
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $subject, $offset, $flags));
+
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $nonEmptySubject, $offset, $flags));
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $nonEmptySubject, $offset, $flags));
+
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
+		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, -1, $flags));
+		assertType('(list<non-empty-string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
+		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -25,15 +25,15 @@ class HelloWorld
 
 	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void
 	{
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, $offset, $flags));
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split("//", $subject, $offset, $flags));
+		assertType('list<array{string, int<0, max>}|string>|false', preg_split($pattern, $subject, $offset, $flags));
+		assertType('list<array{string, int<0, max>}|string>|false', preg_split("//", $subject, $offset, $flags));
 
-		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, "1-2-3", $offset, $flags));
-		assertType('(list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $subject, -1, $flags));
-		assertType('(list<non-empty-string>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
-		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("(list<string>|false)", preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE));
-		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('non-empty-list<array{string, int<0, max>}|string>|false', preg_split($pattern, "1-2-3", $offset, $flags));
+		assertType('list<array{string, int<0, max>}|string>|false', preg_split($pattern, $subject, -1, $flags));
+		assertType('list<non-empty-string>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_NO_EMPTY));
+		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("list<string>|false", preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE));
+		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
 	}
 
 	/**
@@ -41,17 +41,17 @@ class HelloWorld
 	 */
 	public function doWithNonEmptySubject(string $pattern, string $nonEmptySubject, int $offset, int $flags): void
 	{
-		assertType('(non-empty-list<string>|false)', preg_split("//", $nonEmptySubject));
+		assertType('non-empty-list<string>|false', preg_split("//", $nonEmptySubject));
 
-		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split($pattern, $nonEmptySubject, $offset, $flags));
-		assertType('(non-empty-list<array{string, int<0, max>}|string>|false)', preg_split("//", $nonEmptySubject, $offset, $flags));
+		assertType('non-empty-list<array{string, int<0, max>}|string>|false', preg_split($pattern, $nonEmptySubject, $offset, $flags));
+		assertType('non-empty-list<array{string, int<0, max>}|string>|false', preg_split("//", $nonEmptySubject, $offset, $flags));
 
-		assertType('(non-empty-list<array{string, int<0, max>}>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('(non-empty-list<non-empty-string>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY));
-		assertType('(non-empty-list<string>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_DELIM_CAPTURE));
-		assertType('(non-empty-list<array{string, int<0, max>}>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('(non-empty-list<array{non-empty-string, int<0, max>}>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('(non-empty-list<non-empty-string>|false)', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE));
+		assertType('non-empty-list<array{string, int<0, max>}>|false', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('non-empty-list<non-empty-string>|false', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY));
+		assertType('non-empty-list<string>|false', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_DELIM_CAPTURE));
+		assertType('non-empty-list<array{string, int<0, max>}>|false', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('non-empty-list<array{non-empty-string, int<0, max>}>|false', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('non-empty-list<non-empty-string>|false', preg_split("/-/", $nonEmptySubject, $offset, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE));
 	}
 
 	/**
@@ -64,9 +64,9 @@ class HelloWorld
 	 */
 	public static function splitWithOffset($pattern, $subject, $limit = -1, $flags = 0)
 	{
-		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, $flags | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags));
-		assertType('(list<array{non-empty-string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags | PREG_SPLIT_NO_EMPTY));
+		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, $flags | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags));
+		assertType('list<array{non-empty-string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, PREG_SPLIT_OFFSET_CAPTURE | $flags | PREG_SPLIT_NO_EMPTY));
 	}
 
 	/**
@@ -82,6 +82,6 @@ class HelloWorld
 			$flags |= PREG_SPLIT_NO_EMPTY;
 		}
 
-		assertType('(list<array{string, int<0, max>}>|false)', preg_split($pattern, $subject, $limit, $flags));
+		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $limit, $flags));
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -11,21 +11,21 @@ class HelloWorld
 
 	public function doFoo()
 	{
-		assertType("array{''}", preg_split('/-/', ''));
-		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{'1', '-', '2', '-', '3'}", preg_split('/ *(-) */', '1- 2-3', -1, PREG_SPLIT_DELIM_CAPTURE));
-		assertType("array{array{'', 0}}", preg_split('/-/', '', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3'));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{'1', '3'}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
-		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
-		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{''}|false", preg_split('/-/', ''));
+		assertType("array{}|false", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{'1', '-', '2', '-', '3'}|false", preg_split('/ *(-) */', '1- 2-3', -1, PREG_SPLIT_DELIM_CAPTURE));
+		assertType("array{array{'', 0}}|false", preg_split('/-/', '', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{}|false", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{'1', '2', '3'}|false", preg_split('/-/', '1-2-3'));
+		assertType("array{'1', '2', '3'}|false", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{'1', '3'}|false", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}|false", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}|false", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}|false", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
+		assertType("array{array{'1', 0}, array{'3', 3}}|false", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
 
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', self::NUMERIC_STRING_NEGATIVE_1));
-		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, self::NUMERIC_STRING_1));
+		assertType("array{'1', '2', '3'}|false", preg_split('/-/', '1-2-3', self::NUMERIC_STRING_NEGATIVE_1));
+		assertType("array{'1', '2', '3'}|false", preg_split('/-/', '1-2-3', -1, self::NUMERIC_STRING_1));
 	}
 
 	public function doWithError() {
@@ -40,8 +40,8 @@ class HelloWorld
 
 	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void
 	{
-		assertType("array{'1', '2', '3'}|array{'1-2-3'}", preg_split('/-/', '1-2-3', $this->generate()));
-		assertType("array{'1', '2', '3'}|array{'1-2-3'}", preg_split('/-/', '1-2-3', $this->generate(), $this->generate()));
+		assertType("array{'1', '2', '3'}|array{'1-2-3'}|false", preg_split('/-/', '1-2-3', $this->generate()));
+		assertType("array{'1', '2', '3'}|array{'1-2-3'}|false", preg_split('/-/', '1-2-3', $this->generate(), $this->generate()));
 
 		assertType('list<array{string, int<0, max>}|string>|false', preg_split($pattern, $subject, $offset, $flags));
 		assertType('list<array{string, int<0, max>}|string>|false', preg_split("//", $subject, $offset, $flags));

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -8,6 +8,7 @@ class HelloWorld
 {
 	private const NUMERIC_STRING_1 = "1";
 	private const NUMERIC_STRING_NEGATIVE_1 = "-1";
+
 	public function doFoo()
 	{
 		assertType("array{''}", preg_split('/-/', ''));
@@ -39,6 +40,9 @@ class HelloWorld
 
 	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void
 	{
+		assertType("array{'1', '2', '3'}|array{'1-2-3'}", preg_split('/-/', '1-2-3', $this->generate()));
+		assertType("array{'1', '2', '3'}|array{'1-2-3'}", preg_split('/-/', '1-2-3', $this->generate(), $this->generate()));
+
 		assertType('list<array{string, int<0, max>}|string>|false', preg_split($pattern, $subject, $offset, $flags));
 		assertType('list<array{string, int<0, max>}|string>|false', preg_split("//", $subject, $offset, $flags));
 
@@ -48,6 +52,13 @@ class HelloWorld
 		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("list<string>|false", preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE));
 		assertType('list<array{string, int<0, max>}>|false', preg_split($pattern, $subject, $offset, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE));
+	}
+
+	/**
+	 * @return 1|'17'
+	 */
+	private function generate(): int|string {
+		return (rand() % 2 === 0) ? 1 : "17";
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/preg_split.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_split.php
@@ -6,9 +6,10 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
+	private const NUMERIC_STRING_1 = "1";
+	private const NUMERIC_STRING_NEGATIVE_1 = "-1";
 	public function doFoo()
 	{
-		assertType('*ERROR*', preg_split('/[0-9a]', '1-2-3'));
 		assertType("array{''}", preg_split('/-/', ''));
 		assertType("array{}", preg_split('/-/', '', -1, PREG_SPLIT_NO_EMPTY));
 		assertType("array{'1', '-', '2', '-', '3'}", preg_split('/ *(-) */', '1- 2-3', -1, PREG_SPLIT_DELIM_CAPTURE));
@@ -21,6 +22,19 @@ class HelloWorld
 		assertType("array{array{'1', 0}, array{'2', 2}, array{'3', 4}}", preg_split('/-/', '1-2-3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("array{array{'1', 0}, array{'', 2}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_OFFSET_CAPTURE));
 		assertType("array{array{'1', 0}, array{'3', 3}}", preg_split('/-/', '1--3', -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_OFFSET_CAPTURE));
+
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', self::NUMERIC_STRING_NEGATIVE_1));
+		assertType("array{'1', '2', '3'}", preg_split('/-/', '1-2-3', -1, self::NUMERIC_STRING_1));
+	}
+
+	public function doWithError() {
+		assertType('*ERROR*', preg_split('/[0-9a]', '1-2-3'));
+		assertType('*ERROR*', preg_split('/-/', '1-2-3', 'hogehoge'));
+		assertType('*ERROR*', preg_split('/-/', '1-2-3', -1, 'hogehoge'));
+		assertType('*ERROR*', preg_split('/-/', '1-2-3', [], self::NUMERIC_STRING_NEGATIVE_1));
+		assertType('*ERROR*', preg_split('/-/', '1-2-3', null, self::NUMERIC_STRING_NEGATIVE_1));
+		assertType('*ERROR*', preg_split('/-/', '1-2-3', -1, []));
+		assertType('*ERROR*', preg_split('/-/', '1-2-3', -1, null));
 	}
 
 	public function doWithVariables(string $pattern, string $subject, int $offset, int $flags): void


### PR DESCRIPTION
I developed further extended the extension for the `preg_split()` function.

The `preg_split()` function can specify ReturnType with the following cases:

- When the regular expression passed as the `$pattern` argument is invalid.
- When the `$pattern` and `$subject` arguments are constants.
- When the string passed as the `$subject` argument is non-empty-string.
- When the `$flag` argument is set to one or more of the following: `PREG_SPLIT_OFFSET_CAPTURE`, `PREG_SPLIT_NO_EMPTY`, or `PREG_SPLIT_DELIM_CAPTURE`.

The detailed cases are specified in the test cases.
