### PR TITLE
Fix ImpossibleCheckTypeFunctionCallRule for `is_subclass` and `is_a`

### DIFF
--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -8,7 +8,6 @@ use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function sprintf;
-use function strtolower;
 
 /**
  * @implements Rule<Node\Expr\FuncCall>
@@ -38,9 +37,6 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		}
 
 		$functionName = (string) $node->name;
-		if (strtolower($functionName) === 'is_a') {
-			return [];
-		}
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
 		if ($isAlways === null) {
 			return [];

--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -9,12 +9,9 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
-use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\TypeCombinator;
 use function count;
 use function strtolower;
 
@@ -50,14 +47,10 @@ final class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifying
 		$allowStringType = isset($node->getArgs()[2]) ? $scope->getType($node->getArgs()[2]->value) : new ConstantBooleanType(false);
 		$allowString = !$allowStringType->equals(new ConstantBooleanType(false));
 
-		$superType = $allowString
-			? TypeCombinator::union(new ObjectWithoutClassType(), new ClassStringType())
-			: new ObjectWithoutClassType();
-
 		$resultType = $this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, true);
 
 		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
-		if ($resultType->equals($superType) && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
+		if ($classType->getConstantStrings() === [] && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
 			return new SpecifiedTypes([], []);
 		}
 

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -9,9 +9,12 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\TypeCombinator;
 use function count;
 use function strtolower;
 
@@ -48,9 +51,20 @@ final class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeS
 			return new SpecifiedTypes([], []);
 		}
 
+		$superType = $allowString
+			? TypeCombinator::union(new ObjectWithoutClassType(), new ClassStringType())
+			: new ObjectWithoutClassType();
+
+		$resultType = $this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, false);
+
+		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
+		if ($resultType->equals($superType) && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
+			return new SpecifiedTypes([], []);
+		}
+
 		return $this->typeSpecifier->create(
 			$node->getArgs()[0]->value,
-			$this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, false),
+			$resultType,
 			$context,
 			false,
 			$scope,

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -9,12 +9,9 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\Generic\GenericClassStringType;
-use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\TypeCombinator;
 use function count;
 use function strtolower;
 
@@ -51,14 +48,10 @@ final class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeS
 			return new SpecifiedTypes([], []);
 		}
 
-		$superType = $allowString
-			? TypeCombinator::union(new ObjectWithoutClassType(), new ClassStringType())
-			: new ObjectWithoutClassType();
-
 		$resultType = $this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, false);
 
 		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
-		if ($resultType->equals($superType) && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
+		if ($classType->getConstantStrings() === [] && $resultType->isSuperTypeOf($objectOrClassType)->yes()) {
 			return new SpecifiedTypes([], []);
 		}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -1133,9 +1133,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					new Arg(new Variable('stringOrNull')),
 					new Arg(new Expr\ConstFetch(new Name('false'))),
 				]),
-				[
-					'$object' => 'object',
-				],
+				[],
 				[],
 			],
 			[

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1102,4 +1102,11 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/always-true-preg-match.php'], []);
 	}
 
+	public function testBug3979(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-3979.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1127,4 +1127,16 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8954.php'], []);
 	}
 
+	public function testBugPR3404(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-pr-3404.php'], [
+			[
+				'Call to function is_a() with arguments BugPR3404\Location, \'BugPR3404\\\\Location\' and true will always evaluate to true.',
+				21,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1109,4 +1109,22 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3979.php'], []);
 	}
 
+	public function testBug8464(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0.');
+		}
+
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8464.php'], []);
+	}
+
+	public function testBug8954(): void
+	{
+		$this->checkAlwaysTrueCheckTypeFunctionCall = true;
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-8954.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-3979.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3979.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Bug3979;
+
+class A { }
+class B extends A { }
+class C { }
+
+/**
+ * @param mixed $value
+ * @param string $class_type
+ */
+function check_class($value, $class_type): bool
+{
+	if (!is_string($value) || !class_exists($value) ||
+		($class_type && !is_subclass_of($value, $class_type)))
+		return false;
+	return true;
+}
+
+var_dump(check_class("B", "A")); // true
+var_dump(check_class("C", "A")); // false
+
+/**
+ * @param class-string $value
+ * @param string $class_type
+ */
+function check_class2($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string|object $value
+ * @param string $class_type
+ */
+function check_class3($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string|object $value
+ * @param string $class_type
+ */
+function check_class4($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param string $class_type
+ */
+function check_class5($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param string $class_type
+ */
+function check_class6($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param class-string $class_type
+ */
+function check_class7($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param object $value
+ * @param class-string $class_type
+ */
+function check_class8($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string $value
+ * @param class-string $class_type
+ */
+function check_class9($value, $class_type): bool
+{
+	if (is_a($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * @param class-string $value
+ * @param class-string $class_type
+ */
+function check_class10($value, $class_type): bool
+{
+	if (is_subclass_of($value, $class_type, true)) {
+		return true;
+	}
+	return false;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-8464.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8464.php
@@ -1,0 +1,18 @@
+<?php // lint >= 8.0
+
+namespace Bug8464;
+
+final class ObjectUtil
+{
+	/**
+	 * @param class-string $type
+	 */
+	public static function instanceOf(mixed $object, string $type): bool
+	{
+		return \is_object($object)
+			&& (
+				$object::class === $type ||
+				is_subclass_of($object, $type)
+			);
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-8954.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8954.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8954;
+
+/**
+ * @template U
+ * @template V
+ *
+ * @param ?class-string<U> $class
+ * @param class-string<V> $expected
+ *
+ * @return ?class-string<V>
+ */
+function ensureSubclassOf(?string $class, string $expected): ?string {
+	if ($class === null) {
+		return $class;
+	}
+
+	if (!class_exists($class)) {
+		throw new \Exception("Class “{$class}” does not exist.");
+	}
+
+	if (!is_subclass_of($class, $expected)) {
+		throw new \Exception("Class “{$class}” is not a subclass of “{$expected}”.");
+	}
+
+	return $class;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-pr-3404.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-pr-3404.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.0
+
+namespace BugPR3404;
+
+interface Location
+{
+
+}
+
+/** @return class-string<Location> */
+function aaa(): string
+{
+
+}
+
+function (Location $l): void {
+	if (is_a($l, aaa(), true)) {
+		// might not always be true. $l might be one subtype of Location, aaa() might return a name of a different subtype of Location
+	}
+
+	if (is_a($l, Location::class, true)) {
+		// always true
+	}
+};


### PR DESCRIPTION
Improved strategy for https://github.com/phpstan/phpstan-src/pull/3404

The main idea is that `always true` error can always be reported if the second param is a Constant class-string (or union of them).

I included a non regression test from
https://github.com/phpstan/phpstan-src/pull/3404#issuecomment-2600896183

Closes https://github.com/phpstan/phpstan/issues/3979
Closes https://github.com/phpstan/phpstan/issues/8464