### PR TITLE
Faster TrinaryLogic->and()

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -79,9 +79,15 @@ final class TrinaryLogic
 
 	public function and(self ...$operands): self
 	{
-		$operandValues = array_column($operands, 'value');
-		$operandValues[] = $this->value;
-		return self::create(min($operandValues));
+		$min = $this->value;
+		foreach ($operands as $operand) {
+			if ($operand->value >= $min) {
+				continue;
+			}
+
+			$min = $operand->value;
+		}
+		return self::create($min);
 	}
 
 	/**


### PR DESCRIPTION
Similar to https://github.com/phpstan/phpstan-src/pull/3859 this method is called super often.

we make it faster by reducing how often the php runtime needs to switch between userland code and php-src native code.
as this method is called so often, switching between userland and native code takes more time compared to the time we safe by running it natively.

before
```
➜  PhpSpreadsheet git:(master) ✗ hyperfine 'php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug' # after
Benchmark 1: php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug
  Time (mean ± σ):      8.775 s ±  0.011 s    [User: 8.608 s, System: 0.163 s]
  Range (min … max):    8.751 s …  8.790 s    10 runs
```

after
```
➜  PhpSpreadsheet git:(master) ✗ hyperfine 'php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug' # before
Benchmark 1: php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug
  Time (mean ± σ):      8.744 s ±  0.017 s    [User: 8.571 s, System: 0.170 s]
  Range (min … max):    8.723 s …  8.772 s    10 runs
```