### PR TITLE
fix: explicitly use StreamSelectLoop for Pro download

### DIFF
--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -338,6 +338,9 @@ final class FixerApplication
 		$dnsConfig = new Config();
 		$dnsConfig->nameservers = $this->dnsServers;
 
+		$loop = new StreamSelectLoop();
+		Loop::set($loop); // @phpstan-ignore staticMethod.internal (required because of the await() call below)
+
 		$client = new Browser(
 			new Connector(
 				[
@@ -347,7 +350,9 @@ final class FixerApplication
 					],
 					'dns' => $dnsConfig,
 				],
+				$loop,
 			),
+			$loop,
 		);
 
 		/**
@@ -388,7 +393,7 @@ final class FixerApplication
 			$this->printDownloadError($output, $e);
 		});
 
-		Loop::run();
+		$loop->run();
 
 		fclose($pharPathResource);
 


### PR DESCRIPTION
Hello!

The Pro download kept failing in a Docker container when the `uv`
extension was enabled (which set the default global loop to the
`ExtUvLoop` instance) with the following error:

    Connection to tls://fixer-download-api.phpstan.com:443 timed out after 5 seconds (ETIMEDOUT)

This can be fixed by explicitly using a `StreamSelectLoop` for the
Pro download, which is the same loop that's used everywhere else in the
codebase.

Note that we have to set this as the global loop because the `await()`
function no longer supports passing a loop as an argument.

Thanks!