### PR TITLE
Added regression test

### DIFF
--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -870,6 +870,13 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8649.php'], []);
 	}
 
+	public function testBug11447(): void
+	{
+		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
+
+		$this->analyse([__DIR__ . '/data/bug-11447.php'], []);
+	}
+
 	public function testNarrowSuperglobals(): void
 	{
 		$this->reportPossiblyNonexistentGeneralArrayOffset = true;

--- a/tests/PHPStan/Rules/Arrays/data/bug-11447.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-11447.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Bug11447;
+
+function doFoo() {
+	\assert( \array_key_exists( 'key1', $_GET ) && \is_numeric( $_GET['key1'] ) );
+	\assert( isset( $_GET['key2'] ) && \is_numeric( $_GET['key2'] ) );
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11447

was fixed with https://github.com/phpstan/phpstan-src/pull/3871

before this fix

```
1) PHPStan\Rules\Arrays\NonexistentOffsetInArrayDimFetchRuleTest::testBug11447
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'
+'06: Offset 'key1' might not exist on array<mixed>.
 '

/Users/m.staab/Documents/GitHub/phpstan-src/src/Testing/RuleTestCase.php:165
/Users/m.staab/Documents/GitHub/phpstan-src/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php:877
```