### PR TITLE
Fix "Using null as an array offset is deprecated, use an empty string instead"

### DIFF
--- a/src/Analyser/TypeSpecifierContext.php
+++ b/src/Analyser/TypeSpecifierContext.php
@@ -27,8 +27,9 @@ final class TypeSpecifierContext
 
 	private static function create(?int $value): self
 	{
-		self::$registry[$value] ??= new self($value);
-		return self::$registry[$value ?? ''];
+		$key = $value ?? '';
+		self::$registry[$key] ??= new self($value);
+		return self::$registry[$key];
 	}
 
 	public static function createTrue(): self


### PR DESCRIPTION
Fixes PHP8.5 deprecation warnings [in CI build](https://github.com/phpstan/phpstan-src/actions/runs/17546772633/job/49830331478?pr=4294)

> Deprecated: Using null as an array offset is deprecated, use an empty string instead on phar:///home/runner/work/phpstan-src/phpstan-src/extension/vendor/phpstan/phpstan/phpstan.phar/src/Analyser/TypeSpecifierContext.php:28

`null` is converted into empty-string implicitly, see https://3v4l.org/5TTAO