### PR TITLE
Fix elapsed time format for result cache restore time

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -37,7 +37,6 @@ use function is_array;
 use function is_file;
 use function ksort;
 use function microtime;
-use function round;
 use function sha1_file;
 use function sort;
 use function sprintf;

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -297,7 +297,7 @@ final class ResultCacheManager
 		if ($output->isVeryVerbose()) {
 			$elapsed = microtime(true) - $startTime;
 			$elapsedString = $elapsed > 5
-				? sprintf(' in %f seconds', round($elapsed, 1))
+				? sprintf(' in %.1f seconds', $elapsed)
 				: '';
 
 			$output->writeLineFormatted(sprintf(


### PR DESCRIPTION
Before: `Result cache restored in 6.400000 seconds.`
Now: `Result cache restored in 6.4 seconds.`