### PR TITLE
Add non regression test for 3616

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -307,6 +307,11 @@ class CallCallablesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9614.php'], []);
 	}
 
+	public function testBug3616(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-3616.php'], []);
+	}
+
 	public function testBug10814(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-10814.php'], [

--- a/tests/PHPStan/Rules/Functions/data/bug-3616.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-3616.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3616;
+
+class Factory {
+	public static function a(): void { echo 'A'; }
+	public static function b(): void { echo 'B'; }
+}
+
+class HelloWorld
+{
+	/** @var array<string, callable():void> */
+	const FACTORIES = [
+		'a' => [Factory::class, 'a'],
+		'b' => [Factory::class, 'b']
+	];
+
+	public function withLiteral(): void
+	{
+		(self::FACTORIES['a'])();
+	}
+
+	public function withVariable(string $id): void
+	{
+		if (!isset(self::FACTORIES[$id])) {
+			return;
+		}
+
+		(self::FACTORIES[$id])();
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-3616.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-3616.php
@@ -29,3 +29,25 @@ class HelloWorld
 		(self::FACTORIES[$id])();
 	}
 }
+
+class HelloWorld2
+{
+	const FACTORIES = [
+		'a' => [Factory::class, 'a'],
+		'b' => [Factory::class, 'b']
+	];
+
+	public function withLiteral(): void
+	{
+		(self::FACTORIES['a'])();
+	}
+
+	public function withVariable(string $id): void
+	{
+		if (!isset(self::FACTORIES[$id])) {
+			return;
+		}
+
+		(self::FACTORIES[$id])();
+	}
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/3616

There is no error on https://phpstan.org/r/cb3fafd4-7c39-47c9-ac6a-972d110b47d5
with and without the phpdoc `/** @var array<string, callable():void> */`.
- https://phpstan.org/r/7db4d2c7-2a51-4ee2-a553-89ad2b357397
- https://phpstan.org/r/34eb20b5-0605-4427-b80c-c84dc880ad09