### PR TITLE
Fix narrowing of superglobals

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/superglobals.php
+++ b/tests/PHPStan/Analyser/nsrt/superglobals.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Superglobals;
+
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+class Superglobals
+{
+
+	public function originalTypes(): void
+	{
+		assertType('array<mixed>', $GLOBALS);
+		assertType('array<mixed>', $_SERVER);
+		assertType('array<mixed>', $_GET);
+		assertType('array<mixed>', $_POST);
+		assertType('array<mixed>', $_FILES);
+		assertType('array<mixed>', $_COOKIE);
+		assertType('array<mixed>', $_SESSION);
+		assertType('array<mixed>', $_REQUEST);
+		assertType('array<mixed>', $_ENV);
+	}
+
+	public function canBeOverwritten(): void
+	{
+		$GLOBALS = [];
+		assertType('array{}', $GLOBALS);
+		assertNativeType('array{}', $GLOBALS);
+	}
+
+	public function canBePartlyOverwritten(): void
+	{
+		$GLOBALS['foo'] = 'foo';
+		assertType("non-empty-array&hasOffsetValue('foo', 'foo')", $GLOBALS);
+		assertNativeType("non-empty-array&hasOffsetValue('foo', 'foo')", $GLOBALS);
+	}
+
+	public function canBeNarrowed(): void
+	{
+		if (isset($GLOBALS['foo'])) {
+			assertType("non-empty-array&hasOffsetValue('foo', mixed~null)", $GLOBALS);
+			assertNativeType("non-empty-array<mixed>&hasOffset('foo')", $GLOBALS); // https://github.com/phpstan/phpstan/issues/8395
+		} else {
+			assertType('array<mixed>', $GLOBALS);
+			assertNativeType('array<mixed>', $GLOBALS);
+		}
+		assertType('array<mixed>', $GLOBALS);
+		assertNativeType('array<mixed>', $GLOBALS);
+	}
+
+}
+
+function functionScope() {
+	assertType('array<mixed>', $GLOBALS);
+	assertNativeType('array<mixed>', $GLOBALS);
+}
+
+assertType('array<mixed>', $GLOBALS);
+assertNativeType('array<mixed>', $GLOBALS);
+
+function badNarrowing() {
+	if (empty($_GET['id'])) {
+		echo "b";
+	} else {
+		echo "b";
+	}
+	assertType('array<mixed>', $_GET);
+	assertType('mixed', $_GET['id']);
+};

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1001,4 +1001,9 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12772(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12772.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-12772.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-12772.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12772;
+
+class HelloWorld
+{
+	public function sayHello(DateTimeImutable $date): void
+	{
+		foreach ($tables as $table) {
+
+			// If view exists, and 'add drop view' is selected: Drop it!
+			if ($_POST['what'] !== 'nocopy' && isset($_POST['drop_if_exists']) && $_POST['drop_if_exists'] === 'true') {
+
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -473,4 +473,11 @@ class IssetRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9328.php'], []);
 	}
 
+	public function testBug12771(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+
+		$this->analyse([__DIR__ . '/data/bug-12771.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-12771.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-12771.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Bug12771;
+
+final class ErrorReportController
+{
+
+	public function __invoke(ServerRequest $request)
+	{
+		if (
+			isset($_SESSION['prev_error_subm_time'], $_SESSION['error_subm_count'])
+			&& $_SESSION['error_subm_count'] >= 3
+			&& ($_SESSION['prev_error_subm_time'] - time()) <= 3000
+		) {
+			$_SESSION['error_subm_count'] = 0;
+			$_SESSION['prev_errors'] = '';
+		} else {
+			$_SESSION['prev_error_subm_time'] = time();
+			$_SESSION['error_subm_count'] = isset($_SESSION['error_subm_count'])
+				? $_SESSION['error_subm_count'] + 1
+				: 0;
+		}
+
+	}
+}


### PR DESCRIPTION
Improvements of https://github.com/phpstan/phpstan-src/pull/3871, pulling in parts of https://github.com/phpstan/phpstan-src/pull/3762 basically

Fixes https://github.com/phpstan/phpstan/issues/12771
Fixes https://github.com/phpstan/phpstan/issues/12772
Maybe fixes https://github.com/phpstan/phpstan/issues/12776

I did not take over the changes where the expressions are passed over through classes, functions and namespaces in scopes. Those would deal with some edge cases, but not sure if it's worth.

fyi @staabm 