### PR TITLE
MatchExpressionRule - ignore reportAlwaysTrueInLastCondition with enums

### DIFF
--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -105,7 +105,8 @@ final class MatchExpressionRule implements Rule
 					continue;
 				}
 
-				if ($i === $armsCount - 1 && !$this->reportAlwaysTrueInLastCondition) {
+				$reportAlwaysTrueInLastCondition = $this->reportAlwaysTrueInLastCondition && $matchConditionType->getEnumCases() === [];
+				if ($i === $armsCount - 1 && !$reportAlwaysTrueInLastCondition) {
 					continue;
 				}
 				$errorBuilder = RuleErrorBuilder::message(sprintf(
@@ -113,7 +114,7 @@ final class MatchExpressionRule implements Rule
 					$armConditionScope->getType($matchCondition)->describe(VerbosityLevel::value()),
 					$armConditionScope->getType($armCondition->getCondition())->describe(VerbosityLevel::value()),
 				))->line($armLine);
-				if ($i !== $armsCount - 1 && !$this->reportAlwaysTrueInLastCondition) {
+				if ($i !== $armsCount - 1 && !$reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
 

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -297,19 +297,17 @@ class MatchExpressionRuleTest extends RuleTestCase
 		yield [true, [
 			[
 				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
-				15,
-			],
-			[
-				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
 				23,
-			],
-			[
-				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
-				45,
+				'Remove remaining cases below this one and this error will disappear too.',
 			],
 			[
 				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
 				49,
+				'Remove remaining cases below this one and this error will disappear too.',
+			],
+			[
+				'Match arm comparison between false and false is always true.',
+				58,
 			],
 		]];
 	}

--- a/tests/PHPStan/Rules/Comparison/data/match-always-true-last-arm.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-always-true-last-arm.php
@@ -51,4 +51,12 @@ enum Foo
 		};
 	}
 
+	public function doNonEnum(bool $a): void
+	{
+		match ($a) {
+			true => 0,
+			false => 1,
+		};
+	}
+
 }


### PR DESCRIPTION
This code is fine:

```php
match ($this) {
	self::ONE => 'One',
	self::TWO => 'Two',
	self::THREE => 'Three',
};
```

Enabling `reportAlwaysTrueInLastCondition` forces me to write worse code:

```php
match ($this) {
	self::ONE => 'One',
	self::TWO => 'Two',
	default => 'Three',
};
```

It's worse for two reasons:

1. `self::THREE` is not explicitly listed making it less obvious what the last arm does.
2. If I add another case to the enum then the first code will correctly report an error but the second won't.
