### PR TITLE
Add non regression test for 3761

### DIFF
--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1001,6 +1001,11 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10884.php'], []);
 	}
 
+	public function testBug3761(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-3761.php'], []);
+	}
+
 	public function testBug13208(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-13208.php'], []);

--- a/tests/PHPStan/Rules/Comparison/data/bug-3761.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3761.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3761;
+
+class NamedTag{
+	public function getValue() : int{
+		return 1;
+	}
+}
+
+class SubclassOfNamedTag extends NamedTag{}
+
+class OtherSubclassOfNamedTag extends NamedTag{}
+
+class HelloWorld
+{
+	public function getTag() : ?NamedTag{
+		return new SubclassOfNamedTag();
+	}
+
+	/**
+	 * @phpstan-param class-string<NamedTag> $class
+	 */
+	public function getTagValue(string $class = NamedTag::class) : int{
+		$tag = $this->getTag();
+		if($tag instanceof $class){
+			return $tag->getValue();
+		}
+
+		throw new \RuntimeException(($tag === null ? "Missing" : get_class($tag)));
+	}
+}
+
+(new HelloWorld())->getTagValue(OtherSubclassOfNamedTag::class); //runtime exception: SubclassOfNamedTag


### PR DESCRIPTION
Rules about unreachable branch was removed in
https://github.com/phpstan/phpstan-src/compare/7d74a638011774d9e59aa1f9472c39c00182365c...cc7ff8b217021402dcbe817f7002b29a48722811

The error doesn't exists anymore 
https://phpstan.org/r/788cdf82-69e5-450b-8851-f475793aadcc

I added the test regression to ensure we won't get the following error
https://phpstan.org/r/b888b1ec-063b-49dc-8db8-daa1a0495200

Closes https://github.com/phpstan/phpstan/issues/3761