### PR TITLE
Lock container creation

### DIFF
--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -191,7 +191,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 				continue;
 			}
 			$fileName = $fileInfo->getFilename();
-			if ($fileName === 'container.journal') {
+			if ($fileName === 'container.journal' || $fileName === 'container.lock') {
 				continue;
 			}
 			if (!str_ends_with($fileName, '.php')) {

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -15,6 +15,9 @@ use function array_keys;
 use function count;
 use function error_reporting;
 use function explode;
+use function fclose;
+use function flock;
+use function fopen;
 use function implode;
 use function in_array;
 use function is_dir;
@@ -29,6 +32,8 @@ use function time;
 use function trim;
 use function unlink;
 use const E_USER_DEPRECATED;
+use const LOCK_EX;
+use const LOCK_UN;
 use const PHP_RELEASE_VERSION;
 use const PHP_VERSION_ID;
 
@@ -74,6 +79,15 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 	#[Override]
 	public function loadContainer(): string
 	{
+		$directory = $this->getContainerCacheDirectory();
+		$locked = false;
+		if ($this->journalContainer && is_dir($directory)) {
+			$lockFile = $directory . '/container.lock';
+			$handle = fopen($lockFile, 'c'); // @ is escalated to exception
+			flock($handle, LOCK_EX);
+			$locked = true;
+		}
+
 		$loader = new ContainerLoader(
 			$this->getContainerCacheDirectory(),
 			$this->staticParameters['debugMode'],
@@ -95,6 +109,10 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 
 		if ($this->journalContainer) {
 			$this->journal($className);
+			if ($locked) {
+				flock($handle, LOCK_UN);
+				fclose($handle);
+			}
 		}
 
 		return $className;


### PR DESCRIPTION
This solves errors like these:
```
 Child process error (exit code 1): PHP Warning:  rename(/app/tmp/cache/phpstan/cache/nette.configurator/Container_37633cd6c1.php.tmp,/app/tmp/cache/phpstan/cache/nette.configurator/Container_37633cd6c1.php): No such file or   
     directory in phar:///app/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/ContainerLoader.php on line 68                                                                                                                
     Warning: rename(/app/tmp/cache/phpstan/cache/nette.configurator/Container_37633cd6c1.php.tmp,/app/tmp/cache/phpstan/cache/nette.configurator/Container_37633cd6c1.php): No such file or directory in                              
     phar:///app/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/di/src/DI/ContainerLoader.php on line 68                                                                                                                             
                                                                                                                                                                                                                                       
     In ContainerLoader.php line 71:                                                                                                                                                                                                   
                                                                                                                                                                                                                                       
       Unable to create file '/app/tmp/cache/phpstan/cache/nette.configurator/Container_37633cd6c1.php'.                                                                                                                               
                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                       
     worker [-c|--configuration CONFIGURATION] [-l|--level LEVEL] [-a|--autoload-file AUTOLOAD-FILE] [--memory-limit MEMORY-LIMIT] [--xdebug] [--port PORT] [--identifier IDENTIFIER] [--tmp-file TMP-FILE] [--instead-of INSTEAD-OF]  
     [--] [<paths>...]                                                                                                                                                                                                                 
                                                                                                                                                                                                                                       
      while running parallel worker                 
```

This is caused by the journal code deleting the file (because it hasn't been added to the journal yet) while another process is creating it. Since the container php files are quite large the file_put_contents call lasts quite long, and an unlink will work while file_put_contents is running. This then causes the rename to fail since the file has been deleted.