### PR TITLE
MissingTypehintCheck: reduce duplicate work

### DIFF
--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -91,7 +91,7 @@ final class MissingTypehintCheck
 				}
 				if ($type instanceof IntersectionType) {
 					if ($type->isList()->yes()) {
-						return $traverse($type->getIterableValueType());
+						return $traverse($iterableValue);
 					}
 
 					return $type;


### PR DESCRIPTION
after PR

```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyze bug-12661.php --debug' -i
Benchmark 1: php bin/phpstan analyze bug-12661.php --debug
  Time (mean ± σ):      1.059 s ±  0.005 s    [User: 0.953 s, System: 0.102 s]
  Range (min … max):    1.053 s …  1.068 s    10 runs
 
  Warning: Ignoring non-zero exit code.
 
```

before this PR

```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyze bug-12661.php --debug' -i
Benchmark 1: php bin/phpstan analyze bug-12661.php --debug
  Time (mean ± σ):      1.111 s ±  0.019 s    [User: 0.993 s, System: 0.115 s]
  Range (min … max):    1.083 s …  1.151 s    10 runs
 
  Warning: Ignoring non-zero exit code.
```

on the reproducer of https://github.com/phpstan/phpstan/issues/12661

<img width="479" alt="grafik" src="https://github.com/user-attachments/assets/d33e3524-58d1-405f-94d8-62a5cfd4fc8c" />
