### PR TITLE
Improve property access when type hinting declared with @property

### DIFF
--- a/src/Rules/Properties/AccessPropertiesCheck.php
+++ b/src/Rules/Properties/AccessPropertiesCheck.php
@@ -23,9 +23,11 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function count;
+use function in_array;
 use function sprintf;
 
 #[AutowiredService]
@@ -125,10 +127,17 @@ final class AccessPropertiesCheck
 				}
 			}
 
+			$propertyTags = [];
 			if (count($classNames) === 1) {
 				$propertyClassReflection = $this->reflectionProvider->getClass($classNames[0]);
 				$parentClassReflection = $propertyClassReflection->getParentClass();
+				$propertyTags = $propertyClassReflection->isInterface() ? [] : $propertyClassReflection->getPropertyTags();
+
 				while ($parentClassReflection !== null) {
+					if (!$parentClassReflection->isInterface()) {
+						$propertyTags[] = $parentClassReflection->getPropertyTags();
+					}
+
 					if ($parentClassReflection->hasProperty($name)) {
 						if ($write) {
 							if ($scope->canWriteProperty($parentClassReflection->getProperty($name, $scope))) {
@@ -146,9 +155,12 @@ final class AccessPropertiesCheck
 							))->identifier('property.private')->build(),
 						];
 					}
-
 					$parentClassReflection = $parentClassReflection->getParentClass();
 				}
+			}
+
+			if (in_array($name, array_keys($propertyTags), true)) {
+				return [];
 			}
 
 			if ($node->name instanceof Expr) {

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -1019,7 +1019,38 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->checkThisOnly = false;
 		$this->checkUnionTypes = true;
 		$this->checkDynamicProperties = true;
-		$this->analyse([__DIR__ . '/data/property-exists.php'], []);
+		$this->analyse([__DIR__ . '/data/property-exists.php'], [
+			[
+				'Access to an undefined property PropertyExists\Model::$getCreatedByColumn.',
+				27,
+				'Learn more: <fg=cyan>https://phpstan.org/blog/solving-phpstan-access-to-undefined-property</>',
+			],
+			[
+				'Access to an undefined property PropertyExists\Model::$getUpdatedByColumn.',
+				27,
+				'Learn more: <fg=cyan>https://phpstan.org/blog/solving-phpstan-access-to-undefined-property</>',
+			],
+			[
+				'Access to an undefined property PropertyExists\Model::$getDeletedByColumn.',
+				27,
+				'Learn more: <fg=cyan>https://phpstan.org/blog/solving-phpstan-access-to-undefined-property</>',
+			],
+			[
+				'Access to an undefined property PropertyExists\Model::$getCreatedAtColumn.',
+				27,
+				'Learn more: <fg=cyan>https://phpstan.org/blog/solving-phpstan-access-to-undefined-property</>',
+			],
+			[
+				'Access to an undefined property PropertyExists\Model::$getUpdatedAtColumn.',
+				27,
+				'Learn more: <fg=cyan>https://phpstan.org/blog/solving-phpstan-access-to-undefined-property</>',
+			],
+			[
+				'Access to an undefined property PropertyExists\Model::$getDeletedAtColumn.',
+				27,
+				'Learn more: <fg=cyan>https://phpstan.org/blog/solving-phpstan-access-to-undefined-property</>',
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/property-exists.php
+++ b/tests/PHPStan/Rules/Properties/data/property-exists.php
@@ -2,9 +2,11 @@
 
 namespace PropertyExists;
 
+/**
+ * @property-read \stdClass $getCreator
+ */
 class Model
 {
-
 }
 
 class Defaults
@@ -12,6 +14,7 @@ class Defaults
 	public function defaults(Model $model): void
 	{
 		$columns = [
+			'getCreator',
 			'getCreatedByColumn',
 			'getUpdatedByColumn',
 			'getDeletedByColumn',
@@ -21,9 +24,7 @@ class Defaults
 		];
 
 		foreach ($columns as $column) {
-			if (property_exists($model, $column)) {
-				echo $model->{$column};
-			}
+            echo $model->{$column};
 		}
 	}
 }


### PR DESCRIPTION
### Problem
Previously, accessing properties declared with `@property-read` annotations would incorrectly trigger " Access to an undefined property" error.

```PHP
<?php declare(strict_types = 1);

use function PHPStan\dumpType;
use function PHPStan\Testing\assertType;

/**
 * @property-read \stdClass $getCreator
 */
class Model
{
}

class Defaults
{
    public function defaults(Model $model): void
    {
        $creator = $model->getCreator;  // Access to an undefined property Model::$getCreator.

    }
}
```

Playground: [phpstan.org/r/7c5fd6b0-da88-4298-8e72-59bebdd48d08](https://phpstan.org/r/7c5fd6b0-da88-4298-8e72-59bebdd48d08)

### Solution
Enhanced property access checking to properly recognize properties declared via PHPDoc annotations.