### PR TITLE
Excluded path: include example for optional path

### DIFF
--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -383,11 +383,13 @@ final class CommandHelper
 			if (count($suggestOptional) > 0) {
 				$errorOutput->writeLineFormatted('If the excluded path can sometimes exist, append <fg=cyan>(?)</>');
 				$errorOutput->writeLineFormatted('to its config entry to mark it as optional. Example:');
-				$errorOutput->writeLineFormatted('<fg=cyan>excludePaths:</>');
+				$errorOutput->writeLineFormatted('');
+				$errorOutput->writeLineFormatted('<fg=cyan>parameters:</>');
+				$errorOutput->writeLineFormatted("\t<fg=cyan>excludePaths:</>");
 				foreach ($suggestOptional as $key => $suggestOptionalPaths) {
-					$errorOutput->writeLineFormatted(sprintf('  <fg=cyan>%s:</>', $key));
+					$errorOutput->writeLineFormatted(sprintf("\t\t<fg=cyan>%s:</>", $key));
 					foreach ($suggestOptionalPaths as $suggestOptionalPath) {
-						$errorOutput->writeLineFormatted(sprintf('    - <fg=cyan>%s (?)</>', $suggestOptionalPath));
+						$errorOutput->writeLineFormatted(sprintf("\t\t\t- <fg=cyan>%s (?)</>", $suggestOptionalPath));
 					}
 				}
 				$errorOutput->writeLineFormatted('');

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -380,7 +380,8 @@ final class CommandHelper
 			}
 
 			$errorOutput->writeLineFormatted('If the excluded path can sometimes exist, append <fg=cyan>(?)</>');
-			$errorOutput->writeLineFormatted('to its config entry to mark it as optional.');
+			$errorOutput->writeLineFormatted('to its config entry to mark it as optional. Example:');
+			$errorOutput->writeLineFormatted(' <fg=cyan>- path/something (?)</>');
 			$errorOutput->writeLineFormatted('');
 
 			throw new InceptionNotSuccessfulException();

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -25,6 +25,7 @@ use PHPStan\ExtensionInstaller\GeneratedConfig;
 use PHPStan\File\FileExcluder;
 use PHPStan\File\FileFinder;
 use PHPStan\File\FileHelper;
+use PHPStan\File\ParentDirectoryRelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Internal\DirectoryCreator;
@@ -381,6 +382,10 @@ final class CommandHelper
 
 			$suggestOptional = $e->getSuggestOptional();
 			if (count($suggestOptional) > 0) {
+				$baselinePathHelper = null;
+				if ($projectConfigFile !== null) {
+					$baselinePathHelper = new ParentDirectoryRelativePathHelper(dirname($projectConfigFile));
+				}
 				$errorOutput->writeLineFormatted('If the excluded path can sometimes exist, append <fg=cyan>(?)</>');
 				$errorOutput->writeLineFormatted('to its config entry to mark it as optional. Example:');
 				$errorOutput->writeLineFormatted('');
@@ -389,7 +394,12 @@ final class CommandHelper
 				foreach ($suggestOptional as $key => $suggestOptionalPaths) {
 					$errorOutput->writeLineFormatted(sprintf("\t\t<fg=cyan>%s:</>", $key));
 					foreach ($suggestOptionalPaths as $suggestOptionalPath) {
-						$errorOutput->writeLineFormatted(sprintf("\t\t\t- <fg=cyan>%s (?)</>", $suggestOptionalPath));
+						if ($baselinePathHelper === null) {
+							$errorOutput->writeLineFormatted(sprintf("\t\t\t- <fg=cyan>%s (?)</>", $suggestOptionalPath));
+							continue;
+						}
+
+						$errorOutput->writeLineFormatted(sprintf("\t\t\t- <fg=cyan>%s (?)</>", $baselinePathHelper->getRelativePath($suggestOptionalPath)));
 					}
 				}
 				$errorOutput->writeLineFormatted('');

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -379,10 +379,19 @@ final class CommandHelper
 				$errorOutput->writeLineFormatted('');
 			}
 
-			$errorOutput->writeLineFormatted('If the excluded path can sometimes exist, append <fg=cyan>(?)</>');
-			$errorOutput->writeLineFormatted('to its config entry to mark it as optional. Example:');
-			$errorOutput->writeLineFormatted(' <fg=cyan>- path/something (?)</>');
-			$errorOutput->writeLineFormatted('');
+			$suggestOptional = $e->getSuggestOptional();
+			if (count($suggestOptional) > 0) {
+				$errorOutput->writeLineFormatted('If the excluded path can sometimes exist, append <fg=cyan>(?)</>');
+				$errorOutput->writeLineFormatted('to its config entry to mark it as optional. Example:');
+				$errorOutput->writeLineFormatted('<fg=cyan>excludePaths:</>');
+				foreach ($suggestOptional as $key => $suggestOptionalPaths) {
+					$errorOutput->writeLineFormatted(sprintf('  <fg=cyan>%s:</>', $key));
+					foreach ($suggestOptionalPaths as $suggestOptionalPath) {
+						$errorOutput->writeLineFormatted(sprintf('    - <fg=cyan>%s (?)</>', $suggestOptionalPath));
+					}
+				}
+				$errorOutput->writeLineFormatted('');
+			}
 
 			throw new InceptionNotSuccessfulException();
 		} catch (ValidationException $e) {

--- a/src/DependencyInjection/InvalidExcludePathsException.php
+++ b/src/DependencyInjection/InvalidExcludePathsException.php
@@ -10,8 +10,9 @@ final class InvalidExcludePathsException extends Exception
 
 	/**
 	 * @param string[] $errors
+	 * @param array{analyse?: list<string>, analyseAndScan?: list<string>} $suggestOptional
 	 */
-	public function __construct(private array $errors)
+	public function __construct(private array $errors, private array $suggestOptional)
 	{
 		parent::__construct(implode("\n", $this->errors));
 	}
@@ -22,6 +23,14 @@ final class InvalidExcludePathsException extends Exception
 	public function getErrors(): array
 	{
 		return $this->errors;
+	}
+
+	/**
+	 * @return array{analyse?: list<string>, analyseAndScan?: list<string>}
+	 */
+	public function getSuggestOptional(): array
+	{
+		return $this->suggestOptional;
 	}
 
 }

--- a/src/DependencyInjection/ValidateIgnoredErrorsExtension.php
+++ b/src/DependencyInjection/ValidateIgnoredErrorsExtension.php
@@ -168,7 +168,7 @@ final class ValidateIgnoredErrorsExtension extends CompilerExtension
 						continue;
 					}
 
-					$errors[] = sprintf('Path %s is neither a directory, nor a file path, nor a fnmatch pattern.', $ignorePath);
+					$errors[] = sprintf('Path "%s" is neither a directory, nor a file path, nor a fnmatch pattern.', $ignorePath);
 				}
 			}
 		}


### PR DESCRIPTION
Make more clear how to mark an excluded path optional, with the use of `(?)` suffix