### PR TITLE
Add a test covering a hooked property in a readonly class

### DIFF
--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -174,6 +174,10 @@ class PropertyInClassRuleTest extends RuleTestCase
 				'Hooked properties cannot be readonly.',
 				19,
 			],
+			[
+				'Hooked properties cannot be readonly.',
+				24,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php
@@ -18,3 +18,11 @@ abstract class HiWorld
 {
 	public abstract readonly string $firstName { get { return 'jake'; } set; }
 }
+
+readonly class GoodMorningWorld
+{
+	public string $firstName {
+		get => $this->firstName;
+		set => $this->firstName;
+	}
+}


### PR DESCRIPTION
`$node->isReadOnly()` returns `true` when a property lives inside a readonly class, so I've added only a simple test to existing test suite :).

Fulfills `Readonly classes cannot have hooked properties` (ref: https://github.com/phpstan/phpstan/issues/12336)