### PR TITLE
ResultCache: allow customization of params not invalidating cache

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -189,6 +189,19 @@ parameters:
 			- '1.1.1.2'
 		tmpDir: %sysGetTempDir%/phpstan-fixer
 	__validate: true
+	parametersNotInvalidatingCache:
+		- parameters.editorUrl
+		- parameters.editorUrlTitle
+		- parameters.errorFormat
+		- parameters.ignoreErrors
+		- parameters.reportUnmatchedIgnoredErrors
+		- parameters.tipsOfTheDay
+		- parameters.parallel
+		- parameters.internalErrorsCountLimit
+		- parameters.cache
+		- parameters.memoryLimitFile
+		- parameters.pro
+		- parametersSchema
 
 extensions:
 	rules: PHPStan\DependencyInjection\RulesExtension
@@ -502,6 +515,7 @@ services:
 			scanFiles: %scanFiles%
 			scanDirectories: %scanDirectories%
 			checkDependenciesOfProjectExtensionFiles: %resultCacheChecksProjectExtensionFilesDependencies%
+			parametersNotInvalidatingCache: %parametersNotInvalidatingCache%
 
 	-
 		class: PHPStan\Analyser\ResultCache\ResultCacheClearer

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -166,6 +166,7 @@ parametersSchema:
 	])
 	env: arrayOf(string(), anyOf(int(), string()))
 	sysGetTempDir: string()
+	parametersNotInvalidatingCache: listOf(string())
 
 	# playground mode
 	sourceLocatorPlaygroundMode: bool()

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -16,6 +16,7 @@ use PHPStan\File\CouldNotReadFileException;
 use PHPStan\File\FileFinder;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileWriter;
+use PHPStan\Internal\ArrayHelper;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\Reflection\ReflectionProvider;
@@ -29,6 +30,7 @@ use function array_keys;
 use function array_unique;
 use function array_values;
 use function count;
+use function explode;
 use function get_loaded_extensions;
 use function implode;
 use function is_array;
@@ -65,6 +67,7 @@ final class ResultCacheManager
 	 * @param string[] $bootstrapFiles
 	 * @param string[] $scanFiles
 	 * @param string[] $scanDirectories
+	 * @param list<string> $parametersNotInvalidatingCache
 	 */
 	public function __construct(
 		private Container $container,
@@ -82,6 +85,7 @@ final class ResultCacheManager
 		private array $scanFiles,
 		private array $scanDirectories,
 		private bool $checkDependenciesOfProjectExtensionFiles,
+		private array $parametersNotInvalidatingCache,
 	)
 	{
 	}
@@ -887,18 +891,9 @@ return [
 		sort($extensions);
 
 		if ($projectConfigArray !== null) {
-			unset($projectConfigArray['parameters']['editorUrl']);
-			unset($projectConfigArray['parameters']['editorUrlTitle']);
-			unset($projectConfigArray['parameters']['errorFormat']);
-			unset($projectConfigArray['parameters']['ignoreErrors']);
-			unset($projectConfigArray['parameters']['reportUnmatchedIgnoredErrors']);
-			unset($projectConfigArray['parameters']['tipsOfTheDay']);
-			unset($projectConfigArray['parameters']['parallel']);
-			unset($projectConfigArray['parameters']['internalErrorsCountLimit']);
-			unset($projectConfigArray['parameters']['cache']);
-			unset($projectConfigArray['parameters']['memoryLimitFile']);
-			unset($projectConfigArray['parameters']['pro']);
-			unset($projectConfigArray['parametersSchema']);
+			foreach ($this->parametersNotInvalidatingCache as $parameterPath) {
+				ArrayHelper::unsetKeyAtPath($projectConfigArray, explode('.', $parameterPath));
+			}
 
 			ksort($projectConfigArray);
 		}

--- a/src/Internal/ArrayHelper.php
+++ b/src/Internal/ArrayHelper.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use function array_slice;
+use function count;
+
+final class ArrayHelper
+{
+
+	/**
+	 * @param mixed[] $array
+	 * @param non-empty-list<string> $path
+	 */
+	public static function unsetKeyAtPath(array &$array, array $path): void
+	{
+		[$head, $tail] = [$path[0], array_slice($path, 1)];
+
+		if (count($tail) === 0) {
+			unset($array[$head]);
+		} else {
+			self::unsetKeyAtPath($array[$head], $tail);
+		}
+	}
+
+}

--- a/src/Internal/ArrayHelper.php
+++ b/src/Internal/ArrayHelper.php
@@ -18,7 +18,8 @@ final class ArrayHelper
 
 		if (count($tail) === 0) {
 			unset($array[$head]);
-		} else {
+
+		} elseif (isset($array[$head])) {
 			self::unsetKeyAtPath($array[$head], $tail);
 		}
 	}

--- a/tests/PHPStan/Internal/ArrayHelperTest.php
+++ b/tests/PHPStan/Internal/ArrayHelperTest.php
@@ -19,8 +19,7 @@ class ArrayHelperTest extends TestCase
 			'dep1b' => null,
 		];
 
-		$path = ['dep1a', 'dep2a', 'dep3a'];
-		ArrayHelper::unsetKeyAtPath($array, $path);
+		ArrayHelper::unsetKeyAtPath($array, ['dep1a', 'dep2a', 'dep3a']);
 
 		$this->assertSame([
 			'dep1a' => [
@@ -29,6 +28,34 @@ class ArrayHelperTest extends TestCase
 			],
 			'dep1b' => null,
 		], $array);
+
+		ArrayHelper::unsetKeyAtPath($array, ['dep1a', 'dep2a']);
+
+		$this->assertSame([
+			'dep1a' => [
+				'dep2b' => null,
+			],
+			'dep1b' => null,
+		], $array);
+
+		ArrayHelper::unsetKeyAtPath($array, ['dep1a']);
+
+		$this->assertSame([
+			'dep1b' => null,
+		], $array);
+
+		ArrayHelper::unsetKeyAtPath($array, ['dep1b']);
+
+		$this->assertSame([], $array);
+	}
+
+	public function testUnsetKeyAtPathEmpty(): void
+	{
+		$array = [];
+
+		ArrayHelper::unsetKeyAtPath($array, ['foo', 'bar']);
+
+		$this->assertSame([], $array);
 	}
 
 }

--- a/tests/PHPStan/Internal/ArrayHelperTest.php
+++ b/tests/PHPStan/Internal/ArrayHelperTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use PHPUnit\Framework\TestCase;
+
+class ArrayHelperTest extends TestCase
+{
+
+	public function testUnsetKeyAtPath(): void
+	{
+		$array = [
+			'dep1a' => [
+				'dep2a' => [
+					'dep3a' => null,
+				],
+				'dep2b' => null,
+			],
+			'dep1b' => null,
+		];
+
+		$path = ['dep1a', 'dep2a', 'dep3a'];
+		ArrayHelper::unsetKeyAtPath($array, $path);
+
+		$this->assertSame([
+			'dep1a' => [
+				'dep2a' => [],
+				'dep2b' => null,
+			],
+			'dep1b' => null,
+		], $array);
+	}
+
+}


### PR DESCRIPTION
- Currently, I'm improving our dead-code-detector with some [optional debug output](https://github.com/shipmonk-rnd/dead-code-detector/pull/165/files). 
- This is configured via parameter that is wired to a Rule hooked to `CollectedDataNode`. 
- As this runs after parallel analysis is done, changing such parameter never affects result cache, but it gets invalidated anyway. 
- This PR solves this issue by providing configuration option where even phpstan extensions can mark their parameters as not affecting result cache.