### PR TITLE
Fix build

### DIFF
--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -170,6 +170,7 @@ class ClassReflectionTest extends PHPStanTestCase
 		];
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	#[DataProvider('dataIsAttributeClass')]
 	public function testIsAttributeClass(string $className, bool $expected, int $expectedFlags = Attribute::TARGET_ALL): void
 	{


### PR DESCRIPTION
fixes php 7.4 only errors:

```
There were 3 failures:

1) PHPStan\Reflection\ClassReflectionTest::testIsAttributeClass with data set #2 ('Attributes\IsAttribute2', true, 128)
Failed asserting that 64 is identical to 128.

/home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Reflection/ClassReflectionTest.php:181
/home/runner/work/phpstan-src/phpstan-src/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:146

2) PHPStan\Reflection\ClassReflectionTest::testIsAttributeClass with data set #1 ('Attributes\IsAttribute', true)
Failed asserting that 63 is identical to 127.

/home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Reflection/ClassReflectionTest.php:181
/home/runner/work/phpstan-src/phpstan-src/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:146

3) PHPStan\Reflection\ClassReflectionTest::testIsAttributeClass with data set #3 ('Attributes\IsAttribute3', true, 136)
Failed asserting that 72 is identical to 136.

/home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Reflection/ClassReflectionTest.php:181
/home/runner/work/phpstan-src/phpstan-src/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:146
```

https://github.com/phpstan/phpstan-src/actions/runs/16799140529/job/47576177091