### PR TITLE
Faster ArrayType->hasOffsetValueType()

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -268,8 +268,12 @@ class ArrayType implements Type
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
-		$allowedArrayKeys = AllowedArrayKeysTypes::getType();
-		$offsetType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
+		$offsetArrayKeyType = $offsetType->toArrayKey();
+		if ($offsetArrayKeyType instanceof ErrorType) {
+			$allowedArrayKeys = AllowedArrayKeysTypes::getType();
+			$offsetArrayKeyType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
+		}
+		$offsetType = $offsetArrayKeyType;
 
 		if ($this->getKeyType()->isSuperTypeOf($offsetType)->no()
 			&& ($offsetType->isString()->no() || !$offsetType->isConstantScalarValue()->no())

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -582,8 +582,11 @@ class ConstantArrayType implements Type
 
 	public function hasOffsetValueType(Type $offsetType): TrinaryLogic
 	{
-		$allowedArrayKeys = AllowedArrayKeysTypes::getType();
-		$offsetArrayKeyType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
+		$offsetArrayKeyType = $offsetType->toArrayKey();
+		if ($offsetArrayKeyType instanceof ErrorType) {
+			$allowedArrayKeys = AllowedArrayKeysTypes::getType();
+			$offsetArrayKeyType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
+		}
 
 		return $this->recursiveHasOffsetValueType($offsetArrayKeyType);
 	}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/13455

---

with this PR:

```
➜  phpstan-src git:(faster12) ✗ time php bin/phpstan analyze bug-12800.php --debug
Note: Using configuration file /Users/staabm/workspace/phpstan-src/phpstan.neon.dist.
/Users/staabm/workspace/phpstan-src/bug-12800.php
php -v ------ --------------------------------------------- 
  Line   bug-12800.php                                
 ------ --------------------------------------------- 
  5      Class Bug12800\a must be abstract or final.  
         🪪  phpstan.finalClass                       
 ------ --------------------------------------------- 


                                                                                                                        
 [ERROR] Found 1 error                                                                                                  
                                                                                                                        

php bin/phpstan analyze bug-12800.php --debug  3.50s user 0.18s system 99% cpu 3.684 total
```