### PR TITLE
RegexGroupParser - cache regex parsing results

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -43,6 +43,7 @@ final class RegexGroupParser
 
 	private static ?Parser $parser = null;
 
+	/** @var array<string, array{array<int, RegexCapturingGroup>, list<string>}|null> */
 	private static array $resultCache = [];
 
 	public function __construct(
@@ -261,7 +262,7 @@ final class RegexGroupParser
 			$astWalkResult = $astWalkResult->addCapturingGroup($group);
 
 			if ($alternation !== null) {
-				$alternation->pushGroup($combinationIndex, $group);
+				$alternation = $alternation->pushGroup($combinationIndex, $group);
 			}
 		}
 

--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -20,6 +20,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use function array_key_exists;
 use function array_values;
 use function count;
 use function in_array;
@@ -42,6 +43,8 @@ final class RegexGroupParser
 
 	private static ?Parser $parser = null;
 
+	private static array $resultCache = [];
+
 	public function __construct(
 		private PhpVersion $phpVersion,
 		private RegexExpressionHelper $regexExpressionHelper,
@@ -53,6 +56,18 @@ final class RegexGroupParser
 	 * @return array{array<int, RegexCapturingGroup>, list<string>}|null
 	 */
 	public function parseGroups(string $regex): ?array
+	{
+		if (array_key_exists($regex, self::$resultCache)) {
+			return self::$resultCache[$regex];
+		}
+
+		return self::$resultCache[$regex] = $this->parse($regex);
+	}
+
+	/**
+	 * @return array{array<int, RegexCapturingGroup>, list<string>}|null
+	 */
+	private function parse(string $regex): ?array
 	{
 		if (self::$parser === null) {
 			/** @throws void */


### PR DESCRIPTION
running https://github.com/phpstan/phpstan-src/blob/327ac3e54bd04d85aec3af9f893f8e3e8f38af7d/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php 

before this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyze test.php --debug' -i
Benchmark 1: php bin/phpstan analyze test.php --debug
  Time (mean ± σ):      1.677 s ±  0.007 s    [User: 1.563 s, System: 0.110 s]
  Range (min … max):    1.666 s …  1.685 s    10 runs
```

after this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyze test.php --debug' -i
Benchmark 1: php bin/phpstan analyze test.php --debug
  Time (mean ± σ):      1.280 s ±  0.018 s    [User: 1.165 s, System: 0.111 s]
  Range (min … max):    1.264 s …  1.311 s    10 runs
```
