### PR TITLE
Allow 8.5 as PHP version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/reflection-golden-test.yml
+++ b/.github/workflows/reflection-golden-test.yml
@@ -67,6 +67,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
       - uses: Wandalen/wretry.action@v3.8.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,6 +80,7 @@ jobs:
         php-version:
           - "8.2"
           - "8.3"
+          - "8.4"
           - "8.5"
 
     steps:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,6 +34,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         operating-system: [ubuntu-latest, windows-latest]
 
     steps:
@@ -79,7 +80,7 @@ jobs:
         php-version:
           - "8.2"
           - "8.3"
-          - "8.4"
+          - "8.5"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
         operating-system: [ ubuntu-latest, windows-latest ]
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 build: cs tests phpstan
 
 tests: install-paratest
+	rm vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php
 	XDEBUG_MODE=off php tests/vendor/bin/paratest --runner WrapperRunner --no-coverage
 
 tests-integration: install-paratest

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 build: cs tests phpstan
 
 tests: install-paratest
-	rm vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php
 	XDEBUG_MODE=off php tests/vendor/bin/paratest --runner WrapperRunner --no-coverage
 
 tests-integration: install-paratest

--- a/composer.json
+++ b/composer.json
@@ -235,7 +235,7 @@
 	"prefer-stable": true,
 	"scripts": {
 		"post-install-cmd": [
-			"rm vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php"
+			"rm -f vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php"
 		]
 	},
 	"bin": [

--- a/composer.json
+++ b/composer.json
@@ -233,6 +233,11 @@
 	],
 	"minimum-stability": "dev",
 	"prefer-stable": true,
+	"scripts": {
+		"post-install-cmd": [
+			"rm vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php"
+		]
+	},
 	"bin": [
 		"bin/phpstan"
 	]

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -87,10 +87,10 @@ parametersSchema:
 		buffer: int()
 	])
 	phpVersion: schema(anyOf(
-		schema(int(), min(70100), max(80499)),
+		schema(int(), min(70100), max(80599)),
 		structure([
-			min: schema(int(), min(70100), max(80499)),
-			max: schema(int(), min(70100), max(80499))
+			min: schema(int(), min(70100), max(80599)),
+			max: schema(int(), min(70100), max(80599))
 		])
 	), nullable())
 	polluteScopeWithLoopInitialAssignments: bool()

--- a/e2e/composer-min-open-end-version/test.php
+++ b/e2e/composer-min-open-end-version/test.php
@@ -1,6 +1,6 @@
 <?php
 
-\PHPStan\Testing\assertType('int<80100, 80499>', PHP_VERSION_ID);
+\PHPStan\Testing\assertType('int<80100, 80599>', PHP_VERSION_ID);
 \PHPStan\Testing\assertType('8', PHP_MAJOR_VERSION);
-\PHPStan\Testing\assertType('int<1, 4>', PHP_MINOR_VERSION);
+\PHPStan\Testing\assertType('int<1, 5>', PHP_MINOR_VERSION);
 \PHPStan\Testing\assertType('int<0, max>', PHP_RELEASE_VERSION);

--- a/e2e/composer-min-version/test.php
+++ b/e2e/composer-min-version/test.php
@@ -1,6 +1,6 @@
 <?php
 
-\PHPStan\Testing\assertType('int<80100, 80499>', PHP_VERSION_ID);
+\PHPStan\Testing\assertType('int<80100, 80599>', PHP_VERSION_ID);
 \PHPStan\Testing\assertType('8', PHP_MAJOR_VERSION);
-\PHPStan\Testing\assertType('int<1, 4>', PHP_MINOR_VERSION);
+\PHPStan\Testing\assertType('int<1, 5>', PHP_MINOR_VERSION);
 \PHPStan\Testing\assertType('int<0, max>', PHP_RELEASE_VERSION);

--- a/e2e/composer-no-versions/test.php
+++ b/e2e/composer-no-versions/test.php
@@ -1,6 +1,6 @@
 <?php
 
-\PHPStan\Testing\assertType('int<50207, 80499>', PHP_VERSION_ID);
+\PHPStan\Testing\assertType('int<50207, 80599>', PHP_VERSION_ID);
 \PHPStan\Testing\assertType('int<5, 8>', PHP_MAJOR_VERSION);
 \PHPStan\Testing\assertType('int<0, max>', PHP_MINOR_VERSION);
 \PHPStan\Testing\assertType('int<0, max>', PHP_RELEASE_VERSION);

--- a/src/Php/PhpVersionFactory.php
+++ b/src/Php/PhpVersionFactory.php
@@ -13,7 +13,7 @@ final class PhpVersionFactory
 {
 
 	public const MIN_PHP_VERSION = 70100;
-	public const MAX_PHP_VERSION = 80499;
+	public const MAX_PHP_VERSION = 80599;
 	public const MAX_PHP5_VERSION = 50699;
 	public const MAX_PHP7_VERSION = 70499;
 

--- a/tests/PHPStan/Analyser/ScopePhpVersionTest.php
+++ b/tests/PHPStan/Analyser/ScopePhpVersionTest.php
@@ -15,11 +15,11 @@ class ScopePhpVersionTest extends TypeInferenceTestCase
 	{
 		return [
 			[
-				'int<80000, 80499>',
+				'int<80000, 80599>',
 				__DIR__ . '/data/scope-constants-global.php',
 			],
 			[
-				'int<80000, 80499>',
+				'int<80000, 80599>',
 				__DIR__ . '/data/scope-constants-namespace.php',
 			],
 		];

--- a/tests/PHPStan/Analyser/nsrt/predefined-constants.php
+++ b/tests/PHPStan/Analyser/nsrt/predefined-constants.php
@@ -7,7 +7,7 @@ assertType('non-falsy-string', PHP_VERSION);
 assertType('int<5, 8>', PHP_MAJOR_VERSION);
 assertType('int<0, max>', PHP_MINOR_VERSION);
 assertType('int<0, max>', PHP_RELEASE_VERSION);
-assertType('int<50207, 80499>', PHP_VERSION_ID);
+assertType('int<50207, 80599>', PHP_VERSION_ID);
 assertType('string', PHP_EXTRA_VERSION);
 assertType('0|1', PHP_ZTS);
 assertType('0|1', PHP_DEBUG);

--- a/tests/PHPStan/Php/PhpVersionFactoryTest.php
+++ b/tests/PHPStan/Php/PhpVersionFactoryTest.php
@@ -81,14 +81,20 @@ class PhpVersionFactoryTest extends TestCase
 			[
 				null,
 				'8.5',
-				80499,
-				'8.4.99',
+				80500,
+				'8.5',
 			],
 			[
 				null,
 				'8.0.95',
 				80095,
 				'8.0.95',
+			],
+			[
+				null,
+				'8.6',
+				80599,
+				'8.5.99',
 			],
 		];
 	}


### PR DESCRIPTION
Since the [update of `nikic/PHP-Parser`](https://github.com/phpstan/phpstan-src/commit/90f8b11d423e18ff00fd4927907230b22edebcee), PHPStan recognises PHP 8.5 constants (such as `T_PIPE` or `T_VOID_CAST`), so let's allow setting up 8.5 as the PHP version.