### PR TITLE
Do not report constructor unused parameter if class implements an Interface that defines a constructor

### DIFF
--- a/src/Rules/Classes/UnusedConstructorParametersRule.php
+++ b/src/Rules/Classes/UnusedConstructorParametersRule.php
@@ -48,6 +48,12 @@ final class UnusedConstructorParametersRule implements Rule
 			return [];
 		}
 
+		foreach ($node->getClassReflection()->getInterfaces() as $interface) {
+			if ($interface->hasMethod('__construct')) {
+				return [];
+			}
+		}
+
 		$message = sprintf(
 			'Constructor of class %s has an unused parameter $%%s.',
 			SprintfHelper::escapeFormatString($node->getClassReflection()->getDisplayName()),

--- a/src/Rules/Classes/UnusedConstructorParametersRule.php
+++ b/src/Rules/Classes/UnusedConstructorParametersRule.php
@@ -16,7 +16,6 @@ use function array_map;
 use function array_values;
 use function count;
 use function sprintf;
-use function strtolower;
 
 /**
  * @implements Rule<InClassMethodNode>
@@ -37,7 +36,7 @@ final class UnusedConstructorParametersRule implements Rule
 	{
 		$method = $node->getMethodReflection();
 		$originalNode = $node->getOriginalNode();
-		if (strtolower($method->getName()) !== '__construct' || $originalNode->stmts === null) {
+		if (!$method->isConstructor() || $originalNode->stmts === null) {
 			return [];
 		}
 
@@ -49,7 +48,7 @@ final class UnusedConstructorParametersRule implements Rule
 		}
 
 		foreach ($node->getClassReflection()->getInterfaces() as $interface) {
-			if ($interface->hasMethod('__construct')) {
+			if ($interface->hasConstructor()) {
 				return [];
 			}
 		}

--- a/tests/PHPStan/Rules/Classes/UnusedConstructorParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/UnusedConstructorParametersRuleTest.php
@@ -71,4 +71,9 @@ class UnusedConstructorParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10865.php'], []);
 	}
 
+	public function testBug11454(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-11454.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-11454.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-11454.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11454;
+
+interface ConstructorInterface
+{
+	public function __construct(string $a);
+}
+
+class Foo implements ConstructorInterface {
+	public function __construct(string $a)
+	{
+	}
+}


### PR DESCRIPTION
If the class implements an interface that defines a constructor, then the class constructor needs to match the signature of the constructor in the interface. In this case we should not report any unused constructor parameters and this is what this PR achieves

Fixes https://github.com/phpstan/phpstan/issues/11454