### PR TITLE
Allow write access to offsets of readonly ArrayAccess properties

### DIFF
--- a/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
@@ -5,6 +5,8 @@ namespace PHPStan\Rules\Properties;
 use ArrayAccess;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\SetOffsetValueTypeExpr;
+use PHPStan\Node\Expr\UnsetOffsetExpr;
 use PHPStan\Node\PropertyAssignNode;
 use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Reflection\MethodReflection;
@@ -91,7 +93,11 @@ final class ReadOnlyPropertyAssignRule implements Rule
 				continue;
 			}
 
-			if ((new ObjectType(ArrayAccess::class))->isSuperTypeOf($propertyReflection->getNativeType())->yes()) {
+			$expr = $node->getAssignedExpr();
+			if (
+				(new ObjectType(ArrayAccess::class))->isSuperTypeOf($propertyReflection->getNativeType())->yes()
+				 && (($expr instanceof SetOffsetValueTypeExpr) || ($expr instanceof UnsetOffsetExpr))
+			) {
 				continue;
 			}
 

--- a/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use ArrayAccess;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\PropertyAssignNode;
@@ -10,6 +11,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeUtils;
 use function in_array;
 use function sprintf;
@@ -86,6 +88,10 @@ final class ReadOnlyPropertyAssignRule implements Rule
 						->build();
 				}
 
+				continue;
+			}
+
+			if ((new ObjectType(ArrayAccess::class))->isSuperTypeOf($propertyReflection->getNativeType())->yes()) {
 				continue;
 			}
 

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -174,7 +174,12 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 			self::markTestSkipped('Test requires PHP 8.1');
 		}
 
-		$this->analyse([__DIR__ . '/data/bug-8929.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-8929.php'], [
+			[
+				'Readonly property Bug8929\Test::$cache is assigned outside of the constructor.',
+				19,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -168,4 +168,13 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug8929(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			self::markTestSkipped('Test requires PHP 8.1');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-8929.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-8929.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8929.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug8929;
+
+class Test
+{
+    /** @var \WeakMap<object, mixed> */
+    protected readonly \WeakMap $cache;
+
+    public function __construct()
+    {
+        $this->cache = new \WeakMap();
+    }
+
+    public function add(object $key, mixed $value): void
+    {
+        $this->cache[$key] = $value;
+    }
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-8929.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8929.php
@@ -14,6 +14,8 @@ class Test
 
     public function add(object $key, mixed $value): void
     {
-        $this->cache[$key] = $value;
+        $this->cache[$key] = $value; // valid offset access
+        unset($this->cache[$key]);   // valid offset access
+        $this->cache = new \WeakMap(); // reassigning is invalid however
     }
 }


### PR DESCRIPTION
In case a readonly property is an object which implements ArrayAccess, offet accesses to said property are turned into method calls on PHP's side and are allowed even on read-only properties.

this fixes phpstan/phpstan#8929