### PR TITLE
Add stringable access check to AccessPropertiesCheck

### DIFF
--- a/tests/PHPStan/Rules/Properties/AccessPropertiesInAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesInAssignRuleTest.php
@@ -19,7 +19,7 @@ class AccessPropertiesInAssignRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		return new AccessPropertiesInAssignRule(
-			new AccessPropertiesCheck($reflectionProvider, new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true), new PhpVersion(PHP_VERSION_ID), true, true),
+			new AccessPropertiesCheck($reflectionProvider, new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true), new PhpVersion(PHP_VERSION_ID), true, true, true),
 		);
 	}
 
@@ -94,6 +94,21 @@ class AccessPropertiesInAssignRuleTest extends RuleTestCase
 	public function testBug4492(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-4492.php'], []);
+	}
+
+	public function testDynamicStringableAccess(): void
+	{
+		// All warnings are reported by the AccessPropertiesRule.
+		// The AccessPropertiesInAssignRule does not report any warnings.
+		$this->analyse([__DIR__ . '/data/dynamic-stringable-access.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0')]
+	public function testDynamicStringableNullsafeAccess(): void
+	{
+		// All warnings are reported by the AccessPropertiesRule.
+		// The AccessPropertiesInAssignRule does not report any warnings.
+		$this->analyse([__DIR__ . '/data/dynamic-stringable-nullsafe-access.php'], []);
 	}
 
 	public function testObjectShapes(): void

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -26,7 +26,7 @@ class AccessPropertiesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
-		return new AccessPropertiesRule(new AccessPropertiesCheck($reflectionProvider, new RuleLevelHelper($reflectionProvider, true, $this->checkThisOnly, $this->checkUnionTypes, false, false, false, true), new PhpVersion(PHP_VERSION_ID), true, $this->checkDynamicProperties));
+		return new AccessPropertiesRule(new AccessPropertiesCheck($reflectionProvider, new RuleLevelHelper($reflectionProvider, true, $this->checkThisOnly, $this->checkUnionTypes, false, false, false, true), new PhpVersion(PHP_VERSION_ID), true, $this->checkDynamicProperties, true));
 	}
 
 	public function testAccessProperties(): void
@@ -971,6 +971,84 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->checkUnionTypes = true;
 		$this->checkDynamicProperties = true;
 		$this->analyse([__DIR__ . '/data/bug-8629.php'], []);
+	}
+
+	public function testDynamicStringableAccess(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = false;
+		$this->checkDynamicProperties = false;
+		$this->analyse([__DIR__ . '/data/dynamic-stringable-access.php'], [
+			// DynamicStringableAccess\Foo::testProperties()
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but $this(DynamicStringableAccess\Foo) was given.',
+				13,
+			],
+			[
+				'Property name for DynamicStringableAccess\Foo must be a string, but $this(DynamicStringableAccess\Foo) was given.',
+				14,
+			],
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but $this(DynamicStringableAccess\Foo) was given.',
+				15,
+			],
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but $this(DynamicStringableAccess\Foo) was given.',
+				16,
+			],
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but object was given.',
+				17,
+			],
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but array was given.',
+				18,
+			],
+			// DynamicStringableAccess\Foo::testPropertyAssignments()
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but $this(DynamicStringableAccess\Foo) was given.',
+				30,
+			],
+			[
+				'Property name for DynamicStringableAccess\Foo must be a string, but $this(DynamicStringableAccess\Foo) was given.',
+				31,
+			],
+			[
+				'Property name for $this(DynamicStringableAccess\Foo) must be a string, but object was given.',
+				32,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0')]
+	public function testDynamicStringableNullsafeAccess(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = false;
+		$this->checkDynamicProperties = false;
+		$this->analyse([__DIR__ . '/data/dynamic-stringable-nullsafe-access.php'], [
+			// DynamicStringableNullsafeAccess\Foo::testNullsafePropertyFetch()
+			[
+				'Property name for $this(DynamicStringableNullsafeAccess\Foo) must be a string, but $this(DynamicStringableNullsafeAccess\Foo) was given.',
+				13,
+			],
+			[
+				'Property name for DynamicStringableNullsafeAccess\Foo must be a string, but $this(DynamicStringableNullsafeAccess\Foo) was given.',
+				14,
+			],
+			[
+				'Property name for $this(DynamicStringableNullsafeAccess\Foo) must be a string, but $this(DynamicStringableNullsafeAccess\Foo) was given.',
+				15,
+			],
+			[
+				'Property name for $this(DynamicStringableNullsafeAccess\Foo) must be a string, but $this(DynamicStringableNullsafeAccess\Foo) was given.',
+				16,
+			],
+			[
+				'Property name for $this(DynamicStringableNullsafeAccess\Foo) must be a string, but object was given.',
+				17,
+			],
+		]);
 	}
 
 	#[RequiresPhp('>= 8.0')]

--- a/tests/PHPStan/Rules/Properties/data/dynamic-stringable-access.php
+++ b/tests/PHPStan/Rules/Properties/data/dynamic-stringable-access.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace DynamicStringableAccess;
+
+use Stringable;
+
+final class Foo
+{
+	private self $var;
+
+	public function testProperties(string $name, Stringable $stringable, object $object, array $array): void
+	{
+		echo $this->{$this}->name;
+		echo $this->var->$this;
+		echo $this->$this->$name;
+		echo $this->$this->name;
+		echo $this->$object;
+		echo $this->$array;
+
+		echo $this->$name; // valid
+		echo $this->$stringable; // valid
+		echo $this->{1111}; // valid
+		echo $this->{true}; // valid
+		echo $this->{false}; // valid
+		echo $this->{null}; // valid
+	}
+
+	public function testPropertyAssignments(string $name, Stringable $stringable, object $object): void
+	{
+		$this->{$this} = $name;
+		$this->var->{$this} = $name;
+		$this->$object = $name;
+
+		$this->$name = $name; // valid
+		$this->$stringable = $name; // valid
+		$this->{1111} = $name; // valid
+		$this->{true} = $name; // valid
+		$this->{false} = $name; // valid
+		$this->{null} = $name; // valid
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/dynamic-stringable-nullsafe-access.php
+++ b/tests/PHPStan/Rules/Properties/data/dynamic-stringable-nullsafe-access.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1); // lint >= 8.0
+
+namespace DynamicStringableNullsafeAccess;
+
+use Stringable;
+
+final class Foo
+{
+	private self $var;
+
+	public function testNullsafePropertyFetch(string $name, Stringable $stringable, object $object): void
+	{
+		echo $this?->{$this}?->name;
+		echo $this?->var?->$this;
+		echo $this?->$this?->$name;
+		echo $this?->$this?->name;
+		echo $this?->$object;
+
+		echo $this?->$name; // valid
+		echo $this?->$stringable; // valid
+		echo $this?->{1111}; // valid
+		echo $this?->{true}; // valid
+		echo $this?->{false}; // valid
+		echo $this?->{null}; // valid
+	}
+
+}


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/13238

In the context of property fetching, string keys are implicitly cast.

 * https://3v4l.org/0noRl

Property names starting with a number cannot be defined, but there is no need to exclude numeric, as they are accessible via the `__get()` magic method.

-----

For work reasons, this branch is based on https://github.com/phpstan/phpstan-src/pull/3910, so it will be rebased once that is merged.