### PR TITLE
Improve `ConstantArrayType::sliceArray()` with non constant integer args

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -939,8 +939,23 @@ class ConstantArrayType implements Type
 			return $this;
 		}
 
-		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : 0;
-		$length = $lengthType instanceof ConstantIntegerType ? $lengthType->getValue() : $keyTypesCount;
+		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : null;
+
+		if ($lengthType instanceof ConstantIntegerType) {
+			$length = $lengthType->getValue();
+		} elseif ($lengthType->isNull()->yes()) {
+			$length = $keyTypesCount;
+		} else {
+			$length = null;
+		}
+
+		if ($offset === null || $length === null) {
+			$builder = ConstantArrayTypeBuilder::createFromConstantArray($this);
+			$builder->degradeToGeneralArray();
+
+			return $builder->getArray()
+				->sliceArray($offsetType, $lengthType, $preserveKeys);
+		}
 
 		if ($length < 0) {
 			// Negative lengths prevent access to the most right n elements

--- a/tests/PHPStan/Analyser/nsrt/array-slice.php
+++ b/tests/PHPStan/Analyser/nsrt/array-slice.php
@@ -43,6 +43,7 @@ class Foo
 		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
 		assertType('array{b: \'bar\', 0: \'baz\'}', array_slice($arr, 1, 2));
 		assertType('array{b: \'bar\', 19: \'baz\'}', array_slice($arr, 1, 2, true));
+		assertType('array<17|19|\'b\', \'bar\'|\'baz\'|\'foo\'>', array_slice($arr, rand(0, 1) ? 0 : 1, rand(0, 1) ? 0 : 1));
 
 		/** @var array{17: 'foo', 19: 'bar', 21: 'baz'}|array{foo: 17, bar: 19, baz: 21} $arr */
 		assertType('array{\'bar\', \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2));


### PR DESCRIPTION
`ConstantArrayType::sliceArray()` is one of the more complex constant array methods I once came up with. But it can only handle constant integer offsets and lengths so far. I tried to add support for e.g. unions, but this would increase complexity even more.

Currently there is an issue where it naively falls back the defaults (offset 0, length null = full array) when it encounters invalid values. Instead of that, I think it's better and safer to degrade to a general array and do the slice there to avoid incorrect types. 