### PR TITLE
Add support for pseudo-abstract/self-referencing constants

### DIFF
--- a/src/Rules/Traits/ConflictingTraitConstantsRule.php
+++ b/src/Rules/Traits/ConflictingTraitConstantsRule.php
@@ -224,26 +224,58 @@ final class ConflictingTraitConstantsRule implements Rule
 		}
 
 		$classConstantValueType = $this->initializerExprTypeResolver->getType($valueExpr, InitializerExprContext::fromClassReflection($classReflection));
-		$traitConstantValueType = $this->initializerExprTypeResolver->getType(
-			$traitConstant->getValueExpression(),
-			InitializerExprContext::fromClass(
-				$traitDeclaringClass->getName(),
-				$traitDeclaringClass->getFileName() !== false ? $traitDeclaringClass->getFileName() : null,
-			),
+		$traitValueExpr = $traitConstant->getValueExpression();
+		$isTraitSelfReferencing = (
+			$traitValueExpr instanceof Node\Expr\ClassConstFetch
+			&& $traitValueExpr->class->name === 'self'
+			&& $traitValueExpr->name->name === $traitConstant->getName()
 		);
-		if (!$classConstantValueType->equals($traitConstantValueType)) {
-			$errors[] = RuleErrorBuilder::message(sprintf(
-				'Constant %s::%s with value %s overriding constant %s::%s with different value %s should have the same value.',
-				$classReflection->getDisplayName(),
-				$traitConstant->getName(),
-				$classConstantValueType->describe(VerbosityLevel::value()),
-				$traitConstant->getDeclaringClass()->getName(),
-				$traitConstant->getName(),
-				$traitConstantValueType->describe(VerbosityLevel::value()),
-			))
-				->nonIgnorable()
-				->identifier('classConstant.value')
-				->build();
+		if ($isTraitSelfReferencing) {
+			$isValueSelfReference = (
+				$valueExpr instanceof Node\Expr\ClassConstFetch
+				&& $valueExpr->class->name === 'self'
+				&& $valueExpr->name->name === $traitConstant->getName()
+			);
+			if (
+				!$isValueSelfReference
+				&& isset($classConstantValueType)
+				&& !$classConstantValueType instanceof $constantNativeTypeType
+				&& $classConstantValueType->isSuperTypeOf($constantNativeTypeType)->no()
+			) {
+				$errors[] = RuleErrorBuilder::message(sprintf(
+					'Constant %s::%s with value %s cannot override native type of constant %s::%s.',
+					$classReflection->getDisplayName(),
+					$traitConstant->getName(),
+					$classConstantValueType->describe(VerbosityLevel::value()),
+					$traitConstant->getDeclaringClass()->getName(),
+					$traitConstant->getName(),
+				))
+					->nonIgnorable()
+					->identifier('classConstant.value')
+					->build();
+			}
+		} else {
+			$traitConstantValueType = $this->initializerExprTypeResolver->getType(
+				$traitValueExpr,
+				InitializerExprContext::fromClass(
+					$traitDeclaringClass->getName(),
+					$traitDeclaringClass->getFileName() !== false ? $traitDeclaringClass->getFileName() : null,
+				),
+			);
+			if (!$classConstantValueType->equals($traitConstantValueType)) {
+					$errors[] = RuleErrorBuilder::message(sprintf(
+						'Constant %s::%s with value %s overriding constant %s::%s with different value %s should have the same value.',
+						$classReflection->getDisplayName(),
+						$traitConstant->getName(),
+						$classConstantValueType->describe(VerbosityLevel::value()),
+						$traitConstant->getDeclaringClass()->getName(),
+						$traitConstant->getName(),
+						$traitConstantValueType->describe(VerbosityLevel::value()),
+					))
+						->nonIgnorable()
+						->identifier('classConstant.value')
+						->build();
+			}
 		}
 
 		return $errors;

--- a/src/Rules/Traits/ConflictingTraitConstantsRule.php
+++ b/src/Rules/Traits/ConflictingTraitConstantsRule.php
@@ -227,18 +227,22 @@ final class ConflictingTraitConstantsRule implements Rule
 		$traitValueExpr = $traitConstant->getValueExpression();
 		$isTraitSelfReferencing = (
 			$traitValueExpr instanceof Node\Expr\ClassConstFetch
+			&& $traitValueExpr->class instanceof Node\Name
+			&& $traitValueExpr->name instanceof Node\Identifier
 			&& $traitValueExpr->class->name === 'self'
 			&& $traitValueExpr->name->name === $traitConstant->getName()
 		);
 		if ($isTraitSelfReferencing) {
 			$isValueSelfReference = (
 				$valueExpr instanceof Node\Expr\ClassConstFetch
+				&& $valueExpr->class instanceof Node\Name
+				&& $valueExpr->name instanceof Node\Identifier
 				&& $valueExpr->class->name === 'self'
 				&& $valueExpr->name->name === $traitConstant->getName()
 			);
 			if (
 				!$isValueSelfReference
-				&& isset($classConstantValueType)
+				&& isset($constantNativeTypeType)
 				&& !$classConstantValueType instanceof $constantNativeTypeType
 				&& $classConstantValueType->isSuperTypeOf($constantNativeTypeType)->no()
 			) {

--- a/tests/PHPStan/Rules/Traits/ConflictingTraitConstantsRuleTest.php
+++ b/tests/PHPStan/Rules/Traits/ConflictingTraitConstantsRuleTest.php
@@ -78,6 +78,18 @@ class ConflictingTraitConstantsRuleTest extends RuleTestCase
 				'Constant ConflictingTraitConstantsTypes\Lorem::FOO_CONST overriding constant ConflictingTraitConstantsTypes\Foo::FOO_CONST (int|string) should also have native type int|string.',
 				39,
 			],
+			[
+				'Constant ConflictingTraitConstantsTypes\SelfRefWrongType::SR_CONST with value array{1} cannot override native type of constant ConflictingTraitConstantsTypes\SelfRef::SR_CONST.',
+				64,
+			],
+			[
+				'Constant ConflictingTraitConstantsTypes\SelfRefExtWrong::SR_CONST (string) overriding constant ConflictingTraitConstantsTypes\SelfRef::SR_CONST (int) should have the same native type int.',
+				82,
+			],
+			[
+				'Constant ConflictingTraitConstantsTypes\SelfRefExtOverrideExt::SR_CONST with value mixed overriding constant ConflictingTraitConstantsTypes\SelfRefExtOverride::SR_CONST with different value 1 should have the same value.',
+				100,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Traits/data/conflicting-trait-constants-types.php
+++ b/tests/PHPStan/Rules/Traits/data/conflicting-trait-constants-types.php
@@ -39,3 +39,64 @@ class Lorem
 	public const FOO_CONST = 1;
 
 }
+
+trait SelfRef
+{
+
+	public const int SR_CONST = self::SR_CONST;
+
+}
+
+class SelfRefOverride
+{
+
+	use SelfRef;
+
+	public const int SR_CONST = 1;
+
+}
+
+class SelfRefWrongType
+{
+
+	use SelfRef;
+
+	public const int SR_CONST = [1];
+
+}
+
+class SelfRefExt
+{
+
+	use SelfRef;
+
+	public const int SR_CONST = self::SR_CONST;
+
+}
+
+class SelfRefExtWrong
+{
+
+	use SelfRef;
+
+	public const string SR_CONST = self::SR_CONST;
+
+}
+
+class SelfRefExtOverride
+{
+
+	use SelfRefExt;
+
+	public const int SR_CONST = 1;
+
+}
+
+class SelfRefExtOverrideExt
+{
+
+	use SelfRefExtOverride;
+
+	public const int SR_CONST = self::SR_CONST;
+
+}


### PR DESCRIPTION
PHP doesn't support abstract constants, so using self-referencing constants in traits in order to force implementer classes to define the constant is not unheard of.
An example of such an implementation would be:
```php
trait Greeter {
    private const string WHO = self::WHO;

    public static function greeting() : string {
        return "Hello, " . static::WHO;
    }
}

class JackGreeter {
    use Greeter;
    private const string WHO = 'Jake';
}
```

Unfortunately PHPStan does not currently take into consideration that self-referencing constants are (usually) meant to be overridden.

This Pull Request omits the Constant Type check for self-referencing constants.