### PR TITLE
Add non regression test for 9401

### DIFF
--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -357,4 +357,17 @@ class ReturnTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug9401(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkNullables = true;
+
+		$this->analyse([__DIR__ . '/data/bug-9401.php'], [
+			[
+				'Function Bug9401\foo() should return list<int<1, max>> but returns list<int<0, max>>.',
+				17,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-9401.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-9401.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9401;
+
+/**
+ * @param array<mixed> $foos
+ * @return list<positive-int>
+ */
+function foo(array $foos): array
+{
+	$list = [];
+	foreach ($foos as $foo) {
+		if (is_int($foo) && $foo >= 0) {
+			$list[] = $foo;
+		}
+	}
+	return $list;
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/9401

The issue was about the `array<int<0, max>, int<0, max>> might not be a list.` hint which 
- was incorrect
- which is not here anymore (https://phpstan.org/r/f6667d80-d551-419b-9e03-fd8a1508daba) 