### PR TITLE
Only set return native type from null return type when declaring class is built in on __toString()

### DIFF
--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -330,11 +330,9 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 					return $this->nativeReturnType = new VoidType();
 				}
 				if ($name === '__tostring') {
-					if ($this->declaringClass->isBuiltin()) {
-						return $this->nativeReturnType = new StringType();
-					} else {
-						return $this->nativeReturnType = new MixedType();
-					}
+					return $this->nativeReturnType = $this->declaringClass->isBuiltin()
+						? new StringType()
+						: new MixedType();
 				}
 				if ($name === '__isset') {
 					return $this->nativeReturnType = new BooleanType();

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -324,7 +324,7 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 	{
 		if ($this->nativeReturnType === null) {
 			$returnType = $this->reflection->getReturnType();
-			if ($returnType === null) {
+			if ($returnType === null && $this->declaringClass->isBuiltin()) {
 				$name = strtolower($this->getName());
 				if (in_array($this->getName(), ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
 					return $this->nativeReturnType = new VoidType();

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -324,12 +324,12 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 	{
 		if ($this->nativeReturnType === null) {
 			$returnType = $this->reflection->getReturnType();
-			if ($returnType === null && $this->declaringClass->isBuiltin()) {
+			if ($returnType === null) {
 				$name = strtolower($this->getName());
 				if (in_array($this->getName(), ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
 					return $this->nativeReturnType = new VoidType();
 				}
-				if ($name === '__tostring') {
+				if ($name === '__tostring' && $this->declaringClass->isBuiltin()) {
 					return $this->nativeReturnType = new StringType();
 				}
 				if ($name === '__isset') {

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -332,7 +332,11 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 				if ($name === '__tostring') {
 					return $this->nativeReturnType = $this->declaringClass->isBuiltin()
 						? new StringType()
-						: new MixedType();
+						: TypehintHelper::decideTypeFromReflection(
+							$returnType,
+							null,
+							$this->declaringClass,
+						);
 				}
 				if ($name === '__isset') {
 					return $this->nativeReturnType = new BooleanType();

--- a/src/Reflection/Php/PhpMethodReflection.php
+++ b/src/Reflection/Php/PhpMethodReflection.php
@@ -329,8 +329,12 @@ final class PhpMethodReflection implements ExtendedMethodReflection
 				if (in_array($this->getName(), ['__construct', '__destruct', '__unset', '__wakeup', '__clone'], true)) {
 					return $this->nativeReturnType = new VoidType();
 				}
-				if ($name === '__tostring' && $this->declaringClass->isBuiltin()) {
-					return $this->nativeReturnType = new StringType();
+				if ($name === '__tostring') {
+					if ($this->declaringClass->isBuiltin()) {
+						return $this->nativeReturnType = new StringType();
+					} else {
+						return $this->nativeReturnType = new MixedType();
+					}
 				}
 				if ($name === '__isset') {
 					return $this->nativeReturnType = new BooleanType();

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -26,6 +26,10 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 	private static function findTestFiles(): iterable
 	{
 		foreach (self::findTestDataFilesFromDirectory(__DIR__ . '/nsrt') as $testFile) {
+			if (str_ends_with($testFile, 'tests/PHPStan/Analyser/nsrt/bug-2471.php') && PHP_VERSION_ID < 80000) {
+				continue;
+			}
+
 			yield $testFile;
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -26,7 +26,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 	private static function findTestFiles(): iterable
 	{
 		foreach (self::findTestDataFilesFromDirectory(__DIR__ . '/nsrt') as $testFile) {
-			if (str_ends_with($testFile, 'tests/PHPStan/Analyser/nsrt/bug-2471.php') && PHP_VERSION_ID < 80000) {
+			if (str_ends_with($testFile, 'bug-2471.php') && PHP_VERSION_ID < 80000) {
 				continue;
 			}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -26,10 +26,6 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 	private static function findTestFiles(): iterable
 	{
 		foreach (self::findTestDataFilesFromDirectory(__DIR__ . '/nsrt') as $testFile) {
-			if (str_ends_with($testFile, 'bug-2471.php') && PHP_VERSION_ID < 80000) {
-				continue;
-			}
-
 			yield $testFile;
 		}
 


### PR DESCRIPTION
Start from PHPStan 2.1.14, in `Rector`, we got notice when downgrade code:

```php
class ParentClassWithToStringMixedReturn
{
    public function __toString()
    {
        return 'a';
    }
}

class WithParentMixedReturn extends ParentClassWithToStringMixedReturn
{
    public function __toString()
    {
        return 'value';
    }
}

echo (new WithParentMixedReturn());
```

This add `string` return to `WithParentMixedReturn::__toString()` see https://3v4l.org/IrE2q#v7.4.33

The issue is when **code consumed by user**: https://3v4l.org/kdcEh#v7.4.33 it got error:

```
Fatal error: Declaration of Consumer::__toString() must be compatible with WithParentMixedReturn::__toString(): string in /in/kdcEh on line 21
```

On our rector-src code, I patch there with use our AstResolver to specify on `__toString` when no return and non-built in

- https://github.com/rectorphp/rector-src/pull/6879

to return `MixedType`

@TomasVotruba if this accepted, we may can rollback to original implementation 👍 