### PR TITLE
Nothing is lower than null and object is never equal to null

### DIFF
--- a/src/Type/NullType.php
+++ b/src/Type/NullType.php
@@ -110,6 +110,10 @@ class NullType implements ConstantScalarType
 			return $otherType->isGreaterThan($this, $phpVersion);
 		}
 
+		if ($otherType->isObject()->yes()) {
+			return TrinaryLogic::createYes();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 
@@ -121,6 +125,10 @@ class NullType implements ConstantScalarType
 
 		if ($otherType instanceof CompoundType) {
 			return $otherType->isGreaterThanOrEqual($this, $phpVersion);
+		}
+
+		if ($otherType->isObject()->yes()) {
+			return TrinaryLogic::createYes();
 		}
 
 		return TrinaryLogic::createMaybe();

--- a/src/Type/Traits/UndecidedComparisonCompoundTypeTrait.php
+++ b/src/Type/Traits/UndecidedComparisonCompoundTypeTrait.php
@@ -13,11 +13,19 @@ trait UndecidedComparisonCompoundTypeTrait
 
 	public function isGreaterThan(Type $otherType, PhpVersion $phpVersion): TrinaryLogic
 	{
+		if ($otherType->isNull()->yes() && $this->isObject()->yes()) {
+			return TrinaryLogic::createYes();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 
 	public function isGreaterThanOrEqual(Type $otherType, PhpVersion $phpVersion): TrinaryLogic
 	{
+		if ($otherType->isNull()->yes()) {
+			return TrinaryLogic::createYes();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 

--- a/src/Type/Traits/UndecidedComparisonTypeTrait.php
+++ b/src/Type/Traits/UndecidedComparisonTypeTrait.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Traits;
 use PHPStan\Php\PhpVersion;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 
 trait UndecidedComparisonTypeTrait
@@ -12,11 +13,19 @@ trait UndecidedComparisonTypeTrait
 
 	public function isSmallerThan(Type $otherType, PhpVersion $phpVersion): TrinaryLogic
 	{
+		if ($otherType->isNull()->yes()) {
+			return TrinaryLogic::createNo();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 
 	public function isSmallerThanOrEqual(Type $otherType, PhpVersion $phpVersion): TrinaryLogic
 	{
+		if ($otherType->isNull()->yes() && $this->isObject()->yes()) {
+			return TrinaryLogic::createNo();
+		}
+
 		return TrinaryLogic::createMaybe();
 	}
 
@@ -32,11 +41,15 @@ trait UndecidedComparisonTypeTrait
 
 	public function getGreaterType(PhpVersion $phpVersion): Type
 	{
-		return new MixedType();
+		return new MixedType(subtractedType: new NullType());
 	}
 
 	public function getGreaterOrEqualType(PhpVersion $phpVersion): Type
 	{
+		if ($this->isObject()->yes()) {
+			return new MixedType(subtractedType: new NullType());
+		}
+
 		return new MixedType();
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -190,10 +190,10 @@ class Foo
 		assertType('*ERROR*', $a ** $b);
 		assertType('*ERROR*', $a << $b);
 		assertType('*ERROR*', $a >> $b);
-		assertType('bool', $a < $b);
-		assertType('bool', $a <= $b);
-		assertType('bool', $a > $b);
-		assertType('bool', $a >= $b);
+		assertType('false', $a < $b);
+		assertType('false', $a <= $b);
+		assertType('true', $a > $b);
+		assertType('true', $a >= $b);
 		assertType('int<-1, 1>', $a <=> $b);
 		assertType('bool', $a == $b);
 		assertType('bool', $a != $b);

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3588,6 +3588,26 @@ class CallMethodsRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10719(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10719.php'], []);
+	}
+
+	public function testBug9141(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-9141.php'], []);
+	}
+
 	public function testBug3396(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/bug-10719.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-10719.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10719;
+
+use DateTime;
+
+$dt1 = null;
+$dt2 = new DateTime();
+
+if (rand(0, 1)) {
+	$dt1 = (clone $dt2)->setTimestamp($dt2->getTimestamp() + 1000);
+}
+
+if ($dt1 > $dt2) {
+	echo $dt1->getTimestamp();
+}

--- a/tests/PHPStan/Rules/Methods/data/bug-9141.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-9141.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9141;
+
+use DateTimeImmutable;
+
+class HelloWorld
+{
+
+	private ?DateTimeImmutable $startTime;
+
+	public function __construct() {
+		$this->startTime = new DateTimeImmutable();
+	}
+
+	public function getStartTime(): ?DateTimeImmutable
+	{
+		return $this->startTime;
+	}
+
+}
+
+$helloWorld = new HelloWorld();
+if ($helloWorld->getStartTime() > new DateTimeImmutable()) {
+	echo sprintf('%s', $helloWorld->getStartTime()->format('d.m.y.'));
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/10719
Closes https://github.com/phpstan/phpstan/issues/9141

$a < null is always false.
$a <= null is always when $a is an object.

It needs https://github.com/phpstan/phpstan-src/pull/4132 first.