### PR TITLE
Implements BackedEnumFromDynamicStaticMethodThrowTypeExtension

### DIFF
--- a/src/Type/Php/BackedEnumFromDynamicStaticMethodThrowTypeExtension.php
+++ b/src/Type/Php/BackedEnumFromDynamicStaticMethodThrowTypeExtension.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VoidType;
+use function count;
+
+#[AutowiredService]
+final class BackedEnumFromDynamicStaticMethodThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'from'
+			&& $methodReflection->getDeclaringClass()->isBackedEnum();
+	}
+
+	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+	{
+		$arguments = $methodCall->getArgs();
+		if (count($arguments) < 1) {
+			return $methodReflection->getThrowType();
+		}
+
+		$valueType = $scope->getType($arguments[0]->value);
+		if (!$valueType->isConstantScalarValue()->yes()) {
+			return $methodReflection->getThrowType();
+		}
+
+		$enumCases = $methodReflection->getDeclaringClass()->getEnumCases();
+
+		$backingValueTypes = [];
+		foreach ($enumCases as $enumCase) {
+			if ($enumCase->getBackingValueType() === null) {
+				return $methodReflection->getThrowType();
+			}
+
+			$backingValueTypes[] = $enumCase->getBackingValueType();
+		}
+
+		$backingValueType = TypeCombinator::union(...$backingValueTypes);
+		if (!$backingValueType->isSuperTypeOf($valueType)->yes()) {
+			return $methodReflection->getThrowType();
+		}
+
+		return new VoidType();
+	}
+
+}

--- a/tests/PHPStan/Rules/Exceptions/MissingCheckedExceptionInMethodThrowsRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/MissingCheckedExceptionInMethodThrowsRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Exceptions;
 use PHPStan\Rules\Rule;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use function sprintf;
 use const PHP_VERSION_ID;
 
@@ -68,6 +69,29 @@ class MissingCheckedExceptionInMethodThrowsRuleTest extends RuleTestCase
 			];
 		}
 		$this->analyse([__DIR__ . '/data/missing-exception-method-throws.php'], $errors);
+	}
+
+	#[RequiresPhp('>= 8.1')]
+	public function testBug13297(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13297.php'], [
+			[
+				"Method Bug13297\HelloWorld::sayHello3() throws checked exception ValueError but it's missing from the PHPDoc @throws tag.",
+				25,
+			],
+			[
+				"Method Bug13297\HelloWorld::sayHello3() throws checked exception TypeError but it's missing from the PHPDoc @throws tag.",
+				25,
+			],
+			[
+				"Method Bug13297\HelloWorld::sayHello4() throws checked exception ValueError but it's missing from the PHPDoc @throws tag.",
+				31,
+			],
+			[
+				"Method Bug13297\HelloWorld::sayHello4() throws checked exception TypeError but it's missing from the PHPDoc @throws tag.",
+				31,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Exceptions/data/bug-13297.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-13297.php
@@ -1,0 +1,33 @@
+<?php // lint >= 8.1
+
+namespace Bug13297;
+
+enum Foo: int {
+	case A = 1;
+	case B = 2;
+}
+
+class HelloWorld
+{
+	/** @param value-of<Foo> $int */
+	public function sayHello(int $int): void
+	{
+		Foo::from($int);
+	}
+
+	public function sayHello2(): void
+	{
+		Foo::from(1);
+	}
+
+	public function sayHello3(int $int): void
+	{
+		Foo::from($int);
+	}
+
+	/** @param 1|2|3 $int */
+	public function sayHello4(int $int): void
+	{
+		Foo::from($int);
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13297

Currently, even doing a simple `Enum::from(1)` where `1` is a value valid, reports missing `@throws` phpdoc.