### PR TITLE
Increment on non-numeric string is deprecated, use str_increment() instead

### DIFF
--- a/build/ignore-by-php-version.neon.php
+++ b/build/ignore-by-php-version.neon.php
@@ -38,6 +38,11 @@ if (PHP_VERSION_ID < 80200) {
 } else {
 	$includes[] = __DIR__ . '/new-phpunit.neon';
 }
+
+if (PHP_VERSION_ID < 80300) {
+	$includes[] = __DIR__ . '/str-increment.neon';
+}
+
 $config = [];
 $config['includes'] = $includes;
 

--- a/build/str-increment.neon
+++ b/build/str-increment.neon
@@ -1,0 +1,4 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Used function str_increment not found\.#'

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -150,6 +150,7 @@ use function array_slice;
 use function array_values;
 use function count;
 use function explode;
+use function function_exists;
 use function get_class;
 use function implode;
 use function in_array;
@@ -160,6 +161,7 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
+use function str_increment;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
@@ -1731,16 +1733,22 @@ final class MutatingScope implements Scope
 				$newTypes = [];
 
 				foreach ($varScalars as $varValue) {
+					// until PHP 8.5 it was valid to increment/decrement an empty string.
+					// see https://github.com/php/php-src/issues/19597
 					if ($node instanceof Expr\PreInc) {
-						// until PHP 8.5 it was valid to increment an empty string.
-						// see https://github.com/php/php-src/issues/19597
 						if ($varValue === '') {
 							$varValue = '1';
+						} elseif (is_string($varValue) && function_exists('str_increment')) {
+							$varValue = str_increment($varValue);
 						} elseif (!is_bool($varValue)) {
 							++$varValue;
 						}
-					} elseif (is_numeric($varValue)) {
-						--$varValue;
+					} else {
+						if ($varValue === '') {
+							$varValue = -1;
+						} elseif (is_numeric($varValue)) {
+							--$varValue;
+						}
 					}
 
 					$newTypes[] = $this->getTypeFromValue($varValue);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1734,7 +1734,11 @@ final class MutatingScope implements Scope
 
 				foreach ($varScalars as $varValue) {
 					if ($node instanceof Expr\PreInc) {
-						if (!is_bool($varValue)) {
+						// until PHP 8.5 it was valid to increment an empty string.
+						// see https://github.com/php/php-src/issues/19597
+						if ($varValue === '') {
+							$varValue = '1';
+						} elseif (!is_bool($varValue)) {
 							if (function_exists('str_increment') && is_string($varValue)) {
 								$varValue = str_increment($varValue);
 							} else {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -161,7 +161,6 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
-use function str_decrement;
 use function str_increment;
 use function str_starts_with;
 use function strlen;
@@ -1736,18 +1735,14 @@ final class MutatingScope implements Scope
 				foreach ($varScalars as $varValue) {
 					if ($node instanceof Expr\PreInc) {
 						if (!is_bool($varValue)) {
-							if (function_exists('str_increment')) {
+							if (function_exists('str_increment') && is_string($varValue)) {
 								$varValue = str_increment($varValue);
 							} else {
 								++$varValue;
 							}
 						}
 					} elseif (is_numeric($varValue)) {
-						if (function_exists('str_decrement')) {
-							$varValue = str_decrement($varValue);
-						} else {
-							--$varValue;
-						}
+						--$varValue;
 					}
 
 					$newTypes[] = $this->getTypeFromValue($varValue);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1738,7 +1738,11 @@ final class MutatingScope implements Scope
 					if ($node instanceof Expr\PreInc) {
 						if ($varValue === '') {
 							$varValue = '1';
-						} elseif (is_string($varValue) && function_exists('str_increment')) {
+						} elseif (
+							is_string($varValue)
+							&& !is_numeric($varValue)
+							&& function_exists('str_increment')
+						) {
 							$varValue = str_increment($varValue);
 						} elseif (!is_bool($varValue)) {
 							++$varValue;

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -150,6 +150,7 @@ use function array_slice;
 use function array_values;
 use function count;
 use function explode;
+use function function_exists;
 use function get_class;
 use function implode;
 use function in_array;
@@ -160,6 +161,8 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
+use function str_decrement;
+use function str_increment;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
@@ -1733,10 +1736,18 @@ final class MutatingScope implements Scope
 				foreach ($varScalars as $varValue) {
 					if ($node instanceof Expr\PreInc) {
 						if (!is_bool($varValue)) {
-							++$varValue;
+							if (function_exists('str_increment')) {
+								$varValue = str_increment($varValue);
+							} else {
+								++$varValue;
+							}
 						}
 					} elseif (is_numeric($varValue)) {
-						--$varValue;
+						if (function_exists('str_decrement')) {
+							$varValue = str_decrement($varValue);
+						} else {
+							--$varValue;
+						}
 					}
 
 					$newTypes[] = $this->getTypeFromValue($varValue);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -150,7 +150,6 @@ use function array_slice;
 use function array_values;
 use function count;
 use function explode;
-use function function_exists;
 use function get_class;
 use function implode;
 use function in_array;
@@ -161,7 +160,6 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
-use function str_increment;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
@@ -1739,11 +1737,7 @@ final class MutatingScope implements Scope
 						if ($varValue === '') {
 							$varValue = '1';
 						} elseif (!is_bool($varValue)) {
-							if (function_exists('str_increment') && is_string($varValue)) {
-								$varValue = str_increment($varValue);
-							} else {
-								++$varValue;
-							}
+							++$varValue;
 						}
 					} elseif (is_numeric($varValue)) {
 						--$varValue;

--- a/src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrIncrementDecrementFunctionReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
@@ -13,6 +14,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function chr;
 use function count;
+use function function_exists;
 use function implode;
 use function in_array;
 use function is_float;
@@ -21,6 +23,7 @@ use function is_numeric;
 use function is_string;
 use function ord;
 use function preg_match;
+use function str_increment;
 use function str_split;
 use function stripos;
 
@@ -101,6 +104,14 @@ final class StrIncrementDecrementFunctionReturnTypeExtension implements DynamicF
 
 				return $s;
 			}
+		}
+
+		if ($s === '') {
+			throw new ShouldNotHappenException();
+		}
+
+		if (function_exists('str_increment')) {
+			return str_increment($s);
 		}
 
 		return (string) ++$s;

--- a/tests/PHPStan/Analyser/nsrt/pre-dec.php
+++ b/tests/PHPStan/Analyser/nsrt/pre-dec.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PreDec;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	$s = '';
+	--$s;
+	assertType("-1", $s);
+}
+
+function doFoo2() {
+	$s = '123';
+	--$s;
+	assertType("122", $s);
+}
+
+function doFooBar() {
+	$s = 'abc';
+	--$s;
+	assertType("'abc'", $s);
+}

--- a/tests/PHPStan/Analyser/nsrt/pre-inc.php
+++ b/tests/PHPStan/Analyser/nsrt/pre-inc.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PreInc;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	$s = '';
+	++$s;
+	assertType("'1'", $s);
+}
+
+function doFoo2() {
+	$s = '123';
+	++$s;
+	assertType("'124'", $s);
+}
+
+function doFooBar() {
+	$s = 'abc';
+	++$s;
+	assertType("'abd'", $s);
+}

--- a/tests/PHPStan/Analyser/nsrt/pre-inc.php
+++ b/tests/PHPStan/Analyser/nsrt/pre-inc.php
@@ -13,7 +13,7 @@ function doFoo() {
 function doFoo2() {
 	$s = '123';
 	++$s;
-	assertType("'124'", $s);
+	assertType("124", $s);
 }
 
 function doFooBar() {


### PR DESCRIPTION
fixes PHP 8.5 deprecations like

```
1) PHPStan\Rules\Operators\OperandInArithmeticPostDecrementRuleTest::testRule
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
Deprecated: Increment on non-numeric string is deprecated, use str_increment() instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/MutatingScope.php:1268
```