### PR TITLE
Resolve static in assert phpdoc

### DIFF
--- a/src/Reflection/Dummy/ChangedTypeMethodReflection.php
+++ b/src/Reflection/Dummy/ChangedTypeMethodReflection.php
@@ -27,6 +27,7 @@ final class ChangedTypeMethodReflection implements ExtendedMethodReflection
 		private ?array $namedArgumentsVariants,
 		private ?Type $selfOutType,
 		private ?Type $throwType,
+		private Assertions $assertions,
 	)
 	{
 	}
@@ -133,7 +134,7 @@ final class ChangedTypeMethodReflection implements ExtendedMethodReflection
 
 	public function getAsserts(): Assertions
 	{
-		return $this->reflection->getAsserts();
+		return $this->assertions;
 	}
 
 	public function acceptsNamedArguments(): TrinaryLogic

--- a/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CallbackUnresolvedMethodPrototypeReflection.php
@@ -137,6 +137,7 @@ final class CallbackUnresolvedMethodPrototypeReflection implements UnresolvedMet
 			$namedArgumentVariants,
 			$selfOutType,
 			$throwType,
+			$method->getAsserts()->mapTypes($this->transformStaticTypeCallback),
 		);
 	}
 

--- a/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
+++ b/src/Reflection/Type/CalledOnTypeUnresolvedMethodPrototypeReflection.php
@@ -132,6 +132,7 @@ final class CalledOnTypeUnresolvedMethodPrototypeReflection implements Unresolve
 			$namedArgumentsVariants,
 			$selfOutType,
 			$throwType,
+			$method->getAsserts()->mapTypes(fn (Type $type): Type => $this->transformStaticType($type)),
 		);
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12376.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12376.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12376;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * workaround https://github.com/phpstan/phpstan-src/pull/3853
+ *
+ * @template T of object
+ * @param class-string<T> $class
+ * @return T
+ */
+function newNonFinalInstance(string $class): object
+{
+	return new $class();
+}
+
+class Base {}
+
+class A extends Base
+{
+	/**
+	 * @template T of object
+	 * @param T $object
+	 * @return (T is static ? T : static)
+	 *
+	 * @phpstan-assert static $object
+	 */
+	public static function assertInstanceOf(object $object)
+	{
+		if (!$object instanceof static) {
+			throw new \Exception();
+		}
+
+		return $object;
+	}
+}
+
+class B extends A {}
+class C extends Base {}
+
+$o = newNonFinalInstance(\DateTime::class);
+$r = A::assertInstanceOf($o);
+assertType('*NEVER*', $o);
+assertType('Bug12376\A', $r);
+
+$o = newNonFinalInstance(A::class);
+$r = A::assertInstanceOf($o);
+assertType('Bug12376\A', $o);
+assertType('Bug12376\A', $r);
+
+$o = newNonFinalInstance(B::class);
+$r = A::assertInstanceOf($o);
+assertType('Bug12376\B', $o);
+assertType('Bug12376\B', $r);
+
+$o = newNonFinalInstance(C::class);
+$r = A::assertInstanceOf($o);
+assertType('*NEVER*', $o);
+assertType('Bug12376\A', $r);
+
+$o = newNonFinalInstance(A::class);
+$r = B::assertInstanceOf($o);
+assertType('Bug12376\B', $o);
+assertType('Bug12376\B', $r);

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3608,6 +3608,16 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9141.php'], []);
 	}
 
+	public function testBug12548(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-12548.php'], []);
+	}
+
 	public function testBug3589(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Methods/data/bug-12548.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12548.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12548;
+
+class BaseSat extends \stdClass
+{
+	/**
+	 * @template T of object
+	 *
+	 * @param T $object
+	 *
+	 * @phpstan-assert-if-true =static $object
+	 */
+	public static function assertInstanceOf(object $object): bool
+	{
+		return $object instanceof static;
+	}
+
+	/**
+	 * @template T of object
+	 *
+	 * @param T $object
+	 *
+	 * @return (T is static ? T : static)
+	 *
+	 * @phpstan-assert static $object
+	 */
+	public static function assertInstanceOf2(object $object)
+	{
+		if (!$object instanceof static) {
+			throw new \Error('Object is not an instance of static class');
+		}
+
+		return $object;
+	}
+}
+
+class StdSat extends BaseSat
+{
+	public function foo(): void {}
+
+	/**
+	 * @template T of object
+	 *
+	 * @param T $object
+	 *
+	 * @return (T is static ? T : static)
+	 *
+	 * @phpstan-assert static $object
+	 */
+	public static function assertInstanceOf3(object $object)
+	{
+		if (!$object instanceof static) {
+			throw new \Error('Object is not an instance of static class');
+		}
+
+		return $object;
+	}
+}
+
+class TestCase
+{
+	private function createStdSat(): \stdClass
+	{
+		return new StdSat();
+	}
+
+	public function testAssertInstanceOf(): void
+	{
+		$o = $this->createStdSat();
+		$o->foo(); // @phpstan-ignore method.nonObject (EXPECTED)
+
+		$o = $this->createStdSat();
+		if (StdSat::assertInstanceOf($o)) {
+			$o->foo();
+		}
+
+		$o = $this->createStdSat();
+		StdSat::assertInstanceOf2($o);
+		$o->foo();
+
+		$o = $this->createStdSat();
+		StdSat::assertInstanceOf3($o);
+		$o->foo();
+	}
+}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -1165,6 +1165,14 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug11289(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->checkDynamicProperties = false;
+		$this->analyse([__DIR__ . '/data/bug-11289.php'], []);
+	}
+
 	public function testBug8668(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Properties/data/bug-11289.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-11289.php
@@ -1,0 +1,37 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug11289;
+
+abstract class SomeAbstractClass
+{
+	private bool $someValue = true;
+
+	/**
+	 * @phpstan-assert-if-true =static $other
+	 */
+	public function equals(?self $other): bool
+	{
+		return $other instanceof static
+			&& $this->someValue === $other->someValue;
+	}
+}
+
+class SomeConcreteClass extends SomeAbstractClass
+{
+	public function __construct(
+		private bool $someOtherValue,
+	) {}
+
+	public function equals(?SomeAbstractClass $other): bool
+	{
+		return parent::equals($other)
+			&& $this->someOtherValue === $other->someOtherValue;
+	}
+}
+
+$a = new SomeConcreteClass(true);
+$b = new SomeConcreteClass(false);
+
+var_dump($a->equals($b), $b->equals($b));


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12548

I didn't exactly copy-paste the snippet given because I don't understand how you can expect
```
/**
     * @template T of object
     *
     * @param T $object
     *
     * @return (T is static ? T : static)
     *
     * @phpstan-assert-if-true =static $object
     */
    public static function assertInstanceOf(object $object)
    {
        if (!$object instanceof static) {
            throw new \Error('Object is not an instance of static class');
        }

        return $object;
    }
```
to correctly work: `phpstan-assert-if-true` only work if the method returns a boolean.

Closes https://github.com/phpstan/phpstan/issues/11289
Closes https://github.com/phpstan/phpstan/issues/12376