### PR TITLE
Fix GetNonVirtualPropertyHookReadRule on abstract property

### DIFF
--- a/src/Rules/Properties/GetNonVirtualPropertyHookReadRule.php
+++ b/src/Rules/Properties/GetNonVirtualPropertyHookReadRule.php
@@ -93,6 +93,10 @@ final class GetNonVirtualPropertyHookReadRule implements Rule
 				continue;
 			}
 
+			if ($propertyReflection->isAbstract()->yes()) {
+				continue;
+			}
+
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'Get hook for non-virtual property %s::$%s does not read its value.',
 				$classReflection->getDisplayName(),

--- a/src/Rules/Properties/GetNonVirtualPropertyHookReadRule.php
+++ b/src/Rules/Properties/GetNonVirtualPropertyHookReadRule.php
@@ -76,6 +76,10 @@ final class GetNonVirtualPropertyHookReadRule implements Rule
 					continue;
 				}
 
+				if ($hook->body === null) {
+					continue;
+				}
+
 				$hasGetHook = true;
 				break;
 			}
@@ -90,10 +94,6 @@ final class GetNonVirtualPropertyHookReadRule implements Rule
 
 			$propertyReflection = $classReflection->getNativeProperty($propertyNode->getName());
 			if ($propertyReflection->isVirtual()->yes()) {
-				continue;
-			}
-
-			if ($propertyReflection->isAbstract()->yes()) {
 				continue;
 			}
 

--- a/tests/PHPStan/Rules/Properties/GetNonVirtualPropertyHookReadRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/GetNonVirtualPropertyHookReadRuleTest.php
@@ -35,4 +35,13 @@ class GetNonVirtualPropertyHookReadRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testAbstractProperty(): void
+	{
+		if (PHP_VERSION_ID < 80400) {
+			$this->markTestSkipped('Test requires PHP 8.4.');
+		}
+
+		$this->analyse([__DIR__ . '/data/get-abstract-property-hook-read.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/get-abstract-property-hook-read.php
+++ b/tests/PHPStan/Rules/Properties/data/get-abstract-property-hook-read.php
@@ -1,0 +1,15 @@
+<?php // lint >= 8.4
+
+namespace GetAbstractPropertyHook;
+
+class NonFinalClass
+{
+	public string $publicProperty;
+}
+
+abstract class Foo extends NonFinalClass
+{
+	abstract public string $publicProperty {
+		get;
+	}
+}


### PR DESCRIPTION
I found https://phpstan.org/r/0299facc-d23d-4ed8-9567-e1c7c8c30536 which I think should not report a error on line 9 on PHP 8.4

https://3v4l.org/ZD4oE