### PR TITLE
Add stringable access check to ClassConstantRule

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -1,6 +1,7 @@
 parameters:
 	featureToggles:
 		bleedingEdge: true
+		checkNonStringableDynamicAccess: true
 		checkParameterCastableToNumberFunctions: true
 		skipCheckGenericClasses!: []
 		stricterFunctionMap: true

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -17,9 +17,6 @@ conditionalTags:
 
 services:
 	-
-		class: PHPStan\Rules\Classes\ClassConstantRule
-
-	-
 		class: PHPStan\Rules\Classes\NewStaticInAbstractClassStaticMethodRule
 
 	-

--- a/conf/config.level0.neon
+++ b/conf/config.level0.neon
@@ -17,6 +17,9 @@ conditionalTags:
 
 services:
 	-
+		class: PHPStan\Rules\Classes\ClassConstantRule
+
+	-
 		class: PHPStan\Rules\Classes\NewStaticInAbstractClassStaticMethodRule
 
 	-

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -24,6 +24,7 @@ parameters:
 			tooWideThrowType: true
 	featureToggles:
 		bleedingEdge: false
+		checkNonStringableDynamicAccess: false
 		checkParameterCastableToNumberFunctions: false
 		skipCheckGenericClasses: []
 		stricterFunctionMap: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -28,6 +28,7 @@ parametersSchema:
 	])
 	featureToggles: structure([
 		bleedingEdge: bool(),
+		checkNonStringableDynamicAccess: bool(),
 		checkParameterCastableToNumberFunctions: bool(),
 		skipCheckGenericClasses: listOf(string()),
 		stricterFunctionMap: bool()

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -76,9 +76,8 @@ final class ClassConstantRule implements Rule
 					static fn (Type $type) => $type->isString()->yes(),
 				);
 
-				$type = $nameTypeResult->getType();
-
-				if (!$type->isString()->yes()) {
+				$nameType = $nameTypeResult->getType();
+				if (!$nameType instanceof ErrorType && !$nameType->isString()->yes()) {
 					$className = $node->class instanceof Name
 						? $scope->resolveName($node->class)
 						: $scope->getType($node->class)->describe(VerbosityLevel::typeOnly());

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -67,14 +67,14 @@ final class ClassConstantRule implements Rule
 			}
 
 			if ($this->checkNonStringableDynamicAccess) {
-				$typeResult = $this->ruleLevelHelper->findTypeToCheck(
+				$nameTypeResult = $this->ruleLevelHelper->findTypeToCheck(
 					$scope,
 					$node->name,
 					'',
 					static fn (Type $type) => $type->isString()->yes(),
 				);
 
-				$type = $typeResult->getType();
+				$type = $nameTypeResult->getType();
 
 				if (!$type->isString()->yes()) {
 					$className = $node->class instanceof Name

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -81,8 +81,8 @@ final class ClassConstantRule implements Rule
 						? $scope->resolveName($node->class)
 						: $scope->getType($node->class)->describe(VerbosityLevel::typeOnly());
 
-					$errors[] = RuleErrorBuilder::message(sprintf('Cannot fetch constant from %s with a non-stringable type %s.', $className, $nameType->describe(VerbosityLevel::precise())))
-						->identifier('classConstant.fetchInvalidExpression')
+					$errors[] = RuleErrorBuilder::message(sprintf('Class constant name for %s must be a string, but %s was given.', $className, $nameType->describe(VerbosityLevel::precise())))
+						->identifier('classConstant.nameNotString')
 						->build();
 				}
 			}

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Classes;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
@@ -76,7 +77,11 @@ final class ClassConstantRule implements Rule
 				$type = $typeResult->getType();
 
 				if (!$type->isString()->yes()) {
-					$errors[] = RuleErrorBuilder::message(sprintf('Cannot fetch class constant with a non-stringable type %s.', $nameType->describe(VerbosityLevel::precise())))
+					$className = $node->class instanceof Name
+						? $scope->resolveName($node->class)
+						: $scope->getType($node->class)->describe(VerbosityLevel::typeOnly());
+
+					$errors[] = RuleErrorBuilder::message(sprintf('Cannot fetch constant from %s with a non-stringable type %s.', $className, $nameType->describe(VerbosityLevel::precise())))
 						->identifier('classConstant.fetchInvalidExpression')
 						->build();
 				}

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -42,6 +42,7 @@ final class ClassConstantRule implements Rule
 		private RuleLevelHelper $ruleLevelHelper,
 		private ClassNameCheck $classCheck,
 		private PhpVersion $phpVersion,
+		private bool $checkNonStringableDynamicAccess = true,
 	)
 	{
 	}
@@ -62,6 +63,23 @@ final class ClassConstantRule implements Rule
 			foreach ($nameType->getConstantStrings() as $constantString) {
 				$name = $constantString->getValue();
 				$constantNameScopes[$name] = $scope->filterByTruthyValue(new Identical($node->name, new String_($name)));
+			}
+
+			if ($this->checkNonStringableDynamicAccess) {
+				$typeResult = $this->ruleLevelHelper->findTypeToCheck(
+					$scope,
+					$node->name,
+					'',
+					static fn (Type $type) => $type->isString()->yes(),
+				);
+
+				$type = $typeResult->getType();
+
+				if (!$type->isString()->yes()) {
+					$errors[] = RuleErrorBuilder::message(sprintf('Cannot fetch class constant with a non-stringable type %s.', $nameType->describe(VerbosityLevel::precise())))
+						->identifier('classConstant.fetchInvalidExpression')
+						->build();
+				}
 			}
 		}
 

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Internal\SprintfHelper;
 use PHPStan\Php\PhpVersion;
@@ -43,7 +44,8 @@ final class ClassConstantRule implements Rule
 		private RuleLevelHelper $ruleLevelHelper,
 		private ClassNameCheck $classCheck,
 		private PhpVersion $phpVersion,
-		private bool $checkNonStringableDynamicAccess = true,
+		#[AutowiredParameter(ref: '%featureToggles.checkNonStringableDynamicAccess%')]
+		private bool $checkNonStringableDynamicAccess,
 	)
 	{
 	}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -449,7 +449,7 @@ class ClassConstantRuleTest extends RuleTestCase
 				17,
 			],
 			[
-				'Cannot fetch class constant with a non-stringable type object.',
+				'Cannot fetch constant from ClassConstantDynamicAccess\Foo with a non-stringable type object.',
 				19,
 			],
 			[
@@ -494,32 +494,52 @@ class ClassConstantRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/dynamic-constant-stringable-access.php'], [
 			[
-				'Cannot fetch class constant with a non-stringable type mixed.',
-				13,
-			],
-			[
-				'Cannot fetch class constant with a non-stringable type string|null.',
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type mixed.',
 				14,
 			],
 			[
-				'Cannot fetch class constant with a non-stringable type Stringable|null.',
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type string|null.',
 				15,
 			],
 			[
-				'Cannot fetch class constant with a non-stringable type int.',
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type Stringable|null.',
 				16,
 			],
 			[
-				'Cannot fetch class constant with a non-stringable type int|null.',
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type int.',
 				17,
 			],
 			[
-				'Cannot fetch class constant with a non-stringable type DateTime|string.',
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type int|null.',
 				18,
 			],
 			[
-				'Cannot fetch class constant with a non-stringable type 1111.',
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type DateTime|string.',
 				19,
+			],
+			[
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type 1111.',
+				20,
+			],
+			[
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type Stringable.',
+				22,
+			],
+			[
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type mixed.',
+				32,
+			],
+			[
+				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Bar with a non-stringable type mixed.',
+				33,
+			],
+			[
+				'Cannot fetch constant from DateTime|DateTimeImmutable with a non-stringable type mixed.',
+				38,
+			],
+			[
+				'Cannot fetch constant from object with a non-stringable type mixed.',
+				39,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -26,7 +26,7 @@ class ClassConstantRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		return new ClassConstantRule(
 			$reflectionProvider,
-			new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true),
+			new RuleLevelHelper($reflectionProvider, true, false, true, true, true, false, true),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
 				new ClassForbiddenNameCheck(self::getContainer()),
@@ -34,6 +34,7 @@ class ClassConstantRuleTest extends RuleTestCase
 				self::getContainer(),
 			),
 			new PhpVersion($this->phpVersion),
+			true,
 		);
 	}
 
@@ -58,6 +59,10 @@ class ClassConstantRuleTest extends RuleTestCase
 				[
 					'Access to undefined constant ClassConstantNamespace\Foo::DOLOR.',
 					10,
+				],
+				[
+					'Cannot access constant LOREM on mixed.',
+					11,
 				],
 				[
 					'Access to undefined constant ClassConstantNamespace\Foo::DOLOR.',
@@ -441,6 +446,14 @@ class ClassConstantRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/dynamic-constant-access.php'], [
 			[
 				'Access to undefined constant ClassConstantDynamicAccess\Foo::FOO.',
+				17,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type object.',
+				19,
+			],
+			[
+				'Access to undefined constant ClassConstantDynamicAccess\Foo::FOO.',
 				20,
 			],
 			[
@@ -470,6 +483,43 @@ class ClassConstantRuleTest extends RuleTestCase
 			[
 				'Access to undefined constant ClassConstantDynamicAccess\Foo::FOO.',
 				44,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.3')]
+	public function testStringableDynamicAccess(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+
+		$this->analyse([__DIR__ . '/data/dynamic-constant-stringable-access.php'], [
+			[
+				'Cannot fetch class constant with a non-stringable type mixed.',
+				13,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type string|null.',
+				14,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type Stringable|null.',
+				15,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type int.',
+				16,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type int|null.',
+				17,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type DateTime|string.',
+				18,
+			],
+			[
+				'Cannot fetch class constant with a non-stringable type 1111.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -449,7 +449,7 @@ class ClassConstantRuleTest extends RuleTestCase
 				17,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicAccess\Foo with a non-stringable type object.',
+				'Class constant name for ClassConstantDynamicAccess\Foo must be a string, but object was given.',
 				19,
 			],
 			[
@@ -494,51 +494,51 @@ class ClassConstantRuleTest extends RuleTestCase
 
 		$this->analyse([__DIR__ . '/data/dynamic-constant-stringable-access.php'], [
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type mixed.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but mixed was given.',
 				14,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type string|null.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but string|null was given.',
 				15,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type Stringable|null.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but Stringable|null was given.',
 				16,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type int.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but int was given.',
 				17,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type int|null.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but int|null was given.',
 				18,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type DateTime|string.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but DateTime|string was given.',
 				19,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type 1111.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but 1111 was given.',
 				20,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type Stringable.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but Stringable was given.',
 				22,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Foo with a non-stringable type mixed.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Foo must be a string, but mixed was given.',
 				32,
 			],
 			[
-				'Cannot fetch constant from ClassConstantDynamicStringableAccess\Bar with a non-stringable type mixed.',
+				'Class constant name for ClassConstantDynamicStringableAccess\Bar must be a string, but mixed was given.',
 				33,
 			],
 			[
-				'Cannot fetch constant from DateTime|DateTimeImmutable with a non-stringable type mixed.',
+				'Class constant name for DateTime|DateTimeImmutable must be a string, but mixed was given.',
 				38,
 			],
 			[
-				'Cannot fetch constant from object with a non-stringable type mixed.',
+				'Class constant name for object must be a string, but mixed was given.',
 				39,
 			],
 		]);

--- a/tests/PHPStan/Rules/Classes/data/dynamic-constant-access.php
+++ b/tests/PHPStan/Rules/Classes/data/dynamic-constant-access.php
@@ -14,7 +14,7 @@ final class Foo
 	{
 		$bar = 'FOO';
 
-		echo self::{$foo};
+		echo self::{$bar};
 		echo self::{$string};
 		echo self::{$obj};
 		echo self::{$this->name};
@@ -43,6 +43,5 @@ final class Foo
 
 		echo self::{$name};
 	}
-
 
 }

--- a/tests/PHPStan/Rules/Classes/data/dynamic-constant-stringable-access.php
+++ b/tests/PHPStan/Rules/Classes/data/dynamic-constant-stringable-access.php
@@ -1,0 +1,24 @@
+<?php  // lint >= 8.3
+
+namespace ClassConstantDynamicStringableAccess;
+
+use Stringable;
+use DateTime;
+
+final class Foo
+{
+
+	public function test(mixed $mixed, ?string $nullableStr, ?Stringable $nullableStringable, int $int, ?int $nullableInt, DateTime|string $datetimeOrStr, Stringable $stringable): void
+	{
+		echo self::{$mixed};
+		echo self::{$nullableStr};
+		echo self::{$nullableStringable};
+		echo self::{$int};
+		echo self::{$nullableInt};
+		echo self::{$datetimeOrStr};
+		echo self::{1111};
+		echo self::{(string)$stringable};
+		echo self::{$stringable}; // Uncast Stringable objects will cause a runtime error
+	}
+
+}

--- a/tests/PHPStan/Rules/Classes/data/dynamic-constant-stringable-access.php
+++ b/tests/PHPStan/Rules/Classes/data/dynamic-constant-stringable-access.php
@@ -4,8 +4,9 @@ namespace ClassConstantDynamicStringableAccess;
 
 use Stringable;
 use DateTime;
+use DateTimeImmutable;
 
-final class Foo
+abstract class Foo
 {
 
 	public function test(mixed $mixed, ?string $nullableStr, ?Stringable $nullableStringable, int $int, ?int $nullableInt, DateTime|string $datetimeOrStr, Stringable $stringable): void
@@ -19,6 +20,23 @@ final class Foo
 		echo self::{1111};
 		echo self::{(string)$stringable};
 		echo self::{$stringable}; // Uncast Stringable objects will cause a runtime error
+	}
+
+}
+
+final class Bar extends Foo
+{
+
+	public function test(mixed $mixed, ?string $nullableStr, ?Stringable $nullableStringable, int $int, ?int $nullableInt, DateTime|string $datetimeOrStr, Stringable $stringable): void
+	{
+		echo parent::{$mixed};
+		echo self::{$mixed};
+	}
+
+	public function testClassDynamic(DateTime|DateTimeImmutable $datetime, object $obj, mixed $mixed): void
+	{
+		echo $datetime::{$mixed};
+		echo $obj::{$mixed};
 	}
 
 }


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan-src/pull/3885#pullrequestreview-2694393342, https://github.com/phpstan/phpstan-src/pull/3886#issuecomment-2735632469, https://github.com/phpstan/phpstan/issues/13238

In the context of class constant fetching, string keys are not implicitly cast.
* https://3v4l.org/WZTCC