### PR TITLE
Update `curl_getinfo()` return types

### DIFF
--- a/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/CurlGetinfoFunctionDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -16,6 +17,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -63,8 +65,10 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 		$floatType = new FloatType();
 		$falseType = new ConstantBooleanType(false);
 		$stringFalseType = TypeCombinator::union($stringType, $falseType);
-		$integerStringArrayType = new ArrayType($integerType, $stringType);
-		$nestedStringStringArrayType = new ArrayType($integerType, new ArrayType($stringType, $stringType));
+		$integerFalseType = TypeCombinator::union($integerType, $falseType);
+		$stringListType = TypeCombinator::intersect(new ArrayType($integerType, $stringType), new AccessoryArrayListType());
+		$nestedArrayInListType = TypeCombinator::intersect(new ArrayType($integerType, new ArrayType($stringType, $stringType)), new AccessoryArrayListType());
+		$mixedType = new MixedType();
 
 		$componentTypesPairedConstants = [
 			'CURLINFO_EFFECTIVE_URL' => $stringType,
@@ -76,15 +80,15 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'CURLINFO_STARTTRANSFER_TIME' => $floatType,
 			'CURLINFO_REDIRECT_COUNT' => $integerType,
 			'CURLINFO_REDIRECT_TIME' => $floatType,
-			'CURLINFO_REDIRECT_URL' => $stringType,
+			'CURLINFO_REDIRECT_URL' => $stringFalseType,
 			'CURLINFO_PRIMARY_IP' => $stringType,
 			'CURLINFO_PRIMARY_PORT' => $integerType,
 			'CURLINFO_LOCAL_IP' => $stringType,
 			'CURLINFO_LOCAL_PORT' => $integerType,
-			'CURLINFO_SIZE_UPLOAD' => $integerType,
-			'CURLINFO_SIZE_DOWNLOAD' => $integerType,
-			'CURLINFO_SPEED_DOWNLOAD' => $integerType,
-			'CURLINFO_SPEED_UPLOAD' => $integerType,
+			'CURLINFO_SIZE_UPLOAD' => $floatType,
+			'CURLINFO_SIZE_DOWNLOAD' => $floatType,
+			'CURLINFO_SPEED_DOWNLOAD' => $floatType,
+			'CURLINFO_SPEED_UPLOAD' => $floatType,
 			'CURLINFO_HEADER_SIZE' => $integerType,
 			'CURLINFO_HEADER_OUT' => $stringFalseType,
 			'CURLINFO_REQUEST_SIZE' => $integerType,
@@ -92,25 +96,26 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'CURLINFO_CONTENT_LENGTH_DOWNLOAD' => $floatType,
 			'CURLINFO_CONTENT_LENGTH_UPLOAD' => $floatType,
 			'CURLINFO_CONTENT_TYPE' => $stringFalseType,
-			'CURLINFO_PRIVATE' => $stringFalseType,
+			'CURLINFO_PRIVATE' => $mixedType,
 			'CURLINFO_RESPONSE_CODE' => $integerType,
+			'CURLINFO_HTTP_CODE' => $integerType,
 			'CURLINFO_HTTP_CONNECTCODE' => $integerType,
 			'CURLINFO_HTTPAUTH_AVAIL' => $integerType,
 			'CURLINFO_PROXYAUTH_AVAIL' => $integerType,
 			'CURLINFO_OS_ERRNO' => $integerType,
 			'CURLINFO_NUM_CONNECTS' => $integerType,
-			'CURLINFO_SSL_ENGINES' => $integerStringArrayType,
-			'CURLINFO_COOKIELIST' => $integerStringArrayType,
+			'CURLINFO_SSL_ENGINES' => $stringListType,
+			'CURLINFO_COOKIELIST' => $stringListType,
 			'CURLINFO_FTP_ENTRY_PATH' => $stringFalseType,
 			'CURLINFO_APPCONNECT_TIME' => $floatType,
-			'CURLINFO_CERTINFO' => $nestedStringStringArrayType,
+			'CURLINFO_CERTINFO' => $nestedArrayInListType,
 			'CURLINFO_CONDITION_UNMET' => $integerType,
 			'CURLINFO_RTSP_CLIENT_CSEQ' => $integerType,
 			'CURLINFO_RTSP_CSEQ_RECV' => $integerType,
 			'CURLINFO_RTSP_SERVER_CSEQ' => $integerType,
-			'CURLINFO_RTSP_SESSION_ID' => $integerType,
+			'CURLINFO_RTSP_SESSION_ID' => $stringFalseType,
 			'CURLINFO_HTTP_VERSION' => $integerType,
-			'CURLINFO_PROTOCOL' => $stringType,
+			'CURLINFO_PROTOCOL' => $integerType,
 			'CURLINFO_PROXY_SSL_VERIFYRESULT' => $integerType,
 			'CURLINFO_SCHEME' => $stringType,
 			'CURLINFO_CONTENT_LENGTH_DOWNLOAD_T' => $integerType,
@@ -127,6 +132,18 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'CURLINFO_REDIRECT_TIME_T' => $integerType,
 			'CURLINFO_STARTTRANSFER_TIME_T' => $integerType,
 			'CURLINFO_TOTAL_TIME_T' => $integerType,
+			'CURLINFO_EFFECTIVE_METHOD' => $stringType,
+			'CURLINFO_PROXY_ERROR' => $integerType,
+			'CURLINFO_REFERER' => $stringFalseType,
+			'CURLINFO_RETRY_AFTER' => $integerType,
+			'CURLINFO_CAINFO' => $stringFalseType,
+			'CURLINFO_CAPATH' => $stringFalseType,
+			'CURLINFO_POSTTRANSFER_TIME_T' => $integerFalseType,
+			'CURLINFO_QUEUE_TIME_T' => $integerFalseType,
+			'CURLINFO_USED_PROXY' => $integerFalseType,
+			'CURLINFO_HTTPAUTH_USED' => $integerFalseType,
+			'CURLINFO_PROXYAUTH_USED' => $integerFalseType,
+			'CURLINFO_CONN_ID' => $integerFalseType,
 		];
 
 		foreach ($componentTypesPairedConstants as $constantName => $type) {
@@ -156,7 +173,7 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 		$integerType = new IntegerType();
 		$floatType = new FloatType();
 		$stringOrNullType = TypeCombinator::union($stringType, new NullType());
-		$nestedStringStringArrayType = new ArrayType($integerType, new ArrayType($stringType, $stringType));
+		$nestedArrayInListType = TypeCombinator::intersect(new ArrayType($integerType, new ArrayType($stringType, $stringType)), new AccessoryArrayListType());
 
 		$componentTypesPairedStrings = [
 			'url' => $stringType,
@@ -181,7 +198,7 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'redirect_time' => $floatType,
 			'redirect_url' => $stringType,
 			'primary_ip' => $stringType,
-			'certinfo' => $nestedStringStringArrayType,
+			'certinfo' => $nestedArrayInListType,
 			'primary_port' => $integerType,
 			'local_ip' => $stringType,
 			'local_port' => $integerType,
@@ -189,6 +206,23 @@ final class CurlGetinfoFunctionDynamicReturnTypeExtension implements DynamicFunc
 			'protocol' => $integerType,
 			'ssl_verifyresult' => $integerType,
 			'scheme' => $stringType,
+			'appconnect_time_us' => $integerType,
+			'queue_time_us' => $integerType,
+			'connect_time_us' => $integerType,
+			'namelookup_time_us' => $integerType,
+			'pretransfer_time_us' => $integerType,
+			'redirect_time_us' => $integerType,
+			'starttransfer_time_us' => $integerType,
+			'posttransfer_time_us' => $integerType,
+			'total_time_us' => $integerType,
+			'request_header' => $stringType,
+			'effective_method' => $stringType,
+			'capath' => $stringType,
+			'cainfo' => $stringType,
+			'used_proxy' => $integerType,
+			'httpauth_used' => $integerType,
+			'proxyauth_used' => $integerType,
+			'conn_id' => $integerType,
 		];
 		foreach ($componentTypesPairedStrings as $componentName => $componentValueType) {
 			$builder->setOffsetValueType(new ConstantStringType($componentName), $componentValueType);

--- a/tests/PHPStan/Analyser/nsrt/curl_getinfo.php
+++ b/tests/PHPStan/Analyser/nsrt/curl_getinfo.php
@@ -9,15 +9,17 @@ class Foo
 {
 	public function bar()
 	{
+		$curlGetInfoType = '(array{url: string, content_type: string|null, http_code: int, header_size: int, request_size: int, filetime: int, ssl_verify_result: int, redirect_count: int, total_time: float, namelookup_time: float, connect_time: float, pretransfer_time: float, size_upload: float, size_download: float, speed_download: float, speed_upload: float, download_content_length: float, upload_content_length: float, starttransfer_time: float, redirect_time: float, redirect_url: string, primary_ip: string, certinfo: list<array<string, string>>, primary_port: int, local_ip: string, local_port: int, http_version: int, protocol: int, ssl_verifyresult: int, scheme: string, appconnect_time_us: int, queue_time_us: int, connect_time_us: int, namelookup_time_us: int, pretransfer_time_us: int, redirect_time_us: int, starttransfer_time_us: int, posttransfer_time_us: int, total_time_us: int, request_header: string, effective_method: string, capath: string, cainfo: string, used_proxy: int, httpauth_used: int, proxyauth_used: int, conn_id: int}|false)';
+
 		$handle = new CurlHandle();
 		assertType('mixed', curl_getinfo());
 		assertType('mixed', CURL_GETINFO());
 		assertType('mixed', CuRl_GeTiNfO());
 		assertType('false', curl_getinfo($handle, 'Invalid Argument'));
-		assertType('(array{url: string, content_type: string|null, http_code: int, header_size: int, request_size: int, filetime: int, ssl_verify_result: int, redirect_count: int, total_time: float, namelookup_time: float, connect_time: float, pretransfer_time: float, size_upload: float, size_download: float, speed_download: float, speed_upload: float, download_content_length: float, upload_content_length: float, starttransfer_time: float, redirect_time: float, redirect_url: string, primary_ip: string, certinfo: array<int, array<string, string>>, primary_port: int, local_ip: string, local_port: int, http_version: int, protocol: int, ssl_verifyresult: int, scheme: string}|false)', curl_getinfo($handle, PHP_INT_MAX));
+		assertType($curlGetInfoType, curl_getinfo($handle, PHP_INT_MAX));
 		assertType('false', curl_getinfo($handle, PHP_EOL));
-		assertType('(array{url: string, content_type: string|null, http_code: int, header_size: int, request_size: int, filetime: int, ssl_verify_result: int, redirect_count: int, total_time: float, namelookup_time: float, connect_time: float, pretransfer_time: float, size_upload: float, size_download: float, speed_download: float, speed_upload: float, download_content_length: float, upload_content_length: float, starttransfer_time: float, redirect_time: float, redirect_url: string, primary_ip: string, certinfo: array<int, array<string, string>>, primary_port: int, local_ip: string, local_port: int, http_version: int, protocol: int, ssl_verifyresult: int, scheme: string}|false)', curl_getinfo($handle));
-		assertType('(array{url: string, content_type: string|null, http_code: int, header_size: int, request_size: int, filetime: int, ssl_verify_result: int, redirect_count: int, total_time: float, namelookup_time: float, connect_time: float, pretransfer_time: float, size_upload: float, size_download: float, speed_download: float, speed_upload: float, download_content_length: float, upload_content_length: float, starttransfer_time: float, redirect_time: float, redirect_url: string, primary_ip: string, certinfo: array<int, array<string, string>>, primary_port: int, local_ip: string, local_port: int, http_version: int, protocol: int, ssl_verifyresult: int, scheme: string}|false)', curl_getinfo($handle, null));
+		assertType($curlGetInfoType, curl_getinfo($handle));
+		assertType($curlGetInfoType, curl_getinfo($handle, null));
 		assertType('string', curl_getinfo($handle, CURLINFO_EFFECTIVE_URL));
 		assertType('string', curl_getinfo($handle, 1048577)); // CURLINFO_EFFECTIVE_URL int value without using constant
 		assertType('false', curl_getinfo($handle, 12345678)); // Non constant non CURLINFO_* int value
@@ -29,15 +31,15 @@ class Foo
 		assertType('float', curl_getinfo($handle, CURLINFO_STARTTRANSFER_TIME));
 		assertType('int', curl_getinfo($handle, CURLINFO_REDIRECT_COUNT));
 		assertType('float', curl_getinfo($handle, CURLINFO_REDIRECT_TIME));
-		assertType('string', curl_getinfo($handle, CURLINFO_REDIRECT_URL));
+		assertType('string|false', curl_getinfo($handle, CURLINFO_REDIRECT_URL));
 		assertType('string', curl_getinfo($handle, CURLINFO_PRIMARY_IP));
 		assertType('int', curl_getinfo($handle, CURLINFO_PRIMARY_PORT));
 		assertType('string', curl_getinfo($handle, CURLINFO_LOCAL_IP));
 		assertType('int', curl_getinfo($handle, CURLINFO_LOCAL_PORT));
-		assertType('int', curl_getinfo($handle, CURLINFO_SIZE_UPLOAD));
-		assertType('int', curl_getinfo($handle, CURLINFO_SIZE_DOWNLOAD));
-		assertType('int', curl_getinfo($handle, CURLINFO_SPEED_DOWNLOAD));
-		assertType('int', curl_getinfo($handle, CURLINFO_SPEED_UPLOAD));
+		assertType('float', curl_getinfo($handle, CURLINFO_SIZE_UPLOAD));
+		assertType('float', curl_getinfo($handle, CURLINFO_SIZE_DOWNLOAD));
+		assertType('float', curl_getinfo($handle, CURLINFO_SPEED_DOWNLOAD));
+		assertType('float', curl_getinfo($handle, CURLINFO_SPEED_UPLOAD));
 		assertType('int', curl_getinfo($handle, CURLINFO_HEADER_SIZE));
 		assertType('string|false', curl_getinfo($handle, CURLINFO_HEADER_OUT));
 		assertType('int', curl_getinfo($handle, CURLINFO_REQUEST_SIZE));
@@ -45,22 +47,23 @@ class Foo
 		assertType('float', curl_getinfo($handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD));
 		assertType('float', curl_getinfo($handle, CURLINFO_CONTENT_LENGTH_UPLOAD));
 		assertType('string|false', curl_getinfo($handle, CURLINFO_CONTENT_TYPE));
-		assertType('string|false', curl_getinfo($handle, CURLINFO_PRIVATE));
+		assertType('mixed', curl_getinfo($handle, CURLINFO_PRIVATE));
 		assertType('int', curl_getinfo($handle, CURLINFO_RESPONSE_CODE));
+		assertType('int', curl_getinfo($handle, CURLINFO_HTTP_CODE));;
 		assertType('int', curl_getinfo($handle, CURLINFO_HTTP_CONNECTCODE));
 		assertType('int', curl_getinfo($handle, CURLINFO_HTTPAUTH_AVAIL));
 		assertType('int', curl_getinfo($handle, CURLINFO_PROXYAUTH_AVAIL));
 		assertType('int', curl_getinfo($handle, CURLINFO_OS_ERRNO));
 		assertType('int', curl_getinfo($handle, CURLINFO_NUM_CONNECTS));
-		assertType('array<int, string>', curl_getinfo($handle, CURLINFO_SSL_ENGINES));
-		assertType('array<int, string>', curl_getinfo($handle, CURLINFO_COOKIELIST));
+		assertType('list<string>', curl_getinfo($handle, CURLINFO_SSL_ENGINES));
+		assertType('list<string>', curl_getinfo($handle, CURLINFO_COOKIELIST));
 		assertType('string|false', curl_getinfo($handle, CURLINFO_FTP_ENTRY_PATH));
 		assertType('float', curl_getinfo($handle, CURLINFO_APPCONNECT_TIME));
-		assertType('array<int, array<string, string>>', curl_getinfo($handle, CURLINFO_CERTINFO));
+		assertType('list<array<string, string>>', curl_getinfo($handle, CURLINFO_CERTINFO));
 		assertType('int', curl_getinfo($handle, CURLINFO_CONDITION_UNMET));
 		assertType('int', curl_getinfo($handle, CURLINFO_RTSP_CLIENT_CSEQ));
 		assertType('int', curl_getinfo($handle, CURLINFO_RTSP_CSEQ_RECV));
 		assertType('int', curl_getinfo($handle, CURLINFO_RTSP_SERVER_CSEQ));
-		assertType('int', curl_getinfo($handle, CURLINFO_RTSP_SESSION_ID));
+		assertType('string|false', curl_getinfo($handle, CURLINFO_RTSP_SESSION_ID));
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/curl_getinfo_7.3.php
+++ b/tests/PHPStan/Analyser/nsrt/curl_getinfo_7.3.php
@@ -5,14 +5,15 @@ namespace CurlGetinfo73;
 use CurlHandle;
 use function PHPStan\Testing\assertType;
 
-class Foo {
+class Foo
+{
 	public function bar()
 	{
 		$handle = new CurlHandle();
 		assertType('int', curl_getinfo($handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T));
 		assertType('int', curl_getinfo($handle, CURLINFO_CONTENT_LENGTH_UPLOAD_T));
 		assertType('int', curl_getinfo($handle, CURLINFO_HTTP_VERSION));
-		assertType('string', curl_getinfo($handle, CURLINFO_PROTOCOL));
+		assertType('int', curl_getinfo($handle, CURLINFO_PROTOCOL));
 		assertType('int', curl_getinfo($handle, CURLINFO_PROXY_SSL_VERIFYRESULT));
 		assertType('string', curl_getinfo($handle, CURLINFO_SCHEME));
 		assertType('int', curl_getinfo($handle, CURLINFO_SIZE_DOWNLOAD_T));

--- a/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.2.php
+++ b/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.2.php
@@ -1,0 +1,18 @@
+<?php // lint >= 8.2
+
+namespace CurlGetinfo82;
+
+use CurlHandle;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function bar()
+	{
+		$handle = new CurlHandle();
+		assertType('string', curl_getinfo($handle, CURLINFO_EFFECTIVE_METHOD));
+		assertType('int', curl_getinfo($handle, CURLINFO_PROXY_ERROR));
+		assertType('string|false', curl_getinfo($handle, CURLINFO_REFERER));
+		assertType('int', curl_getinfo($handle, CURLINFO_RETRY_AFTER));
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.3.php
+++ b/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.3.php
@@ -1,0 +1,16 @@
+<?php // lint >= 8.3
+
+namespace CurlGetinfo83;
+
+use CurlHandle;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function bar()
+	{
+		$handle = new CurlHandle();
+		assertType('string|false', curl_getinfo($handle, CURLINFO_CAINFO));
+		assertType('string|false', curl_getinfo($handle, CURLINFO_CAPATH));
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.4.php
+++ b/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.4.php
@@ -1,0 +1,15 @@
+<?php // lint >= 8.4
+
+namespace CurlGetinfo84;
+
+use CurlHandle;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function bar()
+	{
+		$handle = new CurlHandle();
+		assertType('int|false', curl_getinfo($handle, CURLINFO_POSTTRANSFER_TIME_T));
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.5.php
+++ b/tests/PHPStan/Analyser/nsrt/curl_getinfo_8.5.php
@@ -1,0 +1,19 @@
+<?php // lint >= 8.5
+
+namespace CurlGetinfo85;
+
+use CurlHandle;
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function bar()
+	{
+		$handle = new CurlHandle();
+		assertType('int|false', curl_getinfo($handle, CURLINFO_QUEUE_TIME_T));
+		assertType('int|false', curl_getinfo($handle, CURLINFO_USED_PROXY));
+		assertType('int|false', curl_getinfo($handle, CURLINFO_HTTPAUTH_USED));
+		assertType('int|false', curl_getinfo($handle, CURLINFO_PROXYAUTH_USED));
+		assertType('int|false', curl_getinfo($handle, CURLINFO_CONN_ID));
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds new return types for `curl_getinfo()` for new `CURLINFO_*` constants that were added in recent PHP 8.x versions. It also corrects the return types of some existing options that were incorrect.

I have also added the appropriate tests for all new constants and adjusted the existing ones.

## Details

> [!NOTE]
> Theoretically, every single option could potentially return `false` if the loaded curl library doesn't support it.[^1] However, as this is unlikely to happen in production, I decided to keep things mostly as they are, to avoid breaking any existing setups. I only added `false` to the return type if the option is only available in newer cURL versions (`>=8.0.0` – March 2023[^2]), or if there is another specific reason for doing so.

### Changed Types
- 🛠️ `CURLINFO_REDIRECT_URL`: Returns a string if `CURLOPT_FOLLOWLOCATION` is disabled, `false` otherwise.
- 🛠️ `CURLINFO_SIZE_UPLOAD`, `CURLINFO_SIZE_DOWNLOAD`, `CURLINFO_SPEED_DOWNLOAD`, `CURLINFO_SPEED_UPLOAD`: Returns an integer.
- 🛠️ `CURLINFO_PRIVATE`: PHP treats this like a classic variable.[^3] I tested `null|bool|int|float|string|array|object|resource`.[^4]
- 🆕 `CURLINFO_HTTP_CODE`: (Legacy) alias of `CURLINFO_RESPONSE_CODE` as of PHP 5.5 and cURL 7.10.8.
- 🛠️ `CURLINFO_SSL_ENGINES`, `CURLINFO_COOKIELIST`: Returns a list (instead of an indexed array).
- 🛠️ `CURLINFO_CERTINFO`: Returns a list of associative arrays (instead of an indexed array).
- 🛠️ `CURLINFO_RTSP_SESSION_ID`: Returns a string.[^5][^6] Returns `false` if no ID was set or if the protocol is not `rtsp://`.
- 🛠️ `CURLINFO_PROTOCOL`: Returns an integer, a `CURLPROTO_*` constant value: $\\{{-1}, 2^0, 2^1, 2^2, \dots, 2^{27}, 2^{28}\\}$.

### Added Types (PHP 8.2)
- 🆕 `CURLINFO_EFFECTIVE_METHOD`: Returns a string.
- 🆕 `CURLINFO_PROXY_ERROR`: Returns an integer, a `CURLPX_*` constant value: $\\{0, 1, \dots, 32, 33\\}$.
- 🆕 `CURLINFO_REFERER`: Returns a string if `CURLOPT_FOLLOWLOCATION` and `CURLOPT_AUTOREFERER` are enabled, `false` otherwise.
- 🆕 `CURLINFO_RETRY_AFTER`: Returns an integer (number of seconds, even if the `Retry-After` header is a timestamp string).

### Added Types (PHP 8.3)
- 🆕 `CURLINFO_CAINFO`: Returns a string for the CA file path or `false` if it is not set.
- 🆕 `CURLINFO_CAPATH`: Returns a string for the CA directory or `false` if it is not set.

### Added Types (PHP 8.4)
- 🆕 `CURLINFO_POSTTRANSFER_TIME_T`: Returns an integer. Since cURL v8.10.0, `false` otherwise.

> [!NOTE]
> PHP 8.4 introduced some more unrelated `CURLINFO_*` constants, such as `CURLINFO_DATA_IN` and `CURLINFO_SSL_DATA_IN`. These constants are not intended for use with `curl_getinfo()`. Instead, they are used in the callback of `CURLOPT_DEBUGFUNCTION`.

### Added Types (PHP 8.5)
- 🆕 `CURLINFO_QUEUE_TIME_T`: Returns an integer. Since cURL v8.6.0, `false` otherwise.
- 🆕 `CURLINFO_USED_PROXY`: Returns an integer, resprenting no/yes: $\\{0, 1\\}$. Since cURL v8.7.0, `false` otherwise.
- 🆕 `CURLINFO_HTTPAUTH_USED`: Returns an integer (a `CURLAUTH_*` constant value). Since cURL v8.12.0, `false` otherwise.
- 🆕 `CURLINFO_PROXYAUTH_USED`: Returns an integer (a `CURLAUTH_*` constant value). Since cURL v8.12.0, `false` otherwise.
- 🆕 `CURLINFO_CONN_ID`: Returns an integer. Since cURL v8.2.0, `false` otherwise.

## Sources
### PHP Manual:
- https://www.php.net/manual/en/curl.constants.php#constant.curl-getinfo.constants
- https://www.php.net/manual/en/function.curl-getinfo.php

### cURL Documentation
- https://curl.se/libcurl/c/curl_easy_getinfo.html
- https://curl.se/libcurl/c/symbols-in-versions.html

### PHP.Watch
- [https://php.watch/codex?search=CURLINFO_](https://php.watch/codex?search=CURLINFO_)

### GitHub Repos
- [`curl/curl`](https://github.com/curl/curl):
  - [/include/curl/curl.h#L2904-L3000](https://github.com/curl/curl/blob/ad42850b231a557d8955bf296a6b93383d416d92/include/curl/curl.h#L2904-L3000)
  - [/lib/vtls/openssl.c#L390-L624](https://github.com/curl/curl/blob/c72bb7aec4db2ad32f9d82758b4f55663d0ebd60/lib/vtls/openssl.c#L390-L624)
- [`php/php-src`](https://github.com/php/php-src):
  - [/ext/curl/interface.c#L2476-L2638](https://github.com/php/php-src/blob/d85662d6cc2c6d5f69403f6fb2001ff78e1bd174/ext/curl/interface.c#L2476-L2638)
  - [/ext/curl/interface.c#L2641-L2732](https://github.com/php/php-src/blob/d85662d6cc2c6d5f69403f6fb2001ff78e1bd174/ext/curl/interface.c#L2641-L2732)
- [`JetBrains/phpstorm-stubs`](https://github.com/JetBrains/phpstorm-stubs):
  - [/blob/master/curl/curl_d.php](https://github.com/JetBrains/phpstorm-stubs/blob/master/curl/curl_d.php)

[^1]: There are `RETURN FALSE` fallbacks for every data type: [`php/php-src/ext/curl/interface.c`#L2641-L2732](https://github.com/php/php-src/blob/d85662d6cc2c6d5f69403f6fb2001ff78e1bd174/ext/curl/interface.c#L2641-L2732)

[^2]:  cURL 8.0.0 release: https://curl.se/ch/8.0.0.html

[^3]: PHP uses the general `zval` container data type for the private data: [`php/php-src/ext/curl/interface.c`#L1966-L1967](https://github.com/php/php-src/blob/d85662d6cc2c6d5f69403f6fb2001ff78e1bd174/ext/curl/interface.c#L1966-L1967)

[^4]: PHP Debugging Script (PHP 8.2.12 and cURL 8.4.0): https://gist.github.com/FeBe95/8a947dd392c1d1693cfc72eb9501d2c7

[^5]: IETF RTSP RFC, section "3.4 Session Identifiers": [https://www.ietf.org/rfc/rfc2326.txt](https://www.ietf.org/rfc/rfc2326.txt#:~:text=3%2E4%20Session%20Identifiers%20Session%20identifiers%20are%20opaque%20strings)

[^6]: The value of `CURLINFO_RTSP_SESSION_ID` is `CURLINFO_STRING + 36`: [`curl/curl/include/curl/curl.h`#L2962](https://github.com/curl/curl/blob/ad42850b231a557d8955bf296a6b93383d416d92/include/curl/curl.h#L2962)
