### PR TITLE
Exclude first-party stubs from validation

### DIFF
--- a/src/PhpDoc/DefaultStubFilesProvider.php
+++ b/src/PhpDoc/DefaultStubFilesProvider.php
@@ -10,7 +10,9 @@ use PHPStan\Internal\ComposerHelper;
 use function array_filter;
 use function array_map;
 use function array_values;
+use function dirname;
 use function str_contains;
+use function str_starts_with;
 
 #[AutowiredService(as: StubFilesProvider::class)]
 final class DefaultStubFilesProvider implements StubFilesProvider
@@ -60,7 +62,13 @@ final class DefaultStubFilesProvider implements StubFilesProvider
 			return $this->cachedProjectFiles;
 		}
 
+		$phpstanStubsDirectory = $this->fileHelper->normalizePath(dirname(dirname(__DIR__)) . '/stubs');
+
 		$filteredStubFiles = $this->getStubFiles();
+		$filteredStubFiles = array_filter(
+			$filteredStubFiles,
+			static fn (string $file): bool => !str_starts_with($file, $phpstanStubsDirectory)
+		);
 		foreach ($this->composerAutoloaderProjectPaths as $composerAutoloaderProjectPath) {
 			$composerConfig = ComposerHelper::getComposerConfig($composerAutoloaderProjectPath);
 			if ($composerConfig === null) {

--- a/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
+++ b/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
@@ -5,7 +5,9 @@ namespace PHPStan\PhpDoc;
 use Override;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
+use function dirname;
 use function sprintf;
+use const DIRECTORY_SEPARATOR;
 
 class DefaultStubFilesProviderTest extends PHPStanTestCase
 {
@@ -30,10 +32,15 @@ class DefaultStubFilesProviderTest extends PHPStanTestCase
 	public function testGetProjectStubFiles(): void
 	{
 		$thirdPartyStubFile = sprintf('%s/vendor/thirdpartyStub.stub', $this->currentWorkingDirectory);
-		$defaultStubFilesProvider = $this->createDefaultStubFilesProvider(['/projectStub.stub', $thirdPartyStubFile]);
+		$firstPartyStubFile = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'spl.stub';
+		$defaultStubFilesProvider = $this->createDefaultStubFilesProvider(['/projectStub.stub', $thirdPartyStubFile, $firstPartyStubFile]);
 		$projectStubFiles = $defaultStubFilesProvider->getProjectStubFiles();
 		$this->assertContains('/projectStub.stub', $projectStubFiles);
 		$this->assertNotContains($thirdPartyStubFile, $projectStubFiles);
+		$this->assertNotContains($firstPartyStubFile, $projectStubFiles);
+
+		$fileHelper = new FileHelper(__DIR__);
+		$this->assertNotContains($fileHelper->normalizePath($firstPartyStubFile), $projectStubFiles);
 	}
 
 	public function testGetProjectStubFilesWhenPathContainsWindowsSeparator(): void


### PR DESCRIPTION
Stub files from vendor directories aren't validated. But the stub files that ship with PHPstan itself weren't excluded, and they were hitting the `checkMissingOverrideMethodAttribute` check.

This didn't happen when PHPstan was installed through composer, since then the stub files happened to be in a vendor directory. But it did happen when PHPstan ran as a phar.

Resolves https://github.com/phpstan/phpstan/issues/11907.