### PR TITLE
fix build

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
@@ -27,10 +27,6 @@ class CallToMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 				15,
 			],
 			[
-				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
-				16,
-			],
-			[
 				'Call to method Exception::getCode() on a separate line has no effect.',
 				21,
 			],

--- a/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Methods;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use function array_merge;
 use const PHP_VERSION_ID;
 
@@ -19,12 +20,40 @@ class CallToMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		return new CallToMethodStatementWithoutSideEffectsRule(new RuleLevelHelper(self::createReflectionProvider(), true, false, true, false, false, false, true));
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	public function testRule(): void
 	{
 		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects.php'], [
 			[
 				'Call to method DateTimeImmutable::modify() on a separate line has no effect.',
 				15,
+			],
+			[
+				'Call to method Exception::getCode() on a separate line has no effect.',
+				21,
+			],
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bar::doPure() on a separate line has no effect.',
+				63,
+			],
+			[
+				'Call to method MethodCallStatementNoSideEffects\Bar::doPureWithThrowsVoid() on a separate line has no effect.',
+				64,
+			],
+		]);
+	}
+
+	#[RequiresPhp('< 8')]
+	public function testRulePhp7(): void
+	{
+		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects.php'], [
+			[
+				'Call to method DateTimeImmutable::modify() on a separate line has no effect.',
+				15,
+			],
+			[
+				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
+				16,
 			],
 			[
 				'Call to method Exception::getCode() on a separate line has no effect.',

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
@@ -25,10 +25,6 @@ class CallToStaticMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects.php'], [
 			[
-				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
-				12,
-			],
-			[
 				'Call to method DateTime::format() on a separate line has no effect.',
 				23,
 			],

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Methods;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<CallToStaticMethodStatementWithoutSideEffectsRule>
@@ -21,9 +22,25 @@ class CallToStaticMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		);
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	public function testRule(): void
 	{
 		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects.php'], [
+			[
+				'Call to method DateTime::format() on a separate line has no effect.',
+				23,
+			],
+		]);
+	}
+
+	#[RequiresPhp('< 8')]
+	public function testRulePhp7(): void
+	{
+		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects.php'], [
+			[
+				'Call to static method DateTimeImmutable::createFromFormat() on a separate line has no effect.',
+				12,
+			],
 			[
 				'Call to method DateTime::format() on a separate line has no effect.',
 				23,


### PR DESCRIPTION
According to [php.net/manual/en/datetime.createfromformat.php#refsect1-datetime.createfromformat-errors](https://www.php.net/manual/en/datetime.createfromformat.php#refsect1-datetime.createfromformat-errors)
since PHP 8, createFromFormat can throws ValueError when the datetime contains NULL-bytes.

see https://github.com/JetBrains/phpstorm-stubs/pull/1760