### PR TITLE
Fix PHP8.5 deprecation warnings with ReflectionProperty::setAccessible()

### DIFF
--- a/src/Fixable/Patcher.php
+++ b/src/Fixable/Patcher.php
@@ -19,6 +19,7 @@ use function implode;
 use function sha1;
 use function str_starts_with;
 use function substr;
+use const PHP_VERSION_ID;
 use const PREG_SPLIT_DELIM_CAPTURE;
 use const PREG_SPLIT_NO_EMPTY;
 
@@ -62,7 +63,9 @@ final class Patcher
 
 		$refMerge = new ReflectionClass(PhpMerge::class);
 		$refMergeMethod = $refMerge->getMethod('mergeHunks');
-		$refMergeMethod->setAccessible(true);
+		if (PHP_VERSION_ID < 80100) {
+			$refMergeMethod->setAccessible(true);
+		}
 
 		$result = Line::createArray(array_map(
 			static fn ($l) => [$l, Differ::OLD],

--- a/src/Testing/TestCaseSourceLocatorFactory.php
+++ b/src/Testing/TestCaseSourceLocatorFactory.php
@@ -68,7 +68,9 @@ final class TestCaseSourceLocatorFactory
 				),
 			];
 			$vendorDirProperty = $classLoaderReflection->getProperty('vendorDir');
-			$vendorDirProperty->setAccessible(true);
+			if (PHP_VERSION_ID < 80100) {
+				$vendorDirProperty->setAccessible(true);
+			}
 			foreach ($classLoaders as $classLoader) {
 				$composerProjectPath = dirname($vendorDirProperty->getValue($classLoader));
 				if (!is_file($composerProjectPath . '/composer.json')) {


### PR DESCRIPTION
fixes test errors:

```
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

Warning:       No code coverage driver available

PHP Deprecated:  Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect in phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TestCaseSourceLocatorFactory.php on line 73
...R
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect in phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TestCaseSourceLocatorFactory.php on line 73
.....................................................         57 / 57 (100%)

Time: 00:52.874, Memory: 110.00 MB

There was 1 risky test:

1) PHPStan\Rules\BooleansInConditions\BooleanInBooleanAndRuleTest::testRule
Test code or tested code printed unexpected output: 
Deprecated: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect in phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Testing/TestCaseSourceLocatorFactory.php on line 73
```

`setAccessible` is a no-op since 8.1 - see https://wiki.php.net/rfc/make-reflection-setaccessible-no-op
