### PR TITLE
feat: add parameter closure this extension

### DIFF
--- a/src/DependencyInjection/Type/LazyParameterClosureThisExtensionProvider.php
+++ b/src/DependencyInjection/Type/LazyParameterClosureThisExtensionProvider.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\Type;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\Type\FunctionParameterClosureThisExtension;
+use PHPStan\Type\MethodParameterClosureThisExtension;
+use PHPStan\Type\StaticMethodParameterClosureThisExtension;
+
+#[AutowiredService(as: ParameterClosureThisExtensionProvider::class)]
+final class LazyParameterClosureThisExtensionProvider implements ParameterClosureThisExtensionProvider
+{
+
+	public const FUNCTION_TAG = 'phpstan.functionParameterClosureThisExtension';
+	public const METHOD_TAG = 'phpstan.methodParameterClosureThisExtension';
+	public const STATIC_METHOD_TAG = 'phpstan.staticMethodParameterClosureThisExtension';
+
+	/** @var FunctionParameterClosureThisExtension[]|null */
+	private ?array $functionExtensions = null;
+
+	/** @var MethodParameterClosureThisExtension[]|null */
+	private ?array $methodExtensions = null;
+
+	/** @var StaticMethodParameterClosureThisExtension[]|null */
+	private ?array $staticMethodExtensions = null;
+
+	public function __construct(private Container $container)
+	{
+	}
+
+	public function getFunctionParameterClosureThisExtensions(): array
+	{
+		return $this->functionExtensions ??= $this->container->getServicesByTag(self::FUNCTION_TAG);
+	}
+
+	public function getMethodParameterClosureThisExtensions(): array
+	{
+		return $this->methodExtensions ??= $this->container->getServicesByTag(self::METHOD_TAG);
+	}
+
+	public function getStaticMethodParameterClosureThisExtensions(): array
+	{
+		return $this->staticMethodExtensions ??= $this->container->getServicesByTag(self::STATIC_METHOD_TAG);
+	}
+
+}

--- a/src/DependencyInjection/Type/ParameterClosureThisExtensionProvider.php
+++ b/src/DependencyInjection/Type/ParameterClosureThisExtensionProvider.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection\Type;
+
+use PHPStan\Type\FunctionParameterClosureThisExtension;
+use PHPStan\Type\MethodParameterClosureThisExtension;
+use PHPStan\Type\StaticMethodParameterClosureThisExtension;
+
+interface ParameterClosureThisExtensionProvider
+{
+
+	/**
+	 * @return FunctionParameterClosureThisExtension[]
+	 */
+	public function getFunctionParameterClosureThisExtensions(): array;
+
+	/**
+	 * @return MethodParameterClosureThisExtension[]
+	 */
+	public function getMethodParameterClosureThisExtensions(): array;
+
+	/**
+	 * @return StaticMethodParameterClosureThisExtension[]
+	 */
+	public function getStaticMethodParameterClosureThisExtensions(): array;
+
+}

--- a/src/DependencyInjection/ValidateServiceTagsExtension.php
+++ b/src/DependencyInjection/ValidateServiceTagsExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Broker\BrokerFactory;
 use PHPStan\Collectors\Collector;
 use PHPStan\Collectors\RegistryFactory as CollectorRegistryFactory;
 use PHPStan\DependencyInjection\Type\LazyDynamicThrowTypeExtensionProvider;
+use PHPStan\DependencyInjection\Type\LazyParameterClosureThisExtensionProvider;
 use PHPStan\DependencyInjection\Type\LazyParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\LazyParameterOutTypeExtensionProvider;
 use PHPStan\Diagnose\DiagnoseExtension;
@@ -47,13 +48,16 @@ use PHPStan\Type\DynamicMethodThrowTypeExtension;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
 use PHPStan\Type\ExpressionTypeResolverExtension;
+use PHPStan\Type\FunctionParameterClosureThisExtension;
 use PHPStan\Type\FunctionParameterClosureTypeExtension;
 use PHPStan\Type\FunctionParameterOutTypeExtension;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\MethodParameterClosureThisExtension;
 use PHPStan\Type\MethodParameterClosureTypeExtension;
 use PHPStan\Type\MethodParameterOutTypeExtension;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
 use PHPStan\Type\OperatorTypeSpecifyingExtension;
+use PHPStan\Type\StaticMethodParameterClosureThisExtension;
 use PHPStan\Type\StaticMethodParameterClosureTypeExtension;
 use PHPStan\Type\StaticMethodParameterOutTypeExtension;
 use PHPStan\Type\StaticMethodTypeSpecifyingExtension;
@@ -86,6 +90,9 @@ final class ValidateServiceTagsExtension extends CompilerExtension
 		DynamicFunctionThrowTypeExtension::class => LazyDynamicThrowTypeExtensionProvider::FUNCTION_TAG,
 		DynamicMethodThrowTypeExtension::class => LazyDynamicThrowTypeExtensionProvider::METHOD_TAG,
 		DynamicStaticMethodThrowTypeExtension::class => LazyDynamicThrowTypeExtensionProvider::STATIC_METHOD_TAG,
+		FunctionParameterClosureThisExtension::class => LazyParameterClosureThisExtensionProvider::FUNCTION_TAG,
+		MethodParameterClosureThisExtension::class => LazyParameterClosureThisExtensionProvider::METHOD_TAG,
+		StaticMethodParameterClosureThisExtension::class => LazyParameterClosureThisExtensionProvider::STATIC_METHOD_TAG,
 		FunctionParameterClosureTypeExtension::class => LazyParameterClosureTypeExtensionProvider::FUNCTION_TAG,
 		MethodParameterClosureTypeExtension::class => LazyParameterClosureTypeExtensionProvider::METHOD_TAG,
 		StaticMethodParameterClosureTypeExtension::class => LazyParameterClosureTypeExtensionProvider::STATIC_METHOD_TAG,

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -17,6 +17,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Collectors\Registry as CollectorRegistry;
 use PHPStan\Dependency\DependencyResolver;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
+use PHPStan\DependencyInjection\Type\ParameterClosureThisExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
 use PHPStan\File\FileHelper;
@@ -105,6 +106,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 				$typeSpecifier,
 				self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
 				$readWritePropertiesExtensions !== [] ? new DirectReadWritePropertiesExtensionProvider($readWritePropertiesExtensions) : self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
+				self::getContainer()->getByType(ParameterClosureThisExtensionProvider::class),
 				self::getContainer()->getByType(ParameterClosureTypeExtensionProvider::class),
 				self::createScopeFactory($reflectionProvider, $typeSpecifier),
 				$this->shouldPolluteScopeWithLoopInitialAssignments(),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
+use PHPStan\DependencyInjection\Type\ParameterClosureThisExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
 use PHPStan\File\FileHelper;
@@ -83,6 +84,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$typeSpecifier,
 			self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
 			self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
+			self::getContainer()->getByType(ParameterClosureThisExtensionProvider::class),
 			self::getContainer()->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			self::getContainer()->getParameter('polluteScopeWithLoopInitialAssignments'),

--- a/src/Type/FunctionParameterClosureThisExtension.php
+++ b/src/Type/FunctionParameterClosureThisExtension.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParameterReflection;
+
+/**
+ * This is the interface for dynamically specifying the $this context
+ * for closure parameters in function calls.
+ *
+ * To register it in the configuration file use the `phpstan.functionParameterClosureThisExtension` service tag:
+ *
+ * ```
+ * services:
+ * 	-
+ * 		class: App\PHPStan\MyExtension
+ * 		tags:
+ * 			- phpstan.functionParameterClosureThisExtension
+ * ```
+ *
+ * @api
+ */
+interface FunctionParameterClosureThisExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool;
+
+	public function getClosureThisTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type;
+
+}

--- a/src/Type/MethodParameterClosureThisExtension.php
+++ b/src/Type/MethodParameterClosureThisExtension.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+
+/**
+ * This is the interface for dynamically specifying the $this context
+ * for closure parameters in method calls.
+ *
+ * To register it in the configuration file use the `phpstan.methodParameterClosureThisExtension` service tag:
+ *
+ * ```
+ * services:
+ * 	-
+ * 		class: App\PHPStan\MyExtension
+ * 		tags:
+ * 			- phpstan.methodParameterClosureThisExtension
+ * ```
+ *
+ * @api
+ */
+interface MethodParameterClosureThisExtension
+{
+
+	public function isMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool;
+
+	public function getClosureThisTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, ParameterReflection $parameter, Scope $scope): ?Type;
+
+}

--- a/src/Type/StaticMethodParameterClosureThisExtension.php
+++ b/src/Type/StaticMethodParameterClosureThisExtension.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+
+/**
+ * This is the interface for dynamically specifying the $this context
+ * for closure parameters in static method calls.
+ *
+ * To register it in the configuration file use the `phpstan.staticMethodParameterClosureThisExtension` service tag:
+ *
+ * ```
+ * services:
+ * 	-
+ * 		class: App\PHPStan\MyExtension
+ * 		tags:
+ * 			- phpstan.staticMethodParameterClosureThisExtension
+ * ```
+ *
+ * @api
+ */
+interface StaticMethodParameterClosureThisExtension
+{
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool;
+
+	public function getClosureThisTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, ParameterReflection $parameter, Scope $scope): ?Type;
+
+}

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -13,6 +13,7 @@ use PHPStan\Dependency\DependencyResolver;
 use PHPStan\Dependency\ExportedNodeResolver;
 use PHPStan\DependencyInjection\Nette\NetteContainer;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
+use PHPStan\DependencyInjection\Type\ParameterClosureThisExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
 use PHPStan\Node\Printer\ExprPrinter;
@@ -749,6 +750,7 @@ class AnalyserTest extends PHPStanTestCase
 			$typeSpecifier,
 			self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
 			self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
+			self::getContainer()->getByType(ParameterClosureThisExtensionProvider::class),
 			self::getContainer()->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			false,

--- a/tests/PHPStan/Analyser/ParameterClosureThisExtensionTest.php
+++ b/tests/PHPStan/Analyser/ParameterClosureThisExtensionTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ParameterClosureThisExtensionTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/parameter-closure-this-extension.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataFileAsserts')]
+	public function testFileAsserts(string $assertType, string $file, ...$args): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/parameter-closure-this-extension.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/parameter-closure-this-extension.php
+++ b/tests/PHPStan/Analyser/data/parameter-closure-this-extension.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ParameterClosureThisExtension;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use function PHPStan\Testing\assertType;
+
+class TestFunctionParameterClosureThisExtension implements \PHPStan\Type\FunctionParameterClosureThisExtension
+{
+	public function isFunctionSupported(FunctionReflection $functionReflection, ParameterReflection $parameter): bool
+	{
+		return $functionReflection->getName() === 'ParameterClosureThisExtension\testFunction'
+			&& $parameter->getName() === 'closure';
+	}
+
+	public function getClosureThisTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		return new ObjectType(TestContext::class);
+	}
+}
+
+class TestMethodParameterClosureThisExtension implements \PHPStan\Type\MethodParameterClosureThisExtension
+{
+	public function isMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
+	{
+		return $methodReflection->getDeclaringClass()->getName() === TestClass::class
+			&& $methodReflection->getName() === 'methodWithClosure'
+			&& $parameter->getName() === 'closure';
+	}
+
+	public function getClosureThisTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		return new ObjectType(TestContext::class);
+	}
+}
+
+class TestStaticMethodParameterClosureThisExtension implements \PHPStan\Type\StaticMethodParameterClosureThisExtension
+{
+	public function isStaticMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
+	{
+		return $methodReflection->getDeclaringClass()->getName() === TestClass::class
+			&& $methodReflection->getName() === 'staticMethodWithClosure'
+			&& $parameter->getName() === 'closure';
+	}
+
+	public function getClosureThisTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, ParameterReflection $parameter, Scope $scope): ?Type
+	{
+		return new ObjectType(TestContext::class);
+	}
+}
+
+class TestContext
+{
+	public function contextMethod(): string
+	{
+		return 'context';
+	}
+}
+
+class TestClass
+{
+	public function methodWithClosure(callable $closure): void
+	{
+	}
+
+	public static function staticMethodWithClosure(callable $closure): void
+	{
+	}
+}
+
+/**
+ * @param callable $closure
+ */
+function testFunction(callable $closure): void
+{
+}
+
+testFunction(function () {
+	assertType('ParameterClosureThisExtension\TestContext', $this);
+	assertType('string', $this->contextMethod());
+});
+
+$test = new TestClass();
+$test->methodWithClosure(function () {
+	assertType('ParameterClosureThisExtension\TestContext', $this);
+	assertType('string', $this->contextMethod());
+});
+
+TestClass::staticMethodWithClosure(function () {
+	assertType('ParameterClosureThisExtension\TestContext', $this);
+	assertType('string', $this->contextMethod());
+});
+
+testFunction(fn () => assertType('ParameterClosureThisExtension\TestContext', $this));
+
+testFunction(static function () {
+	assertType('*ERROR*', $this);
+});
+
+testFunction(static fn () => assertType('*ERROR*', $this));

--- a/tests/PHPStan/Analyser/parameter-closure-this-extension.neon
+++ b/tests/PHPStan/Analyser/parameter-closure-this-extension.neon
@@ -1,0 +1,13 @@
+services:
+	-
+		class: ParameterClosureThisExtension\TestFunctionParameterClosureThisExtension
+		tags:
+			- phpstan.functionParameterClosureThisExtension
+	-
+		class: ParameterClosureThisExtension\TestMethodParameterClosureThisExtension
+		tags:
+			- phpstan.methodParameterClosureThisExtension
+	-
+		class: ParameterClosureThisExtension\TestStaticMethodParameterClosureThisExtension
+		tags:
+			- phpstan.staticMethodParameterClosureThisExtension


### PR DESCRIPTION
Hello!

## Summary

This PR introduces extension interfaces that allow PHPStan extensions to dynamically specify the `$this` context for closure parameters.

## Problem

Currently, PHPStan only supports static `@param-closure-this` PHPDoc annotations, which cannot handle dynamic scenarios where the closure's `$this` type depends on runtime context. This particularly affects frameworks like PestPHP, which heavily rely on closures with dynamic `$this` bindings, and cannot properly communicate type information to PHPStan.

### Real-world Example (PestPHP)

```php
// PestPHP test file
test('user can login', function () {
    // PHPStan thinks $this is PHPUnit\Framework\TestCase (from @param-closure-this)
    // But it's actually the user's custom test class with additional methods
    $this->loginAs($user);  // <- PHPStan error: method not found
    $this->assertAuthenticated();
});
```

## Solution

This PR adds three new extension interfaces that mirror the existing parameter type extensions:

- `FunctionParameterClosureThisExtension` - For function calls
- `MethodParameterClosureThisExtension` - For method calls  
- `StaticMethodParameterClosureThisExtension` - For static method calls

These extensions can inspect the call context (AST nodes, scope, arguments) and return the appropriate `$this` type for the closure.

## Implementation Details

### Architecture

The implementation follows PHPStan's established patterns with minimal invasiveness:

1. **Extension interfaces** define the API for specifying closure `$this` types
2. **Provider infrastructure** manages and lazy-loads registered extensions
3. **Integration in NodeScopeResolver** checks extensions when processing closures
4. **Service tags** for DI registration: `phpstan.functionParameterClosureThisExtension`, etc.

## Usage Example

Here's a psuedo-code example of how PestPHP could use this feature:

```php
<?php
use PHPStan\Type\FunctionParameterClosureThisExtension;

class PestTestExtension implements FunctionParameterClosureThisExtension
{
    public function isFunctionSupported(FunctionReflection $function, ParameterReflection $parameter): bool
    {
        return in_array($function->getName(), ['test', 'it', 'beforeEach', 'afterEach'])
            && $parameter->getName() === 'closure';
    }

    public function getClosureThisTypeFromFunctionCall(FunctionReflection $function, FuncCall $call, ParameterReflection $parameter, Scope $scope): ?Type
    {
        // Detect the test class from file/namespace context
        $namespace = $scope->getNamespace();
        if ($namespace !== null && str_ends_with($namespace, '\\Tests')) {
            $testClass = $this->findTestClassInFile($scope->getFile());
            if ($testClass !== null) {
                return new ObjectType($testClass);
            }
        }

        return null;
    }
}
```

Register in `phpstan.neon`:
```yaml
services:
  - class: PestTestExtension
    tags: [phpstan.functionParameterClosureThisExtension]
```

Thanks!
