### PR TITLE
fix bug 13292 (Invalid UTF-8)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,9 @@
 			],
 			"react/http": [
 				"patches/Sender.patch"
+			],
+			"symfony/console": [
+				"patches/OutputFormatter.patch"
 			]
 		}
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1864a8c99d0aaeef9b86b09034862603",
+    "content-hash": "7ae4c46e6b8ec4f1410bb8cd33167642",
     "packages": [
         {
             "name": "clue/ndjson-react",

--- a/patches/OutputFormatter.patch
+++ b/patches/OutputFormatter.patch
@@ -1,0 +1,70 @@
+--- Formatter/OutputFormatter.php
++++ Formatter/OutputFormatter.php
+@@ -12,6 +12,7 @@
+ namespace Symfony\Component\Console\Formatter;
+
+ use Symfony\Component\Console\Exception\InvalidArgumentException;
++use Symfony\Component\Console\Helper\Helper;
+
+ use function Symfony\Component\String\b;
+
+@@ -160,9 +161,11 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+                 continue;
+             }
+
++            // convert byte position to character position.
++            $pos = Helper::length(substr($message, 0, $pos));
+             // add the text up to the next tag
+-            $output .= $this->applyCurrentStyle(substr($message, $offset, $pos - $offset), $output, $width, $currentLineLength);
+-            $offset = $pos + \strlen($text);
++            $output .= $this->applyCurrentStyle(Helper::substr($message, $offset, $pos - $offset), $output, $width, $currentLineLength);
++            $offset = $pos + Helper::length($text);
+
+             // opening tag?
+             if ($open = '/' != $text[1]) {
+@@ -183,7 +186,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+             }
+         }
+
+-        $output .= $this->applyCurrentStyle(substr($message, $offset), $output, $width, $currentLineLength);
++        $output .= $this->applyCurrentStyle(Helper::substr($message, $offset), $output, $width, $currentLineLength);
+
+         return strtr($output, ["\0" => '\\', '\\<' => '<', '\\>' => '>']);
+     }
+@@ -253,8 +256,8 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+         }
+
+         if ($currentLineLength) {
+-            $prefix = substr($text, 0, $i = $width - $currentLineLength)."\n";
+-            $text = substr($text, $i);
++            $prefix = Helper::substr($text, 0, $i = $width - $currentLineLength)."\n";
++            $text = Helper::substr($text, $i);
+         } else {
+             $prefix = '';
+         }
+@@ -270,7 +273,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+         $lines = explode("\n", $text);
+
+         foreach ($lines as $line) {
+-            $currentLineLength += \strlen($line);
++            $currentLineLength += Helper::length($line);
+             if ($width <= $currentLineLength) {
+                 $currentLineLength = 0;
+             }
+--- Helper/Helper.php
++++ Helper/Helper.php
+@@ -100,6 +100,14 @@ abstract class Helper implements HelperInterface
+     {
+         $string ?? $string = '';
+
++        if (preg_match('//u', $string)) {
++            $result = grapheme_substr((new UnicodeString($string))->toString(), $from, $length);
++
++            return false === $result
++                ? ''
++                : $result;
++        }
++
+         if (false === $encoding = mb_detect_encoding($string, null, true)) {
+             return substr($string, $from, $length);
+         }

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -320,6 +320,36 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		self::expectNotToPerformAssertions();
 	}
 
+	public function testBug13292(): void
+	{
+		putenv('COLUMNS=200');
+		$formatter = $this->createErrorFormatter(null);
+		$formatter->formatErrors(
+			new AnalysisResult(
+				[
+					new Error(
+						'Parameter #1 $arrayabc of method Abcdefghijklmnopqrstuvwxyzabcdefghijk::translateAbcdefgh() expects array{status: int, error: string, date?: string}, non-empty-array<mixed, mixed> given.',
+						'Foo.php',
+						5,
+						identifier: 'argument.type',
+					),
+				],
+				[],
+				[],
+				[],
+				[],
+				false,
+				null,
+				true,
+				0,
+				false,
+				[],
+			),
+			$this->getOutput(),
+		);
+		self::expectNotToPerformAssertions();
+	}
+
 	private function createErrorFormatter(?string $editorUrl, ?string $editorUrlTitle = null): TableErrorFormatter
 	{
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/13292

The patch is from https://github.com/symfony/symfony/pull/61242 rebased onto symfony/console 5.4. The PR contains a BC break (not relevant for PHPStan), so I'm not sure whether they'll accept it. And since PHPStan uses v5.4, it wouldn't get the fix anyway.