### PR TITLE
Reduce method calls in ExpressionTypeHolder

### DIFF
--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -35,15 +35,15 @@ final class ExpressionTypeHolder
 
 	public function and(self $other): self
 	{
-		if ($this->getType()->equals($other->getType())) {
-			$type = $this->getType();
+		if ($this->type->equals($other->type)) {
+			$type = $this->type;
 		} else {
-			$type = TypeCombinator::union($this->getType(), $other->getType());
+			$type = TypeCombinator::union($this->type, $other->type);
 		}
 		return new self(
 			$this->expr,
 			$type,
-			$this->getCertainty()->and($other->getCertainty()),
+			$this->certainty->and($other->certainty),
 		);
 	}
 


### PR DESCRIPTION
while looking into https://github.com/phpstan/phpstan/issues/12647 I noticed `ExpressionTypeHolder->and` is on a very hot path. 

<img width="582" alt="grafik" src="https://github.com/user-attachments/assets/cb9a2c92-1a80-4171-9569-fc7deffc7474" />


lets micro optimize by remove unnecessary method calls in this path

before
```
➜  PhpSpreadsheet git:(master) ✗ hyperfine 'php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug' # before
Benchmark 1: php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug
  Time (mean ± σ):      8.948 s ±  0.020 s    [User: 8.774 s, System: 0.170 s]
  Range (min … max):    8.913 s …  8.975 s    10 runs
```

after
```
➜  PhpSpreadsheet git:(master) ✗ hyperfine 'php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug' # after
Benchmark 1: php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug
  Time (mean ± σ):      8.775 s ±  0.011 s    [User: 8.608 s, System: 0.163 s]
  Range (min … max):    8.751 s …  8.790 s    10 runs
```