### PR TITLE
Add non regression tests for strict rules issues

### DIFF
--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1007,6 +1007,18 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugStrictRule147(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-strict-147.php'], []);
+	}
+
+	public function testBugStrictRule143(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-strict-143.php'], []);
+	}
+
 	public function testBug12412(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/data/bug-strict-143.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-strict-143.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+namespace BugStrict143;
+
+function foo(string $key, array $arr): void {
+	$found = array_key_exists($key . 'foo', $arr) && array_key_exists($key . 'bar', $arr);
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-strict-147.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-strict-147.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace BugStrict147;
+
+$array = ['a', 'c', 'b'];
+asort($array);
+if (array_is_list($array)) {
+	print 'array was in order';
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan-strict-rules/issues/147
Closes https://github.com/phpstan/phpstan-strict-rules/issues/143

Also, you can manually close https://github.com/phpstan/phpstan-strict-rules/issues/141,
because you already solve the issue in https://github.com/phpstan/phpstan-strict-rules/commit/88e714c05658eb18a45ab6a6f4d17a29d44cc065


