### PR TITLE
Resolve self/parent/static in Closure::bind() scope

### DIFF
--- a/src/Analyser/ClosureBindScopeResolver.php
+++ b/src/Analyser/ClosureBindScopeResolver.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Parser\ClosureBindArgVisitor;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use function count;
+
+/**
+ * Resolves the class scope that a `self`/`parent`/`static` class-name node is bound to
+ * by a surrounding `Closure::bind()` call. {@see ClosureBindArgVisitor} annotates such
+ * nodes with the bind scope argument (the 3rd argument of `Closure::bind()`).
+ */
+#[AutowiredService]
+final class ClosureBindScopeResolver
+{
+
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+	)
+	{
+	}
+
+	/**
+	 * Returns the class the given class-name node is bound to via `Closure::bind()`, or
+	 * null when the node is not inside a bound closure or the bind scope argument does not
+	 * resolve to a single known class (e.g. the default "static" scope).
+	 */
+	public function resolveScopeClass(Scope $scope, Name $class): ?ClassReflection
+	{
+		$scopeArg = $class->getAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME);
+		if (!$scopeArg instanceof Expr) {
+			// Either the node is not inside a bound closure, or the attribute is null for
+			// the default "static" scope. Both keep the enclosing class.
+			return null;
+		}
+
+		$objectClassNames = $scope->getType($scopeArg)->getClassStringObjectType()->getObjectClassNames();
+		if (count($objectClassNames) !== 1) {
+			return null;
+		}
+
+		$className = $objectClassNames[0];
+		if (!$this->reflectionProvider->hasClass($className)) {
+			return null;
+		}
+
+		return $this->reflectionProvider->getClass($className);
+	}
+
+}

--- a/src/Analyser/ExprHandler/ClassConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ClassConstFetchHandler.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser\ExprHandler;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
@@ -18,10 +19,14 @@ use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Parser\ClosureBindArgVisitor;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use function array_merge;
+use function count;
 
 /**
  * @implements ExprHandler<ClassConstFetch>
@@ -33,6 +38,7 @@ final class ClassConstFetchHandler implements ExprHandler
 	public function __construct(
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 		private ExpressionResultFactory $expressionResultFactory,
+		private ReflectionProvider $reflectionProvider,
 	)
 	{
 	}
@@ -48,12 +54,49 @@ final class ClassConstFetchHandler implements ExprHandler
 			return new MixedType();
 		}
 
+		$classReflection = $scope->isInClass() ? $scope->getClassReflection() : null;
+		$bindScopeReflection = $this->resolveClosureBindScopeReflection($scope, $expr->class);
+		if ($bindScopeReflection !== null) {
+			$classReflection = $bindScopeReflection;
+		}
+
 		return $this->initializerExprTypeResolver->getClassConstFetchTypeByReflection(
 			$expr->class,
 			$expr->name->name,
-			$scope->isInClass() ? $scope->getClassReflection() : null,
+			$classReflection,
 			static fn (Expr $e): Type => $scope->getType($e),
 		);
+	}
+
+	/**
+	 * Resolves the `Closure::bind()` scope class annotated on a `self`/`parent`/`static`
+	 * class name node by {@see ClosureBindArgVisitor}. Returns null when the node is not
+	 * inside a bound closure or the scope argument does not resolve to a single known class.
+	 */
+	private function resolveClosureBindScopeReflection(MutatingScope $scope, Expr|Name $class): ?ClassReflection
+	{
+		if (!$class instanceof Name || !$class->hasAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME)) {
+			return null;
+		}
+
+		$scopeArg = $class->getAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME);
+		if (!$scopeArg instanceof Expr) {
+			// null attribute means the default "static" scope: keep the enclosing class.
+			return null;
+		}
+
+		$scopeArgType = $scope->getType($scopeArg);
+		$objectClassNames = $scopeArgType->getClassStringObjectType()->getObjectClassNames();
+		if (count($objectClassNames) !== 1) {
+			return null;
+		}
+
+		$className = $objectClassNames[0];
+		if (!$this->reflectionProvider->hasClass($className)) {
+			return null;
+		}
+
+		return $this->reflectionProvider->getClass($className);
 	}
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult

--- a/src/Analyser/ExprHandler/ClassConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ClassConstFetchHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
 use PHPStan\Analyser\ExpressionResultFactory;
@@ -19,14 +20,10 @@ use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredService;
-use PHPStan\Parser\ClosureBindArgVisitor;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use function array_merge;
-use function count;
 
 /**
  * @implements ExprHandler<ClassConstFetch>
@@ -38,7 +35,7 @@ final class ClassConstFetchHandler implements ExprHandler
 	public function __construct(
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 		private ExpressionResultFactory $expressionResultFactory,
-		private ReflectionProvider $reflectionProvider,
+		private ClosureBindScopeResolver $closureBindScopeResolver,
 	)
 	{
 	}
@@ -55,9 +52,11 @@ final class ClassConstFetchHandler implements ExprHandler
 		}
 
 		$classReflection = $scope->isInClass() ? $scope->getClassReflection() : null;
-		$bindScopeReflection = $this->resolveClosureBindScopeReflection($scope, $expr->class);
-		if ($bindScopeReflection !== null) {
-			$classReflection = $bindScopeReflection;
+		if ($expr->class instanceof Name) {
+			$bindScopeReflection = $this->closureBindScopeResolver->resolveScopeClass($scope, $expr->class);
+			if ($bindScopeReflection !== null) {
+				$classReflection = $bindScopeReflection;
+			}
 		}
 
 		return $this->initializerExprTypeResolver->getClassConstFetchTypeByReflection(
@@ -66,37 +65,6 @@ final class ClassConstFetchHandler implements ExprHandler
 			$classReflection,
 			static fn (Expr $e): Type => $scope->getType($e),
 		);
-	}
-
-	/**
-	 * Resolves the `Closure::bind()` scope class annotated on a `self`/`parent`/`static`
-	 * class name node by {@see ClosureBindArgVisitor}. Returns null when the node is not
-	 * inside a bound closure or the scope argument does not resolve to a single known class.
-	 */
-	private function resolveClosureBindScopeReflection(MutatingScope $scope, Expr|Name $class): ?ClassReflection
-	{
-		if (!$class instanceof Name || !$class->hasAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME)) {
-			return null;
-		}
-
-		$scopeArg = $class->getAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME);
-		if (!$scopeArg instanceof Expr) {
-			// null attribute means the default "static" scope: keep the enclosing class.
-			return null;
-		}
-
-		$scopeArgType = $scope->getType($scopeArg);
-		$objectClassNames = $scopeArgType->getClassStringObjectType()->getObjectClassNames();
-		if (count($objectClassNames) !== 1) {
-			return null;
-		}
-
-		$className = $objectClassNames[0];
-		if (!$this->reflectionProvider->hasClass($className)) {
-			return null;
-		}
-
-		return $this->reflectionProvider->getClass($className);
 	}
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -126,7 +126,10 @@ final class StaticCallHandler implements ExprHandler
 						// deferred until the closure argument is processed: with
 						// closures processed last, the bound $this/scope arguments
 						// are already evaluated on the scope the factory receives
-						$closureBindScopeFactory = static function (MutatingScope $boundScope) use ($expr): MutatingScope {
+						$closureBindScopeFactory = static function (MutatingScope $boundScope) use ($expr, $parametersAcceptor): MutatingScope {
+							// normalized so that $newThis and $newScope are found at their
+							// parameter positions even when the call names its arguments
+							$expr = ArgumentsNormalizer::reorderStaticCallArguments($parametersAcceptor, $expr) ?? $expr;
 							$thisType = null;
 							$nativeThisType = null;
 							if (isset($expr->getArgs()[1])) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1420,13 +1420,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		$originalClass = (string) $name;
 		$lowerClass = strtolower($originalClass);
 
-		$bindScopeClassName = $this->resolveClosureBindScopeClassName($name);
-		if ($bindScopeClassName !== null) {
+		$bindScopeClassReflection = $this->resolveClosureBindScopeClass($name);
+		if ($bindScopeClassReflection !== null) {
 			if (in_array($lowerClass, ['self', 'static'], true)) {
-				return $bindScopeClassName;
+				return $bindScopeClassReflection->getName();
 			}
-			if ($lowerClass === 'parent' && $this->reflectionProvider->hasClass($bindScopeClassName)) {
-				$parentClassReflection = $this->reflectionProvider->getClass($bindScopeClassName)->getParentClass();
+			if ($lowerClass === 'parent') {
+				$parentClassReflection = $bindScopeClassReflection->getParentClass();
 				if ($parentClassReflection !== null) {
 					return $parentClassReflection->getName();
 				}
@@ -1456,10 +1456,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	/** @api */
 	public function resolveTypeByName(Name $name): TypeWithClassName
 	{
-		$bindScopeClassName = $this->resolveClosureBindScopeClassName($name);
+		$bindScopeClassReflection = $this->resolveClosureBindScopeClass($name);
 		if ($name->toLowerString() === 'static') {
-			if ($bindScopeClassName !== null && $this->reflectionProvider->hasClass($bindScopeClassName)) {
-				return new StaticType($this->reflectionProvider->getClass($bindScopeClassName));
+			if ($bindScopeClassReflection !== null) {
+				return new StaticType($bindScopeClassReflection);
 			}
 			if ($this->isInClass()) {
 				if ($this->inClosureBindScopeClasses !== [] && $this->inClosureBindScopeClasses !== ['static']) {
@@ -1473,7 +1473,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		$originalClass = $this->resolveName($name);
-		if ($bindScopeClassName !== null && $this->reflectionProvider->hasClass($originalClass)) {
+		if ($bindScopeClassReflection !== null && $this->reflectionProvider->hasClass($originalClass)) {
 			return new ObjectType($originalClass);
 		}
 		if ($this->isInClass()) {
@@ -1495,31 +1495,25 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	}
 
 	/**
-	 * Resolves the class name that a `self`/`parent`/`static` node is bound to by a
-	 * surrounding `Closure::bind()` call, annotated by {@see ClosureBindArgVisitor}. Returns
-	 * null when the node is not inside a bound closure or the bind scope argument does not
-	 * resolve to a single known class (e.g. the default "static" scope). This works even
-	 * outside a class context, because the type of a bound closure's body is inferred in the
-	 * enclosing scope where the closure-bind scope classes are not otherwise available.
+	 * Resolves the class a `self`/`parent`/`static` node is bound to by a surrounding
+	 * `Closure::bind()` call, annotated by {@see ClosureBindArgVisitor} and resolved by
+	 * {@see ClosureBindScopeResolver}. Returns null when the node is not inside a bound
+	 * closure or the bind scope argument does not resolve to a single known class (e.g.
+	 * the default "static" scope).
+	 *
+	 * This complements enterClosureBind() and inClosureBindScopeClasses: that scope-based
+	 * path owns member accessibility while the closure body is being processed, but cannot
+	 * reach this case, because the body's type is inferred in the enclosing scope where the
+	 * closure-bind scope classes are not available (including outside any class).
 	 */
-	/** @return non-empty-string|null */
-	private function resolveClosureBindScopeClassName(Name $name): ?string
+	private function resolveClosureBindScopeClass(Name $name): ?ClassReflection
 	{
+		// Cheap pre-check so the common path stays free of a container lookup.
 		if (!$name->hasAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME)) {
 			return null;
 		}
 
-		$scopeArg = $name->getAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME);
-		if (!$scopeArg instanceof Expr) {
-			return null;
-		}
-
-		$objectClassNames = $this->getType($scopeArg)->getClassStringObjectType()->getObjectClassNames();
-		if (count($objectClassNames) !== 1) {
-			return null;
-		}
-
-		return $objectClassNames[0];
+		return $this->container->getByType(ClosureBindScopeResolver::class)->resolveScopeClass($this, $name);
 	}
 
 	/**

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -41,6 +41,7 @@ use PHPStan\Node\Expr\SetExistingOffsetValueTypeExpr;
 use PHPStan\Node\IssetExpr;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\VirtualNode;
+use PHPStan\Parser\ClosureBindArgVisitor;
 use PHPStan\Parser\Parser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Php\PhpVersionFactory;
@@ -1417,8 +1418,22 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	public function resolveName(Name $name): string
 	{
 		$originalClass = (string) $name;
+		$lowerClass = strtolower($originalClass);
+
+		$bindScopeClassName = $this->resolveClosureBindScopeClassName($name);
+		if ($bindScopeClassName !== null) {
+			if (in_array($lowerClass, ['self', 'static'], true)) {
+				return $bindScopeClassName;
+			}
+			if ($lowerClass === 'parent' && $this->reflectionProvider->hasClass($bindScopeClassName)) {
+				$parentClassReflection = $this->reflectionProvider->getClass($bindScopeClassName)->getParentClass();
+				if ($parentClassReflection !== null) {
+					return $parentClassReflection->getName();
+				}
+			}
+		}
+
 		if ($this->isInClass()) {
-			$lowerClass = strtolower($originalClass);
 			if (in_array($lowerClass, [
 				'self',
 				'static',
@@ -1441,17 +1456,26 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 	/** @api */
 	public function resolveTypeByName(Name $name): TypeWithClassName
 	{
-		if ($name->toLowerString() === 'static' && $this->isInClass()) {
-			if ($this->inClosureBindScopeClasses !== [] && $this->inClosureBindScopeClasses !== ['static']) {
-				if ($this->reflectionProvider->hasClass($this->inClosureBindScopeClasses[0])) {
-					return new StaticType($this->reflectionProvider->getClass($this->inClosureBindScopeClasses[0]));
-				}
+		$bindScopeClassName = $this->resolveClosureBindScopeClassName($name);
+		if ($name->toLowerString() === 'static') {
+			if ($bindScopeClassName !== null && $this->reflectionProvider->hasClass($bindScopeClassName)) {
+				return new StaticType($this->reflectionProvider->getClass($bindScopeClassName));
 			}
+			if ($this->isInClass()) {
+				if ($this->inClosureBindScopeClasses !== [] && $this->inClosureBindScopeClasses !== ['static']) {
+					if ($this->reflectionProvider->hasClass($this->inClosureBindScopeClasses[0])) {
+						return new StaticType($this->reflectionProvider->getClass($this->inClosureBindScopeClasses[0]));
+					}
+				}
 
-			return new StaticType($this->getClassReflection());
+				return new StaticType($this->getClassReflection());
+			}
 		}
 
 		$originalClass = $this->resolveName($name);
+		if ($bindScopeClassName !== null && $this->reflectionProvider->hasClass($originalClass)) {
+			return new ObjectType($originalClass);
+		}
 		if ($this->isInClass()) {
 			if ($this->inClosureBindScopeClasses === [$originalClass]) {
 				if ($this->reflectionProvider->hasClass($originalClass)) {
@@ -1468,6 +1492,34 @@ class MutatingScope implements Scope, NodeCallbackInvoker, CollectedDataEmitter
 		}
 
 		return new ObjectType($originalClass);
+	}
+
+	/**
+	 * Resolves the class name that a `self`/`parent`/`static` node is bound to by a
+	 * surrounding `Closure::bind()` call, annotated by {@see ClosureBindArgVisitor}. Returns
+	 * null when the node is not inside a bound closure or the bind scope argument does not
+	 * resolve to a single known class (e.g. the default "static" scope). This works even
+	 * outside a class context, because the type of a bound closure's body is inferred in the
+	 * enclosing scope where the closure-bind scope classes are not otherwise available.
+	 */
+	/** @return non-empty-string|null */
+	private function resolveClosureBindScopeClassName(Name $name): ?string
+	{
+		if (!$name->hasAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME)) {
+			return null;
+		}
+
+		$scopeArg = $name->getAttribute(ClosureBindArgVisitor::SCOPE_ATTRIBUTE_NAME);
+		if (!$scopeArg instanceof Expr) {
+			return null;
+		}
+
+		$objectClassNames = $this->getType($scopeArg)->getClassStringObjectType()->getObjectClassNames();
+		if (count($objectClassNames) !== 1) {
+			return null;
+		}
+
+		return $objectClassNames[0];
 	}
 
 	/**

--- a/src/Parser/ClosureBindArgVisitor.php
+++ b/src/Parser/ClosureBindArgVisitor.php
@@ -12,7 +12,6 @@ use PHPStan\DependencyInjection\AutowiredService;
 use function array_key_exists;
 use function array_shift;
 use function array_unshift;
-use function count;
 use function spl_object_id;
 
 #[AutowiredService]
@@ -58,14 +57,39 @@ final class ClosureBindArgVisitor extends NodeVisitorAbstract
 			&& $node->name->toLowerString() === 'bind'
 			&& !$node->isFirstClassCallable()
 		) {
-			$args = $node->getArgs();
-			if (count($args) > 1) {
-				$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);
+			$closureArg = null;
+			$newThisArg = null;
+			$newScopeArg = null;
+			foreach ($node->getArgs() as $i => $arg) {
+				if ($arg->name === null) {
+					if ($i === 0) {
+						$closureArg = $arg;
+					} elseif ($i === 1) {
+						$newThisArg = $arg;
+					} elseif ($i === 2) {
+						$newScopeArg = $arg;
+					}
+					continue;
+				}
 
-				$closure = $args[0]->value;
+				if ($arg->name->toString() === 'closure') {
+					$closureArg = $arg;
+				} elseif ($arg->name->toString() === 'newThis') {
+					$newThisArg = $arg;
+				} elseif ($arg->name->toString() === 'newScope') {
+					$newScopeArg = $arg;
+				}
+			}
+
+			if ($closureArg !== null) {
+				if ($newThisArg !== null) {
+					$closureArg->setAttribute(self::ATTRIBUTE_NAME, true);
+				}
+
+				$closure = $closureArg->value;
 				if ($closure instanceof Expr\Closure || $closure instanceof Expr\ArrowFunction) {
 					// null means default scope "static"
-					$this->boundClosures[spl_object_id($closure)] = $args[2]->value ?? null;
+					$this->boundClosures[spl_object_id($closure)] = $newScopeArg !== null ? $newScopeArg->value : null;
 				}
 			}
 		}

--- a/src/Parser/ClosureBindArgVisitor.php
+++ b/src/Parser/ClosureBindArgVisitor.php
@@ -4,9 +4,14 @@ namespace PHPStan\Parser;
 
 use Override;
 use PhpParser\Node;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
+use function array_key_exists;
+use function array_shift;
+use function array_unshift;
 use function count;
 
 #[AutowiredService]
@@ -14,6 +19,11 @@ final class ClosureBindArgVisitor extends NodeVisitorAbstract
 {
 
 	public const ATTRIBUTE_NAME = 'closureBindArg';
+
+	public const SCOPE_ATTRIBUTE_NAME = 'closureBindScope';
+
+	/** @var list<?Expr> */
+	private array $scopeStack = [];
 
 	#[Override]
 	public function enterNode(Node $node): ?Node
@@ -30,7 +40,35 @@ final class ClosureBindArgVisitor extends NodeVisitorAbstract
 			if (count($args) > 1) {
 				$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);
 			}
+
+			// null means default scope "static"
+			array_unshift($this->scopeStack, $args[2]->value ?? null);
 		}
+
+		if ($node instanceof Name
+			&& array_key_exists(0, $this->scopeStack)
+			&& $node->isSpecialClassName()
+		) {
+			$node->setAttribute(self::SCOPE_ATTRIBUTE_NAME, $this->scopeStack[0]);
+		}
+
+		return null;
+	}
+
+	#[Override]
+	public function leaveNode(Node $node): ?Node
+	{
+		if (
+			$node instanceof Node\Expr\StaticCall
+			&& $node->class instanceof Node\Name
+			&& $node->class->toLowerString() === 'closure'
+			&& $node->name instanceof Identifier
+			&& $node->name->toLowerString() === 'bind'
+			&& !$node->isFirstClassCallable()
+		) {
+			array_shift($this->scopeStack);
+		}
+
 		return null;
 	}
 

--- a/src/Parser/ClosureBindArgVisitor.php
+++ b/src/Parser/ClosureBindArgVisitor.php
@@ -13,6 +13,7 @@ use function array_key_exists;
 use function array_shift;
 use function array_unshift;
 use function count;
+use function spl_object_id;
 
 #[AutowiredService]
 final class ClosureBindArgVisitor extends NodeVisitorAbstract
@@ -24,6 +25,27 @@ final class ClosureBindArgVisitor extends NodeVisitorAbstract
 
 	/** @var list<?Expr> */
 	private array $scopeStack = [];
+
+	/**
+	 * Maps the object id of an inline closure/arrow function passed as the 1st argument of
+	 * `Closure::bind()` to that call's scope argument (the 3rd argument, or null for the
+	 * default "static" scope). Only the closure body is rescoped, not the other arguments.
+	 *
+	 * @var array<int, ?Expr>
+	 */
+	private array $boundClosures = [];
+
+	#[Override]
+	public function beforeTraverse(array $nodes): ?array
+	{
+		// This visitor is a shared service, so its per-file state must be reset for each
+		// traversal. Otherwise object ids reused across files (spl_object_id() is only unique
+		// among live objects) could match a stale entry and rescope unrelated nodes.
+		$this->scopeStack = [];
+		$this->boundClosures = [];
+
+		return null;
+	}
 
 	#[Override]
 	public function enterNode(Node $node): ?Node
@@ -39,10 +61,17 @@ final class ClosureBindArgVisitor extends NodeVisitorAbstract
 			$args = $node->getArgs();
 			if (count($args) > 1) {
 				$args[0]->setAttribute(self::ATTRIBUTE_NAME, true);
-			}
 
-			// null means default scope "static"
-			array_unshift($this->scopeStack, $args[2]->value ?? null);
+				$closure = $args[0]->value;
+				if ($closure instanceof Expr\Closure || $closure instanceof Expr\ArrowFunction) {
+					// null means default scope "static"
+					$this->boundClosures[spl_object_id($closure)] = $args[2]->value ?? null;
+				}
+			}
+		}
+
+		if (array_key_exists(spl_object_id($node), $this->boundClosures)) {
+			array_unshift($this->scopeStack, $this->boundClosures[spl_object_id($node)]);
 		}
 
 		if ($node instanceof Name
@@ -58,14 +87,7 @@ final class ClosureBindArgVisitor extends NodeVisitorAbstract
 	#[Override]
 	public function leaveNode(Node $node): ?Node
 	{
-		if (
-			$node instanceof Node\Expr\StaticCall
-			&& $node->class instanceof Node\Name
-			&& $node->class->toLowerString() === 'closure'
-			&& $node->name instanceof Identifier
-			&& $node->name->toLowerString() === 'bind'
-			&& !$node->isFirstClassCallable()
-		) {
+		if (array_key_exists(spl_object_id($node), $this->boundClosures)) {
 			array_shift($this->scopeStack);
 		}
 

--- a/src/Rules/Classes/ClassConstantRule.php
+++ b/src/Rules/Classes/ClassConstantRule.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\BinaryOp\Identical;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
@@ -22,6 +23,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\ErrorType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -44,6 +46,7 @@ final class ClassConstantRule implements Rule
 		private RuleLevelHelper $ruleLevelHelper,
 		private ClassNameCheck $classCheck,
 		private PhpVersion $phpVersion,
+		private ClosureBindScopeResolver $closureBindScopeResolver,
 		#[AutowiredParameter(ref: '%featureToggles.checkNonStringableDynamicAccess%')]
 		private bool $checkNonStringableDynamicAccess,
 	)
@@ -110,35 +113,51 @@ final class ClassConstantRule implements Rule
 		if ($class instanceof Node\Name) {
 			$className = (string) $class;
 			$lowercasedClassName = strtolower($className);
+			$bindScopeClassReflection = $this->closureBindScopeResolver->resolveScopeClass($scope, $class);
 			if (in_array($lowercasedClassName, ['self', 'static'], true)) {
-				if (!$scope->isInClass()) {
+				if ($bindScopeClassReflection !== null) {
+					$classType = new ObjectType($bindScopeClassReflection->getName());
+				} elseif (!$scope->isInClass()) {
 					return [
 						RuleErrorBuilder::message(sprintf('Using %s outside of class scope.', $className))
 							->identifier(sprintf('outOfClass.%s', $lowercasedClassName))
 							->build(),
 					];
+				} else {
+					$classType = $scope->resolveTypeByName($class);
 				}
-
-				$classType = $scope->resolveTypeByName($class);
 			} elseif ($lowercasedClassName === 'parent') {
-				if (!$scope->isInClass()) {
+				if ($bindScopeClassReflection !== null) {
+					$parentClassReflection = $bindScopeClassReflection->getParentClass();
+					if ($parentClassReflection === null) {
+						return [
+							RuleErrorBuilder::message(sprintf(
+								'Access to parent::%s but %s does not extend any class.',
+								$constantName,
+								$bindScopeClassReflection->getDisplayName(),
+							))->identifier('class.noParent')->build(),
+						];
+					}
+					$classType = new ObjectType($parentClassReflection->getName());
+				} elseif (!$scope->isInClass()) {
 					return [
 						RuleErrorBuilder::message(sprintf('Using %s outside of class scope.', $className))
 							->identifier(sprintf('outOfClass.%s', $lowercasedClassName))
 							->build(),
 					];
+				} else {
+					$currentClassReflection = $scope->getClassReflection();
+					if ($currentClassReflection->getParentClass() === null) {
+						return [
+							RuleErrorBuilder::message(sprintf(
+								'Access to parent::%s but %s does not extend any class.',
+								$constantName,
+								$currentClassReflection->getDisplayName(),
+							))->identifier('class.noParent')->build(),
+						];
+					}
+					$classType = $scope->resolveTypeByName($class);
 				}
-				$currentClassReflection = $scope->getClassReflection();
-				if ($currentClassReflection->getParentClass() === null) {
-					return [
-						RuleErrorBuilder::message(sprintf(
-							'Access to parent::%s but %s does not extend any class.',
-							$constantName,
-							$currentClassReflection->getDisplayName(),
-						))->identifier('class.noParent')->build(),
-					];
-				}
-				$classType = $scope->resolveTypeByName($class);
 			} else {
 				if (!$this->reflectionProvider->hasClass($className)) {
 					if ($scope->isInClassExists($className)) {

--- a/src/Rules/Classes/InstantiationRule.php
+++ b/src/Rules/Classes/InstantiationRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Classes;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\New_;
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
@@ -59,6 +60,7 @@ final class InstantiationRule implements Rule
 		private ClassNameCheck $classCheck,
 		private RuleLevelHelper $ruleLevelHelper,
 		private ConsistentConstructorHelper $consistentConstructorHelper,
+		private ClosureBindScopeResolver $closureBindScopeResolver,
 		#[AutowiredParameter(ref: '%featureToggles.newOnNonObject%')]
 		private bool $newOnNonObject,
 		#[AutowiredParameter(ref: '%tips.discoveringSymbols%')]
@@ -128,8 +130,15 @@ final class InstantiationRule implements Rule
 		$lowercasedClass = strtolower($class);
 		$messages = [];
 		$isStatic = false;
+		$bindScopeClassReflection = $node->class instanceof Node\Name
+			? $this->closureBindScopeResolver->resolveScopeClass($scope, $node->class)
+			: null;
 		if ($lowercasedClass === 'static') {
-			if (!$scope->isInClass()) {
+			if ($bindScopeClassReflection !== null) {
+				$classReflection = $bindScopeClassReflection;
+			} elseif ($scope->isInClass()) {
+				$classReflection = $scope->getClassReflection();
+			} else {
 				return [
 					RuleErrorBuilder::message(sprintf('Using %s outside of class scope.', $class))
 						->identifier('outOfClass.static')
@@ -138,7 +147,6 @@ final class InstantiationRule implements Rule
 			}
 
 			$isStatic = true;
-			$classReflection = $scope->getClassReflection();
 			if (!$classReflection->isFinal()) {
 				if (!$classReflection->hasConstructor()) {
 					return [];
@@ -156,33 +164,48 @@ final class InstantiationRule implements Rule
 				}
 			}
 		} elseif ($lowercasedClass === 'self') {
-			if (!$scope->isInClass()) {
+			if ($bindScopeClassReflection !== null) {
+				$classReflection = $bindScopeClassReflection;
+			} elseif ($scope->isInClass()) {
+				$classReflection = $scope->getClassReflection();
+			} else {
 				return [
 					RuleErrorBuilder::message(sprintf('Using %s outside of class scope.', $class))
 						->identifier('outOfClass.self')
 						->build(),
 				];
 			}
-			$classReflection = $scope->getClassReflection();
 		} elseif ($lowercasedClass === 'parent') {
-			if (!$scope->isInClass()) {
-				return [
-					RuleErrorBuilder::message(sprintf('Using %s outside of class scope.', $class))
-						->identifier('outOfClass.parent')
-						->build(),
-				];
+			if ($bindScopeClassReflection !== null) {
+				if ($bindScopeClassReflection->getParentClass() === null) {
+					return [
+						RuleErrorBuilder::message(sprintf(
+							'Using new parent but %s does not extend any class.',
+							$bindScopeClassReflection->getDisplayName(),
+						))->identifier('class.noParent')->build(),
+					];
+				}
+				$classReflection = $bindScopeClassReflection->getParentClass();
+			} else {
+				if (!$scope->isInClass()) {
+					return [
+						RuleErrorBuilder::message(sprintf('Using %s outside of class scope.', $class))
+							->identifier('outOfClass.parent')
+							->build(),
+					];
+				}
+				if ($scope->getClassReflection()->getParentClass() === null) {
+					return [
+						RuleErrorBuilder::message(sprintf(
+							'%s::%s() calls new parent but %s does not extend any class.',
+							$scope->getClassReflection()->getDisplayName(),
+							$scope->getFunctionName(),
+							$scope->getClassReflection()->getDisplayName(),
+						))->identifier('class.noParent')->build(),
+					];
+				}
+				$classReflection = $scope->getClassReflection()->getParentClass();
 			}
-			if ($scope->getClassReflection()->getParentClass() === null) {
-				return [
-					RuleErrorBuilder::message(sprintf(
-						'%s::%s() calls new parent but %s does not extend any class.',
-						$scope->getClassReflection()->getDisplayName(),
-						$scope->getFunctionName(),
-						$scope->getClassReflection()->getDisplayName(),
-					))->identifier('class.noParent')->build(),
-				];
-			}
-			$classReflection = $scope->getClassReflection()->getParentClass();
 		} else {
 			if (!$this->reflectionProvider->hasClass($class)) {
 				if ($scope->isInClassExists($class)) {

--- a/src/Rules/Methods/StaticMethodCallCheck.php
+++ b/src/Rules/Methods/StaticMethodCallCheck.php
@@ -6,6 +6,7 @@ use DOMDocument;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
@@ -44,6 +45,7 @@ final class StaticMethodCallCheck
 		private ReflectionProvider $reflectionProvider,
 		private RuleLevelHelper $ruleLevelHelper,
 		private ClassNameCheck $classCheck,
+		private ClosureBindScopeResolver $closureBindScopeResolver,
 		#[AutowiredParameter]
 		private bool $checkFunctionNameCase,
 		#[AutowiredParameter(ref: '%tips.discoveringSymbols%')]
@@ -75,8 +77,9 @@ final class StaticMethodCallCheck
 
 			$className = (string) $class;
 			$lowercasedClassName = strtolower($className);
+			$bindScopeClassReflection = $this->closureBindScopeResolver->resolveScopeClass($scope, $class);
 			if (in_array($lowercasedClassName, ['self', 'static'], true)) {
-				if (!$scope->isInClass()) {
+				if ($bindScopeClassReflection === null && !$scope->isInClass()) {
 					return [
 						[
 							RuleErrorBuilder::message(sprintf(
@@ -92,42 +95,60 @@ final class StaticMethodCallCheck
 				}
 				$classType = $scope->resolveTypeByName($class);
 			} elseif ($lowercasedClassName === 'parent') {
-				if (!$scope->isInClass()) {
-					return [
-						[
-							RuleErrorBuilder::message(sprintf(
-								'Calling %s::%s() outside of class scope.',
-								$className,
-								$methodName,
-							))
-								->line($astName->getStartLine())
-								->identifier(sprintf('outOfClass.parent'))
-								->build(),
-						],
-						null,
-					];
-				}
-				$currentClassReflection = $scope->getClassReflection();
-				if ($currentClassReflection->getParentClass() === null) {
-					return [
-						[
-							RuleErrorBuilder::message(sprintf(
-								'%s::%s() calls parent::%s() but %s does not extend any class.',
-								$scope->getClassReflection()->getDisplayName(),
-								$scope->getFunctionName(),
-								$methodName,
-								$scope->getClassReflection()->getDisplayName(),
-							))
-								->line($astName->getStartLine())
-								->identifier('class.noParent')
-								->build(),
-						],
-						null,
-					];
-				}
+				if ($bindScopeClassReflection !== null) {
+					if ($bindScopeClassReflection->getParentClass() === null) {
+						return [
+							[
+								RuleErrorBuilder::message(sprintf(
+									'Calling parent::%s() but %s does not extend any class.',
+									$methodName,
+									$bindScopeClassReflection->getDisplayName(),
+								))
+									->line($astName->getStartLine())
+									->identifier('class.noParent')
+									->build(),
+							],
+							null,
+						];
+					}
+				} else {
+					if (!$scope->isInClass()) {
+						return [
+							[
+								RuleErrorBuilder::message(sprintf(
+									'Calling %s::%s() outside of class scope.',
+									$className,
+									$methodName,
+								))
+									->line($astName->getStartLine())
+									->identifier(sprintf('outOfClass.parent'))
+									->build(),
+							],
+							null,
+						];
+					}
+					$currentClassReflection = $scope->getClassReflection();
+					if ($currentClassReflection->getParentClass() === null) {
+						return [
+							[
+								RuleErrorBuilder::message(sprintf(
+									'%s::%s() calls parent::%s() but %s does not extend any class.',
+									$scope->getClassReflection()->getDisplayName(),
+									$scope->getFunctionName(),
+									$methodName,
+									$scope->getClassReflection()->getDisplayName(),
+								))
+									->line($astName->getStartLine())
+									->identifier('class.noParent')
+									->build(),
+							],
+							null,
+						];
+					}
 
-				if ($scope->getFunctionName() === null) {
-					throw new ShouldNotHappenException();
+					if ($scope->getFunctionName() === null) {
+						throw new ShouldNotHappenException();
+					}
 				}
 
 				$classType = $scope->resolveTypeByName($class);

--- a/src/Rules/Properties/AccessStaticPropertiesCheck.php
+++ b/src/Rules/Properties/AccessStaticPropertiesCheck.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Analyser\NullsafeOperatorHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
@@ -48,6 +49,7 @@ final class AccessStaticPropertiesCheck
 		private RuleLevelHelper $ruleLevelHelper,
 		private ClassNameCheck $classCheck,
 		private PhpVersion $phpVersion,
+		private ClosureBindScopeResolver $closureBindScopeResolver,
 		#[AutowiredParameter(ref: '%tips.discoveringSymbols%')]
 		private bool $discoveringSymbolsTip,
 	)
@@ -82,8 +84,9 @@ final class AccessStaticPropertiesCheck
 		if ($node->class instanceof Name) {
 			$class = (string) $node->class;
 			$lowercasedClass = strtolower($class);
+			$bindScopeClassReflection = $this->closureBindScopeResolver->resolveScopeClass($scope, $node->class);
 			if (in_array($lowercasedClass, ['self', 'static'], true)) {
-				if (!$scope->isInClass()) {
+				if ($bindScopeClassReflection === null && !$scope->isInClass()) {
 					return [
 						RuleErrorBuilder::message(sprintf(
 							'Accessing %s::$%s outside of class scope.',
@@ -97,31 +100,46 @@ final class AccessStaticPropertiesCheck
 				}
 				$classType = $scope->resolveTypeByName($node->class);
 			} elseif ($lowercasedClass === 'parent') {
-				if (!$scope->isInClass()) {
-					return [
-						RuleErrorBuilder::message(sprintf(
-							'Accessing %s::$%s outside of class scope.',
-							$class,
-							$name,
-						))
-							->line($node->name->getStartLine())
-							->identifier('outOfClass.parent')
-							->build(),
-					];
-				}
-				if ($scope->getClassReflection()->getParentClass() === null) {
-					return [
-						RuleErrorBuilder::message(sprintf(
-							'%s::%s() accesses parent::$%s but %s does not extend any class.',
-							$scope->getClassReflection()->getDisplayName(),
-							$scope->getFunctionName(),
-							$name,
-							$scope->getClassReflection()->getDisplayName(),
-						))
-							->line($node->name->getStartLine())
-							->identifier('class.noParent')
-							->build(),
-					];
+				if ($bindScopeClassReflection !== null) {
+					if ($bindScopeClassReflection->getParentClass() === null) {
+						return [
+							RuleErrorBuilder::message(sprintf(
+								'Accessing parent::$%s but %s does not extend any class.',
+								$name,
+								$bindScopeClassReflection->getDisplayName(),
+							))
+								->line($node->name->getStartLine())
+								->identifier('class.noParent')
+								->build(),
+						];
+					}
+				} else {
+					if (!$scope->isInClass()) {
+						return [
+							RuleErrorBuilder::message(sprintf(
+								'Accessing %s::$%s outside of class scope.',
+								$class,
+								$name,
+							))
+								->line($node->name->getStartLine())
+								->identifier('outOfClass.parent')
+								->build(),
+						];
+					}
+					if ($scope->getClassReflection()->getParentClass() === null) {
+						return [
+							RuleErrorBuilder::message(sprintf(
+								'%s::%s() accesses parent::$%s but %s does not extend any class.',
+								$scope->getClassReflection()->getDisplayName(),
+								$scope->getFunctionName(),
+								$name,
+								$scope->getClassReflection()->getDisplayName(),
+							))
+								->line($node->name->getStartLine())
+								->identifier('class.noParent')
+								->build(),
+						];
+					}
 				}
 
 				$classType = $scope->resolveTypeByName($node->class);

--- a/tests/PHPStan/Analyser/nsrt/closure-bind-scope-named-arguments.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-bind-scope-named-arguments.php
@@ -1,0 +1,30 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace ClosureBindScopeNamedArguments;
+
+use Closure;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	protected const A = 'Foo';
+
+}
+
+final class Bar extends Foo
+{
+
+	protected const A = 'Bar';
+
+}
+
+// The bind scope is resolved by argument name, so any order works.
+assertType("'Foo'", Closure::bind(closure: static fn () => self::A, newThis: null, newScope: Foo::class)());
+assertType("'Foo'", Closure::bind(closure: static fn () => self::A, newScope: Foo::class, newThis: null)());
+assertType("'Bar'", Closure::bind(newScope: Bar::class, closure: static fn () => self::A, newThis: null)());
+
+// Positional and named arguments mixed together.
+assertType("'Foo'", Closure::bind(static fn () => parent::A, null, newScope: Bar::class)());

--- a/tests/PHPStan/Analyser/nsrt/closure-bind-scope.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-bind-scope.php
@@ -10,6 +10,15 @@ class Foo
 
 	protected const A = 'Foo';
 
+	/** @var int */
+	protected static $staticProp = 1;
+
+	/** @return 'Foo' */
+	protected static function staticMethod(): string
+	{
+		return 'Foo';
+	}
+
 }
 
 final class Bar extends Foo
@@ -17,17 +26,36 @@ final class Bar extends Foo
 
 	protected const A = 'Bar';
 
+	/** @return 'Bar' */
+	protected static function staticMethod(): string // @phpstan-ignore method.childReturnType
+	{
+		return 'Bar';
+	}
+
 }
 
-// Explicit class names resolve regardless of the bound scope.
+// Class constants: explicit names resolve regardless of scope, self/parent follow the bound scope.
 assertType("'Foo'", Closure::bind(static fn () => Foo::A, null, Foo::class)());
-assertType("'Foo'", Closure::bind(static fn () => Foo::A, null, Bar::class)());
 assertType("'Bar'", Closure::bind(static fn () => Bar::A, null, Bar::class)());
-
-// `self` / `parent` resolve against the Closure::bind() scope (3rd argument).
 assertType("'Foo'", Closure::bind(static fn () => self::A, null, Foo::class)());
 assertType("'Bar'", Closure::bind(static fn () => self::A, null, Bar::class)());
 assertType("'Foo'", Closure::bind(static fn () => parent::A, null, Bar::class)());
+
+// ::class magic constant.
+assertType("'ClosureBindScope\\\\Foo'", Closure::bind(static fn () => self::class, null, Foo::class)());
+assertType("'ClosureBindScope\\\\Foo'", Closure::bind(static fn () => parent::class, null, Bar::class)());
+
+// Static method calls.
+assertType("'Foo'", Closure::bind(static fn () => self::staticMethod(), null, Foo::class)());
+assertType("'Bar'", Closure::bind(static fn () => self::staticMethod(), null, Bar::class)());
+assertType("'Foo'", Closure::bind(static fn () => parent::staticMethod(), null, Bar::class)());
+
+// Static property access.
+assertType('int', Closure::bind(static fn () => self::$staticProp, null, Foo::class)());
+
+// Instantiation via self/parent/static.
+assertType('ClosureBindScope\Foo', Closure::bind(static fn () => new self(), null, Foo::class)());
+assertType('ClosureBindScope\Foo', Closure::bind(static fn () => new parent(), null, Bar::class)());
 
 class Container
 {
@@ -38,6 +66,7 @@ class Container
 		// scope wins over the enclosing class.
 		assertType("'Foo'", Closure::bind(static fn () => self::A, null, Foo::class)());
 		assertType("'Bar'", Closure::bind(static fn () => self::A, null, Bar::class)());
+		assertType('ClosureBindScope\Foo', Closure::bind(static fn () => new self(), null, Foo::class)());
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/closure-bind-scope.php
+++ b/tests/PHPStan/Analyser/nsrt/closure-bind-scope.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace ClosureBindScope;
+
+use Closure;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	protected const A = 'Foo';
+
+}
+
+final class Bar extends Foo
+{
+
+	protected const A = 'Bar';
+
+}
+
+// Explicit class names resolve regardless of the bound scope.
+assertType("'Foo'", Closure::bind(static fn () => Foo::A, null, Foo::class)());
+assertType("'Foo'", Closure::bind(static fn () => Foo::A, null, Bar::class)());
+assertType("'Bar'", Closure::bind(static fn () => Bar::A, null, Bar::class)());
+
+// `self` / `parent` resolve against the Closure::bind() scope (3rd argument).
+assertType("'Foo'", Closure::bind(static fn () => self::A, null, Foo::class)());
+assertType("'Bar'", Closure::bind(static fn () => self::A, null, Bar::class)());
+assertType("'Foo'", Closure::bind(static fn () => parent::A, null, Bar::class)());
+
+class Container
+{
+
+	public function doBindFromInsideClass(): void
+	{
+		// Even when Closure::bind() is called from inside another class, the bound
+		// scope wins over the enclosing class.
+		assertType("'Foo'", Closure::bind(static fn () => self::A, null, Foo::class)());
+		assertType("'Bar'", Closure::bind(static fn () => self::A, null, Bar::class)());
+	}
+
+}

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -188,6 +188,13 @@ class ClassConstantRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
+	public function testClosureBindNamedArguments(): void
+	{
+		$this->phpVersion = PHP_VERSION_ID;
+		$this->analyse([__DIR__ . '/data/closure-bind-named-arguments.php'], []);
+	}
+
 	public function testClassExists(): void
 	{
 		$this->phpVersion = PHP_VERSION_ID;

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Classes;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
@@ -46,6 +47,7 @@ class ClassConstantRuleTest extends RuleTestCase
 				$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
 			),
 			new PhpVersion($this->phpVersion),
+			new ClosureBindScopeResolver($reflectionProvider),
 			checkNonStringableDynamicAccess: true,
 		);
 	}

--- a/tests/PHPStan/Rules/Classes/ForbiddenNameCheckExtensionRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ForbiddenNameCheckExtensionRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Classes;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
 use PHPStan\Rules\ClassForbiddenNameCheck;
@@ -59,6 +60,7 @@ class ForbiddenNameCheckExtensionRuleTest extends RuleTestCase
 			),
 			$ruleLevelHelper,
 			new ConsistentConstructorHelper(),
+			new ClosureBindScopeResolver($reflectionProvider),
 			newOnNonObject: true,
 			discoveringSymbolsTip: true,
 		);

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Classes;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
 use PHPStan\Rules\ClassForbiddenNameCheck;
@@ -63,6 +64,7 @@ class InstantiationRuleTest extends RuleTestCase
 			),
 			$ruleLevelHelper,
 			new ConsistentConstructorHelper(),
+			new ClosureBindScopeResolver($reflectionProvider),
 			newOnNonObject: true,
 			discoveringSymbolsTip: true,
 		);

--- a/tests/PHPStan/Rules/Classes/data/closure-bind-named-arguments.php
+++ b/tests/PHPStan/Rules/Classes/data/closure-bind-named-arguments.php
@@ -1,0 +1,23 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace ClosureBindNamedArguments;
+
+use Closure;
+
+class Target
+{
+
+	protected const C = 'c';
+
+}
+
+// Every form binds the scope to Target, so accessing its protected constant is allowed
+// no matter how the arguments are written.
+Closure::bind(static fn () => self::C, null, Target::class);
+Closure::bind(closure: static fn () => self::C, newThis: null, newScope: Target::class);
+Closure::bind(closure: static fn () => self::C, newScope: Target::class, newThis: null);
+Closure::bind(newScope: Target::class, closure: static fn () => self::C, newThis: null);
+Closure::bind(static fn () => self::C, null, newScope: Target::class);
+Closure::bind(static fn () => self::C, newScope: Target::class, newThis: null);

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Methods;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
 use PHPStan\Rules\ClassForbiddenNameCheck;
@@ -58,6 +59,7 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
 				),
+				new ClosureBindScopeResolver($reflectionProvider),
 				checkFunctionNameCase: true,
 				discoveringSymbolsTip: true,
 				reportMagicMethods: true,

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Methods;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
@@ -50,6 +51,7 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 					$reflectionProvider,
 					$container->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
 				),
+				new ClosureBindScopeResolver($reflectionProvider),
 				checkFunctionNameCase: true,
 				discoveringSymbolsTip: true,
 				reportMagicMethods: true,

--- a/tests/PHPStan/Rules/Properties/AccessStaticPropertiesInAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessStaticPropertiesInAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
@@ -43,6 +44,7 @@ class AccessStaticPropertiesInAssignRuleTest extends RuleTestCase
 					self::getContainer()->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
 				),
 				new PhpVersion(PHP_VERSION_ID),
+				new ClosureBindScopeResolver($reflectionProvider),
 				discoveringSymbolsTip: true,
 			),
 		);

--- a/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessStaticPropertiesRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Analyser\ClosureBindScopeResolver;
 use PHPStan\Classes\ForbiddenClassNameExtension;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\ClassCaseSensitivityCheck;
@@ -43,6 +44,7 @@ class AccessStaticPropertiesRuleTest extends RuleTestCase
 					self::getContainer()->getExtensionsCollection(RestrictedClassNameUsageExtension::class),
 				),
 				new PhpVersion(PHP_VERSION_ID),
+				new ClosureBindScopeResolver($reflectionProvider),
 				discoveringSymbolsTip: true,
 			),
 		);


### PR DESCRIPTION
Resolves `self` / `parent` / `static` against the `Closure::bind()` scope (the 3rd argument) inside the bound closure body, for both type inference and the related rules.

Rebased onto `2.2.x` and reworked: the original inline patch in `MutatingScope::getType()` no longer exists after expression handling was split into `ExprHandler` services, so the logic now lives where each expression/rule resolves its class scope.

### What works now

Inside `Closure::bind(fn () => …, $newThis, Scope::class)`:

- **Class constants** — `self::CONST`, `parent::CONST` resolve against the bound scope.
- **`::class`** — `self::class`, `parent::class`.
- **Static method calls** — `self::method()`, `parent::method()` return types.
- **Static property access** — `self::$prop`, `parent::$prop` types.
- **Instantiation** — `new self`, `new parent`, `new static`.
- **Rules** no longer emit `Using self outside of class scope.` etc. and check accessibility against the bound class: `ClassConstantRule`, `StaticMethodCallCheck`, `AccessStaticPropertiesCheck`, `InstantiationRule`.

This works even when `Closure::bind()` is called outside a class context (the closure body type is inferred in the enclosing scope, where the closure-bind scope classes are otherwise unavailable — hence the class-name nodes are annotated by `ClosureBindArgVisitor`).

### Approach

- `ClosureBindArgVisitor` annotates `self`/`parent`/`static` class-name nodes **inside the closure body only** (1st argument) with the bind scope argument. The `$newThis`/`$newScope` arguments are intentionally not rescoped — this keeps `Closure::bind(self::cond() ? … : …, …)` correct (see #6319).
- `ClosureBindScopeResolver` (new) resolves that annotation to a `ClassReflection`, shared by `ClassConstFetchHandler` and the rules.
- `MutatingScope::resolveName()` / `resolveTypeByName()` honour the annotation so static calls / properties / `new` resolve without touching each handler.

### Issues

- Advances phpstan/phpstan#5987 — `self::`/`parent::` constant, `::class`, static method, and private-member cases now resolve. (Remaining: `static::` late static binding and the bound `$this` object type — a separate concern, overlaps #2972.)
- Regression coverage for phpstan/phpstan#7675, #6319, #4865 (all already fixed; unchanged here).

### Not included (follow-ups)

- `Closure::bindTo()` (phpstan/phpstan#8569) — separate call, separate visitor path.
- `static::` LSB + bound `$this` type (phpstan/phpstan#5987 remainder) — overlaps the stalled #2972; better decided after review of this approach.
