### PR TITLE
Fix missing detection of dead code in arrow functions

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3206,7 +3206,7 @@ final class NodeScopeResolver
 			return new ExpressionResult(
 				$result->getScope(),
 				$result->hasYield(),
-				$result->isAlwaysTerminating(),
+				false,
 				[],
 				[],
 			);
@@ -4818,7 +4818,7 @@ final class NodeScopeResolver
 		$nodeCallback(new InArrowFunctionNode($arrowFunctionType, $expr), $arrowFunctionScope);
 		$exprResult = $this->processExprNode($stmt, $expr->expr, $arrowFunctionScope, $nodeCallback, ExpressionContext::createTopLevel());
 
-		return new ExpressionResult($scope, false, false, $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
+		return new ExpressionResult($scope, false, $exprResult->isAlwaysTerminating(), $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
 	}
 
 	/**
@@ -5246,6 +5246,7 @@ final class NodeScopeResolver
 				if ($callCallbackImmediately) {
 					$throwPoints = array_merge($throwPoints, array_map(static fn (ThrowPoint $throwPoint) => $throwPoint->isExplicit() ? ThrowPoint::createExplicit($scope, $throwPoint->getType(), $arg->value, $throwPoint->canContainAnyThrowable()) : ThrowPoint::createImplicit($scope, $arg->value), $arrowFunctionResult->getThrowPoints()));
 					$impurePoints = array_merge($impurePoints, $arrowFunctionResult->getImpurePoints());
+					$isAlwaysTerminating = $isAlwaysTerminating || $arrowFunctionResult->isAlwaysTerminating();
 				}
 			} else {
 				$exprType = $scope->getType($arg->value);

--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -82,6 +82,10 @@ class ExpressionResultTest extends PHPStanTestCase
 				false,
 			],
 			[
+				'(fn() => exit())();', // immediately invoked function expression
+				true,
+			],
+			[
 				'@exit();',
 				true,
 			],

--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -102,6 +102,10 @@ class ExpressionResultTest extends PHPStanTestCase
 				true,
 			],
 			[
+				'call_user_func(fn() => exit());',
+				true,
+			],
+			[
 				'var_dump(1+exit());',
 				true,
 			],

--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -86,6 +86,10 @@ class ExpressionResultTest extends PHPStanTestCase
 				true,
 			],
 			[
+				'register_shutdown_function(fn() => exit());',
+				false,
+			],
+			[
 				'@exit();',
 				true,
 			],


### PR DESCRIPTION
followup to https://github.com/phpstan/phpstan-src/pull/4090