### PR TITLE
Fix imprecise types after assignment when strict-types=1

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5626,9 +5626,20 @@ final class NodeScopeResolver
 				$nodeCallback(new PropertyAssignNode($var, $assignedExpr, $isAssignOp), $scope);
 				if ($propertyReflection->canChangeTypeAfterAssignment()) {
 					if ($propertyReflection->hasNativeType() && $scope->isDeclareStrictTypes()) {
+						$assignedNativeType = $scope->getNativeType($assignedExpr);
 						$propertyNativeType = $propertyReflection->getNativeType();
 
-						$scope = $scope->assignExpression($var, TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType), TypeCombinator::intersect($scope->getNativeType($assignedExpr)->toCoercedArgumentType(true), $propertyNativeType));
+						$newAssignedType = TypeCombinator::intersect($assignedExprType, $propertyNativeType);
+						if ($newAssignedType instanceof NeverType) {
+							$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
+						}
+
+						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType, $propertyNativeType);
+						if ($newAssignedNativeType instanceof NeverType) {
+							$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
+						}
+
+						$scope = $scope->assignExpression($var, $newAssignedType, $newAssignedNativeType);
 					} else {
 						$scope = $scope->assignExpression($var, $assignedExprType, $scope->getNativeType($assignedExpr));
 					}
@@ -5697,9 +5708,20 @@ final class NodeScopeResolver
 				$nodeCallback(new PropertyAssignNode($var, $assignedExpr, $isAssignOp), $scope);
 				if ($propertyReflection !== null && $propertyReflection->canChangeTypeAfterAssignment()) {
 					if ($propertyReflection->hasNativeType() && $scope->isDeclareStrictTypes()) {
+						$assignedNativeType = $scope->getNativeType($assignedExpr);
 						$propertyNativeType = $propertyReflection->getNativeType();
 
-						$scope = $scope->assignExpression($var, TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType), TypeCombinator::intersect($scope->getNativeType($assignedExpr)->toCoercedArgumentType(true), $propertyNativeType));
+						$newAssignedType = TypeCombinator::intersect($assignedExprType, $propertyNativeType);
+						if ($newAssignedType instanceof NeverType) {
+							$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
+						}
+
+						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType, $propertyNativeType);
+						if ($newAssignedNativeType instanceof NeverType) {
+							$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
+						}
+
+						$scope = $scope->assignExpression($var, $newAssignedType, $newAssignedNativeType);
 					} else {
 						$scope = $scope->assignExpression($var, $assignedExprType, $scope->getNativeType($assignedExpr));
 					}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5625,18 +5625,27 @@ final class NodeScopeResolver
 				$assignedExprType = $scope->getType($assignedExpr);
 				$nodeCallback(new PropertyAssignNode($var, $assignedExpr, $isAssignOp), $scope);
 				if ($propertyReflection->canChangeTypeAfterAssignment()) {
-					if ($propertyReflection->hasNativeType() && $scope->isDeclareStrictTypes()) {
+					if ($propertyReflection->hasNativeType()) {
 						$assignedNativeType = $scope->getNativeType($assignedExpr);
 						$propertyNativeType = $propertyReflection->getNativeType();
 
-						$newAssignedType = TypeCombinator::intersect($assignedExprType, $propertyNativeType);
-						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType, $propertyNativeType);
-						if ($newAssignedType instanceof NeverType || $newAssignedNativeType instanceof NeverType) {
-							$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
-							$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
+						$assignedTypeIsCompatible = false;
+						foreach(TypeUtils::flattenTypes($propertyNativeType) as $type) {
+							if ($type->isSuperTypeOf($assignedNativeType)->yes()) {
+								$assignedTypeIsCompatible = true;
+								break;
+							}
 						}
 
-						$scope = $scope->assignExpression($var, $newAssignedType, $newAssignedNativeType);
+						if (!$assignedTypeIsCompatible && $scope->isDeclareStrictTypes()) {
+							$scope = $scope->assignExpression(
+								$var,
+								TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType),
+								TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType)
+							);
+						} else {
+							$scope = $scope->assignExpression($var, $assignedExprType, $assignedNativeType);
+						}
 					} else {
 						$scope = $scope->assignExpression($var, $assignedExprType, $scope->getNativeType($assignedExpr));
 					}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5630,12 +5630,9 @@ final class NodeScopeResolver
 						$propertyNativeType = $propertyReflection->getNativeType();
 
 						$newAssignedType = TypeCombinator::intersect($assignedExprType, $propertyNativeType);
-						if ($newAssignedType instanceof NeverType) {
-							$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
-						}
-
 						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType, $propertyNativeType);
-						if ($newAssignedNativeType instanceof NeverType) {
+						if ($newAssignedType instanceof NeverType || $newAssignedNativeType instanceof NeverType) {
+							$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
 							$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
 						}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5713,10 +5713,27 @@ final class NodeScopeResolver
 				$assignedExprType = $scope->getType($assignedExpr);
 				$nodeCallback(new PropertyAssignNode($var, $assignedExpr, $isAssignOp), $scope);
 				if ($propertyReflection !== null && $propertyReflection->canChangeTypeAfterAssignment()) {
-					if ($propertyReflection->hasNativeType() && $scope->isDeclareStrictTypes()) {
+					if ($propertyReflection->hasNativeType()) {
+						$assignedNativeType = $scope->getNativeType($assignedExpr);
 						$propertyNativeType = $propertyReflection->getNativeType();
 
-						$scope = $scope->assignExpression($var, TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType), TypeCombinator::intersect($scope->getNativeType($assignedExpr)->toCoercedArgumentType(true), $propertyNativeType));
+						$assignedTypeIsCompatible = false;
+						foreach (TypeUtils::flattenTypes($propertyNativeType) as $type) {
+							if ($type->isSuperTypeOf($assignedNativeType)->yes()) {
+								$assignedTypeIsCompatible = true;
+								break;
+							}
+						}
+
+						if ($assignedTypeIsCompatible) {
+							$scope = $scope->assignExpression($var, $assignedExprType, $assignedNativeType);
+						} elseif ($scope->isDeclareStrictTypes()) {
+							$scope = $scope->assignExpression(
+								$var,
+								TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType),
+								TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType),
+							);
+						}
 					} else {
 						$scope = $scope->assignExpression($var, $assignedExprType, $scope->getNativeType($assignedExpr));
 					}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5711,15 +5711,8 @@ final class NodeScopeResolver
 						$assignedNativeType = $scope->getNativeType($assignedExpr);
 						$propertyNativeType = $propertyReflection->getNativeType();
 
-						$newAssignedType = TypeCombinator::intersect($assignedExprType, $propertyNativeType);
-						if ($newAssignedType instanceof NeverType) {
-							$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
-						}
-
-						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType, $propertyNativeType);
-						if ($newAssignedNativeType instanceof NeverType) {
-							$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
-						}
+						$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
+						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
 
 						$scope = $scope->assignExpression($var, $newAssignedType, $newAssignedNativeType);
 					} else {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5637,14 +5637,14 @@ final class NodeScopeResolver
 							}
 						}
 
-						if (!$assignedTypeIsCompatible && $scope->isDeclareStrictTypes()) {
+						if ($assignedTypeIsCompatible) {
+							$scope = $scope->assignExpression($var, $assignedExprType, $assignedNativeType);
+						} elseif ($scope->isDeclareStrictTypes()) {
 							$scope = $scope->assignExpression(
 								$var,
 								TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType),
 								TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType),
 							);
-						} else {
-							$scope = $scope->assignExpression($var, $assignedExprType, $assignedNativeType);
 						}
 					} else {
 						$scope = $scope->assignExpression($var, $assignedExprType, $scope->getNativeType($assignedExpr));

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5630,7 +5630,7 @@ final class NodeScopeResolver
 						$propertyNativeType = $propertyReflection->getNativeType();
 
 						$assignedTypeIsCompatible = false;
-						foreach(TypeUtils::flattenTypes($propertyNativeType) as $type) {
+						foreach (TypeUtils::flattenTypes($propertyNativeType) as $type) {
 							if ($type->isSuperTypeOf($assignedNativeType)->yes()) {
 								$assignedTypeIsCompatible = true;
 								break;
@@ -5641,7 +5641,7 @@ final class NodeScopeResolver
 							$scope = $scope->assignExpression(
 								$var,
 								TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType),
-								TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType)
+								TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType),
 							);
 						} else {
 							$scope = $scope->assignExpression($var, $assignedExprType, $assignedNativeType);
@@ -5714,13 +5714,9 @@ final class NodeScopeResolver
 				$nodeCallback(new PropertyAssignNode($var, $assignedExpr, $isAssignOp), $scope);
 				if ($propertyReflection !== null && $propertyReflection->canChangeTypeAfterAssignment()) {
 					if ($propertyReflection->hasNativeType() && $scope->isDeclareStrictTypes()) {
-						$assignedNativeType = $scope->getNativeType($assignedExpr);
 						$propertyNativeType = $propertyReflection->getNativeType();
 
-						$newAssignedType = TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType);
-						$newAssignedNativeType = TypeCombinator::intersect($assignedNativeType->toCoercedArgumentType(true), $propertyNativeType);
-
-						$scope = $scope->assignExpression($var, $newAssignedType, $newAssignedNativeType);
+						$scope = $scope->assignExpression($var, TypeCombinator::intersect($assignedExprType->toCoercedArgumentType(true), $propertyNativeType), TypeCombinator::intersect($scope->getNativeType($assignedExpr)->toCoercedArgumentType(true), $propertyNativeType));
 					} else {
 						$scope = $scope->assignExpression($var, $assignedExprType, $scope->getNativeType($assignedExpr));
 					}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -398,7 +398,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 
 			@fclose($f);
 
-			if (preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m) === 1) {
+			if (preg_match('~<?php\\s*(?:declare\\s*\([^)]+\)\\s*;\\s*)?\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m) === 1) {
 				return version_compare(PHP_VERSION, $m[2], $m[1]) === false;
 			}
 		}

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -398,7 +398,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 
 			@fclose($f);
 
-			if (preg_match('~<?php\\s*(?:declare\\s*\([^)]+\)\\s*;\\s*)?\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m) === 1) {
+			if (preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m) === 1) {
 				return version_compare(PHP_VERSION, $m[2], $m[1]) === false;
 			}
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-12902-non-strict.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902-non-strict.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 0); // lint >= 8.1
+
+namespace Bug12902;
+
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+class NarrowsNativeConstantValue
+{
+	private readonly int|float $i;
+
+	public function __construct()
+	{
+		$this->i = 1;
+	}
+
+	public function doFoo(): void
+	{
+		assertType('1', $this->i);
+		assertNativeType('1', $this->i);
+	}
+}
+
+class NarrowsNativeReadonlyUnion {
+	private readonly int|float $i;
+
+	public function __construct()
+	{
+		$this->i = getInt();
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+	}
+
+	public function doFoo(): void {
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+	}
+}
+
+class NarrowsNativeUnion {
+	private int|float $i;
+
+	public function __construct()
+	{
+		$this->i = getInt();
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+
+		$this->impureCall();
+		assertType('float|int', $this->i);
+		assertNativeType('float|int', $this->i);
+	}
+
+	public function doFoo(): void {
+		assertType('float|int', $this->i);
+		assertNativeType('float|int', $this->i);
+	}
+
+	/** @phpstan-impure  */
+	public function impureCall(): void {}
+}
+
+class NarrowsStaticNativeUnion {
+	private static int|float $i;
+
+	public function __construct()
+	{
+		self::$i = getInt();
+		assertType('int', self::$i);
+		assertNativeType('int', self::$i);
+
+		$this->impureCall();
+		assertType('int', self::$i); // should be float|int
+		assertNativeType('int', self::$i); // should be float|int
+	}
+
+	public function doFoo(): void {
+		assertType('float|int', self::$i);
+		assertNativeType('float|int', self::$i);
+	}
+
+	/** @phpstan-impure  */
+	public function impureCall(): void {}
+}
+
+function getInt(): int {
+	return 1;
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12902-non-strict.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902-non-strict.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 0); // lint >= 8.1
 
-namespace Bug12902;
+namespace Bug12902NonStrict;
 
 use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;

--- a/tests/PHPStan/Analyser/nsrt/bug-12902-non-strict.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902-non-strict.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 0); // lint >= 8.1
+<?php // lint >= 8.1
+
+declare(strict_types = 0);
 
 namespace Bug12902NonStrict;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+namespace Bug12902;
+
 use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -66,12 +66,12 @@ class NarrowsStaticNativeUnion {
 	public function __construct()
 	{
 		self::$i = getInt();
-		assertType('float|int', self::$i); // could be int
-		assertNativeType('float|int', self::$i); // could be int
+		assertType('int', self::$i);
+		assertNativeType('int', self::$i);
 
 		$this->impureCall();
-		assertType('float|int', self::$i);
-		assertNativeType('float|int', self::$i);
+		assertType('int', self::$i); // should be float|int
+		assertNativeType('int', self::$i); // should be float|int
 	}
 
 	public function doFoo(): void {

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -5,6 +5,28 @@ namespace Bug12902;
 use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;
 
+class NarrowsNativeConstantValue
+{
+	private readonly int|float $i;
+
+	public function __construct()
+	{
+		$this->i = 1;
+	}
+
+	public function doFoo(): void
+	{
+		assertType('1', $this->i);
+		assertNativeType('1', $this->i);
+	}
+}
+
+function getInt(): int
+{
+	return 1;
+}
+
+
 class NarrowsNativeReadonlyUnion {
 	private readonly int|float $i;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+class NarrowsNativeUnion {
+	private readonly int|float $i;
+
+	public function __construct()
+	{
+		$this->i = getInt();
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+	}
+
+	public function doFoo(): void {
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+	}
+}
+
+class NarrowsStaticNativeUnion {
+	private static int|float $i;
+
+	public function __construct()
+	{
+		self::$i = getInt();
+		assertType('int', self::$i);
+		assertNativeType('int', self::$i);
+	}
+
+	public function doFoo(): void {
+		assertType('float|int', self::$i);
+		assertNativeType('float|int', self::$i);
+	}
+}
+
+function getInt(): int {
+	return 1;
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -29,12 +29,20 @@ class NarrowsStaticNativeUnion {
 		self::$i = getInt();
 		assertType('int', self::$i);
 		assertNativeType('int', self::$i);
+
+		$this->impureCall();
+
+		assertType('float|int', self::$i);
+		assertNativeType('float|int', self::$i);
 	}
 
 	public function doFoo(): void {
 		assertType('float|int', self::$i);
 		assertNativeType('float|int', self::$i);
 	}
+
+	/** @phpstan-impure  */
+	public function impureCall(): void {}
 }
 
 function getInt(): int {

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types = 1); // lint >= 8.1
 
 namespace Bug12902;
 
@@ -30,7 +30,7 @@ class NarrowsNativeUnion {
 		assertType('int', $this->i);
 		assertNativeType('int', $this->i);
 
-		$this->impureCall();;
+		$this->impureCall();
 		assertType('float|int', $this->i);
 		assertNativeType('float|int', $this->i);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1); // lint >= 8.1
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
 
 namespace Bug12902;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -5,7 +5,7 @@ namespace Bug12902;
 use function PHPStan\Testing\assertNativeType;
 use function PHPStan\Testing\assertType;
 
-class NarrowsNativeUnion {
+class NarrowsNativeReadonlyUnion {
 	private readonly int|float $i;
 
 	public function __construct()
@@ -21,17 +21,39 @@ class NarrowsNativeUnion {
 	}
 }
 
+class NarrowsNativeUnion {
+	private int|float $i;
+
+	public function __construct()
+	{
+		$this->i = getInt();
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+
+		$this->impureCall();;
+		assertType('float|int', $this->i);
+		assertNativeType('float|int', $this->i);
+	}
+
+	public function doFoo(): void {
+		assertType('float|int', $this->i);
+		assertNativeType('float|int', $this->i);
+	}
+
+	/** @phpstan-impure  */
+	public function impureCall(): void {}
+}
+
 class NarrowsStaticNativeUnion {
 	private static int|float $i;
 
 	public function __construct()
 	{
 		self::$i = getInt();
-		assertType('int', self::$i);
-		assertNativeType('int', self::$i);
+		assertType('float|int', self::$i); // could be int
+		assertNativeType('float|int', self::$i); // could be int
 
 		$this->impureCall();
-
 		assertType('float|int', self::$i);
 		assertNativeType('float|int', self::$i);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-12902.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12902.php
@@ -21,12 +21,6 @@ class NarrowsNativeConstantValue
 	}
 }
 
-function getInt(): int
-{
-	return 1;
-}
-
-
 class NarrowsNativeReadonlyUnion {
 	private readonly int|float $i;
 

--- a/tests/PHPStan/Analyser/nsrt/remember-non-nullable-property-non-strict.php
+++ b/tests/PHPStan/Analyser/nsrt/remember-non-nullable-property-non-strict.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 0); // lint >= 8.1
+<?php // lint >= 8.1
+
+declare(strict_types = 0);
 
 namespace RememberNonNullablePropertyWhenStrictTypesDisabled;
 

--- a/tests/PHPStan/Analyser/nsrt/remember-non-nullable-property-non-strict.php
+++ b/tests/PHPStan/Analyser/nsrt/remember-non-nullable-property-non-strict.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 0); // lint >= 8.1
+
+namespace RememberNonNullablePropertyWhenStrictTypesDisabled;
+
+use function PHPStan\Testing\assertNativeType;
+use function PHPStan\Testing\assertType;
+
+class KeepsPropertyNonNullable {
+	private readonly int $i;
+
+	public function __construct()
+	{
+		$this->i = getIntOrNull();
+	}
+
+	public function doFoo(): void {
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+	}
+}
+
+class DontCoercePhpdocType {
+	/** @var int */
+	private $i;
+
+	public function __construct()
+	{
+		$this->i = getIntOrNull();
+	}
+
+	public function doFoo(): void {
+		assertType('int', $this->i);
+		assertNativeType('mixed', $this->i);
+	}
+}
+
+function getIntOrNull(): ?int {
+	if (rand(0, 1) === 0) {
+		return null;
+	}
+	return 1;
+}
+
+
+class KeepsPropertyNonNullable2 {
+	private int|float $i;
+
+	public function __construct()
+	{
+		$this->i = getIntOrFloatOrNull();
+	}
+
+	public function doFoo(): void {
+		assertType('float|int', $this->i);
+		assertNativeType('float|int', $this->i);
+	}
+}
+
+function getIntOrFloatOrNull(): null|int|float {
+	if (rand(0, 1) === 0) {
+		return null;
+	}
+
+	if (rand(0, 10) === 0) {
+		return 1.0;
+	}
+	return 1;
+}
+
+class NarrowsNativeUnion {
+	private readonly int|float $i;
+
+	public function __construct()
+	{
+		$this->i = getInt();
+	}
+
+	public function doFoo(): void {
+		assertType('int', $this->i);
+		assertNativeType('int', $this->i);
+	}
+}
+
+function getInt(): int {
+	return 1;
+}


### PR DESCRIPTION
work with coecered type only when the assigned one is incompatible with the natively defined property type

closes https://github.com/phpstan/phpstan/issues/12902

supercedes https://github.com/phpstan/phpstan-src/pull/3943