### PR TITLE
fix union/intersect involving enum case

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1693,12 +1693,6 @@ parameters:
 			path: src/Type/TypeCombinator.php
 
 		-
-			message: '#^Doing instanceof PHPStan\\Type\\Enum\\EnumCaseObjectType is error\-prone and deprecated\. Use Type\:\:getEnumCases\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 2
-			path: src/Type/TypeCombinator.php
-
-		-
 			message: '#^Doing instanceof PHPStan\\Type\\FloatType is error\-prone and deprecated\. Use Type\:\:isFloat\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1693,6 +1693,12 @@ parameters:
 			path: src/Type/TypeCombinator.php
 
 		-
+			message: '#^Doing instanceof PHPStan\\Type\\Enum\\EnumCaseObjectType is error\-prone and deprecated\. Use Type\:\:getEnumCases\(\) instead\.$#'
+			identifier: phpstanApi.instanceofType
+			count: 2
+			path: src/Type/TypeCombinator.php
+
+		-
 			message: '#^Doing instanceof PHPStan\\Type\\FloatType is error\-prone and deprecated\. Use Type\:\:isFloat\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 1

--- a/src/Type/Enum/EnumCaseObjectType.php
+++ b/src/Type/Enum/EnumCaseObjectType.php
@@ -18,6 +18,7 @@ use PHPStan\Type\CompoundType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IsSuperTypeOfResult;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\SubtractableType;
 use PHPStan\Type\Type;
@@ -94,7 +95,7 @@ class EnumCaseObjectType extends ObjectType
 
 	public function subtract(Type $type): Type
 	{
-		return $this;
+		return $this->changeSubtractedType($type);
 	}
 
 	public function getTypeWithoutSubtractedType(): Type
@@ -104,7 +105,11 @@ class EnumCaseObjectType extends ObjectType
 
 	public function changeSubtractedType(?Type $subtractedType): Type
 	{
-		return $this;
+		if ($subtractedType === null || ! $this->equals($subtractedType)) {
+			return $this;
+		}
+
+		return new NeverType();
 	}
 
 	public function getSubtractedType(): ?Type

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -18,6 +18,7 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateArrayType;
 use PHPStan\Type\Generic\TemplateBenevolentUnionType;
@@ -539,7 +540,7 @@ final class TypeCombinator
 			return $type;
 		}
 
-		if ($type instanceof SubtractableType) {
+		if ($type instanceof SubtractableType && ! $type instanceof EnumCaseObjectType) {
 			$subtractedType = $type->getSubtractedType() === null
 				? $subtractedType
 				: self::union($type->getSubtractedType(), $subtractedType);
@@ -595,7 +596,7 @@ final class TypeCombinator
 			}
 
 			$subtractedType = self::union(...$subtractedTypes);
-		} elseif ($b instanceof SubtractableType) {
+		} elseif ($b instanceof SubtractableType && ! $b instanceof EnumCaseObjectType) {
 			$subtractedType = $b->getSubtractedType();
 			if ($subtractedType === null) {
 				return $a->getTypeWithoutSubtractedType();

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -18,7 +18,6 @@ use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateArrayType;
 use PHPStan\Type\Generic\TemplateBenevolentUnionType;
@@ -540,7 +539,7 @@ final class TypeCombinator
 			return $type;
 		}
 
-		if ($type instanceof SubtractableType && ! $type instanceof EnumCaseObjectType) {
+		if ($type instanceof SubtractableType) {
 			$subtractedType = $type->getSubtractedType() === null
 				? $subtractedType
 				: self::union($type->getSubtractedType(), $subtractedType);
@@ -596,17 +595,31 @@ final class TypeCombinator
 			}
 
 			$subtractedType = self::union(...$subtractedTypes);
-		} elseif ($b instanceof SubtractableType && ! $b instanceof EnumCaseObjectType) {
-			$subtractedType = $b->getSubtractedType();
-			if ($subtractedType === null) {
-				return $a->getTypeWithoutSubtractedType();
-			}
 		} else {
-			$subtractedTypeTmp = self::intersect($a->getTypeWithoutSubtractedType(), $a->getSubtractedType());
-			if ($b->isSuperTypeOf($subtractedTypeTmp)->yes()) {
-				return $a->getTypeWithoutSubtractedType();
+			$isBAlreadySubtracted = $a->getSubtractedType()->isSuperTypeOf($b);
+
+			if ($isBAlreadySubtracted->no()) {
+				return $a;
+			} elseif ($isBAlreadySubtracted->yes()) {
+				$subtractedType = self::remove($a->getSubtractedType(), $b);
+
+				if ($subtractedType instanceof NeverType) {
+					$subtractedType = null;
+				}
+
+				return $a->changeSubtractedType($subtractedType);
+			} elseif ($b instanceof SubtractableType) {
+				$subtractedType = $b->getSubtractedType();
+				if ($subtractedType === null) {
+					return $a->getTypeWithoutSubtractedType();
+				}
+			} else {
+				$subtractedTypeTmp = self::intersect($a->getTypeWithoutSubtractedType(), $a->getSubtractedType());
+				if ($b->isSuperTypeOf($subtractedTypeTmp)->yes()) {
+					return $a->getTypeWithoutSubtractedType();
+				}
+				$subtractedType = new MixedType(false, $b);
 			}
-			$subtractedType = new MixedType(false, $b);
 		}
 
 		$subtractedType = self::intersect(

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8105,11 +8105,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$array',
 			],
 			[
-				'non-empty-array&hasOffsetValue(\'key\', mixed)',
+				'non-empty-array&hasOffsetValue(\'key\', mixed~null)',
 				'$generalArray',
 			],
 			[
-				'mixed',
+				'mixed~null',
 				'$generalArray[\'key\']',
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/enum-vs-in-array.php
+++ b/tests/PHPStan/Analyser/nsrt/enum-vs-in-array.php
@@ -1,0 +1,43 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace EnumVsInArray;
+
+use function PHPStan\Testing\assertType;
+
+enum FooEnum
+{
+	case A;
+	case B;
+	case C;
+	case D;
+	case E;
+	case F;
+	case G;
+	case H;
+	case I;
+	case J;
+}
+
+function foo(FooEnum $e): int
+{
+	if (in_array($e, [FooEnum::A, FooEnum::B, FooEnum::C], true)) {
+		throw new \Exception('a');
+	}
+
+	assertType('EnumVsInArray\FooEnum~(EnumVsInArray\FooEnum::A|EnumVsInArray\FooEnum::B|EnumVsInArray\FooEnum::C)', $e);
+
+	if (rand(0, 10) === 1) {
+		if (!in_array($e, [FooEnum::D, FooEnum::E], true)) {
+			throw new \Exception('d');
+		}
+	}
+
+	assertType('EnumVsInArray\FooEnum~(EnumVsInArray\FooEnum::A|EnumVsInArray\FooEnum::B|EnumVsInArray\FooEnum::C)', $e);
+
+	return match ($e) {
+		FooEnum::D, FooEnum::E, FooEnum::F, FooEnum::G, FooEnum::H, FooEnum::I => 2,
+		FooEnum::J => 3,
+	};
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1069,7 +1069,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 					new ObjectWithoutClassType(new ObjectType('A')),
 				],
 				MixedType::class,
-				'mixed=implicit',
+				'mixed~int=implicit',
 			],
 			[
 				[
@@ -1125,7 +1125,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 					new ObjectType('InvalidArgumentException'),
 				],
 				MixedType::class,
-				'mixed=implicit', // should be MixedType~Exception+InvalidArgumentException
+				'mixed~Exception~InvalidArgumentException=implicit',
 			],
 			[
 				[

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2264,6 +2264,36 @@ class TypeCombinatorTest extends PHPStanTestCase
 
 		yield [
 			[
+				new ObjectType('PHPStan\Fixture\ManyCasesTestEnum', new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
+				])),
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'C'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'D'),
+				]),
+			],
+			ObjectType::class,
+			'PHPStan\Fixture\ManyCasesTestEnum~(PHPStan\Fixture\ManyCasesTestEnum::A|PHPStan\Fixture\ManyCasesTestEnum::B)',
+		];
+
+		yield [
+			[
+				new ObjectType('PHPStan\Fixture\ManyCasesTestEnum', new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
+				])),
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'D'),
+				]),
+			],
+			ObjectType::class,
+			'PHPStan\Fixture\ManyCasesTestEnum~PHPStan\Fixture\ManyCasesTestEnum::B',
+		];
+
+		yield [
+			[
 				new ThisType(
 					$reflectionProvider->getClass(\ThisSubtractable\Foo::class), // phpcs:ignore
 					new UnionType([new ObjectType(\ThisSubtractable\Bar::class), new ObjectType(\ThisSubtractable\Baz::class)]), // phpcs:ignore
@@ -4222,6 +4252,27 @@ class TypeCombinatorTest extends PHPStanTestCase
 			],
 			IntersectionType::class,
 			'$this(stdClass)&stdClass::foo',
+		];
+
+		yield [
+			[
+				new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+				new MixedType(false, new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A')),
+			],
+			NeverType::class,
+			'*NEVER*=implicit',
+		];
+
+		yield [
+			[
+				new UnionType([
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A'),
+					new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'B'),
+				]),
+				new MixedType(false, new EnumCaseObjectType('PHPStan\Fixture\ManyCasesTestEnum', 'A')),
+			],
+			EnumCaseObjectType::class,
+			'PHPStan\Fixture\ManyCasesTestEnum::B',
 		];
 
 		yield [


### PR DESCRIPTION
Fixes https://phpstan.org/r/2bf03c1e-d38f-4d1d-9d67-0b4ace5e1629

IMO the real issue is that `EnumCaseObjectType` should not be `SubtractableType` (i.e. there is nothing to subtract from it, other than itself which should then be `NeverType`). Unfortunately, it inherits `SubtractableType` implementation from `ObjectType`. I checked the other types and the only other suspicious "subtractable" type I found is `ErrorType` (it doesn't subtract anything).

I'm not sure what the best way to fix it is. Phpstorm found just 15 usages of `instanceof SubtractableType`. So a quick and dirty fix along the lines I did could probably be feasible (at least in the short term). I was thinking e.g. adding `isReallySubtractable(): bool` to `SubtractableType`, or having `isSubtractableType(Type): bool` somewhere, ... For now I did just the minimal changes necessary to make the tests pass, but the other usages may also be causing bugs.

OFC a proper fix would be to get rid of the inheritance. Since PHPStorm reports `instanceof ...Type` as errors, I assume that is the long-term plan. But given that `ObjectType` is >1600 lines, I don't think that I have enough experience to tackle that.

Please let me know what you think. If you say that I should just wait until the inheritance is removed then that's fine with me.
