### PR TITLE
TableErrorFormatter: Use two spaces instead of one

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -84,7 +84,7 @@ final class TableErrorFormatter implements ErrorFormatter
 				$filePath = $error->getTraitFilePath() ?? $error->getFilePath();
 				if ($error->getIdentifier() !== null && $error->canBeIgnored()) {
 					$message .= "\n";
-					$message .= '🪪 ' . $error->getIdentifier();
+					$message .= '🪪  ' . $error->getIdentifier();
 				}
 				if ($error->getTip() !== null) {
 					$tip = $error->getTip();
@@ -94,11 +94,11 @@ final class TableErrorFormatter implements ErrorFormatter
 					if (str_contains($tip, "\n")) {
 						$lines = explode("\n", $tip);
 						foreach ($lines as $line) {
-							$message .= '💡 ' . ltrim($line, ' •') . "\n";
+							$message .= '💡  ' . ltrim($line, ' •') . "\n";
 						}
 						$message = rtrim($message, "\n");
 					} else {
-						$message .= '💡 ' . $tip;
+						$message .= '💡  ' . $tip;
 					}
 				}
 				if (is_string($this->editorUrl)) {
@@ -118,7 +118,7 @@ final class TableErrorFormatter implements ErrorFormatter
 						$title = $this->relativePathHelper->getRelativePath($filePath);
 					}
 
-					$message .= "\n✏️ <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
+					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
 				}
 
 				if (

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -94,14 +94,14 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   4      Foo
  ------ -------------------------------------------------------------------
 
- ------ ----------
+ ------ -----------
   Line   foo.php
- ------ ----------
+ ------ -----------
   1      Foo<Bar>
   5      Bar
          Bar2
-         💡 a tip
- ------ ----------
+         💡  a tip
+ ------ -----------
 
  [ERROR] Found 4 errors
 
@@ -143,14 +143,14 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
   4      Foo
  ------ -------------------------------------------------------------------
 
- ------ ----------
+ ------ -----------
   Line   foo.php
- ------ ----------
+ ------ -----------
   1      Foo<Bar>
   5      Bar
          Bar2
-         💡 a tip
- ------ ----------
+         💡  a tip
+ ------ -----------
 
  -- -----------------------
      Error
@@ -190,13 +190,13 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			'numGenericErrors' => 0,
 			'verbose' => false,
 			'extraEnvVars' => [],
-			'expected' => ' ------ ---------------
+			'expected' => ' ------ ----------------
   Line   foo.php
- ------ ---------------
+ ------ ----------------
   5      Foobar\Buz
-         🪪 foobar.buz
-         💡 a tip
- ------ ---------------
+         🪪  foobar.buz
+         💡  a tip
+ ------ ----------------
 
 
  [ERROR] Found 1 error
@@ -211,13 +211,13 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			'numGenericErrors' => 0,
 			'verbose' => true,
 			'extraEnvVars' => [],
-			'expected' => ' ------ ---------------
+			'expected' => ' ------ ----------------
   Line   foo.php
- ------ ---------------
+ ------ ----------------
   5      Foobar\Buz
-         🪪 foobar.buz
-         💡 a tip
- ------ ---------------
+         🪪  foobar.buz
+         💡  a tip
+ ------ ----------------
 
 
  [ERROR] Found 1 error


### PR DESCRIPTION
## Description

This PR reverts commit 59a003a4bf84b319d94fd2a4ff43a5870c316923 which was part of #3821.

## Why?

Before merging #3821, I was asked to replace the seemingly incorrect double spaces with a single space.

After upgrading to the latest version of PHPStan today, I noticed that the double spaces from before were used on purpose, because an emoji character may exceed the width of a single monospace character. Depending on the terminal engine in use, the following characters are either overlapped or shifted to the right.

Using two spaces instead of one makes sure that the output looks good in all terminals (see "**After**" examples).

## Example 1: PhpStorm
The emoji overlaps the next character.

<table>
  <thead>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  </thead>
  <tbody>
  <tr>
    <td valign="top"><img src="https://github.com/user-attachments/assets/10e78adb-b8d6-4b15-ab25-2bfd5738ff68"></td>
    <td valign="top"><img src="https://github.com/user-attachments/assets/59e0522b-38c7-4c8b-8922-8037e39c5a29"></td>
  </tr>
  </tbody>
</table>

## Example 2: Windows Terminal
The emoji pushes all following characters to the right.

<table>
  <thead>
  <tr>
    <th width="50%">Before</th>
    <th width="50%">After</th>
  </tr>
  </thead>
  <tbody>
  <tr>
    <td valign="top"><img src="https://github.com/user-attachments/assets/d90abdd2-6335-4337-ace5-494f61fbd9c3"></td>
    <td valign="top"><img src="https://github.com/user-attachments/assets/e4f25e37-e09f-4445-9829-a1c67044b6d9"></td>
  </tr>
  </tbody>
</table>