### PR TITLE
Fix InvalidComparisonOperationRule for UnionType

### DIFF
--- a/src/Rules/Operators/InvalidComparisonOperationRule.php
+++ b/src/Rules/Operators/InvalidComparisonOperationRule.php
@@ -62,7 +62,7 @@ final class InvalidComparisonOperationRule implements Rule
 
 		$isLeftNumberType = $this->isNumberType($scope, $node->left);
 		$isRightNumberType = $this->isNumberType($scope, $node->right);
-		if (($isLeftNumberType && $isRightNumberType) || (!$isLeftNumberType && !$isRightNumberType)) {
+		if ($isLeftNumberType === $isRightNumberType) {
 			return [];
 		}
 

--- a/src/Rules/Operators/InvalidComparisonOperationRule.php
+++ b/src/Rules/Operators/InvalidComparisonOperationRule.php
@@ -12,13 +12,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\BenevolentUnionType;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function get_class;
@@ -59,7 +60,9 @@ final class InvalidComparisonOperationRule implements Rule
 			return [];
 		}
 
-		if ($this->isNumberType($scope, $node->left) && $this->isNumberType($scope, $node->right)) {
+		$isLeftNumberType = $this->isNumberType($scope, $node->left);
+		$isRightNumberType = $this->isNumberType($scope, $node->right);
+		if (($isLeftNumberType && $isRightNumberType) || (!$isLeftNumberType && !$isRightNumberType)) {
 			return [];
 		}
 
@@ -80,10 +83,10 @@ final class InvalidComparisonOperationRule implements Rule
 		}
 
 		if (
-			($this->isNumberType($scope, $node->left) && (
+			($isLeftNumberType && (
 				$this->isPossiblyNullableObjectType($scope, $node->right) || $this->isPossiblyNullableArrayType($scope, $node->right)
 			))
-			|| ($this->isNumberType($scope, $node->right) && (
+			|| ($isRightNumberType && (
 				$this->isPossiblyNullableObjectType($scope, $node->left) || $this->isPossiblyNullableArrayType($scope, $node->left)
 			))
 		) {
@@ -113,45 +116,18 @@ final class InvalidComparisonOperationRule implements Rule
 
 	private function isPossiblyNullableObjectType(Scope $scope, Node\Expr $expr): bool
 	{
-		$acceptedType = new ObjectWithoutClassType();
+		$type = $scope->getType($expr);
+		$acceptedType = new UnionType([new ObjectWithoutClassType(), new NullType()]);
 
-		$type = $this->ruleLevelHelper->findTypeToCheck(
-			$scope,
-			$expr,
-			'',
-			static fn (Type $type): bool => $acceptedType->isSuperTypeOf($type)->yes(),
-		)->getType();
-
-		if ($type instanceof ErrorType) {
-			return false;
-		}
-
-		if (TypeCombinator::containsNull($type) && !$type->isNull()->yes()) {
-			$type = TypeCombinator::removeNull($type);
-		}
-
-		$isSuperType = $acceptedType->isSuperTypeOf($type);
-		if ($type instanceof BenevolentUnionType) {
-			return !$isSuperType->no();
-		}
-
-		return $isSuperType->yes();
+		return !$type->isNull()->yes() && $acceptedType->isSuperTypeOf($type)->yes();
 	}
 
 	private function isPossiblyNullableArrayType(Scope $scope, Node\Expr $expr): bool
 	{
-		$type = $this->ruleLevelHelper->findTypeToCheck(
-			$scope,
-			$expr,
-			'',
-			static fn (Type $type): bool => $type->isArray()->yes(),
-		)->getType();
+		$type = $scope->getType($expr);
+		$acceptedType = new UnionType([new ArrayType(new MixedType(), new MixedType()), new NullType()]);
 
-		if (TypeCombinator::containsNull($type) && !$type->isNull()->yes()) {
-			$type = TypeCombinator::removeNull($type);
-		}
-
-		return !($type instanceof ErrorType) && $type->isArray()->yes();
+		return !$type->isNull()->yes() && $acceptedType->isSuperTypeOf($type)->yes();
 	}
 
 	/** @return list<IdentifierRuleError> */

--- a/tests/PHPStan/Rules/Operators/InvalidComparisonOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidComparisonOperationRuleTest.php
@@ -14,10 +14,12 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 class InvalidComparisonOperationRuleTest extends RuleTestCase
 {
 
+	private bool $checkUnion = true;
+
 	protected function getRule(): Rule
 	{
 		return new InvalidComparisonOperationRule(
-			new RuleLevelHelper(self::createReflectionProvider(), true, false, true, false, false, false, true),
+			new RuleLevelHelper(self::createReflectionProvider(), true, false, $this->checkUnion, false, false, false, true),
 			$this->getContainer()->getByType(OperatorTypeSpecifyingExtensionRegistryProvider::class),
 			true,
 		);
@@ -164,6 +166,21 @@ class InvalidComparisonOperationRuleTest extends RuleTestCase
 			[
 				'Comparison operation "==" between stdClass|null and int results in an error.',
 				12,
+			],
+		]);
+	}
+
+	public function testBug3364(): void
+	{
+		$this->checkUnion = false;
+		$this->analyse([__DIR__ . '/data/bug-3364.php'], [
+			[
+				'Comparison operation "!=" between array<int|string>|null and 1 results in an error.',
+				18,
+			],
+			[
+				'Comparison operation "!=" between object|null and 1 results in an error.',
+				26,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Operators/data/bug-3364.php
+++ b/tests/PHPStan/Rules/Operators/data/bug-3364.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3364;
+
+class HelloWorld
+{
+	/**
+	 * @param string|array<int|string>|null $value
+	 */
+	public function transform($value) {
+		$value != 1;
+	}
+
+	/**
+	 * @param array<int|string>|null $value
+	 */
+	public function transform2($value) {
+		$value != 1;
+	}
+
+
+	/**
+	 * @param object|null $value
+	 */
+	public function transform3($value) {
+		$value != 1;
+	}
+
+	/**
+	 * @param array<int|string>|object $value
+	 */
+	public function transform4($value) {
+		$value != 1;
+	}
+
+	/**
+	 * @param null $value
+	 */
+	public function transform5($value) {
+		$value != 1;
+	}
+}


### PR DESCRIPTION
I'm not sure about the purpose of the InvalidComparisonOperationRule which seams to forbid comparison between number and object or number and arrays. Technically something like `$int == $array` is supported by php (and 0 == [] for instance).
Maybe the message 
```
Comparison operation "!=" between array and 0 results in an error.
```
should be improved, but that's another topic.

Looking at the implementation, both `isPossiblyNullableObjectType` and `isPossiblyNullableArrayType` shouldn't use the RuleLevelHelper, because it will removed non-array/non-object on lower level and this is the reason why an error happen on level 6 (and then disappear in level 7).

Finally, I notice that currently a comparison between `int` and `object|array` is not reported.
This is easy to fix, but since I dunno the whole purpose of this rule, I prefer to ask you first @ondrejmirtes if I should fix it too.

Closes https://github.com/phpstan/phpstan/issues/3364