### PR TITLE
feat: add api to get ObjectType from ClassReflection and EnumCaseReflection

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -1422,6 +1422,19 @@ final class ClassReflection
 		return $flags;
 	}
 
+	public function getObjectType(): ObjectType
+	{
+		if (!$this->isGeneric()) {
+			return new ObjectType($this->getName());
+		}
+
+		return new GenericObjectType(
+			$this->getName(),
+			$this->typeMapToList($this->getActiveTemplateTypeMap()),
+			variances: $this->varianceMapToList($this->getCallSiteVarianceMap()),
+		);
+	}
+
 	public function getTemplateTypeMap(): TemplateTypeMap
 	{
 		if ($this->templateTypeMap !== null) {

--- a/src/Reflection/EnumCaseReflection.php
+++ b/src/Reflection/EnumCaseReflection.php
@@ -7,6 +7,7 @@ use PHPStan\BetterReflection\Reflection\Adapter\ReflectionEnumUnitCase;
 use PHPStan\Internal\DeprecatedAttributeHelper;
 use PHPStan\Reflection\Deprecation\DeprecationProvider;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Type;
 
 /**
@@ -53,6 +54,14 @@ final class EnumCaseReflection
 	public function getName(): string
 	{
 		return $this->reflection->getName();
+	}
+
+	public function getEnumCaseObjectType(): EnumCaseObjectType
+	{
+		return new EnumCaseObjectType(
+			$this->declaringEnum->getName(),
+			$this->getName(),
+		);
 	}
 
 	public function getBackingValueType(): ?Type

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -133,19 +133,6 @@ class ObjectType implements TypeWithClassName, SubtractableType
 		self::$enumCases = [];
 	}
 
-	private static function createFromReflection(ClassReflection $reflection): self
-	{
-		if (!$reflection->isGeneric()) {
-			return new ObjectType($reflection->getName());
-		}
-
-		return new GenericObjectType(
-			$reflection->getName(),
-			$reflection->typeMapToList($reflection->getActiveTemplateTypeMap()),
-			variances: $reflection->varianceMapToList($reflection->getCallSiteVarianceMap()),
-		);
-	}
-
 	public function getClassName(): string
 	{
 		return $this->className;
@@ -1639,7 +1626,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return null;
 		}
 
-		return $this->cachedParent = self::createFromReflection($parentReflection);
+		return $this->cachedParent = $parentReflection->getObjectType();
 	}
 
 	/** @return ObjectType[] */
@@ -1653,7 +1640,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return $this->cachedInterfaces = [];
 		}
 
-		return $this->cachedInterfaces = array_map(static fn (ClassReflection $interfaceReflection): self => self::createFromReflection($interfaceReflection), $thisReflection->getInterfaces());
+		return $this->cachedInterfaces = array_map(static fn (ClassReflection $interfaceReflection): self => $interfaceReflection->getObjectType(), $thisReflection->getInterfaces());
 	}
 
 	public function tryRemove(Type $typeToRemove): ?Type


### PR DESCRIPTION
Hello!

This PR adds the following two methods to the api:
- `ClassReflection::getObjectType(): ObjectType`
- `EnumCaseReflection:getEnumCaseObjectType(): EnumCaseObjectType`

### Motivation

It's very easy to get all the `ClassReflection`s from a `Type` with `$type->getObjectClassReflections()`. However, there have been several occasions where I've needed to go the other direction (get an `ObjectType` from a `ClassReflection`) and have not been able to do so easily.

I was digging around in the code, and I discovered a private static method  `ObjectType::createFromReflection()` that already did just this. So I opted to *move* the logic in `ObjectType::createFromReflection()` to `ClassReflection::getObjectType()` instead of simply making the private method public as I didn't think allowing child classes to statically call this method would be a good idea (e.g., `TemplateObjectType::createFromReflection()`)


Thanks!