### PR TITLE
Make constant array degradation to general array more DRY

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -913,10 +913,7 @@ class ConstantArrayType implements Type
 
 	public function shuffleArray(): Type
 	{
-		$builder = ConstantArrayTypeBuilder::createFromConstantArray($this->getValuesArray());
-		$builder->degradeToGeneralArray();
-
-		return $builder->getArray();
+		return $this->getValuesArray()->degradeToGeneralArray();
 	}
 
 	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
@@ -937,10 +934,7 @@ class ConstantArrayType implements Type
 		}
 
 		if ($offset === null || $length === null) {
-			$builder = ConstantArrayTypeBuilder::createFromConstantArray($this);
-			$builder->degradeToGeneralArray();
-
-			return $builder->getArray()
+			return $this->degradeToGeneralArray()
 				->sliceArray($offsetType, $lengthType, $preserveKeys);
 		}
 
@@ -1250,6 +1244,14 @@ class ConstantArrayType implements Type
 		}
 
 		return new self($this->keyTypes, $valueTypes, $this->nextAutoIndexes, $this->optionalKeys, $this->isList);
+	}
+
+	private function degradeToGeneralArray(): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createFromConstantArray($this);
+		$builder->degradeToGeneralArray();
+
+		return $builder->getArray();
 	}
 
 	public function getKeysArray(): self


### PR DESCRIPTION
I will need this once more in `spliceArray()`, but since that PR is not ready yet, I decided to extract this small refactor first.