### PR TITLE
More `DynamicFunctionReturnTypeExtension` converted to `#[AutowiredService]` attribute usage

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -1135,80 +1135,17 @@ services:
 		class: PHPStan\Type\BitwiseFlagHelper
 
 	-
-		class: PHPStan\Type\Php\ArgumentBasedFunctionReturnTypeExtension
+		class: PHPStan\Type\Php\CompactFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
+		arguments:
+			checkMaybeUndefinedVariables: %checkMaybeUndefinedVariables%
 
 	-
-		class: PHPStan\Type\Php\ArrayChangeKeyCaseFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
+		class: PHPStan\Type\Php\ConstantHelper
 
 	-
-		class: PHPStan\Type\Php\ArrayIntersectKeyFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayChunkFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayColumnHelper
-
-	-
-		class: PHPStan\Type\Php\ArrayColumnFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayCombineFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayCurrentDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayFillFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayFillKeysFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayFilterFunctionReturnTypeHelper
-
-	-
-		class: PHPStan\Type\Php\ArrayFilterFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayFlipFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayFindFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayFindKeyFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayKeyDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
+		class: PHPStan\Type\Php\DateFunctionReturnTypeHelper
 
 	-
 		class: PHPStan\Type\Php\ArrayKeyExistsFunctionTypeSpecifyingExtension
@@ -1216,79 +1153,9 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
-		class: PHPStan\Type\Php\ArrayKeyFirstDynamicReturnTypeExtension
+		class: PHPStan\Type\Php\AssertThrowTypeExtension
 		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayKeyLastDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayKeysFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayMapFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayMergeFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayNextDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayPopFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayRandFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayReduceFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayReplaceFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayReverseFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayShiftFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArraySliceFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArraySpliceFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArraySearchFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
+			- phpstan.dynamicFunctionThrowTypeExtension
 
 	-
 		class: PHPStan\Type\Php\ArraySearchFunctionTypeSpecifyingExtension
@@ -1296,39 +1163,14 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
-		class: PHPStan\Type\Php\ArrayValuesFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArraySumFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\AssertThrowTypeExtension
-		tags:
-			- phpstan.dynamicFunctionThrowTypeExtension
-
-	-
-		class: PHPStan\Type\Php\BackedEnumFromMethodDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\Base64DecodeDynamicFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\BcMathStringOrNullReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
 		class: PHPStan\Type\Php\ClosureBindDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+	-
+		class: PHPStan\Type\Php\CountFunctionTypeSpecifyingExtension
+		tags:
+			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
 		class: PHPStan\Type\Php\ClosureBindToDynamicReturnTypeExtension
@@ -1341,57 +1183,14 @@ services:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
 	-
-		class: PHPStan\Type\Php\CompactFunctionReturnTypeExtension
+		class: PHPStan\Type\Php\BackedEnumFromMethodDynamicReturnTypeExtension
 		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-		arguments:
-			checkMaybeUndefinedVariables: %checkMaybeUndefinedVariables%
-
-	-
-		class: PHPStan\Type\Php\ConstantFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ConstantHelper
-
-	-
-		class: PHPStan\Type\Php\CountFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\CountCharsFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\CountFunctionTypeSpecifyingExtension
-		tags:
-			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
-
-	-
-		class: PHPStan\Type\Php\CurlGetinfoFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\DateFunctionReturnTypeHelper
-
-	-
-		class: PHPStan\Type\Php\DateFormatFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
+			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\DateFormatMethodReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\DateFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\DateIntervalConstructorThrowTypeExtension
@@ -1402,16 +1201,6 @@ services:
 		class: PHPStan\Type\Php\DateIntervalDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\DateTimeCreateDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\DateTimeDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\DateTimeModifyReturnTypeExtension
@@ -1458,86 +1247,9 @@ services:
 			- phpstan.dynamicMethodThrowTypeExtension
 
 	-
-		class: PHPStan\Type\Php\DioStatDynamicFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ExplodeFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\FilterFunctionReturnTypeHelper
-
-	-
-		class: PHPStan\Type\Php\FilterInputDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\FilterVarDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\FilterVarArrayDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GetCalledClassDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GetClassDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GetDebugTypeFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GetDefinedVarsFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GetParentClassDynamicFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GettypeFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\GettimeofdayDynamicFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-	-
-		class: PHPStan\Type\Php\HashFunctionsReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\HighlightStringDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
 		class: PHPStan\Type\Php\IntdivThrowTypeExtension
 		tags:
 			- phpstan.dynamicFunctionThrowTypeExtension
-
-	-
-		class: PHPStan\Type\Php\IniGetReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\JsonThrowTypeExtension
@@ -1630,89 +1342,9 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
-		class: PHPStan\Type\Php\MinMaxFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\NumberFormatFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\PathinfoFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\PregFilterFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\PregSplitDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
 		class: PHPStan\Type\Php\ReflectionClassIsSubclassOfTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.methodTypeSpecifyingExtension
-
-	-
-		class: PHPStan\Type\Php\ReplaceFunctionsDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ArrayPointerFunctionsDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\LtrimFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\MbFunctionsReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\MbConvertEncodingFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\MbSubstituteCharacterDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\MbStrlenFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\MicrotimeFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\HrtimeFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\ImplodeFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\NonEmptyStringFunctionsReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\SetTypeFunctionTypeSpecifyingExtension
@@ -1720,89 +1352,14 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
-		class: PHPStan\Type\Php\StrCaseFunctionsReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrlenFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrIncrementDecrementFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrPadFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrRepeatFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrrevFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\SubstrDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
 		class: PHPStan\Type\Php\ThrowableReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
-		class: PHPStan\Type\Php\ParseUrlFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\TriggerErrorDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\TrimFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
 		class: PHPStan\Type\Php\VersionCompareFunctionDynamicReturnTypeExtension
 		arguments:
 			configPhpVersion: %phpVersion%
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\PowFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\RoundFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrtotimeFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\RandomIntFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\RangeFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
@@ -1815,11 +1372,6 @@ services:
 		class: PHPStan\Type\Php\ClassExistsFunctionTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
-
-	-
-		class: PHPStan\Type\Php\ClassImplementsFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\DefineConstantTypeSpecifyingExtension
@@ -1862,11 +1414,6 @@ services:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
 
 	-
-		class: PHPStan\Type\Php\IteratorToArrayFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
 		class: PHPStan\Type\Php\IsAFunctionTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
@@ -1878,11 +1425,6 @@ services:
 		class: PHPStan\Type\Php\CtypeDigitFunctionTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
-
-	-
-		class: PHPStan\Type\Php\JsonThrowOnErrorDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
 		class: PHPStan\Type\Php\TypeSpecifyingFunctionsDynamicReturnTypeExtension
@@ -1903,32 +1445,12 @@ services:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 
 	-
-		class: PHPStan\Type\Php\StrSplitFunctionReturnTypeExtension
+		class: PHPStan\Type\Php\LtrimFunctionReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
-		class: PHPStan\Type\Php\StrTokFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\SprintfFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\SscanfFunctionDynamicReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrvalFamilyFunctionReturnTypeExtension
-		tags:
-			- phpstan.broker.dynamicFunctionReturnTypeExtension
-
-	-
-		class: PHPStan\Type\Php\StrWordCountFunctionDynamicReturnTypeExtension
+		class: PHPStan\Type\Php\TrimFunctionDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 

--- a/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -13,6 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
 
+#[AutowiredService]
 final class ArgumentBasedFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayChangeKeyCaseFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayChangeKeyCaseFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -29,6 +30,7 @@ use function strtoupper;
 use const CASE_LOWER;
 use const CASE_UPPER;
 
+#[AutowiredService]
 final class ArrayChangeKeyCaseFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayChunkFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayChunkFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -14,6 +15,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class ArrayChunkFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Php;
 
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
@@ -17,6 +18,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayColumnHelper
 {
 

--- a/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
@@ -23,6 +24,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class ArrayCombineFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayCurrentDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCurrentDynamicReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayCurrentDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -20,6 +21,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ArrayFillFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -12,6 +13,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeExtension.php
@@ -4,10 +4,12 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 
+#[AutowiredService]
 final class ArrayFilterFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Return_;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
@@ -38,6 +39,7 @@ use function is_string;
 use function sprintf;
 use function substr;
 
+#[AutowiredService]
 final class ArrayFilterFunctionReturnTypeHelper
 {
 

--- a/src/Type/Php/ArrayFindFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFindFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
@@ -11,6 +12,7 @@ use PHPStan\Type\TypeCombinator;
 use function array_map;
 use function count;
 
+#[AutowiredService]
 final class ArrayFindFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayFindKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFindKeyFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
@@ -11,6 +12,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ArrayFindKeyFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
@@ -14,6 +15,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayIntersectKeyFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -14,6 +15,7 @@ use PHPStan\Type\TypeCombinator;
 use function array_slice;
 use function count;
 
+#[AutowiredService]
 final class ArrayIntersectKeyFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayKeyDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyDynamicReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayKeyDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyFirstDynamicReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayKeyFirstDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyLastDynamicReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayKeyLastDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeysFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -13,6 +14,7 @@ use PHPStan\Type\Type;
 use function count;
 use function strtolower;
 
+#[AutowiredService]
 final class ArrayKeysFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -23,6 +24,7 @@ use function array_reduce;
 use function array_slice;
 use function count;
 
+#[AutowiredService]
 final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -22,6 +23,7 @@ use function array_keys;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayNextDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayNextDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -11,6 +12,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function in_array;
 
+#[AutowiredService]
 final class ArrayNextDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPointerFunctionsDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -12,6 +13,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class ArrayPointerFunctionsDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayRandFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayRandFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -16,6 +17,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class ArrayRandFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\TrinaryLogic;
@@ -13,6 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReplaceFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
@@ -13,6 +14,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function strtolower;
 
+#[AutowiredService]
 final class ArrayReplaceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayReverseFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReverseFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -12,6 +13,7 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 
+#[AutowiredService]
 final class ArrayReverseFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -14,6 +15,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySliceFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -13,6 +14,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class ArraySliceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArraySpliceFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
@@ -13,6 +14,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class ArraySpliceFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\BinaryOp\Plus;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\Int_;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -16,6 +17,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ArraySumFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -13,6 +14,7 @@ use PHPStan\Type\Type;
 use function count;
 use function strtolower;
 
+#[AutowiredService]
 final class ArrayValuesFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -13,6 +14,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 
+#[AutowiredService]
 final class Base64DecodeDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
+++ b/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\UnaryMinus;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
@@ -21,6 +22,7 @@ use PHPStan\Type\UnionType;
 use function in_array;
 use function is_numeric;
 
+#[AutowiredService]
 final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ClassImplementsFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ClassImplementsFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\TrinaryLogic;
@@ -18,6 +19,7 @@ use PHPStan\Type\UnionType;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class ClassImplementsFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ConstantFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ConstantFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
@@ -11,6 +12,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
 
+#[AutowiredService]
 final class ConstantFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/CountCharsFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/CountCharsFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
@@ -18,6 +19,7 @@ use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class CountCharsFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/CountFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CountFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -12,6 +13,7 @@ use function count;
 use function in_array;
 use const COUNT_RECURSIVE;
 
+#[AutowiredService]
 final class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\ArrayType;
@@ -22,6 +23,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function count;
 
+#[AutowiredService]
 final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/DateFormatFunctionReturnTypeExtension.php
+++ b/src/Type/Php/DateFormatFunctionReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class DateFormatFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/DateFunctionReturnTypeExtension.php
+++ b/src/Type/Php/DateFunctionReturnTypeExtension.php
@@ -4,11 +4,13 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class DateFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/DateTimeCreateDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateTimeCreateDynamicReturnTypeExtension.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -16,6 +17,7 @@ use function count;
 use function date_create;
 use function in_array;
 
+#[AutowiredService]
 final class DateTimeCreateDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -15,6 +16,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class DateTimeDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/DioStatDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/DioStatDynamicFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -12,6 +13,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 
+#[AutowiredService]
 final class DioStatDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ExplodeFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -25,6 +26,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function count;
 
+#[AutowiredService]
 final class ExplodeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Php;
 
 use PhpParser\Node;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
@@ -33,6 +34,7 @@ use function octdec;
 use function preg_match;
 use function sprintf;
 
+#[AutowiredService]
 final class FilterFunctionReturnTypeHelper
 {
 

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -4,11 +4,13 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class FilterInputDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/FilterVarArrayDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarArrayDynamicReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -26,6 +27,7 @@ use function count;
 use function in_array;
 use function strtolower;
 
+#[AutowiredService]
 final class FilterVarArrayDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use function count;
 use function strtolower;
 
+#[AutowiredService]
 final class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GetCalledClassDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetCalledClassDynamicReturnTypeExtension.php
@@ -6,11 +6,13 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 
+#[AutowiredService]
 final class GetCalledClassDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GetClassDynamicReturnTypeExtension.php
+++ b/src/Type/Php/GetClassDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -23,6 +24,7 @@ use PHPStan\Type\TypeUtils;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class GetClassDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetDebugTypeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -15,6 +16,7 @@ use function array_key_first;
 use function array_map;
 use function count;
 
+#[AutowiredService]
 final class GetDebugTypeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GetDefinedVarsFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetDefinedVarsFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
@@ -13,6 +14,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 
+#[AutowiredService]
 final class GetDefinedVarsFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GetParentClassDynamicFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -18,6 +19,7 @@ use PHPStan\Type\UnionType;
 use function array_map;
 use function count;
 
+#[AutowiredService]
 final class GetParentClassDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GettimeofdayDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GettimeofdayDynamicFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -15,6 +16,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 
+#[AutowiredService]
 final class GettimeofdayDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/GettypeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/GettypeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -15,6 +16,7 @@ use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class GettypeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/HashFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashFunctionsReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -24,6 +25,7 @@ use function in_array;
 use function is_bool;
 use function strtolower;
 
+#[AutowiredService]
 final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/HighlightStringDynamicReturnTypeExtension.php
+++ b/src/Type/Php/HighlightStringDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BooleanType;
@@ -13,6 +14,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class HighlightStringDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/HrtimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/HrtimeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -16,6 +17,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function count;
 
+#[AutowiredService]
 final class HrtimeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ImplodeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Internal\CombinationsHelper;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -23,6 +24,7 @@ use function count;
 use function implode;
 use function in_array;
 
+#[AutowiredService]
 final class ImplodeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/IniGetReturnTypeExtension.php
+++ b/src/Type/Php/IniGetReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -13,6 +14,7 @@ use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
 use function count;
 
+#[AutowiredService]
 final class IniGetReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/IteratorToArrayFunctionReturnTypeExtension.php
+++ b/src/Type/Php/IteratorToArrayFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
@@ -15,6 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function strtolower;
 
+#[AutowiredService]
 final class IteratorToArrayFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
@@ -20,6 +21,7 @@ use PHPStan\Type\TypeCombinator;
 use function is_bool;
 use function json_decode;
 
+#[AutowiredService]
 final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/MbConvertEncodingFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MbConvertEncodingFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -18,6 +19,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class MbConvertEncodingFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/MbFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/MbFunctionsReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
@@ -21,6 +22,7 @@ use function array_map;
 use function array_unique;
 use function count;
 
+#[AutowiredService]
 final class MbFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
@@ -32,6 +33,7 @@ use function sort;
 use function sprintf;
 use function var_export;
 
+#[AutowiredService]
 final class MbStrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/MbSubstituteCharacterDynamicReturnTypeExtension.php
+++ b/src/Type/Php/MbSubstituteCharacterDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BooleanType;
@@ -18,6 +19,7 @@ use PHPStan\Type\TypeCombinator;
 use function in_array;
 use function strtolower;
 
+#[AutowiredService]
 final class MbSubstituteCharacterDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/MicrotimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MicrotimeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -14,6 +15,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class MicrotimeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\BinaryOp\Smaller;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Ternary;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Expr\AlwaysRememberedExpr;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
@@ -20,6 +21,7 @@ use PHPStan\Type\UnionType;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/NonEmptyStringFunctionsReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
@@ -17,6 +18,7 @@ use function count;
 use function in_array;
 use const ENT_SUBSTITUTE;
 
+#[AutowiredService]
 final class NonEmptyStringFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/NumberFormatFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/NumberFormatFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -14,6 +15,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function in_array;
 
+#[AutowiredService]
 final class NumberFormatFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -30,6 +31,7 @@ use const PHP_URL_QUERY;
 use const PHP_URL_SCHEME;
 use const PHP_URL_USER;
 
+#[AutowiredService]
 final class ParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
@@ -17,6 +18,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function sprintf;
 
+#[AutowiredService]
 final class PathinfoFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/PowFunctionReturnTypeExtension.php
+++ b/src/Type/Php/PowFunctionReturnTypeExtension.php
@@ -5,11 +5,13 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\BinaryOp\Pow;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class PowFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/PregFilterFunctionReturnTypeExtension.php
+++ b/src/Type/Php/PregFilterFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ArrayType;
@@ -15,6 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class PregFilterFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PregSplitDynamicReturnTypeExtension.php
@@ -6,6 +6,7 @@ use Nette\Utils\RegexpException;
 use Nette\Utils\Strings;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
@@ -32,6 +33,7 @@ use function is_numeric;
 use function preg_split;
 use function strtolower;
 
+#[AutowiredService]
 final class PregSplitDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -17,6 +18,7 @@ use function in_array;
 use function max;
 use function min;
 
+#[AutowiredService]
 final class RandomIntFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
@@ -27,6 +28,7 @@ use function count;
 use function is_array;
 use function range;
 
+#[AutowiredService]
 final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -22,6 +23,7 @@ use function array_key_exists;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/RoundFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RoundFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNumericStringType;
@@ -22,6 +23,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class RoundFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SprintfFunctionDynamicReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Internal\CombinationsHelper;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -36,6 +37,7 @@ use function sprintf;
 use function substr;
 use function vsprintf;
 
+#[AutowiredService]
 final class SprintfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/SscanfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SscanfFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
@@ -21,6 +22,7 @@ use function count;
 use function in_array;
 use function preg_match_all;
 
+#[AutowiredService]
 final class SscanfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrCaseFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/StrCaseFunctionsReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
@@ -26,6 +27,7 @@ use function mb_check_encoding;
 use const MB_CASE_LOWER;
 use const MB_CASE_UPPER;
 
+#[AutowiredService]
 final class StrCaseFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -23,6 +24,7 @@ use function preg_match;
 use function str_split;
 use function stripos;
 
+#[AutowiredService]
 final class StrIncrementDecrementFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrPadFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrPadFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -17,6 +18,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class StrPadFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrRepeatFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrRepeatFunctionReturnTypeExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use Nette\Utils\Strings;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -24,6 +25,7 @@ use function count;
 use function str_repeat;
 use function strlen;
 
+#[AutowiredService]
 final class StrRepeatFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\ShouldNotHappenException;
@@ -29,6 +30,7 @@ use function mb_internal_encoding;
 use function mb_str_split;
 use function str_split;
 
+#[AutowiredService]
 final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrTokFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrTokFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -14,6 +15,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use function count;
 
+#[AutowiredService]
 final class StrTokFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrWordCountFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/StrWordCountFunctionDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -16,6 +17,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use function count;
 
+#[AutowiredService]
 final class StrWordCountFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrlenFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -21,6 +22,7 @@ use function range;
 use function sort;
 use function strlen;
 
+#[AutowiredService]
 final class StrlenFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrrevFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrrevFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
@@ -18,6 +19,7 @@ use PHPStan\Type\TypeCombinator;
 use function count;
 use function strrev;
 
+#[AutowiredService]
 final class StrrevFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrtotimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrtotimeFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -21,6 +22,7 @@ use function gettype;
 use function min;
 use function strtotime;
 
+#[AutowiredService]
 final class StrtotimeFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/StrvalFamilyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrvalFamilyFunctionReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -15,6 +16,7 @@ use PHPStan\Type\Type;
 use function count;
 use function in_array;
 
+#[AutowiredService]
 final class StrvalFamilyFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/SubstrDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SubstrDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -25,6 +26,7 @@ use function is_bool;
 use function mb_substr;
 use function substr;
 
+#[AutowiredService]
 final class SubstrDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 

--- a/src/Type/Php/TriggerErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TriggerErrorDynamicReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -18,6 +19,7 @@ use const E_USER_ERROR;
 use const E_USER_NOTICE;
 use const E_USER_WARNING;
 
+#[AutowiredService]
 final class TriggerErrorDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 


### PR DESCRIPTION
bulk add the attribute where possible. on the way I discovered a few special cases which I left in the config.neon and will look into in separate PRs