### PR TITLE
ResultCacheManager: fix meta key difference for projectConfig

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -312,17 +312,26 @@ final class ResultCacheManager
 	}
 
 	/**
+	 * @param mixed[]|null $projectConfig
+	 */
+	private function normalizeMetaProjectConfig(?array $projectConfig): ?string
+	{
+		if ($projectConfig !== null) {
+			ksort($projectConfig);
+
+			return Neon::encode($projectConfig);
+		}
+
+		return null;
+	}
+
+	/**
 	 * @param mixed[] $cachedMeta
 	 * @param mixed[] $currentMeta
 	 */
 	private function isMetaDifferent(array $cachedMeta, array $currentMeta): bool
 	{
-		$projectConfig = $currentMeta['projectConfig'];
-		if ($projectConfig !== null) {
-			ksort($currentMeta['projectConfig']);
-
-			$currentMeta['projectConfig'] = Neon::encode($currentMeta['projectConfig']);
-		}
+		$currentMeta['projectConfig'] = $this->normalizeMetaProjectConfig($currentMeta['projectConfig']);
 
 		return $cachedMeta !== $currentMeta;
 	}
@@ -337,6 +346,10 @@ final class ResultCacheManager
 	{
 		$diffs = [];
 		foreach ($cachedMeta as $key => $value) {
+			if ($key === 'projectConfig') {
+				$value = $this->normalizeMetaProjectConfig($value);
+			}
+
 			if (!array_key_exists($key, $currentMeta)) {
 				$diffs[] = $key;
 				continue;


### PR DESCRIPTION
Previously, `projectConfig` was **always reported as different** because if was comparing neon string with array:

![image](https://github.com/user-attachments/assets/474854f5-e2c9-47fe-ae2d-d61970cd8081)
