### PR TITLE
fix: add updated signature for `getenv`

### DIFF
--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -53,6 +53,7 @@ return [
 		'forward_static_call_array' => ['mixed', 'function'=>'callable', 'parameters'=>'array<int|string,mixed>'],
 		'get_debug_type' => ['string', 'var'=>'mixed'],
 		'get_resource_id' => ['int', 'res'=>'resource'],
+		'getenv' => ['string|array<string,string>|false', 'name='=>'string|null', 'local_only='=>'bool'],
 		'gmdate' => ['string', 'format'=>'string', 'timestamp='=>'int'],
 		'gmmktime' => ['int|false', 'hour'=>'int', 'minute='=>'int', 'second='=>'int', 'month='=>'int', 'day='=>'int', 'year='=>'int'],
 		'hash' => ['non-falsy-string', 'algo'=>'string', 'data'=>'string', 'raw_output='=>'bool'],

--- a/tests/PHPStan/Analyser/nsrt/bug-4538-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-4538-php7.php
@@ -1,0 +1,17 @@
+<?php // lint < 8.0
+
+namespace Bug4538;
+
+use function PHPStan\Testing\assertType;
+
+class FooPhp7
+{
+	/**
+	 * @param string $index
+	 */
+	public function bar(string $index): void
+	{
+		assertType('string|false', getenv($index));
+		assertType('array<string, string>', getenv());
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-4538-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-4538-php8.php
@@ -1,17 +1,18 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug4538;
 
 use function PHPStan\Testing\assertType;
 
-class Foo
+class FooPhp8
 {
 	/**
 	 * @param string $index
 	 */
 	public function bar(string $index): void
 	{
-		assertType('string|false', getenv($index));
+		assertType('string|array<string,string>|false', getenv($index));
 		assertType('array<string, string>', getenv());
+		assertType('array<string, string>', getenv(null));
 	}
 }


### PR DESCRIPTION
Add the following signature for `getenv`:

     getenv(?string $name = null, bool $local_only = false): string|array|false

to the function map (specifically for PHP 8 and above). This replaces all existing signatures, and should fix [13065][1].

[1]: https://github.com/phpstan/phpstan/issues/13065