### PR TITLE
Replace instanceof checks in JsonThrowOnErrorDynamicReturnTypeExtension

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1606,18 +1606,6 @@ parameters:
 			path: src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
 
 		-
-			rawMessage: 'Doing instanceof PHPStan\Type\ConstantScalarType is error-prone and deprecated. Use Type::isConstantScalarValue() or Type::getConstantScalarTypes() or Type::getConstantScalarValues() instead.'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
-
-		-
-			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
-
-		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
 			identifier: phpstanApi.instanceofType
 			count: 1

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -12,12 +12,12 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\BitwiseFlagHelper;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
-use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\ConstantTypeHelper;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use function count;
 use function is_bool;
 use function json_decode;
 
@@ -87,8 +87,14 @@ final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctio
 		}
 
 		$firstValueType = $scope->getType($args[0]->value);
-		if ($firstValueType instanceof ConstantStringType) {
-			return $this->resolveConstantStringType($firstValueType, $isForceArray);
+		if ($firstValueType->getConstantStrings() !== []) {
+			$types = [];
+
+			foreach ($firstValueType->getConstantStrings() as $constantString) {
+				$types[] = $this->resolveConstantStringType($constantString, $isForceArray);
+			}
+
+			return TypeCombinator::union(...$types);
 		}
 
 		if ($isForceArray) {
@@ -109,7 +115,7 @@ final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctio
 		}
 
 		$secondArgType = $scope->getType($args[1]->value);
-		$secondArgValue = $secondArgType instanceof ConstantScalarType ? $secondArgType->getValue() : null;
+		$secondArgValue = count($secondArgType->getConstantScalarValues()) === 1 ? $secondArgType->getConstantScalarValues()[0] : null;
 
 		if (is_bool($secondArgValue)) {
 			return $secondArgValue;

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\BitwiseFlagHelper;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -17,7 +18,6 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use function count;
 use function is_bool;
 use function json_decode;
 
@@ -97,7 +97,7 @@ final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctio
 			return TypeCombinator::union(...$types);
 		}
 
-		if ($isForceArray) {
+		if ($isForceArray->yes()) {
 			return TypeCombinator::remove($fallbackType, new ObjectWithoutClassType());
 		}
 
@@ -107,33 +107,55 @@ final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctio
 	/**
 	 * Is "json_decode(..., true)"?
 	 */
-	private function isForceArray(FuncCall $funcCall, Scope $scope): bool
+	private function isForceArray(FuncCall $funcCall, Scope $scope): TrinaryLogic
 	{
 		$args = $funcCall->getArgs();
+		$flagValue = $this->getFlagValue($funcCall, $scope);
 		if (!isset($args[1])) {
-			return false;
+			return TrinaryLogic::createNo();
 		}
 
 		$secondArgType = $scope->getType($args[1]->value);
-		$secondArgValue = count($secondArgType->getConstantScalarValues()) === 1 ? $secondArgType->getConstantScalarValues()[0] : null;
-
-		if (is_bool($secondArgValue)) {
-			return $secondArgValue;
+		$secondArgValues = [];
+		foreach ($secondArgType->getConstantScalarValues() as $value) {
+			if ($value === null) {
+				$secondArgValues[] = $flagValue;
+				continue;
+			}
+			if (!is_bool($value)) {
+				return TrinaryLogic::createNo();
+			}
+			$secondArgValues[] = TrinaryLogic::createFromBoolean($value);
 		}
 
-		if ($secondArgValue !== null || !isset($args[3])) {
-			return false;
+		if ($secondArgValues === []) {
+			return TrinaryLogic::createNo();
+		}
+
+		return TrinaryLogic::extremeIdentity(...$secondArgValues);
+	}
+
+	private function resolveConstantStringType(ConstantStringType $constantStringType, TrinaryLogic $isForceArray): Type
+	{
+		$types = [];
+		/** @var bool $asArray */
+		foreach ($isForceArray->toBooleanType()->getConstantScalarValues() as $asArray) {
+			$decodedValue = json_decode($constantStringType->getValue(), $asArray);
+			$types[] = ConstantTypeHelper::getTypeFromValue($decodedValue);
+		}
+
+		return TypeCombinator::union(...$types);
+	}
+
+	private function getFlagValue(FuncCall $funcCall, Scope $scope): TrinaryLogic
+	{
+		$args = $funcCall->getArgs();
+		if (!isset($args[3])) {
+			return TrinaryLogic::createNo();
 		}
 
 		// depends on used constants, @see https://www.php.net/manual/en/json.constants.php#constant.json-object-as-array
-		return $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($args[3]->value, $scope, 'JSON_OBJECT_AS_ARRAY')->yes();
-	}
-
-	private function resolveConstantStringType(ConstantStringType $constantStringType, bool $isForceArray): Type
-	{
-		$decodedValue = json_decode($constantStringType->getValue(), $isForceArray);
-
-		return ConstantTypeHelper::getTypeFromValue($decodedValue);
+		return $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($args[3]->value, $scope, 'JSON_OBJECT_AS_ARRAY');
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/json-decode/json_object_as_array.php
+++ b/tests/PHPStan/Analyser/nsrt/json-decode/json_object_as_array.php
@@ -31,3 +31,10 @@ function ($mixed, $unknownFlags) {
 	$value = json_decode($mixed, null, 512, $unknownFlags);
 	assertType('mixed', $value);
 };
+
+function(string $json, ?bool $asArray): void {
+	/** @var '{}'|'null' $json */
+
+	$value = json_decode($json, null, 512, JSON_OBJECT_AS_ARRAY);
+	assertType('array{}|null', $value);
+};

--- a/tests/PHPStan/Analyser/nsrt/json-decode/narrow_type.php
+++ b/tests/PHPStan/Analyser/nsrt/json-decode/narrow_type.php
@@ -32,3 +32,12 @@ function ($mixed) {
 	$value = json_decode($mixed, false);
 	assertType('mixed', $value);
 };
+
+function(string $json): void {
+	/** @var '{}'|'null' $json */
+	$value = json_decode($json);
+	assertType('stdClass|null', $value);
+
+	$value = json_decode($json, true);
+	assertType('array{}|null', $value);
+};

--- a/tests/PHPStan/Analyser/nsrt/json-decode/narrow_type.php
+++ b/tests/PHPStan/Analyser/nsrt/json-decode/narrow_type.php
@@ -33,11 +33,22 @@ function ($mixed) {
 	assertType('mixed', $value);
 };
 
-function(string $json): void {
+function ($mixed, $asArray) {
+	$value = json_decode($mixed, $asArray);
+	assertType('mixed', $value);
+};
+
+function(string $json, ?bool $asArray): void {
 	/** @var '{}'|'null' $json */
 	$value = json_decode($json);
 	assertType('stdClass|null', $value);
 
 	$value = json_decode($json, true);
 	assertType('array{}|null', $value);
+
+	$value = json_decode($json, $asArray);
+	assertType('array{}|stdClass|null', $value);
+
+	$value = json_decode($json, 'foo');
+	assertType('stdClass|null', $value);
 };


### PR DESCRIPTION
Hope this is OK, I just cloned this rule for https://github.com/thecodingmachine/phpstan-safe-rule/pull/61 and found these deprecated checks.