### PR TITLE
Add non regression test for 13043

### DIFF
--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -1239,6 +1239,11 @@ class ReturnTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13043(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13043.php'], []);
+	}
+
 	public function testBug12928(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-12928.php'], [

--- a/tests/PHPStan/Rules/Methods/data/bug-13043.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-13043.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13043;
+
+class HelloWorld
+{
+	private string $prefix = '';
+
+	/** @var non-empty-string $name */
+	private string $name = 'identifier';
+
+	/** @return non-empty-string */
+	public function getPrefixedName(): string
+	{
+		$name = $this->prefix;
+
+		$search = str_split('()<>@');
+		$replace = array_map(rawurlencode(...), $search);
+
+		$name .= str_replace($search, $replace, $this->name);
+
+		return $name;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13043

This was resolved when improving the array_map return type.

Also, I tried doing some triage and I think some issues which might be closed:
- https://github.com/phpstan/phpstan/issues/11680 is closed by https://github.com/phpstan/phpstan-src/pull/3326
- https://github.com/phpstan/phpstan/issues/13070 is an PEST issue not a PHPStan one
- https://github.com/phpstan/phpstan/issues/13078 is a valid error related to https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static that someone wants to ignore
- https://github.com/phpstan/phpstan/issues/13080 is a valid error to me (as explained to the author)
- https://github.com/phpstan/phpstan/issues/13134 which is valid (and the user got an answer why)
- https://github.com/phpstan/phpstan/issues/13207 which was explained

Dunno if it helps you (?)