### PR TITLE
Add regression tests

### DIFF
--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -197,6 +197,15 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12458.php'], []);
 	}
 
+	public function testBug11015(): void
+	{
+		$this->checkTypeAgainstNativeType = true;
+		$this->checkTypeAgainstPhpDocType = true;
+		$this->strictWideningCheck = true;
+
+		$this->analyse([__DIR__ . '/data/bug-11015.php'], []);
+	}
+
 	public function testEnums(): void
 	{
 		if (PHP_VERSION_ID < 80100) {

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -206,6 +206,15 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11015.php'], []);
 	}
 
+	public function testBug10861(): void
+	{
+		$this->checkTypeAgainstNativeType = true;
+		$this->checkTypeAgainstPhpDocType = true;
+		$this->strictWideningCheck = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10861.php'], []);
+	}
+
 	public function testEnums(): void
 	{
 		if (PHP_VERSION_ID < 80100) {

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -215,6 +215,15 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10861.php'], []);
 	}
 
+	public function testBug11535(): void
+	{
+		$this->checkTypeAgainstNativeType = true;
+		$this->checkTypeAgainstPhpDocType = true;
+		$this->strictWideningCheck = true;
+
+		$this->analyse([__DIR__ . '/data/bug-11535.php'], []);
+	}
+
 	public function testEnums(): void
 	{
 		if (PHP_VERSION_ID < 80100) {

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-10861.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-10861.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10861;
+
+class HelloWorld
+{
+	/**
+	 *
+	 * @param array<string,mixed>           $array1
+	 * @param-out array<string,mixed>       $array1
+	 */
+	public function sayHello(array &$array1): void
+	{
+		$values_1 = $array1;
+
+		$values_1 = array_filter($values_1, function (mixed $value): bool {
+			return $value !== [];
+		});
+
+		/** @var array<string,mixed> $values_1 */
+		$array1 = $values_1;
+	}
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-11015.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-11015.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11015;
+
+class HelloWorld
+{
+	public function sayHello(PDOStatement $date): void
+	{
+		$b = $date->fetch();
+		if (empty($b)) {
+			return;
+		}
+
+		/** @var array<string, int> $b */
+		echo $b['a'];
+	}
+
+	public function sayHello2(PDOStatement $date): void
+	{
+		$b = $date->fetch();
+
+		/** @var array<string, int> $b */
+		echo $b['a'];
+	}
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-11535.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-11535.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11535;
+
+/** @var \Closure(string): array<int> */
+$a = function(string $b) {
+	return [1,2,3];
+};
+
+/** @var \Closure(array): array */
+$a = function(array $b) {
+	return $b;
+};
+
+/** @var \Closure(string): string */
+$a = function(string $b) {
+	return $b;
+};


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/11015
Closes https://github.com/phpstan/phpstan/issues/10861
Closes https://github.com/phpstan/phpstan/issues/11535

For https://github.com/phpstan/phpstan/issues/7934, I'm not sure the issue is related/solved 
The issue was about `Variable $fails1 in PHPDoc tag @var does not exist.`.
