### PR TITLE
Fix readonly property assign with ArrayAccess offset

### DIFF
--- a/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
@@ -2,14 +2,18 @@
 
 namespace PHPStan\Rules\Properties;
 
+use ArrayAccess;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\SetOffsetValueTypeExpr;
+use PHPStan\Node\Expr\UnsetOffsetExpr;
 use PHPStan\Node\PropertyAssignNode;
 use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeUtils;
 use function in_array;
 use function sprintf;
@@ -86,6 +90,14 @@ final class ReadOnlyPropertyAssignRule implements Rule
 						->build();
 				}
 
+				continue;
+			}
+
+			$assignedExpr = $node->getAssignedExpr();
+			if (
+				($assignedExpr instanceof SetOffsetValueTypeExpr || $assignedExpr instanceof UnsetOffsetExpr)
+				&& (new ObjectType(ArrayAccess::class))->isSuperTypeOf($scope->getType($assignedExpr->getVar()))->yes()
+			) {
 				continue;
 			}
 

--- a/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyByPhpDocPropertyAssignRuleTest.php
@@ -125,6 +125,10 @@ class ReadOnlyByPhpDocPropertyAssignRuleTest extends RuleTestCase
 				'@readonly property ReadonlyPropertyAssignPhpDoc\C::$c is assigned outside of the constructor.',
 				293,
 			],
+			[
+				'@readonly property ReadonlyPropertyAssignPhpDoc\ArrayAccessPropertyFetch::$storage is assigned outside of the constructor.',
+				311,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -123,6 +123,11 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 			];
 		}
 
+		$errors[] = [
+			'Readonly property ReadonlyPropertyAssign\ArrayAccessPropertyFetch::$storage is assigned outside of the constructor.',
+			212,
+		];
+
 		$this->analyse([__DIR__ . '/data/readonly-assign.php'], $errors);
 	}
 
@@ -166,6 +171,24 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 				16,
 			],
 		]);
+	}
+
+	public function testBug8929(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-8929.php'], []);
+	}
+
+	public function testBug12537(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-12537.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-12537.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12537.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug12537;
+
+use WeakMap;
+
+class Metadata {
+	/**
+	 * @var WeakMap<stdClass, int>
+	 */
+	private readonly WeakMap $storage;
+
+	public function __construct() {
+		$this->storage = new WeakMap();
+	}
+
+	public function set(stdClass $class, int $value): void {
+		$this->storage[$class] = $value;
+	}
+
+	public function get(stdClass $class): mixed {
+		return $this->storage[$class] ?? null;
+	}
+}
+
+$class = new stdClass();
+$meta  = new Metadata();
+
+$meta->set($class, 123);
+
+var_dump($meta->get($class));

--- a/tests/PHPStan/Rules/Properties/data/bug-8929.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-8929.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug8929;
+
+class Test
+{
+	/** @var \WeakMap<object, mixed> */
+	protected readonly \WeakMap $cache;
+
+	public function __construct()
+	{
+		$this->cache = new \WeakMap();
+	}
+
+	public function add(object $key, mixed $value): void
+	{
+		$this->cache[$key] = $value;
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign-phpdoc.php
@@ -294,3 +294,21 @@ class C extends B
 	}
 
 }
+
+class ArrayAccessPropertyFetch
+{
+
+	/** @readonly */
+	private \ArrayObject $storage;
+
+	public function __construct() {
+		$this->storage = new \ArrayObject();
+	}
+
+	public function set(\stdClass $class, int $value): void {
+		$this->storage[$class] = $value;
+		unset($this->storage[$class]);
+		$this->storage = new \WeakMap(); // invalid
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/readonly-assign.php
+++ b/tests/PHPStan/Rules/Properties/data/readonly-assign.php
@@ -196,3 +196,20 @@ class TestCase
 	}
 
 }
+
+class ArrayAccessPropertyFetch
+{
+
+	private readonly \ArrayObject $storage;
+
+	public function __construct() {
+		$this->storage = new \ArrayObject();
+	}
+
+	public function set(\stdClass $class, int $value): void {
+		$this->storage[$class] = $value;
+		unset($this->storage[$class]);
+		$this->storage = new \WeakMap(); // invalid
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/8929
Closes https://github.com/phpstan/phpstan/issues/12537

UPDATE: added test for 8929 and dealing with unset after realizing the bug duplicate and also finding https://github.com/phpstan/phpstan-src/pull/3795. I don't mind which one gets merged first, anybody feel free to re-use parts from here in the other MR or directly.