### PR TITLE
Fix mb_convert_encoding signature

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -6312,7 +6312,7 @@ return [
 'mb_check_encoding' => ['bool', 'var='=>'string|array<string>', 'encoding='=>'string'],
 'mb_chr' => ['string|false', 'cp'=>'int', 'encoding='=>'string'],
 'mb_convert_case' => ['string', 'sourcestring'=>'string', 'mode'=>'int', 'encoding='=>'string'],
-'mb_convert_encoding' => ['string|array<int, string>|false', 'val'=>'string|array<int, string>', 'to_encoding'=>'string', 'from_encoding='=>'mixed'],
+'mb_convert_encoding' => ['string|array|false', 'val'=>'string|array', 'to_encoding'=>'string', 'from_encoding='=>'mixed'],
 'mb_convert_kana' => ['string', 'str'=>'string', 'option='=>'string', 'encoding='=>'string'],
 'mb_convert_variables' => ['string|false', 'to_encoding'=>'string', 'from_encoding'=>'array|string', '&rw_vars'=>'string|array|object', '&...rw_vars='=>'string|array|object'],
 'mb_decode_mimeheader' => ['string', 'string'=>'string'],

--- a/src/Type/Php/MbConvertEncodingFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MbConvertEncodingFunctionReturnTypeExtension.php
@@ -5,11 +5,18 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\IntegerType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use function count;
 
 final class MbConvertEncodingFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -30,16 +37,54 @@ final class MbConvertEncodingFunctionReturnTypeExtension implements DynamicFunct
 		}
 
 		$argType = $scope->getType($functionCall->getArgs()[0]->value);
-		$isString = $argType->isString();
-		$isArray = $argType->isArray();
-		$compare = $isString->compareTo($isArray);
-		if ($compare === $isString) {
-			return new StringType();
-		} elseif ($compare === $isArray) {
-			return new ArrayType(new IntegerType(), new StringType());
+
+		$initialReturnType = ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$functionCall->getArgs(),
+			$functionReflection->getVariants(),
+		)->getReturnType();
+
+		$result = TypeCombinator::intersect($initialReturnType, $this->generalizeStringType($argType));
+		if ($result instanceof NeverType) {
+			return null;
 		}
 
-		return null;
+		return TypeCombinator::union($result, new ConstantBooleanType(false));
+	}
+
+	public function generalizeStringType(Type $type): Type
+	{
+		if ($type instanceof UnionType) {
+			return $type->traverse([$this, 'generalizeStringType']);
+		}
+
+		if ($type->isString()->yes()) {
+			return new StringType();
+		}
+
+		$constantArrays = $type->getConstantArrays();
+		if (count($constantArrays) > 0) {
+			$types = [];
+			foreach ($constantArrays as $constantArray) {
+				$types[] = $constantArray->traverse([$this, 'generalizeStringType']);
+			}
+
+			return TypeCombinator::union(...$types);
+		}
+
+		if ($type->isArray()->yes()) {
+			$newArrayType = new ArrayType($type->getIterableKeyType(), $this->generalizeStringType($type->getIterableValueType()));
+			if ($type->isIterableAtLeastOnce()->yes()) {
+				$newArrayType = TypeCombinator::intersect($newArrayType, new NonEmptyArrayType());
+			}
+			if ($type->isList()->yes()) {
+				$newArrayType = TypeCombinator::intersect($newArrayType, new AccessoryArrayListType());
+			}
+
+			return $newArrayType;
+		}
+
+		return $type;
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-3336.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3336.php
@@ -3,8 +3,8 @@
 namespace Bug3336;
 
 function (array $arr, string $str, $mixed): void {
-	\PHPStan\Testing\assertType('array<int, string>', mb_convert_encoding($arr));
-	\PHPStan\Testing\assertType('string', mb_convert_encoding($str));
-	\PHPStan\Testing\assertType('array<int, string>|string|false', mb_convert_encoding($mixed));
-	\PHPStan\Testing\assertType('array<int, string>|string|false', mb_convert_encoding());
+	\PHPStan\Testing\assertType('array|false', mb_convert_encoding($arr));
+	\PHPStan\Testing\assertType('string|false', mb_convert_encoding($str));
+	\PHPStan\Testing\assertType('array|string|false', mb_convert_encoding($mixed));
+	\PHPStan\Testing\assertType('array|string|false', mb_convert_encoding());
 };

--- a/tests/PHPStan/Analyser/nsrt/mb_convert_encoding.php
+++ b/tests/PHPStan/Analyser/nsrt/mb_convert_encoding.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace MbConvertEncoding;
+
+/**
+ * @param 'foo'|'bar' $constantString
+ * @param array{foo: string, bar: int, baz: 'foo'} $structuredArray
+ * @param list<string> $stringList
+ * @param list<int> $intList
+ * @param 'foo'|'bar'|array{foo: string, bar: int, baz: 'foo'}|bool $union
+ */
+function test_mb_convert_encoding(
+	mixed $mixed,
+	string $constantString,
+	string $string,
+	array $mixedArray,
+	array $structuredArray,
+	array $stringList,
+	array $intList,
+	string|array|bool $union,
+	int $int,
+): void {
+	\PHPStan\Testing\assertType('array|string|false', mb_convert_encoding($mixed, 'UTF-8'));
+	\PHPStan\Testing\assertType('string|false', mb_convert_encoding($constantString, 'UTF-8'));
+	\PHPStan\Testing\assertType('string|false', mb_convert_encoding($string, 'UTF-8'));
+	\PHPStan\Testing\assertType('array|false', mb_convert_encoding($mixedArray, 'UTF-8'));
+	\PHPStan\Testing\assertType('array{foo: string, bar: int, baz: string}|false', mb_convert_encoding($structuredArray, 'UTF-8'));
+	\PHPStan\Testing\assertType('list<string>|false', mb_convert_encoding($stringList, 'UTF-8'));
+	\PHPStan\Testing\assertType('list<int>|false', mb_convert_encoding($intList, 'UTF-8'));
+	\PHPStan\Testing\assertType('array{foo: string, bar: int, baz: string}|string|false', mb_convert_encoding($union, 'UTF-8'));
+	\PHPStan\Testing\assertType('array|string|false', mb_convert_encoding($int, 'UTF-8'));
+};


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12309

Closes https://github.com/phpstan/phpstan-src/pull/3749

Following the example https://3v4l.org/OrdDb
- mb_convert_encoding accepts array of non-string values, and just ignores them
- mb_convert_encoding accepts array of array and works recursively