### PR TITLE
Add `Type::spliceArray()`, improve `splice_array()` array type narrowing

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -954,7 +954,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantArrayType is error\-prone and deprecated\. Use Type\:\:getConstantArrays\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 5
+			count: 6
 			path: src/Type/Constant/ConstantArrayType.php
 
 		-

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -248,6 +248,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -214,6 +214,15 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		if ((new ConstantIntegerType(0))->isSuperTypeOf($lengthType)->yes()) {
+			return $this;
+		}
+
+		return new MixedType();
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -274,6 +274,15 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		if ((new ConstantIntegerType(0))->isSuperTypeOf($lengthType)->yes()) {
+			return $this;
+		}
+
+		return new MixedType();
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -223,6 +223,18 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		if (
+			(new ConstantIntegerType(0))->isSuperTypeOf($lengthType)->yes()
+			|| $replacementType->toArray()->isIterableAtLeastOnce()->yes()
+		) {
+			return $this;
+		}
+
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -214,6 +214,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1022,6 +1022,108 @@ class ConstantArrayType implements Type
 		return $builder->getArray();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		$keyTypesCount = count($this->keyTypes);
+
+		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : null;
+
+		if ($lengthType instanceof ConstantIntegerType) {
+			$length = $lengthType->getValue();
+		} elseif ($lengthType->isNull()->yes()) {
+			$length = $keyTypesCount;
+		} else {
+			$length = null;
+		}
+
+		if ($offset === null || $length === null) {
+			return $this->degradeToGeneralArray()
+				->spliceArray($offsetType, $lengthType, $replacementType);
+		}
+
+		if ($keyTypesCount + $offset <= 0) {
+			// A negative offset cannot reach left outside the array twice
+			$offset = 0;
+		}
+
+		if ($keyTypesCount + $length <= 0) {
+			// A negative length cannot reach left outside the array twice
+			$length = 0;
+		}
+
+		$offsetWasNegative = false;
+		if ($offset < 0) {
+			$offsetWasNegative = true;
+			$offset = $keyTypesCount + $offset;
+		}
+
+		if ($length < 0) {
+			$length = $keyTypesCount - $offset + $length;
+		}
+
+		$extractType = $this->sliceArray($offsetType, $lengthType, TrinaryLogic::createYes());
+
+		$types = [];
+		foreach ($replacementType->toArray()->getArrays() as $replacementArrayType) {
+			$removeKeysCount = 0;
+			$optionalKeysBeforeReplacement = 0;
+
+			$builder = ConstantArrayTypeBuilder::createEmpty();
+			for ($i = 0;; $i++) {
+				$isOptional = $this->isOptionalKey($i);
+
+				if (!$offsetWasNegative && $i < $offset && $isOptional) {
+					$optionalKeysBeforeReplacement++;
+				}
+
+				if ($i === $offset + $optionalKeysBeforeReplacement) {
+					// When the offset is reached we have to a) put the replacement array in and b) remove $length elements
+					$removeKeysCount = $length;
+
+					if ($replacementArrayType instanceof self) {
+						$valuesArray = $replacementArrayType->getValuesArray();
+						for ($j = 0, $jMax = count($valuesArray->keyTypes); $j < $jMax; $j++) {
+							$builder->setOffsetValueType(null, $valuesArray->valueTypes[$j], $valuesArray->isOptionalKey($j));
+						}
+					} else {
+						$builder->degradeToGeneralArray();
+						$builder->setOffsetValueType($replacementArrayType->getValuesArray()->getIterableKeyType(), $replacementArrayType->getIterableValueType(), true);
+					}
+				}
+
+				if (!isset($this->keyTypes[$i])) {
+					break;
+				}
+
+				if ($removeKeysCount > 0) {
+					$extractTypeHasOffsetValueType = $extractType->hasOffsetValueType($this->keyTypes[$i]);
+
+					if (
+						(!$isOptional && $extractTypeHasOffsetValueType->yes())
+						|| ($isOptional && $extractTypeHasOffsetValueType->maybe())
+					) {
+						$removeKeysCount--;
+						continue;
+					}
+				}
+
+				if (!$isOptional && $extractType->hasOffsetValueType($this->keyTypes[$i])->maybe()) {
+					$isOptional = true;
+				}
+
+				$builder->setOffsetValueType(
+					$this->keyTypes[$i]->isInteger()->no() ? $this->keyTypes[$i] : null,
+					$this->valueTypes[$i],
+					$isOptional,
+				);
+			}
+
+			$types[] = $builder->getArray();
+		}
+
+		return TypeCombinator::union(...$types);
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		$keysCount = count($this->keyTypes);

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -919,10 +919,7 @@ class ConstantArrayType implements Type
 
 	public function shuffleArray(): Type
 	{
-		$builder = ConstantArrayTypeBuilder::createFromConstantArray($this->getValuesArray());
-		$builder->degradeToGeneralArray();
-
-		return $builder->getArray();
+		return $this->getValuesArray()->degradeToGeneralArray();
 	}
 
 	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
@@ -943,10 +940,7 @@ class ConstantArrayType implements Type
 		}
 
 		if ($offset === null || $length === null) {
-			$builder = ConstantArrayTypeBuilder::createFromConstantArray($this);
-			$builder->degradeToGeneralArray();
-
-			return $builder->getArray()
+			return $this->degradeToGeneralArray()
 				->sliceArray($offsetType, $lengthType, $preserveKeys);
 		}
 
@@ -1266,6 +1260,14 @@ class ConstantArrayType implements Type
 		}
 
 		return new self($this->keyTypes, $valueTypes, $this->nextAutoIndexes, $this->optionalKeys, $this->isList);
+	}
+
+	private function degradeToGeneralArray(): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createFromConstantArray($this);
+		$builder->degradeToGeneralArray();
+
+		return $builder->getArray();
 	}
 
 	public function getKeysArray(): self

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -913,6 +913,11 @@ class IntersectionType implements CompoundType
 		return $result;
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->spliceArray($offsetType, $lengthType, $replacementType));
+	}
+
 	public function getEnumCases(): array
 	{
 		$compare = [];

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -287,6 +287,15 @@ class MixedType implements CompoundType, SubtractableType
 		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -333,6 +333,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return new NeverType();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -455,6 +455,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->sliceArray($offsetType, $lengthType, $preserveKeys);
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return $this->getStaticObjectType()->spliceArray($offsetType, $lengthType, $replacementType);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -308,6 +308,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->sliceArray($offsetType, $lengthType, $preserveKeys);
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return $this->resolve()->spliceArray($offsetType, $lengthType, $replacementType);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -99,4 +99,9 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -99,4 +99,9 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -158,6 +158,8 @@ interface Type
 
 	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type;
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type;
+
 	/**
 	 * @return list<EnumCaseObjectType>
 	 */

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -791,6 +791,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->sliceArray($offsetType, $lengthType, $preserveKeys));
 	}
 
+	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->spliceArray($offsetType, $lengthType, $replacementType));
+	}
+
 	public function getEnumCases(): array
 	{
 		return $this->pickFromTypes(

--- a/tests/PHPStan/Analyser/nsrt/array_splice.php
+++ b/tests/PHPStan/Analyser/nsrt/array_splice.php
@@ -20,42 +20,367 @@ final class Foo
 function insertViaArraySplice(array $arr): void
 {
 	$brr = $arr;
-	array_splice($brr, 0, 0, 1);
+	$extract = array_splice($brr, 0, 0, 1);
+	assertType('non-empty-array<int, int>', $brr);
+	assertType('array{}', $extract);
+
+	$brr = $arr;
+	$extract = array_splice($brr, 0, 0, [1]);
+	assertType('non-empty-array<int, int>', $brr);
+	assertType('array{}', $extract);
+
+	$brr = $arr;
+	$extract = array_splice($brr, 0, 0, '');
+	assertType('non-empty-array<int, \'\'|int>', $brr);
+	assertType('array{}', $extract);
+
+	$brr = $arr;
+	$extract = array_splice($brr, 0, 0, ['']);
+	assertType('non-empty-array<int, \'\'|int>', $brr);
+	assertType('array{}', $extract);
+
+	$brr = $arr;
+	$extract = array_splice($brr, 0, 0, null);
 	assertType('array<int, int>', $brr);
+	assertType('array{}', $extract);
 
 	$brr = $arr;
-	array_splice($brr, 0, 0, [1]);
-	assertType('array<int, int>', $brr);
+	$extract = array_splice($brr, 0, 0, [null]);
+	assertType('non-empty-array<int, int|null>', $brr);
+	assertType('array{}', $extract);
 
 	$brr = $arr;
-	array_splice($brr, 0, 0, '');
-	assertType('array<int, \'\'|int>', $brr);
+	$extract = array_splice($brr, 0, 0, new Foo());
+	assertType('non-empty-array<int, bool|int|string>', $brr);
+	assertType('array{}', $extract);
 
 	$brr = $arr;
-	array_splice($brr, 0, 0, ['']);
-	assertType('array<int, \'\'|int>', $brr);
+	$extract = array_splice($brr, 0, 0, [new \stdClass()]);
+	assertType('non-empty-array<int, int|stdClass>', $brr);
+	assertType('array{}', $extract);
 
 	$brr = $arr;
-	array_splice($brr, 0, 0, null);
-	assertType('array<int, int>', $brr);
+	$extract = array_splice($brr, 0, 0, false);
+	assertType('non-empty-array<int, int|false>', $brr);
+	assertType('array{}', $extract);
 
 	$brr = $arr;
-	array_splice($brr, 0, 0, [null]);
-	assertType('array<int, int|null>', $brr);
+	$extract = array_splice($brr, 0, 0, [false]);
+	assertType('non-empty-array<int, int|false>', $brr);
+	assertType('array{}', $extract);
 
 	$brr = $arr;
-	array_splice($brr, 0, 0, new Foo());
-	assertType('array<int, bool|int|string>', $brr);
+	$extract = array_splice($brr, 0);
+	assertType('array{}', $brr);
+	assertType('list<int>', $extract);
+}
 
-	$brr = $arr;
-	array_splice($brr, 0, 0, [new \stdClass()]);
-	assertType('array<int, int|stdClass>', $brr);
+function constantArrays(array $arr, array $arr2): void
+{
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 0, 1, ['hello']);
+	assertType('array{0: \'hello\', b: \'bar\', 1: \'baz\'}', $arr);
+	assertType('array{\'foo\'}', $extract);
 
-	$brr = $arr;
-	array_splice($brr, 0, 0, false);
-	assertType('array<int, int|false>', $brr);
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 1, 2, ['hello']);
+	assertType('array{\'foo\', \'hello\'}', $arr);
+	assertType('array{b: \'bar\', 0: \'baz\'}', $extract);
 
-	$brr = $arr;
-	array_splice($brr, 0, 0, [false]);
-	assertType('array<int, int|false>', $brr);
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 0, -1, ['hello']);
+	assertType('array{\'hello\', \'baz\'}', $arr);
+	assertType('array{0: \'foo\', b: \'bar\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 0, -2, ['hello']);
+	assertType('array{0: \'hello\', b: \'bar\', 1: \'baz\'}', $arr);
+	assertType('array{\'foo\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, -1, -1, ['hello']);
+	assertType('array{0: \'foo\', b: \'bar\', 1: \'hello\', 2: \'baz\'}', $arr);
+	assertType('array{}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, -2, -2, ['hello']);
+	assertType('array{0: \'foo\', 1: \'hello\', b: \'bar\', 2: \'baz\'}', $arr);
+	assertType('array{}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 99, 0, ['hello']);
+	assertType('array{0: \'foo\', b: \'bar\', 1: \'baz\'}', $arr);
+	assertType('array{}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 1, 99, ['hello']);
+	assertType('array{\'foo\', \'hello\'}', $arr);
+	assertType('array{b: \'bar\', 0: \'baz\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, -99, 99, ['hello']);
+	assertType('array{\'hello\'}', $arr);
+	assertType('array{0: \'foo\', b: \'bar\', 1: \'baz\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 0, -99, ['hello']);
+	assertType('array{0: \'hello\', 1: \'foo\', b: \'bar\', 2: \'baz\'}', $arr);
+	assertType('array{}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, -2, 1, ['hello']);
+	assertType('array{\'foo\', \'hello\', \'baz\'}', $arr);
+	assertType('array{b: \'bar\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, -1, 1, ['hello']);
+	assertType('array{0: \'foo\', b: \'bar\', 1: \'hello\'}', $arr);
+	assertType('array{\'baz\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 0, null, ['hello']);
+	assertType('array{\'hello\'}', $arr);
+	assertType('array{0: \'foo\', b: \'bar\', 1: \'baz\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	$arr;
+	$extract = array_splice($arr, 0);
+	assertType('array{}', $arr);
+	assertType('array{0: \'foo\', b: \'bar\', 1: \'baz\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	/** @var array<\stdClass> $arr2 */
+	$arr;
+	$extract = array_splice($arr, 1, 1, $arr2);
+	assertType('non-empty-array<int<0, max>, \'baz\'|\'foo\'|stdClass>', $arr);
+	assertType('array{b: \'bar\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	/** @var array<\stdClass> $arr2 */
+	$arr;
+	$extract = array_splice($arr, 0, 1, $arr2);
+	assertType('non-empty-array<\'b\'|int<0, max>, \'bar\'|\'baz\'|stdClass>', $arr);
+	assertType('array{\'foo\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	/** @var array{x: 'x', y?: 'y', 3: 66}|array{z: 'z', 5?: 77, 4: int} $arr2 */
+	$arr;
+	$extract = array_splice($arr, 0, 1, $arr2);
+	assertType('array{0: \'x\'|\'z\', 1: \'y\'|int, 2: \'baz\'|int, b: \'bar\', 3?: \'baz\'}', $arr);
+	assertType('array{\'foo\'}', $extract);
+
+	/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+	/** @var array{x: 'x', y?: 'y', 3: 66}|array{z: 'z', 5?: 77, 4: int}|array<object|null> $arr2 */
+	$arr;
+	$extract = array_splice($arr, 0, 1, $arr2);
+	assertType('non-empty-array<\'b\'|int<0, max>, \'bar\'|\'baz\'|\'x\'|\'y\'|\'z\'|int|object|null>', $arr);
+	assertType('array{\'foo\'}', $extract);
+}
+
+function constantArraysWithOptionalKeys(array $arr): void
+{
+	/**
+	 * @see https://3v4l.org/2UJ3u
+	 * @var array{a?: 0, b: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 0, 1, ['hello']);
+	assertType('array{0: \'hello\', b?: 1, c: 2}', $arr);
+	assertType('array{a?: 0, b?: 1}', $extract);
+
+	/**
+	 * @see https://3v4l.org/Aq4l6
+	 * @var array{a?: 0, b: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 1, 1, ['hello']);
+	assertType('array{a?: 0, b?: 1, 0: \'hello\', c?: 2}', $arr);
+	assertType('array{b?: 1, c?: 2}', $extract);
+
+	/**
+	 * @see https://3v4l.org/GBMps
+	 * @var array{a?: 0, b: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, -1, 0, ['hello']);
+	assertType('array{a?: 0, b: 1, 0: \'hello\', c: 2}', $arr);
+	assertType('array{}', $extract);
+
+	/**
+	 * @see https://3v4l.org/dQVgY
+	 * @var array{a?: 0, b: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 0, -1, ['hello']);
+	assertType('array{0: \'hello\', c: 2}', $arr);
+	assertType('array{a?: 0, b: 1}', $extract);
+
+	/**
+	 * @see https://3v4l.org/5XWRC
+	 * @var array{a: 0, b?: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 0, 1, ['hello']);
+	assertType('array{0: \'hello\', b?: 1, c: 2}', $arr);
+	assertType('array{a: 0}', $extract);
+
+	/**
+	 * @see https://3v4l.org/QXZre
+	 * @var array{a: 0, b?: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 1, 1, ['hello']);
+	assertType('array{a: 0, 0: \'hello\', c?: 2}', $arr);
+	assertType('array{b?: 1, c?: 2}', $extract);
+
+	/**
+	 * @see https://3v4l.org/4JvMu
+	 * @var array{a: 0, b?: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, -1, 0, ['hello']);
+	assertType('array{a: 0, b?: 1, 0: \'hello\', c: 2}', $arr);
+	assertType('array{}', $extract);
+
+	/**
+	 * @see https://3v4l.org/srHon
+	 * @var array{a: 0, b?: 1, c: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 0, -1, ['hello']);
+	assertType('array{0: \'hello\', c: 2}', $arr);
+	assertType('array{a: 0, b?: 1}', $extract);
+
+	/**
+	 * @see https://3v4l.org/d0b0c
+	 * @var array{a: 0, b: 1, c?: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 0, 1, ['hello']);
+	assertType('array{0: \'hello\', b: 1, c?: 2}', $arr);
+	assertType('array{a: 0}', $extract);
+
+	/**
+	 * @see https://3v4l.org/OPfIf
+	 * @var array{a: 0, b: 1, c?: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 1, 1, ['hello']);
+	assertType('array{a: 0, 0: \'hello\', c?: 2}', $arr);
+	assertType('array{b: 1}', $extract);
+
+	/**
+	 * @see https://3v4l.org/b9R9E
+	 * @var array{a: 0, b: 1, c?: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, -1, 0, ['hello']);
+	assertType('array{a: 0, b: 1, 0: \'hello\', c?: 2}', $arr);
+	assertType('array{}', $extract);
+
+	/**
+	 * @see https://3v4l.org/0lFX6
+	 * @var array{a: 0, b: 1, c?: 2} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 0, -1, ['hello']);
+	assertType('array{0: \'hello\', b?: 1, c?: 2}', $arr);
+	assertType('array{a: 0, b?: 1}', $extract);
+
+	/**
+	 * @see https://3v4l.org/PLHYv
+	 * @var array{a: 0, b?: 1, c?: 2, d: 3} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, 1, 2, ['hello']);
+	assertType('array{a: 0, 0: \'hello\', d?: 3}', $arr);
+	assertType('array{b?: 1, c?: 2, d?: 3}', $extract);
+
+	/**
+	 * @see https://3v4l.org/Li5bj
+	 * @var array{a: 0, b?: 1, c?: 2, d: 3} $arr
+	 */
+	$arr;
+	$extract = array_splice($arr, -2, 2, ['hello']);
+	assertType('array{a?: 0, b?: 1, 0: \'hello\'}', $arr);
+	assertType('array{a?: 0, b?: 1, c?: 2, d: 3}', $extract);
+}
+
+function offsets(array $arr): void
+{
+	if (array_key_exists(1, $arr)) {
+		$extract = array_splice($arr, 0, 1, 'hello');
+		assertType('non-empty-array', $arr);
+		assertType('array', $extract);
+	}
+
+	if (array_key_exists(1, $arr)) {
+		$extract = array_splice($arr, 0, 0, 'hello');
+		assertType('non-empty-array&hasOffset(1)', $arr);
+		assertType('array{}', $extract);
+	}
+
+	if (array_key_exists(1, $arr) && $arr[1] === 'foo') {
+		$extract = array_splice($arr, 0, 1, 'hello');
+		assertType('non-empty-array', $arr);
+		assertType('array', $extract);
+	}
+
+	if (array_key_exists(1, $arr) && $arr[1] === 'foo') {
+		$extract = array_splice($arr, 0, 0, 'hello');
+		assertType('non-empty-array&hasOffsetValue(1, \'foo\')', $arr);
+		assertType('array{}', $extract);
+	}
+}
+
+function lists(array $arr): void
+{
+	/** @var list<string> $arr */
+	$arr;
+	$extract = array_splice($arr, 0, 1, 'hello');
+	assertType('non-empty-list<string>', $arr);
+	assertType('list<string>', $extract);
+
+	/** @var non-empty-list<string> $arr */
+	$arr;
+	$extract = array_splice($arr, 0, 1);
+	assertType('list<string>', $arr);
+	assertType('non-empty-list<string>', $extract);
+
+	/** @var list<string> $arr */
+	$arr;
+	$extract = array_splice($arr, 0, 0, 'hello');
+	assertType('non-empty-list<string>', $arr);
+	assertType('array{}', $extract);
+
+	/** @var list<string> $arr */
+	$arr;
+	$extract = array_splice($arr, 0, null, 'hello');
+	assertType('non-empty-list<string>', $arr);
+	assertType('list<string>', $extract);
+
+	/** @var list<string> $arr */
+	$arr;
+	$extract = array_splice($arr, 0, null);
+	assertType('array{}', $arr);
+	assertType('list<string>', $extract);
+
+	/** @var list<string> $arr */
+	$arr;
+	$extract = array_splice($arr, 0, 1);
+	assertType('list<string>', $arr);
+	assertType('list<string>', $extract);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11917.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11917.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11917;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @return list<string>
+ */
+function generateList(string $name): array
+{
+	$a = ['a', 'b', 'c', $name];
+	assertType('array{\'a\', \'b\', \'c\', string}', $a);
+	$b = ['d', 'e'];
+	assertType('array{\'d\', \'e\'}', $b);
+
+	array_splice($a, 2, 0, $b);
+	assertType('array{\'a\', \'b\', \'d\', \'e\', \'c\', string}', $a);
+
+	return $a;
+}
+
+var_dump(generateList('John'));

--- a/tests/PHPStan/Analyser/nsrt/bug-5017.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-5017.php
@@ -12,10 +12,10 @@ class Foo
 		$items = [0, 1, 2, 3, 4];
 
 		while ($items) {
-			assertType('non-empty-array<0|1|2|3|4, 0|1|2|3|4>', $items);
+			assertType('non-empty-list<int<min, 4>>', $items);
 			$batch = array_splice($items, 0, 2);
-			assertType('array<0|1|2|3|4, 0|1|2|3|4>', $items);
-			assertType('list<0|1|2|3|4>', $batch);
+			assertType('list<int<min, 4>>', $items);
+			assertType('non-empty-list<int<min, 4>>', $batch);
 		}
 	}
 
@@ -37,7 +37,7 @@ class Foo
 		$items = [0, 1, 2, 3, 4];
 		assertType('array{0, 1, 2, 3, 4}', $items);
 		$batch = array_splice($items, 0, 2);
-		assertType('array<0|1|2|3|4, 0|1|2|3|4>', $items);
+		assertType('array{2, 3, 4}', $items);
 		assertType('array{0, 1}', $batch);
 	}
 

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -336,6 +336,13 @@ class ReturnTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug11917(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkNullables = true;
+		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-11917.php'], []);
+	}
+
 	public function testBug12274(): void
 	{
 		$this->checkExplicitMixed = true;


### PR DESCRIPTION
~**Needs https://github.com/phpstan/phpstan-src/pull/3959 first**~ DONE

Closes https://github.com/phpstan/phpstan/issues/11917

This is very similar to `Type:: sliceArray()` and it is used in `NodeScopeResolver` in a similar fashion as `Type::popArray()` is. Moving logic to `Type` deals obviously with all accessory types which were not working properly before too like e.g. list or non-empty-array.

First commit is a tiny refactor I didn't want to cause more noise and dependencies with another PR..