### PR TITLE
Set `editorUrl` from xdebug configuration

### DIFF
--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -39,14 +39,17 @@ use function array_unique;
 use function count;
 use function dirname;
 use function extension_loaded;
+use function get_cfg_var;
 use function getenv;
 use function ini_get;
 use function is_array;
 use function is_file;
 use function is_readable;
+use function is_string;
 use function spl_object_id;
 use function sprintf;
 use function str_ends_with;
+use function strtr;
 use function substr;
 
 /**
@@ -148,6 +151,12 @@ final class ContainerFactory
 		}
 
 		$configurator->setAllConfigFiles($allConfigFiles);
+
+		if (!array_key_exists('editorUrl', $projectConfig['parameters'])) {
+			$configurator->addParameters([
+				'editorUrl' => $this->getEditorUrlFromPhpIni(),
+			]);
+		}
 
 		$container = $configurator->createContainer()->getByType(Container::class);
 		$this->validateParameters($container->getParameters(), $projectConfig['parametersSchema']);
@@ -389,6 +398,25 @@ final class ContainerFactory
 		}
 
 		return $argument;
+	}
+
+	/**
+	 * Try to fetch an editor URL from php.ini by reading xdebug configuration.
+	 *
+	 * This works even if the xdebug extension is not loaded.
+	 */
+	private function getEditorUrlFromPhpIni(): ?string
+	{
+		$xdebugFileLinkFormat = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+
+		if (is_string($xdebugFileLinkFormat) && $xdebugFileLinkFormat !== '') {
+			return strtr($xdebugFileLinkFormat, [
+				'%f' => '%file%',
+				'%l' => '%line%',
+			]);
+		}
+
+		return null;
 	}
 
 }


### PR DESCRIPTION
Recently discovered the `editorUrl` property but it's a bit of a chore to go and set it in the many projects I have locally. 

Fortunately it's possible to reuse the xdebug extensions configuration which a [number of other projects](https://github.com/search?q=NOT+is%3Afork+NOT+is%3Aarchived+%2Fget_cfg_var%5C%28%5Cs*%5B%22%27%5Dxdebug%5C.file_link_format%2F&type=code) do:

* https://github.com/vimeo/psalm/blob/a27feaff099dd4e609c92d7555ca4961591de53d/src/Psalm/Report/ConsoleReport.php#L138
* https://github.com/filp/whoops/blob/075bc0c26631110584175de6523ab3f1652eb28e/src/Whoops/Handler/PrettyPageHandler.php#L141
* https://github.com/symfony/symfony/blob/a90bd41dd757706a8f4b291ab0a076ae49a2da7c/src/Symfony/Component/VarDumper/Dumper/CliDumper.php#L87
* https://github.com/symfony/symfony/blob/a90bd41dd757706a8f4b291ab0a076ae49a2da7c/src/Symfony/Component/ErrorHandler/ErrorRenderer/FileLinkFormatter.php#L41


So there is decent precedent for this, I've searched previous issues/pulls/discussions and only found a [single reference to this in the context of PHPStan](https://github.com/phpstan/phpstan/discussions/5283) which kinda incorrectly concluded it wasn't possible.

I'm not sure if my implementation is correct but it certainly works, it was the easiest way I could find of adding a default value to a property at runtime which can be completely overridden by the configuration files. Happy to make any changes that are needed though if the premise is acceptable.