### PR TITLE
Add more precise return types for the openssl cipher functions

### DIFF
--- a/src/Type/Php/OpensslCipherFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/OpensslCipherFunctionsReturnTypeExtension.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function array_map;
+use function array_unique;
+use function count;
+use function function_exists;
+use function in_array;
+use function is_null;
+use function openssl_get_cipher_methods;
+use function strtoupper;
+
+#[AutowiredService]
+final class OpensslCipherFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	/** @var string[]|null */
+	private ?array $supportedAlgorithms = null;
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return in_array($functionReflection->getName(), ['openssl_cipher_iv_length', 'openssl_cipher_key_length'], true);
+	}
+
+	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+	{
+		if (!$this->phpVersion->throwsValueErrorForInternalFunctions()) {
+			return null;
+		}
+
+		if (count($functionCall->getArgs()) < 1) {
+			return null;
+		}
+
+		$strings = $scope->getType($functionCall->getArgs()[0]->value)->getConstantStrings();
+		$results = array_unique(array_map(fn (ConstantStringType $algorithm): bool => $this->isSupportedAlgorithm($algorithm->getValue()), $strings));
+
+		if (count($results) !== 1) {
+			return null;
+		}
+
+		$returnType = ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$functionCall->getArgs(),
+			$functionReflection->getVariants(),
+		)->getReturnType();
+
+		return $results[0]
+			? TypeCombinator::remove($returnType, new ConstantBooleanType(false))
+			: new ConstantBooleanType(false);
+	}
+
+	private function isSupportedAlgorithm(string $algorithm): bool
+	{
+		return in_array(strtoupper($algorithm), $this->getSupportedAlgorithms(), true);
+	}
+
+	/** @return string[] */
+	private function getSupportedAlgorithms(): array
+	{
+		if (!is_null($this->supportedAlgorithms)) {
+			return $this->supportedAlgorithms;
+		}
+
+		$supportedAlgorithms = [];
+		if (function_exists('openssl_get_cipher_methods')) {
+			$supportedAlgorithms = openssl_get_cipher_methods(true);
+		}
+		$this->supportedAlgorithms = array_map('strtoupper', $supportedAlgorithms);
+
+		return $this->supportedAlgorithms;
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/openssl-cipher-iv-length-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/openssl-cipher-iv-length-php7.php
@@ -1,0 +1,24 @@
+<?php // lint < 8.0
+
+namespace OpensslCipherIvLengthPhp7;
+
+use function PHPStan\Testing\assertType;
+
+class OpensslCipher
+{
+
+	/**
+	 * @param 'aes-256-cbc'|'aes128'|'aes-128-cbc' $validAlgorithms
+	 * @param 'aes-256-cbc'|'invalid' $validAndInvalidAlgorithms
+	 */
+	public function doFoo(string $s, $validAlgorithms, $validAndInvalidAlgorithms)
+	{
+		assertType('int|false', openssl_cipher_iv_length('aes-256-cbc'));
+		assertType('int|false', openssl_cipher_iv_length('AES-256-CBC'));
+		assertType('int|false', openssl_cipher_iv_length('unsupported'));
+		assertType('int|false', openssl_cipher_iv_length($s));
+		assertType('int|false', openssl_cipher_iv_length($validAlgorithms));
+		assertType('int|false', openssl_cipher_iv_length($validAndInvalidAlgorithms));
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/openssl-cipher-iv-length-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/openssl-cipher-iv-length-php8.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.0
+
+namespace OpensslCipherIvLengthPhp8;
+
+use function PHPStan\Testing\assertType;
+
+class OpensslCipher
+{
+
+	/**
+	 * @param 'aes-256-cbc'|'aes128'|'aes-128-cbc' $validAlgorithms
+	 * @param 'aes-256-cbc'|'invalid' $validAndInvalidAlgorithms
+	 */
+	public function doFoo(string $s, $validAlgorithms, $validAndInvalidAlgorithms)
+	{
+		assertType('int', openssl_cipher_iv_length('aes-256-cbc'));
+		assertType('int', openssl_cipher_iv_length('AES-256-CBC'));
+		assertType('false', openssl_cipher_iv_length('unsupported'));
+		assertType('int|false', openssl_cipher_iv_length($s));
+		assertType('int', openssl_cipher_iv_length($validAlgorithms));
+		assertType('int|false', openssl_cipher_iv_length($validAndInvalidAlgorithms));
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/openssl-cipher-key-length.php
+++ b/tests/PHPStan/Analyser/nsrt/openssl-cipher-key-length.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.2
+
+namespace OpensslCipherKeyLength;
+
+use function PHPStan\Testing\assertType;
+
+class OpensslCipher
+{
+
+	/**
+	 * @param 'aes-256-cbc'|'aes128'|'aes-128-cbc' $validAlgorithms
+	 * @param 'aes-256-cbc'|'invalid' $validAndInvalidAlgorithms
+	 */
+	public function doFoo(string $s, $validAlgorithms, $validAndInvalidAlgorithms)
+	{
+		assertType('int', openssl_cipher_key_length('aes-256-cbc'));
+		assertType('int', openssl_cipher_key_length('AES-256-CBC'));
+		assertType('false', openssl_cipher_key_length('unsupported'));
+		assertType('int|false', openssl_cipher_key_length($s));
+		assertType('int', openssl_cipher_key_length($validAlgorithms));
+		assertType('int|false', openssl_cipher_key_length($validAndInvalidAlgorithms));
+	}
+
+}


### PR DESCRIPTION
Those functions return false (and trigger a warning) only when the argument is an unknown algorithm, which is not something worth checking when using them with a known algorithm.

I'm providing this improvement only on PHP 8+, because PHP 7 can have other kind of warnings (that have been upgraded to `ValueError` in PHP 8)

Replaces https://github.com/phpstan/phpstan-src/pull/3582