### PR TITLE
Add generic typings to array_uintersect

### DIFF
--- a/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
@@ -25,14 +25,12 @@ final class ArgumentBasedFunctionReturnTypeExtension implements DynamicFunctionR
 		'array_diff' => 0,
 		'array_udiff_assoc' => 0,
 		'array_udiff_uassoc' => 0,
-		'array_udiff' => 0,
 		'array_intersect_assoc' => 0,
 		'array_intersect_uassoc' => 0,
 		'array_intersect_ukey' => 0,
 		'array_intersect' => 0,
 		'array_uintersect_assoc' => 0,
 		'array_uintersect_uassoc' => 0,
-		'array_uintersect' => 0,
 	];
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -58,11 +58,11 @@ function uksort(array &$array, callable $callback): bool
 }
 
 /**
- * @template T of mixed
- *
+ * @template T
+ * @template U
  * @param array<T> $one
- * @param array<T> $two
- * @param callable(T, T): int $three
+ * @param array<U> $two
+ * @param callable(T, U): int $three
  */
 function array_udiff(
     array $one,
@@ -72,9 +72,10 @@ function array_udiff(
 
 /**
  * @template T
+ * @template U
  * @param array<T> $one
- * @param array<T> $two
- * @param callable(T, T): int $three
+ * @param array<U> $two
+ * @param callable(T, U): int $three
  */
 function array_uintersect(
     array $one,

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -71,6 +71,18 @@ function array_udiff(
 ): int {}
 
 /**
+ * @template T
+ * @param array<T> $one
+ * @param array<T> $two
+ * @param callable(T, T): int $three
+ */
+function array_uintersect(
+    array $one,
+    array $two,
+    callable $three
+): int {}
+
+/**
  * @param array<array-key, mixed> $value
  * @return ($value is list ? true : false)
  */

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -58,30 +58,32 @@ function uksort(array &$array, callable $callback): bool
 }
 
 /**
- * @template T
- * @template U
- * @param array<T> $one
- * @param array<U> $two
- * @param callable(T, U): int $three
+ * @template T of array
+ * @template U of array
+ * @param T $one
+ * @param U $two
+ * @param callable(value-of<T>, value-of<U>): int $three
+ * @return array<key-of<T>, value-of<T>>
  */
 function array_udiff(
     array $one,
     array $two,
     callable $three
-): int {}
+): array {}
 
 /**
- * @template T
- * @template U
- * @param array<T> $one
- * @param array<U> $two
- * @param callable(T, U): int $three
+ * @template T of array
+ * @template U of array
+ * @param T $one
+ * @param U $two
+ * @param callable(value-of<T>, value-of<U>): int $three
+ * @return array<key-of<T>, value-of<T>>
  */
 function array_uintersect(
     array $one,
     array $two,
     callable $three
-): int {}
+): array {}
 
 /**
  * @param array<array-key, mixed> $value

--- a/stubs/arrayFunctions.stub
+++ b/stubs/arrayFunctions.stub
@@ -58,12 +58,13 @@ function uksort(array &$array, callable $callback): bool
 }
 
 /**
- * @template T of array
- * @template U of array
- * @param T $one
- * @param U $two
- * @param callable(value-of<T>, value-of<U>): int $three
- * @return array<key-of<T>, value-of<T>>
+ * @template TKey of array-key
+ * @template TValue
+ * @template UValue
+ * @param array<TKey, TValue> $one
+ * @param array<UValue> $two
+ * @param callable(TValue, UValue): int $three
+ * @return array<TKey, TValue>
  */
 function array_udiff(
     array $one,
@@ -72,12 +73,13 @@ function array_udiff(
 ): array {}
 
 /**
- * @template T of array
- * @template U of array
- * @param T $one
- * @param U $two
- * @param callable(value-of<T>, value-of<U>): int $three
- * @return array<key-of<T>, value-of<T>>
+ * @template TKey of array-key
+ * @template TValue
+ * @template UValue
+ * @param array<TKey, TValue> $one
+ * @param array<UValue> $two
+ * @param callable(TValue, UValue): int $three
+ * @return array<TKey, TValue>
  */
 function array_uintersect(
     array $one,

--- a/tests/PHPStan/Analyser/nsrt/array_udiff.php
+++ b/tests/PHPStan/Analyser/nsrt/array_udiff.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ArrayUdiff;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array<int> $array1
+ * @param array<string> $array2
+ * @param array<int, int> $array3
+ * @param list<string> $list
+ * @param non-empty-array<int> $nonEmptyArray
+ */
+function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray): void
+{
+	assertType('array<int|string, int>', array_udiff($array1, $array2, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('string', $b);
+
+		return strcasecmp((string) $a, $b);
+	}));
+
+	assertType('array<int|string, string>', array_udiff($array2, $array1, static function (mixed $a, mixed $b) {
+		assertType('string', $a);
+		assertType('int', $b);
+
+		return strcasecmp($a, (string) $b);
+	}));
+
+	assertType('array<int|string, int>', array_udiff($array1, $array3, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int, int>', array_udiff($array3, $array1, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int|string, int>', array_udiff($array1, $list, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('string', $b);
+
+		return strcasecmp((string) $a, $b);
+	}));
+
+	assertType('array<int, string>', array_udiff($list, $array1, static function (mixed $a, mixed $b) {
+		assertType('string', $a);
+		assertType('int', $b);
+
+		return strcasecmp($a, (string) $b);
+	}));
+
+	assertType('array<int|string, int>', array_udiff($nonEmptyArray, $array1, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int|string, int>', array_udiff($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+}

--- a/tests/PHPStan/Analyser/nsrt/array_udiff.php
+++ b/tests/PHPStan/Analyser/nsrt/array_udiff.php
@@ -15,21 +15,21 @@ use function PHPStan\Testing\assertType;
  */
 function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray, array $arrayShape1, array $arrayShape2): void
 {
-	assertType('array<int|string, int>', array_udiff($array1, $array2, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_udiff($array1, $array2, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('string', $b);
 
 		return strcasecmp((string) $a, $b);
 	}));
 
-	assertType('array<int|string, string>', array_udiff($array2, $array1, static function (mixed $a, mixed $b) {
+	assertType('array<string>', array_udiff($array2, $array1, static function (mixed $a, mixed $b) {
 		assertType('string', $a);
 		assertType('int', $b);
 
 		return strcasecmp($a, (string) $b);
 	}));
 
-	assertType('array<int|string, int>', array_udiff($array1, $array3, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_udiff($array1, $array3, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int', $b);
 
@@ -43,49 +43,49 @@ function test(array $array1, array $array2, array $array3, array $list, array $n
 		return $a <=> $b;
 	}));
 
-	assertType('array<int|string, int>', array_udiff($array1, $list, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_udiff($array1, $list, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('string', $b);
 
 		return strcasecmp((string) $a, $b);
 	}));
 
-	assertType('array<int, string>', array_udiff($list, $array1, static function (mixed $a, mixed $b) {
+	assertType('array<int<0, max>, string>', array_udiff($list, $array1, static function (mixed $a, mixed $b) {
 		assertType('string', $a);
 		assertType('int', $b);
 
 		return strcasecmp($a, (string) $b);
 	}));
 
-	assertType('array<int|string, int>', array_udiff($nonEmptyArray, $array1, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_udiff($nonEmptyArray, $array1, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType('array<int|string, int>', array_udiff($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_udiff($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType('array<int|string, int>', array_udiff($array1, $arrayShape1, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_udiff($array1, $arrayShape1, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int|string', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType("array<'foo'|0, int|string>", array_udiff($arrayShape1, $array1, static function (mixed $a, mixed $b) {
+	assertType("array<0|'foo', int|string>", array_udiff($arrayShape1, $array1, static function (mixed $a, mixed $b) {
 		assertType('int|string', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType("array<'bar'|'foo', string>", array_udiff($arrayShape2, $array1, static function (mixed $a, mixed $b) {
+	assertType("array<'bar'|'foo', int|string>", array_udiff($arrayShape2, $array1, static function (mixed $a, mixed $b) {
 		assertType('int|string', $a);
 		assertType('int', $b);
 

--- a/tests/PHPStan/Analyser/nsrt/array_udiff.php
+++ b/tests/PHPStan/Analyser/nsrt/array_udiff.php
@@ -10,8 +10,10 @@ use function PHPStan\Testing\assertType;
  * @param array<int, int> $array3
  * @param list<string> $list
  * @param non-empty-array<int> $nonEmptyArray
+ * @param array{foo: string, 0?: int} $arrayShape1
+ * @param array{foo: string, bar?: int} $arrayShape2
  */
-function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray): void
+function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray, array $arrayShape1, array $arrayShape2): void
 {
 	assertType('array<int|string, int>', array_udiff($array1, $array2, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
@@ -64,6 +66,27 @@ function test(array $array1, array $array2, array $array3, array $list, array $n
 
 	assertType('array<int|string, int>', array_udiff($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int|string, int>', array_udiff($array1, $arrayShape1, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int|string', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType("array<'foo'|0, int|string>", array_udiff($arrayShape1, $array1, static function (mixed $a, mixed $b) {
+		assertType('int|string', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType("array<'bar'|'foo', string>", array_udiff($arrayShape2, $array1, static function (mixed $a, mixed $b) {
+		assertType('int|string', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;

--- a/tests/PHPStan/Analyser/nsrt/array_uintersect.php
+++ b/tests/PHPStan/Analyser/nsrt/array_uintersect.php
@@ -15,21 +15,21 @@ use function PHPStan\Testing\assertType;
  */
 function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray, array $arrayShape1, array $arrayShape2): void
 {
-	assertType('array<int|string, int>', array_uintersect($array1, $array2, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_uintersect($array1, $array2, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('string', $b);
 
 		return strcasecmp((string) $a, $b);
 	}));
 
-	assertType('array<int|string, string>', array_uintersect($array2, $array1, static function (mixed $a, mixed $b) {
+	assertType('array<string>', array_uintersect($array2, $array1, static function (mixed $a, mixed $b) {
 		assertType('string', $a);
 		assertType('int', $b);
 
 		return strcasecmp($a, (string) $b);
 	}));
 
-	assertType('array<int|string, int>', array_uintersect($array1, $array3, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_uintersect($array1, $array3, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int', $b);
 
@@ -43,49 +43,49 @@ function test(array $array1, array $array2, array $array3, array $list, array $n
 		return $a <=> $b;
 	}));
 
-	assertType('array<int|string, int>', array_uintersect($array1, $list, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_uintersect($array1, $list, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('string', $b);
 
 		return strcasecmp((string) $a, $b);
 	}));
 
-	assertType('array<int, string>', array_uintersect($list, $array1, static function (mixed $a, mixed $b) {
+	assertType('array<int<0, max>, string>', array_uintersect($list, $array1, static function (mixed $a, mixed $b) {
 		assertType('string', $a);
 		assertType('int', $b);
 
 		return strcasecmp($a, (string) $b);
 	}));
 
-	assertType('array<int|string, int>', array_uintersect($nonEmptyArray, $array1, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_uintersect($nonEmptyArray, $array1, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType('array<int|string, int>', array_uintersect($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_uintersect($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType('array<int|string, int>', array_uintersect($array1, $arrayShape1, static function (mixed $a, mixed $b) {
+	assertType('array<int>', array_uintersect($array1, $arrayShape1, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
 		assertType('int|string', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType("array<'foo'|0, int|string>", array_uintersect($arrayShape1, $array1, static function (mixed $a, mixed $b) {
+	assertType("array<0|'foo', int|string>", array_uintersect($arrayShape1, $array1, static function (mixed $a, mixed $b) {
 		assertType('int|string', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;
 	}));
 
-	assertType("array<'bar'|'foo', string>", array_uintersect($arrayShape2, $array1, static function (mixed $a, mixed $b) {
+	assertType("array<'bar'|'foo', int|string>", array_uintersect($arrayShape2, $array1, static function (mixed $a, mixed $b) {
 		assertType('int|string', $a);
 		assertType('int', $b);
 

--- a/tests/PHPStan/Analyser/nsrt/array_uintersect.php
+++ b/tests/PHPStan/Analyser/nsrt/array_uintersect.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace ArrayUintersect;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array<int> $array1
+ * @param array<string> $array2
+ * @param array<int, int> $array3
+ * @param list<string> $list
+ * @param non-empty-array<int> $nonEmptyArray
+ */
+function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray): void
+{
+	assertType('array<int|string, int>', array_uintersect($array1, $array2, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('string', $b);
+
+		return strcasecmp((string) $a, $b);
+	}));
+
+	assertType('array<int|string, string>', array_uintersect($array2, $array1, static function (mixed $a, mixed $b) {
+		assertType('string', $a);
+		assertType('int', $b);
+
+		return strcasecmp($a, (string) $b);
+	}));
+
+	assertType('array<int|string, int>', array_uintersect($array1, $array3, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int, int>', array_uintersect($array3, $array1, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int|string, int>', array_uintersect($array1, $list, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('string', $b);
+
+		return strcasecmp((string) $a, $b);
+	}));
+
+	assertType('array<int, string>', array_uintersect($list, $array1, static function (mixed $a, mixed $b) {
+		assertType('string', $a);
+		assertType('int', $b);
+
+		return strcasecmp($a, (string) $b);
+	}));
+
+	assertType('array<int|string, int>', array_uintersect($nonEmptyArray, $array1, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int|string, int>', array_uintersect($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+}

--- a/tests/PHPStan/Analyser/nsrt/array_uintersect.php
+++ b/tests/PHPStan/Analyser/nsrt/array_uintersect.php
@@ -10,8 +10,10 @@ use function PHPStan\Testing\assertType;
  * @param array<int, int> $array3
  * @param list<string> $list
  * @param non-empty-array<int> $nonEmptyArray
+ * @param array{foo: string, 0?: int} $arrayShape1
+ * @param array{foo: string, bar?: int} $arrayShape2
  */
-function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray): void
+function test(array $array1, array $array2, array $array3, array $list, array $nonEmptyArray, array $arrayShape1, array $arrayShape2): void
 {
 	assertType('array<int|string, int>', array_uintersect($array1, $array2, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
@@ -64,6 +66,27 @@ function test(array $array1, array $array2, array $array3, array $list, array $n
 
 	assertType('array<int|string, int>', array_uintersect($array1, $nonEmptyArray, static function (mixed $a, mixed $b) {
 		assertType('int', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType('array<int|string, int>', array_uintersect($array1, $arrayShape1, static function (mixed $a, mixed $b) {
+		assertType('int', $a);
+		assertType('int|string', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType("array<'foo'|0, int|string>", array_uintersect($arrayShape1, $array1, static function (mixed $a, mixed $b) {
+		assertType('int|string', $a);
+		assertType('int', $b);
+
+		return $a <=> $b;
+	}));
+
+	assertType("array<'bar'|'foo', string>", array_uintersect($arrayShape2, $array1, static function (mixed $a, mixed $b) {
+		assertType('int|string', $a);
 		assertType('int', $b);
 
 		return $a <=> $b;

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -663,6 +663,32 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testArrayUintersectCallback(): void
+	{
+		$this->analyse([__DIR__ . '/data/array_uintersect.php'], [
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(string, string): string given.',
+				6,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(int, int): (literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string) given.',
+				14,
+			],
+			[
+				'Parameter #1 $arr1 of function array_uintersect expects array<string>, null given.',
+				20,
+			],
+			[
+				'Parameter #2 $arr2 of function array_uintersect expects array<string>, null given.',
+				21,
+			],
+			[
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(string, string): int, Closure(string, int): non-empty-string given.',
+				22,
+			],
+		]);
+	}
+
 	public function testPregReplaceCallback(): void
 	{
 		$this->analyse([__DIR__ . '/data/preg_replace_callback.php'], [

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -641,11 +641,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_udiff.php'], [
 			[
-				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(string, string): string given.',
+				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3, 4|5|6): int, Closure(string, string): string given.',
 				6,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_udiff expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(int, int): (literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string) given.',
+				"Parameter #3 \$data_comp_func of function array_udiff expects callable(1|2|3, 4|5|6): int, Closure(int, int): ('14'|'15'|'16'|'24'|'25'|'26'|'34'|'35'|'36') given.",
 				14,
 			],
 			[
@@ -653,11 +653,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				20,
 			],
 			[
-				'Parameter #2 $arr2 of function array_udiff expects array<string>, null given.',
+				'Parameter #2 $arr2 of function array_udiff expects array<int>, null given.',
 				21,
 			],
 			[
-				'Parameter #3 $data_comp_func of function array_udiff expects callable(string, string): int, Closure(string, int): non-empty-string given.',
+				'Parameter #3 $data_comp_func of function array_udiff expects callable(string, int): int, Closure(string, int): non-empty-string given.',
 				22,
 			],
 		]);
@@ -667,11 +667,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/array_uintersect.php'], [
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(string, string): string given.',
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3, 4|5|6): int, Closure(string, string): string given.',
 				6,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(1|2|3|4|5|6, 1|2|3|4|5|6): int, Closure(int, int): (literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string) given.',
+				"Parameter #3 \$data_compare_func of function array_uintersect expects callable(1|2|3, 4|5|6): int, Closure(int, int): ('14'|'15'|'16'|'24'|'25'|'26'|'34'|'35'|'36') given.",
 				14,
 			],
 			[
@@ -679,11 +679,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				20,
 			],
 			[
-				'Parameter #2 $arr2 of function array_uintersect expects array<string>, null given.',
+				'Parameter #2 $arr2 of function array_uintersect expects array<int>, null given.',
 				21,
 			],
 			[
-				'Parameter #3 $data_compare_func of function array_uintersect expects callable(string, string): int, Closure(string, int): non-empty-string given.',
+				'Parameter #3 $data_compare_func of function array_uintersect expects callable(string, int): int, Closure(string, int): non-empty-string given.',
 				22,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -649,7 +649,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				14,
 			],
 			[
-				'Parameter #1 $arr1 of function array_udiff expects array<string>, null given.',
+				'Parameter #1 $arr1 of function array_udiff expects array<TKey of (int|string), string>, null given.',
 				20,
 			],
 			[
@@ -675,7 +675,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				14,
 			],
 			[
-				'Parameter #1 $arr1 of function array_uintersect expects array<string>, null given.',
+				'Parameter #1 $arr1 of function array_uintersect expects array<TKey of (int|string), string>, null given.',
 				20,
 			],
 			[

--- a/tests/PHPStan/Rules/Functions/data/array_udiff.php
+++ b/tests/PHPStan/Rules/Functions/data/array_udiff.php
@@ -37,3 +37,11 @@ array_udiff(
 	["26","27"],
 	'strcasecmp',
 );
+
+array_udiff(
+	[100, 200, 300],
+	['200', '300', '400'],
+	function(int $a, string $b): int {
+		return (string) $a <=> $b;
+	},
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+array_uintersect(
+	[1,2,3],
+	[4,5,6],
+	function(string $a, string $b): string {
+		return $a . $b;
+	},
+);
+
+array_uintersect(
+	[1,2,3],
+	[4,5,6],
+	function(int $a, int $b): string {
+		return $a . $b;
+	},
+);
+
+array_uintersect(
+	null,
+	null,
+	function(string $a, int $b): string {
+		return $a . $b;
+	},
+);
+
+array_uintersect(
+	[25,26],
+	[26,27],
+	static function(int $a, int $b): int {
+		return $a <=> $b;
+	},
+);
+
+array_uintersect(
+	["25","26"],
+	["26","27"],
+	'strcasecmp',
+);

--- a/tests/PHPStan/Rules/Functions/data/array_uintersect.php
+++ b/tests/PHPStan/Rules/Functions/data/array_uintersect.php
@@ -37,3 +37,11 @@ array_uintersect(
 	["26","27"],
 	'strcasecmp',
 );
+
+array_uintersect(
+	[100, 200, 300],
+	['200', '300', '400'],
+	function(int $a, string $b): int {
+		return (string) $a <=> $b;
+	},
+);


### PR DESCRIPTION
This PR adds generic typings to `array_uintersect`, I copied the annotations from `array_udiff`