### PR TITLE
Handle preserve_keys in `array_slice()` for normal arrays

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -442,6 +442,10 @@ class ArrayType implements Type
 
 	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
 	{
+		if ($preserveKeys->no() && $this->keyType->isInteger()->yes()) {
+			return TypeCombinator::intersect(new self(new IntegerType(), $this->itemType), new AccessoryArrayListType());
+		}
+
 		return $this;
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/array-slice.php
+++ b/tests/PHPStan/Analyser/nsrt/array-slice.php
@@ -30,7 +30,7 @@ class Foo
 	public function normalArrays(array $arr): void
 	{
 		/** @var array<int, bool> $arr */
-		assertType('array<int, bool>', array_slice($arr, 1, 2));
+		assertType('list<bool>', array_slice($arr, 1, 2));
 		assertType('array<int, bool>', array_slice($arr, 1, 2, true));
 
 		/** @var array<string, int> $arr */

--- a/tests/PHPStan/Analyser/nsrt/bug-10721.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10721.php
@@ -86,15 +86,15 @@ final class HandpickedWordlistProvider
 	public function arrayVariants(array $strings, $maybeZero): void
 	{
 		assertType("array<int, string>", $strings);
-		assertType("array<int, string>", array_slice($strings, 0));
-		assertType("array<int, string>", array_slice($strings, 1));
-		assertType("array<int, string>", array_slice($strings, $maybeZero));
+		assertType("list<string>", array_slice($strings, 0));
+		assertType("list<string>", array_slice($strings, 1));
+		assertType("list<string>", array_slice($strings, $maybeZero));
 
 		if (count($strings) > 0) {
 			assertType("non-empty-array<int, string>", $strings);
-			assertType("non-empty-array<int, string>", array_slice($strings, 0));
-			assertType("array<int, string>", array_slice($strings, 1));
-			assertType("array<int, string>", array_slice($strings, $maybeZero));
+			assertType("non-empty-list<string>", array_slice($strings, 0));
+			assertType("list<string>", array_slice($strings, 1));
+			assertType("list<string>", array_slice($strings, $maybeZero));
 		}
 	}
 }

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3606,4 +3606,14 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12793.php'], []);
 	}
 
+	public function testBug12880(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-12880.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-12880.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12880.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12880;
+
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		$this->test([1, 2, 3, true]);
+	}
+
+	/**
+	 * @param  list<mixed>  $ids
+	 */
+	private function test(array $ids): void
+	{
+		$ids = array_unique($ids);
+		\PHPStan\dumpType($ids);
+		$ids = array_slice($ids, 0, 5);
+		\PHPStan\dumpType($ids);
+		$this->expectList($ids);
+	}
+
+	/**
+	 * @param  list<mixed>  $ids
+	 */
+	private function expectList(array $ids): void
+	{
+		var_dump($ids);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12880

https://www.php.net/manual/en/function.array-slice.php

> array_slice() will reorder and reset the integer array indices by default. This behaviour can be changed by setting preserve_keys to [true](https://www.php.net/manual/en/reserved.constants.php#constant.true). String keys are always preserved, regardless of this parameter.

https://3v4l.org/7njtg