### PR TITLE
Fix HasOffsetValueType::searchArray

### DIFF
--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -15,10 +15,12 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
@@ -266,7 +268,10 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 			$needleType instanceof ConstantScalarType && $this->valueType instanceof ConstantScalarType
 			&& $needleType->getValue() === $this->valueType->getValue()
 		) {
-			return $this->offsetType;
+			return new UnionType([
+				new IntegerType(),
+				new StringType(),
+			]);
 		}
 
 		return new MixedType();

--- a/tests/PHPStan/Analyser/nsrt/array-search.php
+++ b/tests/PHPStan/Analyser/nsrt/array-search.php
@@ -29,7 +29,7 @@ class Foo
 		}
 
 		if (array_key_exists(17, $arr) && $arr[17] === 'foo') {
-			assertType('17', array_search('foo', $arr, true));
+			assertType('int', array_search('foo', $arr, true));
 			assertType('int|false', array_search('foo', $arr));
 			assertType('int|false', array_search($string, $arr, true));
 		}


### PR DESCRIPTION
See https://onlinephp.io/c/192c51

We're sure that the function cannot return false, but we cannot sure it's not an early key.

cc @herndlm since you implemented it.