### PR TITLE
Fix "Unsafe use of new static when trait enforces constructor via abstract method"

### DIFF
--- a/src/Rules/Classes/NewStaticRule.php
+++ b/src/Rules/Classes/NewStaticRule.php
@@ -9,6 +9,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\TrinaryLogic;
 use function strtolower;
 
 /**
@@ -90,9 +91,8 @@ final class NewStaticRule implements Rule
 		) {
 			$traitReflection = $scope->getTraitReflection();
 			if ($traitReflection->hasConstructor()) {
-				$traitConstructor = $traitReflection->getConstructor();
-
-				if ($traitConstructor instanceof PhpMethodReflection && $traitConstructor->isAbstract()) {
+				$isAbstract = $traitReflection->getConstructor()->isAbstract();
+				if ($isAbstract === true || ($isAbstract instanceof TrinaryLogic && $isAbstract->yes())) {
 					return [];
 				}
 			}

--- a/src/Rules/Classes/NewStaticRule.php
+++ b/src/Rules/Classes/NewStaticRule.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Classes;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -16,6 +17,12 @@ use function strtolower;
 #[RegisteredRule(level: 0)]
 final class NewStaticRule implements Rule
 {
+
+	public function __construct(
+		private PhpVersion $phpVersion,
+	)
+	{
+	}
 
 	public function getNodeType(): string
 	{
@@ -74,6 +81,20 @@ final class NewStaticRule implements Rule
 			$prototype = $constructor->getPrototype();
 			if ($prototype->isAbstract()) {
 				return [];
+			}
+		}
+
+		if (
+			$this->phpVersion->supportsAbstractTraitMethods()
+			&& $scope->isInTrait()
+		) {
+			$traitReflection = $scope->getTraitReflection();
+			if ($traitReflection->hasConstructor()) {
+				$traitConstructor = $traitReflection->getConstructor();
+
+				if ($traitConstructor instanceof PhpMethodReflection && $traitConstructor->isAbstract()) {
+					return [];
+				}
 			}
 		}
 

--- a/tests/PHPStan/Rules/Classes/NewStaticRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/NewStaticRuleTest.php
@@ -2,8 +2,10 @@
 
 namespace PHPStan\Rules\Classes;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<NewStaticRule>
@@ -13,7 +15,9 @@ class NewStaticRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new NewStaticRule();
+		return new NewStaticRule(
+			new PhpVersion(PHP_VERSION_ID),
+		);
 	}
 
 	public function testRule(): void
@@ -37,6 +41,25 @@ class NewStaticRuleTest extends RuleTestCase
 	public function testRuleWithConsistentConstructor(): void
 	{
 		$this->analyse([__DIR__ . '/data/new-static-consistent-constructor.php'], []);
+	}
+
+	public function testBug9654(): void
+	{
+		$errors = [];
+		if (PHP_VERSION_ID < 80000) {
+			$errors[] = [
+				'Unsafe usage of new static()',
+				11,
+				'See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static',
+			];
+			$errors[] = [
+				'Unsafe usage of new static()',
+				11,
+				'See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static',
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-9654.php'], $errors);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-9654.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-9654.php
@@ -1,0 +1,32 @@
+<?php // lint >= 8.0
+
+namespace Bug9654;
+
+trait Abc
+{
+	abstract public function __construct();
+
+	public static function create(): static
+	{
+		return new static();  // this is safe as the constructor is defined abstract in this trait
+	}
+}
+
+class Foo
+{
+	use Abc;
+
+	public function __construct() {
+
+	}
+}
+
+class Bar
+{
+	use Abc;
+
+	public function __construct(int $i = 0)
+	{
+		$i = $i*2;
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/9654

Closes https://github.com/phpstan/phpstan-src/pull/2767

