### PR TITLE
Implemented NativeTypeExpr

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -37,6 +37,7 @@ use PHPStan\Node\Expr\ExistingArrayDimFetch;
 use PHPStan\Node\Expr\GetIterableKeyTypeExpr;
 use PHPStan\Node\Expr\GetIterableValueTypeExpr;
 use PHPStan\Node\Expr\GetOffsetValueTypeExpr;
+use PHPStan\Node\Expr\NativeTypeExpr;
 use PHPStan\Node\Expr\OriginalPropertyTypeExpr;
 use PHPStan\Node\Expr\ParameterVariableOriginalValueExpr;
 use PHPStan\Node\Expr\PropertyInitializationExpr;
@@ -765,6 +766,12 @@ final class MutatingScope implements Scope
 		}
 		if ($node instanceof TypeExpr) {
 			return $node->getExprType();
+		}
+		if ($node instanceof NativeTypeExpr) {
+			if ($this->nativeTypesPromoted) {
+				return $node->getNativeType();
+			}
+			return $node->getPhpDocType();
 		}
 
 		if ($node instanceof OriginalPropertyTypeExpr) {

--- a/src/Node/Expr/NativeTypeExpr.php
+++ b/src/Node/Expr/NativeTypeExpr.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Node\Expr;
+
+use Override;
+use PhpParser\Node\Expr;
+use PHPStan\Node\VirtualNode;
+use PHPStan\Type\Type;
+
+/**
+ * @api
+ */
+final class NativeTypeExpr extends Expr implements VirtualNode
+{
+
+	/** @api */
+	public function __construct(private Type $phpdocType, private Type $nativeType)
+	{
+		parent::__construct();
+	}
+
+	public function getPhpDocType(): Type
+	{
+		return $this->phpdocType;
+	}
+
+	public function getNativeType(): Type
+	{
+		return $this->nativeType;
+	}
+
+	#[Override]
+	public function getType(): string
+	{
+		return 'PHPStan_Node_NativeTypeExpr';
+	}
+
+	/**
+	 * @return string[]
+	 */
+	#[Override]
+	public function getSubNodeNames(): array
+	{
+		return [];
+	}
+
+}

--- a/src/Node/Printer/Printer.php
+++ b/src/Node/Printer/Printer.php
@@ -9,6 +9,7 @@ use PHPStan\Node\Expr\ExistingArrayDimFetch;
 use PHPStan\Node\Expr\GetIterableKeyTypeExpr;
 use PHPStan\Node\Expr\GetIterableValueTypeExpr;
 use PHPStan\Node\Expr\GetOffsetValueTypeExpr;
+use PHPStan\Node\Expr\NativeTypeExpr;
 use PHPStan\Node\Expr\OriginalPropertyTypeExpr;
 use PHPStan\Node\Expr\ParameterVariableOriginalValueExpr;
 use PHPStan\Node\Expr\PropertyInitializationExpr;
@@ -30,6 +31,11 @@ final class Printer extends Standard
 	protected function pPHPStan_Node_TypeExpr(TypeExpr $expr): string // phpcs:ignore
 	{
 		return sprintf('__phpstanType(%s)', $expr->getExprType()->describe(VerbosityLevel::precise()));
+	}
+
+	protected function pPHPStan_Node_NativeTypeExpr(NativeTypeExpr $expr): string // phpcs:ignore
+	{
+		return sprintf('__phpstanNativeType(%s, %s)', $expr->getPhpDocType()->describe(VerbosityLevel::precise()), $expr->getNativeType()->describe(VerbosityLevel::precise()));
 	}
 
 	protected function pPHPStan_Node_GetOffsetValueTypeExpr(GetOffsetValueTypeExpr $expr): string // phpcs:ignore

--- a/tests/PHPStan/Analyser/nsrt/bug-11322.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11322.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bug11322;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo() {
+	$result = ['map' => ['a' => 'b']];
+	assertType("array{map: array{a: 'b'}}", $result);
+	usort($result['map'], fn (string $a, string $b) => $a <=> $b);
+	assertType("array{map: non-empty-list<'b'>}", $result);
+}

--- a/tests/PHPStan/Analyser/nsrt/shuffle.php
+++ b/tests/PHPStan/Analyser/nsrt/shuffle.php
@@ -13,7 +13,7 @@ class Foo
 		/** @var mixed[] $arr */
 		shuffle($arr);
 		assertType('list<mixed>', $arr);
-		assertNativeType('list<mixed>', $arr);
+		assertNativeType('list', $arr);
 		assertType('list<int<0, max>>', array_keys($arr));
 		assertType('list<mixed>', array_values($arr));
 	}
@@ -23,7 +23,7 @@ class Foo
 		/** @var non-empty-array<string, int> $arr */
 		shuffle($arr);
 		assertType('non-empty-list<int>', $arr);
-		assertNativeType('non-empty-list<int>', $arr);
+		assertNativeType('list', $arr);
 		assertType('non-empty-list<int<0, max>>', array_keys($arr));
 		assertType('non-empty-list<int>', array_values($arr));
 	}
@@ -67,7 +67,7 @@ class Foo
 		/** @var array{0?: 1, 1?: 2, 2?: 3} $arr */
 		shuffle($arr);
 		assertType('list<1|2|3>', $arr);
-		assertNativeType('list<1|2|3>', $arr);
+		assertNativeType('list', $arr);
 		assertType('list<0|1|2>', array_keys($arr));
 		assertType('list<1|2|3>', array_values($arr));
 	}
@@ -107,7 +107,7 @@ class Foo
 		/** @var array{foo?: 1, bar: 2, }|array{baz: 3, foobar?: 4} $arr */
 		shuffle($arr);
 		assertType('non-empty-list<1|2|3|4>', $arr);
-		assertNativeType('non-empty-list<1|2|3|4>', $arr);
+		assertNativeType('list', $arr);
 		assertType('non-empty-list<0|1>', array_keys($arr));
 		assertType('non-empty-list<1|2|3|4>', array_values($arr));
 	}

--- a/tests/PHPStan/Analyser/nsrt/sort.php
+++ b/tests/PHPStan/Analyser/nsrt/sort.php
@@ -91,17 +91,17 @@ class Foo
 		$arr1 = $arr;
 		sort($arr1);
 		assertType('list<string>', $arr1);
-		assertNativeType('list<string>', $arr1);
+		assertNativeType('list', $arr1);
 
 		$arr2 = $arr;
 		rsort($arr2);
 		assertType('list<string>', $arr2);
-		assertNativeType('list<string>', $arr2);
+		assertNativeType('list', $arr2);
 
 		$arr3 = $arr;
 		usort($arr3, fn(int $a, int $b) => $a <=> $b);
 		assertType('list<string>', $arr3);
-		assertNativeType('list<string>', $arr3);
+		assertNativeType('list', $arr3);
 	}
 
 	public function mixed($arr): void

--- a/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidBinaryOperationRuleTest.php
@@ -807,4 +807,11 @@ class InvalidBinaryOperationRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10595(): void
+	{
+		$this->checkImplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10595.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/bug-10595.php
+++ b/tests/PHPStan/Rules/Operators/data/bug-10595.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bug10595;
+
+function doFoo() {
+	$test = [];
+	$test[0] = [0, []];
+	$test[0][1]['h'] = 'h';
+
+	foreach ($test as $value) {
+		sort($value[1]);
+		$value[1] = implode(',', $value[1]);
+		$label = 'test' . $value[1];
+	}
+}
+

--- a/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/EmptyRuleTest.php
@@ -96,10 +96,6 @@ class EmptyRuleTest extends RuleTestCase
 				'Variable $a in empty() always exists and is always falsy.',
 				12,
 			],
-			[
-				'Variable $a in empty() always exists and is not falsy.',
-				30,
-			],
 		]);
 	}
 


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan-src/pull/4294#discussion_r2329702345 we add a new VirtualNode type which can carry a native-type in tandem with a phpdoc type.

before this PR, we only had `TypeExpr` which was not able to provide 2 types, but just a single one.

so this PR fixes a few shortcomings, which we accepted with a recent change in https://github.com/phpstan/phpstan-src/pull/4294/commits/4702c2b2e2ff562e887571b492a62c34fdcb41de