### PR TITLE
Limit int ranges when narrowing arrays via `count()`

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1542,6 +1542,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug12787(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12787.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-12787.php
+++ b/tests/PHPStan/Analyser/data/bug-12787.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12787;
+
+class HelloWorld
+{
+	protected const MAX_COUNT = 100000000;
+
+	/**
+	 * @return string[]
+	 */
+	public function accumulate(): array
+	{
+		$items = [];
+
+		do {
+			$items[] = 'something';
+		} while (count($items) < self::MAX_COUNT);
+
+		return $items;
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -341,12 +341,15 @@ class CountWithOptionalKeys
 
 	/**
 	 * @param array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null} $row
+	 * @param list<string> $listRow
 	 * @param int<2, 3> $twoOrThree
 	 * @param int<2, max> $twoOrMore
 	 * @param int<min, 3> $maxThree
 	 * @param int<10, 11> $tenOrEleven
+	 * @param int<3, 32> $threeOrMoreInRangeLimit
+	 * @param int<3, 512> $threeOrMoreOverRangeLimit
 	 */
-	protected function testOptionalKeysInUnionListWithIntRange($row, $twoOrThree, $twoOrMore, int $maxThree, $tenOrEleven): void
+	protected function testOptionalKeysInUnionListWithIntRange($row, $listRow, $twoOrThree, $twoOrMore, int $maxThree, $tenOrEleven, $threeOrMoreInRangeLimit, $threeOrMoreOverRangeLimit): void
 	{
 		if (count($row) >= $twoOrThree) {
 			assertType('array{0: int, 1: string|null, 2?: int|null}', $row);
@@ -370,6 +373,30 @@ class CountWithOptionalKeys
 			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
 		} else {
 			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+		}
+
+		if (count($row) >= $threeOrMoreInRangeLimit) {
+			assertType('list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+		} else {
+			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+		}
+
+		if (count($listRow) >= $threeOrMoreInRangeLimit) {
+			assertType('list{0: string, 1: string, 2: string, 3?: string, 4?: string, 5?: string, 6?: string, 7?: string, 8?: string, 9?: string, 10?: string, 11?: string, 12?: string, 13?: string, 14?: string, 15?: string, 16?: string, 17?: string, 18?: string, 19?: string, 20?: string, 21?: string, 22?: string, 23?: string, 24?: string, 25?: string, 26?: string, 27?: string, 28?: string, 29?: string, 30?: string, 31?: string}', $listRow);
+		} else {
+			assertType('list<string>', $listRow);
+		}
+
+		if (count($row) >= $threeOrMoreOverRangeLimit) {
+			assertType('list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+		} else {
+			assertType('array{string}|list{0: int, 1?: string|null, 2?: int|null, 3?: float|null}', $row);
+		}
+
+		if (count($listRow) >= $threeOrMoreOverRangeLimit) {
+			assertType('non-empty-list<string>', $listRow);
+		} else {
+			assertType('list<string>', $listRow);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/12787

for const ints a limit existed already.