### PR TITLE
Collected data: reduce memory consumption & result cache size

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -3,8 +3,7 @@
 namespace PHPStan\Analyser;
 
 use Closure;
-use PhpParser\Node;
-use PHPStan\Collectors\Collector;
+use PHPStan\Collectors\CollectedData;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Rules\Registry as RuleRegistry;
 use Throwable;
@@ -13,6 +12,9 @@ use function array_merge;
 use function count;
 use function memory_get_peak_usage;
 
+/**
+ * @phpstan-import-type CollectorData from CollectedData
+ */
 final class Analyser
 {
 
@@ -60,7 +62,7 @@ final class Analyser
 		$linesToIgnore = [];
 		$unmatchedLineIgnores = [];
 
-		/** @var array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData */
+		/** @var CollectorData $collectedData */
 		$collectedData = [];
 
 		$internalErrorsCount = 0;

--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -3,7 +3,8 @@
 namespace PHPStan\Analyser;
 
 use Closure;
-use PHPStan\Collectors\CollectedData;
+use PhpParser\Node;
+use PHPStan\Collectors\Collector;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Rules\Registry as RuleRegistry;
 use Throwable;
@@ -59,7 +60,7 @@ final class Analyser
 		$linesToIgnore = [];
 		$unmatchedLineIgnores = [];
 
-		/** @var list<CollectedData> $collectedData */
+		/** @var array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData */
 		$collectedData = [];
 
 		$internalErrorsCount = 0;

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -2,7 +2,8 @@
 
 namespace PHPStan\Analyser;
 
-use PHPStan\Collectors\CollectedData;
+use PhpParser\Node;
+use PHPStan\Collectors\Collector;
 use PHPStan\Dependency\RootExportedNode;
 use function usort;
 
@@ -22,7 +23,7 @@ final class AnalyserResult
 	 * @param list<Error> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param list<CollectedData> $collectedData
+	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
 	 * @param list<InternalError> $internalErrors
 	 * @param array<string, array<string>>|null $dependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
@@ -125,7 +126,7 @@ final class AnalyserResult
 	}
 
 	/**
-	 * @return list<CollectedData>
+	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
 	 */
 	public function getCollectedData(): array
 	{

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -2,13 +2,13 @@
 
 namespace PHPStan\Analyser;
 
-use PhpParser\Node;
-use PHPStan\Collectors\Collector;
+use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 use function usort;
 
 /**
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
+ * @phpstan-import-type CollectorData from CollectedData
  */
 final class AnalyserResult
 {
@@ -23,7 +23,7 @@ final class AnalyserResult
 	 * @param list<Error> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
+	 * @param CollectorData $collectedData
 	 * @param list<InternalError> $internalErrors
 	 * @param array<string, array<string>>|null $dependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
@@ -126,7 +126,7 @@ final class AnalyserResult
 	}
 
 	/**
-	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
+	 * @return CollectorData
 	 */
 	public function getCollectedData(): array
 	{

--- a/src/Analyser/FileAnalyser.php
+++ b/src/Analyser/FileAnalyser.php
@@ -7,7 +7,7 @@ use PHPStan\AnalysedCodeException;
 use PHPStan\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use PHPStan\BetterReflection\Reflection\Exception\CircularReference;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
-use PHPStan\Collectors\CollectedData;
+use PHPStan\Collectors\Collector;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Dependency\DependencyResolver;
 use PHPStan\Node\FileNode;
@@ -76,7 +76,7 @@ final class FileAnalyser
 		/** @var list<Error> $locallyIgnoredErrors */
 		$locallyIgnoredErrors = [];
 
-		/** @var list<CollectedData> $fileCollectedData */
+		/** @var array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $fileCollectedData */
 		$fileCollectedData = [];
 
 		$fileDependencies = [];
@@ -195,11 +195,7 @@ final class FileAnalyser
 							continue;
 						}
 
-						$fileCollectedData[] = new CollectedData(
-							$collectedData,
-							$scope->getFile(),
-							get_class($collector),
-						);
+						$fileCollectedData[$scope->getFile()][get_class($collector)][] = $collectedData;
 					}
 
 					try {

--- a/src/Analyser/FileAnalyser.php
+++ b/src/Analyser/FileAnalyser.php
@@ -7,7 +7,7 @@ use PHPStan\AnalysedCodeException;
 use PHPStan\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use PHPStan\BetterReflection\Reflection\Exception\CircularReference;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
-use PHPStan\Collectors\Collector;
+use PHPStan\Collectors\CollectedData;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Dependency\DependencyResolver;
 use PHPStan\Node\FileNode;
@@ -37,6 +37,9 @@ use const E_USER_NOTICE;
 use const E_USER_WARNING;
 use const E_WARNING;
 
+/**
+ * @phpstan-import-type CollectorData from CollectedData
+ */
 final class FileAnalyser
 {
 
@@ -76,7 +79,7 @@ final class FileAnalyser
 		/** @var list<Error> $locallyIgnoredErrors */
 		$locallyIgnoredErrors = [];
 
-		/** @var array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $fileCollectedData */
+		/** @var CollectorData $fileCollectedData */
 		$fileCollectedData = [];
 
 		$fileDependencies = [];

--- a/src/Analyser/FileAnalyserResult.php
+++ b/src/Analyser/FileAnalyserResult.php
@@ -2,7 +2,8 @@
 
 namespace PHPStan\Analyser;
 
-use PHPStan\Collectors\CollectedData;
+use PhpParser\Node;
+use PHPStan\Collectors\Collector;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
@@ -16,7 +17,7 @@ final class FileAnalyserResult
 	 * @param list<Error> $filteredPhpErrors
 	 * @param list<Error> $allPhpErrors
 	 * @param list<Error> $locallyIgnoredErrors
-	 * @param list<CollectedData> $collectedData
+	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
 	 * @param list<string> $dependencies
 	 * @param list<RootExportedNode> $exportedNodes
 	 * @param LinesToIgnore $linesToIgnore
@@ -69,7 +70,7 @@ final class FileAnalyserResult
 	}
 
 	/**
-	 * @return list<CollectedData>
+	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
 	 */
 	public function getCollectedData(): array
 	{

--- a/src/Analyser/FileAnalyserResult.php
+++ b/src/Analyser/FileAnalyserResult.php
@@ -2,12 +2,12 @@
 
 namespace PHPStan\Analyser;
 
-use PhpParser\Node;
-use PHPStan\Collectors\Collector;
+use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
  * @phpstan-type LinesToIgnore = array<string, array<int, non-empty-list<string>|null>>
+ * @phpstan-import-type CollectorData from CollectedData
  */
 final class FileAnalyserResult
 {
@@ -17,7 +17,7 @@ final class FileAnalyserResult
 	 * @param list<Error> $filteredPhpErrors
 	 * @param list<Error> $allPhpErrors
 	 * @param list<Error> $locallyIgnoredErrors
-	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
+	 * @param CollectorData $collectedData
 	 * @param list<string> $dependencies
 	 * @param list<RootExportedNode> $exportedNodes
 	 * @param LinesToIgnore $linesToIgnore
@@ -70,7 +70,7 @@ final class FileAnalyserResult
 	}
 
 	/**
-	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
+	 * @return CollectorData
 	 */
 	public function getCollectedData(): array
 	{

--- a/src/Analyser/ResultCache/ResultCache.php
+++ b/src/Analyser/ResultCache/ResultCache.php
@@ -2,9 +2,10 @@
 
 namespace PHPStan\Analyser\ResultCache;
 
+use PhpParser\Node;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
-use PHPStan\Collectors\CollectedData;
+use PHPStan\Collectors\Collector;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
@@ -20,7 +21,7 @@ final class ResultCache
 	 * @param array<string, list<Error>> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param array<string, array<CollectedData>> $collectedData
+	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
 	 * @param array<string, array<string>> $dependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
 	 * @param array<string, array{string, bool, string}> $projectExtensionFiles
@@ -101,7 +102,7 @@ final class ResultCache
 	}
 
 	/**
-	 * @return array<string, array<CollectedData>>
+	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
 	 */
 	public function getCollectedData(): array
 	{

--- a/src/Analyser/ResultCache/ResultCache.php
+++ b/src/Analyser/ResultCache/ResultCache.php
@@ -2,14 +2,14 @@
 
 namespace PHPStan\Analyser\ResultCache;
 
-use PhpParser\Node;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
-use PHPStan\Collectors\Collector;
+use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
+ * @phpstan-import-type CollectorData from CollectedData
  */
 final class ResultCache
 {
@@ -21,7 +21,7 @@ final class ResultCache
 	 * @param array<string, list<Error>> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
+	 * @param CollectorData $collectedData
 	 * @param array<string, array<string>> $dependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
 	 * @param array<string, array{string, bool, string}> $projectExtensionFiles
@@ -102,7 +102,7 @@ final class ResultCache
 	}
 
 	/**
-	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
+	 * @return CollectorData
 	 */
 	public function getCollectedData(): array
 	{

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -3,12 +3,10 @@
 namespace PHPStan\Analyser\ResultCache;
 
 use Nette\Neon\Neon;
-use PhpParser\Node;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Collectors\CollectedData;
-use PHPStan\Collectors\Collector;
 use PHPStan\Command\Output;
 use PHPStan\Dependency\ExportedNodeFetcher;
 use PHPStan\Dependency\RootExportedNode;
@@ -51,6 +49,7 @@ use const PHP_VERSION_ID;
 
 /**
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
+ * @phpstan-import-type CollectorData from CollectedData
  */
 final class ResultCacheManager
 {
@@ -576,8 +575,8 @@ final class ResultCacheManager
 	}
 
 	/**
-	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $freshCollectedDataByFile
-	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
+	 * @param CollectorData $freshCollectedDataByFile
+	 * @return CollectorData
 	 */
 	private function mergeCollectedData(ResultCache $resultCache, array $freshCollectedDataByFile): array
 	{

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -3,10 +3,12 @@
 namespace PHPStan\Analyser\ResultCache;
 
 use Nette\Neon\Neon;
+use PhpParser\Node;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Collectors\CollectedData;
+use PHPStan\Collectors\Collector;
 use PHPStan\Command\Output;
 use PHPStan\Dependency\ExportedNodeFetcher;
 use PHPStan\Dependency\RootExportedNode;
@@ -406,10 +408,7 @@ final class ResultCacheManager
 			$freshLocallyIgnoredErrorsByFile[$error->getFilePath()][] = $error;
 		}
 
-		$freshCollectedDataByFile = [];
-		foreach ($analyserResult->getCollectedData() as $collectedData) {
-			$freshCollectedDataByFile[$collectedData->getFilePath()][] = $collectedData;
-		}
+		$freshCollectedDataByFile = $analyserResult->getCollectedData();
 
 		$meta = $resultCache->getMeta();
 		$projectConfigArray = $meta['projectConfig'];
@@ -524,13 +523,6 @@ final class ResultCacheManager
 			}
 		}
 
-		$flatCollectedData = [];
-		foreach ($collectedDataByFile as $fileCollectedData) {
-			foreach ($fileCollectedData as $collectedData) {
-				$flatCollectedData[] = $collectedData;
-			}
-		}
-
 		return new ResultCacheProcessResult(new AnalyserResult(
 			$flatErrors,
 			$analyserResult->getFilteredPhpErrors(),
@@ -539,7 +531,7 @@ final class ResultCacheManager
 			$linesToIgnore,
 			$unmatchedLineIgnores,
 			$internalErrors,
-			$flatCollectedData,
+			$collectedDataByFile,
 			$dependencies,
 			$exportedNodes,
 			$analyserResult->hasReachedInternalErrorsCountLimit(),
@@ -584,8 +576,8 @@ final class ResultCacheManager
 	}
 
 	/**
-	 * @param array<string, array<CollectedData>> $freshCollectedDataByFile
-	 * @return array<string, array<CollectedData>>
+	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $freshCollectedDataByFile
+	 * @return array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
 	 */
 	private function mergeCollectedData(ResultCache $resultCache, array $freshCollectedDataByFile): array
 	{
@@ -704,7 +696,7 @@ final class ResultCacheManager
 	 * @param array<string, list<Error>> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
 	 * @param array<string, LinesToIgnore> $unmatchedLineIgnores
-	 * @param array<string, array<CollectedData>> $collectedData
+	 * @param array<string, array<string, list<CollectedData>>> $collectedData
 	 * @param array<string, array<string>> $dependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
 	 * @param array<string, array{string, bool, string}> $projectExtensionFiles
@@ -759,6 +751,10 @@ final class ResultCacheManager
 		ksort($unmatchedLineIgnores);
 		ksort($collectedData);
 		ksort($invertedDependencies);
+
+		foreach ($collectedData as & $collectedDataPerFile) {
+			ksort($collectedDataPerFile);
+		}
 
 		foreach ($invertedDependencies as $file => $fileData) {
 			$dependentFiles = $fileData['dependentFiles'];

--- a/src/Collectors/CollectedData.php
+++ b/src/Collectors/CollectedData.php
@@ -8,6 +8,8 @@ use ReturnTypeWillChange;
 
 /**
  * @api
+ *
+ * @phpstan-type CollectorData = array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>>
  */
 final class CollectedData implements JsonSerializable
 {

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -2,10 +2,13 @@
 
 namespace PHPStan\Command;
 
+use PhpParser\Node;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\AnalyserResultFinalizer;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
 use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
+use PHPStan\Collectors\CollectedData;
+use PHPStan\Collectors\Collector;
 use PHPStan\Internal\BytesHelper;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\PhpDoc\StubValidator;
@@ -150,7 +153,7 @@ final class AnalyseApplication
 			$notFileSpecificErrors,
 			$internalErrors,
 			[],
-			$collectedData,
+			$this->mapCollectedData($collectedData),
 			$defaultLevelUsed,
 			$projectConfigFile,
 			$savedResultCache,
@@ -158,6 +161,22 @@ final class AnalyseApplication
 			$isResultCacheUsed,
 			$changedProjectExtensionFilesOutsideOfAnalysedPaths,
 		);
+	}
+
+	/**
+	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
+	 *
+	 * @return list<CollectedData>
+	 */
+	private function mapCollectedData(array $collectedData): array
+	{
+		$result = [];
+		foreach ($collectedData as $file => $dataPerCollector) {
+			foreach ($dataPerCollector as $collectorType => $rawData) {
+				$result[] = new CollectedData($rawData, $file, $collectorType);
+			}
+		}
+		return $result;
 	}
 
 	/**

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -2,13 +2,11 @@
 
 namespace PHPStan\Command;
 
-use PhpParser\Node;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\AnalyserResultFinalizer;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
 use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
 use PHPStan\Collectors\CollectedData;
-use PHPStan\Collectors\Collector;
 use PHPStan\Internal\BytesHelper;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\PhpDoc\StubValidator;
@@ -22,6 +20,9 @@ use function microtime;
 use function sha1_file;
 use function sprintf;
 
+/**
+ * @phpstan-import-type CollectorData from CollectedData
+ */
 final class AnalyseApplication
 {
 
@@ -164,7 +165,7 @@ final class AnalyseApplication
 	}
 
 	/**
-	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
+	 * @param CollectorData $collectedData
 	 *
 	 * @return list<CollectedData>
 	 */

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -226,8 +226,12 @@ final class WorkerCommand extends Command
 					foreach ($fileAnalyserResult->getLocallyIgnoredErrors() as $locallyIgnoredError) {
 						$locallyIgnoredErrors[] = $locallyIgnoredError;
 					}
-					foreach ($fileAnalyserResult->getCollectedData() as $data) {
-						$collectedData[] = $data;
+					foreach ($fileAnalyserResult->getCollectedData() as $collectedFile => $dataPerCollector) {
+						foreach ($dataPerCollector as $collectorType => $collectorData) {
+							foreach ($collectorData as $data) {
+								$collectedData[$collectedFile][$collectorType][] = $data;
+							}
+						}
 					}
 				} catch (Throwable $t) {
 					$internalErrorsCount++;

--- a/src/Node/CollectedDataNode.php
+++ b/src/Node/CollectedDataNode.php
@@ -4,16 +4,18 @@ namespace PHPStan\Node;
 
 use PhpParser\Node;
 use PhpParser\NodeAbstract;
+use PHPStan\Collectors\CollectedData;
 use PHPStan\Collectors\Collector;
 
 /**
  * @api
+ * @phpstan-import-type CollectorData from CollectedData
  */
 final class CollectedDataNode extends NodeAbstract implements VirtualNode
 {
 
 	/**
-	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
+	 * @param CollectorData $collectedData
 	 */
 	public function __construct(private array $collectedData, private bool $onlyFiles)
 	{

--- a/src/Node/CollectedDataNode.php
+++ b/src/Node/CollectedDataNode.php
@@ -4,9 +4,7 @@ namespace PHPStan\Node;
 
 use PhpParser\Node;
 use PhpParser\NodeAbstract;
-use PHPStan\Collectors\CollectedData;
 use PHPStan\Collectors\Collector;
-use function array_key_exists;
 
 /**
  * @api
@@ -15,7 +13,7 @@ final class CollectedDataNode extends NodeAbstract implements VirtualNode
 {
 
 	/**
-	 * @param CollectedData[] $collectedData
+	 * @param array<string, array<class-string<Collector<Node, mixed>>, list<mixed>>> $collectedData
 	 */
 	public function __construct(private array $collectedData, private bool $onlyFiles)
 	{
@@ -31,17 +29,14 @@ final class CollectedDataNode extends NodeAbstract implements VirtualNode
 	public function get(string $collectorType): array
 	{
 		$result = [];
-		foreach ($this->collectedData as $collectedData) {
-			if ($collectedData->getCollectorType() !== $collectorType) {
+		foreach ($this->collectedData as $filePath => $collectedDataPerCollector) {
+			if (!isset($collectedDataPerCollector[$collectorType])) {
 				continue;
 			}
 
-			$filePath = $collectedData->getFilePath();
-			if (!array_key_exists($filePath, $result)) {
-				$result[$filePath] = [];
+			foreach ($collectedDataPerCollector[$collectorType] as $rawData) {
+				$result[$filePath][] = $rawData;
 			}
-
-			$result[$filePath][] = $collectedData->getData();
 		}
 
 		return $result;

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -9,7 +9,6 @@ use Nette\Utils\Random;
 use PHPStan\Analyser\AnalyserResult;
 use PHPStan\Analyser\Error;
 use PHPStan\Analyser\InternalError;
-use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 use PHPStan\Process\ProcessHelper;
 use React\EventLoop\LoopInterface;
@@ -211,8 +210,12 @@ final class ParallelAnalyser
 					$locallyIgnoredErrors[] = $locallyIgnoredFileError;
 				}
 
-				foreach ($json['collectedData'] as $jsonData) {
-					$collectedData[] = CollectedData::decode($jsonData);
+				foreach ($json['collectedData'] as $file => $jsonDataByCollector) {
+					foreach ($jsonDataByCollector as $collectorType => $listOfCollectedData) {
+						foreach ($listOfCollectedData as $rawCollectedData) {
+							$collectedData[$file][$collectorType][] = $rawCollectedData;
+						}
+					}
 				}
 
 				/**


### PR DESCRIPTION
Previous state:
- for **each emit** inside Collector, **filepath and collector class is carried along the raw data**
  - this adds significant amount of bytes transferred and stored in result cache

New state:
- collected data are groupped by file & collector class
  - this causes significant improvement for projects like [Dead Code Detector](https://github.com/shipmonk-rnd/dead-code-detector) where we emit very often

Impact:
- my [old analysis](https://github.com/shipmonk-rnd/dead-code-detector/pull/30) where I made similar optimization in userland was:
  - filesize of `resultCache.php` dropped from `384M` to `213M` (**44%** down)
  - RAM usage dropped from `20.14 GB` to `19.52 GB`

