### PR TITLE
Ignore negative keys on checking whether a ConstantArray is a list

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -933,13 +933,7 @@ parameters:
 		-
 			message: '#^PHPDoc tag @var with type float\|int is not subtype of native type int\.$#'
 			identifier: varTag.nativeType
-			count: 1
-			path: src/Type/Constant/ConstantArrayTypeBuilder.php
-
-		-
-			message: '#^PHPDoc tag @var with type float\|int is not subtype of native type int\<1, max\>\.$#'
-			identifier: varTag.nativeType
-			count: 1
+			count: 2
 			path: src/Type/Constant/ConstantArrayTypeBuilder.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -933,7 +933,13 @@ parameters:
 		-
 			message: '#^PHPDoc tag @var with type float\|int is not subtype of native type int\.$#'
 			identifier: varTag.nativeType
-			count: 2
+			count: 1
+			path: src/Type/Constant/ConstantArrayTypeBuilder.php
+
+		-
+			message: '#^PHPDoc tag @var with type float\|int is not subtype of native type int\<1, max\>\.$#'
+			identifier: varTag.nativeType
+			count: 1
 			path: src/Type/Constant/ConstantArrayTypeBuilder.php
 
 		-

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -162,7 +162,7 @@ final class ConstantArrayTypeBuilder
 				$this->keyTypes[] = $offsetType;
 				$this->valueTypes[] = $valueType;
 
-				if ($offsetType instanceof ConstantIntegerType) {
+				if ($offsetType instanceof ConstantIntegerType && $offsetType->getValue() >= 0) {
 					$min = min($this->nextAutoIndexes);
 					$max = max($this->nextAutoIndexes);
 					if ($offsetType->getValue() > $min) {

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -162,19 +162,25 @@ final class ConstantArrayTypeBuilder
 				$this->keyTypes[] = $offsetType;
 				$this->valueTypes[] = $valueType;
 
-				if ($offsetType instanceof ConstantIntegerType && $offsetType->getValue() >= 0) {
+				if ($offsetType instanceof ConstantIntegerType) {
 					$min = min($this->nextAutoIndexes);
 					$max = max($this->nextAutoIndexes);
-					if ($offsetType->getValue() > $min) {
-						if ($offsetType->getValue() <= $max) {
-							$this->isList = $this->isList->and(TrinaryLogic::createMaybe());
-						} else {
-							$this->isList = TrinaryLogic::createNo();
+					$offsetValue = $offsetType->getValue();
+					if ($offsetValue >= 0) {
+						if ($offsetValue > $min) {
+							if ($offsetValue <= $max) {
+								$this->isList = $this->isList->and(TrinaryLogic::createMaybe());
+							} else {
+								$this->isList = TrinaryLogic::createNo();
+							}
 						}
+					} else {
+						$this->isList = TrinaryLogic::createNo();
 					}
-					if ($offsetType->getValue() >= $max) {
+
+					if ($offsetValue >= $max) {
 						/** @var int|float $newAutoIndex */
-						$newAutoIndex = $offsetType->getValue() + 1;
+						$newAutoIndex = $offsetValue + 1;
 						if (is_float($newAutoIndex)) {
 							$newAutoIndex = $max;
 						}

--- a/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
@@ -99,4 +99,5 @@ class VarTagChangedExpressionTypeRuleTest extends RuleTestCase
 			],
 		]);
 	}
+
 }

--- a/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
@@ -78,4 +78,25 @@ class VarTagChangedExpressionTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12708(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12708.php'], [
+			[
+				"PHPDoc tag @var with type list<string> is not subtype of native type array{1: 'b', 2: 'c'}.",
+				12,
+			],
+			[
+				"PHPDoc tag @var with type list<string> is not subtype of native type array{0: 'a', 2: 'c'}.",
+				18,
+			],
+			[
+				"PHPDoc tag @var with type list<string> is not subtype of native type array{-1: 'z', 0: 'a', 1: 'b', 2: 'c'}.",
+				24,
+			],
+			[
+				"PHPDoc tag @var with type list<string> is not subtype of native type array{0: 'a', -1: 'z', 1: 'b', 2: 'c'}.",
+				30,
+			],
+		]);
+	}
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-12708.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-12708.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+function do0()
+{
+	/** @var list<string> */
+	return [0 => 'a', 1 => 'b', 2 => 'c'];
+}
+
+function do1()
+{
+	/** @var list<string> */
+	return [1 => 'b', 2 => 'c'];
+}
+
+function do2()
+{
+	/** @var list<string> */
+	return [0 => 'a', 2 => 'c'];
+}
+
+function do3()
+{
+	/** @var list<string> */
+	return [-1 => 'z', 0 => 'a', 1 => 'b', 2 => 'c'];
+}
+
+function do4()
+{
+	/** @var list<string> */
+	return [0 => 'a', -1 => 'z', 1 => 'b', 2 => 'c'];
+}


### PR DESCRIPTION
In `ConstantArrayTypeBuilder`, `setOffsetValueType()` uses `ConstantIntegerType` of `offsetType` for checking whether a `ConstantArray` is a list, but doesn't check whether it is positive. Because of that, a `ConstantArray` that has negative integer keys is treated as list.

This PR resolves phpstan/phpstan#12708.