### PR TITLE
Fix typo false-positive

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,3 +8,7 @@ ignore-hidden = false
 # Known typos
 NonRemoveableTypeTrait = "NonRemoveableTypeTrait"
 supportsLessOverridenParametersWithVariadic = "supportsLessOverridenParametersWithVariadic"
+
+[default.extend-words]
+# override false-positives
+Excluder = "Excluder"


### PR DESCRIPTION
should fix build error

```
error: `Excluder` should be `Excluded`
  --> src/DependencyInjection/ValidateIgnoredErrorsExtension.php:159:14
    |
159 |      if (FileExcluder::isAbsolutePath($ignorePath)) {
    |              ^^^^^^^^
    |
```