### PR TITLE
Remember value of arguments passed to `{min,max}()`

### DIFF
--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\BinaryOp\Smaller;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\Expr\AlwaysRememberedExpr;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -60,15 +61,20 @@ final class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 			$argType1 = $scope->getType($args[1]->value);
 
 			if ($argType0->isArray()->no() && $argType1->isArray()->no()) {
+				$comparisonExpr = new Smaller(
+					new AlwaysRememberedExpr($args[0]->value, $argType0, $scope->getNativeType($args[0]->value)),
+					new AlwaysRememberedExpr($args[1]->value, $argType1, $scope->getNativeType($args[1]->value)),
+				);
+
 				if ($functionName === 'min') {
 					return $scope->getType(new Ternary(
-						new Smaller($args[0]->value, $args[1]->value),
+						$comparisonExpr,
 						$args[0]->value,
 						$args[1]->value,
 					));
 				} elseif ($functionName === 'max') {
 					return $scope->getType(new Ternary(
-						new Smaller($args[0]->value, $args[1]->value),
+						$comparisonExpr,
 						$args[1]->value,
 						$args[0]->value,
 					));

--- a/tests/PHPStan/Analyser/nsrt/bug-12731.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12731.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug12731;
+
+use function PHPStan\Testing\assertType;
+
+/** @phpstan-impure */
+function impure_int(): int {
+	return rand(0, 100) - 50;
+}
+
+/** @phpstan-pure */
+function pure_int(): int {
+	return -42;
+}
+
+assertType('int<4, max>', max(4, pure_int()));
+
+$_ = impure_int();
+assertType('int<4, max>', max(4, $_));
+
+assertType('int<4, max>', max(4, impure_int()));
+assertType('int<4, max>', max(impure_int(), 4));
+assertType('int', impure_int());


### PR DESCRIPTION
Fixes phpstan/phpstan#12731

Hopefully this is a suitable fix as I started playing around with other ways of trying to achieve this when I found `AlwaysRememberedExpr` which makes this really simple!