### PR TITLE
Fix "Named arguments are supported only on PHP 8.0 and later." false positive

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -391,6 +391,9 @@ jobs:
               cd e2e/composer-version-config
               composer install
               ../../bin/phpstan analyze test.php --level=0
+          - script: |
+              cd e2e/composer-version-named-args
+              ../../bin/phpstan analyze test.php --level=0
 
     steps:
       - name: "Checkout"

--- a/build/ignore-by-php-version.neon.php
+++ b/build/ignore-by-php-version.neon.php
@@ -36,7 +36,7 @@ if (PHP_VERSION_ID >= 80400) {
 $config = [];
 $config['includes'] = $includes;
 
-// overrides config.platform.php in composer.json
-$config['parameters']['phpVersion'] = PHP_VERSION_ID;
+// undo config.platform.php from composer.json
+unset($config['parameters']['phpVersion']);
 
 return $config;

--- a/build/ignore-by-php-version.neon.php
+++ b/build/ignore-by-php-version.neon.php
@@ -36,7 +36,7 @@ if (PHP_VERSION_ID >= 80400) {
 $config = [];
 $config['includes'] = $includes;
 
-// undo config.platform.php from composer.json
-unset($config['parameters']['phpVersion']);
+// overrides config.platform.php in composer.json
+$config['parameters']['phpVersion'] = PHP_VERSION_ID;
 
 return $config;

--- a/e2e/composer-version-named-args/test.php
+++ b/e2e/composer-version-named-args/test.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace NamedAttributesPhpversion;
+
+use Exception;
+use function PHPStan\debugScope;
+use function PHPStan\dumpType;
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/** @return mixed[] */
+	public function sayHello(): array|null
+	{
+		if(PHP_VERSION_ID >= 80400) {
+		} else {
+		}
+		return [
+			new Exception(previous: new Exception()),
+		];
+	}
+}
+
+class HelloWorld2
+{
+	/** @return mixed[] */
+	public function sayHello(): array|null
+	{
+		return [
+			PHP_VERSION_ID >= 80400 ? 1 : 0,
+			new Exception(previous: new Exception()),
+		];
+	}
+}

--- a/src/Analyser/ConstantResolver.php
+++ b/src/Analyser/ConstantResolver.php
@@ -34,7 +34,7 @@ use const PHP_INT_SIZE;
 final class ConstantResolver
 {
 
-	public const PHP_MIN_VERSION_ID = 50207;
+	public const PHP_MIN_ANALYZABLE_VERSION_ID = 50207;
 
 	/** @var array<string, true> */
 	private array $currentlyResolving = [];
@@ -143,7 +143,7 @@ final class ConstantResolver
 			return $this->createInteger($minRelease, $maxRelease);
 		}
 		if ($resolvedConstantName === 'PHP_VERSION_ID') {
-			$minVersion = self::PHP_MIN_VERSION_ID;
+			$minVersion = self::PHP_MIN_ANALYZABLE_VERSION_ID;
 			$maxVersion = null;
 			if ($minPhpVersion !== null) {
 				$minVersion = max($minVersion, $minPhpVersion->getVersionId());

--- a/src/Analyser/ConstantResolver.php
+++ b/src/Analyser/ConstantResolver.php
@@ -34,6 +34,8 @@ use const PHP_INT_SIZE;
 final class ConstantResolver
 {
 
+	public const int PHP_MIN_VERSION_ID = 50207;
+
 	/** @var array<string, true> */
 	private array $currentlyResolving = [];
 
@@ -141,7 +143,7 @@ final class ConstantResolver
 			return $this->createInteger($minRelease, $maxRelease);
 		}
 		if ($resolvedConstantName === 'PHP_VERSION_ID') {
-			$minVersion = 50207;
+			$minVersion = self::PHP_MIN_VERSION_ID;
 			$maxVersion = null;
 			if ($minPhpVersion !== null) {
 				$minVersion = max($minVersion, $minPhpVersion->getVersionId());

--- a/src/Analyser/ConstantResolver.php
+++ b/src/Analyser/ConstantResolver.php
@@ -34,7 +34,7 @@ use const PHP_INT_SIZE;
 final class ConstantResolver
 {
 
-	public const int PHP_MIN_VERSION_ID = 50207;
+	public const PHP_MIN_VERSION_ID = 50207;
 
 	/** @var array<string, true> */
 	private array $currentlyResolving = [];

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -6238,7 +6238,7 @@ final class MutatingScope implements Scope
 		$minPhpVersion = IntegerRangeType::fromInterval(ConstantResolver::PHP_MIN_VERSION_ID, null);
 
 		$constType = $this->getGlobalConstantType(new Name('PHP_VERSION_ID'));
-		if ($constType !== null && !$minPhpVersion->isSuperTypeOf($constType)->yes()) {
+		if ($constType !== null && !$constType->isSuperTypeOf($minPhpVersion)->yes()) {
 			return new PhpVersions($constType);
 		}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -6235,8 +6235,10 @@ final class MutatingScope implements Scope
 
 	public function getPhpVersion(): PhpVersions
 	{
+		$minPhpVersion = IntegerRangeType::fromInterval(ConstantResolver::PHP_MIN_VERSION_ID, null);
+
 		$constType = $this->getGlobalConstantType(new Name('PHP_VERSION_ID'));
-		if ($constType !== null) {
+		if ($constType !== null && !$minPhpVersion->isSuperTypeOf($constType)->yes()) {
 			return new PhpVersions($constType);
 		}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -52,6 +52,7 @@ use PHPStan\Parser\ArrayMapArgVisitor;
 use PHPStan\Parser\NewAssignedToPropertyVisitor;
 use PHPStan\Parser\Parser;
 use PHPStan\Php\PhpVersion;
+use PHPStan\Php\PhpVersionFactory;
 use PHPStan\Php\PhpVersions;
 use PHPStan\PhpDoc\Tag\TemplateTag;
 use PHPStan\Reflection\Assertions;
@@ -6235,10 +6236,10 @@ final class MutatingScope implements Scope
 
 	public function getPhpVersion(): PhpVersions
 	{
-		$minPhpVersion = IntegerRangeType::fromInterval(ConstantResolver::PHP_MIN_VERSION_ID, null);
+		$overallPhpVersionRange = IntegerRangeType::fromInterval(ConstantResolver::PHP_MIN_ANALYZABLE_VERSION_ID, PhpVersionFactory::MAX_PHP_VERSION);
 
 		$constType = $this->getGlobalConstantType(new Name('PHP_VERSION_ID'));
-		if ($constType !== null && !$constType->isSuperTypeOf($minPhpVersion)->yes()) {
+		if ($constType !== null && !$constType->equals($overallPhpVersionRange)) {
 			return new PhpVersions($constType);
 		}
 


### PR DESCRIPTION
- running https://phpstan.org/r/8df32644-1f4b-4b46-934d-5134753fbd47 in a codebase outside of phpstan-src did not reproduce the error

- putting the reproducer under `CallMethodsRuleTest` did also not reproduce the error, as `ignore-by-php-version.neon.php` is not loaded in the test-suite