### PR TITLE
Fix `array_slice()` edge cases

### DIFF
--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -216,10 +216,7 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 
 	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
 	{
-		if (
-			(new ConstantIntegerType(0))->isSuperTypeOf($offsetType)->yes()
-			&& ($lengthType->isNull()->yes() || IntegerRangeType::fromInterval(1, null)->isSuperTypeOf($lengthType)->yes())
-		) {
+		if ((new ConstantIntegerType(0))->isSuperTypeOf($offsetType)->yes() && $lengthType->isNull()->yes()) {
 			return $this;
 		}
 

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -442,6 +442,10 @@ class ArrayType implements Type
 
 	public function sliceArray(Type $offsetType, Type $lengthType, TrinaryLogic $preserveKeys): Type
 	{
+		if ((new ConstantIntegerType(0))->isSuperTypeOf($lengthType)->yes()) {
+			return new ConstantArrayType([], []);
+		}
+
 		if ($preserveKeys->no() && $this->keyType->isInteger()->yes()) {
 			return TypeCombinator::intersect(new self(new IntegerType(), $this->itemType), new AccessoryArrayListType());
 		}

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -944,15 +944,25 @@ class ConstantArrayType implements Type
 				->sliceArray($offsetType, $lengthType, $preserveKeys);
 		}
 
+		if ($keyTypesCount + $offset <= 0) {
+			// A negative offset cannot reach left outside the array twice
+			$offset = 0;
+		}
+
+		if ($keyTypesCount + $length <= 0) {
+			// A negative length cannot reach left outside the array twice
+			$length = 0;
+		}
+
+		if ($length === 0 || ($offset < 0 && $length < 0 && $offset - $length >= 0)) {
+			// 0 / 0, 3 / 0 or e.g. -3 / -3 or -3 / -4 and so on never extract anything
+			return new self([], []);
+		}
+
 		if ($length < 0) {
 			// Negative lengths prevent access to the most right n elements
 			return $this->removeLastElements($length * -1)
 				->sliceArray($offsetType, new NullType(), $preserveKeys);
-		}
-
-		if ($keyTypesCount + $offset <= 0) {
-			// A negative offset cannot reach left outside the array
-			$offset = 0;
 		}
 
 		if ($offset < 0) {

--- a/tests/PHPStan/Analyser/nsrt/array-slice.php
+++ b/tests/PHPStan/Analyser/nsrt/array-slice.php
@@ -36,6 +36,22 @@ class Foo
 		/** @var array<string, int> $arr */
 		assertType('array<string, int>', array_slice($arr, 1, 2));
 		assertType('array<string, int>', array_slice($arr, 1, 2, true));
+
+		/** @var non-empty-array<string> $arr */
+		assertType('array{}', array_slice($arr, 0, 0));
+		assertType('array{}', array_slice($arr, 0, 0, true));
+
+		/** @var non-empty-array<string> $arr */
+		assertType('array<string>', array_slice($arr, 0, 1));
+		assertType('array<string>', array_slice($arr, 0, 1, true));
+
+		/** @var list<string> $arr */
+		assertType('list<string>', array_slice($arr, 0, 1));
+		assertType('list<string>', array_slice($arr, 0, 1, true));
+
+		/** @var non-empty-list<string> $arr */
+		assertType('non-empty-list<string>', array_slice($arr, 0, 1));
+		assertType('non-empty-list<string>', array_slice($arr, 0, 1, true));
 	}
 
 	public function constantArrays(array $arr): void
@@ -48,6 +64,14 @@ class Foo
 		/** @var array{17: 'foo', 19: 'bar', 21: 'baz'}|array{foo: 17, bar: 19, baz: 21} $arr */
 		assertType('array{\'bar\', \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2));
 		assertType('array{19: \'bar\', 21: \'baz\'}|array{bar: 19, baz: 21}', array_slice($arr, 1, 2, true));
+
+		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+		assertType('array{}', array_slice($arr, -1, -1));
+		assertType('array{}', array_slice($arr, -1, -1, true));
+
+		/** @var array{17: 'foo', b: 'bar', 19: 'baz'} $arr */
+		assertType('array{}', array_slice($arr, -1, -2));
+		assertType('array{}', array_slice($arr, -1, -2, true));
 	}
 
 	public function constantArraysWithOptionalKeys(array $arr): void

--- a/tests/PHPStan/Analyser/nsrt/bug-5017.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-5017.php
@@ -15,7 +15,7 @@ class Foo
 			assertType('non-empty-array<0|1|2|3|4, 0|1|2|3|4>', $items);
 			$batch = array_splice($items, 0, 2);
 			assertType('array<0|1|2|3|4, 0|1|2|3|4>', $items);
-			assertType('non-empty-list<0|1|2|3|4>', $batch);
+			assertType('list<0|1|2|3|4>', $batch);
 		}
 	}
 
@@ -28,7 +28,7 @@ class Foo
 			assertType('non-empty-array<int>', $items);
 			$batch = array_splice($items, 0, 2);
 			assertType('array<int>', $items);
-			assertType('non-empty-array<int>', $batch);
+			assertType('array<int>', $batch);
 		}
 	}
 


### PR DESCRIPTION
Noticed this while finishing https://github.com/phpstan/phpstan-src/pull/3952

Edge cases fixed here:

1. Bug fix: we cannot assume that the result of `array_slice($array, 0, <positive int>) ` with a non-empty-array as input will also return a non-empty array because we don't know which of the keys is set. That only can be done for a non-empty-list. The last test change shows this nicely
```diff
                        assertType('non-empty-array<int>', $items);
                        $batch = array_splice($items, 0, 2);
                        assertType('array<int>', $items);
-                       assertType('non-empty-array<int>', $batch);
+                       assertType('array<int>', $batch);
```

2. Improvement: `array_slice` with length set to 0 will always return `array{}`

3. Bug fix: `array_slice` with negative offset and negative length of the same value or smaller will always return `array{}`