### PR TITLE
Faster ClassNameHelper

### DIFF
--- a/src/Reflection/ClassNameHelper.php
+++ b/src/Reflection/ClassNameHelper.php
@@ -3,15 +3,23 @@
 namespace PHPStan\Reflection;
 
 use Nette\Utils\Strings;
+use function array_key_exists;
 use function ltrim;
 
 final class ClassNameHelper
 {
 
+	/** @var array<string, bool> */
+	private static array $checked = [];
+
 	public static function isValidClassName(string $name): bool
 	{
-		// from https://stackoverflow.com/questions/3195614/validate-class-method-names-with-regex#comment104531582_12011255
-		return Strings::match(ltrim($name, '\\'), '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*(\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/') !== null;
+		if (!array_key_exists($name, self::$checked)) {
+			// from https://stackoverflow.com/questions/3195614/validate-class-method-names-with-regex#comment104531582_12011255
+			self::$checked[$name] = Strings::match(ltrim($name, '\\'), '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*(\\\\[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)*$/') !== null;
+
+		}
+		return self::$checked[$name];
 	}
 
 }


### PR DESCRIPTION
70% faster edge case in `vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug10979` - which is currently the slowest `AnalyserIntegrationTest` in the repo.

Before this PR
```
➜  phpstan-src git:(regr) ✗ php vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug10979 
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

Random Seed:   1747292998
Warning:       No code coverage driver available

.                                                                   1 / 1 (100%)

Time: 00:03.944, Memory: 74.00 MB

OK (1 test, 1 assertion)
➜  phpstan-src git:(regr) ✗ php vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug10979
```

After this PR
```
➜  phpstan-src git:(regr) ✗ php vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug10979
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

Random Seed:   1747293054
Warning:       No code coverage driver available

.                                                                   1 / 1 (100%)

Time: 00:01.452, Memory: 74.00 MB

OK (1 test, 1 assertion)
```

---

Profile before the PR

<img width="429" alt="grafik" src="https://github.com/user-attachments/assets/464acdaa-360d-4fc4-820d-f45997ae2d83" />

triggered on [`IntersectionType->getFiniteTypes()`](https://github.com/phpstan/phpstan-src/blob/2fb3dbe482362e96ba2f9e23768d627a80064ae8/src/Type/IntersectionType.php#L1210-L1227)
```
➜  phpstan-src git:(fast) ✗ php -v
PHP 8.3.21 (cli) (built: May  6 2025 13:58:10) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.21, Copyright (c) Zend Technologies
```