### PR TITLE
Fix IntersectionType::isIterableOnce

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1266,10 +1266,9 @@ class IntersectionType implements CompoundType
 	}
 
 	/**
-	 * @param callable(Type $type): Type        $getType
-	 * @param (callable(Type $type): Type)|null $filter
+	 * @param callable(Type $type): Type $getType
 	 */
-	private function intersectTypes(callable $getType, ?callable $filter = null): Type
+	private function intersectTypes(callable $getType): Type
 	{
 		$operands = array_map($getType, $this->types);
 		return TypeCombinator::intersect(...$operands);

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -39,6 +39,7 @@ use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonRemoveableTypeTrait;
+use function array_filter;
 use function array_intersect_key;
 use function array_map;
 use function array_shift;
@@ -599,7 +600,10 @@ class IntersectionType implements CompoundType
 
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
-		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isIterableAtLeastOnce());
+		return $this->intersectResults(
+			static fn (Type $type): TrinaryLogic => $type->isIterableAtLeastOnce(),
+			static fn (Type $type): bool => !$type->isIterable()->no(),
+		);
 	}
 
 	public function getArraySize(): Type
@@ -1243,16 +1247,29 @@ class IntersectionType implements CompoundType
 
 	/**
 	 * @param callable(Type $type): TrinaryLogic $getResult
+	 * @param (callable(Type $type): bool)|null  $filter
 	 */
-	private function intersectResults(callable $getResult): TrinaryLogic
+	private function intersectResults(
+		callable $getResult,
+		?callable $filter = null,
+	): TrinaryLogic
 	{
-		return TrinaryLogic::lazyMaxMin($this->types, $getResult);
+		$types = $this->types;
+		if ($filter !== null) {
+			$types = array_filter($types, $filter);
+		}
+		if (count($types) === 0) {
+			return TrinaryLogic::createNo();
+		}
+
+		return TrinaryLogic::lazyMaxMin($types, $getResult);
 	}
 
 	/**
-	 * @param callable(Type $type): Type $getType
+	 * @param callable(Type $type): Type        $getType
+	 * @param (callable(Type $type): Type)|null $filter
 	 */
-	private function intersectTypes(callable $getType): Type
+	private function intersectTypes(callable $getType, ?callable $filter = null): Type
 	{
 		$operands = array_map($getType, $this->types);
 		return TypeCombinator::intersect(...$operands);

--- a/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
@@ -40,4 +40,9 @@ class DeadForeachRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8292.php'], []);
 	}
 
+	public function testBug13248(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13248.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-13248.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-13248.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bug13248;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+class X
+{
+}
+
+/**
+ * @implements IteratorAggregate<int, string>
+ */
+class Y extends X implements IteratorAggregate
+{
+	/**
+	 * @return ArrayIterator<int<0, 2>, 'a'|'b'|'c'>
+	 */
+	public function getIterator(): Traversable
+	{
+		return new ArrayIterator(['a', 'b', 'c']);
+	}
+}
+
+/**
+ * @return X&Traversable<int, string>
+ */
+function y(): X
+{
+	return new Y();
+}
+
+foreach (y() as $item) { // hm?
+	echo $item . PHP_EOL;
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13248

I feel like non-iterable should be excluded since as soon as one subtype is iterable the whole intersection is iterable.