### PR TITLE
Fix DateTime::format('u') return type II

### DIFF
--- a/src/Type/Php/DateFunctionReturnTypeHelper.php
+++ b/src/Type/Php/DateFunctionReturnTypeHelper.php
@@ -76,11 +76,11 @@ final class DateFunctionReturnTypeHelper
 				return $this->buildNumericRangeType(0, 1, false);
 			case 'u':
 				return $useMicrosec
-					? new IntersectionType([new StringType(), new AccessoryNonFalsyStringType(), new AccessoryNumericStringType()])
+					? new IntersectionType([new StringType(), new AccessoryNumericStringType()])
 					: new ConstantStringType('000000');
 			case 'v':
 				return $useMicrosec
-					? new IntersectionType([new StringType(), new AccessoryNonFalsyStringType(), new AccessoryNumericStringType()])
+					? new IntersectionType([new StringType(), new AccessoryNumericStringType()])
 					: new ConstantStringType('000');
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-10893.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10893.php
@@ -5,19 +5,19 @@ namespace Bug10893;
 use function PHPStan\Testing\assertType;
 
 /**
- * @param non-falsy-string&numeric-string $str
+ * @param numeric-string $str
  */
 function hasMicroseconds(\DateTimeInterface $value, string $str): bool
 {
-	assertType('non-falsy-string&numeric-string', $str);
+	assertType('numeric-string', $str);
 	assertType('int', (int)$str);
 	assertType('bool', (int)$str !== 0);
 
-	assertType('non-falsy-string&numeric-string', $value->format('u'));
+	assertType('numeric-string', $value->format('u'));
 	assertType('int', (int)$value->format('u'));
 	assertType('bool', (int)$value->format('u') !== 0);
 
-	assertType('non-falsy-string&numeric-string', $value->format('v'));
+	assertType('numeric-string', $value->format('v'));
 	assertType('int', (int)$value->format('v'));
 	assertType('bool', (int)$value->format('v') !== 0);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-6613.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6613.php
@@ -6,10 +6,10 @@ use function PHPStan\Testing\assertType;
 
 function (\DateTime $dt) {
 	assertType("'000000'", date('u'));
-	assertType('non-falsy-string&numeric-string', date_format($dt, 'u'));
-	assertType('non-falsy-string&numeric-string', $dt->format('u'));
+	assertType('numeric-string', date_format($dt, 'u'));
+	assertType('numeric-string', $dt->format('u'));
 
 	assertType("'000'", date('v'));
-	assertType('non-falsy-string&numeric-string', date_format($dt, 'v'));
-	assertType('non-falsy-string&numeric-string', $dt->format('v'));
+	assertType('numeric-string', date_format($dt, 'v'));
+	assertType('numeric-string', $dt->format('v'));
 };


### PR DESCRIPTION
fix https://github.com/phpstan/phpstan/issues/12965 and https://github.com/phpstan/phpstan-src/pull/3919