### PR TITLE
Remove DomNode::ownerDocument stub

### DIFF
--- a/stubs/dom.stub
+++ b/stubs/dom.stub
@@ -49,9 +49,6 @@ class DOMElement extends DOMNode
 	/** @var DOMNamedNodeMap<DOMAttr> */
 	public $attributes;
 
-	/** @var DOMDocument */
-	public $ownerDocument;
-
 	/**
 	 * @param string $name
 	 * @return DOMNodeList<DOMElement>
@@ -98,48 +95,10 @@ class DOMXPath
 class DOMAttr extends DOMNode
 {
 
-	/** @var DOMDocument */
-	public $ownerDocument;
-
-}
-
-class DOMCharacterData
-{
-
-	/** @var DOMDocument */
-	public $ownerDocument;
-
-}
-
-class DOMDocumentType
-{
-
-	/** @var DOMDocument */
-	public $ownerDocument;
-
-}
-
-class DOMEntity
-{
-
-	/** @var DOMDocument */
-	public $ownerDocument;
-
-}
-
-class DOMNotation
-{
-
-	/** @var DOMDocument */
-	public $ownerDocument;
-
 }
 
 class DOMProcessingInstruction
 {
-
-	/** @var DOMDocument */
-	public $ownerDocument;
 
 	/**
 	 * @var string


### PR DESCRIPTION
1) This seems to still be nullable:
For instance https://3v4l.org/mMQj8#v8.4.11

2) According to https://github.com/phpstan/phpstan/issues/8837 this wasn't working anyway.

You also might want to close the issue https://github.com/phpstan/phpstan/issues/8837 since it asked to infer `DomElement::ownerDocument` as non nullable while the 3v4l example is showing it can be null.