### PR TITLE
Update RangeFunctionReturnTypeExtension to include known integer ranges for keys

### DIFF
--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -93,7 +93,7 @@ final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 							}
 							return TypeCombinator::intersect(
 								new ArrayType(
-									new IntegerType(),
+									IntegerRangeType::fromInterval(0, (int) (($endConstant->getValue() - $startConstant->getValue()) / $stepConstant->getValue())),
 									IntegerRangeType::fromInterval($startConstant->getValue(), $endConstant->getValue()),
 								),
 								new NonEmptyArrayType(),


### PR DESCRIPTION
Right now, the `range` function returns a list Type for large numbers. we can narrow this down, because we do actually know the upper and lower bounds of the keys, by subtracting the lower bound from the upper bound and dividing that by the step number.

I think this covers all scenarios, let me know if I've missed anything!