### PR TITLE
Micro optimize LazyInternalScopeFactory

### DIFF
--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -17,10 +17,16 @@ use PHPStan\Rules\Properties\PropertyReflectionFinder;
 final class LazyInternalScopeFactory implements InternalScopeFactory
 {
 
+	/**
+	 * @var int|array{min: int, max: int}|null
+	 */
+	private int|array|null $phpVersion;
+
 	public function __construct(
 		private Container $container,
 	)
 	{
+		$this->phpVersion = $this->container->getParameter('phpVersion');
 	}
 
 	public function create(
@@ -58,7 +64,7 @@ final class LazyInternalScopeFactory implements InternalScopeFactory
 			$context,
 			$this->container->getByType(PhpVersion::class),
 			$this->container->getByType(AttributeReflectionFactory::class),
-			$this->container->getParameter('phpVersion'),
+			$this->phpVersion,
 			$declareStrictTypes,
 			$function,
 			$namespace,

--- a/src/Analyser/LazyInternalScopeFactory.php
+++ b/src/Analyser/LazyInternalScopeFactory.php
@@ -17,9 +17,7 @@ use PHPStan\Rules\Properties\PropertyReflectionFinder;
 final class LazyInternalScopeFactory implements InternalScopeFactory
 {
 
-	/**
-	 * @var int|array{min: int, max: int}|null
-	 */
+	/** @var int|array{min: int, max: int}|null */
 	private int|array|null $phpVersion;
 
 	public function __construct(


### PR DESCRIPTION
`getParameter()` is showing up in perf profiles

<img width="614" alt="grafik" src="https://github.com/user-attachments/assets/d5bc851f-6fc1-4444-ae98-1670ceae3a3b" />

before this PR
```
➜  phpstan-src git:(2.1.x) hyperfine 'php bin/phpstan analyze src/Analyser/NodeScopeResolver.php --debug # Old' -i
Benchmark 1: php bin/phpstan analyze src/Analyser/NodeScopeResolver.php --debug # Old
  Time (mean ± σ):      7.266 s ±  0.020 s    [User: 7.079 s, System: 0.183 s]
  Range (min … max):    7.230 s …  7.292 s    10 runs
```

after this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyze src/Analyser/NodeScopeResolver.php --debug # New' -i
Benchmark 1: php bin/phpstan analyze src/Analyser/NodeScopeResolver.php --debug # New
  Time (mean ± σ):      7.124 s ±  0.018 s    [User: 6.935 s, System: 0.184 s]
  Range (min … max):    7.085 s …  7.156 s    10 runs
```