### PR TITLE
Remember narrowed types from the constructor from deep PropertyFetches

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -356,6 +356,10 @@ final class MutatingScope implements Scope
 
 	private function isReadonlyPropertyFetchOnThis(PropertyFetch $expr): bool
 	{
+		if (!$this->phpVersion->supportsReadOnlyProperties()) {
+			return false;
+		}
+
 		while ($expr instanceof PropertyFetch) {
 			if ($expr->var instanceof Variable) {
 				if (

--- a/tests/PHPStan/Analyser/nsrt/remember-readonly-constructor-narrowed.php
+++ b/tests/PHPStan/Analyser/nsrt/remember-readonly-constructor-narrowed.php
@@ -2,6 +2,7 @@
 
 namespace RememberReadOnlyConstructor;
 
+use LogicException;
 use function PHPStan\Testing\assertType;
 
 class HelloWorldReadonlyProperty {
@@ -105,5 +106,40 @@ class HelloWorldReadonlyPropertySometimesThrowing {
 
 	public function doFoo() {
 		assertType('4|10', $this->i);
+	}
+}
+
+class Foo {
+	public readonly int $readonly;
+	public int $writable;
+
+	public function __construct()
+	{
+		$this->readonly = 5;
+		$this->writable = rand(0,1) ? 5 : 10;
+	}
+}
+
+class DeepPropertyFetching {
+	public readonly ?Foo $prop;
+
+	public function __construct() {
+		$this->prop = new Foo();
+		if($this->prop->readonly != 5) {
+			throw new LogicException();
+		}
+		if ($this->prop->writable != 5) {
+			throw new LogicException();
+		}
+
+		assertType(Foo::class, $this->prop);
+		assertType('5', $this->prop->readonly);
+		assertType('5', $this->prop->writable);
+	}
+
+	public function doFoo() {
+		assertType(Foo::class, $this->prop);
+		assertType('5', $this->prop->readonly);
+		assertType('int', $this->prop->writable);
 	}
 }


### PR DESCRIPTION
types which get narrowed in __construct() on [`readonly` properties can be useful when analyzing other methods](https://staabm.github.io/2025/04/15/phpstan-remember-constructor-types.html).

improve support initially added with https://github.com/phpstan/phpstan-src/pull/3930 by allowing property-fetch-chains, when all involved properties are readonly.

---

preparational work for https://github.com/phpstan/phpstan-src/pull/4313#discussion_r2335791627

commit1 extracts 1:1 a new method
commit2+3 adds support for property-fetch chains
commit4 re-use the new method for shouldInvalidateExpression()