### PR TITLE
fix: place UniversalObjectCratesClassReflectionExtension last

### DIFF
--- a/conf/services.neon
+++ b/conf/services.neon
@@ -69,6 +69,11 @@ services:
 		class: PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
 
 	-
+		class: PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension
+		arguments:
+			classes: %universalObjectCratesClasses%
+
+	-
 		class: PHPStan\Reflection\Mixin\MixinMethodsClassReflectionExtension
 		arguments:
 			mixinExcludeClasses: %mixinExcludeClasses%

--- a/src/DependencyInjection/Reflection/LazyClassReflectionExtensionRegistryProvider.php
+++ b/src/DependencyInjection/Reflection/LazyClassReflectionExtensionRegistryProvider.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\Mixin\MixinMethodsClassReflectionExtension;
 use PHPStan\Reflection\Mixin\MixinPropertiesClassReflectionExtension;
 use PHPStan\Reflection\Php\PhpClassReflectionExtension;
 use PHPStan\Reflection\Php\Soap\SoapClientMethodsClassReflectionExtension;
+use PHPStan\Reflection\Php\UniversalObjectCratesClassReflectionExtension;
 use PHPStan\Reflection\RequireExtension\RequireExtendsMethodsClassReflectionExtension;
 use PHPStan\Reflection\RequireExtension\RequireExtendsPropertiesClassReflectionExtension;
 use function array_merge;
@@ -36,9 +37,10 @@ final class LazyClassReflectionExtensionRegistryProvider implements ClassReflect
 			$mixinMethodsClassReflectionExtension = $this->container->getByType(MixinMethodsClassReflectionExtension::class);
 			$mixinPropertiesClassReflectionExtension = $this->container->getByType(MixinPropertiesClassReflectionExtension::class);
 			$soapClientMethodsClassReflectionExtension = $this->container->getByType(SoapClientMethodsClassReflectionExtension::class);
+			$universalObjectCratesClassReflectionExtension = $this->container->getByType(UniversalObjectCratesClassReflectionExtension::class);
 
 			$this->registry = new ClassReflectionExtensionRegistry(
-				array_merge([$phpClassReflectionExtension], $this->container->getServicesByTag(BrokerFactory::PROPERTIES_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsPropertiesClassReflectionExtension, $mixinPropertiesClassReflectionExtension]),
+				array_merge([$phpClassReflectionExtension], $this->container->getServicesByTag(BrokerFactory::PROPERTIES_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsPropertiesClassReflectionExtension, $mixinPropertiesClassReflectionExtension, $universalObjectCratesClassReflectionExtension]),
 				array_merge([$phpClassReflectionExtension], $this->container->getServicesByTag(BrokerFactory::METHODS_CLASS_REFLECTION_EXTENSION_TAG), [$annotationsMethodsClassReflectionExtension, $mixinMethodsClassReflectionExtension, $soapClientMethodsClassReflectionExtension]),
 				$this->container->getServicesByTag(BrokerFactory::ALLOWED_SUB_TYPES_CLASS_REFLECTION_EXTENSION_TAG),
 				$this->container->getByType(RequireExtendsPropertiesClassReflectionExtension::class),

--- a/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
+++ b/src/Reflection/Php/UniversalObjectCratesClassReflectionExtension.php
@@ -2,8 +2,6 @@
 
 namespace PHPStan\Reflection\Php;
 
-use PHPStan\DependencyInjection\AutowiredParameter;
-use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
@@ -11,7 +9,6 @@ use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\MixedType;
 
-#[AutowiredService]
 final class UniversalObjectCratesClassReflectionExtension
 	implements PropertiesClassReflectionExtension
 {
@@ -21,7 +18,6 @@ final class UniversalObjectCratesClassReflectionExtension
 	 */
 	public function __construct(
 		private ReflectionProvider $reflectionProvider,
-		#[AutowiredParameter(ref: '%universalObjectCratesClasses%')]
 		private array $classes,
 		private AnnotationsPropertiesClassReflectionExtension $annotationClassReflection,
 	)

--- a/tests/PHPStan/Analyser/nsrt/bug-13342.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13342.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13342;
+
+use stdClass;
+use function PHPStan\Testing\assertType;
+
+class Mixin { public bool $test = true; }
+
+/** @mixin Mixin */
+#[\AllowDynamicProperties]
+class TestNormal {}
+
+/** @mixin Mixin */
+#[\AllowDynamicProperties]
+class TestUniversalObjectCrate extends stdClass {}
+
+function test(TestNormal $normal, TestUniversalObjectCrate $crate): void
+{
+	assertType('bool', $normal->test);
+	assertType('bool', $crate->test);
+}


### PR DESCRIPTION
Hello!

This moves the UniversalObjectCratesClassReflectionExtension to the very end of the extensions to give other extensions a chance to override.

Closes https://github.com/phpstan/phpstan/issues/13342

Thanks!