### PR TITLE
Improve idate() return types

### DIFF
--- a/src/Type/Php/IdateFunctionReturnTypeExtension.php
+++ b/src/Type/Php/IdateFunctionReturnTypeExtension.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\Type;
+
+#[AutowiredService]
+final class IdateFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function __construct(private IdateFunctionReturnTypeHelper $idateFunctionReturnTypeHelper)
+	{
+	}
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'idate';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope,
+	): ?Type
+	{
+		$args = $functionCall->getArgs();
+		if ($args === []) {
+			return new ConstantBooleanType(false);
+		}
+
+		return $this->idateFunctionReturnTypeHelper->getTypeFromFormatType(
+			$scope->getType($args[0]->value),
+		);
+	}
+
+}

--- a/src/Type/Php/IdateFunctionReturnTypeHelper.php
+++ b/src/Type/Php/IdateFunctionReturnTypeHelper.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+#[AutowiredService]
+final class IdateFunctionReturnTypeHelper
+{
+
+	public function getTypeFromFormatType(Type $formatType): ?Type
+	{
+		$types = [];
+		foreach ($formatType->getConstantStrings() as $formatString) {
+			$types[] = $this->buildReturnTypeFromFormat($formatString->getValue());
+		}
+
+		if ($types === []) {
+			return null;
+		}
+
+		return TypeCombinator::union(...$types);
+	}
+
+	public function buildReturnTypeFromFormat(string $formatString): Type
+	{
+		// see https://www.php.net/idate
+		switch ($formatString) {
+			case 'd':
+				return IntegerRangeType::fromInterval(1, 31);
+			case 'h':
+				return IntegerRangeType::fromInterval(1, 12);
+			case 'H':
+				return IntegerRangeType::fromInterval(0, 23);
+			case 'i':
+				return IntegerRangeType::fromInterval(0, 59);
+			case 'I':
+				return IntegerRangeType::fromInterval(0, 1);
+			case 'L':
+				return IntegerRangeType::fromInterval(0, 1);
+			case 'm':
+				return IntegerRangeType::fromInterval(1, 12);
+			case 'N':
+				return IntegerRangeType::fromInterval(1, 7);
+			case 's':
+				return IntegerRangeType::fromInterval(0, 59);
+			case 't':
+				return IntegerRangeType::fromInterval(28, 31);
+			case 'w':
+				return IntegerRangeType::fromInterval(0, 6);
+			case 'W':
+				return IntegerRangeType::fromInterval(1, 53);
+			case 'y':
+				return IntegerRangeType::fromInterval(0, 99);
+			case 'z':
+				return IntegerRangeType::fromInterval(0, 365);
+			case 'B':
+			case 'o':
+			case 'U':
+			case 'Y':
+			case 'Z':
+				return new IntegerType();
+			default:
+				return new ConstantBooleanType(false);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/idate.php
+++ b/tests/PHPStan/Analyser/nsrt/idate.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PHPStan\Analyser\nsrt;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @param 'h'|'H' $hour
+	 * @param 'm'|string $format
+	 */
+	public function doFoo(string $string, string $hour, string $format): void
+	{
+		assertType('int<1, 7>', idate('N'));
+		assertType('int', idate('Y'));
+		assertType('false', idate('wrong'));
+		assertType('false', idate(''));
+		assertType('int|false', idate($string));
+		assertType('int<0, 23>', idate($hour));
+		assertType('int|false', idate($format));
+	}
+
+}


### PR DESCRIPTION
My first implementation also modified `DateFunctionReturnTypeHelper` to call `IdateFunctionReturnTypeHelper` but it was quite messy and it wasn't obvious what's coming from where.