### PR TITLE
Support iterable as template type

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1043,6 +1043,11 @@ parameters:
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\IntersectionType is error\\-prone and deprecated\\.$#"
 			count: 3
+			path: src/Type/Generic/TemplateIterableType.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\IntersectionType is error\\-prone and deprecated\\.$#"
+			count: 3
 			path: src/Type/Generic/TemplateKeyOfType.php
 
 		-
@@ -1112,6 +1117,11 @@ parameters:
 
 		-
 			message: "#^Doing instanceof PHPStan\\\\Type\\\\IntersectionType is error\\-prone and deprecated\\.$#"
+			count: 1
+			path: src/Type/Generic/TemplateTypeFactory.php
+
+		-
+			message: "#^Doing instanceof PHPStan\\\\Type\\\\IterableType is error\\-prone and deprecated\\. Use Type\\:\\:isIterable\\(\\) instead\\.$#"
 			count: 1
 			path: src/Type/Generic/TemplateTypeFactory.php
 

--- a/src/Rules/Generics/TemplateTypeCheck.php
+++ b/src/Rules/Generics/TemplateTypeCheck.php
@@ -22,6 +22,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectShapeType;
@@ -123,6 +124,7 @@ final class TemplateTypeCheck
 				&& $boundTypeClass !== ObjectShapeType::class
 				&& $boundTypeClass !== GenericObjectType::class
 				&& $boundTypeClass !== KeyOfType::class
+				&& $boundTypeClass !== IterableType::class
 				&& !$boundType instanceof UnionType
 				&& !$boundType instanceof IntersectionType
 				&& !$boundType instanceof TemplateType

--- a/src/Type/Generic/TemplateIterableType.php
+++ b/src/Type/Generic/TemplateIterableType.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\IterableType;
+use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
+use PHPStan\Type\Type;
+
+/** @api */
+final class TemplateIterableType extends IterableType implements TemplateType
+{
+
+	/** @use TemplateTypeTrait<IterableType> */
+	use TemplateTypeTrait;
+	use UndecidedComparisonCompoundTypeTrait;
+
+	/**
+	 * @param non-empty-string $name
+	 */
+	public function __construct(
+		TemplateTypeScope $scope,
+		TemplateTypeStrategy $templateTypeStrategy,
+		TemplateTypeVariance $templateTypeVariance,
+		string $name,
+		IterableType $bound,
+		?Type $default,
+	)
+	{
+		parent::__construct($bound->getKeyType(), $bound->getItemType());
+		$this->scope = $scope;
+		$this->strategy = $templateTypeStrategy;
+		$this->variance = $templateTypeVariance;
+		$this->name = $name;
+		$this->bound = $bound;
+		$this->default = $default;
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -12,6 +12,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectShapeType;
@@ -105,6 +106,10 @@ final class TemplateTypeFactory
 
 		if ($bound instanceof KeyOfType && ($boundClass === KeyOfType::class || $bound instanceof TemplateType)) {
 			return new TemplateKeyOfType($scope, $strategy, $variance, $name, $bound, $default);
+		}
+
+		if ($bound instanceof IterableType && ($boundClass === IterableType::class || $bound instanceof TemplateType)) {
+			return new TemplateIterableType($scope, $strategy, $variance, $name, $bound, $default);
 		}
 
 		return new TemplateMixedType($scope, $strategy, $variance, $name, new MixedType(true), $default);

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1469,6 +1469,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame('Access to an undefined property object::$bar.', $errors[0]->getMessage());
 	}
 
+	public function testBug12214(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12214.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug11640(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11640.php');

--- a/tests/PHPStan/Analyser/data/bug-12214.php
+++ b/tests/PHPStan/Analyser/data/bug-12214.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bug12214;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param iterable<array-key, mixed> $test
+ */
+function test_iterable(iterable $test): void
+{
+	assertType('iterable<(int|string), mixed>', $test);
+}
+
+/**
+ * @template T of array<array-key, mixed>
+ * @param T $test
+ */
+function test_array(array $test): void
+{
+	assertType('T of array (function Bug12214\test_array(), argument)', $test);
+}
+
+/**
+ * @template T of iterable<array-key, mixed>
+ * @param T $test
+ */
+function test_generic_iterable(iterable $test): void
+{
+	assertType('T of iterable<(int|string), mixed> (function Bug12214\test_generic_iterable(), argument)', $test);
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#12214

Note: I'm targeting 1.12 branch. But I'm not sure whether that is allowed (in this instance). But I tested merging upwards and that seems to work fine (-ish, just a merge conflict with the added unit test methods as more methods are added in the test class).