### PR TITLE
`property-of<...>` Utility type

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -92,6 +92,7 @@ use PHPStan\Type\ObjectShapeType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\OffsetAccessType;
+use PHPStan\Type\PropertyOfType;
 use PHPStan\Type\ResourceType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\StaticTypeFactory;
@@ -760,7 +761,15 @@ final class TypeNodeResolver
 			}
 
 			return new ErrorType();
-		} elseif ($mainTypeName === 'int-mask-of') {
+		} elseif ($mainTypeName === 'property-of') {
+            if (count($genericTypes) === 1) { // property-of<ValueType>
+                $type = new PropertyOfType($genericTypes[0]);
+
+                return $type->isResolvable() ? $type->resolve() : $type;
+            }
+
+            return new ErrorType();
+        } elseif ($mainTypeName === 'int-mask-of') {
 			if (count($genericTypes) === 1) { // int-mask-of<Class::CONST*>
 				$maskType = $this->expandIntMaskToType($genericTypes[0]);
 				if ($maskType !== null) {

--- a/src/Type/PropertyOfType.php
+++ b/src/Type/PropertyOfType.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace PHPStan\Type;
+
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPStan\Type\Traits\LateResolvableTypeTrait;
+use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
+
+class PropertyOfType implements CompoundType, LateResolvableType
+{
+
+    use LateResolvableTypeTrait;
+    use NonGeneralizableTypeTrait;
+
+    public function __construct(private Type $type)
+    {
+    }
+
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    public function getReferencedClasses(): array
+    {
+        return $this->type->getReferencedClasses();
+    }
+
+    public function getReferencedTemplateTypes(TemplateTypeVariance $positionVariance): array
+    {
+        return $this->type->getReferencedTemplateTypes($positionVariance);
+    }
+
+    public function equals(Type $type): bool
+    {
+        return $type instanceof self
+            && $this->type->equals($type->type);
+    }
+
+    public function describe(VerbosityLevel $level): string
+    {
+        return sprintf('property-of<%s>', $this->type->describe($level));
+    }
+
+    public function isResolvable(): bool
+    {
+        return !TypeUtils::containsTemplateType($this->type);
+    }
+
+    protected function getResult(): Type
+    {
+
+        $classReflection = null;
+
+        if ($this->type instanceof TypeWithClassName) {
+            $classReflection = $this->type->getClassReflection();
+        }
+
+        if ($classReflection !== null) {
+
+            $propertiesReflection = $classReflection->getNativeReflection()->getProperties();
+
+            // get the names of the properties
+            // and build a union type from them
+            $propertyNames = array_map(
+                fn($property) => new ConstantStringType($property->getName()),
+                $propertiesReflection
+            );
+
+            return new UnionType($propertyNames);
+
+        }
+
+        return new MixedType();
+    }
+
+    /**
+     * @param callable(Type): Type $cb
+     */
+    public function traverse(callable $cb): Type
+    {
+        $type = $cb($this->type);
+
+        if ($this->type === $type) {
+            return $this;
+        }
+
+        return new self($type);
+    }
+
+    public function traverseSimultaneously(Type $right, callable $cb): Type
+    {
+        if (!$right instanceof self) {
+            return $this;
+        }
+
+        $type = $cb($this->type, $right->type);
+
+        if ($this->type === $type) {
+            return $this;
+        }
+
+        return new self($type);
+    }
+
+    public function toPhpDocNode(): TypeNode
+    {
+        return new GenericTypeNode(new IdentifierTypeNode('property-of'), [$this->type->toPhpDocNode()]);
+    }
+
+}

--- a/src/Type/PropertyOfType.php
+++ b/src/Type/PropertyOfType.php
@@ -54,11 +54,8 @@ class PropertyOfType implements CompoundType, LateResolvableType
     protected function getResult(): Type
     {
 
-        $classReflection = null;
-
-        if ($this->type instanceof TypeWithClassName) {
-            $classReflection = $this->type->getClassReflection();
-        }
+        $classReflections = $this->type->getObjectClassReflections();
+        $classReflection = $classReflections[0] ?? null;
 
         if ($classReflection !== null) {
 

--- a/tests/PHPStan/Analyser/nsrt/property-of.php
+++ b/tests/PHPStan/Analyser/nsrt/property-of.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PropertyOfType;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+    public int $age;
+    public string $name;
+
+    /**
+     * @param property-of<self> $property
+     */
+    public static function fromObject(string $property): void
+    {
+        assertType("'age'|'name'", $property);
+    }
+
+    /**
+     * @param property-of<static> $property
+     */
+    public static function fromStatic(string $property): void
+    {
+        assertType("'age'|'name'", $property);
+    }
+
+
+    /**
+     * @param property-of<Foo> $property
+     */
+    public static function fromClass(string $property): void
+    {
+        assertType("'age'|'name'", $property);
+    }
+
+}


### PR DESCRIPTION
Problem: an easy way to access the names of the properties of an object or a class.

Solution: `property-of<MyObject>` utility type

Example:
```php
class CreateSubscriberDto
{

    public string $email;
    public int $listId;

    /**
     * @param property-of<self> $property
     * @return bool
     */
    public function hasProperty(string $property): bool
    {
        dumpType($property); // 'email'|'listId'

        // ...
    }

}

$dto = new CreateSubscriberDto();
$dto->hasProperty('email'); // no error
$dto->hasProperty('listId'); // no error
$dto->hasProperty('notExisting'); // shows static error
```

TODO:

- [ ] Implement a template-supported version in `PHPStan\Type\Generic`

Notes:

Most of the code was taken from KeyOfType.

If the idea is accepted, I will work on the implementation of the template-supported version.