### PR TITLE
Improve return type of `array_splice()`

### DIFF
--- a/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
@@ -4,13 +4,21 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\ArrayType;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
+use function count;
 
 final class ArraySpliceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -23,13 +31,20 @@ final class ArraySpliceFunctionReturnTypeExtension implements DynamicFunctionRet
 		Scope $scope,
 	): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$arrayArg = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
+		if ($arrayType->isArray()->no()) {
+			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
+		}
 
-		return new ArrayType($arrayArg->getIterableKeyType(), $arrayArg->getIterableValueType());
+		$offsetType = $scope->getType($args[1]->value);
+		$lengthType = isset($args[2]) ? $scope->getType($args[2]->value) : new NullType();
+
+		return $arrayType->sliceArray($offsetType, $lengthType, TrinaryLogic::createNo());
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-5017.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-5017.php
@@ -15,7 +15,7 @@ class Foo
 			assertType('non-empty-array<0|1|2|3|4, 0|1|2|3|4>', $items);
 			$batch = array_splice($items, 0, 2);
 			assertType('array<0|1|2|3|4, 0|1|2|3|4>', $items);
-			assertType('array<0|1|2|3|4, 0|1|2|3|4>', $batch);
+			assertType('non-empty-array<0|1|2|3|4, 0|1|2|3|4>', $batch);
 		}
 	}
 
@@ -28,7 +28,7 @@ class Foo
 			assertType('non-empty-array<int>', $items);
 			$batch = array_splice($items, 0, 2);
 			assertType('array<int>', $items);
-			assertType('array<int>', $batch);
+			assertType('non-empty-array<int>', $batch);
 		}
 	}
 
@@ -38,7 +38,7 @@ class Foo
 		assertType('array{0, 1, 2, 3, 4}', $items);
 		$batch = array_splice($items, 0, 2);
 		assertType('array<0|1|2|3|4, 0|1|2|3|4>', $items);
-		assertType('array<0|1|2|3|4, 0|1|2|3|4>', $batch);
+		assertType('array{0, 1}', $batch);
 	}
 
 	/**


### PR DESCRIPTION
Since `array_splice` returns an extract, similar as `array_slice`, we can make use of what we built already for the latter and get better return types with minimal effort. 

https://www.php.net/manual/en/function.array-splice.php

https://3v4l.org/ggnQB