### PR TITLE
Fix lowercase string usage in template

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -368,6 +368,7 @@ class IntersectionType implements CompoundType
 				if (
 					($type instanceof AccessoryLowercaseStringType || $type instanceof AccessoryUppercaseStringType)
 					&& !$level->isPrecise()
+					&& !$level->isCache()
 				) {
 					continue;
 				}

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -337,7 +337,7 @@ class UnionType implements CompoundType
 				}
 			}
 
-			if ($level->isPrecise()) {
+			if ($level->isPrecise() || $level->isCache()) {
 				$duplicates = array_diff_assoc($typeNames, array_unique($typeNames));
 				if (count($duplicates) > 0) {
 					$indexByDuplicate = array_fill_keys($duplicates, 0);

--- a/src/Type/VerbosityLevel.php
+++ b/src/Type/VerbosityLevel.php
@@ -86,6 +86,11 @@ final class VerbosityLevel
 		return $this->value === self::PRECISE;
 	}
 
+	public function isCache(): bool
+	{
+		return $this->value === self::CACHE;
+	}
+
 	/** @api */
 	public static function getRecommendedLevelByType(Type $acceptingType, ?Type $acceptedType = null): self
 	{

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -1241,7 +1241,7 @@ class ReturnTypeRuleTest extends RuleTestCase
 
 	public function testBug13043(): void
 	{
-		$this->analyse([__DIR__.'/data/bug-13043.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-13043.php'], []);
 	}
 
 	public function testBug12739(): void

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -1241,7 +1241,12 @@ class ReturnTypeRuleTest extends RuleTestCase
 
 	public function testBug13043(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-13043.php'], []);
+		$this->analyse([__DIR__.'/data/bug-13043.php'], []);
+	}
+
+	public function testBug12739(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12739.php'], []);
 	}
 
 	public function testBug12928(): void

--- a/tests/PHPStan/Rules/Methods/data/bug-12739.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12739.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @template TScalar of scalar
+ */
+abstract class ScalarType {
+	/**
+	 * @return class-string<ScalarType<TScalar>>
+	 */
+	abstract public static function getClassIdentify() : string;
+}
+
+/**
+ * @extends ScalarType<int>
+ */
+class MyInt extends ScalarType {
+	public static function getClassIdentify() : string {
+		return MyInt::class;
+	}
+}
+
+/**
+ * @extends ScalarType<string>
+ */
+class MyString extends ScalarType {
+	public static function getClassIdentify() : string {
+		return MyString::class;
+	}
+}
+
+/**
+ * @extends ScalarType<lowercase-string>
+ */
+class MyLowerString extends ScalarType {
+	public static function getClassIdentify() : string {
+		return MyLowerString::class;
+	}
+}
+
+/**
+ * @extends ScalarType<class-string>
+ */
+class MyClassString extends ScalarType {
+	public static function getClassIdentify() : string {
+		return MyClassString::class;
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-12739.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12739.php
@@ -40,6 +40,15 @@ class MyLowerString extends ScalarType {
 }
 
 /**
+ * @extends ScalarType<uppercase-string>
+ */
+class MyUpperString extends ScalarType {
+	public static function getClassIdentify() : string {
+		return MyUpperString::class;
+	}
+}
+
+/**
  * @extends ScalarType<class-string>
  */
 class MyClassString extends ScalarType {

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -708,9 +708,11 @@ class UnionTypeTest extends PHPStanTestCase
 				'int|string',
 				'int|string',
 				'int|string',
+				'int|string',
 			],
 			[
 				new UnionType([new IntegerType(), new StringType(), new NullType()]),
+				'int|string|null',
 				'int|string|null',
 				'int|string|null',
 				'int|string|null',
@@ -733,6 +735,7 @@ class UnionTypeTest extends PHPStanTestCase
 					new ConstantStringType('2'),
 					new ConstantStringType('1'),
 				]),
+				"1|2|2.2|10|'1'|'10'|'10aaa'|'11aaa'|'1aaa'|'2'|'2aaa'|'foo'|stdClass-PHPStan\Type\ObjectType-|true|null",
 				"1|2|2.2|10|'1'|'10'|'10aaa'|'11aaa'|'1aaa'|'2'|'2aaa'|'foo'|stdClass|true|null",
 				"1|2|2.2|10|'1'|'10'|'10aaa'|'11aaa'|'1aaa'|'2'|'2aaa'|'foo'|stdClass|true|null",
 				'float|int|stdClass|string|true|null',
@@ -757,6 +760,7 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				'\'aaa\'|array{a: int, b: float}|array{a: string, b: bool}',
 				'\'aaa\'|array{a: int, b: float}|array{a: string, b: bool}',
+				'\'aaa\'|array{a: int, b: float}|array{a: string, b: bool}',
 				'array<string, bool|float|int|string>|string',
 			],
 			[
@@ -777,6 +781,7 @@ class UnionTypeTest extends PHPStanTestCase
 					]),
 					new ConstantStringType('aaa'),
 				),
+				'\'aaa\'|array{a: string, b: bool}|array{b: int, c: float}',
 				'\'aaa\'|array{a: string, b: bool}|array{b: int, c: float}',
 				'\'aaa\'|array{a: string, b: bool}|array{b: int, c: float}',
 				'array<string, bool|float|int|string>|string',
@@ -801,6 +806,7 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				'\'aaa\'|array{a: string, b: bool}|array{c: int, d: float}',
 				'\'aaa\'|array{a: string, b: bool}|array{c: int, d: float}',
+				'\'aaa\'|array{a: string, b: bool}|array{c: int, d: float}',
 				'array<string, bool|float|int|string>|string',
 			],
 			[
@@ -822,6 +828,7 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				'array{int, bool, float}|array{string}',
 				'array{int, bool, float}|array{string}',
+				'array{int, bool, float}|array{string}',
 				'array<int, bool|float|int|string>',
 			],
 			[
@@ -833,6 +840,7 @@ class UnionTypeTest extends PHPStanTestCase
 						new ConstantStringType('barrr'),
 					]),
 				),
+				'array{}|array{foooo: \'barrr\'}',
 				'array{}|array{foooo: \'barrr\'}',
 				'array{}|array{foooo: \'barrr\'}',
 				'array<string, string>',
@@ -847,6 +855,7 @@ class UnionTypeTest extends PHPStanTestCase
 				),
 				'int|numeric-string',
 				'int|numeric-string',
+				'int|numeric-string',
 				'int|string',
 			],
 			[
@@ -854,6 +863,7 @@ class UnionTypeTest extends PHPStanTestCase
 					IntegerRangeType::fromInterval(0, 4),
 					IntegerRangeType::fromInterval(6, 10),
 				),
+				'int<0, 4>|int<6, 10>',
 				'int<0, 4>|int<6, 10>',
 				'int<0, 4>|int<6, 10>',
 				'int<0, 4>|int<6, 10>',
@@ -869,6 +879,7 @@ class UnionTypeTest extends PHPStanTestCase
 					new NullType(),
 				),
 				'TFoo of int (class foo, parameter)|null',
+				'TFoo of int (class foo, parameter)|null',
 				'(TFoo of int)|null',
 				'(TFoo of int)|null',
 			],
@@ -882,6 +893,7 @@ class UnionTypeTest extends PHPStanTestCase
 					),
 					new GenericClassStringType(new ObjectType('Abc')),
 				),
+				'class-string<Abc-PHPStan\Type\ObjectType->|TFoo of int (class foo, parameter)',
 				'class-string<Abc>|TFoo of int (class foo, parameter)',
 				'class-string<Abc>|TFoo of int',
 				'class-string<Abc>|TFoo of int',
@@ -896,6 +908,7 @@ class UnionTypeTest extends PHPStanTestCase
 					),
 					new NullType(),
 				),
+				'TFoo (class foo, parameter)|null',
 				'TFoo (class foo, parameter)|null',
 				'TFoo|null',
 				'TFoo|null',
@@ -916,11 +929,13 @@ class UnionTypeTest extends PHPStanTestCase
 					new NullType(),
 				),
 				'TFoo of TBar (class foo, parameter) (class foo, parameter)|null',
+				'TFoo of TBar (class foo, parameter) (class foo, parameter)|null',
 				'(TFoo of TBar)|null',
 				'(TFoo of TBar)|null',
 			],
 			[
 				new UnionType([new ObjectType('Foo'), new ObjectType('Foo')]),
+				'Foo-PHPStan\Type\ObjectType-#1|Foo-PHPStan\Type\ObjectType-#2',
 				'Foo#1|Foo#2',
 				'Foo',
 				'Foo',
@@ -931,11 +946,13 @@ class UnionTypeTest extends PHPStanTestCase
 	#[DataProvider('dataDescribe')]
 	public function testDescribe(
 		Type $type,
+		string $expectedCacheDescription,
 		string $expectedPreciseDescription,
 		string $expectedValueDescription,
 		string $expectedTypeOnlyDescription,
 	): void
 	{
+		$this->assertSame($expectedCacheDescription, $type->describe(VerbosityLevel::cache()));
 		$this->assertSame($expectedPreciseDescription, $type->describe(VerbosityLevel::precise()));
 		$this->assertSame($expectedValueDescription, $type->describe(VerbosityLevel::value()));
 		$this->assertSame($expectedTypeOnlyDescription, $type->describe(VerbosityLevel::typeOnly()));


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12739

Seems like the issue is related to the fact that
`ScalarType<string>` and `ScalarType<lowercase-string>` had the same cacheKey or something like that.

`AccessoryLowercaseStringType` and `AccessoryUppercaseStringType` was lost for `level::cache` because the check was only `isPrecise`.

So I added `$level->isCache()` and updated every `$level->isPrecise()` checks (with tests).
But I dunno if it's not better to do something like
```
public function isPrecise(): bool
{
     return $this->value === self::PRECISE || $this->value === self::CACHE;
}
```
(And eventually rename the method to `isAtLeastPrecise` ? Your call @ondrejmirtes.