### PR TITLE
fix unnecessary wrapping in TableErrorFormatter

### DIFF
--- a/patches/OutputFormatter.patch
+++ b/patches/OutputFormatter.patch
@@ -31,23 +31,37 @@
 
          return strtr($output, ["\0" => '\\', '\\<' => '<', '\\>' => '>']);
      }
-@@ -253,8 +256,8 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+@@ -253,8 +256,20 @@ class OutputFormatter implements WrappableOutputFormatterInterface
          }
 
          if ($currentLineLength) {
 -            $prefix = substr($text, 0, $i = $width - $currentLineLength)."\n";
 -            $text = substr($text, $i);
-+            $prefix = Helper::substr($text, 0, $i = $width - $currentLineLength)."\n";
-+            $text = Helper::substr($text, $i);
++            $lines = explode("\n", $text, 2);
++            $prefix = Helper::substr($lines[0], 0, $i = $width - $currentLineLength)."\n";
++            $text = Helper::substr($lines[0], $i);
++
++            if (isset($lines[1])) {
++                // $prefix may contain the full first line in which the \n is already a part of $prefix.
++                if ('' !== $text) {
++                    $text .= "\n";
++                }
++
++                $text .= $lines[1];
++            }
++
++            unset($lines);
          } else {
              $prefix = '';
          }
-@@ -270,7 +273,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+@@ -269,8 +284,8 @@ class OutputFormatter implements WrappableOutputFormatterInterface
+
          $lines = explode("\n", $text);
 
-         foreach ($lines as $line) {
+-        foreach ($lines as $line) {
 -            $currentLineLength += \strlen($line);
-+            $currentLineLength += Helper::length($line);
++        foreach ($lines as $i => $line) {
++            $currentLineLength = 0 === $i ? $currentLineLength + Helper::length($line) : Helper::length($line);
              if ($width <= $currentLineLength) {
                  $currentLineLength = 0;
              }

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -350,6 +350,51 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		self::expectNotToPerformAssertions();
 	}
 
+	public function testBug13317(): void
+	{
+		putenv('COLUMNS=170');
+		$formatter = $this->createErrorFormatter(null);
+		$formatter->formatErrors(
+			new AnalysisResult(
+				[
+					new Error(
+						'Property bla::$error_params (non-empty-list<string>|null) is never assigned non-empty-list<string> so it can be removed from the property type.',
+						'bla.php',
+						6,
+						identifier: 'property.unusedType',
+					),
+				],
+				[],
+				[],
+				[],
+				[],
+				false,
+				null,
+				true,
+				0,
+				false,
+				[],
+			),
+			$this->getOutput(),
+		);
+		$this->assertSame(
+			<<<'TABLE'
+ ------ -------------------------------------------------------------------------------------------------------------------------------------------------
+  Line   bla.php
+ ------ -------------------------------------------------------------------------------------------------------------------------------------------------
+  6      Property bla::$error_params (non-empty-list<string>|null) is never assigned non-empty-list<string> so it can be removed from the property type.
+         🪪  property.unusedType
+ ------ -------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+ [ERROR] Found 1 error
+
+
+TABLE,
+			$this->getOutputContent(),
+		);
+	}
+
 	private function createErrorFormatter(?string $editorUrl, ?string $editorUrlTitle = null): TableErrorFormatter
 	{
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/13317

The change was submitted to symfony in https://github.com/symfony/symfony/pull/61268.

This time I tested the changes with a large project that I have available (~15k PHPStan errors) in two terminal sizes (94 and 382). And I did found one more regressions (first one is with 2.1.18 and the second one is with this PR, don't mind the :pencil2: - I'm using spaces for the editor link):

```
  87     Access to an undefined property object::$id.                                          
         🪪  property.notFound                                                                 
         💡  Learn more:                                                                       
            https://phpstan.org/blog/solving-phpstan-access-to-undefined-property              
         ✏️                  


  87     Access to an undefined property object::$id.                                         
         🪪  property.notFound                                                                
         💡  Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-propert  
         y                                                                                    
         ✏️     
```

As you can see the link is broken (i.e. when I click it it goes to the clipped URL) at this particular size (as well as any smaller size). Removing `<fg=cyan>` from it would fix the issue. Alternatively, it could be shortened. What do you think? I'm not particularly eager to continue fixing more symfony/console issues until the previous PRs are accepted. :sweat_smile: 