### PR TITLE
Resolve `ExtendedFunctionVariant::getReturnType()` more lazily

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1855,6 +1855,12 @@ parameters:
 			path: src/Type/TypehintHelper.php
 
 		-
+			message: '#^Doing instanceof PHPStan\\Type\\TypeWithClassName is error\-prone and deprecated\. Use Type\:\:getObjectClassNames\(\) or Type\:\:getObjectClassReflections\(\) instead\.$#'
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Type/TypehintHelper.php
+
+		-
 			message: '#^Doing instanceof PHPStan\\Type\\CallableType is error\-prone and deprecated\. Use Type\:\:isCallable\(\) and Type\:\:getCallableParametersAcceptors\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 2

--- a/src/Reflection/ExtendedFunctionVariant.php
+++ b/src/Reflection/ExtendedFunctionVariant.php
@@ -5,6 +5,7 @@ namespace PHPStan\Reflection;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypehintHelper;
 
 /**
  * @api
@@ -21,7 +22,7 @@ class ExtendedFunctionVariant extends FunctionVariant implements ExtendedParamet
 		?TemplateTypeMap $resolvedTemplateTypeMap,
 		array $parameters,
 		bool $isVariadic,
-		Type $returnType,
+		private ?Type $returnType,
 		private Type $phpDocReturnType,
 		private Type $nativeReturnType,
 		?TemplateTypeVarianceMap $callSiteVarianceMap = null,
@@ -32,7 +33,10 @@ class ExtendedFunctionVariant extends FunctionVariant implements ExtendedParamet
 			$resolvedTemplateTypeMap,
 			$parameters,
 			$isVariadic,
-			$returnType,
+			$returnType ?? TypehintHelper::decideType(
+				$nativeReturnType,
+				$phpDocReturnType,
+			),
 			$callSiteVarianceMap,
 		);
 	}
@@ -46,6 +50,18 @@ class ExtendedFunctionVariant extends FunctionVariant implements ExtendedParamet
 		$parameters = parent::getParameters();
 
 		return $parameters;
+	}
+
+	public function getReturnType(): Type
+	{
+		if ($this->returnType === null) {
+			return $this->returnType = TypehintHelper::decideType(
+				$this->nativeReturnType,
+				$this->phpDocReturnType,
+			);
+		}
+
+		return $this->returnType;
 	}
 
 	public function getPhpDocReturnType(): Type

--- a/src/Reflection/Php/PhpClassReflectionExtension.php
+++ b/src/Reflection/Php/PhpClassReflectionExtension.php
@@ -954,10 +954,9 @@ final class PhpClassReflectionExtension
 		}
 
 		if ($stubPhpDocReturnType !== null) {
-			$returnType = $stubPhpDocReturnType;
 			$phpDocReturnType = $stubPhpDocReturnType;
 		} else {
-			$returnType = TypehintHelper::decideType($methodSignature->getReturnType(), $phpDocReturnType);
+			$phpDocReturnType = TypehintHelper::decideType($methodSignature->getReturnType(), $phpDocReturnType);
 		}
 
 		return new ExtendedFunctionVariant(
@@ -965,8 +964,8 @@ final class PhpClassReflectionExtension
 			null,
 			$parameters,
 			$methodSignature->isVariadic(),
-			$returnType,
-			$phpDocReturnType ?? new MixedType(),
+			null,
+			$phpDocReturnType,
 			$methodSignature->getNativeReturnType(),
 		);
 	}

--- a/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
+++ b/src/Reflection/Php/PhpFunctionFromParserNodeReflection.php
@@ -112,7 +112,7 @@ class PhpFunctionFromParserNodeReflection implements FunctionReflection, Extende
 					$this->getResolvedTemplateTypeMap(),
 					$this->getParameters(),
 					$this->isVariadic(),
-					$this->getReturnType(),
+					null,
 					$this->getPhpDocReturnType(),
 					$this->getNativeReturnType(),
 				),

--- a/src/Reflection/Php/PhpFunctionReflection.php
+++ b/src/Reflection/Php/PhpFunctionReflection.php
@@ -94,7 +94,7 @@ final class PhpFunctionReflection implements FunctionReflection
 					null,
 					$this->getParameters(),
 					$this->isVariadic(),
-					$this->getReturnType(),
+					null,
 					$this->getPhpDocReturnType(),
 					$this->getNativeReturnType(),
 				),

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -202,7 +202,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 					null,
 					$this->getParameters(),
 					$this->isVariadic(),
-					$this->getReturnType(),
+					null,
 					$this->getPhpDocReturnType(),
 					$this->getNativeReturnType(),
 				),
@@ -302,30 +302,9 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 	private function getReturnType(): Type
 	{
 		if ($this->returnType === null) {
-			$name = strtolower($this->getName());
-			$returnType = $this->reflection->getReturnType();
-			if ($returnType === null) {
-				if (in_array($name, ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
-					return $this->returnType = TypehintHelper::decideType(new VoidType(), $this->phpDocReturnType);
-				}
-				if ($name === '__tostring') {
-					return $this->returnType = TypehintHelper::decideType(new StringType(), $this->phpDocReturnType);
-				}
-				if ($name === '__isset') {
-					return $this->returnType = TypehintHelper::decideType(new BooleanType(), $this->phpDocReturnType);
-				}
-				if ($name === '__sleep') {
-					return $this->returnType = TypehintHelper::decideType(new ArrayType(new IntegerType(), new StringType()), $this->phpDocReturnType);
-				}
-				if ($name === '__set_state') {
-					return $this->returnType = TypehintHelper::decideType(new ObjectWithoutClassType(), $this->phpDocReturnType);
-				}
-			}
-
-			$this->returnType = TypehintHelper::decideTypeFromReflection(
-				$returnType,
+			$this->returnType = TypehintHelper::decideType(
+				$this->getNativeReturnType(),
 				$this->phpDocReturnType,
-				$this->declaringClass,
 			);
 		}
 
@@ -344,8 +323,28 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 	private function getNativeReturnType(): Type
 	{
 		if ($this->nativeReturnType === null) {
+			$returnType = $this->reflection->getReturnType();
+			if ($returnType === null) {
+				$name = strtolower($this->getName());
+				if (in_array($this->getName(), ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
+					return $this->nativeReturnType = new VoidType();
+				}
+				if ($name === '__tostring') {
+					return $this->nativeReturnType = new StringType();
+				}
+				if ($name === '__isset') {
+					return $this->nativeReturnType = new BooleanType();
+				}
+				if ($name === '__sleep') {
+					return $this->nativeReturnType = new ArrayType(new IntegerType(), new StringType());
+				}
+				if ($name === '__set_state') {
+					return $this->nativeReturnType = new ObjectWithoutClassType();
+				}
+			}
+
 			$this->nativeReturnType = TypehintHelper::decideTypeFromReflection(
-				$this->reflection->getReturnType(),
+				$returnType,
 				null,
 				$this->declaringClass,
 			);

--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -139,7 +139,7 @@ final class NativeFunctionReflectionProvider
 						);
 					}, $functionSignature->getParameters()),
 					$functionSignature->isVariadic(),
-					TypehintHelper::decideType($functionSignature->getReturnType(), $phpDocReturnType),
+					null,
 					$phpDocReturnType ?? new MixedType(),
 					$functionSignature->getReturnType(),
 				);

--- a/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
@@ -86,12 +86,12 @@ final class CallbackUnresolvedMethodPrototypeReflection implements UnresolvedMet
 	{
 		$selfOutType = $method->getSelfOutType() !== null ? $this->transformStaticType($method->getSelfOutType()) : null;
 		$variantFn = function (ExtendedParametersAcceptor $acceptor) use (&$selfOutType): ExtendedParametersAcceptor {
-			$originalReturnType = $acceptor->getReturnType();
-			if ($originalReturnType instanceof ThisType && $selfOutType !== null) {
-				$returnType = TypeCombinator::intersect($selfOutType, $this->transformStaticType($originalReturnType));
-				$selfOutType = $returnType;
+			$originalPhpDocReturnType = $acceptor->getPhpDocReturnType();
+			if ($originalPhpDocReturnType instanceof ThisType && $selfOutType !== null) {
+				$phpDocReturnType = TypeCombinator::intersect($selfOutType, $this->transformStaticType($originalPhpDocReturnType));
+				$selfOutType = $phpDocReturnType;
 			} else {
-				$returnType = $this->transformStaticType($originalReturnType);
+				$phpDocReturnType = $this->transformStaticType($originalPhpDocReturnType);
 			}
 			return new ExtendedFunctionVariant(
 				$acceptor->getTemplateTypeMap(),
@@ -114,8 +114,8 @@ final class CallbackUnresolvedMethodPrototypeReflection implements UnresolvedMet
 					$acceptor->getParameters(),
 				),
 				$acceptor->isVariadic(),
-				$returnType,
-				$this->transformStaticType($acceptor->getPhpDocReturnType()),
+				null,
+				$phpDocReturnType,
 				$this->transformStaticType($acceptor->getNativeReturnType()),
 				$acceptor->getCallSiteVarianceMap(),
 			);

--- a/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
@@ -82,11 +82,11 @@ final class CalledOnTypeUnresolvedMethodPrototypeReflection implements Unresolve
 	{
 		$selfOutType = $method->getSelfOutType() !== null ? $this->transformStaticType($method->getSelfOutType()) : null;
 		$variantFn = function (ExtendedParametersAcceptor $acceptor) use ($selfOutType): ExtendedParametersAcceptor {
-			$originalReturnType = $acceptor->getReturnType();
-			if ($originalReturnType instanceof ThisType && $selfOutType !== null) {
-				$returnType = $selfOutType;
+			$originalPhpDocReturnType = $acceptor->getPhpDocReturnType();
+			if ($originalPhpDocReturnType instanceof ThisType && $selfOutType !== null) {
+				$phpDocReturnType = $selfOutType;
 			} else {
-				$returnType = $this->transformStaticType($originalReturnType);
+				$phpDocReturnType = $this->transformStaticType($originalPhpDocReturnType);
 			}
 			return new ExtendedFunctionVariant(
 				$acceptor->getTemplateTypeMap(),
@@ -109,8 +109,8 @@ final class CalledOnTypeUnresolvedMethodPrototypeReflection implements Unresolve
 					$acceptor->getParameters(),
 				),
 				$acceptor->isVariadic(),
-				$returnType,
-				$this->transformStaticType($acceptor->getPhpDocReturnType()),
+				null,
+				$phpDocReturnType,
 				$this->transformStaticType($acceptor->getNativeReturnType()),
 				$acceptor->getCallSiteVarianceMap(),
 			);

--- a/src/Reflection/Type/IntersectionTypeMethodReflection.php
+++ b/src/Reflection/Type/IntersectionTypeMethodReflection.php
@@ -79,7 +79,6 @@ final class IntersectionTypeMethodReflection implements ExtendedMethodReflection
 
 	public function getVariants(): array
 	{
-		$returnType = TypeCombinator::intersect(...array_map(static fn (MethodReflection $method): Type => TypeCombinator::intersect(...array_map(static fn (ParametersAcceptor $acceptor): Type => $acceptor->getReturnType(), $method->getVariants())), $this->methods));
 		$phpDocReturnType = TypeCombinator::intersect(...array_map(static fn (MethodReflection $method): Type => TypeCombinator::intersect(...array_map(static fn (ParametersAcceptor $acceptor): Type => $acceptor->getPhpDocReturnType(), $method->getVariants())), $this->methods));
 		$nativeReturnType = TypeCombinator::intersect(...array_map(static fn (MethodReflection $method): Type => TypeCombinator::intersect(...array_map(static fn (ParametersAcceptor $acceptor): Type => $acceptor->getNativeReturnType(), $method->getVariants())), $this->methods));
 
@@ -88,7 +87,7 @@ final class IntersectionTypeMethodReflection implements ExtendedMethodReflection
 			$acceptor->getResolvedTemplateTypeMap(),
 			$acceptor->getParameters(),
 			$acceptor->isVariadic(),
-			$returnType,
+			null,
 			$phpDocReturnType,
 			$nativeReturnType,
 			$acceptor->getCallSiteVarianceMap(),

--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -12,6 +12,7 @@ use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use ReflectionType;
+use Traversable;
 use function array_map;
 use function count;
 use function get_class;
@@ -118,9 +119,24 @@ final class TypehintHelper
 				}
 			}
 
+			$resolvedPhpDocTypeToBounds = TemplateTypeHelper::resolveToBounds($phpDocType);
+			$isSuperType = $type->isSuperTypeOf($resolvedPhpDocTypeToBounds);
+			if (
+				!$isSuperType->yes()
+				&& (new ObjectType(Traversable::class))->isSuperTypeOf($phpDocType)->yes()
+				&& $type instanceof TypeWithClassName
+			) {
+				// if native type is Iterator and PHPDoc type is Traversable
+				// Allow PHPDoc type to win
+				$traversableAncestor = $type->getAncestorWithClassName(Traversable::class);
+				if ($traversableAncestor !== null) {
+					$isSuperType = $traversableAncestor->isSuperTypeOf($resolvedPhpDocTypeToBounds);
+				}
+			}
+
 			if (
 				(!$phpDocType instanceof NeverType || ($type instanceof MixedType && !$type->isExplicitMixed()))
-				&& $type->isSuperTypeOf(TemplateTypeHelper::resolveToBounds($phpDocType))->yes()
+				&& $isSuperType->yes()
 			) {
 				$resultType = $phpDocType;
 			} else {

--- a/tests/PHPStan/Analyser/nsrt/conditional-return-static-union.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-return-static-union.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ConditionalReturnStaticUnion;
+
+use function PHPStan\Testing\assertType;
+
+class Config {}
+class MainConfig
+{
+	/**
+	 * @param array<mixed>|Config $value
+	 * @return ($value is array ? Config : $this)
+	 */
+	public function invalidReturn(array|Config $value = []): Config|static
+	{
+		if (is_array($value)) {
+			return new Config();
+		}
+		return $this;
+	}
+
+	/**
+	 * @param array<mixed>|Config $value
+	 * @return ($value is array ? Config : $this)
+	 */
+	public function validReturn(array|Config $value = []): Config|self
+	{
+		if (is_array($value)) {
+			return new Config();
+		}
+		return $this;
+	}
+}
+
+function (MainConfig $c): void {
+	assertType(Config::class, (new MainConfig())->invalidReturn());
+	assertType(Config::class, (new MainConfig())->validReturn());
+	assertType(MainConfig::class, (new MainConfig())->invalidReturn(new Config()));
+	assertType(MainConfig::class, (new MainConfig())->validReturn(new Config()));
+
+	assertType(Config::class, $c->invalidReturn());
+	assertType(Config::class, $c->validReturn());
+	assertType(MainConfig::class, $c->invalidReturn(new Config()));
+	assertType(MainConfig::class, $c->validReturn(new Config()));
+};


### PR DESCRIPTION
This will allow the `$this` or `static` in PHPDoc return type to be first replaced with final-overriden ObjectType
before being thrown into `TypehintHelper::decideType()`.