### PR TITLE
Detect accessing static property as non static

### DIFF
--- a/src/Rules/Properties/AccessPropertiesCheck.php
+++ b/src/Rules/Properties/AccessPropertiesCheck.php
@@ -163,10 +163,10 @@ final class AccessPropertiesCheck
 		if ($propertyReflection->isStatic()) {
 			return [
 				RuleErrorBuilder::message(sprintf(
-					'Non static access to static property %s::$%s.',
+					'Non-static access to static property %s::$%s.',
 					$propertyReflection->getDeclaringClass()->getDisplayName(),
 					$name,
-				))->identifier('property.nonStaticAccess')->build(),
+				))->identifier('staticProperty.nonStaticAccess')->build(),
 			];
 		}
 

--- a/src/Rules/Properties/AccessPropertiesCheck.php
+++ b/src/Rules/Properties/AccessPropertiesCheck.php
@@ -160,6 +160,16 @@ final class AccessPropertiesCheck
 		}
 
 		$propertyReflection = $type->getProperty($name, $scope);
+		if ($propertyReflection->isStatic()) {
+			return [
+				RuleErrorBuilder::message(sprintf(
+					'Non static access to static property %s::$%s.',
+					$propertyReflection->getDeclaringClass()->getDisplayName(),
+					$name,
+				))->identifier('property.nonStaticAccess')->build(),
+			];
+		}
+
 		if ($write) {
 			if ($scope->canWriteProperty($propertyReflection)) {
 				return [];

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -350,7 +350,7 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->checkUnionTypes = false;
 		$this->checkDynamicProperties = false;
 		$this->analyse([__DIR__ . '/data/bug-12692.php'], [[
-			'Non static access to static property Bug12692\Foo::$static.',
+			'Non-static access to static property Bug12692\Foo::$static.',
 			14,
 		]]);
 	}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -344,6 +344,16 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testBug12692(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = false;
+		$this->checkDynamicProperties = false;
+		$this->analyse([__DIR__ . '/data/bug-12692.php'], [
+			// This should not be empty!
+		]);
+	}
+
 	public function testAccessPropertiesAfterIsNullInBooleanOr(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -349,9 +349,10 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->checkThisOnly = false;
 		$this->checkUnionTypes = false;
 		$this->checkDynamicProperties = false;
-		$this->analyse([__DIR__ . '/data/bug-12692.php'], [
-			// This should not be empty!
-		]);
+		$this->analyse([__DIR__ . '/data/bug-12692.php'], [[
+			'Non static access to static property Bug12692\Foo::$static.',
+			14,
+		]]);
 	}
 
 	public function testAccessPropertiesAfterIsNullInBooleanOr(): void

--- a/tests/PHPStan/Rules/Properties/data/bug-12692.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12692.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bug12692;
+
+class Foo
+{
+
+	public static $static;
+
+	public function foo()
+	{
+		$this->static;
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12692

Thanks to the pointers provided on the issue, I've managed to copy over some bits from the 'reverse' check and adjust them accordingly:
https://github.com/phpstan/phpstan-src/blob/8d4796d28975b9c60399b228fe23decbe7ef7a1f/src/Rules/Properties/AccessStaticPropertiesRule.php#L213-L228

This seems to work fine, but maybe there's still some configuration to be accounted for, given that while incorrect static access will result in a fatal error, incorrect non static access will only emit an info + warning message. As a consequence maybe this check should be considered less critical/important.