### PR TITLE
Imagick::getConfigureOptions() returns array instead of string

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -4729,7 +4729,7 @@ return [
 'Imagick::getColorspace' => ['Imagick::COLORSPACE_*'],
 'Imagick::getCompression' => ['Imagick::COMPRESSION_*'],
 'Imagick::getCompressionQuality' => ['int'],
-'Imagick::getConfigureOptions' => ['array'],
+'Imagick::getConfigureOptions' => ['array<string, string>'],
 'Imagick::getCopyright' => ['string'],
 'Imagick::getFeatures' => ['string'],
 'Imagick::getFilename' => ['string'],

--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -4729,7 +4729,7 @@ return [
 'Imagick::getColorspace' => ['Imagick::COLORSPACE_*'],
 'Imagick::getCompression' => ['Imagick::COMPRESSION_*'],
 'Imagick::getCompressionQuality' => ['int'],
-'Imagick::getConfigureOptions' => ['string'],
+'Imagick::getConfigureOptions' => ['array'],
 'Imagick::getCopyright' => ['string'],
 'Imagick::getFeatures' => ['string'],
 'Imagick::getFilename' => ['string'],

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -2829,6 +2829,15 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5623.php'], []);
 	}
 
+	public function testImagick(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = false;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = false;
+		$this->analyse([__DIR__ . '/data/imagick.php'], []);
+	}
+
 	public function testImagickPixel(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/imagick.php
+++ b/tests/PHPStan/Rules/Methods/data/imagick.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Methods\data;
+
+use Imagick;
+
+class ImagickText
+{
+	public function isLcmsInstalled(): bool
+	{
+		return str_contains(Imagick::getConfigureOptions()['DELEGATES'], 'lcms');
+	}
+}


### PR DESCRIPTION
Should be fix https://phpstan.org/r/650952e7-9859-4db0-ae91-58b8ca25a1ef

See:
https://github.com/JetBrains/phpstorm-stubs/pull/1707
https://phpimagick.com/Imagick/getConfigureOptions