### PR TITLE
Move isOffsetAccessLegal to MaybeOffsetAccessibleTypeTrait

### DIFF
--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -111,11 +111,6 @@ class HasMethodType implements AccessoryType, CompoundType
 		return sprintf('hasMethod(%s)', $this->methodName);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function hasMethod(string $methodName): TrinaryLogic
 	{
 		if ($this->getCanonicalMethodName() === strtolower($methodName)) {

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -106,11 +106,6 @@ class HasPropertyType implements AccessoryType, CompoundType
 		return sprintf('hasProperty(%s)', $this->propertyName);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function hasProperty(string $propertyName): TrinaryLogic
 	{
 		if ($this->propertyName === $propertyName) {

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -340,11 +340,6 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function getTemplateTypeMap(): TemplateTypeMap
 	{
 		return $this->templateTypeMap;

--- a/src/Type/IterableType.php
+++ b/src/Type/IterableType.php
@@ -256,11 +256,6 @@ class IterableType implements CompoundType
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -420,11 +420,6 @@ class ObjectShapeType implements Type
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function getEnumCases(): array
 	{
 		return [];

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -134,11 +134,6 @@ class ObjectWithoutClassType implements SubtractableType
 		);
 	}
 
-	public function isOffsetAccessLegal(): TrinaryLogic
-	{
-		return TrinaryLogic::createMaybe();
-	}
-
 	public function getEnumCases(): array
 	{
 		return [];

--- a/src/Type/Traits/MaybeOffsetAccessibleTypeTrait.php
+++ b/src/Type/Traits/MaybeOffsetAccessibleTypeTrait.php
@@ -14,6 +14,11 @@ trait MaybeOffsetAccessibleTypeTrait
 		return TrinaryLogic::createMaybe();
 	}
 
+	public function isOffsetAccessLegal(): TrinaryLogic
+	{
+		return TrinaryLogic::createMaybe();
+	}
+
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe();


### PR DESCRIPTION
Is there a reason for not having this offset-related method in the MaybeOffsetAccessibleTypeTrait when all the implementation returns maybe (?)