### PR TITLE
Add `strrev()` to `NonEmptyStringFunctionsReturnTypeExtension`

### DIFF
--- a/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
@@ -34,6 +34,7 @@ final class NonEmptyStringFunctionsReturnTypeExtension implements DynamicFunctio
 			'preg_quote',
 			'rawurlencode',
 			'rawurldecode',
+			'strrev',
 		], true);
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string.php
@@ -359,6 +359,9 @@ class MoreNonEmptyStringFunctions
 		assertType('string', preg_quote($s));
 		assertType('non-empty-string', preg_quote($nonEmpty));
 
+		assertType('string', strrev($s));
+		assertType('non-empty-string', strrev($nonEmpty));
+
 		assertType('string', sprintf($s));
 		assertType('string', sprintf($nonEmpty));
 		assertType('string', sprintf($s, $nonEmpty));

--- a/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
+++ b/tests/PHPStan/Analyser/nsrt/non-falsy-string.php
@@ -110,6 +110,9 @@ class Foo {
 
 		assertType('non-falsy-string', preg_quote($nonFalsey));
 
+		assertType('string', strrev($s));
+		assertType('non-falsy-string', strrev($nonFalsey));
+
 		assertType('string', sprintf($nonFalsey));
 		assertType("'foo'", sprintf('foo'));
 		assertType("string", sprintf(...$arr));


### PR DESCRIPTION
# Problem

If `strrev()` takes `non-falsy-string` or `non-empty-string`, it should return `non-falsy-string` or `non-empty-string`, but it returns just a `string`.

https://phpstan.org/r/f9b50c8a-1a20-43ff-8715-42f267a28e24

```php
\PHPStan\dumpType(strrev("abc"));
// => string
```

# Solution

Add `strrev()` to `NonEmptyStringFunctionsReturnTypeExtension`.