### PR TITLE
Fix condition of fall-through case not used for exhaustive checks

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-11064.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11064.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11064;
+
+use function PHPStan\Testing\assertType;
+
+interface IClass {}
+class ClassA implements IClass {}
+class ClassB implements IClass {}
+
+/**
+ * @param null|'nil'|IClass $val
+ */
+function test($val): string {
+	switch (true) {
+		case $val === null:
+		case $val === 'nil':
+			assertType("'nil'|null", $val);
+			return 'null';
+
+		case $val instanceof ClassA:
+			assertType('Bug11064\\ClassA', $val);
+			return 'class a';
+
+		default:
+			assertType('Bug11064\\IClass~Bug11064\\ClassA', $val);
+			throw new RuntimeException('unsupported class: ' . get_class($val));
+	}
+}
+

--- a/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
+++ b/tests/PHPStan/Rules/Missing/MissingReturnRuleTest.php
@@ -343,4 +343,25 @@ class MissingReturnRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9374.php'], []);
 	}
 
+	public function testBug3488Two(): void
+	{
+		$this->checkExplicitMixedMissingReturn = true;
+		$this->analyse([__DIR__ . '/data/bug-3488-2.php'], [
+			[
+				'Method Bug3488\C::invalidCase() should return int but return statement is missing.',
+				30,
+			],
+		]);
+	}
+
+	public function testBug12722(): void
+	{
+		if (PHP_VERSION_ID < 80100) {
+			$this->markTestSkipped('Test requires PHP 8.1.');
+		}
+
+		$this->checkExplicitMixedMissingReturn = true;
+		$this->analyse([__DIR__ . '/data/bug-12722.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Missing/data/bug-12722.php
+++ b/tests/PHPStan/Rules/Missing/data/bug-12722.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace Bug12722;
+
+enum states {
+	case state1;
+	case statealmost1;
+	case state3;
+}
+
+class HelloWorld
+{
+	public function intentional_fallthrough(states $state): int
+	{
+		switch($state) {
+
+			case states::state1: //intentional fall-trough this case...
+			case states::statealmost1: return 1;
+			case states::state3: return 3;
+		}
+	}
+
+	public function no_fallthrough(states $state): int
+	{
+		switch($state) {
+
+			case states::state1: return 1;
+			case states::statealmost1: return 1;
+			case states::state3: return 3;
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Missing/data/bug-3488-2.php
+++ b/tests/PHPStan/Rules/Missing/data/bug-3488-2.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3488;
+
+interface I {
+	const THING_A = 'a';
+	const THING_B = 'b';
+	const THING_C = 'c';
+}
+
+class C
+{
+	/**
+	 * @param I::THING_* $thing
+	 */
+	public function allCovered(string $thing): int
+	{
+		switch ($thing) { // should not error
+			case I::THING_A:
+			case I::THING_B:
+			case I::THING_C:
+				return 0;
+		}
+	}
+	/**
+	 * @param I::THING_* $thing
+	 */
+	public function invalidCase(string $thing): int
+	{
+		switch ($thing) {
+			case I::THING_A:
+			case I::THING_B:
+				return 0;
+			case 'd':
+				throw new Exception('The error marker should be on the line above');
+		}
+	}
+	/**
+	 * @param I::THING_* $thing
+	 */
+	public function defaultUnnecessary(string $thing): int
+	{
+		switch ($thing) {
+			case I::THING_A:
+			case I::THING_B:
+			case I::THING_C:
+				return 0;
+			default:
+				throw new Exception('This should be detected as unreachable');
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1068,4 +1068,13 @@ class DefinedVariableRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10228.php'], []);
 	}
 
+	public function testBug8719(): void
+	{
+		$this->cliArgumentsVariablesRegistered = true;
+		$this->polluteScopeWithLoopInitialAssignments = true;
+		$this->checkMaybeUndefinedVariables = true;
+		$this->polluteScopeWithAlwaysIterableForeach = true;
+		$this->analyse([__DIR__ . '/data/bug-8719.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -277,10 +277,12 @@ class IssetRuleTest extends RuleTestCase
 				112,
 			],
 			[
-				'Variable $variableInFirstCase in isset() always exists and is not nullable.',
+				// could be Variable $variableInFirstCase in isset() always exists and is not nullable.
+				'Variable $variableInFirstCase in isset() is never defined.',
 				116,
 			],
 			[
+				// could be Variable $variableInSecondCase in isset() always exists and is not nullable.
 				'Variable $variableInSecondCase in isset() is never defined.',
 				117,
 			],

--- a/tests/PHPStan/Rules/Variables/data/bug-8719.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-8719.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8719;
+
+class HelloWorld
+{
+	private const CASE_1 = 1;
+	private const CASE_2 = 2;
+	private const CASE_3 = 3;
+
+	/**
+	 * @return self::CASE_*
+	 */
+	private function getCase(): int
+	{
+		return random_int(1,3);
+	}
+
+	public function ok(): string
+	{
+		switch($this->getCase()) {
+			case self::CASE_1:
+				$foo = 'bar';
+				break;
+			case self::CASE_2:
+				$foo = 'baz';
+				break;
+			case self::CASE_3:
+				$foo = 'barbaz';
+				break;
+		}
+
+		return $foo;
+	}
+
+	public function not_ok(): string
+	{
+		switch($this->getCase()) {
+			case self::CASE_1:
+				$foo = 'bar';
+				break;
+			case self::CASE_2:
+			case self::CASE_3:
+				$foo = 'barbaz';
+				break;
+		}
+
+		return $foo;
+	}
+}


### PR DESCRIPTION
Fix phpstan/phpstan#11064. Unfortunately this causes a regression elsewhere, which by the looks of it already didn't work completely.

The problem there is that the assignment is forgotten because of the `$scopeForBranches = $scopeForBranches->filterByFalseyValue($fullCondExpr)`.