### PR TITLE
Reproduce autoloader bug

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -566,7 +566,10 @@ jobs:
                 echo "FAIL: tmp was created by a worker, meaning sys_temp_dir='tmp~1' was incorrectly evaluated to 'tmp'"
                 exit 1
               fi
-
+          - script: |
+              cd e2e/bug-12972b
+              composer install
+              ../../bin/phpstan analyze
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/e2e/bug-12972b/.gitignore
+++ b/e2e/bug-12972b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/e2e/bug-12972b/autoloader.php
+++ b/e2e/bug-12972b/autoloader.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+spl_autoload_register(function($class) {
+	if ($class === \other12972\MyClass::class) {
+		throw new LogicException('this should not happen');
+	}
+});

--- a/e2e/bug-12972b/composer.json
+++ b/e2e/bug-12972b/composer.json
@@ -1,0 +1,7 @@
+{
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	}
+}

--- a/e2e/bug-12972b/phpstan.dist.neon
+++ b/e2e/bug-12972b/phpstan.dist.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 9
+
+    paths:
+        - src
+
+    bootstrapFiles:
+        - autoloader.php

--- a/e2e/bug-12972b/real-world.php
+++ b/e2e/bug-12972b/real-world.php
@@ -2,4 +2,5 @@
 
 require 'autoloader.php';
 
-new \Foo12972\MyRoot();
+$root = new \Foo12972\MyRoot();
+$root->doBar(new \other12972\MyClass());

--- a/e2e/bug-12972b/real-world.php
+++ b/e2e/bug-12972b/real-world.php
@@ -1,0 +1,5 @@
+<?php
+
+require 'autoloader.php';
+
+new \Foo12972\MyRoot();

--- a/e2e/bug-12972b/src/folder/file2.php
+++ b/e2e/bug-12972b/src/folder/file2.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Foo12972;
+
+use other12972\MyClass;
+
+class MyRoot {
+	function doBar(MyClass $myClass):void {}
+}

--- a/e2e/bug-12972b/src/other/file.php
+++ b/e2e/bug-12972b/src/other/file.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace other12972;
+
+class MyClass {
+	public function doSomething(): int
+	{
+		return 1;
+	}
+}


### PR DESCRIPTION
this test demonstrates how PHPStan analyzes code differently than it would happen at runtime.

---

runtime: run `php real-world.php`
you see the program runs, without the custom autoloader of `e2e/bug-12972b/autoloader.php` beeing invoked.
all involved classes are autoloaded by the composer class loader. the custom class loader is not invoked for `\other12972\MyClass::class`.

---

static analysis time: run `../../bin/phpstan analyze`

you see PHPStan invokes the custom class loader for class `\other12972\MyClass::class`, which does not happen at regular runtime. the composer class loader is not invoked for `\other12972\MyClass::class` (like it is at runtime).

because of the difference in autoloading functions order in runtime vs. analysis time we see errors which cannot happen at runtime - see https://github.com/phpstan/phpstan/issues/12972