### PR TITLE
get rid of couple instanceof *Type checks in TypeCombinator

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1720,25 +1720,7 @@ parameters:
 			path: src/Type/TypeCombinator.php
 
 		-
-			message: '#^Doing instanceof PHPStan\\Type\\BooleanType is error\-prone and deprecated\. Use Type\:\:isBoolean\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/TypeCombinator.php
-
-		-
 			message: '#^Doing instanceof PHPStan\\Type\\CallableType is error\-prone and deprecated\. Use Type\:\:isCallable\(\) and Type\:\:getCallableParametersAcceptors\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/TypeCombinator.php
-
-		-
-			message: '#^Doing instanceof PHPStan\\Type\\ClassStringType is error\-prone and deprecated\. Use Type\:\:isClassStringType\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/TypeCombinator.php
-
-		-
-			message: '#^Doing instanceof PHPStan\\Type\\ConstantScalarType is error\-prone and deprecated\. Use Type\:\:isConstantScalarValue\(\) or Type\:\:getConstantScalarTypes\(\) or Type\:\:getConstantScalarValues\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 1
 			path: src/Type/TypeCombinator.php
@@ -1756,21 +1738,9 @@ parameters:
 			path: src/Type/TypeCombinator.php
 
 		-
-			message: '#^Doing instanceof PHPStan\\Type\\FloatType is error\-prone and deprecated\. Use Type\:\:isFloat\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/TypeCombinator.php
-
-		-
 			message: '#^Doing instanceof PHPStan\\Type\\Generic\\GenericClassStringType is error\-prone and deprecated\. Use Type\:\:isClassStringType\(\) and Type\:\:getClassStringObjectType\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 2
-			path: src/Type/TypeCombinator.php
-
-		-
-			message: '#^Doing instanceof PHPStan\\Type\\IntegerType is error\-prone and deprecated\. Use Type\:\:isInteger\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 1
 			path: src/Type/TypeCombinator.php
 
 		-
@@ -1795,12 +1765,6 @@ parameters:
 			message: '#^Doing instanceof PHPStan\\Type\\ObjectShapeType is error\-prone and deprecated\. Use Type\:\:isObject\(\) and Type\:\:hasProperty\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 2
-			path: src/Type/TypeCombinator.php
-
-		-
-			message: '#^Doing instanceof PHPStan\\Type\\StringType is error\-prone and deprecated\. Use Type\:\:isString\(\) instead\.$#'
-			identifier: phpstanApi.instanceofType
-			count: 1
 			path: src/Type/TypeCombinator.php
 
 		-

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -190,22 +190,22 @@ final class TypeCombinator
 		$enumCaseTypes = [];
 		$integerRangeTypes = [];
 		for ($i = 0; $i < $typesCount; $i++) {
-			if ($types[$i] instanceof ConstantScalarType) {
+			if ($types[$i]->isConstantScalarValue()->yes()) {
 				$type = $types[$i];
 				$scalarTypes[get_class($type)][md5($type->describe(VerbosityLevel::cache()))] = $type;
 				unset($types[$i]);
 				continue;
 			}
-			if ($types[$i] instanceof BooleanType) {
+			if ($types[$i]->isBoolean()->yes()) {
 				$hasGenericScalarTypes[ConstantBooleanType::class] = true;
 			}
-			if ($types[$i] instanceof FloatType) {
+			if ($types[$i]->isFloat()->yes()) {
 				$hasGenericScalarTypes[ConstantFloatType::class] = true;
 			}
-			if ($types[$i] instanceof IntegerType && !$types[$i] instanceof IntegerRangeType) {
+			if ($types[$i]->isInteger()->yes() && !$types[$i] instanceof IntegerRangeType) {
 				$hasGenericScalarTypes[ConstantIntegerType::class] = true;
 			}
-			if ($types[$i] instanceof StringType && !$types[$i] instanceof ClassStringType) {
+			if ($types[$i]->isString()->yes() && $types[$i]->isClassString()->no() && TypeUtils::getAccessoryTypes($types[$i]) === []) {
 				$hasGenericScalarTypes[ConstantStringType::class] = true;
 			}
 			$enumCases = $types[$i]->getEnumCases();

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -827,7 +827,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame('Return type of call to method Bug7094\Foo::getAttribute() contains unresolvable type.', $errors[4]->getMessage());
 		$this->assertSame(79, $errors[4]->getLine());
 
-		$this->assertSame('Parameter #1 $attr of method Bug7094\Foo::setAttributes() expects array{foo?: string, bar?: 5|6|7, baz?: bool}, non-empty-array<K of string, 5|6|7|bool|string> given.', $errors[5]->getMessage());
+		$this->assertSame('Parameter #1 $attr of method Bug7094\Foo::setAttributes() expects array{foo?: string, bar?: 5|6|7, baz?: bool}, non-empty-array<\'bar\'|\'baz\'|\'foo\'|K of string, 5|6|7|bool|string> given.', $errors[5]->getMessage());
 		$this->assertSame(29, $errors[5]->getLine());
 	}
 


### PR DESCRIPTION
Hello 👋🏽 

It is hard to describe how I came up with this patch. But I thought maybe migrating from `instanceof *Type` to method calls is a good enough reason to get it accepted 😅 

There was one test failing. But I think this updated version is more correct.