### PR TITLE
Add missing use statement for the AutowireService attribute

### DIFF
--- a/src/Type/Php/OpensslCipherFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/OpensslCipherFunctionsReturnTypeExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;


### PR DESCRIPTION
I forgot the use statement when rebasing https://github.com/phpstan/phpstan-src/pull/4043

The CI caught the mistake but the PR was merged with a failing CI.