### PR TITLE
Faster MutatingScope->mergeWith(Scope)

### DIFF
--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -36,6 +36,10 @@ final class ExpressionTypeHolder
 	public function and(self $other): self
 	{
 		if ($this->type->equals($other->type)) {
+			if ($this->certainty->equals($other->certainty)) {
+				return $this;
+			}
+
 			$type = $this->type;
 		} else {
 			$type = TypeCombinator::union($this->type, $other->type);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4773,6 +4773,11 @@ final class MutatingScope implements Scope
 		$intersectedVariableTypeHolders = [];
 		foreach ($ourVariableTypeHolders as $exprString => $variableTypeHolder) {
 			if (isset($theirVariableTypeHolders[$exprString])) {
+				if ($variableTypeHolder === $theirVariableTypeHolders[$exprString]) {
+					$intersectedVariableTypeHolders[$exprString] = $variableTypeHolder;
+					continue;
+				}
+
 				$intersectedVariableTypeHolders[$exprString] = $variableTypeHolder->and($theirVariableTypeHolders[$exprString]);
 			} else {
 				$intersectedVariableTypeHolders[$exprString] = ExpressionTypeHolder::createMaybe($variableTypeHolder->getExpr(), $variableTypeHolder->getType());


### PR DESCRIPTION
profilled the `src/PhpSpreadsheet/Reader/Xlsx.php` case further:

we spent most of the time with merging scope objects
profile can be seen here: https://blackfire.io/profiles/0293ba31-80fc-403f-9452-bfda15b7c7c7/graph

<img width="623" alt="grafik" src="https://github.com/user-attachments/assets/269d0220-26f0-4b6d-bb9b-3ceeca6314ba" />


refs https://github.com/phpstan/phpstan-src/pull/3859#issuecomment-2705938819

before this PR
```
➜  PhpSpreadsheet git:(master) ✗ hyperfine 'php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug'
Benchmark 1: php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug
  Time (mean ± σ):      8.659 s ±  0.029 s    [User: 8.479 s, System: 0.175 s]
  Range (min … max):    8.611 s …  8.701 s    10 runs
```

after this PR
```
➜  PhpSpreadsheet git:(master) ✗ hyperfine 'php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug'
Benchmark 1: php ../phpstan-src/bin/phpstan analyze src/PhpSpreadsheet/Reader/Xlsx.php --debug
  Time (mean ± σ):      7.462 s ±  0.073 s    [User: 7.294 s, System: 0.164 s]
  Range (min … max):    7.349 s …  7.550 s    10 runs
```

thesis: most of the time when merging scopes they contain largely identical expression. therefore optimize for the case when expressions are identical.
