### PR TITLE
Fix ArrayColumnHelper for non-empty-list<array<string, mixed>> to ret…

### DIFF
--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -43,7 +43,13 @@ final class ArrayColumnHelper
 
 		if ($returnValueType === null) {
 			$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, true);
-			$iterableAtLeastOnce = TrinaryLogic::createMaybe();
+
+//			if (TypeCombinator::contains($arrayType, new NonEmptyArrayType())) {
+//				$iterableAtLeastOnce = TrinaryLogic::createYes();
+//			} else {
+//				$iterableAtLeastOnce = TrinaryLogic::createMaybe();
+//			}
+
 			if ($returnValueType === null) {
 				throw new ShouldNotHappenException();
 			}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -272,6 +272,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame('Constant SOME_UNKNOWN_CONST not found.', $errors[0]->getMessage());
 	}
 
+	public function testArraysBug(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-array-column.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug3798(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3798.php');

--- a/tests/PHPStan/Analyser/nsrt/array-column.php
+++ b/tests/PHPStan/Analyser/nsrt/array-column.php
@@ -239,6 +239,13 @@ class ArrayColumnTest
 		assertType('non-empty-array<DOMElement>', array_column($array, null, 'foo'));
 	}
 
+	/**
+	 * @param non-empty-list<array<string, mixed>> $list
+	 */
+	public function testList1(array $list): void
+	{
+		assertType('non-empty-list<mixed>', array_column($list, 'value'));
+	}
 }
 
 final class Foo

--- a/tests/PHPStan/Analyser/nsrt/bug-array-column.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-array-column.php
@@ -1,0 +1,18 @@
+<?php // lint < 8.2
+
+namespace ArrayColumn;
+
+use DOMElement;
+use function PHPStan\Testing\assertType;
+
+
+class ArrayColumnTest
+{
+	/**
+	 * @param non-empty-list<array<string, mixed>> $list
+	 */
+	public function testList1(array $list): void
+	{
+		assertType('non-empty-list<mixed>', array_column($list, 'value'));
+	}
+}


### PR DESCRIPTION
Fix when argument of array_column is non-empty-list with mixed array, also return value is non-empty-string
```
<?php declare(strict_types = 1);

use function PHPStan\dumpType;
use function PHPStan\Testing\assertType;

class HelloWorld
{
	/**
	 * @param non-empty-list<array<string, mixed>> $list
	 */
	public function testList1(array $list): void
	{
		assertType('non-empty-list<mixed>', array_column($list, 'value'));
	}
}
```