### PR TITLE
TableErrorFormatter: improve formatting of error tips

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -92,10 +92,11 @@ final class TableErrorFormatter implements ErrorFormatter
 					if (str_contains($tip, "\n")) {
 						$lines = explode("\n", $tip);
 						foreach ($lines as $line) {
-							$message .= '💡 ' . ltrim($line, ' •') . "\n";
+							$message .= '💡  ' . ltrim($line, ' •') . "\n";
 						}
+						$message = rtrim($message, "\n");
 					} else {
-						$message .= '💡 ' . $tip;
+						$message .= '💡  ' . $tip;
 					}
 				}
 				if (is_string($this->editorUrl)) {

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -15,6 +15,7 @@ use function explode;
 use function getenv;
 use function is_string;
 use function ltrim;
+use function rtrim;
 use function sprintf;
 use function str_contains;
 use function str_replace;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -83,7 +83,7 @@ final class TableErrorFormatter implements ErrorFormatter
 				$filePath = $error->getTraitFilePath() ?? $error->getFilePath();
 				if ($error->getIdentifier() !== null && $error->canBeIgnored()) {
 					$message .= "\n";
-					$message .= '🪪  ' . $error->getIdentifier();
+					$message .= '🪪 ' . $error->getIdentifier();
 				}
 				if ($error->getTip() !== null) {
 					$tip = $error->getTip();
@@ -93,11 +93,11 @@ final class TableErrorFormatter implements ErrorFormatter
 					if (str_contains($tip, "\n")) {
 						$lines = explode("\n", $tip);
 						foreach ($lines as $line) {
-							$message .= '💡  ' . ltrim($line, ' •') . "\n";
+							$message .= '💡 ' . ltrim($line, ' •') . "\n";
 						}
 						$message = rtrim($message, "\n");
 					} else {
-						$message .= '💡  ' . $tip;
+						$message .= '💡 ' . $tip;
 					}
 				}
 				if (is_string($this->editorUrl)) {
@@ -117,7 +117,7 @@ final class TableErrorFormatter implements ErrorFormatter
 						$title = $this->relativePathHelper->getRelativePath($filePath);
 					}
 
-					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
+					$message .= "\n✏️ <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
 				}
 				$rows[] = [
 					$this->formatLineNumber($error->getLine()),

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -94,14 +94,14 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   4      Foo
  ------ -------------------------------------------------------------------
 
- ------ -----------
+ ------ ----------
   Line   foo.php
- ------ -----------
+ ------ ----------
   1      Foo<Bar>
   5      Bar
          Bar2
-         💡  a tip
- ------ -----------
+         💡 a tip
+ ------ ----------
 
  [ERROR] Found 4 errors
 
@@ -143,14 +143,14 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   4      Foo
  ------ -------------------------------------------------------------------
 
- ------ -----------
+ ------ ----------
   Line   foo.php
- ------ -----------
+ ------ ----------
   1      Foo<Bar>
   5      Bar
          Bar2
-         💡  a tip
- ------ -----------
+         💡 a tip
+ ------ ----------
 
  -- -----------------------
      Error
@@ -190,13 +190,13 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			'numGenericErrors' => 0,
 			'verbose' => false,
 			'extraEnvVars' => [],
-			'expected' => ' ------ ----------------
+			'expected' => ' ------ ---------------
   Line   foo.php
- ------ ----------------
+ ------ ---------------
   5      Foobar\Buz
-         🪪  foobar.buz
-         💡  a tip
- ------ ----------------
+         🪪 foobar.buz
+         💡 a tip
+ ------ ---------------
 
 
  [ERROR] Found 1 error
@@ -211,13 +211,13 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			'numGenericErrors' => 0,
 			'verbose' => true,
 			'extraEnvVars' => [],
-			'expected' => ' ------ ----------------
+			'expected' => ' ------ ---------------
   Line   foo.php
- ------ ----------------
+ ------ ---------------
   5      Foobar\Buz
-         🪪  foobar.buz
-         💡  a tip
- ------ ----------------
+         🪪 foobar.buz
+         💡 a tip
+ ------ ---------------
 
 
  [ERROR] Found 1 error

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -94,14 +94,14 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   4      Foo
  ------ -------------------------------------------------------------------
 
- ------ ----------
+ ------ -----------
   Line   foo.php
- ------ ----------
+ ------ -----------
   1      Foo<Bar>
   5      Bar
          Bar2
-         💡 a tip
- ------ ----------
+         💡  a tip
+ ------ -----------
 
  [ERROR] Found 4 errors
 
@@ -143,14 +143,14 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   4      Foo
  ------ -------------------------------------------------------------------
 
- ------ ----------
+ ------ -----------
   Line   foo.php
- ------ ----------
+ ------ -----------
   1      Foo<Bar>
   5      Bar
          Bar2
-         💡 a tip
- ------ ----------
+         💡  a tip
+ ------ -----------
 
  -- -----------------------
      Error
@@ -195,7 +195,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  ------ ----------------
   5      Foobar\Buz
          🪪  foobar.buz
-         💡 a tip
+         💡  a tip
  ------ ----------------
 
 
@@ -216,7 +216,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  ------ ----------------
   5      Foobar\Buz
          🪪  foobar.buz
-         💡 a tip
+         💡  a tip
  ------ ----------------
 
 


### PR DESCRIPTION
This PR adds some small improvements to the error output, when using the "table" error formatter:

1. Align tip text after `💡` emoji
2. Trim trailing new-line of multi-line tips

<table>
  <thead>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  </thead>
  <tbody>
  <tr>
    <td valign="top">
<img width="441" height="1">

```
 ------ ----------------------------
  Line   FooBar.php
 ------ ----------------------------
  36     I am an error message.
         🪪  foobar.buz
         💡 I am an error tip.
         💡 I span multiple lines.

         ✏️  FooBar.php
  40     I am an error message.
         🪪  foobar.buz
         💡 I am an error tip.
         💡 I span multiple lines.

         ✏️  FooBar.php
 ------ ----------------------------
```
</td>
    <td valign="top">
<img width="441" height="1">

```
 ------ ----------------------------
  Line   FooBar.php
 ------ ----------------------------
  36     I am an error message.
         🪪  foobar.buz
         💡  I am an error tip.
         💡  I span multiple lines.
         ✏️  FooBar.php
  40     I am an error message.
         🪪  foobar.buz
         💡  I am an error tip.
         💡  I span multiple lines.
         ✏️  FooBar.php
 ------ ----------------------------


```

</td>
  </tr>
  </tbody>
</table>

