### PR TITLE
Fix false positives on non-existing-offset's

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -726,7 +726,7 @@ final class TypeSpecifier
 				if (
 					$expr->expr instanceof FuncCall
 					&& $expr->expr->name instanceof Name
-					&& in_array($expr->expr->name->toLowerString(), ['array_search'], true)
+					&& $expr->expr->name->toLowerString() === 'array_search'
 					&& count($expr->expr->getArgs()) >= 2
 				) {
 					$arrayArg = $expr->expr->getArgs()[1]->value;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -667,16 +667,44 @@ final class TypeSpecifier
 			if ($context->null()) {
 				$specifiedTypes = $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->expr, $context)->setRootExpr($expr);
 
+				// infer $arr[$key] after $key = array_key_first/last($arr)
 				if (
 					$expr->expr instanceof FuncCall
 					&& $expr->expr->name instanceof Name
-					&& $expr->expr->name->toLowerString() === 'array_key_last'
+					&& in_array($expr->expr->name->toLowerString(), ['array_key_first', 'array_key_last'], true)
 					&& count($expr->expr->getArgs()) >= 1
 				) {
 					$arrayArg = $expr->expr->getArgs()[0]->value;
 					$arrayType = $scope->getType($arrayArg);
 					if (
 						$arrayType->isArray()->yes()
+						&& $arrayType->isIterableAtLeastOnce()->yes()
+					) {
+						$dimFetch = new ArrayDimFetch($arrayArg, $expr->var);
+						$iterableValueType = $expr->expr->name->toLowerString() === 'array_key_first'
+							? $arrayType->getFirstIterableValueType()
+							: $arrayType->getLastIterableValueType();
+
+						return $specifiedTypes->unionWith(
+							$this->create($dimFetch, $iterableValueType, TypeSpecifierContext::createTrue(), $scope),
+						);
+					}
+				}
+
+				// infer $list[$count] after $count = count($list) - 1
+				if (
+					$expr->expr instanceof Expr\BinaryOp\Minus
+					&& $expr->expr->left instanceof FuncCall
+					&& $expr->expr->left->name instanceof Name
+					&& in_array($expr->expr->left->name->toLowerString(), ['count', 'sizeof'], true)
+					&& count($expr->expr->left->getArgs()) >= 1
+					&& $expr->expr->right instanceof Node\Scalar\Int_
+					&& $expr->expr->right->value === 1
+				) {
+					$arrayArg = $expr->expr->left->getArgs()[0]->value;
+					$arrayType = $scope->getType($arrayArg);
+					if (
+						$arrayType->isList()->yes()
 						&& $arrayType->isIterableAtLeastOnce()->yes()
 					) {
 						$dimFetch = new ArrayDimFetch($arrayArg, $expr->var);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -665,7 +665,29 @@ final class TypeSpecifier
 				throw new ShouldNotHappenException();
 			}
 			if ($context->null()) {
-				return $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->expr, $context)->setRootExpr($expr);
+				$specifiedTypes = $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->expr, $context)->setRootExpr($expr);
+
+				if (
+					$expr->expr instanceof FuncCall
+					&& $expr->expr->name instanceof Name
+					&& $expr->expr->name->toLowerString() === 'array_key_last'
+					&& count($expr->expr->getArgs()) >= 1
+				) {
+					$arrayArg = $expr->expr->getArgs()[0]->value;
+					$arrayType = $scope->getType($arrayArg);
+					if (
+						$arrayType->isArray()->yes()
+						&& $arrayType->isIterableAtLeastOnce()->yes()
+					) {
+						$dimFetch = new ArrayDimFetch($arrayArg, $expr->var);
+
+						return $specifiedTypes->unionWith(
+							$this->create($dimFetch, $arrayType->getLastIterableValueType(), TypeSpecifierContext::createTrue(), $scope),
+						);
+					}
+				}
+
+				return $specifiedTypes;
 			}
 
 			return $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->var, $context)->setRootExpr($expr);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -664,6 +664,7 @@ final class TypeSpecifier
 			if (!$scope instanceof MutatingScope) {
 				throw new ShouldNotHappenException();
 			}
+
 			if ($context->null()) {
 				$specifiedTypes = $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->expr, $context)->setRootExpr($expr);
 
@@ -718,7 +719,30 @@ final class TypeSpecifier
 				return $specifiedTypes;
 			}
 
-			return $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->var, $context)->setRootExpr($expr);
+			$specifiedTypes = $this->specifyTypesInCondition($scope->exitFirstLevelStatements(), $expr->var, $context)->setRootExpr($expr);
+
+			if ($context->true()) {
+				// infer $arr[$key] after $key = array_search($needle, $arr)
+				if (
+					$expr->expr instanceof FuncCall
+					&& $expr->expr->name instanceof Name
+					&& in_array($expr->expr->name->toLowerString(), ['array_search'], true)
+					&& count($expr->expr->getArgs()) >= 2
+				) {
+					$arrayArg = $expr->expr->getArgs()[1]->value;
+					$arrayType = $scope->getType($arrayArg);
+
+					if ($arrayType->isArray()->yes()) {
+						$dimFetch = new ArrayDimFetch($arrayArg, $expr->var);
+						$iterableValueType = $arrayType->getIterableValueType();
+
+						return $specifiedTypes->unionWith(
+							$this->create($dimFetch, $iterableValueType, TypeSpecifierContext::createTrue(), $scope),
+						);
+					}
+				}
+			}
+			return $specifiedTypes;
 		} elseif (
 			$expr instanceof Expr\Isset_
 			&& count($expr->vars) > 0

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -785,4 +785,16 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12122.php'], []);
 	}
 
+	public function testArrayDimFetchAfterArrayKeyFirstOrLast(): void
+	{
+		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
+
+		$this->analyse([__DIR__ . '/data/array-dim-after-array-key-first-or-last.php'], [
+			[
+				'Offset null does not exist on array{}.',
+				17,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -792,7 +792,27 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/array-dim-after-array-key-first-or-last.php'], [
 			[
 				'Offset null does not exist on array{}.',
-				17,
+				19,
+			],
+		]);
+	}
+
+	public function testArrayDimFetchAfterCount(): void
+	{
+		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
+
+		$this->analyse([__DIR__ . '/data/array-dim-after-count.php'], [
+			[
+				'Offset int<0, max> might not exist on list<string>.',
+				26,
+			],
+			[
+				'Offset int<-1, max> might not exist on array<string>.',
+				35,
+			],
+			[
+				'Offset int<0, max> might not exist on non-empty-array<string>.',
+				42,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -817,4 +817,16 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testArrayDimFetchAfterArraySearch(): void
+	{
+		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
+
+		$this->analyse([__DIR__ . '/data/array-dim-after-array-search.php'], [
+			[
+				'Offset int|string might not exist on array.',
+				20,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/array-dim-after-array-key-first-or-last.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-dim-after-array-key-first-or-last.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayDimAfterArrayKeyFirstOrLast;
+
+class HelloWorld
+{
+	/**
+	 * @param list<string> $hellos
+	 */
+	public function last(array $hellos): string
+	{
+		if ($hellos !== []) {
+			$lastHelloKey = array_key_last($hellos);
+			return $hellos[$lastHelloKey];
+		} else {
+			$lastHelloKey = array_key_last($hellos);
+			return $hellos[$lastHelloKey];
+		}
+	}
+
+	/**
+	 * @param list<string> $hellos
+	 */
+	public function first(array $hellos): string
+	{
+		if ($hellos !== []) {
+			$firstHelloKey = array_key_first($hellos);
+			return $hellos[$firstHelloKey];
+		}
+
+		return 'nothing';
+	}
+
+	/**
+	 * @param array{first: int, middle: float, last: bool} $hellos
+	 */
+	public function shape(array $hellos): int|bool
+	{
+		$firstHelloKey = array_key_first($hellos);
+		$lastHelloKey = array_key_last($hellos);
+
+		if (rand(0,1)) {
+			return $hellos[$firstHelloKey];
+		}
+		return $hellos[$lastHelloKey];
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/array-dim-after-array-key-first-or-last.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-dim-after-array-key-first-or-last.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace ArrayDimAfterArrayKeyFirstOrLast;
 
@@ -10,12 +12,25 @@ class HelloWorld
 	public function last(array $hellos): string
 	{
 		if ($hellos !== []) {
-			$lastHelloKey = array_key_last($hellos);
-			return $hellos[$lastHelloKey];
+			$last = array_key_last($hellos);
+			return $hellos[$last];
 		} else {
-			$lastHelloKey = array_key_last($hellos);
-			return $hellos[$lastHelloKey];
+			$last = array_key_last($hellos);
+			return $hellos[$last];
 		}
+	}
+
+	/**
+	 * @param array<string> $hellos
+	 */
+	public function lastOnArray(array $hellos): string
+	{
+		if ($hellos !== []) {
+			$last = array_key_last($hellos);
+			return $hellos[$last];
+		}
+
+		return 'nothing';
 	}
 
 	/**
@@ -24,8 +39,21 @@ class HelloWorld
 	public function first(array $hellos): string
 	{
 		if ($hellos !== []) {
-			$firstHelloKey = array_key_first($hellos);
-			return $hellos[$firstHelloKey];
+			$first = array_key_first($hellos);
+			return $hellos[$first];
+		}
+
+		return 'nothing';
+	}
+
+	/**
+	 * @param array<string> $hellos
+	 */
+	public function firstOnArray(array $hellos): string
+	{
+		if ($hellos !== []) {
+			$first = array_key_first($hellos);
+			return $hellos[$first];
 		}
 
 		return 'nothing';
@@ -36,12 +64,12 @@ class HelloWorld
 	 */
 	public function shape(array $hellos): int|bool
 	{
-		$firstHelloKey = array_key_first($hellos);
-		$lastHelloKey = array_key_last($hellos);
+		$first = array_key_first($hellos);
+		$last = array_key_last($hellos);
 
 		if (rand(0,1)) {
-			return $hellos[$firstHelloKey];
+			return $hellos[$first];
 		}
-		return $hellos[$lastHelloKey];
+		return $hellos[$last];
 	}
 }

--- a/tests/PHPStan/Rules/Arrays/data/array-dim-after-array-search.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-dim-after-array-search.php
@@ -1,0 +1,37 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace ArrayDimAfterArraySeach;
+
+class HelloWorld
+{
+	public function doFoo(array $arr, string $needle): string
+	{
+		if (($key = array_search($needle, $arr, true)) !== false) {
+			echo $arr[$key];
+		}
+	}
+
+	public function doBar(array $arr, string $needle): string
+	{
+		$key = array_search($needle, $arr, true);
+		if ($key !== false) {
+			echo $arr[$key];
+		}
+	}
+
+	public function doFooBar(array $arr, string $needle): string
+	{
+		if (($key = array_search($needle, $arr, false)) !== false) {
+			echo $arr[$key];
+		}
+	}
+
+	public function doBaz(array $arr, string $needle): string
+	{
+		if (($key = array_search($needle, $arr)) !== false) {
+			echo $arr[$key];
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/array-dim-after-count.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-dim-after-count.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace ArrayDimFetchOnCount;
+
+class HelloWorld
+{
+	/**
+	 * @param list<string> $hellos
+	 */
+	public function works(array $hellos): string
+	{
+		if ($hellos === []) {
+			return 'nothing';
+		}
+
+		$count = count($hellos) - 1;
+		return $hellos[$count];
+	}
+
+	/**
+	 * @param list<string> $hellos
+	 */
+	public function offByOne(array $hellos): string
+	{
+		$count = count($hellos);
+		return $hellos[$count];
+	}
+
+	/**
+	 * @param array<string> $hellos
+	 */
+	public function maybeInvalid(array $hellos): string
+	{
+		$count = count($hellos) - 1;
+		echo $hellos[$count];
+
+		if ($hellos === []) {
+			return 'nothing';
+		}
+
+		$count = count($hellos) - 1;
+		return $hellos[$count];
+	}
+
+}


### PR DESCRIPTION
fixes some false positives we see with `reportPossiblyNonexistentGeneralArrayOffset`.

basic idea is to infer a expression type for `$array[$last]` after `$last = array_key_last($array);` based on the iterable-type of a non-empty `$array`.

refs https://github.com/phpstan/phpstan/issues/11020

---

this PR fixes code like
```php
	/**
	 * @param list<string> $hellos
	 */
	public function last(array $hellos): string
	{
		if ($hellos !== []) {
			$last = array_key_last($hellos);
			return $hellos[$last];
		}
        return '';
	}

	/**
	 * @param list<string> $hellos
	 */
	public function works(array $hellos): string
	{
		if ($hellos === []) {
			return 'nothing';
		}

		$count = count($hellos) - 1;
		return $hellos[$count];
	}
```

but _not_ like (in which no intermediate variable is used)
```php
	/**
	 * @param list<string> $hellos
	 */
	public function last(array $hellos): string
	{
		if ($hellos !== []) {
			return $hellos[array_key_last($hellos)];
		}
        return '';
	}

	/**
	 * @param list<string> $hellos
	 */
	public function works(array $hellos): string
	{
		if ($hellos === []) {
			return 'nothing';
		}

		return $hellos[count($hellos) - 1];
	}
```