### PR TITLE
Fix hasOffsetValueType for arrays

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -8,6 +8,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
 use PHPStan\Reflection\TrivialParametersAcceptor;
+use PHPStan\Rules\Arrays\AllowedArrayKeysTypes;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -267,10 +268,8 @@ class ArrayType implements Type
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
-		$offsetType = $offsetType->toArrayKey();
-		if ($offsetType instanceof ErrorType) {
-			return TrinaryLogic::createNo();
-		}
+		$allowedArrayKeys = AllowedArrayKeysTypes::getType();
+		$offsetType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
 
 		if ($this->getKeyType()->isSuperTypeOf($offsetType)->no()
 			&& ($offsetType->isString()->no() || !$offsetType->isConstantScalarValue()->no())

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -19,6 +19,7 @@ use PHPStan\Reflection\InaccessibleMethod;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\PhpVersionStaticAccessor;
 use PHPStan\Reflection\TrivialParametersAcceptor;
+use PHPStan\Rules\Arrays\AllowedArrayKeysTypes;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\AcceptsResult;
@@ -581,17 +582,14 @@ class ConstantArrayType implements Type
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
-		$offsetArrayKeyType = $offsetType->toArrayKey();
+		$allowedArrayKeys = AllowedArrayKeysTypes::getType();
+		$offsetArrayKeyType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
 
 		return $this->recursiveHasOffsetValueType($offsetArrayKeyType);
 	}
 
 	private function recursiveHasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
-		if ($offsetType instanceof ErrorType) {
-			return TrinaryLogic::createNo();
-		}
-
 		if ($offsetType instanceof UnionType) {
 			$results = [];
 			foreach ($offsetType->getTypes() as $innerType) {

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -1801,7 +1801,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'$this->resource',
 			],
 			[
-				'*ERROR*',
+				'mixed',
 				'$this->yetAnotherAnotherMixedParameter',
 			],
 			[

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
@@ -18,10 +18,5 @@
         "message": "Invalid array key type stdClass.",
         "line": 59,
         "ignorable": true
-    },
-    {
-        "message": "Offset stdClass does not exist on array{baz: 21}|array{foo: 17, bar: 19}.",
-        "line": 59,
-        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-7.json
@@ -10,11 +10,6 @@
         "ignorable": true
     },
     {
-        "message": "Offset int|object might not exist on array|string.",
-        "line": 35,
-        "ignorable": true
-    },
-    {
         "message": "Possibly invalid array key type int|object.",
         "line": 35,
         "ignorable": true

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -193,10 +193,6 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Offset 12.34 might not exist on array|string.',
 				28,
 			],
-			[
-				'Offset int|object might not exist on array|string.',
-				32,
-			],
 		]);
 	}
 
@@ -931,10 +927,6 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Offset int|object does not exist on array{baz: 21}|array{foo: 17, bar: 19}.',
 				12,
-			],
-			[
-				'Offset object does not exist on array<string, int>.',
-				21,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -326,6 +326,11 @@ class NullCoalesceRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10610.php'], []);
 	}
 
+	public function testBugDoctrine(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-doctrine.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.4')]
 	public function testBug12553(): void
 	{

--- a/tests/PHPStan/Rules/Variables/data/bug-doctrine.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-doctrine.php
@@ -4,7 +4,11 @@ namespace BugDoctrine;
 
 class HelloWorld
 {
-	public function sayHello(string|array $a, array $b): void
+	/**
+	 * @param string|array $a
+	 * @param array        $b
+	 */
+	public function sayHello($a, $b): void
 	{
 			$b[$a] ?? 2;
 	}

--- a/tests/PHPStan/Rules/Variables/data/bug-doctrine.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-doctrine.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace BugDoctrine;
+
+class HelloWorld
+{
+	public function sayHello(string|array $a, array $b): void
+	{
+			$b[$a] ?? 2;
+	}
+}


### PR DESCRIPTION
I feel like we should only check for AllowedArrayKeysTypes since others types are checked by InvalidArrayKey rule.