### PR TITLE
Fix return type of bzdecompress()

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -482,7 +482,7 @@ return [
 'bson_encode' => ['string', 'anything'=>'mixed'],
 'bzclose' => ['bool', 'bz'=>'resource'],
 'bzcompress' => ['string|int', 'source'=>'string', 'blocksize100k='=>'int', 'workfactor='=>'int'],
-'bzdecompress' => ['string|false', 'source'=>'string', 'small='=>'int'],
+'bzdecompress' => ['string|int|false', 'source'=>'string', 'small='=>'int'],
 'bzerrno' => ['int', 'bz'=>'resource'],
 'bzerror' => ['array', 'bz'=>'resource'],
 'bzerrstr' => ['string', 'bz'=>'resource'],


### PR DESCRIPTION
It mostly returns `int` error codes on failures and `false` only when it cannot initialize.

Source: [php-src](https://github.com/php/php-src/blob/master/ext/bz2/bz2.c#L489-L558), test code: `var_dump(bzdecompress("invalid"));`