### PR TITLE
Fix array_column inference

### DIFF
--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -39,14 +39,10 @@ final class ArrayColumnHelper
 		}
 
 		$iterableValueType = $arrayType->getIterableValueType();
-		$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
+		[$returnValueType, $certainty] = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope);
 
-		if ($returnValueType === null) {
-			$returnValueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, true);
+		if (!$certainty->yes()) {
 			$iterableAtLeastOnce = TrinaryLogic::createMaybe();
-			if ($returnValueType === null) {
-				throw new ShouldNotHappenException();
-			}
 		}
 
 		return [$returnValueType, $iterableAtLeastOnce];
@@ -57,15 +53,12 @@ final class ArrayColumnHelper
 		if (!$indexType->isNull()->yes()) {
 			$iterableValueType = $arrayType->getIterableValueType();
 
-			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
-			if ($type !== null) {
+			[$type, $certainty] = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope);
+			if ($certainty->yes()) {
 				return $type;
 			}
 
-			$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
-			if ($type !== null) {
-				return TypeCombinator::union($type, new IntegerType());
-			}
+			return TypeCombinator::union($type, new IntegerType());
 		}
 
 		return new IntegerType();
@@ -96,8 +89,8 @@ final class ArrayColumnHelper
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 
 		foreach ($arrayType->getValueTypes() as $i => $iterableValueType) {
-			$valueType = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope, false);
-			if ($valueType === null) {
+			[$valueType, $certainty] = $this->getOffsetOrProperty($iterableValueType, $columnType, $scope);
+			if (!$certainty->yes()) {
 				return null;
 			}
 			if ($valueType instanceof NeverType) {
@@ -105,16 +98,11 @@ final class ArrayColumnHelper
 			}
 
 			if (!$indexType->isNull()->yes()) {
-				$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, false);
-				if ($type !== null) {
+				[$type, $certainty] = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope);
+				if ($certainty->yes()) {
 					$keyType = $type;
 				} else {
-					$type = $this->getOffsetOrProperty($iterableValueType, $indexType, $scope, true);
-					if ($type !== null) {
-						$keyType = TypeCombinator::union($type, new IntegerType());
-					} else {
-						$keyType = null;
-					}
+					$keyType = TypeCombinator::union($type, new IntegerType());
 				}
 			} else {
 				$keyType = null;
@@ -129,11 +117,14 @@ final class ArrayColumnHelper
 		return $builder->getArray();
 	}
 
-	private function getOffsetOrProperty(Type $type, Type $offsetOrProperty, Scope $scope, bool $allowMaybe): ?Type
+	/**
+	 * @return array{Type, TrinaryLogic}
+	 */
+	private function getOffsetOrProperty(Type $type, Type $offsetOrProperty, Scope $scope): array
 	{
 		$offsetIsNull = $offsetOrProperty->isNull();
 		if ($offsetIsNull->yes()) {
-			return $type;
+			return [$type, TrinaryLogic::createYes()];
 		}
 
 		$returnTypes = [];
@@ -145,13 +136,13 @@ final class ArrayColumnHelper
 		if (!$type->canAccessProperties()->no()) {
 			$propertyTypes = $offsetOrProperty->getConstantStrings();
 			if ($propertyTypes === []) {
-				return $allowMaybe ? new MixedType() : null;
+				return [new MixedType(), TrinaryLogic::createMaybe()];
 			}
 			foreach ($propertyTypes as $propertyType) {
 				$propertyName = $propertyType->getValue();
 				$hasProperty = $type->hasProperty($propertyName);
 				if ($hasProperty->maybe()) {
-					return $allowMaybe ? new MixedType() : null;
+					return [new MixedType(), TrinaryLogic::createMaybe()];
 				}
 				if (!$hasProperty->yes()) {
 					continue;
@@ -161,10 +152,11 @@ final class ArrayColumnHelper
 			}
 		}
 
+		$certainty = TrinaryLogic::createYes();
 		if ($type->isOffsetAccessible()->yes()) {
 			$hasOffset = $type->hasOffsetValueType($offsetOrProperty);
-			if (!$allowMaybe && $hasOffset->maybe()) {
-				return null;
+			if ($hasOffset->maybe()) {
+				$certainty = TrinaryLogic::createMaybe();
 			}
 			if (!$hasOffset->no()) {
 				$returnTypes[] = $type->getOffsetValueType($offsetOrProperty);
@@ -172,10 +164,10 @@ final class ArrayColumnHelper
 		}
 
 		if ($returnTypes === []) {
-			return new NeverType();
+			return [new NeverType(), TrinaryLogic::createYes()];
 		}
 
-		return TypeCombinator::union(...$returnTypes);
+		return [TypeCombinator::union(...$returnTypes), $certainty];
 	}
 
 	private function castToArrayKeyType(Type $type): Type

--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;

--- a/src/Type/Php/ArrayColumnHelper.php
+++ b/src/Type/Php/ArrayColumnHelper.php
@@ -145,7 +145,7 @@ final class ArrayColumnHelper
 		if (!$type->canAccessProperties()->no()) {
 			$propertyTypes = $offsetOrProperty->getConstantStrings();
 			if ($propertyTypes === []) {
-				return new MixedType();
+				return $allowMaybe ? new MixedType() : null;
 			}
 			foreach ($propertyTypes as $propertyType) {
 				$propertyName = $propertyType->getValue();

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -207,6 +207,13 @@ class EmptyRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12658.php'], []);
 	}
 
+	public function testBug10367(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10367.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.0')]
 	public function testIssetAfterRememberedConstructor(): void
 	{

--- a/tests/PHPStan/Rules/Variables/data/bug-10367.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-10367.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10367;
+
+final class PackingSlipPdf
+{
+	public function __construct(array $packingSlipItems, string $fullName)
+	{
+		if (empty($packingSlipItems)) {
+			error_log('$packingSlipItems is empty: check company: ' . $fullName);
+		} else {
+			$freightNumbers = array_column($packingSlipItems, 3);
+			if (empty($freightNumbers)) {
+				error_log('$freightNumbers is empty: check company: ' . $fullName);
+				error_log('$freightNumbers is empty: check dataset: ' . print_r($packingSlipItems[0], true));
+			} elseif (empty($freightNumbers[0])) {
+				error_log('$freightNumbers[0] is empty: check company: ' . $fullName);
+				error_log('$freightNumbers[0] is empty: check freigthnumbers: ' . print_r($freightNumbers, true));
+				error_log('$freightNumbers[0] is empty: check dataset: ' . print_r($packingSlipItems[0], true));
+			}
+		}
+	}
+}
+
+$testArray = [
+	[1 => 123, 2 => 413, 4 => 132],
+	[1 => 123, 2 => 413, 4 => 132],
+];
+
+$packingSlipPdf = new PackingSlipPdf($testArray, "TestName");


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/10367

Fix is the first commit https://github.com/phpstan/phpstan-src/pull/4201/commits/5e252bd06b7acf3c37ae7cefa5f2a1e2122ba739

Second commit is just a refacto to reduce the number of method calls https://github.com/phpstan/phpstan-src/pull/4201/commits/26476e034f688b32be8b73db7dcc044b195effd3

Since the method is almost always doing logic like
```
$type = $this->getOffsetOrProperty(...., false);
if ($type !== null) {
     return type;
} else {
     $type = $this->getOffsetOrProperty(...., true);
     // do things
}
```
It's better to directly return the type and the certainty and write
```
[$type, $certainty] = $this->getOffsetOrProperty(...., false);
if ($certainty->yes()) {
     return type;
} else {
     // do things
}
```