### PR TITLE
Fix assertSuperType logic

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -780,7 +780,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\ConstantScalarType is error\-prone and deprecated\. Use Type\:\:isConstantScalarValue\(\) or Type\:\:getConstantScalarTypes\(\) or Type\:\:getConstantScalarValues\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 3
+			count: 2
 			path: src/Testing/TypeInferenceTestCase.php
 
 		-
@@ -2022,7 +2022,7 @@ parameters:
 		-
 			message: '#^Access to constant on internal class PHPUnit\\Framework\\AssertionFailedError\.$#'
 			identifier: classConstant.internalClass
-			count: 1
+			count: 2
 			path: tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
 
 		-

--- a/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
+++ b/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
@@ -38,6 +38,13 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 			),
 		];
 		yield [
+			__DIR__ . '/data/assert-super-type-missing-namespace.php',
+			sprintf(
+				'Missing use statement for assertSuperType() in %s on line 6.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-super-type-missing-namespace.php'),
+			),
+		];
+		yield [
 			__DIR__ . '/data/assert-certainty-wrong-namespace.php',
 			sprintf(
 				'Function PHPStan\Testing\assertVariableCertainty imported with wrong namespace SomeWrong\Namespace\assertVariableCertainty called in %s on line 9.',
@@ -59,6 +66,13 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 			),
 		];
 		yield [
+			__DIR__ . '/data/assert-super-type-wrong-namespace.php',
+			sprintf(
+				'Function PHPStan\Testing\assertSuperType imported with wrong namespace SomeWrong\Namespace\assertSuperType called in %s on line 8.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-super-type-wrong-namespace.php'),
+			),
+		];
+		yield [
 			__DIR__ . '/data/assert-certainty-case-insensitive.php',
 			sprintf(
 				'Missing use statement for assertvariablecertainty() in %s on line 8.',
@@ -77,6 +91,13 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 			sprintf(
 				'Missing use statement for assertTYPe() in %s on line 6.',
 				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-type-case-insensitive.php'),
+			),
+		];
+		yield [
+			__DIR__ . '/data/assert-super-type-case-insensitive.php',
+			sprintf(
+				'Missing use statement for assertSuperTYPe() in %s on line 6.',
+				$fileHelper->normalizePath('tests/PHPStan/Testing/data/assert-super-type-case-insensitive.php'),
 			),
 		];
 	}

--- a/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
+++ b/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
@@ -121,6 +121,28 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 		$this->assertSame("offset 'email'", $offsetAssert[4]);
 	}
 
+	public function testSuperType(): void
+	{
+		foreach (self::gatherAssertTypes(__DIR__ . '/data/assert-super-type.php') as $data) {
+			$this->assertFileAsserts(...$data);
+		}
+	}
+
+	public static function dataSuperTypeFailed(): array
+	{
+		return self::gatherAssertTypes(__DIR__ . '/data/assert-super-type-failed.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataSuperTypeFailed')]
+	public function testSuperTypeFailed(...$args): void
+	{
+		$this->expectException(AssertionFailedError::class);
+		$this->assertFileAsserts(...$args);
+	}
+
 	public function testNonexistentClassInAnalysedFile(): void
 	{
 		foreach (self::gatherAssertTypes(__DIR__ . '/../../notAutoloaded/nonexistentClasses.php') as $data) {

--- a/tests/PHPStan/Testing/data/assert-super-type-case-insensitive.php
+++ b/tests/PHPStan/Testing/data/assert-super-type-case-insensitive.php
@@ -1,0 +1,8 @@
+<?php // lint >= 8.0
+
+namespace MissingTypeCaseSensitive;
+
+function doFoo(string $s) {
+	assertSuperTYPe('string', $s);
+}
+

--- a/tests/PHPStan/Testing/data/assert-super-type-failed.php
+++ b/tests/PHPStan/Testing/data/assert-super-type-failed.php
@@ -1,0 +1,9 @@
+<?php
+
+use function PHPStan\Testing\assertSuperType;
+
+$a = 'Alice';
+
+assertSuperType('never', $a);
+assertSuperType('bool', $a);
+assertSuperType('"Bob"', $a);

--- a/tests/PHPStan/Testing/data/assert-super-type-missing-namespace.php
+++ b/tests/PHPStan/Testing/data/assert-super-type-missing-namespace.php
@@ -1,0 +1,8 @@
+<?php // lint >= 8.0
+
+namespace MissingAssertTypeNamespace;
+
+function doFoo(string $s) {
+	assertSuperType('string', $s);
+}
+

--- a/tests/PHPStan/Testing/data/assert-super-type-wrong-namespace.php
+++ b/tests/PHPStan/Testing/data/assert-super-type-wrong-namespace.php
@@ -1,0 +1,10 @@
+<?php // lint >= 8.0
+
+namespace WrongAssertTypeNamespace;
+
+use function SomeWrong\Namespace\assertSuperType;
+
+function doFoo(string $s) {
+	assertSuperType('string', $s);
+}
+

--- a/tests/PHPStan/Testing/data/assert-super-type.php
+++ b/tests/PHPStan/Testing/data/assert-super-type.php
@@ -1,0 +1,8 @@
+<?php
+
+use function PHPStan\Testing\assertSuperType;
+
+$a = 'Alice';
+
+assertSuperType('string', $a);
+assertSuperType('mixed', $a);


### PR DESCRIPTION
So this should actually make `assertSuperType` work in the wilderness, but I fail to see how to test it. It seems like the `FileAssertRule` needs to reimplement the logic for itself.