### PR TITLE
feat: cache the result of ClassReflection::hasMethod method

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -142,6 +142,9 @@ class ClassReflection
 	/** @var array<string, true> */
 	private static array $resolvingTypeAliasImports = [];
 
+	/** @var array<string, bool> */
+	private array $hasMethodCache = [];
+
 	/**
 	 * @param PropertiesClassReflectionExtension[] $propertiesClassReflectionExtensions
 	 * @param MethodsClassReflectionExtension[] $methodsClassReflectionExtensions
@@ -482,15 +485,25 @@ class ClassReflection
 
 	public function hasMethod(string $methodName): bool
 	{
+		if (array_key_exists($methodName, $this->hasMethodCache)) {
+			return $this->hasMethodCache[$methodName];
+		}
+
 		foreach ($this->methodsClassReflectionExtensions as $extension) {
 			if ($extension->hasMethod($this, $methodName)) {
+				$this->hasMethodCache[$methodName] = true;
+
 				return true;
 			}
 		}
 
 		if ($this->requireExtendsMethodsClassReflectionExtension->hasMethod($this, $methodName)) {
+			$this->hasMethodCache[$methodName] = true;
+
 			return true;
 		}
+
+		$this->hasMethodCache[$methodName] = false;
 
 		return false;
 	}


### PR DESCRIPTION
Hello 👋🏽 

This PR caches the result of the `ClassReflection::hasMethod` method. While investigating some performance issues I found that PHPStan calls method class reflection extensions multiple times for the same class and method. And some extensions might do the actual work in `hasMethod` method rather than `getMethod`, for example Larastan does this to cache stuff internally. 

I can add tests if wanted. Couldn't think of an easy way to do it right away 😅 