### PR TITLE
Improve TypeCombinator::unionWithSubtractedType

### DIFF
--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -36,6 +36,7 @@ use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\SubstractableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
 use function get_class;
 use function sprintf;
@@ -47,6 +48,7 @@ class MixedType implements CompoundType, SubtractableType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonCompoundTypeTrait;
 	use NonGeneralizableTypeTrait;
+	use SubstractableTypeTrait;
 
 	private ?Type $subtractedType;
 
@@ -471,23 +473,9 @@ class MixedType implements CompoundType, SubtractableType
 		return $level->handle(
 			static fn (): string => 'mixed',
 			static fn (): string => 'mixed',
+			fn (): string => 'mixed' . $this->describeSubtractedType($this->subtractedType, $level),
 			function () use ($level): string {
-				$description = 'mixed';
-				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType
-						? sprintf('~(%s)', $this->subtractedType->describe($level))
-						: sprintf('~%s', $this->subtractedType->describe($level));
-				}
-
-				return $description;
-			},
-			function () use ($level): string {
-				$description = 'mixed';
-				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType
-						? sprintf('~(%s)', $this->subtractedType->describe($level))
-						: sprintf('~%s', $this->subtractedType->describe($level));
-				}
+				$description = 'mixed' . $this->describeSubtractedType($this->subtractedType, $level);
 
 				if ($this->isExplicitMixed) {
 					$description .= '=explicit';

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -46,6 +46,7 @@ use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
+use PHPStan\Type\Traits\SubstractableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
 use Stringable;
 use Throwable;
@@ -68,6 +69,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonGeneralizableTypeTrait;
+	use SubstractableTypeTrait;
 
 	private const EXTRA_OFFSET_CLASSES = [
 		'DOMNamedNodeMap', // Only read and existence
@@ -504,16 +506,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			return $reflectionProvider->getClassName($this->className);
 		};
 
-		$preciseWithSubtracted = function () use ($level): string {
-			$description = $this->className;
-			if ($this->subtractedType !== null) {
-				$description .= $this->subtractedType instanceof UnionType
-					? sprintf('~(%s)', $this->subtractedType->describe($level))
-					: sprintf('~%s', $this->subtractedType->describe($level));
-			}
-
-			return $description;
-		};
+		$preciseWithSubtracted = fn (): string => $this->className . $this->describeSubtractedType($this->subtractedType, $level);
 
 		return $level->handle(
 			$preciseNameCallback,
@@ -559,11 +552,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			$description .= '<' . implode(', ', $typeDescriptions) . '>';
 		}
 
-		if ($this->subtractedType !== null) {
-			$description .= $this->subtractedType instanceof UnionType
-				? sprintf('~(%s)', $this->subtractedType->describe(VerbosityLevel::cache()))
-				: sprintf('~%s', $this->subtractedType->describe(VerbosityLevel::cache()));
-		}
+		$description .= $this->describeSubtractedType($this->subtractedType, VerbosityLevel::cache());
 
 		$reflection = $this->classReflection;
 		if ($reflection !== null) {

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -7,8 +7,8 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
 use PHPStan\Type\Traits\ObjectTypeTrait;
+use PHPStan\Type\Traits\SubstractableTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
-use function sprintf;
 
 /** @api */
 class ObjectWithoutClassType implements SubtractableType
@@ -18,6 +18,7 @@ class ObjectWithoutClassType implements SubtractableType
 	use NonGenericTypeTrait;
 	use UndecidedComparisonTypeTrait;
 	use NonGeneralizableTypeTrait;
+	use SubstractableTypeTrait;
 
 	private ?Type $subtractedType;
 
@@ -120,16 +121,7 @@ class ObjectWithoutClassType implements SubtractableType
 		return $level->handle(
 			static fn (): string => 'object',
 			static fn (): string => 'object',
-			function () use ($level): string {
-				$description = 'object';
-				if ($this->subtractedType !== null) {
-					$description .= $this->subtractedType instanceof UnionType
-						? sprintf('~(%s)', $this->subtractedType->describe($level))
-						: sprintf('~%s', $this->subtractedType->describe($level));
-				}
-
-				return $description;
-			},
+			fn (): string => 'object' . $this->describeSubtractedType($this->subtractedType, $level),
 		);
 	}
 

--- a/src/Type/Traits/SubstractableTypeTrait.php
+++ b/src/Type/Traits/SubstractableTypeTrait.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Traits;
+
+use PHPStan\Type\SubtractableType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+trait SubstractableTypeTrait
+{
+
+	public function describeSubtractedType(?Type $subtractedType, VerbosityLevel $level): string
+	{
+		if ($subtractedType === null) {
+			return '';
+		}
+
+		if (
+			$subtractedType instanceof UnionType
+			|| ($subtractedType instanceof SubtractableType && $subtractedType->getSubtractedType() !== null)
+		) {
+			return sprintf('~(%s)', $subtractedType->describe($level));
+		}
+
+		return sprintf('~%s', $subtractedType->describe($level));
+	}
+
+}

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -540,6 +540,18 @@ final class TypeCombinator
 			return $type;
 		}
 
+		if ($subtractedType instanceof SubtractableType) {
+			$withoutSubtracted = $subtractedType->getTypeWithoutSubtractedType();
+			if ($withoutSubtracted->isSuperTypeOf($type)->yes()) {
+				$subtractedSubtractedType = $subtractedType->getSubtractedType();
+				if ($subtractedSubtractedType === null) {
+					return new NeverType();
+				}
+
+				return self::intersect($type, $subtractedSubtractedType);
+			}
+		}
+
 		if ($type instanceof SubtractableType) {
 			$subtractedType = $type->getSubtractedType() === null
 				? $subtractedType

--- a/tests/PHPStan/Analyser/nsrt/subtracted.php
+++ b/tests/PHPStan/Analyser/nsrt/subtracted.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Substracted;
+
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function sayHello(mixed $date, bool $foo): void
+	{
+		if(is_object($date)){
+
+		} else {
+			assertType('mixed~object', $date);
+
+			if ($foo) {
+				$date = new \stdClass();
+			}
+			assertType('mixed~object~stdClass', $date);
+
+			if (is_object($date)) {
+				assertType('stdClass', $date);
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/subtracted.php
+++ b/tests/PHPStan/Analyser/nsrt/subtracted.php
@@ -7,7 +7,11 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
-	public function sayHello(mixed $date, bool $foo): void
+	/**
+	 * @param mixed $date
+	 * @param bool $foo
+	 */
+	public function sayHello($date, $foo): void
 	{
 		if(is_object($date)){
 

--- a/tests/PHPStan/Analyser/nsrt/subtracted.php
+++ b/tests/PHPStan/Analyser/nsrt/subtracted.php
@@ -21,7 +21,7 @@ class HelloWorld
 			if ($foo) {
 				$date = new \stdClass();
 			}
-			assertType('mixed~object~stdClass', $date);
+			assertType('mixed~(object~stdClass)', $date);
 
 			if (is_object($date)) {
 				assertType('stdClass', $date);

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -1140,7 +1140,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 					new ObjectType('InvalidArgumentException'),
 				],
 				MixedType::class,
-				'mixed~Exception~InvalidArgumentException=implicit',
+				'mixed~(Exception~InvalidArgumentException)=implicit',
 			],
 			[
 				[

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -4143,6 +4143,14 @@ class TypeCombinatorTest extends PHPStanTestCase
 				ObjectWithoutClassType::class,
 				'object',
 			],
+			[
+				[
+					new MixedType(subtractedType: new ObjectWithoutClassType(new ObjectType('stdClass'))),
+					new ObjectWithoutClassType(),
+				],
+				ObjectType::class,
+				'stdClass',
+			],
 		];
 
 		if (PHP_VERSION_ID < 80100) {


### PR DESCRIPTION
While thinking about https://github.com/phpstan/phpstan/issues/12390 I just decovered the weird behavior
https://phpstan.org/r/0850c2cb-3c81-4451-b2f6-b570d1d41a30

I expect `mixed~object~stdclass & object` to be `stdClass`.