### PR TITLE
Fix/nullable templates

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1255,6 +1255,12 @@ parameters:
 			message: '#^Doing instanceof PHPStan\\Type\\IntersectionType is error\-prone and deprecated\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 3
+			path: src/Type/Generic/TemplateNullType.php
+
+		-
+			message: '#^Doing instanceof PHPStan\\Type\\IntersectionType is error\-prone and deprecated\.$#'
+			identifier: phpstanApi.instanceofType
+			count: 3
 			path: src/Type/Generic/TemplateObjectShapeType.php
 
 		-
@@ -1331,6 +1337,12 @@ parameters:
 
 		-
 			message: '#^Doing instanceof PHPStan\\Type\\IterableType is error\-prone and deprecated\. Use Type\:\:isIterable\(\) instead\.$#'
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Type/Generic/TemplateTypeFactory.php
+
+		-
+			message: '#^Doing instanceof PHPStan\\Type\\NullType is error\-prone and deprecated\. Use Type\:\:isNull\(\) instead\.$#'
 			identifier: phpstanApi.instanceofType
 			count: 1
 			path: src/Type/Generic/TemplateTypeFactory.php

--- a/src/Rules/Generics/TemplateTypeCheck.php
+++ b/src/Rules/Generics/TemplateTypeCheck.php
@@ -28,6 +28,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectShapeType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -132,6 +133,7 @@ final class TemplateTypeCheck
 				&& $boundTypeClass !== GenericObjectType::class
 				&& $boundTypeClass !== KeyOfType::class
 				&& $boundTypeClass !== IterableType::class
+				&& $boundTypeClass !== NullType::class
 				&& !$boundType instanceof UnionType
 				&& !$boundType instanceof IntersectionType
 				&& !$boundType instanceof TemplateType

--- a/src/Type/Generic/TemplateNullType.php
+++ b/src/Type/Generic/TemplateNullType.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Generic;
+
+use PHPStan\Type\NullType;
+use PHPStan\Type\Traits\UndecidedComparisonCompoundTypeTrait;
+use PHPStan\Type\Type;
+
+final class TemplateNullType extends NullType implements TemplateType
+{
+
+	/** @use TemplateTypeTrait<NullType> */
+	use TemplateTypeTrait;
+	use UndecidedComparisonCompoundTypeTrait;
+
+	/**
+	 * @param non-empty-string $name
+	 */
+	public function __construct(
+		TemplateTypeScope $scope,
+		TemplateTypeStrategy $templateTypeStrategy,
+		TemplateTypeVariance $templateTypeVariance,
+		string $name,
+		NullType $bound,
+		?Type $default,
+	)
+	{
+		parent::__construct();
+		$this->scope = $scope;
+		$this->strategy = $templateTypeStrategy;
+		$this->variance = $templateTypeVariance;
+		$this->name = $name;
+		$this->bound = $bound;
+		$this->default = $default;
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeFactory.php
+++ b/src/Type/Generic/TemplateTypeFactory.php
@@ -15,6 +15,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectShapeType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
@@ -110,6 +111,10 @@ final class TemplateTypeFactory
 
 		if ($bound instanceof IterableType && ($boundClass === IterableType::class || $bound instanceof TemplateType)) {
 			return new TemplateIterableType($scope, $strategy, $variance, $name, $bound, $default);
+		}
+
+		if ($bound instanceof NullType && ($boundClass === NullType::class || $bound instanceof TemplateType)) {
+			return new TemplateNullType($scope, $strategy, $variance, $name, $bound, $default);
 		}
 
 		return new TemplateMixedType($scope, $strategy, $variance, $name, new MixedType(true), $default);

--- a/tests/PHPStan/Analyser/nsrt/bug-12894.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12894.php
@@ -1,18 +1,25 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types = 1); // lint >= 8.0
 
 namespace Bug12894;
+
+use Closure;
 
 /**
  * @template TValue of object|null
  */
-interface Dependency {
+interface Dependency
+{
+
 	/**
 	 * @return TValue
 	 */
 	public function __invoke(): object|null;
+
 }
 
-interface DependencyResolver {
+interface DependencyResolver
+{
+
 	/**
 	 * @template V of object|null
 	 * @template D of Dependency<V>
@@ -22,25 +29,23 @@ interface DependencyResolver {
 	 * @return V
 	 */
 	public function resolve(Dependency $dependency): object|null;
+
 }
 
-/**
- * @internal
- */
-class Resolver implements DependencyResolver {
-	public function __construct(
-		/**
-		 * @var Closure(object|null): void
-		 */
-		protected readonly Closure $run,
-	) {
-		// empty
-	}
+class Resolver implements DependencyResolver
+{
+	/**
+	 * @var Closure(object|null): void
+	 */
+	protected Closure $run;
 
 	public function resolve(Dependency $dependency): object|null {
 		$resolved = $dependency();
+		\PHPStan\Testing\assertType('V of object|null (method Bug12894\DependencyResolver::resolve(), argument)', $resolved);
 		$result = is_object($resolved) ? 1 : 2;
+		\PHPStan\Testing\assertType('V of object (method Bug12894\DependencyResolver::resolve(), argument)|V of null (method Bug12894\DependencyResolver::resolve(), argument)', $resolved);
 		($this->run)($resolved);
 		return $resolved;
 	}
+
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-12894.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12894.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1); // lint >= 8.0
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug12894;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12894.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12894.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12894;
+
+/**
+ * @template TValue of object|null
+ */
+interface Dependency {
+	/**
+	 * @return TValue
+	 */
+	public function __invoke(): object|null;
+}
+
+interface DependencyResolver {
+	/**
+	 * @template V of object|null
+	 * @template D of Dependency<V>
+	 *
+	 * @param D $dependency
+	 *
+	 * @return V
+	 */
+	public function resolve(Dependency $dependency): object|null;
+}
+
+/**
+ * @internal
+ */
+class Resolver implements DependencyResolver {
+	public function __construct(
+		/**
+		 * @var Closure(object|null): void
+		 */
+		protected readonly Closure $run,
+	) {
+		// empty
+	}
+
+	public function resolve(Dependency $dependency): object|null {
+		$resolved = $dependency();
+		$result = is_object($resolved) ? 1 : 2;
+		($this->run)($resolved);
+		return $resolved;
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12989.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12989.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12989;
+
+/**
+ * @template T of int|null
+ * @phpstan-param T $b
+ * @phpstan-return int|T
+ */
+function a(?int $b): ?int
+{
+	if ($b === null) {
+		return $b;
+	}
+	return $b;
+}
+

--- a/tests/PHPStan/Analyser/nsrt/bug-12989.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12989.php
@@ -10,8 +10,8 @@ namespace Bug12989;
 function a(?int $b): ?int
 {
 	if ($b === null) {
+		\PHPStan\Testing\assertType('T of null (function Bug12989\a(), argument)', $b);
 		return $b;
 	}
 	return $b;
 }
-

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -435,4 +435,11 @@ class MatchExpressionRuleTest extends RuleTestCase
 		]);
 	}
 
+
+	#[RequiresPhp('>= 8.0')]
+	public function testBug13048(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13048.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -436,7 +436,7 @@ class MatchExpressionRuleTest extends RuleTestCase
 	}
 
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.1')]
 	public function testBug13048(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-13048.php'], []);

--- a/tests/PHPStan/Rules/Comparison/data/bug-13048.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13048.php
@@ -1,6 +1,6 @@
-<?php // lint >= 8.0
+<?php // lint >= 8.1
 
-namespace Bug11852;
+namespace Bug13048;
 
 enum IndexBy {
 	case A;
@@ -10,7 +10,6 @@ enum IndexBy {
 /**
  * @template T of IndexBy|null
  * @param T $indexBy
- * @return (T is null ? null : string)
  */
 function run(?IndexBy $indexBy = null): ?string
 {

--- a/tests/PHPStan/Rules/Comparison/data/bug-13048.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13048.php
@@ -1,0 +1,22 @@
+<?php // lint >= 8.0
+
+namespace Bug11852;
+
+enum IndexBy {
+	case A;
+	case B;
+}
+
+/**
+ * @template T of IndexBy|null
+ * @param T $indexBy
+ * @return (T is null ? null : string)
+ */
+function run(?IndexBy $indexBy = null): ?string
+{
+	return match ($indexBy) {
+		IndexBy::A => 'by A',
+		IndexBy::B => 'by B',
+		null => null,
+	};
+}

--- a/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
@@ -57,10 +57,6 @@ class FunctionTemplateTypeRuleTest extends RuleTestCase
 				50,
 			],
 			[
-				'PHPDoc tag @template T for function FunctionTemplateType\nullNotSupported() with bound type null is not supported.',
-				68,
-			],
-			[
 				'Call-site variance of covariant int in generic type FunctionTemplateType\GenericCovariant<covariant int> in PHPDoc tag @template U is redundant, template type T of class FunctionTemplateType\GenericCovariant has the same variance.',
 				94,
 				'You can safely remove the call-site variance annotation.',

--- a/tests/PHPStan/Rules/Generics/data/function-template.php
+++ b/tests/PHPStan/Rules/Generics/data/function-template.php
@@ -65,7 +65,7 @@ function nakano()
 }
 
 /** @template T of null */
-function nullNotSupported()
+function nullSupported()
 {
 
 }

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -321,10 +321,6 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 				25,
 			],
 			[
-				'PHPDoc tag @param for parameter $notSupported template T of Closure<T of null>(T): T with bound type null is not supported.',
-				32,
-			],
-			[
 				'PHPDoc tag @param for parameter $shadows template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\testShadowFunction.',
 				40,
 			],
@@ -361,10 +357,6 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 				90,
 			],
 			[
-				'PHPDoc tag @return template T of Closure<T of null>(T): T with bound type null is not supported.',
-				97,
-			],
-			[
 				'PHPDoc tag @return template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\testShadowFunctionReturn.',
 				105,
 			],
@@ -381,10 +373,6 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 				131,
 			],
 			[
-				'PHPDoc tag @param for parameter $notSupported template T of Closure<T of null>(T): T with bound type null is not supported.',
-				138,
-			],
-			[
 				'PHPDoc tag @return template of Closure<stdClass of mixed>(stdClass): stdClass cannot have existing class stdClass as its name.',
 				145,
 			],
@@ -395,10 +383,6 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 			[
 				'PHPDoc tag @return template T of Closure<T of GenericCallablesIncompatible\Invalid>(T): T has invalid bound type GenericCallablesIncompatible\Invalid.',
 				159,
-			],
-			[
-				'PHPDoc tag @return template T of Closure<T of null>(T): T with bound type null is not supported.',
-				166,
 			],
 			[
 				'PHPDoc tag @param-out for parameter $existingClass template T of Closure<T of mixed>(T): T shadows @template T for function GenericCallablesIncompatible\shadowsParamOut.',

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
@@ -187,10 +187,6 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends RuleTestCase
 				26,
 			],
 			[
-				'PHPDoc tag @var template TNull of callable<TNull of null>(TNull): TNull with bound type null is not supported.',
-				31,
-			],
-			[
 				'PHPDoc tag @var template TInvalid of callable<TInvalid of GenericCallableProperties\Invalid>(TInvalid): TInvalid has invalid bound type GenericCallableProperties\Invalid.',
 				36,
 			],

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-callables-incompatible.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-callables-incompatible.php
@@ -27,9 +27,9 @@ function invalidBoundType(Closure $invalidBoundType): void
 }
 
 /**
- * @param Closure<T of null>(T $val): T $notSupported
+ * @param Closure<T of null>(T $val): T $closure
  */
-function notSupported(Closure $notSupported): void
+function testNull(Closure $closure): void
 {
 }
 
@@ -94,7 +94,7 @@ function invalidBoundTypeReturn(): Closure
 /**
  * @return Closure<T of null>(T $val): T
  */
-function notSupportedReturn(): Closure
+function nullReturn(): Closure
 {
 }
 
@@ -133,9 +133,9 @@ class Test2
 	}
 
 	/**
-	 * @param Closure<T of null>(T $val): T $notSupported
+	 * @param Closure<T of null>(T $val): T $closure
 	 */
-	public function notSupported(Closure $notSupported): void
+	public function nullType(Closure $closure): void
 	{
 	}
 
@@ -163,7 +163,7 @@ class Test2
 	/**
 	 * @return Closure<T of null>(T $val): T
 	 */
-	public function notSupportedReturn(): Closure
+	public function nullReturn(): Closure
 	{
 	}
 }


### PR DESCRIPTION
Fixed https://github.com/phpstan/phpstan/issues/13048. Essentially, `T of (A|null)` subtracted by `A` is `T of mixed`