### PR TITLE
Teamcity - show rule identifier when verbose output is set

### DIFF
--- a/src/Command/ErrorFormatter/TeamcityErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TeamcityErrorFormatter.php
@@ -10,6 +10,7 @@ use function array_values;
 use function count;
 use function is_string;
 use function preg_replace;
+use function sprintf;
 use const PHP_EOL;
 
 /**
@@ -41,9 +42,15 @@ final class TeamcityErrorFormatter implements ErrorFormatter
 		]);
 
 		foreach ($fileSpecificErrors as $fileSpecificError) {
+			$message = $fileSpecificError->getMessage();
+
+			if ($fileSpecificError->getIdentifier() !== null && $fileSpecificError->canBeIgnored()) {
+				$message .= sprintf(' (🪪 %s)', $fileSpecificError->getIdentifier());
+			}
+
 			$result .= $this->createTeamcityLine('inspection', [
 				'typeId' => 'phpstan',
-				'message' => $fileSpecificError->getMessage(),
+				'message' => $message,
 				'file' => $this->relativePathHelper->getRelativePath($fileSpecificError->getFile()),
 				'line' => $fileSpecificError->getLine(),
 				// additional attributes

--- a/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
@@ -18,6 +18,7 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			0,
 			0,
 			'',
+			'',
 		];
 
 		yield [
@@ -78,16 +79,27 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 ##teamcity[inspection typeId=\'phpstan\' message=\'second generic<error>\' file=\'.\' SEVERITY=\'ERROR\']
 ',
 		];
+
+		yield [
+			'One file error',
+			1,
+			[4, 2],
+			0,
+			'##teamcity[inspectionType id=\'phpstan\' name=\'phpstan\' category=\'phpstan\' description=\'phpstan Inspection\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Bar||nBar2\' file=\'foo.php\' line=\'\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'\']
+##teamcity[inspection typeId=\'phpstan\' message=\'Foobar\Buz (🪪 foobar.buz)\' file=\'foo.php\' line=\'5\' SEVERITY=\'ERROR\' ignorable=\'1\' tip=\'a tip\']
+',
+		];
 	}
 
 	/**
 	 * @dataProvider dataFormatterOutputProvider
-	 *
+	 * @param array{int, int}|int $numFileErrors
 	 */
 	public function testFormatErrors(
 		string $message,
 		int $exitCode,
-		int $numFileErrors,
+		array|int $numFileErrors,
 		int $numGenericErrors,
 		string $expected,
 	): void


### PR DESCRIPTION
Teamcity Code Inspection - show rule identifier for error when verbose output is set