### PR TITLE
Fix `array_key_exists` narrows `$key` too much

### DIFF
--- a/src/Type/Php/ArrayKeyExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayKeyExistsFunctionTypeSpecifyingExtension.php
@@ -58,7 +58,7 @@ final class ArrayKeyExistsFunctionTypeSpecifyingExtension implements FunctionTyp
 		}
 		$key = $node->getArgs()[0]->value;
 		$array = $node->getArgs()[1]->value;
-		$keyType = $scope->getType($key);
+		$keyType = $scope->getType($key)->toArrayKey();
 		$arrayType = $scope->getType($array);
 
 		if (

--- a/tests/PHPStan/Analyser/nsrt/bug-11724.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11724.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bug11724;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	$f = 5.0;
+	$a = [5 => 'hello'];
+	assertType('true', array_key_exists($f, $a));
+	if (array_key_exists($f, $a)) {
+		assertType('5.0', $f);
+		assertType("array{5: 'hello'}", $a);
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11724

---

for `isset($a[$f])` it already works correctly
- https://phpstan.org/r/b39a70df-b2cd-4ce1-8509-2cd92ea3e641
- https://3v4l.org/9Sv5F#veol