### PR TITLE
Fix hasOffsetValueType with object

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -268,6 +268,9 @@ class ArrayType implements Type
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
 		$offsetType = $offsetType->toArrayKey();
+		if ($offsetType instanceof ErrorType) {
+			return TrinaryLogic::createNo();
+		}
 
 		if ($this->getKeyType()->isSuperTypeOf($offsetType)->no()
 			&& ($offsetType->isString()->no() || !$offsetType->isConstantScalarValue()->no())

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -588,6 +588,10 @@ class ConstantArrayType implements Type
 
 	private function recursiveHasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
+		if ($offsetType instanceof ErrorType) {
+			return TrinaryLogic::createNo();
+		}
+
 		if ($offsetType instanceof UnionType) {
 			$results = [];
 			foreach ($offsetType->getTypes() as $innerType) {

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -702,7 +702,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function toArrayKey(): Type
 	{
-		return $this->toString();
+		return new ErrorType();
 	}
 
 	public function toCoercedArgumentType(bool $strictTypes): Type

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -19,7 +19,6 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 

--- a/src/Type/Traits/ObjectTypeTrait.php
+++ b/src/Type/Traits/ObjectTypeTrait.php
@@ -271,7 +271,7 @@ trait ObjectTypeTrait
 
 	public function toArrayKey(): Type
 	{
-		return new StringType();
+		return new ErrorType();
 	}
 
 	public function toCoercedArgumentType(bool $strictTypes): Type

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -1801,7 +1801,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$this->resource',
 			],
 			[
-				'mixed',
+				'*ERROR*',
 				'$this->yetAnotherAnotherMixedParameter',
 			],
 			[

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
@@ -10,7 +10,17 @@
         "ignorable": true
     },
     {
+        "message": "Offset int|object does not exist on array{baz: 21}|array{foo: 17, bar: 19}.",
+        "line": 55,
+        "ignorable": true
+    },
+    {
         "message": "Invalid array key type stdClass.",
+        "line": 59,
+        "ignorable": true
+    },
+    {
+        "message": "Offset stdClass does not exist on array{baz: 21}|array{foo: 17, bar: 19}.",
         "line": 59,
         "ignorable": true
     }

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
@@ -10,6 +10,11 @@
         "ignorable": true
     },
     {
+        "message": "Offset int|object might not exist on array|string.",
+        "line": 35,
+        "ignorable": true
+    },
+    {
         "message": "Possibly invalid array key type int|object.",
         "line": 35,
         "ignorable": true

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -193,6 +193,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Offset 12.34 might not exist on array|string.',
 				28,
 			],
+			[
+				'Offset int|object might not exist on array|string.',
+				32,
+			],
 		]);
 	}
 
@@ -931,7 +935,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Offset object does not exist on array<string, int>.',
 				21,
-			]
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -921,6 +921,20 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12593.php'], []);
 	}
 
+	public function testBugObject(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-object.php'], [
+			[
+				'Offset int|object does not exist on array{baz: 21}|array{foo: 17, bar: 19}.',
+				12,
+			],
+			[
+				'Offset object does not exist on array<string, int>.',
+				21,
+			]
+		]);
+	}
+
 	public function testBug3747(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-3747.php'], []);

--- a/tests/PHPStan/Rules/Arrays/data/bug-object.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-object.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BugObject;
+
+class B {
+	/**
+	 * @param array{baz: 21}|array{foo: 17, bar: 19} $array
+	 * @param int|object $key
+	 */
+	public function foo($array, $key)
+	{
+		$array[$key];
+	}
+
+	/**
+	 * @param array<string, int> $array
+	 * @param object $key
+	 */
+	public function foo2($array, $key)
+	{
+		$array[$key];
+	}
+}


### PR DESCRIPTION
Cf https://www.php.net/manual/en/language.types.array.php

[Array](https://www.php.net/manual/en/language.types.array.php)s and [object](https://www.php.net/manual/en/language.types.object.php)s can not be used as keys. Doing so will result in a warning: Illegal offset type.

So ObjectType::toArrayKey should be an error.