### PR TITLE
Fix IterableType->equals(TemplateIterableType)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1383,7 +1383,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\IterableType is error\-prone and deprecated\. Use Type\:\:isIterable\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 2
+			count: 1
 			path: src/Type/IterableType.php
 
 		-

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -167,7 +167,7 @@ class IterableType implements CompoundType
 
 	public function equals(Type $type): bool
 	{
-		if (!$type instanceof self) {
+		if (get_class($type) !== static::class) {
 			return false;
 		}
 

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -20,6 +20,7 @@ use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use Traversable;
 use function array_merge;
+use function get_class;
 use function sprintf;
 
 /** @api */

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -8,6 +8,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
@@ -65,6 +66,10 @@ class TemplateTypeFactoryTest extends PHPStanTestCase
 					new StringType(),
 					new IntegerType(),
 				]),
+			],
+			[
+				new IterableType(new IntegerType(), new StringType()),
+				new IterableType(new IntegerType(), new StringType()),
 			],
 		];
 	}


### PR DESCRIPTION
I think this change is necessary, as since https://github.com/phpstan/phpstan-src/commit/8368b0c27e2ae919e1cb874d18d19b2e14a43723 we have `TemplateIterableType extends IterableType`, which we hadn't before.

not sure how to properly test it.