### PR TITLE
Failng test: Trait error ignored with used class path fails with partial analysis

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -467,6 +467,21 @@ class AnalyserTest extends PHPStanTestCase
 		$this->assertNoErrors($result);
 	}
 
+	#[DataProvider('dataIgnoreErrorInTraitUsingClassFilePath')]
+	public function testIgnoreErrorInTraitUsingClassFilePathWithPartialAnalysis(string $pathToIgnore): void
+	{
+		$ignoreErrors = [
+			[
+				'message' => '#Fail\.#',
+				'path' => $pathToIgnore,
+			],
+		];
+		$result = $this->runAnalyser($ignoreErrors, true, [
+			__DIR__ . '/data/traits-ignore/Foo.php',
+		], true);
+		$this->assertNoErrors($result);
+	}
+
 	public function testIgnoredErrorMissingMessage(): void
 	{
 		$ignoreErrors = [


### PR DESCRIPTION
- The support for this ignore was added in https://github.com/phpstan/phpstan-src/commit/14f08c18dbfdd88105e1cafef64336961574a5a7
- Baseline generation uses class path