### PR TITLE
TableErrorFormatter: visually differentiate phpstan assertion errors from rule errors

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -13,6 +13,7 @@ use function array_map;
 use function count;
 use function explode;
 use function getenv;
+use function in_array;
 use function is_string;
 use function ltrim;
 use function sprintf;
@@ -117,6 +118,11 @@ final class TableErrorFormatter implements ErrorFormatter
 
 					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
 				}
+
+				if (in_array($error->getIdentifier(), ['phpstan.type', 'phpstan.nativeType', 'phpstan.variable'], true)) {
+					$message = '<info>' . $message . '</info>';
+				}
+
 				$rows[] = [
 					$this->formatLineNumber($error->getLine()),
 					$message,

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -119,7 +119,10 @@ final class TableErrorFormatter implements ErrorFormatter
 					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
 				}
 
-				if (in_array($error->getIdentifier(), ['phpstan.type', 'phpstan.nativeType', 'phpstan.variable'], true)) {
+				if (
+					$error->getIdentifier() !== null
+					&& in_array($error->getIdentifier(), ['phpstan.type', 'phpstan.nativeType', 'phpstan.variable'], true)
+				) {
 					$message = '<info>' . $message . '</info>';
 				}
 

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -121,9 +121,9 @@ final class TableErrorFormatter implements ErrorFormatter
 
 				if (
 					$error->getIdentifier() !== null
-					&& in_array($error->getIdentifier(), ['phpstan.type', 'phpstan.nativeType', 'phpstan.variable'], true)
+					&& in_array($error->getIdentifier(), ['phpstan.type', 'phpstan.nativeType', 'phpstan.variable', 'phpstan.dumpType', 'phpstan.unknownExpectation'], true)
 				) {
-					$message = '<info>' . $message . '</info>';
+					$message = '<error>' . $message . '</error>';
 				}
 
 				$rows[] = [

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -123,7 +123,7 @@ final class TableErrorFormatter implements ErrorFormatter
 					$error->getIdentifier() !== null
 					&& in_array($error->getIdentifier(), ['phpstan.type', 'phpstan.nativeType', 'phpstan.variable', 'phpstan.dumpType', 'phpstan.unknownExpectation'], true)
 				) {
-					$message = '<error>' . $message . '</error>';
+					$message = '<fg=red>' . $message . '</>';
 				}
 
 				$rows[] = [


### PR DESCRIPTION
before this PR

<img width="1129" alt="grafik" src="https://github.com/user-attachments/assets/2eeed98f-8bc9-481a-98b2-3c77aed31913" />

after this PR

<img width="992" alt="grafik" src="https://github.com/user-attachments/assets/c11cde59-86d0-4871-bdb1-bdb12b12f08b" />
