### PR TITLE
TypehintHelper: remove unneeded default param value

### DIFF
--- a/src/Type/TypehintHelper.php
+++ b/src/Type/TypehintHelper.php
@@ -77,7 +77,7 @@ final class TypehintHelper
 
 	public static function decideType(
 		Type $type,
-		?Type $phpDocType = null,
+		?Type $phpDocType,
 	): Type
 	{
 		if ($type instanceof BenevolentUnionType) {


### PR DESCRIPTION
Calling `TypehintHelper->decideType()` without 2 arguments kind of misses the point. we may pass `null` but calling it with only 1 parameter does not make sense.