### PR TITLE
POC: Use SimultaneousTypeTraverser in RuleLevelHelper::transformAcceptedType

### DIFF
--- a/src/Parser/TypeTraverserInstanceofVisitor.php
+++ b/src/Parser/TypeTraverserInstanceofVisitor.php
@@ -13,6 +13,11 @@ final class TypeTraverserInstanceofVisitor extends NodeVisitorAbstract
 
 	public const ATTRIBUTE_NAME = 'insideTypeTraverserMap';
 
+	private const TYPE_TRAVERSER_CLASSES = [
+		'phpstan\\type\\typetraverser',
+		'phpstan\\type\\simultaneoustypetraverser',
+	];
+
 	private int $depth = 0;
 
 	#[Override]
@@ -33,7 +38,7 @@ final class TypeTraverserInstanceofVisitor extends NodeVisitorAbstract
 		if (
 			$node instanceof Node\Expr\StaticCall
 			&& $node->class instanceof Node\Name
-			&& $node->class->toLowerString() === 'phpstan\\type\\typetraverser'
+			&& \in_array($node->class->toLowerString(), self::TYPE_TRAVERSER_CLASSES, true)
 			&& $node->name instanceof Node\Identifier
 			&& $node->name->toLowerString() === 'map'
 		) {
@@ -49,7 +54,7 @@ final class TypeTraverserInstanceofVisitor extends NodeVisitorAbstract
 		if (
 			$node instanceof Node\Expr\StaticCall
 			&& $node->class instanceof Node\Name
-			&& $node->class->toLowerString() === 'phpstan\\type\\typetraverser'
+			&& \in_array($node->class->toLowerString(), self::TYPE_TRAVERSER_CLASSES, true)
 			&& $node->name instanceof Node\Identifier
 			&& $node->name->toLowerString() === 'map'
 		) {

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Type\BenevolentUnionType;
 use PHPStan\Type\CallableType;
@@ -16,6 +17,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\SimultaneousTypeTraverser;
 use PHPStan\Type\StrictMixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -87,15 +89,18 @@ final class RuleLevelHelper
 	private function transformAcceptedType(Type $acceptingType, Type $acceptedType): array
 	{
 		$checkForUnion = $this->checkUnionTypes;
-		$acceptedType = TypeTraverser::map($acceptedType, function (Type $acceptedType, callable $traverse) use ($acceptingType, &$checkForUnion): Type {
+		$acceptedType = SimultaneousTypeTraverser::map($acceptedType, $acceptingType, function (Type $acceptedType, Type $acceptingType, callable $traverse) use (&$checkForUnion): Type {
 			if ($acceptedType instanceof CallableType) {
 				if ($acceptedType->isCommonCallable()) {
+					return $acceptedType;
+				}
+				if (!$acceptingType instanceof ParametersAcceptor) {
 					return $acceptedType;
 				}
 
 				return new CallableType(
 					$acceptedType->getParameters(),
-					$traverse($this->transformCommonType($acceptedType->getReturnType())),
+					$traverse($this->transformCommonType($acceptedType->getReturnType()), $acceptingType->getReturnType()),
 					$acceptedType->isVariadic(),
 					$acceptedType->getTemplateTypeMap(),
 					$acceptedType->getResolvedTemplateTypeMap(),
@@ -109,9 +114,13 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
+				if (!$acceptingType instanceof ParametersAcceptor) {
+					return $acceptedType;
+				}
+
 				return new ClosureType(
 					$acceptedType->getParameters(),
-					$traverse($this->transformCommonType($acceptedType->getReturnType())),
+					$traverse($this->transformCommonType($acceptedType->getReturnType()), $acceptingType->getReturnType()),
 					$acceptedType->isVariadic(),
 					$acceptedType->getTemplateTypeMap(),
 					$acceptedType->getResolvedTemplateTypeMap(),
@@ -128,21 +137,22 @@ final class RuleLevelHelper
 
 			if (
 				!$this->checkNullables
-				&& !$acceptingType instanceof NullType
-				&& !$acceptedType instanceof NullType
 				&& !$acceptedType instanceof BenevolentUnionType
+				&& !$acceptedType instanceof NullType
+				&& TypeCombinator::containsNull($acceptedType)
+				&& !TypeCombinator::containsNull($acceptingType)
 			) {
-				return $traverse(TypeCombinator::removeNull($acceptedType));
+				return $traverse(TypeCombinator::removeNull($acceptedType), $acceptingType);
 			}
 
 			if ($this->checkBenevolentUnionTypes) {
 				if ($acceptedType instanceof BenevolentUnionType) {
 					$checkForUnion = true;
-					return $traverse(TypeUtils::toStrictUnion($acceptedType));
+					return $traverse(TypeUtils::toStrictUnion($acceptedType), $acceptingType);
 				}
 			}
 
-			return $traverse($this->transformCommonType($acceptedType));
+			return $traverse($this->transformCommonType($acceptedType), $acceptingType);
 		});
 
 		return [$acceptedType, $checkForUnion];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1317,13 +1317,17 @@ class IntersectionType implements CompoundType
 
 	public function traverseSimultaneously(Type $right, callable $cb): Type
 	{
-		if ($this->isArray()->yes() && $right->isArray()->yes()) {
+		if ($this->isArray()->yes() && !$right->isArray()->no()) {
+			$rightArray = $right->isArray()->maybe()
+				? TypeCombinator::intersect($right, new ArrayType(new MixedType(), new MixedType()))
+				: $right;
+
 			$changed = false;
 			$newTypes = [];
 
 			foreach ($this->types as $innerType) {
-				$newKeyType = $cb($innerType->getIterableKeyType(), $right->getIterableKeyType());
-				$newValueType = $cb($innerType->getIterableValueType(), $right->getIterableValueType());
+				$newKeyType = $cb($innerType->getIterableKeyType(), $rightArray->getIterableKeyType());
+				$newValueType = $cb($innerType->getIterableValueType(), $rightArray->getIterableValueType());
 				if ($newKeyType === $innerType->getIterableKeyType() && $newValueType === $innerType->getIterableValueType()) {
 					$newTypes[] = $innerType;
 					continue;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -1715,11 +1715,21 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function traverseSimultaneously(Type $right, callable $cb): Type
 	{
-		if ($this->subtractedType === null) {
+		if (!$right instanceof SubtractableType) {
 			return $this;
 		}
 
-		return new self($this->className);
+		$rightSubtractable = $right->getSubtractedType();
+		if ($this->subtractedType === null || $rightSubtractable === null) {
+			return $this;
+		}
+
+		$newSubtractedType = $cb($this->subtractedType, $rightSubtractable);
+		if ($newSubtractedType !== $this->subtractedType) {
+			return new self($this->className, $newSubtractedType);
+		}
+
+		return $this;
 	}
 
 	public function getNakedClassReflection(): ?ClassReflection

--- a/src/Type/ObjectWithoutClassType.php
+++ b/src/Type/ObjectWithoutClassType.php
@@ -176,11 +176,21 @@ class ObjectWithoutClassType implements SubtractableType
 
 	public function traverseSimultaneously(Type $right, callable $cb): Type
 	{
-		if ($this->subtractedType === null) {
+		if (!$right instanceof SubtractableType) {
 			return $this;
 		}
 
-		return new self();
+		$rightSubtractable = $right->getSubtractedType();
+		if ($this->subtractedType === null || $rightSubtractable === null) {
+			return $this;
+		}
+
+		$newSubtractedType = $cb($this->subtractedType, $rightSubtractable);
+		if ($newSubtractedType !== $this->subtractedType) {
+			return new self($newSubtractedType);
+		}
+
+		return $this;
 	}
 
 	public function tryRemove(Type $typeToRemove): ?Type

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -766,11 +766,21 @@ class StaticType implements TypeWithClassName, SubtractableType
 
 	public function traverseSimultaneously(Type $right, callable $cb): Type
 	{
-		if ($this->subtractedType === null) {
+		if (!$right instanceof SubtractableType) {
 			return $this;
 		}
 
-		return new self($this->classReflection);
+		$rightSubtractable = $right->getSubtractedType();
+		if ($this->subtractedType === null || $rightSubtractable === null) {
+			return $this;
+		}
+
+		$newSubtractedType = $cb($this->subtractedType, $rightSubtractable);
+		if ($newSubtractedType !== $this->subtractedType) {
+			return new self($this->classReflection, $newSubtractedType);
+		}
+
+		return $this;
 	}
 
 	public function subtract(Type $type): Type

--- a/tests/PHPStan/Rules/Functions/ClosureReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ClosureReturnTypeRuleTest.php
@@ -13,9 +13,11 @@ use PHPStan\Testing\RuleTestCase;
 class ClosureReturnTypeRuleTest extends RuleTestCase
 {
 
+	private bool $checkNullables = true;
+
 	protected function getRule(): Rule
 	{
-		return new ClosureReturnTypeRule(new FunctionReturnTypeCheck(new RuleLevelHelper(self::createReflectionProvider(), true, false, true, false, false, false, true)));
+		return new ClosureReturnTypeRule(new FunctionReturnTypeCheck(new RuleLevelHelper(self::createReflectionProvider(), $this->checkNullables, false, true, false, false, false, true)));
 	}
 
 	public function testClosureReturnTypeRule(): void
@@ -126,6 +128,13 @@ class ClosureReturnTypeRuleTest extends RuleTestCase
 	public function testBug7220(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-7220.php'], []);
+	}
+
+	public function testBug12008(): void
+	{
+		$this->checkNullables = false;
+
+		$this->analyse([__DIR__ . '/data/bug-12008.php'], []);
 	}
 
 	public function testBugFunctionMethodConstants(): void

--- a/tests/PHPStan/Rules/Functions/data/bug-12008.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-12008.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12008;
+
+interface ProductOverview {
+	public function getId(): ?int;
+}
+
+/**
+ * @template T
+ */
+readonly class Pagination
+{
+	/**
+	 * @param iterable<T> $records
+	 */
+	public function __construct(
+		public iterable $records,
+	) {
+	}
+}
+
+class HelloWorld
+{
+	private function respondToApiRequest(Closure|null $data): never {
+		exit;
+	}
+
+	/**
+	 * @param list<ProductOverview> $products
+	 */
+	public function run(array $products): never {
+		$this->respondToApiRequest(function () use ($products) {
+			return new Pagination(array_map(
+				fn (ProductOverview $product) => [
+					'id' => $product->getId(),
+				],
+				$products,
+			));
+		});
+	}
+}


### PR DESCRIPTION
Static analysis is failing because TypeTraverserInstanceofVisitor doesn't support SimultaneousTypeTraverser (not sure it should).

The only current test failing is
```
16: Function ReturnListNullables\doFoo() should return array<string>|null but returns list<string|null>.
```
but I feel like we could reproduce more errors because...

UnionType/Intersection types doesn't work well with the SimultaneousTypeTraverser because 
- when it's called with `A&B&C` and `A` we're not traversing because second type is not an Intersection
- when it's called with `A&B&C` and `A&C` we're not traversing because types count are different

The main issue would be, when traversing `A&B&C` and `A&C`, to match types in order to
- traverse (A, A)
- traverse (B, Never)
- traverse (C, C)