### PR TITLE
Added regression test

### DIFF
--- a/tests/PHPStan/Rules/Operators/InvalidComparisonOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidComparisonOperationRuleTest.php
@@ -205,4 +205,9 @@ class InvalidComparisonOperationRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug7280Comment(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7280-comment.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/bug-7280-comment.php
+++ b/tests/PHPStan/Rules/Operators/data/bug-7280-comment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bug7280Comment;
+
+function doFoo() {
+	/**
+	 * @var array<int, int> $numbers
+	 */
+	$numbers = [1, 2];
+
+	$sum = array_reduce(
+		$numbers,
+		fn ($curr, $n) => $curr + $n,
+		0
+	);
+
+	if ($sum > 0) {
+		//
+	}
+}


### PR DESCRIPTION
covers a snippet [mentioned in a comment](https://github.com/phpstan/phpstan/issues/7280#issuecomment-2447420232)

was fixed by https://github.com/phpstan/phpstan-src/pull/4168

the PR does not close the issue, therefore not using a "closing"-link