### PR TITLE
Issue bot - do not test PHP 7.2 anymore

### DIFF
--- a/issue-bot/src/Console/DownloadCommand.php
+++ b/issue-bot/src/Console/DownloadCommand.php
@@ -96,12 +96,12 @@ class DownloadCommand extends Command
 		}
 
 		$matrix = [];
-		foreach ([70200, 70300, 70400, 80000, 80100, 80200, 80300, 80400] as $phpVersion) {
+		foreach ([70300, 70400, 80000, 80100, 80200, 80300, 80400] as $phpVersion) {
 			$phpVersionHashes = [];
 			foreach ($cachedResults as $hash => $result) {
 				$resultPhpVersions = array_keys($result->getVersionedErrors());
 				if ($resultPhpVersions === [70400]) {
-					$resultPhpVersions = [70200, 70300, 70400, 80000];
+					$resultPhpVersions = [70300, 70400, 80000];
 				}
 
 				if (!in_array(80100, $resultPhpVersions, true)) {

--- a/issue-bot/src/Console/EvaluateCommand.php
+++ b/issue-bot/src/Console/EvaluateCommand.php
@@ -101,7 +101,10 @@ class EvaluateCommand extends Command
 				$originalPhpVersions = array_keys($originalErrors);
 				$newResult = $newResults[$hash];
 				if (array_key_exists(70100, $originalErrors) || $originalPhpVersions === [70400]) {
-					$newResult[70100] = $newResult[70200];
+					$newResult[70100] = $newResult[70300];
+				}
+				if (array_key_exists(70200, $originalErrors)) {
+					$newResult[70200] = $newResult[70300];
 				}
 
 				$newTabs = $this->tabCreator->create($this->filterErrors($originalErrors, $newResult));


### PR DESCRIPTION
We need to save the size of the job matrix because right now we get this error:

Job outputs (1049962 bytes) has exceeded maximum size 1048576 bytes.