### PR TITLE
Fix PropertyExistsTypeSpecifyingExtension for union types

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1650,7 +1650,7 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantStringType is error\-prone and deprecated\. Use Type\:\:getConstantStrings\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 2
+			count: 1
 			path: src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1650,12 +1650,6 @@ parameters:
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantStringType is error\-prone and deprecated\. Use Type\:\:getConstantStrings\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
-
-		-
-			message: '#^Doing instanceof PHPStan\\Type\\Constant\\ConstantStringType is error\-prone and deprecated\. Use Type\:\:getConstantStrings\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
 			count: 2
 			path: src/Type/Php/RangeFunctionReturnTypeExtension.php
 

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -68,10 +68,6 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 
 		$hasPropertyTypes = [];
 		foreach ($propertyNameTypes as $propertyNameType) {
-			if($propertyNameType->getValue() === '') {
-				return new SpecifiedTypes([], []);
-			}
-
 			$hasPropertyTypes[] = new HasPropertyType($propertyNameType->getValue());
 		}
 
@@ -82,6 +78,10 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 			$propertyNodes = [];
 
 			foreach($propertyNameTypes as $propertyNameType) {
+				if($propertyNameType->getValue() === '') {
+					return new SpecifiedTypes([], []);
+				}
+
 				$propertyNodes[] = new PropertyFetch(
 					$node->getArgs()[0]->value,
 					new Identifier($propertyNameType->getValue()),

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -68,6 +68,10 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 
 		$hasPropertyTypes = [];
 		foreach ($propertyNameTypes as $propertyNameType) {
+			if($propertyNameType->getValue() === '') {
+				return new SpecifiedTypes([], []);
+			}
+
 			$hasPropertyTypes[] = new HasPropertyType($propertyNameType->getValue());
 		}
 

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -55,8 +55,9 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 		TypeSpecifierContext $context,
 	): SpecifiedTypes
 	{
-		$propertyNameType = $scope->getType($node->getArgs()[1]->value);
-		if (!$propertyNameType instanceof ConstantStringType) {
+		$propertyNameTypes = $scope->getType($node->getArgs()[1]->value)->getConstantStrings();
+
+		if ($propertyNameTypes === []) {
 			return $this->typeSpecifier->create(
 				new FuncCall(new FullyQualified('property_exists'), $node->getRawArgs()),
 				new ConstantBooleanType(true),
@@ -65,26 +66,33 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 			);
 		}
 
-		if ($propertyNameType->getValue() === '') {
-			return new SpecifiedTypes([], []);
+		$hasPropertyTypes = [];
+		foreach ($propertyNameTypes as $propertyNameType) {
+			$hasPropertyTypes[] = new HasPropertyType($propertyNameType->getValue());
 		}
 
 		$objectType = $scope->getType($node->getArgs()[0]->value);
 		if ($objectType instanceof ConstantStringType) {
 			return new SpecifiedTypes([], []);
 		} elseif ($objectType->isObject()->yes()) {
-			$propertyNode = new PropertyFetch(
-				$node->getArgs()[0]->value,
-				new Identifier($propertyNameType->getValue()),
-			);
+			$propertyNodes = [];
+
+			foreach($propertyNameTypes as $propertyNameType) {
+				$propertyNodes[] = new PropertyFetch(
+					$node->getArgs()[0]->value,
+					new Identifier($propertyNameType->getValue()),
+				);
+			}
 		} else {
 			return new SpecifiedTypes([], []);
 		}
 
-		$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNode($propertyNode, $scope);
-		if ($propertyReflection !== null) {
-			if (!$propertyReflection->isNative()) {
-				return new SpecifiedTypes([], []);
+		foreach($propertyNodes as $propertyNode) {
+			$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNode($propertyNode, $scope);
+			if ($propertyReflection !== null) {
+				if (!$propertyReflection->isNative()) {
+					return new SpecifiedTypes([], []);
+				}
 			}
 		}
 
@@ -92,7 +100,7 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 			$node->getArgs()[0]->value,
 			new IntersectionType([
 				new ObjectWithoutClassType(),
-				new HasPropertyType($propertyNameType->getValue()),
+				...$hasPropertyTypes,
 			]),
 			$context,
 			$scope,

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -16,7 +16,6 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -72,23 +71,22 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 		}
 
 		$objectType = $scope->getType($node->getArgs()[0]->value);
-		if ($objectType instanceof ConstantStringType) {
+
+		if (!$objectType->isObject()->yes()) {
 			return new SpecifiedTypes([], []);
-		} elseif ($objectType->isObject()->yes()) {
-			$propertyNodes = [];
+		}
 
-			foreach ($propertyNameTypes as $propertyNameType) {
-				if ($propertyNameType->getValue() === '') {
-					return new SpecifiedTypes([], []);
-				}
+		$propertyNodes = [];
 
-				$propertyNodes[] = new PropertyFetch(
-					$node->getArgs()[0]->value,
-					new Identifier($propertyNameType->getValue()),
-				);
+		foreach ($propertyNameTypes as $propertyNameType) {
+			if ($propertyNameType->getValue() === '') {
+				return new SpecifiedTypes([], []);
 			}
-		} else {
-			return new SpecifiedTypes([], []);
+
+			$propertyNodes[] = new PropertyFetch(
+				$node->getArgs()[0]->value,
+				new Identifier($propertyNameType->getValue()),
+			);
 		}
 
 		foreach ($propertyNodes as $propertyNode) {

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -77,8 +77,8 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 		} elseif ($objectType->isObject()->yes()) {
 			$propertyNodes = [];
 
-			foreach($propertyNameTypes as $propertyNameType) {
-				if($propertyNameType->getValue() === '') {
+			foreach ($propertyNameTypes as $propertyNameType) {
+				if ($propertyNameType->getValue() === '') {
 					return new SpecifiedTypes([], []);
 				}
 
@@ -91,12 +91,14 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 			return new SpecifiedTypes([], []);
 		}
 
-		foreach($propertyNodes as $propertyNode) {
+		foreach ($propertyNodes as $propertyNode) {
 			$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNode($propertyNode, $scope);
-			if ($propertyReflection !== null) {
-				if (!$propertyReflection->isNative()) {
-					return new SpecifiedTypes([], []);
-				}
+			if ($propertyReflection === null) {
+				continue;
+			}
+
+			if (!$propertyReflection->isNative()) {
+				return new SpecifiedTypes([], []);
 			}
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-13304.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13304.php
@@ -4,13 +4,22 @@ namespace Bug13272Property;
 
 use function PHPStan\Testing\assertType;
 
-function foo(object $bar): void
+function foo(object $foo): void
 {
 	foreach (['qux', 'quux'] as $property) {
-		if (!property_exists($bar, $property)) {
+		if (!property_exists($foo, $property)) {
 			throw new \Exception;
 		}
 
-		assertType("object&hasProperty(quux)&hasProperty(qux)", $bar);
+		assertType("object&hasProperty(quux)&hasProperty(qux)", $foo);
 	}
+}
+
+function bar(object $bar): void
+{
+	if (!property_exists($bar, '')) {
+		throw new \Exception;
+	}
+
+	assertType("object", $bar);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-13304.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13304.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bug13272Property;
+
+use function PHPStan\Testing\assertType;
+
+function foo(object $bar): void
+{
+	foreach (['qux', 'quux'] as $property) {
+		if (!property_exists($bar, $property)) {
+			throw new \Exception;
+		}
+
+		assertType("object&hasProperty(quux)&hasProperty(qux)", $bar);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13304.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13304.php
@@ -14,12 +14,3 @@ function foo(object $foo): void
 		assertType("object&hasProperty(quux)&hasProperty(qux)", $foo);
 	}
 }
-
-function bar(object $bar): void
-{
-	if (!property_exists($bar, '')) {
-		throw new \Exception;
-	}
-
-	assertType("object", $bar);
-}

--- a/tests/PHPStan/Analyser/nsrt/bug-13304.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13304.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bug13272Property;
+namespace Bug13304;
 
 use function PHPStan\Testing\assertType;
 


### PR DESCRIPTION
closes [https://github.com/phpstan/phpstan/issues/13304](https://github.com/phpstan/phpstan/issues/13304)

@staabm it'd be great to [take you up](https://github.com/phpstan/phpstan/issues/13272#issuecomment-3106612286) on any guidance - especially because this PR is so heavily based on your changes in https://github.com/phpstan/phpstan-src/pull/4150. Thanks!

I believe my changes allow narrowing based on an array of constant strings, unless:
1. Any of them are empty
2. Any of them aren't native

I was trying to reason as to whether it'd make sense to try and narrow based on parts of the union (for example, if it contains an empty string, but also a non empty string?) but I think I'm out of brainpower for the day.