### PR TITLE
Support arrays with union value-types in implode()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1363,11 +1363,6 @@ parameters:
 			path: src/Type/Php/FunctionExistsFunctionTypeSpecifyingExtension.php
 
 		-
-			message: "#^Doing instanceof PHPStan\\\\Type\\\\ConstantScalarType is error\\-prone and deprecated\\. Use Type\\:\\:isConstantScalarValue\\(\\) or Type\\:\\:getConstantScalarTypes\\(\\) or Type\\:\\:getConstantScalarValues\\(\\) instead\\.$#"
-			count: 1
-			path: src/Type/Php/ImplodeFunctionReturnTypeExtension.php
-
-		-
 			message: """
 				#^Call to deprecated method getConstantScalars\\(\\) of class PHPStan\\\\Type\\\\TypeUtils\\:
 				Use Type\\:\\:isConstantScalarValue\\(\\) or Type\\:\\:getConstantScalarTypes\\(\\) or Type\\:\\:getConstantScalarValues\\(\\)$#

--- a/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Internal\CombinationsHelper;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
@@ -126,6 +127,10 @@ final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnT
 			foreach ($combinations as $combination) {
 				$strings[] = new ConstantStringType(implode($separatorType->getValue(), $combination));
 			}
+		}
+
+		if (count($strings) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
+			return null;
 		}
 
 		return TypeCombinator::union(...$strings);

--- a/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Internal\CombinationsHelper;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -12,7 +13,6 @@ use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
@@ -115,13 +115,17 @@ final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnT
 
 			$arrayValues = [];
 			foreach ($valueTypes as $valueType) {
-				if (!$valueType instanceof ConstantScalarType) {
+				$constScalars = $valueType->getConstantScalarValues();
+				if (count($constScalars) === 0) {
 					return null;
 				}
-				$arrayValues[] = $valueType->getValue();
+				$arrayValues[] = $constScalars;
 			}
 
-			$strings[] = new ConstantStringType(implode($separatorType->getValue(), $arrayValues));
+			$combinations = CombinationsHelper::combinations($arrayValues);
+			foreach ($combinations as $combination) {
+				$strings[] = new ConstantStringType(implode($separatorType->getValue(), $combination));
+			}
 		}
 
 		return TypeCombinator::union(...$strings);

--- a/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
@@ -22,7 +22,6 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function implode;
 use function in_array;
-use const COUNT_RECURSIVE;
 
 final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -116,15 +115,17 @@ final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnT
 			$valueTypes = $array->getValueTypes();
 
 			$arrayValues = [];
+			$combinationsCount = 1;
 			foreach ($valueTypes as $valueType) {
 				$constScalars = $valueType->getConstantScalarValues();
 				if (count($constScalars) === 0) {
 					return null;
 				}
 				$arrayValues[] = $constScalars;
+				$combinationsCount *= count($constScalars);
 			}
 
-			if (count($strings) + count($arrayValues, COUNT_RECURSIVE) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
+			if ($combinationsCount > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
 				return null;
 			}
 
@@ -132,6 +133,10 @@ final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnT
 			foreach ($combinations as $combination) {
 				$strings[] = new ConstantStringType(implode($separatorType->getValue(), $combination));
 			}
+		}
+
+		if (count($strings) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
+			return null;
 		}
 
 		return TypeCombinator::union(...$strings);

--- a/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
@@ -22,6 +22,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function implode;
 use function in_array;
+use const COUNT_RECURSIVE;
 
 final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -123,14 +124,14 @@ final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnT
 				$arrayValues[] = $constScalars;
 			}
 
+			if (count($strings) + count($arrayValues, COUNT_RECURSIVE) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
+				return null;
+			}
+
 			$combinations = CombinationsHelper::combinations($arrayValues);
 			foreach ($combinations as $combination) {
 				$strings[] = new ConstantStringType(implode($separatorType->getValue(), $combination));
 			}
-		}
-
-		if (count($strings) > InitializerExprTypeResolver::CALCULATE_SCALARS_LIMIT) {
-			return null;
 		}
 
 		return TypeCombinator::union(...$strings);

--- a/tests/PHPStan/Analyser/nsrt/bug-11854.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11854.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11854;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		$arr = [];
+		$arr[] = rand(0,1) ? 'A' : 'B';
+		$arr[] = rand(0,1) ? 'C' : '';
+
+		assertType("array{'A'|'B', ''|'C'}", $arr);
+		assertType("'A '|'A C'|'B '|'B C'", implode(' ', $arr));
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/implode.php
+++ b/tests/PHPStan/Analyser/nsrt/implode.php
@@ -21,4 +21,29 @@ class Foo
 		assertType("'x,345'", join(',', [self::X, '345']));
 		assertType("'1,345'", join(',', [self::ONE, '345']));
 	}
+
+	/** @param array{0: 1|2, 1: 'a'|'b'} $constArr */
+	public function constArrays($constArr) {
+		assertType("'1a'|'1b'|'2a'|'2b'", implode('', $constArr));
+	}
+
+	/** @param array{0: 1|2|3, 1: 'a'|'b'|'c'} $constArr */
+	public function constArrays2($constArr) {
+		assertType("'1a'|'1b'|'1c'|'2a'|'2b'|'2c'|'3a'|'3b'|'3c'", implode('', $constArr));
+	}
+
+	/** @param array{0: 1, 1: 'a'|'b', 2: 'x'|'y'} $constArr */
+	public function constArrays3($constArr) {
+		assertType("'1ax'|'1ay'|'1bx'|'1by'", implode('', $constArr));
+	}
+
+	/** @param array{0: 1, 1: 'a'|'b', 2?: 'x'|'y'} $constArr */
+	public function constArrays4($constArr) {
+		assertType("'1a'|'1ax'|'1ay'|'1b'|'1bx'|'1by'", implode('', $constArr));
+	}
+
+	/** @param array{10: 1|2|3, xy: 'a'|'b'|'c'} $constArr */
+	public function constArrays5($constArr) {
+		assertType("'1a'|'1b'|'1c'|'2a'|'2b'|'2c'|'3a'|'3b'|'3c'", implode('', $constArr));
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/implode.php
+++ b/tests/PHPStan/Analyser/nsrt/implode.php
@@ -46,4 +46,9 @@ class Foo
 	public function constArrays5($constArr) {
 		assertType("'1a'|'1b'|'1c'|'2a'|'2b'|'2c'|'3a'|'3b'|'3c'", implode('', $constArr));
 	}
+
+	/** @param array{0: 1, 1: 'a'|'b', 3?: 'c'|'d', 4?: 'e'|'f', 5?: 'g'|'h', 6?: 'x'|'y'} $constArr */
+	public function constArrays6($constArr) {
+		assertType("string", implode('', $constArr));
+	}
 }


### PR DESCRIPTION
Primary motivation: get rid of `instanceof ConstantScalarType`

closes https://github.com/phpstan/phpstan/issues/11854