### PR TITLE
ResultCacheManager: support dots in parametersNotInvalidatingCache

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -191,17 +191,17 @@ parameters:
 		tmpDir: %sysGetTempDir%/phpstan-fixer
 	__validate: true
 	parametersNotInvalidatingCache:
-		- parameters.editorUrl
-		- parameters.editorUrlTitle
-		- parameters.errorFormat
-		- parameters.ignoreErrors
-		- parameters.reportUnmatchedIgnoredErrors
-		- parameters.tipsOfTheDay
-		- parameters.parallel
-		- parameters.internalErrorsCountLimit
-		- parameters.cache
-		- parameters.memoryLimitFile
-		- parameters.pro
+		- [parameters, editorUrl]
+		- [parameters, editorUrlTitle]
+		- [parameters, errorFormat]
+		- [parameters, ignoreErrors]
+		- [parameters, reportUnmatchedIgnoredErrors]
+		- [parameters, tipsOfTheDay]
+		- [parameters, parallel]
+		- [parameters, internalErrorsCountLimit]
+		- [parameters, cache]
+		- [parameters, memoryLimitFile]
+		- [parameters, pro]
 		- parametersSchema
 
 extensions:

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -167,7 +167,10 @@ parametersSchema:
 	])
 	env: arrayOf(string(), anyOf(int(), string()))
 	sysGetTempDir: string()
-	parametersNotInvalidatingCache: listOf(string())
+	parametersNotInvalidatingCache: listOf(schema(anyOf(
+		string(),
+		listOf(string()),
+	)))
 
 	# playground mode
 	sourceLocatorPlaygroundMode: bool()

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -67,7 +67,7 @@ final class ResultCacheManager
 	 * @param string[] $bootstrapFiles
 	 * @param string[] $scanFiles
 	 * @param string[] $scanDirectories
-	 * @param list<string> $parametersNotInvalidatingCache
+	 * @param list<string|non-empty-list<string>> $parametersNotInvalidatingCache
 	 */
 	public function __construct(
 		private Container $container,
@@ -886,7 +886,8 @@ return [
 
 		if ($projectConfigArray !== null) {
 			foreach ($this->parametersNotInvalidatingCache as $parameterPath) {
-				ArrayHelper::unsetKeyAtPath($projectConfigArray, explode('.', $parameterPath));
+				$pathAsArray = is_array($parameterPath) ? $parameterPath : explode('.', $parameterPath);
+				ArrayHelper::unsetKeyAtPath($projectConfigArray, $pathAsArray);
 			}
 
 			ksort($projectConfigArray);


### PR DESCRIPTION
This should allow for example even custom formatters:

```neon
parameters:
    parametersNotInvalidatingCache:
        - [services, errorFormatter.shipmonk]
```
