### PR TITLE
Add stub for \DOMNode::hasAttributes

### DIFF
--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -30,6 +30,17 @@ class DOMDocument
 class DOMNode
 {
 
+	/**
+	 * @var DOMNamedNodeMap|null
+	 */
+	public $attributes;
+
+	/**
+	 * @phpstan-assert-if-true !null $this->attributes
+	 * @return bool
+	 */
+	public function hasAttributes() {}
+
 }
 
 class DOMElement extends DOMNode


### PR DESCRIPTION
I'm not sure if the property should be explicitely declared. It works fine without it. Most likely, it comes from PHPStorm's stubs. Also, I'm not sure if it should be:

```php
@phpstan-assert-if-true DOMNamedNodeMap $this->attributes
```

to be more specific, or is it fine with `!null`?

This PR fixes an issue where PHPStan does not understand chained calls, as discussed here: https://github.com/phpstan/phpstan/issues/12495#issuecomment-2619213520

```php
    if ($node->hasAttributes()) {
      foreach ($node->attributes->getIterator() as $attribute) {
```

```
  22     Cannot call method getIterator() on DOMNamedNodeMap|null.  
         🪪  method.nonObject   
```
