### PR TITLE
MatchExpressionRule - ignore reportAlwaysTrueInLastCondition

### DIFF
--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -31,8 +31,6 @@ final class MatchExpressionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $constantConditionRuleHelper,
 		#[AutowiredParameter]
-		private bool $reportAlwaysTrueInLastCondition,
-		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 	)
 	{
@@ -105,22 +103,20 @@ final class MatchExpressionRule implements Rule
 					continue;
 				}
 
-				$reportAlwaysTrueInLastCondition = $this->reportAlwaysTrueInLastCondition && $matchConditionType->getEnumCases() === [];
-				if ($i === $armsCount - 1 && !$reportAlwaysTrueInLastCondition) {
+				if ($i === $armsCount - 1) {
 					continue;
 				}
-				$errorBuilder = RuleErrorBuilder::message(sprintf(
+
+				$message = sprintf(
 					'Match arm comparison between %s and %s is always true.',
 					$armConditionScope->getType($matchCondition)->describe(VerbosityLevel::value()),
 					$armConditionScope->getType($armCondition->getCondition())->describe(VerbosityLevel::value()),
-				))->line($armLine);
-				if ($i !== $armsCount - 1 && !$reportAlwaysTrueInLastCondition) {
-					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
-				}
-
-				$errorBuilder->identifier('match.alwaysTrue');
-
-				$errors[] = $errorBuilder->build();
+				);
+				$errors[] = RuleErrorBuilder::message($message)
+					->line($armLine)
+					->identifier('match.alwaysTrue')
+					->tip('Remove remaining cases below this one and this error will disappear too.')
+					->build();
 			}
 		}
 

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -4,7 +4,6 @@ namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
@@ -14,8 +13,6 @@ class MatchExpressionRuleTest extends RuleTestCase
 {
 
 	private bool $treatPhpDocTypesAsCertain = true;
-
-	private bool $reportAlwaysTrueInLastCondition = false;
 
 	protected function getRule(): Rule
 	{
@@ -29,7 +26,6 @@ class MatchExpressionRuleTest extends RuleTestCase
 				),
 				$this->treatPhpDocTypesAsCertain,
 			),
-			$this->reportAlwaysTrueInLastCondition,
 			$this->treatPhpDocTypesAsCertain,
 		);
 	}
@@ -280,48 +276,22 @@ class MatchExpressionRuleTest extends RuleTestCase
 		]);
 	}
 
-	public static function dataReportAlwaysTrueInLastCondition(): iterable
-	{
-		yield [false, [
-			[
-				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
-				23,
-				'Remove remaining cases below this one and this error will disappear too.',
-			],
-			[
-				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
-				49,
-				'Remove remaining cases below this one and this error will disappear too.',
-			],
-		]];
-		yield [true, [
-			[
-				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
-				23,
-				'Remove remaining cases below this one and this error will disappear too.',
-			],
-			[
-				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
-				49,
-				'Remove remaining cases below this one and this error will disappear too.',
-			],
-			[
-				'Match arm comparison between false and false is always true.',
-				58,
-			],
-		]];
-	}
-
-	/**
-	 * @param list<array{0: string, 1: int, 2?: string}> $expectedErrors
-	 */
 	#[RequiresPhp('>= 8.1')]
-	#[DataProvider('dataReportAlwaysTrueInLastCondition')]
-	public function testReportAlwaysTrueInLastCondition(bool $reportAlwaysTrueInLastCondition, array $expectedErrors): void
+	public function testLastCondition(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;
-		$this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
-		$this->analyse([__DIR__ . '/data/match-always-true-last-arm.php'], $expectedErrors);
+		$this->analyse([__DIR__ . '/data/match-always-true-last-arm.php'], [
+			[
+				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
+				23,
+				'Remove remaining cases below this one and this error will disappear too.',
+			],
+			[
+				'Match arm comparison between $this(MatchAlwaysTrueLastArm\Foo)&MatchAlwaysTrueLastArm\Foo::BAR and MatchAlwaysTrueLastArm\Foo::BAR is always true.',
+				49,
+				'Remove remaining cases below this one and this error will disappear too.',
+			],
+		]);
 	}
 
 	#[RequiresPhp('>= 8.0')]

--- a/tests/PHPStan/Rules/Comparison/data/match-expr.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-expr.php
@@ -215,3 +215,32 @@ class TestGetDebugType
 	}
 
 }
+
+class LastArm
+{
+	public const TYPE_A = 1;
+	public const TYPE_B = 2;
+
+
+	/**
+	 * @param self::TYPE_* $type
+	 */
+	public function doMatch(int $type): void
+	{
+		match ($type) {
+			self::TYPE_A => 'A',
+			self::TYPE_B => 'B',
+		};
+
+		$day = date('N');
+		match ($day) {
+			'1' => 'Mon',
+			'2' => 'Tue',
+			'3' => 'Wed',
+			'4' => 'Thu',
+			'5' => 'Fri',
+			'6' => 'Sat',
+			'7' => 'Sun',
+		};
+	}
+}


### PR DESCRIPTION
There are other cases where this rule is harmful, I show them in tests.

Doc: https://github.com/phpstan/phpstan/pull/13489