### PR TITLE
ResultCache: configurable days causing cache skip

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -125,6 +125,7 @@ parameters:
 	earlyTerminatingMethodCalls: []
 	earlyTerminatingFunctionCalls: []
 	resultCachePath: %tmpDir%/resultCache.php
+	resultCacheSkipIfOlderThanDays: 7
 	resultCacheChecksProjectExtensionFilesDependencies: false
 	dynamicConstantNames:
 		- ICONV_IMPL
@@ -518,6 +519,7 @@ services:
 			scanDirectories: %scanDirectories%
 			checkDependenciesOfProjectExtensionFiles: %resultCacheChecksProjectExtensionFilesDependencies%
 			parametersNotInvalidatingCache: %parametersNotInvalidatingCache%
+			skipResultCacheIfOlderThanDays: %resultCacheSkipIfOlderThanDays%
 
 	-
 		class: PHPStan\Analyser\ResultCache\ResultCacheClearer

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -148,6 +148,7 @@ parametersSchema:
 	earlyTerminatingMethodCalls: arrayOf(listOf(string()))
 	earlyTerminatingFunctionCalls: listOf(string())
 	resultCachePath: string()
+	resultCacheSkipIfOlderThanDays: int()
 	resultCacheChecksProjectExtensionFilesDependencies: bool()
 	dynamicConstantNames: listOf(string())
 	customRulesetUsed: schema(bool(), nullable())

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -86,6 +86,7 @@ final class ResultCacheManager
 		private array $scanDirectories,
 		private bool $checkDependenciesOfProjectExtensionFiles,
 		private array $parametersNotInvalidatingCache,
+		private int $skipResultCacheIfOlderThanDays,
 	)
 	{
 	}
@@ -148,11 +149,12 @@ final class ResultCacheManager
 			return new ResultCache($allAnalysedFiles, true, time(), $meta, [], [], [], [], [], [], [], []);
 		}
 
-		if (time() - $data['lastFullAnalysisTime'] >= 60 * 60 * 24 * 7) {
+		$daysOldForSkip = $this->skipResultCacheIfOlderThanDays;
+		if (time() - $data['lastFullAnalysisTime'] >= 60 * 60 * 24 * $daysOldForSkip) {
 			if ($output->isVeryVerbose()) {
-				$output->writeLineFormatted('Result cache not used because it\'s more than 7 days since last full analysis.');
+				$output->writeLineFormatted(sprintf("Result cache not used because it's more than %d days since last full analysis.", $daysOldForSkip));
 			}
-			// run full analysis if the result cache is older than 7 days
+			// run full analysis if the result cache is older than X days
 			return new ResultCache($allAnalysedFiles, true, time(), $meta, [], [], [], [], [], [], [], []);
 		}
 


### PR DESCRIPTION
Recently, I implemented a script that allows result cache reuse from CI job. Sometimes, I get back to older MR where I want to continue, but this hardcoded limit slows me down as I cannot reuse the cache anymore for such MR. 

Note: our full PHPStan analysis takes ~10 minutes on 12th Gen Intel Core i7-1255U.