### PR TITLE
Implement TypeSpecifierContext->getReturnType()

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -455,6 +455,9 @@ final class TypeSpecifier
 				!$context->null()
 				&& $expr->right instanceof Expr\CallLike
 			) {
+				if (!$scope instanceof MutatingScope) {
+					throw new ShouldNotHappenException();
+				}
 				$newScope = $scope->filterBySpecifiedTypes($result);
 				$callType = $newScope->getType($expr->right);
 				$newContext = TypeSpecifierContext::createTruthy($callType);

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -457,7 +457,7 @@ final class TypeSpecifier
 			) {
 				$newScope = $scope->filterBySpecifiedTypes($result);
 				$callType = $newScope->getType($expr->right);
-				$newContext = $this->createSpecifierContextReturnType($callType, $context);
+				$newContext = TypeSpecifierContext::createTrue($callType);
 
 				return $this->specifyTypesInCondition(
 					$scope,
@@ -1947,21 +1947,6 @@ final class TypeSpecifier
 		}
 
 		return array_merge(...$extensionsForClass);
-	}
-
-	private function createSpecifierContextReturnType(
-		Type $contextReturnType,
-		TypeSpecifierContext $context,
-	): TypeSpecifierContext
-	{
-		if (!$context->null()) {
-			return TypeSpecifierContext::createTrue($contextReturnType);
-		}
-		//} elseif ($context->false()) {
-		//	return TypeSpecifierContext::createFalse($contextReturnType);
-		//}
-
-		//return $context;
 	}
 
 	public function resolveEqual(Expr\BinaryOp\Equal $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -334,21 +334,6 @@ final class TypeSpecifier
 			if (
 				!$context->null()
 				&& $expr->right instanceof FuncCall
-				&& count($expr->right->getArgs()) >= 3
-				&& $expr->right->name instanceof Name
-				&& in_array(strtolower((string) $expr->right->name), ['preg_match'], true)
-				&& IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($leftType)->yes()
-			) {
-				return $this->specifyTypesInCondition(
-					$scope,
-					new Expr\BinaryOp\NotIdentical($expr->right, new ConstFetch(new Name('false'))),
-					$context,
-				)->setRootExpr($expr);
-			}
-
-			if (
-				!$context->null()
-				&& $expr->right instanceof FuncCall
 				&& count($expr->right->getArgs()) === 1
 				&& $expr->right->name instanceof Name
 				&& in_array(strtolower((string) $expr->right->name), ['strlen', 'mb_strlen'], true)
@@ -464,6 +449,21 @@ final class TypeSpecifier
 						)->setRootExpr($expr),
 					);
 				}
+			}
+
+			if (
+				!$context->null()
+				&& $expr->right instanceof FuncCall
+			) {
+				$newScope = $scope->filterBySpecifiedTypes($result);
+				$callType = $newScope->getType($expr->right);
+				$newContext = $this->createSpecifierContextReturnType($callType, $context);
+
+				return $this->specifyTypesInCondition(
+					$scope,
+					$expr->right,
+					$newContext,
+				)->setRootExpr($expr);
 			}
 
 			return $result;
@@ -1947,6 +1947,20 @@ final class TypeSpecifier
 		}
 
 		return array_merge(...$extensionsForClass);
+	}
+
+	private function createSpecifierContextReturnType(
+		Type $contextReturnType,
+		TypeSpecifierContext $context,
+	): TypeSpecifierContext
+	{
+			if ($context->true()) {
+				return TypeSpecifierContext::createTrue($contextReturnType);
+			} elseif ($context->false()) {
+				return TypeSpecifierContext::createFalse($contextReturnType);
+			}
+
+		return $context;
 	}
 
 	public function resolveEqual(Expr\BinaryOp\Equal $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -457,13 +457,13 @@ final class TypeSpecifier
 			) {
 				$newScope = $scope->filterBySpecifiedTypes($result);
 				$callType = $newScope->getType($expr->right);
-				$newContext = TypeSpecifierContext::createTrue($callType);
+				$newContext = TypeSpecifierContext::createTruthy($callType);
 
-				return $this->specifyTypesInCondition(
+				$result = $result->unionWith($this->specifyTypesInCondition(
 					$scope,
 					$expr->right,
 					$newContext,
-				)->setRootExpr($expr);
+				)->setRootExpr($expr));
 			}
 
 			return $result;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1954,8 +1954,9 @@ final class TypeSpecifier
 		TypeSpecifierContext $context,
 	): TypeSpecifierContext
 	{
-		//if ($context->true()) {
+		if (!$context->null()) {
 			return TypeSpecifierContext::createTrue($contextReturnType);
+		}
 		//} elseif ($context->false()) {
 		//	return TypeSpecifierContext::createFalse($contextReturnType);
 		//}

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1176,7 +1176,7 @@ final class TypeSpecifier
 			return $types->unionWith($this->specifyTypesInCondition(
 				$scope,
 				$exprNode,
-				$context->true() ? TypeSpecifierContext::createTrue() : TypeSpecifierContext::createTrue()->negate(),
+				$context->true() ? TypeSpecifierContext::createTrue($context->getReturnType()) : TypeSpecifierContext::createTrue($context->getReturnType())->negate(),
 			)->setRootExpr($rootExpr));
 		}
 
@@ -1976,7 +1976,7 @@ final class TypeSpecifier
 				return $this->specifyTypesInCondition(
 					$scope,
 					$exprNode,
-					$context->true() ? TypeSpecifierContext::createFalsey() : TypeSpecifierContext::createFalsey()->negate(),
+					$context->true() ? TypeSpecifierContext::createFalsey($context->getReturnType()) : TypeSpecifierContext::createFalsey($context->getReturnType())->negate(),
 				)->setRootExpr($expr);
 			}
 

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -453,7 +453,7 @@ final class TypeSpecifier
 
 			if (
 				!$context->null()
-				&& $expr->right instanceof FuncCall
+				&& $expr->right instanceof Expr\CallLike
 			) {
 				$newScope = $scope->filterBySpecifiedTypes($result);
 				$callType = $newScope->getType($expr->right);
@@ -1954,13 +1954,13 @@ final class TypeSpecifier
 		TypeSpecifierContext $context,
 	): TypeSpecifierContext
 	{
-		if ($context->true()) {
+		//if ($context->true()) {
 			return TypeSpecifierContext::createTrue($contextReturnType);
-		} elseif ($context->false()) {
-			return TypeSpecifierContext::createFalse($contextReturnType);
-		}
+		//} elseif ($context->false()) {
+		//	return TypeSpecifierContext::createFalse($contextReturnType);
+		//}
 
-		return $context;
+		//return $context;
 	}
 
 	public function resolveEqual(Expr\BinaryOp\Equal $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -460,7 +460,7 @@ final class TypeSpecifier
 				}
 				$newScope = $scope->filterBySpecifiedTypes($result);
 				$callType = $newScope->getType($expr->right);
-				$newContext = TypeSpecifierContext::createTruthy($callType);
+				$newContext = $context->true() ? TypeSpecifierContext::createTrue($callType) : TypeSpecifierContext::createTrue($callType)->negate();
 
 				$result = $result->unionWith($this->specifyTypesInCondition(
 					$scope,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1954,11 +1954,11 @@ final class TypeSpecifier
 		TypeSpecifierContext $context,
 	): TypeSpecifierContext
 	{
-			if ($context->true()) {
-				return TypeSpecifierContext::createTrue($contextReturnType);
-			} elseif ($context->false()) {
-				return TypeSpecifierContext::createFalse($contextReturnType);
-			}
+		if ($context->true()) {
+			return TypeSpecifierContext::createTrue($contextReturnType);
+		} elseif ($context->false()) {
+			return TypeSpecifierContext::createFalse($contextReturnType);
+		}
 
 		return $context;
 	}

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -32,7 +32,7 @@ final class TypeSpecifierContext
 	private static function create(?int $value, ?Type $returnType = null): self
 	{
 		if ($returnType !== null) {
-			// return type bound context is unique for each context and therefore not cachable
+			// return type bound context is unique for each context and therefore not cacheable
 			return new self($value, $returnType);
 		}
 

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -3,7 +3,6 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 
 /**
@@ -23,19 +22,27 @@ final class TypeSpecifierContext
 	/** @var self[] */
 	private static array $registry;
 
-	private function __construct(private ?int $value)
+	private function __construct(
+		private ?int $value,
+		private ?Type $returnType,
+	)
 	{
 	}
 
-	private static function create(?int $value): self
+	private static function create(?int $value, ?Type $returnType = null): self
 	{
-		self::$registry[$value] ??= new self($value);
+		if ($returnType !== null) {
+			// return type bound context is unique for each context and therefore not cachable
+			return new self($value, $returnType);
+		}
+
+		self::$registry[$value] ??= new self($value, null);
 		return self::$registry[$value];
 	}
 
-	public static function createTrue(): self
+	public static function createTrue(?Type $returnType = null): self
 	{
-		return self::create(self::CONTEXT_TRUE);
+		return self::create(self::CONTEXT_TRUE, $returnType);
 	}
 
 	public static function createTruthy(): self
@@ -43,9 +50,9 @@ final class TypeSpecifierContext
 		return self::create(self::CONTEXT_TRUTHY);
 	}
 
-	public static function createFalse(): self
+	public static function createFalse(?Type $returnType = null): self
 	{
-		return self::create(self::CONTEXT_FALSE);
+		return self::create(self::CONTEXT_FALSE, $returnType);
 	}
 
 	public static function createFalsey(): self
@@ -91,9 +98,9 @@ final class TypeSpecifierContext
 		return $this->value === null;
 	}
 
-	public function getReturnType(): Type
+	public function getReturnType(): ?Type
 	{
-		return new MixedType();
+		return $this->returnType;
 	}
 
 }

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\MixedType;
 
 /**
  * @api
@@ -87,6 +88,10 @@ final class TypeSpecifierContext
 	public function null(): bool
 	{
 		return $this->value === null;
+	}
+
+	public function getReturnType(): Type {
+		return new MixedType();
 	}
 
 }

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -3,7 +3,9 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 /**
  * @api
@@ -70,7 +72,9 @@ final class TypeSpecifierContext
 		if ($this->value === null) {
 			throw new ShouldNotHappenException();
 		}
-		return self::create(~$this->value & self::CONTEXT_BITMASK);
+
+		$baseType = $this->returnType->generalize(GeneralizePrecision::lessSpecific());
+		return self::create(~$this->value & self::CONTEXT_BITMASK, TypeCombinator::remove($baseType, $this->returnType));
 	}
 
 	public function true(): bool

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -4,6 +4,7 @@ namespace PHPStan\Analyser;
 
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
 
 /**
  * @api
@@ -90,7 +91,8 @@ final class TypeSpecifierContext
 		return $this->value === null;
 	}
 
-	public function getReturnType(): Type {
+	public function getReturnType(): Type
+	{
 		return new MixedType();
 	}
 

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -45,9 +45,9 @@ final class TypeSpecifierContext
 		return self::create(self::CONTEXT_TRUE, $returnType);
 	}
 
-	public static function createTruthy(): self
+	public static function createTruthy(?Type $returnType = null): self
 	{
-		return self::create(self::CONTEXT_TRUTHY);
+		return self::create(self::CONTEXT_TRUTHY, $returnType);
 	}
 
 	public static function createFalse(?Type $returnType = null): self
@@ -55,9 +55,9 @@ final class TypeSpecifierContext
 		return self::create(self::CONTEXT_FALSE, $returnType);
 	}
 
-	public static function createFalsey(): self
+	public static function createFalsey(?Type $returnType = null): self
 	{
-		return self::create(self::CONTEXT_FALSEY);
+		return self::create(self::CONTEXT_FALSEY, $returnType);
 	}
 
 	public static function createNull(): self

--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -73,8 +73,13 @@ final class TypeSpecifierContext
 			throw new ShouldNotHappenException();
 		}
 
-		$baseType = $this->returnType->generalize(GeneralizePrecision::lessSpecific());
-		return self::create(~$this->value & self::CONTEXT_BITMASK, TypeCombinator::remove($baseType, $this->returnType));
+		$negatedReturnType = null;
+		if ($this->returnType !== null) {
+			$baseType = $this->returnType->generalize(GeneralizePrecision::lessSpecific());
+			$negatedReturnType = TypeCombinator::remove($baseType, $this->returnType);
+		}
+
+		return self::create(~$this->value & self::CONTEXT_BITMASK, $negatedReturnType);
 	}
 
 	public function true(): bool

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -147,7 +147,7 @@ final class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 			$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
 				$node->getArgs()[1]->value,
 				new ArrayType(new MixedType(), $arrayValueType),
-				TypeSpecifierContext::createTrue(),
+				TypeSpecifierContext::createTrue($context->getReturnType()),
 				$scope,
 			));
 		}

--- a/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeExtension.neon
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeExtension.neon
@@ -1,5 +1,5 @@
 services:
 	-
-		class: PHPStan\Analyser\TypeSpecifierContextReturnTypeExtension
+		class: PHPStan\Tests\TypeSpecifierContextReturnTypeExtension
 		tags:
 			- phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeExtension.neon
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeExtension.neon
@@ -1,0 +1,5 @@
+services:
+	-
+		class: PHPStan\Analyser\TypeSpecifierContextReturnTypeExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeExtension.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeExtension.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Rules\Properties\PropertyReflectionFinder;
+use PHPStan\Type\Accessory\HasPropertyType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StringType;
+
+class TypeSpecifierContextReturnTypeExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private TypeSpecifier $typeSpecifier;
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+	public function getClass(): string
+	{
+		return \TypeSpecifierContextReturnTypeTest\ContextReturnType::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context,
+	): bool
+	{
+		return str_starts_with($methodReflection->getName(), 'returns');
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context,
+	): SpecifiedTypes
+	{
+		return $this->typeSpecifier->create(
+			$node->getArgs()[0]->value,
+			$context->getReturnType(),
+			$context,
+			$scope,
+		);
+	}
+
+}

--- a/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeTest.php
@@ -2,12 +2,11 @@
 
 namespace PHPStan\Analyser;
 
-use PHPStan\ShouldNotHappenException;
-use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Testing\TypeInferenceTestCase;
 
 class TypeSpecifierContextReturnTypeTest extends TypeInferenceTestCase
 {
+
 	public function dataContextReturnType(): iterable
 	{
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifier-context-return-type.php');
@@ -20,7 +19,7 @@ class TypeSpecifierContextReturnTypeTest extends TypeInferenceTestCase
 	public function testContextReturnType(
 		string $assertType,
 		string $file,
-			   ...$args,
+		...$args,
 	): void
 	{
 		$this->assertFileAsserts($assertType, $file, ...$args);
@@ -29,7 +28,7 @@ class TypeSpecifierContextReturnTypeTest extends TypeInferenceTestCase
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [
-			__DIR__.'/TypeSpecifierContextReturnTypeExtension.neon'
+			__DIR__ . '/TypeSpecifierContextReturnTypeExtension.neon',
 		];
 	}
 

--- a/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextReturnTypeTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class TypeSpecifierContextReturnTypeTest extends TypeInferenceTestCase
+{
+	public function dataContextReturnType(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/type-specifier-context-return-type.php');
+	}
+
+	/**
+	 * @dataProvider dataContextReturnType
+	 * @param mixed ...$args
+	 */
+	public function testContextReturnType(
+		string $assertType,
+		string $file,
+			   ...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__.'/TypeSpecifierContextReturnTypeExtension.neon'
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/TypeSpecifierContextReturnTypeExtension.php
+++ b/tests/PHPStan/Analyser/data/TypeSpecifierContextReturnTypeExtension.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace PHPStan\Analyser;
+namespace PHPStan\Tests;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
@@ -9,12 +9,9 @@ use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Rules\Properties\PropertyReflectionFinder;
-use PHPStan\Type\Accessory\HasPropertyType;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
-use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\StringType;
+use TypeSpecifierContextReturnTypeTest\ContextReturnType;
+use function str_starts_with;
 
 class TypeSpecifierContextReturnTypeExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {
@@ -28,7 +25,7 @@ class TypeSpecifierContextReturnTypeExtension implements MethodTypeSpecifyingExt
 
 	public function getClass(): string
 	{
-		return \TypeSpecifierContextReturnTypeTest\ContextReturnType::class;
+		return ContextReturnType::class;
 	}
 
 	public function isMethodSupported(

--- a/tests/PHPStan/Analyser/data/TypeSpecifierContextReturnTypeExtension.php
+++ b/tests/PHPStan/Analyser/data/TypeSpecifierContextReturnTypeExtension.php
@@ -44,6 +44,10 @@ class TypeSpecifierContextReturnTypeExtension implements MethodTypeSpecifyingExt
 		TypeSpecifierContext $context,
 	): SpecifiedTypes
 	{
+        if ($context->null()) {
+            return new SpecifiedTypes();
+        }
+
 		return $this->typeSpecifier->create(
 			$node->getArgs()[0]->value,
 			$context->getReturnType(),

--- a/tests/PHPStan/Analyser/data/type-specifier-context-return-type.php
+++ b/tests/PHPStan/Analyser/data/type-specifier-context-return-type.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace TypeSpecifierContextReturnTypeTest;
+
+use function PHPStan\Testing\assertType;
+
+class ContextReturnType {
+	public function returnsInt(int $specifiedContextReturnType): int {}
+
+	public function doFoo(int $i) {
+		assertType('int', $i);
+		if ($this->returnsInt($i) > 0) {
+			assertType('int<1, max>', $i);
+		} else {
+			assertType('int<min, 0>', $i);
+		}
+		assertType('int', $i);
+	}
+}

--- a/tests/PHPStan/Analyser/data/type-specifier-context-return-type.php
+++ b/tests/PHPStan/Analyser/data/type-specifier-context-return-type.php
@@ -7,9 +7,19 @@ use function PHPStan\Testing\assertType;
 class ContextReturnType {
 	public function returnsInt(int $specifiedContextReturnType): int {}
 
-	public function doFoo(int $i) {
+	public function doFooLeft(int $i) {
 		assertType('int', $i);
 		if ($this->returnsInt($i) > 0) {
+			assertType('int<1, max>', $i);
+		} else {
+			assertType('int<min, 0>', $i);
+		}
+		assertType('int', $i);
+	}
+
+	public function doFooRight(int $i) {
+		assertType('int', $i);
+		if (0 < $this->returnsInt($i)) {
 			assertType('int<1, max>', $i);
 		} else {
 			assertType('int<min, 0>', $i);


### PR DESCRIPTION
for expression like

`if (doFoo() > 0)` 

we want to pass the context specific return-type information into type-specifying extensions so they can decide not just on true/truethy/false/falsy but also on "remaining return type values" (e.g. preg_match returns `0|1|false`)

this should help to reduce the number of hardcoded hacks within the TypeSpecifier und move over some cases into extensions (which also allows 3rd party extensions todo similar things, as they can't hard-code hack the TypeSpecifier)

ondrej quoted:

> There should be a new method on the context, can be getReturnType
>
> Let’s say we have doFoo(): int
> if (doFoo() > 0), in the then branch, this should return int<1, max>, in the else branch it should return int<min, 0>