### PR TITLE
Fix intersection with substracted

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -544,6 +544,11 @@ final class TypeCombinator
 			$subtractedType = $type->getSubtractedType() === null
 				? $subtractedType
 				: self::union($type->getSubtractedType(), $subtractedType);
+
+			$subtractedType = self::intersect(
+				$type->getTypeWithoutSubtractedType(),
+				$subtractedType,
+			);
 			if ($subtractedType instanceof NeverType) {
 				$subtractedType = null;
 			}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -4127,6 +4127,22 @@ class TypeCombinatorTest extends PHPStanTestCase
 				IntersectionType::class,
 				'lowercase-string&uppercase-string',
 			],
+			[
+				[
+					new ObjectType(DateTime::class),
+					new MixedType(subtractedType: new NullType()),
+				],
+				ObjectType::class,
+				'DateTime',
+			],
+			[
+				[
+					new ObjectWithoutClassType(),
+					new MixedType(subtractedType: new NullType()),
+				],
+				ObjectWithoutClassType::class,
+				'object',
+			],
 		];
 
 		if (PHP_VERSION_ID < 80100) {


### PR DESCRIPTION
Without this fix, the intersection of
```
new ObjectType(DateTime::class),
new MixedType(subtractedType: new NullType()),
```
was `DateTime~null`.

Extracted from https://github.com/phpstan/phpstan-src/pull/4131