### PR TITLE
Add handling an attempt to declare a hooked property static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php \
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks-in-interface.php \
 		--exclude tests/PHPStan/Rules/Properties/data/static-hooked-properties.php \
+		--exclude tests/PHPStan/Rules/Properties/data/static-hooked-property-in-interface.php \
 		--exclude tests/PHPStan/Rules/Properties/data/virtual-hooked-properties.php \
 		--exclude tests/PHPStan/Rules/Classes/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Traits/data/bug-12281.php \

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php \
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks-in-interface.php \
+		--exclude tests/PHPStan/Rules/Properties/data/static-hooked-properties.php \
 		--exclude tests/PHPStan/Rules/Properties/data/virtual-hooked-properties.php \
 		--exclude tests/PHPStan/Rules/Classes/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Traits/data/bug-12281.php \

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -66,6 +66,15 @@ final class PropertiesInInterfaceRule implements Rule
 			];
 		}
 
+		if ($node->isStatic()) {
+			return [
+				RuleErrorBuilder::message('Hooked properties cannot be static.')
+					->nonIgnorable()
+					->identifier('property.hookedStaticInInterface')
+					->build(),
+			];
+		}
+
 		if ($this->hasAnyHookBody($node)) {
 			return [
 				RuleErrorBuilder::message('Interfaces cannot include property hooks with bodies.')

--- a/src/Rules/Properties/PropertiesInInterfaceRule.php
+++ b/src/Rules/Properties/PropertiesInInterfaceRule.php
@@ -70,7 +70,7 @@ final class PropertiesInInterfaceRule implements Rule
 			return [
 				RuleErrorBuilder::message('Hooked properties cannot be static.')
 					->nonIgnorable()
-					->identifier('property.hookedStaticInInterface')
+					->identifier('property.hookedStatic')
 					->build(),
 			];
 		}

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -92,6 +92,17 @@ final class PropertyInClassRule implements Rule
 			}
 		}
 
+		if ($node->isStatic()) {
+			if ($node->hasHooks()) {
+				return [
+					RuleErrorBuilder::message('Hooked properties cannot be static.')
+						->nonIgnorable()
+						->identifier('property.hookStatic')
+						->build(),
+				];
+			}
+		}
+
 		if ($node->isVirtual()) {
 			if ($node->getDefault() !== null) {
 				return [

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -97,7 +97,7 @@ final class PropertyInClassRule implements Rule
 				return [
 					RuleErrorBuilder::message('Hooked properties cannot be static.')
 						->nonIgnorable()
-						->identifier('property.hookStatic')
+						->identifier('property.hookedStatic')
 						->build(),
 				];
 			}

--- a/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertiesInInterfaceRuleTest.php
@@ -140,4 +140,26 @@ class PropertiesInInterfaceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhp84AndStaticHookedPropertyInInterface(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
+
+		$this->analyse([__DIR__ . '/data/static-hooked-property-in-interface.php'], [
+			[
+				'Hooked properties cannot be static.',
+				7,
+			],
+			[
+				'Hooked properties cannot be static.',
+				9,
+			],
+			[
+				'Hooked properties cannot be static.',
+				11,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -195,4 +195,22 @@ class PropertyInClassRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhp84AndStaticHookedProperties(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
+
+		$this->analyse([__DIR__ . '/data/static-hooked-properties.php'], [
+			[
+				'Hooked properties cannot be static.',
+				7,
+			],
+			[
+				'Hooked properties cannot be static.',
+				15,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/static-hooked-properties.php
+++ b/tests/PHPStan/Rules/Properties/data/static-hooked-properties.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace StaticHookedProperties;
+
+class HelloWorld
+{
+	public static string $foo {
+		get => $this->foo;
+		set => $this->foo = $value;
+	}
+}
+
+abstract class HiWorld
+{
+	public static string $foo {
+		get => 'dummy';
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/static-hooked-property-in-interface.php
+++ b/tests/PHPStan/Rules/Properties/data/static-hooked-property-in-interface.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace StaticHookedPropertyInInterface;
+
+interface HelloWorld
+{
+	public static string $firstName { get; set; }
+
+	public static string $middleName { get; }
+
+	public static string $lastName { set; }
+}


### PR DESCRIPTION
Fulfills `Static properties cannot be hooked` (ref: https://github.com/phpstan/phpstan/issues/12336)