### PR TITLE
fix: json error formatter when files are empty

### DIFF
--- a/src/Command/ErrorFormatter/JsonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/JsonErrorFormatter.php
@@ -5,9 +5,10 @@ namespace PHPStan\Command\ErrorFormatter;
 use Nette\Utils\Json;
 use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\Output;
+use stdClass;
 use Symfony\Component\Console\Formatter\OutputFormatter;
-use function array_key_exists;
 use function count;
+use function property_exists;
 
 final class JsonErrorFormatter implements ErrorFormatter
 {
@@ -23,7 +24,7 @@ final class JsonErrorFormatter implements ErrorFormatter
 				'errors' => count($analysisResult->getNotFileSpecificErrors()),
 				'file_errors' => count($analysisResult->getFileSpecificErrors()),
 			],
-			'files' => [],
+			'files' => new stdClass(),
 			'errors' => [],
 		];
 
@@ -31,13 +32,13 @@ final class JsonErrorFormatter implements ErrorFormatter
 
 		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
 			$file = $fileSpecificError->getFile();
-			if (!array_key_exists($file, $errorsArray['files'])) {
-				$errorsArray['files'][$file] = [
+			if (!property_exists($errorsArray['files'], $file)) {
+				$errorsArray['files']->$file = [
 					'errors' => 0,
 					'messages' => [],
 				];
 			}
-			$errorsArray['files'][$file]['errors']++;
+			$errorsArray['files']->$file['errors']++;
 
 			$message = [
 				'message' => $fileSpecificError->getMessage(),
@@ -53,7 +54,7 @@ final class JsonErrorFormatter implements ErrorFormatter
 				$message['identifier'] = $fileSpecificError->getIdentifier();
 			}
 
-			$errorsArray['files'][$file]['messages'][] = $message;
+			$errorsArray['files']->$file['messages'][] = $message;
 		}
 
 		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -24,7 +24,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 		"errors":0,
 		"file_errors":0
 	},
-	"files":[],
+	"files":{},
 	"errors": []
 }',
 		];
@@ -67,7 +67,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 		"errors":1,
 		"file_errors":0
 	},
-	"files":[],
+	"files":{},
 	"errors": [
 		"first generic error"
 	]
@@ -133,7 +133,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 		"errors":2,
 		"file_errors":0
 	},
-	"files":[],
+	"files":{},
 	"errors": [
 		"first generic error",
 		"second generic<error>"


### PR DESCRIPTION
Hey,

I am trying to parse the JSON output of PHPStan in Go.

When it is filled I get:

```
"files: { "filename.php": {}}
```

but when not it's
```
"files": []
```

so it changes it type from object to array and it explodes in another languages like Go:

```
Error: json: cannot unmarshal array into Go struct field PhpStanOutput.files of type map[string]struct { Errors int "json:\"errors\""; Messages []struct { Message string "json:\"message\""; Line int "json:\"line\""; Ignorable bool "json:\"ignorable\""; Identifier string "json:\"identifier\"" } "json:\"messages\"" }
```
