### PR TITLE
Resolve ObjectType::getArraySize() with count() only if defined

### DIFF
--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -946,6 +946,10 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return new ErrorType();
 		}
 
+		if ($this->hasMethod('count')->yes() === false) {
+			return IntegerRangeType::fromInterval(0, null);
+		}
+
 		return RecursionGuard::run($this, fn (): Type => $this->getMethod('count', new OutOfClassScope())->getOnlyVariant()->getReturnType());
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/countable.php
+++ b/tests/PHPStan/Analyser/nsrt/countable.php
@@ -30,6 +30,9 @@ class Bar implements \Countable {
 	}
 }
 
+interface Baz {
+}
+
 class NonCountable {}
 
 function doNonCountable() {
@@ -42,4 +45,8 @@ function doFoo() {
 
 function doBar() {
 	assertType('-1', count(new Bar()));
+}
+
+function doBaz(Baz $baz) {
+	assertType('int<0, max>', count($baz));
 }


### PR DESCRIPTION
Fix for phpstan/phpstan#13187