### PR TITLE
TableErrorFormatter: Link path in PhpStorm

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -130,7 +130,7 @@ final class TableErrorFormatter implements ErrorFormatter
 						$title = $this->relativePathHelper->getRelativePath($filePath);
 					}
 
-					$message .= "\n✏️  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
+					$message .= "\nat  <href=" . OutputFormatter::escape($url) . '>' . $title . '</>';
 				}
 
 				if (

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -100,7 +100,7 @@ final class ErrorsConsoleStyle extends SymfonyStyle
 		foreach ($rows as $i => $column) {
 			$columnRows = explode("\n", $column);
 			foreach ($columnRows as $k => $columnRow) {
-				if (str_starts_with($columnRow, '✏️')) {
+				if (str_starts_with($columnRow, 'at  ')) {
 					continue;
 				}
 				$wrapped = wordwrap(


### PR DESCRIPTION
PhpStorm's internal terminal is very peculiar about paths it link. Pretty much only "at path:line" is linked: https://youtrack.jetbrains.com/issue/IJPL-103639/#focus=Comments-27-3994543.0-0.

I know that I can write my custom error formatter but I see a value in this working by default. Also replicating all features of TableErrorFormatter is not trivial in custom formatter.

Before:
![image](https://github.com/user-attachments/assets/e7e97a43-8387-46e0-b6f3-eb0f5c5dad44)

After:
![image](https://github.com/user-attachments/assets/591ec4d7-75cf-4079-9d27-38290da82209)
