### PR TITLE
Introduce `rawMessage` key in `ignoreErrors`

### DIFF
--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -114,6 +114,7 @@ parametersSchema:
 			structure([
 				?message: string()
 				?messages: listOf(string())
+				?rawMessage: string()
 				?identifier: string()
 				?identifiers: listOf(string())
 				?path: string()

--- a/src/Analyser/Ignore/IgnoredError.php
+++ b/src/Analyser/Ignore/IgnoredError.php
@@ -30,6 +30,8 @@ final class IgnoredError
 		$message = '';
 		if (isset($ignoredError['message'])) {
 			$message = $ignoredError['message'];
+		} elseif (isset($ignoredError['rawMessage'])) {
+			$message = '"' . $ignoredError['rawMessage'] . '"';
 		}
 		if (isset($ignoredError['identifier'])) {
 			if ($message === '') {
@@ -71,6 +73,7 @@ final class IgnoredError
 		FileHelper $fileHelper,
 		Error $error,
 		?string $ignoredErrorPattern,
+		?string $ignoredErrorMessage,
 		?string $identifier,
 		?string $path,
 	): bool
@@ -87,6 +90,12 @@ final class IgnoredError
 			$errorMessage = str_replace(['\r\n', '\r'], '\n', $errorMessage);
 			$ignoredErrorPattern = str_replace([preg_quote('\r\n'), preg_quote('\r')], preg_quote('\n'), $ignoredErrorPattern);
 			if (Strings::match($errorMessage, $ignoredErrorPattern) === null) {
+				return false;
+			}
+		}
+
+		if ($ignoredErrorMessage !== null) {
+			if ($error->getMessage() !== $ignoredErrorMessage) {
 				return false;
 			}
 		}

--- a/src/Analyser/Ignore/IgnoredErrorHelper.php
+++ b/src/Analyser/Ignore/IgnoredErrorHelper.php
@@ -40,7 +40,7 @@ final class IgnoredErrorHelper
 		$expandedIgnoreErrors = [];
 		foreach ($this->ignoreErrors as $ignoreError) {
 			if (is_array($ignoreError)) {
-				if (!isset($ignoreError['message']) && !isset($ignoreError['messages']) && !isset($ignoreError['identifier']) && !isset($ignoreError['identifiers'])) {
+				if (!isset($ignoreError['message']) && !isset($ignoreError['messages']) && !isset($ignoreError['rawMessage']) && !isset($ignoreError['identifier']) && !isset($ignoreError['identifiers'])) {
 					$errors[] = sprintf(
 						'Ignored error %s is missing a message or an identifier.',
 						Json::encode($ignoreError),
@@ -71,7 +71,7 @@ final class IgnoredErrorHelper
 
 		$uniquedExpandedIgnoreErrors = [];
 		foreach ($expandedIgnoreErrors as $ignoreError) {
-			if (!isset($ignoreError['message']) && !isset($ignoreError['identifier'])) {
+			if (!isset($ignoreError['message']) && !isset($ignoreError['rawMessage']) && !isset($ignoreError['identifier'])) {
 				$uniquedExpandedIgnoreErrors[] = $ignoreError;
 				continue;
 			}
@@ -83,6 +83,9 @@ final class IgnoredErrorHelper
 			$key = $ignoreError['path'];
 			if (isset($ignoreError['message'])) {
 				$key = sprintf("%s\n%s", $key, $ignoreError['message']);
+			}
+			if (isset($ignoreError['rawMessage'])) {
+				$key = sprintf("%s\n%s", $key, $ignoreError['rawMessage']);
 			}
 			if (isset($ignoreError['identifier'])) {
 				$key = sprintf("%s\n%s", $key, $ignoreError['identifier']);
@@ -98,6 +101,7 @@ final class IgnoredErrorHelper
 
 			$uniquedExpandedIgnoreErrors[$key] = [
 				'message' => $ignoreError['message'] ?? null,
+				'rawMessage' => $ignoreError['rawMessage'] ?? null,
 				'path' => $ignoreError['path'],
 				'identifier' => $ignoreError['identifier'] ?? null,
 				'count' => ($uniquedExpandedIgnoreErrors[$key]['count'] ?? 1) + ($ignoreError['count'] ?? 1),
@@ -114,7 +118,7 @@ final class IgnoredErrorHelper
 			];
 			try {
 				if (is_array($ignoreError)) {
-					if (!isset($ignoreError['message']) && !isset($ignoreError['identifier'])) {
+					if (!isset($ignoreError['message']) && !isset($ignoreError['rawMessage']) && !isset($ignoreError['identifier'])) {
 						$errors[] = sprintf(
 							'Ignored error %s is missing a message or an identifier.',
 							Json::encode($ignoreError),

--- a/src/Analyser/Ignore/IgnoredErrorHelperResult.php
+++ b/src/Analyser/Ignore/IgnoredErrorHelperResult.php
@@ -58,13 +58,13 @@ final class IgnoredErrorHelperResult
 		$processIgnoreError = function (Error $error, int $i, $ignore) use (&$unmatchedIgnoredErrors, &$stringErrors): bool {
 			$shouldBeIgnored = false;
 			if (is_string($ignore)) {
-				$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore, null, null);
+				$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore, null, null, null);
 				if ($shouldBeIgnored) {
 					unset($unmatchedIgnoredErrors[$i]);
 				}
 			} else {
 				if (isset($ignore['path'])) {
-					$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'] ?? null, $ignore['identifier'] ?? null, $ignore['path']);
+					$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'] ?? null, $ignore['rawMessage'] ?? null, $ignore['identifier'] ?? null, $ignore['path']);
 					if ($shouldBeIgnored) {
 						if (isset($ignore['count'])) {
 							$realCount = $unmatchedIgnoredErrors[$i]['realCount'] ?? 0;
@@ -85,7 +85,7 @@ final class IgnoredErrorHelperResult
 					}
 				} elseif (isset($ignore['paths'])) {
 					foreach ($ignore['paths'] as $j => $ignorePath) {
-						$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'] ?? null, $ignore['identifier'] ?? null, $ignorePath);
+						$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'] ?? null, $ignore['rawMessage'] ?? null, $ignore['identifier'] ?? null, $ignorePath);
 						if (!$shouldBeIgnored) {
 							continue;
 						}
@@ -102,7 +102,7 @@ final class IgnoredErrorHelperResult
 						break;
 					}
 				} else {
-					$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'] ?? null, $ignore['identifier'] ?? null, null);
+					$shouldBeIgnored = IgnoredError::shouldIgnore($this->fileHelper, $error, $ignore['message'] ?? null, $ignore['rawMessage'] ?? null, $ignore['identifier'] ?? null, null);
 					if ($shouldBeIgnored) {
 						unset($unmatchedIgnoredErrors[$i]);
 					}

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -337,14 +337,20 @@ final class ContainerFactory
 				continue;
 			}
 
-			$atLeastOneOf = ['message', 'messages', 'identifier', 'identifiers', 'path', 'paths'];
+			$atLeastOneOf = ['message', 'messages', 'rawMessage', 'identifier', 'identifiers', 'path', 'paths'];
 			if (array_intersect($atLeastOneOf, array_keys($ignoreError)) === []) {
 				throw new InvalidIgnoredErrorException('An ignoreErrors entry must contain at least one of the following fields: ' . implode(', ', $atLeastOneOf) . '.');
 			}
 
-			foreach (['message', 'identifier', 'path'] as $field) {
-				if (array_key_exists($field, $ignoreError) && array_key_exists($field . 's', $ignoreError)) {
-					throw new InvalidIgnoredErrorException(sprintf('An ignoreErrors entry cannot contain both %s and %s fields.', $field, $field . 's'));
+			foreach ([
+				['message', 'messages'],
+				['rawMessage', 'message'],
+				['rawMessage', 'messages'],
+				['identifier', 'identifiers'],
+				['path', 'paths'],
+			] as [$field1, $field2]) {
+				if (array_key_exists($field1, $ignoreError) && array_key_exists($field2, $ignoreError)) {
+					throw new InvalidIgnoredErrorException(sprintf('An ignoreErrors entry cannot contain both %s and %s fields.', $field1, $field2));
 				}
 			}
 

--- a/tests/PHPStan/DependencyInjection/InvalidIgnoredErrorExceptionTest.php
+++ b/tests/PHPStan/DependencyInjection/InvalidIgnoredErrorExceptionTest.php
@@ -20,6 +20,14 @@ class InvalidIgnoredErrorExceptionTest extends PHPStanTestCase
 			'An ignoreErrors entry cannot contain both message and messages fields.',
 		];
 		yield [
+			__DIR__ . '/invalidIgnoreErrors/rawMessage-and-message.neon',
+			'An ignoreErrors entry cannot contain both rawMessage and message fields.',
+		];
+		yield [
+			__DIR__ . '/invalidIgnoreErrors/rawMessage-and-messages.neon',
+			'An ignoreErrors entry cannot contain both rawMessage and messages fields.',
+		];
+		yield [
 			__DIR__ . '/invalidIgnoreErrors/identifier-and-identifiers.neon',
 			'An ignoreErrors entry cannot contain both identifier and identifiers fields.',
 		];
@@ -29,7 +37,7 @@ class InvalidIgnoredErrorExceptionTest extends PHPStanTestCase
 		];
 		yield [
 			__DIR__ . '/invalidIgnoreErrors/missing-main-key.neon',
-			'An ignoreErrors entry must contain at least one of the following fields: message, messages, identifier, identifiers, path, paths.',
+			'An ignoreErrors entry must contain at least one of the following fields: message, messages, rawMessage, identifier, identifiers, path, paths.',
 		];
 		yield [
 			__DIR__ . '/invalidIgnoreErrors/count-without-path.neon',

--- a/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/rawMessage-and-message.neon
+++ b/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/rawMessage-and-message.neon
@@ -1,0 +1,5 @@
+parameters:
+	ignoreErrors:
+		-
+			rawMessage: 'One'
+			message: '#Two#'

--- a/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/rawMessage-and-messages.neon
+++ b/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/rawMessage-and-messages.neon
@@ -1,0 +1,5 @@
+parameters:
+	ignoreErrors:
+		-
+			rawMessage: 'One'
+			messages: ['#Two#']


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/11178#issuecomment-2167343722

This pull request introduces the `rawMessage` key in `ignoreErrors` for non-regex raw error messages:

```neon
parameters:
	ignoreErrors:
		-
			rawMessage: 'Raw message without regex escaping etc.'
			identifier: ...
```