### PR TITLE
Call all involved class on TypeSpecifierAwareExtension

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -519,18 +519,27 @@ final class TypeSpecifier
 			$methodReflection = $scope->getMethodReflection($methodCalledOnType, $expr->name->name);
 			if ($methodReflection !== null) {
 				$referencedClasses = $methodCalledOnType->getObjectClassNames();
-				if (
-					count($referencedClasses) === 1
-					&& $this->reflectionProvider->hasClass($referencedClasses[0])
-				) {
-					$methodClassReflection = $this->reflectionProvider->getClass($referencedClasses[0]);
+				$specifiedTypes = null;
+				foreach ($referencedClasses as $referencedClass) {
+					if (!$this->reflectionProvider->hasClass($referencedClass)) {
+						continue;
+					}
+
+					$methodClassReflection = $this->reflectionProvider->getClass($referencedClass);
 					foreach ($this->getMethodTypeSpecifyingExtensionsForClass($methodClassReflection->getName()) as $extension) {
 						if (!$extension->isMethodSupported($methodReflection, $expr, $context)) {
 							continue;
 						}
 
-						return $extension->specifyTypes($methodReflection, $expr, $scope, $context);
+						if ($specifiedTypes !== null) {
+							$specifiedTypes = $specifiedTypes->unionWith($extension->specifyTypes($methodReflection, $expr, $scope, $context));
+						} else {
+							$specifiedTypes = $extension->specifyTypes($methodReflection, $expr, $scope, $context);
+						}
 					}
+				}
+				if ($specifiedTypes !== null) {
+					return $specifiedTypes;
 				}
 
 				// lazy create parametersAcceptor, as creation can be expensive
@@ -572,18 +581,27 @@ final class TypeSpecifier
 			$staticMethodReflection = $scope->getMethodReflection($calleeType, $expr->name->name);
 			if ($staticMethodReflection !== null) {
 				$referencedClasses = $calleeType->getObjectClassNames();
-				if (
-					count($referencedClasses) === 1
-					&& $this->reflectionProvider->hasClass($referencedClasses[0])
-				) {
-					$staticMethodClassReflection = $this->reflectionProvider->getClass($referencedClasses[0]);
+				$specifiedTypes = null;
+				foreach ($referencedClasses as $referencedClass) {
+					if (!$this->reflectionProvider->hasClass($referencedClass)) {
+						continue;
+					}
+
+					$staticMethodClassReflection = $this->reflectionProvider->getClass($referencedClass);
 					foreach ($this->getStaticMethodTypeSpecifyingExtensionsForClass($staticMethodClassReflection->getName()) as $extension) {
 						if (!$extension->isStaticMethodSupported($staticMethodReflection, $expr, $context)) {
 							continue;
 						}
 
-						return $extension->specifyTypes($staticMethodReflection, $expr, $scope, $context);
+						if ($specifiedTypes !== null) {
+							$specifiedTypes = $specifiedTypes->unionWith($extension->specifyTypes($staticMethodReflection, $expr, $scope, $context));
+						} else {
+							$specifiedTypes = $extension->specifyTypes($staticMethodReflection, $expr, $scope, $context);
+						}
 					}
+				}
+				if ($specifiedTypes !== null) {
+					return $specifiedTypes;
 				}
 
 				// lazy create parametersAcceptor, as creation can be expensive

--- a/tests/PHPStan/Analyser/MultipleTypeSpecifyingExtension.neon
+++ b/tests/PHPStan/Analyser/MultipleTypeSpecifyingExtension.neon
@@ -1,0 +1,21 @@
+services:
+	-
+		class: PHPStan\Tests\AssertionClassMethodTypeSpecifyingExtension
+		arguments:
+			nullContext: true
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+	-
+		class: PHPStan\Tests\AssertionClassStaticMethodTypeSpecifyingExtension
+		arguments:
+			nullContext: true
+		tags:
+			- phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension
+	-
+		class: PHPStan\Tests\AssertionClassMethodMultipleTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
+	-
+		class: PHPStan\Tests\AssertionClassStaticMethodMultipleTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.staticMethodTypeSpecifyingExtension

--- a/tests/PHPStan/Analyser/MultipleTypeSpecifyingExtensionTypeInferenceTest.php
+++ b/tests/PHPStan/Analyser/MultipleTypeSpecifyingExtensionTypeInferenceTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class MultipleTypeSpecifyingExtensionTypeInferenceTest extends TypeInferenceTestCase
+{
+
+	public function dataTypeSpecifyingExtensionsTrue(): iterable
+	{
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/multiple-type-specifying-extensions-1.php');
+	}
+
+	/**
+	 * @dataProvider dataTypeSpecifyingExtensionsTrue
+	 * @param mixed ...$args
+	 */
+	public function testTypeSpecifyingExtensionsTrue(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/MultipleTypeSpecifyingExtension.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/multiple-type-specifying-extensions-1.php
+++ b/tests/PHPStan/Analyser/data/multiple-type-specifying-extensions-1.php
@@ -1,0 +1,16 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+/** @var string|null $foo */
+$foo = null;
+
+/** @var int|null $bar */
+$bar = null;
+
+(new \PHPStan\Tests\AssertionClass())->assertString($foo);
+\PHPStan\Tests\AssertionClass::assertInt($bar);
+
+assertType('non-empty-string', $foo);
+assertType('int<1, max>', $bar);
+

--- a/tests/PHPStan/Tests/AssertionClassMethodMultipleTypeSpecifyingExtension.php
+++ b/tests/PHPStan/Tests/AssertionClassMethodMultipleTypeSpecifyingExtension.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Tests;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+
+class AssertionClassMethodMultipleTypeSpecifyingExtension implements MethodTypeSpecifyingExtension
+{
+
+	public function getClass(): string
+	{
+		return AssertionClass::class;
+	}
+
+	public function isMethodSupported(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		TypeSpecifierContext $context,
+	): bool
+	{
+		return $methodReflection->getName() === 'assertString';
+	}
+
+	public function specifyTypes(
+		MethodReflection $methodReflection,
+		MethodCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context,
+	): SpecifiedTypes
+	{
+		return new SpecifiedTypes(['$foo' => [$node->getArgs()[0]->value, new AccessoryNonEmptyStringType()]]);
+	}
+
+}

--- a/tests/PHPStan/Tests/AssertionClassStaticMethodMultipleTypeSpecifyingExtension.php
+++ b/tests/PHPStan/Tests/AssertionClassStaticMethodMultipleTypeSpecifyingExtension.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Tests;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
+
+class AssertionClassStaticMethodMultipleTypeSpecifyingExtension implements StaticMethodTypeSpecifyingExtension
+{
+
+	public function getClass(): string
+	{
+		return AssertionClass::class;
+	}
+
+	public function isStaticMethodSupported(
+		MethodReflection $staticMethodReflection,
+		StaticCall $node,
+		TypeSpecifierContext $context,
+	): bool
+	{
+		return $staticMethodReflection->getName() === 'assertInt';
+	}
+
+	public function specifyTypes(
+		MethodReflection $staticMethodReflection,
+		StaticCall $node,
+		Scope $scope,
+		TypeSpecifierContext $context,
+	): SpecifiedTypes
+	{
+		return new SpecifiedTypes(['$foo' => [$node->getArgs()[0]->value, IntegerRangeType::createAllGreaterThan(0)]]);
+	}
+
+}


### PR DESCRIPTION
See [ #12741](https://github.com/phpstan/phpstan/issues/12741)

For the moment, we only want to try a modification to see if existing tests passed. The next steps is to implement a test to reproduce the error then we'll re-implement the modification for real.

cc @ChinaskiJr