### PR TITLE
Prevent setting a default value for a virtual property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ lint:
 		--exclude tests/PHPStan/Rules/Properties/data/hooked-properties-without-bodies-in-class.php \
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks.php \
 		--exclude tests/PHPStan/Rules/Properties/data/readonly-property-hooks-in-interface.php \
+		--exclude tests/PHPStan/Rules/Properties/data/virtual-hooked-properties.php \
 		--exclude tests/PHPStan/Rules/Classes/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Traits/data/bug-12281.php \
 		--exclude tests/PHPStan/Rules/Classes/data/invalid-hooked-properties.php \

--- a/src/Node/ClassPropertyNode.php
+++ b/src/Node/ClassPropertyNode.php
@@ -160,4 +160,9 @@ final class ClassPropertyNode extends NodeAbstract implements VirtualNode
 		return $this->originalNode->hooks;
 	}
 
+	public function isVirtual(): bool
+	{
+		return $this->classReflection->getNativeProperty($this->name)->isVirtual()->yes();
+	}
+
 }

--- a/src/Rules/Properties/PropertyInClassRule.php
+++ b/src/Rules/Properties/PropertyInClassRule.php
@@ -92,6 +92,17 @@ final class PropertyInClassRule implements Rule
 			}
 		}
 
+		if ($node->isVirtual()) {
+			if ($node->getDefault() !== null) {
+				return [
+					RuleErrorBuilder::message('Virtual hooked properties cannot have a default value.')
+						->nonIgnorable()
+						->identifier('property.virtualDefault')
+						->build(),
+				];
+			}
+		}
+
 		return [];
 	}
 

--- a/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyInClassRuleTest.php
@@ -177,4 +177,18 @@ class PropertyInClassRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPhp84AndVirtualHookedProperties(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4 or later.');
+		}
+
+		$this->analyse([__DIR__ . '/data/virtual-hooked-properties.php'], [
+			[
+				'Virtual hooked properties cannot have a default value.',
+				17,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/virtual-hooked-properties.php
+++ b/tests/PHPStan/Rules/Properties/data/virtual-hooked-properties.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace VirtualHookedProperties;
+
+class HelloWorld
+{
+	public string $firstName = 'John' {
+		get => $this->firstName;
+		set => $this->firstName = $value;
+	}
+
+	public string $middleName {
+		get => $this->middleName;
+		set => $this->middleName = $value;
+	}
+
+	public string $lastName = 'Doe' {
+		get => 'Smith';
+	}
+
+	public string $maidenName = 'Brown';
+}


### PR DESCRIPTION
Fulfills `Virtual property cannot have default value` (ref: https://github.com/phpstan/phpstan/issues/12336)