### PR TITLE
Ignore PHPUnit cache-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 /tests/PHPStan/Reflection/data/golden/
 tmp/.memory_limit
 e2e/bashunit
-.phpunit.cache/test-results

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /tests/PHPStan/Reflection/data/golden/
 tmp/.memory_limit
 e2e/bashunit
+.phpunit.cache/test-results

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/bootstrap.php" cacheResult="false" colors="true" executionOrder="random" failOnRisky="true" failOnWarning="true" failOnEmptyTestSuite="true" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" beStrictAboutCoverageMetadata="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="tests/bootstrap.php" cacheResult="false" colors="true" executionOrder="random" failOnRisky="true" failOnWarning="true" failOnEmptyTestSuite="true" beStrictAboutChangesToGlobalState="true" beStrictAboutOutputDuringTests="true" cacheDirectory="tmp/.phpunit.cache" beStrictAboutCoverageMetadata="true">
   <testsuites>
     <testsuite name="PHPStan">
       <directory suffix="Test.php">tests/PHPStan</directory>


### PR DESCRIPTION
when running phpunit with `--cache-result`, e.g.

`vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php --cache-result --order-by=defects,random --stop-on-failure`

it creates a result-cache file.

---

lets make sure this file is ignored and not mistakenly committed into the codebase