### PR TITLE
Introduce checkTooWideParameterOutInProtectedAndPublicMethods

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -54,6 +54,7 @@ parameters:
 	checkPhpDocMethodSignatures: false
 	checkExtraArguments: false
 	checkMissingTypehints: false
+	checkTooWideParameterOutInProtectedAndPublicMethods: false
 	checkTooWideReturnTypesInProtectedAndPublicMethods: false
 	checkUninitializedProperties: false
 	checkDynamicProperties: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -58,6 +58,7 @@ parametersSchema:
 	checkPhpDocMethodSignatures: bool()
 	checkExtraArguments: bool()
 	checkMissingTypehints: bool()
+	checkTooWideParameterOutInProtectedAndPublicMethods: bool()
 	checkTooWideReturnTypesInProtectedAndPublicMethods: bool()
 	checkUninitializedProperties: bool()
 	checkDynamicProperties: bool()

--- a/src/Rules/TooWideTypehints/TooWideMethodParameterOutTypeRule.php
+++ b/src/Rules/TooWideTypehints/TooWideMethodParameterOutTypeRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\TooWideTypehints;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\MethodReturnStatementsNode;
 use PHPStan\Rules\Rule;
@@ -18,6 +19,8 @@ final class TooWideMethodParameterOutTypeRule implements Rule
 
 	public function __construct(
 		private TooWideParameterOutTypeCheck $check,
+		#[AutowiredParameter(ref: '%checkTooWideParameterOutInProtectedAndPublicMethods%')]
+		private bool $checkProtectedAndPublicMethods,
 	)
 	{
 	}
@@ -30,6 +33,14 @@ final class TooWideMethodParameterOutTypeRule implements Rule
 	public function processNode(Node $node, Scope $scope): array
 	{
 		$inMethod = $node->getMethodReflection();
+
+		if (!$inMethod->isPrivate()) {
+			if (!$inMethod->getDeclaringClass()->isFinal() && !$inMethod->isFinal()->yes()) {
+				if (!$this->checkProtectedAndPublicMethods) {
+					return [];
+				}
+			}
+		}
 
 		return $this->check->check(
 			$node->getExecutionEnds(),

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodParameterOutTypeRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodParameterOutTypeRuleTest.php
@@ -11,9 +11,11 @@ use PHPStan\Testing\RuleTestCase;
 class TooWideMethodParameterOutTypeRuleTest extends RuleTestCase
 {
 
+	private bool $checkProtectedAndPublicMethods = true;
+
 	protected function getRule(): TRule
 	{
-		return new TooWideMethodParameterOutTypeRule(new TooWideParameterOutTypeCheck());
+		return new TooWideMethodParameterOutTypeRule(new TooWideParameterOutTypeCheck(), $this->checkProtectedAndPublicMethods);
 	}
 
 	public function testRule(): void
@@ -37,6 +39,69 @@ class TooWideMethodParameterOutTypeRuleTest extends RuleTestCase
 				'Method TooWideMethodParameterOut\Foo::bug10699() never assigns 20 to &$out so it can be removed from the @param-out type.',
 				37,
 			],
+			[
+				'Method TooWideMethodParameterOut\Foo::finalDoBaz() never assigns null to &$p so it can be removed from the @param-out type.',
+				45,
+			],
+			[
+				'Method TooWideMethodParameterOut\Foo::doBazProtected() never assigns null to &$p so it can be removed from the @param-out type.',
+				53,
+			],
+			[
+				'Method TooWideMethodParameterOut\Foo::doBazPrivate() never assigns null to &$p so it can be removed from the @param-out type.',
+				61,
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::doBar() never assigns null to &$p so it can be removed from the by-ref type.',
+				76,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::doBaz() never assigns null to &$p so it can be removed from the @param-out type.',
+				84,
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::doLorem() never assigns null to &$p so it can be removed from the by-ref type.',
+				89,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::bug10699() never assigns 20 to &$out so it can be removed from the @param-out type.',
+				100,
+			],
+		]);
+	}
+
+	public function testRuleWithoutProtectedAndPublic(): void
+	{
+		$this->checkProtectedAndPublicMethods = false;
+		$this->analyse([__DIR__ . '/data/too-wide-method-parameter-out.php'], [
+			[
+				'Method TooWideMethodParameterOut\Foo::finalDoBaz() never assigns null to &$p so it can be removed from the @param-out type.',
+				45,
+			],
+			[
+				'Method TooWideMethodParameterOut\Foo::doBazPrivate() never assigns null to &$p so it can be removed from the @param-out type.',
+				61,
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::doBar() never assigns null to &$p so it can be removed from the by-ref type.',
+				76,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::doBaz() never assigns null to &$p so it can be removed from the @param-out type.',
+				84,
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::doLorem() never assigns null to &$p so it can be removed from the by-ref type.',
+				89,
+				'You can narrow the parameter out type with @param-out PHPDoc tag.',
+			],
+			[
+				'Method TooWideMethodParameterOut\FinalFoo::bug10699() never assigns 20 to &$out so it can be removed from the @param-out type.',
+				100,
+			],
 		]);
 	}
 
@@ -48,6 +113,12 @@ class TooWideMethodParameterOutTypeRuleTest extends RuleTestCase
 	public function testBug10687(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-10687.php'], []);
+	}
+
+	public function testBug12080(): void
+	{
+		$this->checkProtectedAndPublicMethods = false;
+		$this->analyse([__DIR__ . '/data/bug-12080.php'], []);
 	}
 
 }

--- a/tests/PHPStan/Rules/TooWideTypehints/data/bug-12080.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/data/bug-12080.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Bug12080;
+
+class C {
+	/**
+	 * @param mixed $x
+	 * @param-out string|int $x
+	 */
+	public function foo(&$x): void {
+		$x = "foo";
+	}
+}
+
+class D extends C {
+	public function foo(&$x): void {
+		$x = 42;
+	}
+}

--- a/tests/PHPStan/Rules/TooWideTypehints/data/too-wide-method-parameter-out.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/data/too-wide-method-parameter-out.php
@@ -39,5 +39,67 @@ class Foo
 
 	}
 
+	/**
+	 * @param-out string|null $p
+	 */
+	final public function finalDoBaz(?string &$p): void
+	{
+		$p = 'foo';
+	}
+
+	/**
+	 * @param-out string|null $p
+	 */
+	protected function doBazProtected(?string &$p): void
+	{
+		$p = 'foo';
+	}
+
+	/**
+	 * @param-out string|null $p
+	 */
+	private function doBazPrivate(?string &$p): void
+	{
+		$p = 'foo';
+	}
+
+}
+
+final class FinalFoo
+{
+
+	public function doFoo(?string &$p): void
+	{
+
+	}
+
+	public function doBar(?string &$p): void
+	{
+		$p = 'foo';
+	}
+
+	/**
+	 * @param-out string|null $p
+	 */
+	public function doBaz(?string &$p): void
+	{
+		$p = 'foo';
+	}
+
+	public function doLorem(?string &$p): void
+	{
+		$p = 'foo';
+	}
+
+	/**
+	 * @param int $flags
+	 * @param 10 $out
+	 *
+	 * @param-out ($flags is 2 ? 20 : 10) $out
+	 */
+	function bug10699(int $flags, &$out): void
+	{
+
+	}
 
 }


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12080

I copied the strategy from TooWideMethodReturnTypehintRule
https://github.com/phpstan/phpstan-src/blob/745ae5a988b7e16185f927663ecd7cdd64f63425/src/Rules/TooWideTypehints/TooWideMethodReturnTypehintRule.php#L45-L56

But I didn't add the `isFirstDeclaration` check yet because it removes almost every reported errors... (and no early return was added before). Also, I already don't really understand the check in TooWideMethodReturnTypehintRule

Cause we're getting
```
class WithoutChild
{
     public function foo(): ?int // No error, but it "should" be reported with checkPublicAndProtected
	{
		return 42;
	}
}

class A
{
	public function foo(): int|string // No error cause it's the first declaration
	{
		return 42;
	}
}

class B extends A
{
	public function foo(): int|string // never returns string so it can be removed from the return type => but it will crash class C.
	{
		return 42;
	}
}

class C extends B
{
	public function foo(): int|string // never returns int so it can be removed from the return type
	{
		return '42';
	}
}
```
