### PR TITLE
Add non regression test for 4993

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -2393,7 +2393,7 @@ return [
 'ffmpeg_movie::hasAudio' => ['bool'],
 'ffmpeg_movie::hasVideo' => ['bool'],
 'fgetc' => ['string|false', 'fp'=>'resource'],
-'fgetcsv' => ['list<string>|array{0: null}|false|null', 'fp'=>'resource', 'length='=>'0|positive-int|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'fgetcsv' => ['non-empty-list<string>|array{0: null}|false|null', 'fp'=>'resource', 'length='=>'0|positive-int|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'fgets' => ['string|false', 'fp'=>'resource', 'length='=>'0|positive-int'],
 'fgetss' => ['string|false', 'fp'=>'resource', 'length='=>'0|positive-int', 'allowable_tags='=>'string'],
 'file' => ['list<string>|false', 'filename'=>'string', 'flags='=>'int-mask<FILE_USE_INCLUDE_PATH|FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES|FILE_NO_DEFAULT_CONTEXT>', 'context='=>'resource'],
@@ -9966,7 +9966,7 @@ return [
 'SplFileObject::fflush' => ['bool'],
 'SplFileObject::fgetc' => ['string|false'],
 // Do not believe https://www.php.net/manual/en/splfileobject.fgetcsv#refsect1-splfileobject.fgetcsv-returnvalues
-'SplFileObject::fgetcsv' => ['list<string>|array{0: null}|false|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+'SplFileObject::fgetcsv' => ['non-empty-list<string>|array{0: null}|false|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 'SplFileObject::fgets' => ['string'],
 'SplFileObject::fgetss' => ['string|false', 'allowable_tags='=>'string'],
 'SplFileObject::flock' => ['bool', 'operation'=>'int-mask<LOCK_SH, LOCK_EX, LOCK_UN, LOCK_NB>', '&w_wouldblock='=>'0|1'],

--- a/resources/functionMap_php80delta.php
+++ b/resources/functionMap_php80delta.php
@@ -46,7 +46,7 @@ return [
 		'error_log' => ['bool', 'message'=>'string', 'message_type='=>'0|1|3|4', 'destination='=>'string', 'extra_headers='=>'string'],
 		'explode' => ['list<string>', 'separator'=>'non-empty-string', 'str'=>'string', 'limit='=>'int'],
 		'fdiv' => ['float', 'dividend'=>'float', 'divisor'=>'float'],
-		'fgetcsv' => ['list<string>|array{0: null}|false', 'fp'=>'resource', 'length='=>'0|positive-int|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
+		'fgetcsv' => ['non-empty-list<string>|array{0: null}|false', 'fp'=>'resource', 'length='=>'0|positive-int|null', 'delimiter='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
 		'filter_input' => ['mixed', 'type'=>'INPUT_GET|INPUT_POST|INPUT_COOKIE|INPUT_SERVER|INPUT_ENV', 'variable_name'=>'string', 'filter='=>'int', 'options='=>'array|int'],
 		'filter_input_array' => ['array|false|null', 'type'=>'INPUT_GET|INPUT_POST|INPUT_COOKIE|INPUT_SERVER|INPUT_ENV', 'definition='=>'int|array', 'add_empty='=>'bool'],
 		'floor' => ['float', 'number'=>'float'],

--- a/tests/PHPStan/Analyser/nsrt/fgetcsv-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/fgetcsv-php7.php
@@ -8,5 +8,5 @@ use function PHPStan\Testing\assertType;
 
 function test($resource): void
 {
-	assertType('list<string|null>|false|null', fgetcsv($resource)); // nullable when invalid argument is given (https://3v4l.org/4WmR5#v7.4.30)
+	assertType('non-empty-list<string|null>|false|null', fgetcsv($resource)); // nullable when invalid argument is given (https://3v4l.org/4WmR5#v7.4.30)
 }

--- a/tests/PHPStan/Analyser/nsrt/fgetcsv-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/fgetcsv-php8.php
@@ -8,5 +8,5 @@ use function PHPStan\Testing\assertType;
 
 function test($resource): void
 {
-	assertType('list<string|null>|false', fgetcsv($resource));
+	assertType('non-empty-list<string|null>|false', fgetcsv($resource));
 }

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -470,7 +470,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$errors = [];
 		if (PHP_VERSION_ID >= 80000) {
 			$errors[] = [
-				'Strict comparison using === between list<string|null> and null will always evaluate to false.',
+				'Strict comparison using === between non-empty-list<string|null> and null will always evaluate to false.',
 				11,
 			];
 		}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -465,6 +465,19 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7684.php'], []);
 	}
 
+	public function testBug4993(): void
+	{
+		$errors = [];
+		if (PHP_VERSION_ID >= 80000) {
+			$errors[] = [
+				'Strict comparison using === between list<string|null> and null will always evaluate to false.',
+				11,
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-4993.php'], $errors);
+	}
+
 	public function testBug6181(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-6181.php'], []);

--- a/tests/PHPStan/Rules/Comparison/data/bug-4993.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4993.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4993;
+
+$inputHandle = fopen('php://stdin','r');
+if ($inputHandle === false)
+{
+	exit(1);
+}
+$row = fgetcsv( $inputHandle );
+if ( $row === false || $row === NULL )
+{
+	exit(1);
+}


### PR DESCRIPTION
So the issue https://github.com/phpstan/phpstan/issues/4993 is unclear to me
- It ask for no error on https://phpstan.org/r/5d0dc8ed-59c6-4b31-90a8-9c8bb85705fa but
  - There is already no error on PHP < 8
  - On PHP 8+ the error about NULL is legit since it's not a possible value. cf (https://github.com/phpstan/phpstan-src/pull/3712)
  
Also the issue talk about the fact the returned array is supposed to be non-empty ; which seems true and supported by psalm https://psalm.dev/r/3176073f08 so I updated the definition.

So I think that
Closes https://github.com/phpstan/phpstan/issues/4993 