### PR TITLE
Fix incorrect analyzing of array_shift with non-empty-list property

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2664,9 +2664,10 @@ final class NodeScopeResolver
 				$arrayArgNativeType = $scope->getNativeType($arrayArg);
 
 				$isArrayPop = $functionReflection->getName() === 'array_pop';
+				$newType = $isArrayPop ? $arrayArgType->popArray() : $arrayArgType->shiftArray();
 				$scope = $scope->invalidateExpression($arrayArg)->assignExpression(
 					$arrayArg,
-					$isArrayPop ? $arrayArgType->popArray() : $arrayArgType->shiftArray(),
+					$newType,
 					$isArrayPop ? $arrayArgNativeType->popArray() : $arrayArgNativeType->shiftArray(),
 				);
 
@@ -2674,7 +2675,7 @@ final class NodeScopeResolver
 					$scope,
 					$stmt,
 					$arrayArg,
-					$arrayArg,
+					new TypeExpr($newType),
 					static function (Node $node, Scope $scope) use ($nodeCallback): void {
 						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
 							return;
@@ -2703,7 +2704,7 @@ final class NodeScopeResolver
 					$scope,
 					$stmt,
 					$arrayArg,
-					$arrayArg,
+					new TypeExpr($arrayType),
 					static function (Node $node, Scope $scope) use ($nodeCallback): void {
 						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
 							return;
@@ -2729,9 +2730,10 @@ final class NodeScopeResolver
 				&& $functionReflection->getName() === 'shuffle'
 			) {
 				$arrayArg = $expr->getArgs()[0]->value;
+				$newType = $scope->getType($arrayArg)->shuffleArray();
 				$scope = $scope->assignExpression(
 					$arrayArg,
-					$scope->getType($arrayArg)->shuffleArray(),
+					$newType,
 					$scope->getNativeType($arrayArg)->shuffleArray(),
 				);
 
@@ -2739,7 +2741,7 @@ final class NodeScopeResolver
 					$scope,
 					$stmt,
 					$arrayArg,
-					$arrayArg,
+					new TypeExpr($newType),
 					static function (Node $node, Scope $scope) use ($nodeCallback): void {
 						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
 							return;
@@ -2766,9 +2768,10 @@ final class NodeScopeResolver
 				$lengthType = isset($expr->getArgs()[2]) ? $scope->getType($expr->getArgs()[2]->value) : new NullType();
 				$replacementType = isset($expr->getArgs()[3]) ? $scope->getType($expr->getArgs()[3]->value) : new ConstantArrayType([], []);
 
+				$newType = $arrayArgType->spliceArray($offsetType, $lengthType, $replacementType);
 				$scope = $scope->invalidateExpression($arrayArg)->assignExpression(
 					$arrayArg,
-					$arrayArgType->spliceArray($offsetType, $lengthType, $replacementType),
+					$newType,
 					$arrayArgNativeType->spliceArray($offsetType, $lengthType, $replacementType),
 				);
 
@@ -2776,7 +2779,7 @@ final class NodeScopeResolver
 					$scope,
 					$stmt,
 					$arrayArg,
-					$arrayArg,
+					new TypeExpr($newType),
 					static function (Node $node, Scope $scope) use ($nodeCallback): void {
 						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
 							return;
@@ -2796,9 +2799,10 @@ final class NodeScopeResolver
 				&& count($expr->getArgs()) >= 1
 			) {
 				$arrayArg = $expr->getArgs()[0]->value;
+				$newType = $this->getArraySortPreserveListFunctionType($scope->getType($arrayArg));
 				$scope = $scope->assignExpression(
 					$arrayArg,
-					$this->getArraySortPreserveListFunctionType($scope->getType($arrayArg)),
+					$newType,
 					$this->getArraySortPreserveListFunctionType($scope->getNativeType($arrayArg)),
 				);
 
@@ -2806,7 +2810,7 @@ final class NodeScopeResolver
 					$scope,
 					$stmt,
 					$arrayArg,
-					$arrayArg,
+					new TypeExpr($newType),
 					static function (Node $node, Scope $scope) use ($nodeCallback): void {
 						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
 							return;
@@ -2826,9 +2830,10 @@ final class NodeScopeResolver
 				&& count($expr->getArgs()) >= 1
 			) {
 				$arrayArg = $expr->getArgs()[0]->value;
+				$newType = $this->getArraySortDoNotPreserveListFunctionType($scope->getType($arrayArg));
 				$scope = $scope->assignExpression(
 					$arrayArg,
-					$this->getArraySortDoNotPreserveListFunctionType($scope->getType($arrayArg)),
+					$newType,
 					$this->getArraySortDoNotPreserveListFunctionType($scope->getNativeType($arrayArg)),
 				);
 
@@ -2836,7 +2841,7 @@ final class NodeScopeResolver
 					$scope,
 					$stmt,
 					$arrayArg,
-					$arrayArg,
+					new TypeExpr($newType),
 					static function (Node $node, Scope $scope) use ($nodeCallback): void {
 						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
 							return;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2669,6 +2669,7 @@ final class NodeScopeResolver
 					$isArrayPop ? $arrayArgType->popArray() : $arrayArgType->shiftArray(),
 					$isArrayPop ? $arrayArgNativeType->popArray() : $arrayArgNativeType->shiftArray(),
 				);
+
 				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
 					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
 				}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2670,9 +2670,22 @@ final class NodeScopeResolver
 					$isArrayPop ? $arrayArgNativeType->popArray() : $arrayArgNativeType->shiftArray(),
 				);
 
-				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
-					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
-				}
+				$scope = $this->processAssignVar(
+					$scope,
+					$stmt,
+					$arrayArg,
+					$arrayArg,
+					static function (Node $node, Scope $scope) use ($nodeCallback): void {
+						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
+							return;
+						}
+
+						$nodeCallback($node, $scope);
+					},
+					$context,
+					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, false, false, [], []),
+					true,
+				)->getScope();
 			}
 
 			if (
@@ -2686,9 +2699,22 @@ final class NodeScopeResolver
 				$arrayArg = $expr->getArgs()[0]->value;
 				$scope = $scope->invalidateExpression($arrayArg)->assignExpression($arrayArg, $arrayType, $arrayNativeType);
 
-				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
-					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
-				}
+				$scope = $this->processAssignVar(
+					$scope,
+					$stmt,
+					$arrayArg,
+					$arrayArg,
+					static function (Node $node, Scope $scope) use ($nodeCallback): void {
+						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
+							return;
+						}
+
+						$nodeCallback($node, $scope);
+					},
+					$context,
+					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, false, false, [], []),
+					true,
+				)->getScope();
 			}
 
 			if (
@@ -2709,9 +2735,22 @@ final class NodeScopeResolver
 					$scope->getNativeType($arrayArg)->shuffleArray(),
 				);
 
-				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
-					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
-				}
+				$scope = $this->processAssignVar(
+					$scope,
+					$stmt,
+					$arrayArg,
+					$arrayArg,
+					static function (Node $node, Scope $scope) use ($nodeCallback): void {
+						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
+							return;
+						}
+
+						$nodeCallback($node, $scope);
+					},
+					$context,
+					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, false, false, [], []),
+					true,
+				)->getScope();
 			}
 
 			if (
@@ -2733,9 +2772,22 @@ final class NodeScopeResolver
 					$arrayArgNativeType->spliceArray($offsetType, $lengthType, $replacementType),
 				);
 
-				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
-					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
-				}
+				$scope = $this->processAssignVar(
+					$scope,
+					$stmt,
+					$arrayArg,
+					$arrayArg,
+					static function (Node $node, Scope $scope) use ($nodeCallback): void {
+						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
+							return;
+						}
+
+						$nodeCallback($node, $scope);
+					},
+					$context,
+					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, false, false, [], []),
+					true,
+				)->getScope();
 			}
 
 			if (
@@ -2750,9 +2802,22 @@ final class NodeScopeResolver
 					$this->getArraySortPreserveListFunctionType($scope->getNativeType($arrayArg)),
 				);
 
-				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
-					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
-				}
+				$scope = $this->processAssignVar(
+					$scope,
+					$stmt,
+					$arrayArg,
+					$arrayArg,
+					static function (Node $node, Scope $scope) use ($nodeCallback): void {
+						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
+							return;
+						}
+
+						$nodeCallback($node, $scope);
+					},
+					$context,
+					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, false, false, [], []),
+					true,
+				)->getScope();
 			}
 
 			if (
@@ -2767,9 +2832,22 @@ final class NodeScopeResolver
 					$this->getArraySortDoNotPreserveListFunctionType($scope->getNativeType($arrayArg)),
 				);
 
-				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
-					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
-				}
+				$scope = $this->processAssignVar(
+					$scope,
+					$stmt,
+					$arrayArg,
+					$arrayArg,
+					static function (Node $node, Scope $scope) use ($nodeCallback): void {
+						if (!$node instanceof PropertyAssignNode && !$node instanceof VariableAssignNode) {
+							return;
+						}
+
+						$nodeCallback($node, $scope);
+					},
+					$context,
+					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, false, false, [], []),
+					true,
+				)->getScope();
 			}
 
 			if (

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2684,6 +2684,10 @@ final class NodeScopeResolver
 
 				$arrayArg = $expr->getArgs()[0]->value;
 				$scope = $scope->invalidateExpression($arrayArg)->assignExpression($arrayArg, $arrayType, $arrayNativeType);
+
+				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
+					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
+				}
 			}
 
 			if (

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2669,6 +2669,9 @@ final class NodeScopeResolver
 					$isArrayPop ? $arrayArgType->popArray() : $arrayArgType->shiftArray(),
 					$isArrayPop ? $arrayArgNativeType->popArray() : $arrayArgNativeType->shiftArray(),
 				);
+				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
+					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
+				}
 			}
 
 			if (

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2707,6 +2707,10 @@ final class NodeScopeResolver
 					$scope->getType($arrayArg)->shuffleArray(),
 					$scope->getNativeType($arrayArg)->shuffleArray(),
 				);
+
+				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
+					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
+				}
 			}
 
 			if (
@@ -2727,6 +2731,10 @@ final class NodeScopeResolver
 					$arrayArgType->spliceArray($offsetType, $lengthType, $replacementType),
 					$arrayArgNativeType->spliceArray($offsetType, $lengthType, $replacementType),
 				);
+
+				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
+					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
+				}
 			}
 
 			if (
@@ -2740,6 +2748,10 @@ final class NodeScopeResolver
 					$this->getArraySortPreserveListFunctionType($scope->getType($arrayArg)),
 					$this->getArraySortPreserveListFunctionType($scope->getNativeType($arrayArg)),
 				);
+
+				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
+					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
+				}
 			}
 
 			if (
@@ -2753,6 +2765,10 @@ final class NodeScopeResolver
 					$this->getArraySortDoNotPreserveListFunctionType($scope->getType($arrayArg)),
 					$this->getArraySortDoNotPreserveListFunctionType($scope->getNativeType($arrayArg)),
 				);
+
+				if ($arrayArg instanceof PropertyFetch || $arrayArg instanceof StaticPropertyFetch) {
+					$nodeCallback(new PropertyAssignNode($arrayArg, new TypeExpr($scope->getType($arrayArg)), false), $scope);
+				}
 			}
 
 			if (

--- a/tests/PHPStan/Analyser/nsrt/bug-11846.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11846.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug11846;
+
+use function PHPStan\Testing\assertType;
+
+function demo(): void
+{
+	$outerList = [];
+	$idList = [1, 2];
+
+	foreach ($idList as $id) {
+		$outerList[$id] = [];
+		array_push($outerList[$id], []);
+	}
+	assertType('non-empty-array<1|2, array{}|array{array{}}>', $outerList);
+
+	foreach ($outerList as $key => $outerElement) {
+		$result = false;
+
+		assertType('array{}|array{array{}}', $outerElement);
+		foreach ($outerElement as $innerElement) {
+			$result = true;
+		}
+		assertType('bool', $result); // could be 'true'
+
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/shuffle.php
+++ b/tests/PHPStan/Analyser/nsrt/shuffle.php
@@ -13,7 +13,7 @@ class Foo
 		/** @var mixed[] $arr */
 		shuffle($arr);
 		assertType('list<mixed>', $arr);
-		assertNativeType('list', $arr);
+		assertNativeType('list<mixed>', $arr);
 		assertType('list<int<0, max>>', array_keys($arr));
 		assertType('list<mixed>', array_values($arr));
 	}
@@ -23,7 +23,7 @@ class Foo
 		/** @var non-empty-array<string, int> $arr */
 		shuffle($arr);
 		assertType('non-empty-list<int>', $arr);
-		assertNativeType('list', $arr);
+		assertNativeType('non-empty-list<int>', $arr);
 		assertType('non-empty-list<int<0, max>>', array_keys($arr));
 		assertType('non-empty-list<int>', array_values($arr));
 	}
@@ -67,7 +67,7 @@ class Foo
 		/** @var array{0?: 1, 1?: 2, 2?: 3} $arr */
 		shuffle($arr);
 		assertType('list<1|2|3>', $arr);
-		assertNativeType('list', $arr);
+		assertNativeType('list<1|2|3>', $arr);
 		assertType('list<0|1|2>', array_keys($arr));
 		assertType('list<1|2|3>', array_values($arr));
 	}
@@ -107,7 +107,7 @@ class Foo
 		/** @var array{foo?: 1, bar: 2, }|array{baz: 3, foobar?: 4} $arr */
 		shuffle($arr);
 		assertType('non-empty-list<1|2|3|4>', $arr);
-		assertNativeType('list', $arr);
+		assertNativeType('non-empty-list<1|2|3|4>', $arr);
 		assertType('non-empty-list<0|1>', array_keys($arr));
 		assertType('non-empty-list<1|2|3|4>', array_values($arr));
 	}

--- a/tests/PHPStan/Analyser/nsrt/sort.php
+++ b/tests/PHPStan/Analyser/nsrt/sort.php
@@ -91,17 +91,17 @@ class Foo
 		$arr1 = $arr;
 		sort($arr1);
 		assertType('list<string>', $arr1);
-		assertNativeType('list', $arr1);
+		assertNativeType('list<string>', $arr1);
 
 		$arr2 = $arr;
 		rsort($arr2);
 		assertType('list<string>', $arr2);
-		assertNativeType('list', $arr2);
+		assertNativeType('list<string>', $arr2);
 
 		$arr3 = $arr;
 		usort($arr3, fn(int $a, int $b) => $a <=> $b);
 		assertType('list<string>', $arr3);
-		assertNativeType('list', $arr3);
+		assertNativeType('list<string>', $arr3);
 	}
 
 	public function mixed($arr): void

--- a/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
@@ -50,4 +50,9 @@ class DeadForeachRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-2560.php'], []);
 	}
 
+	public function testBug2457(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-2457.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/DeadForeachRuleTest.php
@@ -45,4 +45,9 @@ class DeadForeachRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13248.php'], []);
 	}
 
+	public function testBug2560(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-2560.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-2457.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-2457.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Bug2457;
+
+class HelloWorld
+{
+	public function sayHello(array $x, array $y): void
+	{
+		$a = [];
+		$o = [];
+
+		foreach ($x as $t) {
+			if (!isset($a[$t])) {
+				$a[$t] = [];
+			}
+			$o[] = 'x';
+			array_unshift($a[$t], count($o) - 1);
+		}
+
+		foreach ($y as $t) {
+			if (!isset($a[$t])) {
+				continue;
+			}
+			foreach ($a[$t] as $b) {
+				// this will be reached
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/bug-2560.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-2560.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug2560;
+
+class HelloWorld
+{
+	public function test(): void
+	{
+		$arr = [];
+		foreach ([0,1] as $i) {
+			$arr[$i] = [];
+			array_push($arr[$i], "foo");
+		}
+		foreach (array_values($arr) as $vec) {
+			foreach ($vec as $value) {
+				print_r("$value");
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -257,4 +257,10 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12716.php'], []);
 	}
 
+	public function testBug3387(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-3387.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-3387.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-3387.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bug3387;
+
+function (array $items, string $key) {
+	$array = [$key => []];
+	foreach ($items as $item) {
+		$array[$key][] = $item;
+		if (count($array[$key]) > 1) {
+			throw new RuntimeException();
+		}
+	}
+};
+
+function (array $items, string $key) {
+	$array = [$key => []];
+	foreach ($items as $item) {
+		array_unshift($array[$key], $item);
+		if (count($array[$key]) > 1) {
+			throw new RuntimeException();
+		}
+	}
+};
+
+function (array $items, string $key) {
+	$array = [$key => []];
+	foreach ($items as $item) {
+		array_push($array[$key], $item);
+		if (count($array[$key]) > 1) {
+			throw new RuntimeException();
+		}
+	}
+};

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -819,4 +819,45 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7824.php'], []);
 	}
 
+	public function testBug13438(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13438.php'], [
+			[
+				'Property Bug13438\Test::$queue (non-empty-list<int>) does not accept list<int>.',
+				20,
+				'list<int> might be empty.',
+			],
+			[
+				'Property Bug13438\Test::$queue (non-empty-list<int>) does not accept list<int>.',
+				26,
+				'list<int> might be empty.',
+			],
+		]);
+	}
+
+	public function testBug13438b(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13438b.php'], [
+			[
+				'Property Bug13438b\Test::$queue (non-empty-list<int>) does not accept list<int>.',
+				20,
+				'list<int> might be empty.',
+			],
+			[
+				'Property Bug13438b\Test::$queue (non-empty-list<int>) does not accept list<int>.',
+				26,
+				'list<int> might be empty.',
+			],
+
+		]);
+	}
+
+	public function testBug13438c(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13438c.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -882,6 +882,23 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13438f(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13438f.php'], [
+			[
+				'Property Bug13438f\Test::$queue (array<int, non-empty-list<int>>) does not accept non-empty-array<int, list<int>>.',
+				20,
+				'list<int> might be empty.',
+			],
+			[
+				'Property Bug13438f\Test::$queue (array<int, non-empty-list<int>>) does not accept non-empty-array<int, list<int>>.',
+				25,
+				'list<int> might be empty.',
+			],
+		]);
+	}
+
 	public function testBug2888(): void
 	{
 		$this->checkExplicitMixed = true;

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -882,4 +882,23 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug2888(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-2888.php'], [
+			[
+				'Property Bug2888\MyClass::$prop (array<int>) does not accept array<int|string>.',
+				17,
+			],
+			[
+				'Property Bug2888\MyClass::$prop (array<int>) does not accept array<int|string>.',
+				18,
+			],
+			[
+				'Property Bug2888\MyClass::$prop (array<int>) does not accept array<int|string>.',
+				26,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -860,4 +860,26 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13438c.php'], []);
 	}
 
+	public function testBug13438d(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13438d.php'], [
+			[
+				'Property Bug13438d\Test::$queue (array{}) does not accept array{1}.',
+				18,
+			],
+		]);
+	}
+
+	public function testBug13438e(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13438e.php'], [
+			[
+				'Property Bug13438e\Test::$queue (array{}) does not accept array{1}.',
+				18,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-13438.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug13438;
+
+use LogicException;
+
+class Test
+{
+	/**
+	 * @param non-empty-list<int> $queue
+	 */
+	public function __construct(
+		private array $queue,
+	)
+	{
+	}
+
+	public function test1(): int
+	{
+		return array_shift($this->queue)
+			?? throw new LogicException('queue is empty');
+	}
+
+	public function test2(): int
+	{
+		return array_shift($this->queue);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13438.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug13438;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-13438b.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438b.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug13438b;
+
+use LogicException;
+
+class Test
+{
+	/**
+	 * @param non-empty-list<int> $queue
+	 */
+	public function __construct(
+		private array $queue,
+	)
+	{
+	}
+
+	public function test1(): int
+	{
+		return array_pop($this->queue)
+			?? throw new LogicException('queue is empty');
+	}
+
+	public function test2(): int
+	{
+		return array_pop($this->queue);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13438b.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438b.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug13438b;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-13438c.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438c.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bug13438c;
+
+use LogicException;
+
+class Test
+{
+	/**
+	 * @var list<int>
+	 */
+	private $queue;
+
+	/**
+	 * @param non-empty-list<int> $queue
+	 */
+	public function __construct(
+		array $queue,
+	)
+	{
+		$this->queue = $queue;
+	}
+
+	public function test1(): int
+	{
+		return array_shift($this->queue)
+			?? throw new LogicException('queue is empty');
+	}
+
+	public function test2(): int
+	{
+		return array_shift($this->queue);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13438c.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438c.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug13438c;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-13438d.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438d.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug13438d;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-13438d.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438d.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug13438d;
+
+class Test
+{
+	/**
+	 * @param array{} $queue
+	 */
+	public function __construct(
+		private array $queue,
+	)
+	{
+	}
+
+	public function test1(): int
+	{
+		return array_push($this->queue, 1);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13438e.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438e.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug13438e;
+
+class Test
+{
+	/**
+	 * @param array{} $queue
+	 */
+	public function __construct(
+		private array $queue,
+	)
+	{
+	}
+
+	public function test1(): int
+	{
+		return array_unshift($this->queue, 1);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13438e.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438e.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Bug13438e;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-13438f.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438f.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.0
 
 namespace Bug13438f;
 

--- a/tests/PHPStan/Rules/Properties/data/bug-13438f.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13438f.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13438f;
+
+use function PHPStan\dumpType;
+use function PHPStan\Testing\assertType;
+
+class Test
+{
+	/**
+	 * @param array<int, non-empty-list<int>> $queue
+	 */
+	public function __construct(
+		private array $queue,
+	) {
+	}
+
+	public function test1(): void
+	{
+		array_shift($this->queue[5]); // no longer is non-empty-list<int> after this
+	}
+
+	public function test2(): void
+	{
+		$this->queue[5] = []; // normally it works thanks to processAssignVar
+	}
+
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-2888.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-2888.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bug2888;
+
+class MyClass
+{
+	/**
+	 * @var int[]
+	 */
+	private $prop = [];
+
+	/**
+	 * @return void
+	 */
+	public function foo()
+	{
+		array_push($this->prop, 'string');
+		array_unshift($this->prop, 'string');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function bar()
+	{
+		$this->prop[] = 'string';
+	}
+}

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -96,6 +96,10 @@ class EmptyRuleTest extends RuleTestCase
 				'Variable $a in empty() always exists and is always falsy.',
 				12,
 			],
+			[
+				'Variable $a in empty() always exists and is not falsy.',
+				30,
+			],
 		]);
 	}
 


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/13438
closes https://github.com/phpstan/phpstan/issues/2888
closes https://github.com/phpstan/phpstan/issues/3387
closes https://github.com/phpstan/phpstan/issues/2560
closes https://github.com/phpstan/phpstan/issues/2457
closes https://github.com/phpstan/phpstan/issues/11846