### PR TITLE
Add support for result cache meta extensions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -233,6 +233,15 @@ jobs:
               cd e2e/bug-11857
               composer install
               ../../bin/phpstan
+          - script: |
+              cd e2e/result-cache-meta-extension
+              ../../bin/phpstan -vvv
+              ../../bin/phpstan -vvv --fail-without-result-cache
+              echo 'modified-hash' > hash.txt
+              OUTPUT=$(../bashunit -a exit_code "2" "../../bin/phpstan -vvv --fail-without-result-cache")
+              echo "$OUTPUT"
+              ../bashunit -a matches "Note: Using configuration file .+phpstan.neon." "$OUTPUT"
+              ../bashunit -a contains 'Result cache not used because the metadata do not match: metaExtensions' "$OUTPUT"
 
     steps:
       - name: "Checkout"

--- a/composer.json
+++ b/composer.json
@@ -140,6 +140,9 @@
 		"classmap": [
 			"tests/e2e",
 			"tests/PHPStan"
+		],
+		"files": [
+			"e2e/result-cache-meta-extension/src/DummyResultCacheMetaExtension.php"
 		]
 	},
 	"repositories": [

--- a/e2e/result-cache-meta-extension/hash.txt
+++ b/e2e/result-cache-meta-extension/hash.txt
@@ -1,0 +1,1 @@
+initial-hash

--- a/e2e/result-cache-meta-extension/phpstan.neon
+++ b/e2e/result-cache-meta-extension/phpstan.neon
@@ -1,0 +1,10 @@
+parameters:
+	level: 8
+	paths:
+		- src
+
+services:
+	-
+		class: ResultCacheE2E\MetaExtension\DummyResultCacheMetaExtension
+		tags:
+			- phpstan.resultCacheMetaExtension

--- a/e2e/result-cache-meta-extension/src/DummyResultCacheMetaExtension.php
+++ b/e2e/result-cache-meta-extension/src/DummyResultCacheMetaExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ResultCacheE2E\MetaExtension;
+
+use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
+
+final class DummyResultCacheMetaExtension implements ResultCacheMetaExtension
+{
+	public function getKey(): string
+	{
+		return 'e2e-dummy-result-cache-meta-extension';
+	}
+
+	public function getHash(): string
+	{
+		// @phpstan-ignore argument.type (the file is always present so this won't pass `false` as an argument)
+		return trim(file_get_contents(__DIR__ . '/../hash.txt'));
+	}
+}

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -906,7 +906,7 @@ return [
 		return [
 			'cacheVersion' => self::CACHE_VERSION,
 			'phpstanVersion' => ComposerHelper::getPhpStanVersion(),
-			'phpstanExtensions' => $this->getMetaFromPhpStanExtensions(),
+			'metaExtensions' => $this->getMetaFromPhpStanExtensions(),
 			'phpVersion' => PHP_VERSION_ID,
 			'projectConfig' => $projectConfigArray,
 			'analysedPaths' => $this->analysedPaths,

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -10,6 +10,7 @@ use PHPStan\Collectors\CollectedData;
 use PHPStan\Command\Output;
 use PHPStan\Dependency\ExportedNodeFetcher;
 use PHPStan\Dependency\RootExportedNode;
+use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\ProjectConfigHelper;
 use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileFinder;
@@ -66,6 +67,7 @@ final class ResultCacheManager
 	 * @param string[] $scanDirectories
 	 */
 	public function __construct(
+		private Container $container,
 		private ExportedNodeFetcher $exportedNodeFetcher,
 		private FileFinder $scanFileFinder,
 		private ReflectionProvider $reflectionProvider,
@@ -315,6 +317,11 @@ final class ResultCacheManager
 			ksort($currentMeta['projectConfig']);
 
 			$currentMeta['projectConfig'] = Neon::encode($currentMeta['projectConfig']);
+		}
+
+		// Do not invalidate result cache generated before introducing support for result cache meta extensions
+		if (!isset($currentMeta['phpstanExtensions'])) {
+			$currentMeta['phpstanExtensions'] = [];
 		}
 
 		return $cachedMeta !== $currentMeta;
@@ -904,6 +911,7 @@ return [
 		return [
 			'cacheVersion' => self::CACHE_VERSION,
 			'phpstanVersion' => ComposerHelper::getPhpStanVersion(),
+			'phpstanExtensions' => $this->getMetaFromPhpStanExtensions(),
 			'phpVersion' => PHP_VERSION_ID,
 			'projectConfig' => $projectConfigArray,
 			'analysedPaths' => $this->analysedPaths,
@@ -1034,6 +1042,29 @@ return [
 		ksort($stubFiles);
 
 		return $stubFiles;
+	}
+
+	/**
+	 * @return array<string, string>
+	 * @throws ShouldNotHappenException
+	 */
+	private function getMetaFromPhpStanExtensions(): array
+	{
+		$meta = [];
+
+		/** @var ResultCacheMetaExtension $extension */
+		foreach ($this->container->getServicesByTag(ResultCacheMetaExtension::EXTENSION_TAG) as $extension) {
+			if (array_key_exists($extension->getKey(), $meta)) {
+				throw new ShouldNotHappenException(sprintf(
+					'Duplicate ResultCacheMetaExtension with key "%s" found.',
+					$extension->getKey(),
+				));
+			}
+
+			$meta[$extension->getKey()] = $extension->getHash();
+		}
+
+		return $meta;
 	}
 
 }

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -319,11 +319,6 @@ final class ResultCacheManager
 			$currentMeta['projectConfig'] = Neon::encode($currentMeta['projectConfig']);
 		}
 
-		// Do not invalidate result cache generated before introducing support for result cache meta extensions
-		if (!isset($currentMeta['phpstanExtensions'])) {
-			$currentMeta['phpstanExtensions'] = [];
-		}
-
 		return $cachedMeta !== $currentMeta;
 	}
 

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -1059,6 +1059,8 @@ return [
 			$meta[$extension->getKey()] = $extension->getHash();
 		}
 
+		ksort($meta);
+
 		return $meta;
 	}
 

--- a/src/Analyser/ResultCache/ResultCacheMetaExtension.php
+++ b/src/Analyser/ResultCache/ResultCacheMetaExtension.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser\ResultCache;
+
+/**
+ * ResultCacheMetaExtension can be used for extending PHPStan's built-in mechanism that is used for
+ * calculating metadata for result cache. Using this extension you may add additional metadata that will
+ * be used for determining if analysis must be run again, or can be re-used from result cache.
+ *
+ * @see https://github.com/phpstan/phpstan-symfony/issues/255 for the context.
+ *
+ * To register it in the configuration file use the `phpstan.resultCacheMetaExtension` service tag:
+ *
+ * ```
+ * services:
+ * 	-
+ *		class: App\PHPStan\MyExtension
+ *		tags:
+ *			- phpstan.resultCacheMetaExtension
+ * ```
+ *
+ * @api
+ */
+interface ResultCacheMetaExtension
+{
+
+	public const EXTENSION_TAG = 'phpstan.resultCacheMetaExtension';
+
+	/**
+	 * Returns unique key for this result cache meta entry. This describes the source of the metadata.
+	 */
+	public function getKey(): string;
+
+	/**
+	 * Returns hash of the result cache meta entry. This represents the current state of the additional meta source.
+	 */
+	public function getHash(): string;
+
+}

--- a/src/DependencyInjection/ConditionalTagsExtension.php
+++ b/src/DependencyInjection/ConditionalTagsExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\DependencyInjection;
 use Nette;
 use Nette\DI\CompilerExtension;
 use Nette\Schema\Expect;
+use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use PHPStan\Analyser\TypeSpecifierFactory;
 use PHPStan\Broker\BrokerFactory;
 use PHPStan\Collectors\RegistryFactory as CollectorRegistryFactory;
@@ -59,6 +60,7 @@ final class ConditionalTagsExtension extends CompilerExtension
 			LazyParameterOutTypeExtensionProvider::METHOD_TAG => $bool,
 			LazyParameterOutTypeExtensionProvider::STATIC_METHOD_TAG => $bool,
 			DiagnoseExtension::EXTENSION_TAG => $bool,
+			ResultCacheMetaExtension::EXTENSION_TAG => $bool,
 		])->min(1));
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> This feature was brought to you thanks to [GetResponse](https://getresponse.com) - Marketing Software for Professional Email Marketing, which paid for my work on this.

This introduces contract for extending the way how result cache metadata is calculated, so PHPStan extensions can take part into deciding whether analysis should be re-run or its result can be re-use from cache.

It is a base for phpstan/phpstan-symfony#255, which needs separate PR that introduces `ResultCacheMetaExtension` for Symfony DI container. It will be done when this gets merged (and released?).

@ondrejmirtes I need some help / your decisions:

- I did not add any tests, as I don't see any tests for `ResultCacheManager`. Please point me how/if I should test this extension point. Just run `make build` and verified everything passes.
- I've added `phpstanExtensions` entry to the array with metadata but I am not 100% satisfied with it. Maybe it should be `metaExtensions` or `metaFromPhpstanExtensions` or something different. Or maybe it shouldn't be nested, but merged with the main array? Let me know.
- I've added this to `ConditionalTagsExtension` because after code analysis and seeing how e.g. `DiagnoseExtension` is implemented I've encountered such usage and thought `ResultCacheManager` should be there too. But it's a wild guess only, please let me know if I should keep it there.
- Should any of existing `ResultCacheManager::getMeta()` items be converted to an extension? That could act as e2e test, but also could require some hacks in order to keep backward compatibility with existing result caches (depending on the scheme of the array with metadata).