### PR TITLE
Allow to cast resource to float

### DIFF
--- a/src/Type/ResourceType.php
+++ b/src/Type/ResourceType.php
@@ -72,7 +72,7 @@ class ResourceType implements Type
 
 	public function toFloat(): Type
 	{
-		return new ErrorType();
+		return new FloatType();
 	}
 
 	public function toArray(): Type

--- a/tests/PHPStan/Rules/Cast/InvalidCastRuleTest.php
+++ b/tests/PHPStan/Rules/Cast/InvalidCastRuleTest.php
@@ -43,15 +43,15 @@ class InvalidCastRuleTest extends RuleTestCase
 			],
 			[
 				'Cannot cast object to string.',
-				35,
+				36,
 			],
 			[
 				'Cannot cast Test\\Foo to string.',
-				41,
+				42,
 			],
 			[
 				'Cannot cast array|float|int to string.',
-				48,
+				49,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Cast/data/invalid-cast.php
+++ b/tests/PHPStan/Rules/Cast/data/invalid-cast.php
@@ -25,6 +25,7 @@ function (
 
 	(string) fopen('php://memory', 'r');
 	(int) fopen('php://memory', 'r');
+	(float) fopen('php://memory', 'r');
 };
 
 function (


### PR DESCRIPTION
Part of https://github.com/phpstan/phpstan/issues/6560
but not all, (I leave https://github.com/phpstan/phpstan/issues/6560#issuecomment-3274299888)

https://github.com/phpstan/phpstan-src/pull/4152 was wrong, since we can cast a resource to float the same way we can cast it to int.