### PR TITLE
Return given value for dumpType

### DIFF
--- a/src/dumpType.php
+++ b/src/dumpType.php
@@ -3,25 +3,27 @@
 namespace PHPStan;
 
 /**
+ * @template T
  * @phpstan-pure
- * @param mixed $value
- * @return mixed
+ * @param T $value
+ * @return T
  *
  * @throws void
  */
 function dumpType($value) // phpcs:ignore Squiz.Functions.GlobalFunction.Found
 {
-	return null;
+	return $value;
 }
 
 /**
+ * @template T
  * @phpstan-pure
- * @param mixed $value
- * @return mixed
+ * @param T $value
+ * @return T
  *
  * @throws void
  */
 function dumpPhpDocType($value) // phpcs:ignore Squiz.Functions.GlobalFunction.Found
 {
-	return null;
+	return $value;
 }


### PR DESCRIPTION
This make it possible to add PHPStan\dumpType to nested calls like:

```php
$test = new Test(\PHPStan\dumpType($other));
```

without additional errors returned.