### PR TITLE
Resolve array~list

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -609,6 +609,10 @@ class ArrayType implements Type
 			return TypeCombinator::intersect($this, new NonEmptyArrayType());
 		}
 
+		if ($typeToRemove->isSuperTypeOf(new ConstantArrayType([], []))->yes()) {
+			return TypeCombinator::intersect($this, new NonEmptyArrayType());
+		}
+
 		if ($typeToRemove instanceof NonEmptyArrayType) {
 			return new ConstantArrayType([], []);
 		}

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-type-specifying.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-type-specifying.php
@@ -8,7 +8,7 @@ function foo(array $foo) {
 	if (array_is_list($foo)) {
         assertType('list', $foo);
     } else {
-		assertType('array', $foo);
+		assertType('non-empty-array', $foo);
 	}
 }
 
@@ -51,7 +51,7 @@ if (array_is_list($bar)) {
 if (array_is_list($foo)) {
     assertType('list', $foo);
 } else {
-	assertType('array<int|string, mixed>', $foo);
+	assertType('non-empty-array<int|string, mixed>', $foo);
 }
 
 $baz = [];

--- a/tests/PHPStan/Analyser/nsrt/assert-docblock.php
+++ b/tests/PHPStan/Analyser/nsrt/assert-docblock.php
@@ -71,7 +71,7 @@ function takesArrayIfTrue(array $arr) : void {
 	if (validateStringArrayIfTrue($arr)) {
 		assertType('array<string>', $arr);
 	} else {
-		assertType('array<mixed>', $arr);
+		assertType('non-empty-array<mixed>', $arr);
 	}
 }
 /**
@@ -81,7 +81,7 @@ function takesArrayIfTrue1(array $arr) : void {
 	assertType('array<mixed>', $arr);
 
 	if (!validateStringArrayIfTrue($arr)) {
-		assertType('array<mixed>', $arr);
+		assertType('non-empty-array<mixed>', $arr);
 	} else {
 		assertType('array<string>', $arr);
 	}
@@ -96,7 +96,7 @@ function takesArrayIfFalse(array $arr) : void {
 	if (!validateStringArrayIfFalse($arr)) {
 		assertType('array<string>', $arr);
 	} else {
-		assertType('array<mixed>', $arr);
+		assertType('non-empty-array<mixed>', $arr);
 	}
 }
 
@@ -107,7 +107,7 @@ function takesArrayIfFalse1(array $arr) : void {
 	assertType('array<mixed>', $arr);
 
 	if (validateStringArrayIfFalse($arr)) {
-		assertType('array<mixed>', $arr);
+		assertType('non-empty-array<mixed>', $arr);
 	} else {
 		assertType('array<string>', $arr);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-9734.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9734.php
@@ -17,7 +17,7 @@ class Foo
 		if (array_is_list($a)) {
 			assertType('list', $a);
 		} else {
-			assertType('array<mixed>', $a); // could be non-empty-array
+			assertType('non-empty-array<mixed>', $a);
 		}
 	}
 
@@ -43,5 +43,92 @@ class Foo
 			assertType('non-empty-array<mixed>', $a);
 		}
 	}
+
+}
+
+class Bar
+{
+	/**
+	 * @param array<array-key, mixed> $value
+	 * @return ($value is non-empty-list ? true : false)
+	 */
+	public function assertIsNonEmptyList($value): bool
+	{
+		return false;
+	}
+
+	/**
+	 * @param array<array-key, mixed> $value
+	 * @return ($value is list<string> ? true : false)
+	 */
+	public function assertIsStringList($value): bool
+	{
+		return false;
+	}
+
+	/**
+	 * @param array<array-key, mixed> $value
+	 * @return ($value is list{string, string} ? true : false)
+	 */
+	public function assertIsConstantList($value): bool
+	{
+		return false;
+	}
+
+	/**
+	 * @param array<array-key, mixed> $value
+	 * @return ($value is list{0?: string, 1?: string} ? true : false)
+	 */
+	public function assertIsOptionalConstantList($value): bool
+	{
+		return false;
+	}
+
+	/**
+	 * @param array<array-key, mixed> $value
+	 * @return ($value is array<string> ? true : false)
+	 */
+	public function assertIsStringArray($value): bool
+	{
+		return false;
+	}
+
+	/**
+	 * @param array<mixed> $a
+	 * @return void
+	 */
+	public function doFoo(array $a): void
+	{
+		if ($this->assertIsNonEmptyList($a)) {
+			assertType('non-empty-list', $a);
+		} else {
+			assertType('array<mixed>', $a);
+		}
+
+		if ($this->assertIsStringList($a)) {
+			assertType('list<string>', $a);
+		} else {
+			assertType('non-empty-array', $a);
+		}
+
+		if ($this->assertIsConstantList($a)) {
+			assertType('array{string, string}', $a);
+		} else {
+			assertType('array', $a);
+		}
+
+		if ($this->assertIsOptionalConstantList($a)) {
+			assertType('list{0?: string, 1?: string}', $a);
+		} else {
+			assertType('non-empty-array', $a);
+		}
+
+		if ($this->assertIsStringArray($a)) {
+			assertType('array<string>', $a);
+		} else {
+			assertType('non-empty-array', $a);
+		}
+	}
+
 
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-9734.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9734.php
@@ -44,6 +44,19 @@ class Foo
 		}
 	}
 
+	/**
+	 * @param mixed $a
+	 * @return void
+	 */
+	public function doFoo4($a): void
+	{
+		if (array_is_list($a)) {
+			assertType('list', $a);
+		} else {
+			assertType('mixed~list', $a);
+		}
+	}
+
 }
 
 class Bar


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/9734

I'll need your decision on the condition to chose in ArrayType::tryRemove @ondrejmirtes 

We could have 
```
if ($typeToRemove->isSuperTypeOf(new ConstantArrayType([], []))->yes()) {
     return TypeCombinator::intersect($this, new NonEmptyArrayType());
}
```
but it means that now a 
```
@phpstan-assert-if-true string[] $array
```
will infer a non empty array for the `false` case.

It could make sens since in order to say that all the values are not string, it require to access to at least one value.

If preferred we could restrict such behavior to the list with an extra `$typeToRemove->isList()->yes()` check.

Or, to just solve `array_is_list` ; the check can be something like `$typeToRemove->describe(...) === 'list'`...