### PR TITLE
Improve NAN inferences

### DIFF
--- a/src/Type/ConstantTypeHelper.php
+++ b/src/Type/ConstantTypeHelper.php
@@ -16,7 +16,6 @@ use function is_array;
 use function is_bool;
 use function is_float;
 use function is_int;
-use function is_nan;
 use function is_object;
 use function is_string;
 
@@ -34,9 +33,6 @@ final class ConstantTypeHelper
 		if (is_int($value)) {
 			return new ConstantIntegerType($value);
 		} elseif (is_float($value)) {
-			if (is_nan($value)) {
-				return new MixedType();
-			}
 			return new ConstantFloatType($value);
 		} elseif (is_bool($value)) {
 			return new ConstantBooleanType($value);

--- a/tests/PHPStan/Analyser/nsrt/bug-13097.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13097.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug13097;
+
+use function PHPStan\Testing\assertType;
+
+$f = -1 * INF;
+assertType('-INF', $f);
+
+$f = 0 * INF;
+assertType('NAN', $f);
+
+$f = 1 * INF;
+assertType('INF', $f);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13097

This was introduced in https://github.com/phpstan/phpstan-src/commit/29fcf80e1676f1a13ee04e88db6dbeb8685b58e1 but seems like the `return NAN` doesn't exists anymore so we can improve NAN inferences without regression.