### PR TITLE
Fix lint on PHP 8.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,11 @@ lint:
 		--exclude tests/PHPStan/Rules/Constants/data/final-private-const.php \
 		--exclude tests/PHPStan/Rules/Properties/data/abstract-final-property-hook-parse-error.php \
 		--exclude tests/PHPStan/Rules/Playground/data/promote-missing-override.php \
+		--exclude tests/PHPStan/Rules/Traits/data/trait-attributes.php \
+		--exclude tests/PHPStan/Rules/Classes/data/non-class-attribute-class.php \
+		--exclude tests/PHPStan/Rules/Classes/data/enum-cannot-be-attribute.php \
+		--exclude tests/PHPStan/Rules/Classes/data/class-attributes.php \
+		--exclude tests/PHPStan/Rules/Classes/data/enum-attributes.php \
 		src tests
 
 install-paratest:


### PR DESCRIPTION
```
Syntax error found in 5 files

------------------------------------------------------------
Parse error: tests/PHPStan/Rules/Traits/data/trait-attributes.php:6
    4| 
    5| #[\Attribute]
  > 6| abstract class AbstractAttribute {}
    7| 
    8| #[AbstractAttribute]
Cannot apply #[\Attribute] to abstract class TraitAttributes\AbstractAttribute
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/Classes/data/non-class-attribute-class.php:6
    4| 
    5| #[\Attribute]
  > 6| interface Foo
    7| {
    8|
Cannot apply #[\Attribute] to interface NonClassAttributeClass\Foo
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/Classes/data/enum-cannot-be-attribute.php:6
    4| 
    5| #[\Attribute]
  > 6| enum Foo
    7| {
    8|
Cannot apply #[\Attribute] to enum EnumAsAttribute\Foo
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/Classes/data/class-attributes.php:72
    70| 
    71| #[\Attribute]
  > 72| abstract class AbstractAttribute
    73| {
    74|
Cannot apply #[\Attribute] to abstract class ClassAttributes\AbstractAttribute
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/Classes/data/enum-attributes.php:30
    28| 
    29| #[\Attribute]
  > 30| enum EnumAsAttribute
    31| {
    32|
Cannot apply #[\Attribute] to enum EnumAttributes\EnumAsAttribute
```