### PR TITLE
Support narrowing a constant array to a list with count

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/count-type.php
+++ b/tests/PHPStan/Analyser/nsrt/count-type.php
@@ -87,6 +87,16 @@ class Foo
 		assertType('1|2', count($arr));
 	}
 
+	public function constantArrayWhichCanBecomeList(string $h): void
+	{
+		preg_match('#^([a-z0-9-]+)\..+$#', $h, $matches);
+		if (count($matches) !== 2) {
+			return;
+		}
+
+		assertType('array{string, non-empty-string}', $matches);
+	}
+
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -379,9 +379,8 @@ class CountWithOptionalKeys
 	 */
 	protected function testOptionalKeysInUnionArrayWithIntRange($row, $twoOrThree): void
 	{
-		// doesn't narrow because no list
 		if (count($row) >= $twoOrThree) {
-			assertType('array{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+			assertType('array{0: int, 1: string|null, 2?: int|null}', $row);
 		} else {
 			assertType('array{0: int, 1?: string|null, 2?: int|null, 3?: float|null}|array{string}', $row);
 		}


### PR DESCRIPTION
Implementing what was found/suggested in https://github.com/phpstan/phpstan-src/pull/3709#issuecomment-2714931508 and improves very special cases with int ranges. 

PR title is maybe misleading. it's making keys non-optional if it can for list-like cases.