### PR TITLE
Prevent declaring hooked properties as readonly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,7 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php \
+		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks-in-interface.php \
 		--exclude tests/PHPStan/Rules/Classes/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Traits/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Classes/data/invalid-hooked-properties.php \

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/non-abstract-hooked-properties-in-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-in-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php \
+		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php \
 		--exclude tests/PHPStan/Rules/Classes/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Traits/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Classes/data/invalid-hooked-properties.php \

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -57,6 +57,15 @@ final class PropertiesInInterfaceRule implements Rule
 			];
 		}
 
+		if ($node->isReadOnly()) {
+			return [
+				RuleErrorBuilder::message('Interfaces cannot include readonly hooked properties.')
+					->nonIgnorable()
+					->identifier('property.readOnlyInInterface')
+					->build(),
+			];
+		}
+
 		if ($this->hasAnyHookBody($node)) {
 			return [
 				RuleErrorBuilder::message('Interfaces cannot include property hooks with bodies.')

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -72,8 +72,6 @@ final class PropertyInClassRule implements Rule
 						->build(),
 				];
 			}
-
-			return [];
 		}
 
 		if ($node->isReadOnly()) {
@@ -87,13 +85,15 @@ final class PropertyInClassRule implements Rule
 			}
 		}
 
-		if (!$this->doAllHooksHaveBody($node)) {
-			return [
-				RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
-					->nonIgnorable()
-					->identifier('property.hookWithoutBody')
-					->build(),
-			];
+		if (!$node->isAbstract() && !$node->isReadOnly()) {
+			if (!$this->doAllHooksHaveBody($node)) {
+				return [
+					RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
+						->nonIgnorable()
+						->identifier('property.hookWithoutBody')
+						->build(),
+				];
+			}
 		}
 
 		return [];

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -76,6 +76,17 @@ final class PropertyInClassRule implements Rule
 			return [];
 		}
 
+		if ($node->isReadOnly()) {
+			if ($node->hasHooks()) {
+				return [
+					RuleErrorBuilder::message('Hooked properties cannot be readonly.')
+						->nonIgnorable()
+						->identifier('property.hookReadOnly')
+						->build(),
+				];
+			}
+		}
+
 		if (!$this->doAllHooksHaveBody($node)) {
 			return [
 				RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -72,6 +72,13 @@ final class PropertyInClassRule implements Rule
 						->build(),
 				];
 			}
+		} elseif (!$this->doAllHooksHaveBody($node)) {
+			return [
+				RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
+					->nonIgnorable()
+					->identifier('property.hookWithoutBody')
+					->build(),
+			];
 		}
 
 		if ($node->isReadOnly()) {
@@ -80,17 +87,6 @@ final class PropertyInClassRule implements Rule
 					RuleErrorBuilder::message('Hooked properties cannot be readonly.')
 						->nonIgnorable()
 						->identifier('property.hookReadOnly')
-						->build(),
-				];
-			}
-		}
-
-		if (!$node->isAbstract() && !$node->isReadOnly()) {
-			if (!$this->doAllHooksHaveBody($node)) {
-				return [
-					RuleErrorBuilder::message('Non-abstract properties cannot include hooks without bodies.')
-						->nonIgnorable()
-						->identifier('property.hookWithoutBody')
 						->build(),
 				];
 			}

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -118,4 +118,26 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhp84AndReadonlyPropertyHooksInInterface(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
+
+		$this->analyse([__DIR__ . '/data/readonly-property-hooks-in-interface.php'], [
+			[
+				'Interfaces cannot include readonly hooked properties.',
+				7,
+			],
+			[
+				'Interfaces cannot include readonly hooked properties.',
+				9,
+			],
+			[
+				'Interfaces cannot include readonly hooked properties.',
+				11,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -170,6 +170,10 @@ class PropertyInClassRuleTest extends RuleTestCase
 				'Hooked properties cannot be readonly.',
 				14,
 			],
+			[
+				'Hooked properties cannot be readonly.',
+				19,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -151,4 +151,26 @@ class PropertyInClassRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhp84AndReadonlyHookedProperties(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
+
+		$this->analyse([__DIR__ . '/data/readonly-property-hooks.php'], [
+			[
+				'Hooked properties cannot be readonly.',
+				7,
+			],
+			[
+				'Hooked properties cannot be readonly.',
+				12,
+			],
+			[
+				'Hooked properties cannot be readonly.',
+				14,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php
+++ b/tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php
@@ -12,7 +12,7 @@ class AbstractPerson
 class PromotedHookedPropertyWithoutVisibility
 {
 
-	public function __construct(mixed $test { get; })
+	public function __construct(public mixed $test { get; })
 	{
 
 	}

--- a/tests/PHPStan/Rules/Properties/data/readonly-property-hooks-in-interface.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-property-hooks-in-interface.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace ReadonlyPropertyHooksInInterface;
+
+interface HelloWorld
+{
+	public readonly string $firstName { get; set; }
+
+	public readonly string $middleName { get; }
+
+	public readonly string $lastName { set; }
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace ReadonlyPropertyHooks;
+
+class HelloWorld
+{
+	public readonly string $firstName {
+		get => $this->firstName;
+		set => $this->firstName;
+	}
+
+	public readonly string $middleName { get => $this->middleName; }
+
+	public readonly string $lastName { set => $this->lastName; }
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php
@@ -13,3 +13,8 @@ class HelloWorld
 
 	public readonly string $lastName { set => $this->lastName; }
 }
+
+abstract class HiWorld
+{
+	public abstract readonly string $firstName { get { return 'jake'; } set; }
+}


### PR DESCRIPTION
Fulfills `Hooked properties cannot be readonly` from https://github.com/phpstan/phpstan/issues/12336 :)