### PR TITLE
Fix false positives on non-existing-offset's

### DIFF
--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
@@ -14,6 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 use function count;
 use function in_array;
+use function is_string;
 use function sprintf;
 
 /**
@@ -106,7 +107,11 @@ final class NonexistentOffsetInArrayDimFetchRule implements Rule
 			$arrayArg = $node->dim->getArgs()[0]->value;
 			$arrayType = $scope->getType($arrayArg);
 			if (
-				$arrayType->isArray()->yes()
+				$arrayArg instanceof Node\Expr\Variable
+				&& $node->var instanceof Node\Expr\Variable
+				&& is_string($arrayArg->name)
+				&& $arrayArg->name === $node->var->name
+				&& $arrayType->isArray()->yes()
 				&& $arrayType->isIterableAtLeastOnce()->yes()
 			) {
 				return [];
@@ -125,7 +130,11 @@ final class NonexistentOffsetInArrayDimFetchRule implements Rule
 			$arrayArg = $node->dim->left->getArgs()[0]->value;
 			$arrayType = $scope->getType($arrayArg);
 			if (
-				$arrayType->isList()->yes()
+				$arrayArg instanceof Node\Expr\Variable
+				&& $node->var instanceof Node\Expr\Variable
+				&& is_string($arrayArg->name)
+				&& $arrayArg->name === $node->var->name
+				&& $arrayType->isList()->yes()
 				&& $arrayType->isIterableAtLeastOnce()->yes()
 			) {
 				return [];

--- a/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
+++ b/src/Rules/Arrays/NonexistentOffsetInArrayDimFetchRule.php
@@ -13,6 +13,7 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 use function count;
+use function in_array;
 use function sprintf;
 
 /**
@@ -94,6 +95,41 @@ final class NonexistentOffsetInArrayDimFetchRule implements Rule
 
 		if ($dimType === null) {
 			return [];
+		}
+
+		if (
+			$node->dim instanceof Node\Expr\FuncCall
+			&& $node->dim->name instanceof Node\Name
+			&& in_array($node->dim->name->toLowerString(), ['array_key_first', 'array_key_last'], true)
+			&& count($node->dim->getArgs()) >= 1
+		) {
+			$arrayArg = $node->dim->getArgs()[0]->value;
+			$arrayType = $scope->getType($arrayArg);
+			if (
+				$arrayType->isArray()->yes()
+				&& $arrayType->isIterableAtLeastOnce()->yes()
+			) {
+				return [];
+			}
+		}
+
+		if (
+			$node->dim instanceof Node\Expr\BinaryOp\Minus
+			&& $node->dim->left instanceof Node\Expr\FuncCall
+			&& $node->dim->left->name instanceof Node\Name
+			&& in_array($node->dim->left->name->toLowerString(), ['count', 'sizeof'], true)
+			&& count($node->dim->left->getArgs()) >= 1
+			&& $node->dim->right instanceof Node\Scalar\Int_
+			&& $node->dim->right->value === 1
+		) {
+			$arrayArg = $node->dim->left->getArgs()[0]->value;
+			$arrayType = $scope->getType($arrayArg);
+			if (
+				$arrayType->isList()->yes()
+				&& $arrayType->isIterableAtLeastOnce()->yes()
+			) {
+				return [];
+			}
 		}
 
 		return $this->nonexistentOffsetInArrayDimFetchCheck->check(

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -838,6 +838,14 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Offset 0|null might not exist on list<string>.',
 				12,
 			],
+			[
+				'Offset (int|string) might not exist on non-empty-list<string>.',
+				16,
+			],
+			[
+				'Offset int<-1, max> might not exist on non-empty-list<string>.',
+				45,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -829,6 +829,18 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testArrayDimFetchOnArrayKeyFirsOrLastOrCount(): void
+	{
+		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
+
+		$this->analyse([__DIR__ . '/data/array-dim-fetch-on-array-key-first-last.php'], [
+			[
+				'Offset 0|null might not exist on list<string>.',
+				12,
+			],
+		]);
+	}
+
 	public function testBug8649(): void
 	{
 		$this->reportPossiblyNonexistentGeneralArrayOffset = true;

--- a/tests/PHPStan/Rules/Arrays/data/array-dim-fetch-on-array-key-first-last.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-dim-fetch-on-array-key-first-last.php
@@ -6,12 +6,16 @@ class Hello {
 	/**
 	 * @param list<string> $hellos
 	 */
-	public function first(array $hellos): string
+	public function first(array $hellos, array $anotherArray): string
 	{
 		if (rand(0,1)) {
 			return $hellos[array_key_first($hellos)];
 		}
 		if ($hellos !== []) {
+			if ($anotherArray !== []) {
+				return $hellos[array_key_first($anotherArray)];
+			}
+
 			return $hellos[array_key_first($hellos)];
 		}
 		return '';
@@ -31,10 +35,14 @@ class Hello {
 	/**
 	 * @param list<string> $hellos
 	 */
-	public function works(array $hellos): string
+	public function countOnArray(array $hellos, array $anotherArray): string
 	{
 		if ($hellos === []) {
 			return 'nothing';
+		}
+
+		if (rand(0,1)) {
+			return $hellos[count($anotherArray) - 1];
 		}
 
 		return $hellos[count($hellos) - 1];

--- a/tests/PHPStan/Rules/Arrays/data/array-dim-fetch-on-array-key-first-last.php
+++ b/tests/PHPStan/Rules/Arrays/data/array-dim-fetch-on-array-key-first-last.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace ArrayDimFetchOnArrayKeyFirstOrLast;
+
+class Hello {
+	/**
+	 * @param list<string> $hellos
+	 */
+	public function first(array $hellos): string
+	{
+		if (rand(0,1)) {
+			return $hellos[array_key_first($hellos)];
+		}
+		if ($hellos !== []) {
+			return $hellos[array_key_first($hellos)];
+		}
+		return '';
+	}
+
+	/**
+	 * @param array<string> $hellos
+	 */
+	public function last(array $hellos): string
+	{
+		if ($hellos !== []) {
+			return $hellos[array_key_last($hellos)];
+		}
+		return '';
+	}
+
+	/**
+	 * @param list<string> $hellos
+	 */
+	public function works(array $hellos): string
+	{
+		if ($hellos === []) {
+			return 'nothing';
+		}
+
+		return $hellos[count($hellos) - 1];
+	}
+}


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan-src/pull/3766#issuecomment-2708842018 with this PR we detect some more array-dim fetch false-positive cases we see with `reportPossiblyNonexistentGeneralArrayOffset`.

closes https://github.com/phpstan/phpstan/issues/11020