### PR TITLE
Fix SimpleXMLElement::xpath return type

### DIFF
--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -3144,7 +3144,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$simpleXMLWritingXML',
 			],
 			[
-				'array<SimpleXMLElement>',
+				'array<SimpleXMLElement>|null',
 				'$simpleXMLRightXpath',
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/bug-9714.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9714.php
@@ -10,7 +10,6 @@ class ExampleClass
 	{
 		$xml = new \SimpleXmlElement('');
 		$elements = $xml->xpath('//data');
-		assertType('array<SimpleXmlElement>', $elements);
+		assertType('array<SimpleXmlElement>|null', $elements);
 	}
 }
-


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13236

The initial purpose of the dynamic return type was to remove the false return type.