### PR TITLE
Add non regression test for 3474

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-3474.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3474.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug3474;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param mixed[] $a
+ */
+function acceptsArray(array $a) : void{
+
+}
+
+/**
+ * @param mixed[] $a
+ */
+function dummy(array $a) : void{
+	if(!is_array($a["test"])){
+		throw new \RuntimeException("oops");
+	}
+
+	assertType('array<mixed, mixed>', $a['test']);
+	assertType('array<mixed, mixed>', $a["test"]);
+
+	acceptsArray($a['test']);
+}


### PR DESCRIPTION
Seems like it's correctly normalized since both single quote and double quote have the correct type.

Closes https://github.com/phpstan/phpstan/issues/3474