### PR TITLE
Do not report constructor unused parameter if class is an Attribute class

### DIFF
--- a/src/Rules/Classes/UnusedConstructorParametersRule.php
+++ b/src/Rules/Classes/UnusedConstructorParametersRule.php
@@ -44,6 +44,9 @@ final class UnusedConstructorParametersRule implements Rule
 		if (count($originalNode->params) === 0) {
 			return [];
 		}
+		if ($node->getClassReflection()->isAttributeClass()) {
+			return [];
+		}
 
 		$message = sprintf(
 			'Constructor of class %s has an unused parameter $%%s.',

--- a/tests/PHPStan/Rules/Classes/UnusedConstructorParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/UnusedConstructorParametersRuleTest.php
@@ -61,6 +61,11 @@ class UnusedConstructorParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-1917.php'], []);
 	}
 
+	public function testBug7165(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7165.php'], []);
+	}
+
 	public function testBug10865(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-10865.php'], []);

--- a/tests/PHPStan/Rules/Classes/data/bug-7165.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-7165.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1); // lint >= 8.0
+
+namespace Bug7165;
+
+#[\Attribute]
+class MyAttribute
+{
+	public function __construct(string $name)
+	{
+	}
+}
+


### PR DESCRIPTION
When defining `Attribute` classes usually the constructor parameters are not used, as the values are retrieved using reflection.

This PR modifies the `UnusedConstructorParametersRule` class so that unused constructor parameters are not reported if the class is an `Attribute` class.

Fixes https://github.com/phpstan/phpstan/issues/7165