### PR TITLE
Handle empty array case via `ConstantArrayType::spliceArray()`

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1019,6 +1019,9 @@ class ConstantArrayType implements Type
 	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type
 	{
 		$keyTypesCount = count($this->keyTypes);
+		if ($keyTypesCount === 0) {
+			return $this;
+		}
 
 		$offset = $offsetType instanceof ConstantIntegerType ? $offsetType->getValue() : null;
 

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1493,6 +1493,13 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug13279(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13279.php');
+		$this->assertCount(1, $errors);
+		$this->assertSame('Parameter #2 $offset of function array_splice expects int, string given.', $errors[0]->getMessage());
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return Error[]

--- a/tests/PHPStan/Analyser/data/bug-13279.php
+++ b/tests/PHPStan/Analyser/data/bug-13279.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13279;
+
+class ReproduceMe
+{
+	public function crashIt(string $addMe = ''): string
+	{
+		$arg = [];
+		if ($addMe !== '') {
+			$arg[] = $addMe;
+		}
+
+		array_splice($arg, 'extra', 1);
+
+		return implode(' ', $arg);
+	}
+}


### PR DESCRIPTION
This basically acts as recursion guard because a bit later the following piece of code

```php
		if ($offset === null || $length === null) {
			return $this->degradeToGeneralArray()
				->spliceArray($offsetType, $lengthType, $replacementType);
		}
```

would degrade the empty constant array to the same empty constant array, calling the same method again, which then leads to infinite recursion.
We have that exact same code for `sliceArray()` as well btw.

Closes https://github.com/phpstan/phpstan/issues/13279

Was introduced in https://github.com/phpstan/phpstan-src/pull/3952