### PR TITLE
feat: add option to report ignores without comments

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -118,6 +118,7 @@ parameters:
 		resolvedPhpDocBlockCacheCountMax: 2048
 		nameScopeMapMemoryCacheCountMax: 2048
 	reportUnmatchedIgnoredErrors: true
+	reportIgnoresWithoutComments: false
 	typeAliases: []
 	universalObjectCratesClasses:
 		- stdClass
@@ -226,6 +227,7 @@ parameters:
 		- [parameters, errorFormat]
 		- [parameters, ignoreErrors]
 		- [parameters, reportUnmatchedIgnoredErrors]
+		- [parameters, reportIgnoresWithoutComments]
 		- [parameters, tipsOfTheDay]
 		- [parameters, parallel]
 		- [parameters, internalErrorsCountLimit]

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -143,6 +143,7 @@ parametersSchema:
 		nameScopeMapMemoryCacheCountMax: int()
 	])
 	reportUnmatchedIgnoredErrors: bool()
+	reportIgnoresWithoutComments: bool()
 	typeAliases: arrayOf(string())
 	universalObjectCratesClasses: listOf(string())
 	stubFiles: listOf(string())

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -28,19 +28,18 @@ final class AnalyserResultFinalizer
 		private LocalIgnoresProcessor $localIgnoresProcessor,
 		#[AutowiredParameter]
 		private bool $reportUnmatchedIgnoredErrors,
+		#[AutowiredParameter]
+		private bool $reportIgnoresWithoutComments,
 	)
 	{
 	}
 
 	public function finalize(AnalyserResult $analyserResult, bool $onlyFiles, bool $debug): FinalizerResult
 	{
-		if (count($analyserResult->getCollectedData()) === 0) {
-			return $this->addUnmatchedIgnoredErrors($this->mergeFilteredPhpErrors($analyserResult), [], []);
-		}
-
+		$hasCollectedData = count($analyserResult->getCollectedData()) > 0;
 		$hasInternalErrors = count($analyserResult->getInternalErrors()) > 0 || $analyserResult->hasReachedInternalErrorsCountLimit();
-		if ($hasInternalErrors) {
-			return $this->addUnmatchedIgnoredErrors($this->mergeFilteredPhpErrors($analyserResult), [], []);
+		if (! $hasCollectedData || $hasInternalErrors) {
+			return $this->addUnmatchedIgnoredErrors($this->addIgnoresWithoutCommentErrors($this->mergeFilteredPhpErrors($analyserResult)), [], []);
 		}
 
 		$nodeType = CollectedDataNode::class;
@@ -134,7 +133,7 @@ final class AnalyserResultFinalizer
 			$allUnmatchedLineIgnores[$file] = $localIgnoresProcessorResult->getUnmatchedLineIgnores();
 		}
 
-		return $this->addUnmatchedIgnoredErrors(new AnalyserResult(
+		return $this->addUnmatchedIgnoredErrors($this->addIgnoresWithoutCommentErrors(new AnalyserResult(
 			unorderedErrors: array_merge($errors, $analyserResult->getFilteredPhpErrors()),
 			filteredPhpErrors: [],
 			allPhpErrors: $analyserResult->getAllPhpErrors(),
@@ -148,7 +147,7 @@ final class AnalyserResultFinalizer
 			exportedNodes: $analyserResult->getExportedNodes(),
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
-		), $collectorErrors, $locallyIgnoredCollectorErrors);
+		)), $collectorErrors, $locallyIgnoredCollectorErrors);
 	}
 
 	private function mergeFilteredPhpErrors(AnalyserResult $analyserResult): AnalyserResult
@@ -205,7 +204,7 @@ final class AnalyserResultFinalizer
 
 					foreach ($identifiers as $identifier) {
 						$errors[] = (new Error(
-							sprintf('No error with identifier %s is reported on line %d.', $identifier, $line),
+							sprintf('No error with identifier %s is reported on line %d.', $identifier['name'], $line),
 							$file,
 							$line,
 							false,
@@ -234,6 +233,61 @@ final class AnalyserResultFinalizer
 			),
 			$collectorErrors,
 			$locallyIgnoredCollectorErrors,
+		);
+	}
+
+	private function addIgnoresWithoutCommentErrors(AnalyserResult $analyserResult): AnalyserResult
+	{
+		if (!$this->reportIgnoresWithoutComments) {
+			return $analyserResult;
+		}
+
+		$errors = $analyserResult->getUnorderedErrors();
+		foreach ($analyserResult->getLinesToIgnore() as $file => $data) {
+			foreach ($data as $ignoredFile => $lines) {
+				if ($ignoredFile !== $file) {
+					continue;
+				}
+
+				foreach ($lines as $line => $identifiers) {
+					if ($identifiers === null) {
+						continue;
+					}
+
+					foreach ($identifiers as $identifier) {
+						['name' => $name, 'comment' => $comment] = $identifier;
+						if ($comment !== null) {
+							continue;
+						}
+
+						$errors[] = (new Error(
+							sprintf('Ignore with identifier %s has no comment.', $name),
+							$file,
+							$line,
+							false,
+							$file,
+							null,
+							'Explain why this ignore is necessary in parentheses after the identifier.',
+						))->withIdentifier('ignore.noComment');
+					}
+				}
+			}
+		}
+
+		return new AnalyserResult(
+			$errors,
+			$analyserResult->getFilteredPhpErrors(),
+			$analyserResult->getAllPhpErrors(),
+			$analyserResult->getLocallyIgnoredErrors(),
+			$analyserResult->getLinesToIgnore(),
+			$analyserResult->getUnmatchedLineIgnores(),
+			$analyserResult->getInternalErrors(),
+			$analyserResult->getCollectedData(),
+			$analyserResult->getDependencies(),
+			$analyserResult->getUsedTraitDependencies(),
+			$analyserResult->getExportedNodes(),
+			$analyserResult->hasReachedInternalErrorsCountLimit(),
+			$analyserResult->getPeakMemoryUsageBytes(),
 		);
 	}
 

--- a/src/Analyser/FileAnalyserCallback.php
+++ b/src/Analyser/FileAnalyserCallback.php
@@ -21,6 +21,7 @@ use function sprintf;
 
 /**
  * @phpstan-import-type CollectorData from CollectedData
+ * @phpstan-import-type Identifier from FileAnalyserResult
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
  */
 final class FileAnalyserCallback
@@ -231,7 +232,7 @@ final class FileAnalyserCallback
 
 	/**
 	 * @param Node[] $nodes
-	 * @return array<int, non-empty-list<string>|null>
+	 * @return array<int, non-empty-list<Identifier>|null>
 	 */
 	private function getLinesToIgnoreFromTokens(array $nodes): array
 	{
@@ -239,7 +240,7 @@ final class FileAnalyserCallback
 			return [];
 		}
 
-		/** @var array<int, non-empty-list<string>|null> */
+		/** @var array<int, non-empty-list<Identifier>|null> */
 		return $nodes[0]->getAttribute('linesToIgnore', []);
 	}
 

--- a/src/Analyser/FileAnalyserResult.php
+++ b/src/Analyser/FileAnalyserResult.php
@@ -6,7 +6,8 @@ use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
- * @phpstan-type LinesToIgnore = array<string, array<int, non-empty-list<string>|null>>
+ * @phpstan-type Identifier = array{name: string, comment: string|null}
+ * @phpstan-type LinesToIgnore = array<string, array<int, non-empty-list<Identifier>|null>>
  * @phpstan-import-type CollectorData from CollectedData
  */
 final class FileAnalyserResult

--- a/src/Analyser/LocalIgnoresProcessor.php
+++ b/src/Analyser/LocalIgnoresProcessor.php
@@ -49,7 +49,7 @@ final class LocalIgnoresProcessor
 				}
 
 				foreach ($identifiers as $i => $ignoredIdentifier) {
-					if ($ignoredIdentifier !== $tmpFileError->getIdentifier()) {
+					if ($ignoredIdentifier['name'] !== $tmpFileError->getIdentifier()) {
 						continue;
 					}
 
@@ -68,7 +68,7 @@ final class LocalIgnoresProcessor
 						$unmatchedIgnoredIdentifiers = $unmatchedLineIgnores[$tmpFileError->getFile()][$line];
 						if (is_array($unmatchedIgnoredIdentifiers)) {
 							foreach ($unmatchedIgnoredIdentifiers as $j => $unmatchedIgnoredIdentifier) {
-								if ($ignoredIdentifier !== $unmatchedIgnoredIdentifier) {
+								if ($ignoredIdentifier['name'] !== $unmatchedIgnoredIdentifier['name']) {
 									continue;
 								}
 

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -313,7 +313,7 @@ final class FixerWorkerCommand extends Command
 					if ($error->getIdentifier() === null) {
 						continue;
 					}
-					if (!in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched', 'ignore.unmatchedLine', 'ignore.unmatchedIdentifier'], true)) {
+					if (!in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched', 'ignore.unmatchedLine', 'ignore.unmatchedIdentifier', 'ignore.noComment'], true)) {
 						continue;
 					}
 					$ignoreFileErrors[] = $error;

--- a/src/Parser/RichParser.php
+++ b/src/Parser/RichParser.php
@@ -7,12 +7,14 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Token;
+use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Analyser\Ignore\IgnoreLexer;
 use PHPStan\Analyser\Ignore\IgnoreParseException;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\File\FileReader;
 use PHPStan\ShouldNotHappenException;
 use function array_filter;
+use function array_key_last;
 use function array_map;
 use function count;
 use function implode;
@@ -30,6 +32,9 @@ use const T_COMMENT;
 use const T_DOC_COMMENT;
 use const T_WHITESPACE;
 
+/**
+ * @phpstan-import-type Identifier from FileAnalyserResult
+ */
 final class RichParser implements Parser
 {
 
@@ -120,7 +125,7 @@ final class RichParser implements Parser
 
 	/**
 	 * @param Token[] $tokens
-	 * @return array{lines: array<int, non-empty-list<string>|null>, errors: array<int, non-empty-list<string>>}
+	 * @return array{lines: array<int, non-empty-list<Identifier>|null>, errors: array<int, non-empty-list<string>>}
 	 */
 	private function getLinesToIgnore(array $tokens): array
 	{
@@ -277,33 +282,29 @@ final class RichParser implements Parser
 	}
 
 	/**
-	 * @return non-empty-list<string>
+	 * @return non-empty-list<Identifier>
 	 * @throws IgnoreParseException
 	 */
 	private function parseIdentifiers(string $text, int $ignorePos): array
 	{
 		$text = substr($text, $ignorePos + strlen('@phpstan-ignore'));
-		$originalTokens = $this->ignoreLexer->tokenize($text);
-		$tokens = [];
-
-		foreach ($originalTokens as $originalToken) {
-			if ($originalToken[IgnoreLexer::TYPE_OFFSET] === IgnoreLexer::TOKEN_WHITESPACE) {
-				continue;
-			}
-			$tokens[] = $originalToken;
-		}
+		$tokens = $this->ignoreLexer->tokenize($text);
 
 		$c = count($tokens);
 
 		$identifiers = [];
+		$comment = null;
 		$openParenthesisCount = 0;
 		$expected = [IgnoreLexer::TOKEN_IDENTIFIER];
+		$lastTokenTypeLabel = '@phpstan-ignore';
 
 		for ($i = 0; $i < $c; $i++) {
-			$lastTokenTypeLabel = isset($tokenType) ? $this->ignoreLexer->getLabel($tokenType) : '@phpstan-ignore';
+			if (isset($tokenType) && $tokenType !== IgnoreLexer::TOKEN_WHITESPACE) {
+				$lastTokenTypeLabel = $this->ignoreLexer->getLabel($tokenType);
+			}
 			[IgnoreLexer::VALUE_OFFSET => $content, IgnoreLexer::TYPE_OFFSET => $tokenType, IgnoreLexer::LINE_OFFSET => $tokenLine] = $tokens[$i];
 
-			if ($expected !== null && !in_array($tokenType, $expected, true)) {
+			if ($expected !== null && !in_array($tokenType, [...$expected, IgnoreLexer::TOKEN_WHITESPACE], true)) {
 				$tokenTypeLabel = $this->ignoreLexer->getLabel($tokenType);
 				$otherTokenContent = $tokenType === IgnoreLexer::TOKEN_OTHER ? sprintf(" '%s'", $content) : '';
 				$expectedLabels = implode(' or ', array_map(fn ($token) => $this->ignoreLexer->getLabel($token), $expected));
@@ -312,6 +313,9 @@ final class RichParser implements Parser
 			}
 
 			if ($tokenType === IgnoreLexer::TOKEN_OPEN_PARENTHESIS) {
+				if ($openParenthesisCount > 0) {
+					$comment .= $content;
+				}
 				$openParenthesisCount++;
 				$expected = null;
 				continue;
@@ -320,17 +324,25 @@ final class RichParser implements Parser
 			if ($tokenType === IgnoreLexer::TOKEN_CLOSE_PARENTHESIS) {
 				$openParenthesisCount--;
 				if ($openParenthesisCount === 0) {
+					$key = array_key_last($identifiers);
+					if ($key !== null) {
+						$identifiers[$key]['comment'] = $comment;
+						$comment = null;
+					}
 					$expected = [IgnoreLexer::TOKEN_COMMA, IgnoreLexer::TOKEN_END];
+				} else {
+					$comment .= $content;
 				}
 				continue;
 			}
 
 			if ($openParenthesisCount > 0) {
+				$comment .= $content;
 				continue; // waiting for comment end
 			}
 
 			if ($tokenType === IgnoreLexer::TOKEN_IDENTIFIER) {
-				$identifiers[] = $content;
+				$identifiers[] = ['name' => $content, 'comment' => null];
 				$expected = [IgnoreLexer::TOKEN_COMMA, IgnoreLexer::TOKEN_END, IgnoreLexer::TOKEN_OPEN_PARENTHESIS];
 				continue;
 			}
@@ -349,6 +361,7 @@ final class RichParser implements Parser
 			throw new IgnoreParseException('Missing identifier', 1);
 		}
 
+		/** @phpstan-ignore return.type (return type is correct, not sure why it's being changed from array shape to key-value shape) */
 		return $identifiers;
 	}
 

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -327,6 +327,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			self::createScopeFactory($reflectionProvider, self::getContainer()->getService('typeSpecifier')),
 			new LocalIgnoresProcessor(),
 			true,
+			false,
 		);
 
 		return [

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -639,6 +639,28 @@ class AnalyserTest extends PHPStanTestCase
 	}
 
 	#[DataProvider('dataTrueAndFalse')]
+	public function testIgnoresWithoutCommentsReported(): void
+	{
+		$expects = [
+			[9, 'variable.undefined'],
+			[12, 'variable.undefined'],
+			[12, 'wrong.id'],
+			[13, 'wrong.id'],
+			[14, 'variable.undefined'],
+		];
+		$result = $this->runAnalyser([], false, [
+			__DIR__ . '/data/ignore-no-comments.php',
+		], true, true);
+		$this->assertCount(5, $result);
+		foreach ($expects as $i => $expect) {
+			$this->assertArrayHasKey($i, $result);
+			$this->assertInstanceOf(Error::class, $result[$i]);
+			$this->assertStringContainsString(sprintf('Ignore with identifier %s has no comment.', $expect[1]), $result[$i]->getMessage());
+			$this->assertSame($expect[0], $result[$i]->getLine());
+		}
+	}
+
+	#[DataProvider('dataTrueAndFalse')]
 	public function testIgnoreLine(bool $reportUnmatchedIgnoredErrors): void
 	{
 		$result = $this->runAnalyser([], $reportUnmatchedIgnoredErrors, [
@@ -747,6 +769,7 @@ class AnalyserTest extends PHPStanTestCase
 		bool $reportUnmatchedIgnoredErrors,
 		$filePaths,
 		bool $onlyFiles,
+		bool $reportIgnoresWithoutComments = false,
 	): array
 	{
 		$analyser = $this->createAnalyser();
@@ -779,6 +802,7 @@ class AnalyserTest extends PHPStanTestCase
 			),
 			new LocalIgnoresProcessor(),
 			$reportUnmatchedIgnoredErrors,
+			$reportIgnoresWithoutComments,
 		);
 		$analyserResult = $finalizer->finalize($analyserResult, $onlyFiles, false)->getAnalyserResult();
 

--- a/tests/PHPStan/Analyser/data/ignore-no-comments.php
+++ b/tests/PHPStan/Analyser/data/ignore-no-comments.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace IgnoreNoComments;
+
+class Foo
+{
+	public function doFoo(): void
+	{
+		echo $foo; // @phpstan-ignore variable.undefined
+		echo $foo; // @phpstan-ignore wrong.id (comment)
+
+		echo $foo, $bar;  // @phpstan-ignore variable.undefined, wrong.id
+		echo $foo, $bar;  // @phpstan-ignore variable.undefined (comment), wrong.id
+		echo $foo, $bar;  // @phpstan-ignore variable.undefined, wrong.id (comment)
+		echo $foo, $bar;  // @phpstan-ignore variable.undefined (comment), wrong.id (comment)
+	}
+
+}

--- a/tests/PHPStan/Parser/RichParserTest.php
+++ b/tests/PHPStan/Parser/RichParserTest.php
@@ -2,10 +2,14 @@
 
 namespace PHPStan\Parser;
 
+use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_EOL;
 
+/**
+ * @phpstan-import-type Identifier from FileAnalyserResult
+ */
 class RichParserTest extends PHPStanTestCase
 {
 
@@ -50,7 +54,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore test',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -58,7 +62,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref',
 			[
-				2 => ['return.ref'],
+				2 => [['name' => 'return.ref', 'comment' => null]],
 			],
 		];
 
@@ -66,7 +70,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref, return.non',
 			[
-				2 => ['return.ref', 'return.non'],
+				2 => [['name' => 'return.ref', 'comment' => null], ['name' => 'return.non', 'comment' => null]],
 			],
 		];
 
@@ -74,7 +78,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref, return.non (foo)',
 			[
-				2 => ['return.ref', 'return.non'],
+				2 => [['name' => 'return.ref', 'comment' => null], ['name' => 'return.non', 'comment' => 'foo']],
 			],
 		];
 
@@ -82,7 +86,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref, return.non (foo, because...)',
 			[
-				2 => ['return.ref', 'return.non'],
+				2 => [['name' => 'return.ref', 'comment' => null], ['name' => 'return.non', 'comment' => 'foo, because...']],
 			],
 		];
 
@@ -90,7 +94,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'/* @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -98,7 +102,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'/** @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -106,7 +110,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'  /** @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -114,7 +118,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test();  /** @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -123,7 +127,7 @@ class RichParserTest extends PHPStanTestCase
 			'// @phpstan-ignore test' . PHP_EOL .
 			'test();',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -132,7 +136,7 @@ class RichParserTest extends PHPStanTestCase
 			'// @phpstan-ignore test' . PHP_EOL .
 			'test(); // @phpstan-ignore test',
 			[
-				3 => ['test', 'test'],
+				3 => [['name' => 'test', 'comment' => null], ['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -141,7 +145,7 @@ class RichParserTest extends PHPStanTestCase
 			'   // @phpstan-ignore test' . PHP_EOL .
 			'test();',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -153,7 +157,7 @@ class RichParserTest extends PHPStanTestCase
 			' */' . PHP_EOL .
 			'test();',
 			[
-				6 => ['test'],
+				6 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -163,7 +167,7 @@ class RichParserTest extends PHPStanTestCase
 			'/** @phpstan-ignore test */' . PHP_EOL .
 			'test();',
 			[
-				4 => ['test'],
+				4 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -174,7 +178,7 @@ class RichParserTest extends PHPStanTestCase
 			' * @phpstan-ignore test' . PHP_EOL .
 			' */ test();',
 			[
-				5 => ['test'],
+				5 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -185,7 +189,7 @@ class RichParserTest extends PHPStanTestCase
 			' * @phpstan-ignore test' . PHP_EOL .
 			' */',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -194,7 +198,7 @@ class RichParserTest extends PHPStanTestCase
 			PHP_EOL .
 			'/** @phpstan-ignore test */' . PHP_EOL,
 			[
-				4 => ['test'],
+				4 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -204,7 +208,7 @@ class RichParserTest extends PHPStanTestCase
 			'/** @phpstan-ignore test */' . PHP_EOL .
 			'doFoo();' . PHP_EOL,
 			[
-				4 => ['test'],
+				4 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -213,7 +217,7 @@ class RichParserTest extends PHPStanTestCase
 			PHP_EOL .
 			'/** @phpstan-ignore test */',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -221,7 +225,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (comment), identifier2 (comment2)' . PHP_EOL,
 			[
-				2 => ['identifier', 'identifier2'],
+				2 => [['name' => 'identifier', 'comment' => 'comment'], ['name' => 'identifier2', 'comment' => 'comment2']],
 			],
 		];
 
@@ -229,7 +233,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			"test(); // @phpstan-ignore  identifier (comment1),\tidentifier2 ,  identifier3 (comment3) " . PHP_EOL,
 			[
-				2 => ['identifier', 'identifier2', 'identifier3'],
+				2 => [['name' => 'identifier', 'comment' => 'comment1'], ['name' => 'identifier2', 'comment' => null], ['name' => 'identifier3', 'comment' => 'comment3']],
 			],
 		];
 
@@ -237,7 +241,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (comment with inner (parenthesis))' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'comment with inner (parenthesis)']],
 			],
 		];
 
@@ -245,7 +249,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier ((((multi!))))' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => '(((multi!)))']],
 			],
 		];
 
@@ -253,7 +257,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (var_export() is used intentionally)' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'var_export() is used intentionally']],
 			],
 		];
 
@@ -261,7 +265,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (FileSystem::write() does not support LOCK_EX)' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'FileSystem::write() does not support LOCK_EX']],
 			],
 		];
 
@@ -269,7 +273,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (type ensured in self::createClient())' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'type ensured in self::createClient()']],
 			],
 		];
 
@@ -287,7 +291,7 @@ class RichParserTest extends PHPStanTestCase
 			'  }' . PHP_EOL .
 			'}',
 			[
-				10 => ['variable.undefined'],
+				10 => [['name' => 'variable.undefined', 'comment' => null]],
 			],
 		];
 
@@ -308,13 +312,13 @@ class RichParserTest extends PHPStanTestCase
 			'  }' . PHP_EOL .
 			'}',
 			[
-				13 => ['variable.undefined'],
+				13 => [['name' => 'variable.undefined', 'comment' => null]],
 			],
 		];
 	}
 
 	/**
-	 * @param array<int, list<string>|null> $expectedLines
+	 * @param array<int, list<Identifier>|null> $expectedLines
 	 */
 	#[DataProvider('dataLinesToIgnore')]
 	public function testLinesToIgnore(string $code, array $expectedLines): void


### PR DESCRIPTION
Hello!

Closes https://github.com/phpstan/phpstan/issues/11340

This PR adds the following two option (false by default):
- ~`reportIgnoresWithoutIdentifiers`: reports `@phpstan-ignore-line` and `@phpstan-ignore-next-line` usages~
- `reportIgnoresWithoutComments`: reports `@phpstan-ignore` usages without comments

Thanks!