### PR TITLE
NodeScopeResolver: 10x Faster constant array processing

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5771,7 +5771,10 @@ final class NodeScopeResolver
 		foreach (array_reverse($offsetTypes) as $i => $offsetType) {
 			/** @var Type $offsetValueType */
 			$offsetValueType = array_pop($offsetValueTypeStack);
-			if (!$offsetValueType instanceof MixedType) {
+			if (
+				!$offsetValueType instanceof MixedType
+				&& !$offsetValueType->isConstantArray()->yes()
+			) {
 				$types = [
 					new ArrayType(new MixedType(), new MixedType()),
 					new ObjectType(ArrayAccess::class),


### PR DESCRIPTION
`vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug11913` triggers the by-far slowest unit test in the phpstan-src codebase

before this PR it takes 10-11 seconds
after this PR it finishes in 0.3-0.4 seconds
(run on macbook pro m4 with PHP 8.3.15)

---

the code is dominated by calculating intersections in https://github.com/phpstan/phpstan-src/blob/cdf51107e19c8e90a3b64616eaf9bd60d7d8ae5b/src/Analyser/NodeScopeResolver.php#L5783

my thesis is, that when we know a array is constant, it will always intersect with `new ArrayType(new MixedType(), new MixedType())` and therefore don't need to take the slow path