### PR TITLE
Fix args are mistakenly handled as immediately-invoked

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1824,7 +1824,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\IntersectionType is error\-prone and deprecated\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 3
+			count: 4
 			path: src/Type/TypeUtils.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1824,7 +1824,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\IntersectionType is error\-prone and deprecated\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 4
+			count: 3
 			path: src/Type/TypeUtils.php
 
 		-

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5139,21 +5139,20 @@ final class NodeScopeResolver
 				$scopeToPass = $closureBindScope;
 			}
 
-			if (
-				$parameterType === null
-				|| $parameterType instanceof MixedType
-				|| $parameterType->isCallable()->no()
-			) {
-				$callCallbackImmediately = false;
-			} elseif ($parameter instanceof ExtendedParameterReflection) {
+			$parameterCallableType = null;
+			if ($parameterType !== null) {
+				$parameterCallableType = TypeUtils::findCallableType($parameterType);
+			}
+
+			if ($parameter instanceof ExtendedParameterReflection) {
 				$parameterCallImmediately = $parameter->isImmediatelyInvokedCallable();
 				if ($parameterCallImmediately->maybe()) {
-					$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
+					$callCallbackImmediately = $parameterCallableType !== null && $calleeReflection instanceof FunctionReflection;
 				} else {
 					$callCallbackImmediately = $parameterCallImmediately->yes();
 				}
 			} else {
-				$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
+				$callCallbackImmediately = $parameterCallableType !== null && $calleeReflection instanceof FunctionReflection;
 			}
 
 			if ($arg->value instanceof Expr\Closure) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5139,7 +5139,13 @@ final class NodeScopeResolver
 				$scopeToPass = $closureBindScope;
 			}
 
-			if ($parameter instanceof ExtendedParameterReflection) {
+			if (
+				$parameterType === null
+				|| $parameterType instanceof MixedType
+				|| $parameterType->isCallable()->no()
+			) {
+				$callCallbackImmediately = false;
+			} elseif ($parameter instanceof ExtendedParameterReflection) {
 				$parameterCallImmediately = $parameter->isImmediatelyInvokedCallable();
 				if ($parameterCallImmediately->maybe()) {
 					$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
@@ -5149,6 +5155,7 @@ final class NodeScopeResolver
 			} else {
 				$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
 			}
+
 			if ($arg->value instanceof Expr\Closure) {
 				$restoreThisScope = null;
 				if (

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5139,15 +5139,21 @@ final class NodeScopeResolver
 				$scopeToPass = $closureBindScope;
 			}
 
-			if ($parameter instanceof ExtendedParameterReflection) {
+			if (
+				$parameterType === null
+				|| $parameterType instanceof MixedType
+				|| $parameterType->isCallable()->no()
+			) {
+				$callCallbackImmediately = false;
+			} elseif ($parameter instanceof ExtendedParameterReflection) {
 				$parameterCallImmediately = $parameter->isImmediatelyInvokedCallable();
 				if ($parameterCallImmediately->maybe()) {
-					$callCallbackImmediately = $calleeReflection instanceof FunctionReflection && !$calleeReflection->isBuiltin();
+					$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
 				} else {
 					$callCallbackImmediately = $parameterCallImmediately->yes();
 				}
 			} else {
-				$callCallbackImmediately = $calleeReflection instanceof FunctionReflection && !$calleeReflection->isBuiltin();
+				$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
 			}
 
 			if ($arg->value instanceof Expr\Closure) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5139,21 +5139,15 @@ final class NodeScopeResolver
 				$scopeToPass = $closureBindScope;
 			}
 
-			if (
-				$parameterType === null
-				|| $parameterType instanceof MixedType
-				|| $parameterType->isCallable()->no()
-			) {
-				$callCallbackImmediately = false;
-			} elseif ($parameter instanceof ExtendedParameterReflection) {
+			if ($parameter instanceof ExtendedParameterReflection) {
 				$parameterCallImmediately = $parameter->isImmediatelyInvokedCallable();
 				if ($parameterCallImmediately->maybe()) {
-					$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
+					$callCallbackImmediately = $calleeReflection instanceof FunctionReflection && !$calleeReflection->isBuiltin();
 				} else {
 					$callCallbackImmediately = $parameterCallImmediately->yes();
 				}
 			} else {
-				$callCallbackImmediately = $calleeReflection instanceof FunctionReflection;
+				$callCallbackImmediately = $calleeReflection instanceof FunctionReflection && !$calleeReflection->isBuiltin();
 			}
 
 			if ($arg->value instanceof Expr\Closure) {

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -170,6 +170,24 @@ final class TypeUtils
 		return null;
 	}
 
+	public static function findCallableType(Type $type): ?Type
+	{
+		if ($type->isCallable()->yes()) {
+			return $type;
+		}
+
+		if ($type instanceof UnionType || $type instanceof IntersectionType) {
+			foreach ($type->getTypes() as $innerType) {
+				$callableType = self::findCallableType($innerType);
+				if ($callableType !== null) {
+					return $callableType;
+				}
+			}
+		}
+
+		return null;
+	}
+
 	/**
 	 * @return HasPropertyType[]
 	 */

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -176,7 +176,7 @@ final class TypeUtils
 			return $type;
 		}
 
-		if ($type instanceof UnionType || $type instanceof IntersectionType) {
+		if ($type instanceof UnionType) {
 			foreach ($type->getTypes() as $innerType) {
 				$callableType = self::findCallableType($innerType);
 				if ($callableType !== null) {

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -337,3 +337,13 @@ function pcntl_signal(int $signal, $handler, bool $restart_syscalls = true): boo
  * @param-later-invoked-callable $callback
  */
 function set_error_handler(?callable $callback, int $error_levels = E_ALL): ?callable {}
+
+/**
+ * @param-later-invoked-callable $callback
+ */
+function spl_autoload_register(?callable $callback = null, bool $throw = true, bool $prepend = false): bool {}
+
+/**
+ * @param-later-invoked-callable $callback
+ */
+function register_shutdown_function(callable $callback, mixed ...$args): void {}

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -352,3 +352,8 @@ function spl_autoload_register(?callable $callback = null, bool $throw = true, b
  * @param-later-invoked-callable $callback
  */
 function register_shutdown_function(callable $callback, mixed ...$args): void {}
+
+/**
+ * @param-later-invoked-callable $callback
+ */
+function header_register_callback(callable $callback): bool {}

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -327,3 +327,14 @@ function get_defined_constants(bool $categorize = false): array {}
  */
 function getopt(string $short_options, array $long_options = [], &$rest_index = null) {}
 
+/**
+ * @param callable|int $handler
+ * @param-later-invoked-callable $handler
+ */
+function pcntl_signal(int $signal, $handler, bool $restart_syscalls = true): bool {}
+
+/**
+ * @param-later-invoked-callable $callback
+ * @return string|array|object|null
+ */
+function set_error_handler(?callable $callback, int $error_levels = E_ALL) {}

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -335,6 +335,5 @@ function pcntl_signal(int $signal, $handler, bool $restart_syscalls = true): boo
 
 /**
  * @param-later-invoked-callable $callback
- * @return string|array|object|null
  */
-function set_error_handler(?callable $callback, int $error_levels = E_ALL) {}
+function set_error_handler(?callable $callback, int $error_levels = E_ALL): ?callable {}

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -341,6 +341,11 @@ function set_error_handler(?callable $callback, int $error_levels = E_ALL): ?cal
 /**
  * @param-later-invoked-callable $callback
  */
+function set_exception_handler(?callable $callback): ?callable {}
+
+/**
+ * @param-later-invoked-callable $callback
+ */
 function spl_autoload_register(?callable $callback = null, bool $throw = true, bool $prepend = false): bool {}
 
 /**

--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -357,3 +357,8 @@ function register_shutdown_function(callable $callback, mixed ...$args): void {}
  * @param-later-invoked-callable $callback
  */
 function header_register_callback(callable $callback): bool {}
+
+/**
+ * @param-later-invoked-callable $callback
+ */
+function register_tick_function(callable $callback, mixed ...$args): bool {}

--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -7,7 +7,9 @@ use PHPStan\Parser\Parser;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function count;
 use function get_class;
@@ -127,6 +129,22 @@ class ExpressionResultTest extends PHPStanTestCase
 				'var_dump(exit()."a");',
 				true,
 			],
+			[
+				'array_push($arr, fn() => "exit");',
+				false,
+			],
+			[
+				'array_push($arr, function() { exit(); });',
+				false,
+			],
+			[
+				'array_push($arr, "exit");',
+				false,
+			],
+			[
+				'array_unshift($arr, "exit");',
+				false,
+			],
 		];
 	}
 
@@ -155,7 +173,8 @@ class ExpressionResultTest extends PHPStanTestCase
 		/** @var ScopeFactory $scopeFactory */
 		$scopeFactory = self::getContainer()->getByType(ScopeFactory::class);
 		$scope = $scopeFactory->create(ScopeContext::create('test.php'))
-			->assignVariable('x', new IntegerType(), new IntegerType(), TrinaryLogic::createYes());
+			->assignVariable('x', new IntegerType(), new IntegerType(), TrinaryLogic::createYes())
+			->assignVariable('arr', new ArrayType(new MixedType(), new MixedType()), new ArrayType(new MixedType(), new MixedType()), TrinaryLogic::createYes());
 
 		$result = $nodeScopeResolver->processExprNode(
 			$stmt,

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -355,4 +355,10 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13288.php'], []);
 	}
 
+	public function testBug13311(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-13311.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -348,4 +348,11 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.1')]
+	public function testBug13288(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-13288.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -361,4 +361,10 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13311.php'], []);
 	}
 
+	public function testBug13331(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-13331.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/UnreachableStatementRuleTest.php
@@ -361,6 +361,12 @@ class UnreachableStatementRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13311.php'], []);
 	}
 
+	public function testBug13307(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-13307.php'], []);
+	}
+
 	public function testBug13331(): void
 	{
 		$this->treatPhpDocTypesAsCertain = false;

--- a/tests/PHPStan/Rules/DeadCode/data/bug-13288.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-13288.php
@@ -1,0 +1,11 @@
+<?php // lint >= 8.1
+
+namespace Bug13288;
+
+function error_to_exception(int $errno, string $errstr, string $errfile = 'unknown', int $errline = 0): never {
+	throw new \ErrorException($errstr, $errno, $errno, $errfile, $errline);
+}
+
+set_error_handler(error_to_exception(...));
+
+echo 'ok';

--- a/tests/PHPStan/Rules/DeadCode/data/bug-13307.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-13307.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug13307;
+
+function dd(): never {
+	exit(1);
+}
+
+class HelloWorld
+{
+	public function testMethod(): string
+	{
+		var_dump("dd");
+
+		return "test";
+	}
+
+	public function testMethod2(): string
+	{
+		var_dump("DD");
+
+		return "test";
+	}
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-13307.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-13307.php
@@ -10,14 +10,14 @@ class HelloWorld
 {
 	public function testMethod(): string
 	{
-		var_dump("dd");
+		var_dump("\Bug13307\dd");
 
 		return "test";
 	}
 
 	public function testMethod2(): string
 	{
-		var_dump("DD");
+		var_dump("\Bug13307\DD");
 
 		return "test";
 	}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-13311.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-13311.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bug13311;
+
+use Exception;
+
+$error_handler = static function () { throw new Exception(); };
+set_error_handler($error_handler, \E_NOTICE | \E_WARNING);
+
+try {
+	$out = iconv($from, $to . $iconv_options, $str);
+} catch (Throwable $e) {
+	$out = false;
+}

--- a/tests/PHPStan/Rules/DeadCode/data/bug-13331.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-13331.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13331;
+
+$signalHandler = function () {
+	exit();
+};
+
+pcntl_async_signals(true);
+pcntl_signal(SIGINT, $signalHandler);
+pcntl_signal(SIGQUIT, $signalHandler);
+pcntl_signal(SIGTERM, $signalHandler);

--- a/tests/PHPStan/Rules/Exceptions/data/missing-exception-function-throws.php
+++ b/tests/PHPStan/Rules/Exceptions/data/missing-exception-function-throws.php
@@ -56,3 +56,10 @@ function doBar3(): void
 {
 	throw new \LogicException(); // error
 }
+
+function bug13288(array $a): void
+{
+	array_push($a, function() {
+		throw new \LogicException(); // ok, as array_push() will not invoke the function
+	});
+}

--- a/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
@@ -204,4 +204,9 @@ class PureFunctionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13201.php'], []);
 	}
 
+	public function testBug12119(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12119.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
@@ -108,6 +108,14 @@ class PureFunctionRuleTest extends RuleTestCase
 				'Impure call to function array_push() in pure function PureFunction\bug13288().',
 				171,
 			],
+			[
+				'Impure call to function array_push() in pure function PureFunction\bug13288().',
+				175,
+			],
+			[
+				'Impure call to function array_push() in pure function PureFunction\bug13288().',
+				182,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
@@ -104,6 +104,10 @@ class PureFunctionRuleTest extends RuleTestCase
 				'Impure output between PHP opening and closing tags in pure function PureFunction\justContainsInlineHtml().',
 				160,
 			],
+			[
+				'Impure call to function array_push() in pure function PureFunction\bug13288().',
+				171,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
+++ b/tests/PHPStan/Rules/Pure/PureFunctionRuleTest.php
@@ -116,6 +116,18 @@ class PureFunctionRuleTest extends RuleTestCase
 				'Impure call to function array_push() in pure function PureFunction\bug13288().',
 				182,
 			],
+			[
+				'Impure exit in pure function PureFunction\bug13288b().',
+				200,
+			],
+			[
+				'Impure exit in pure function PureFunction\bug13288c().',
+				217,
+			],
+			[
+				'Impure exit in pure function PureFunction\bug13288d().',
+				230,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Pure/data/bug-12119.php
+++ b/tests/PHPStan/Rules/Pure/data/bug-12119.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bug12119;
+
+/** @phpstan-pure */
+function testFunction(string $s): string { return ''; }
+
+class HelloWorld
+{
+	/** @phpstan-pure */
+	public function testMethod(string $s): string { return ''; }
+
+	/** @phpstan-pure */
+	public function sayHello(string $s): string
+	{
+		$a = $this->testMethod('random_int');
+		$b = testFunction('random_int');
+
+		return $a . $b;
+	}
+}

--- a/tests/PHPStan/Rules/Pure/data/pure-function.php
+++ b/tests/PHPStan/Rules/Pure/data/pure-function.php
@@ -164,3 +164,11 @@ function justContainsInlineHtml()
 	</table>
 	<?php
 }
+
+/** @phpstan-pure */
+function bug13288(array $a)
+{
+	array_push($a, function() { // error because by ref arg
+		exit(); // ok, as array_push() will not invoke the function
+	});
+}

--- a/tests/PHPStan/Rules/Pure/data/pure-function.php
+++ b/tests/PHPStan/Rules/Pure/data/pure-function.php
@@ -171,4 +171,16 @@ function bug13288(array $a)
 	array_push($a, function() { // error because by ref arg
 		exit(); // ok, as array_push() will not invoke the function
 	});
+
+	array_push($a, // error because by ref arg
+		fn() => exit() // ok, as array_push() will not invoke the function
+	);
+
+	$closure = function() {
+		exit();
+	};
+	array_push($a, // error because by ref arg
+		$closure // ok, as array_push() will not invoke the function
+	);
 }
+

--- a/tests/PHPStan/Rules/Pure/data/pure-function.php
+++ b/tests/PHPStan/Rules/Pure/data/pure-function.php
@@ -168,7 +168,7 @@ function justContainsInlineHtml()
 /** @phpstan-pure */
 function bug13288(array $a)
 {
-	array_push($a, function() { // error because by ref arg
+	array_push($a, function () { // error because by ref arg
 		exit(); // ok, as array_push() will not invoke the function
 	});
 
@@ -176,11 +176,76 @@ function bug13288(array $a)
 		fn() => exit() // ok, as array_push() will not invoke the function
 	);
 
-	$closure = function() {
+	$exitingClosure = function () {
 		exit();
 	};
 	array_push($a, // error because by ref arg
-		$closure // ok, as array_push() will not invoke the function
+		$exitingClosure // ok, as array_push() will not invoke the function
 	);
+
+	takesString("exit"); // ok, as the maybe callable type string is not typed with immediately-invoked-callable
+}
+
+/** @phpstan-pure */
+function takesString(string $s) {
+}
+
+/** @phpstan-pure */
+function bug13288b()
+{
+	$exitingClosure = function () {
+		exit();
+	};
+
+	takesMixed($exitingClosure); // error because immediately invoked
+}
+
+/**
+ * @phpstan-pure
+ * @param-immediately-invoked-callable $m
+ */
+function takesMixed(mixed $m) {
+}
+
+/** @phpstan-pure */
+function bug13288c()
+{
+	$exitingClosure = function () {
+		exit();
+	};
+
+	takesMaybeCallable($exitingClosure);
+}
+
+/** @phpstan-pure */
+function takesMaybeCallable(?callable $c) { // arguments passed to functions are considered "immediately called" by default
+}
+
+/** @phpstan-pure */
+function bug13288d()
+{
+	$exitingClosure = function () {
+		exit();
+	};
+	takesMaybeCallable2($exitingClosure);
+}
+
+/** @phpstan-pure */
+function takesMaybeCallable2(?\Closure $c) { // Closures are considered "immediately called"
+}
+
+/** @phpstan-pure */
+function bug13288e(MyClass $m)
+{
+	$exitingClosure = function () {
+		exit();
+	};
+	$m->takesMaybeCallable($exitingClosure);
+}
+
+class MyClass {
+	/** @phpstan-pure */
+	function takesMaybeCallable(?callable $c) { // arguments passed to methods are considered "later called" by default
+	}
 }
 


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/13288
closes https://github.com/phpstan/phpstan/issues/13311
closes https://github.com/phpstan/phpstan/issues/13331
closes https://github.com/phpstan/phpstan/issues/13307
closes https://github.com/phpstan/phpstan/issues/12119
