### PR TITLE
Issue-Bot: Emit GitHub Action annotation when issues are affected

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -166,7 +166,7 @@ jobs:
           exit_code="$?"
 
           if [[ "$exit_code" == "2" ]]; then
-            echo "::notice file=.github/workflows/issue-bot.yml,line=1 ::Issue bot detected open issues which are affected by this pull request - see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "::notice ::Issue bot detected open issues which are affected by this pull request - see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             exit 0
           fi
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -166,7 +166,7 @@ jobs:
           exit_code="$?"
 
           if [[ "$exit_code" == "2" ]]; then
-            echo "::notice file=.github/workflows/issue-bot.yml ::Issue bot detected open issues which are affected by this pull request - see [Issue bot job summary(https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)]."
+            echo "::notice file=.github/workflows/issue-bot.yml,line=1 ::Issue bot detected open issues which are affected by this pull request - see [Issue bot job summary](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
             exit 0
           fi
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -166,7 +166,7 @@ jobs:
           exit_code="$?"
 
           if [[ "$exit_code" == "2" ]]; then
-            echo "##[info]Issue bot detected open issues which are affected by this pull request - see Issue bot job summary."
+            echo "::notice::Issue bot detected open issues which are affected by this pull request - see Issue bot job summary."
             exit 0
           fi
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -160,7 +160,17 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./console.php evaluate >> $GITHUB_STEP_SUMMARY
+        run: |
+          set +e
+          ./console.php evaluate >> $GITHUB_STEP_SUMMARY
+          exit_code="$?"
+
+          if [[ "$exit_code" == "2" ]]; then
+            echo "##[info]Issue bot detected open issues which are affected by this pull request - see Issue bot job summary."
+            exit 0
+          fi
+
+          exit $exit_code
 
       - name: "Evaluate results - push"
         working-directory: "issue-bot"
@@ -169,4 +179,13 @@ jobs:
           GITHUB_PAT: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           PHPSTAN_SRC_COMMIT_BEFORE: ${{ github.event.before }}
           PHPSTAN_SRC_COMMIT_AFTER: ${{ github.event.after }}
-        run: ./console.php evaluate --post-comments >> $GITHUB_STEP_SUMMARY
+        run: |
+          set +e
+          ./console.php evaluate --post-comments >> $GITHUB_STEP_SUMMARY
+
+          # its fine when issue-bot found affected issues
+          if [[ "$exit_code" == "2" ]]; then
+            exit 0
+          fi
+
+          exit $exit_code

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -166,7 +166,7 @@ jobs:
           exit_code="$?"
 
           if [[ "$exit_code" == "2" ]]; then
-            echo "::notice::Issue bot detected open issues which are affected by this pull request - see Issue bot job summary."
+            echo "::notice file=.github/workflows/issue-bot.yml ::Issue bot detected open issues which are affected by this pull request - see [Issue bot job summary(https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)]."
             exit 0
           fi
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -166,7 +166,7 @@ jobs:
           exit_code="$?"
 
           if [[ "$exit_code" == "2" ]]; then
-            echo "::notice ::Issue bot detected open issues which are affected by this pull request - see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "::notice file=.github/workflows/issue-bot.yml,line=3 ::Issue bot detected open issues which are affected by this pull request - see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             exit 0
           fi
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -166,7 +166,7 @@ jobs:
           exit_code="$?"
 
           if [[ "$exit_code" == "2" ]]; then
-            echo "::notice file=.github/workflows/issue-bot.yml,line=1 ::Issue bot detected open issues which are affected by this pull request - see [Issue bot job summary](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            echo "::notice file=.github/workflows/issue-bot.yml,line=1 ::Issue bot detected open issues which are affected by this pull request - see https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             exit 0
           fi
 

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -182,6 +182,7 @@ jobs:
         run: |
           set +e
           ./console.php evaluate --post-comments >> $GITHUB_STEP_SUMMARY
+          exit_code="$?"
 
           # its fine when issue-bot found affected issues
           if [[ "$exit_code" == "2" ]]; then

--- a/issue-bot/src/Console/EvaluateCommand.php
+++ b/issue-bot/src/Console/EvaluateCommand.php
@@ -33,9 +33,9 @@ use function unserialize;
 class EvaluateCommand extends Command
 {
 
-	const EXIT_ERROR = 1;
-	const EXIT_AFFECTS_ISSUES = 2;
-	const EXIT_NO_AFFECTED_ISSUES = 0;
+	private const EXIT_ERROR = 1;
+	private const EXIT_AFFECTS_ISSUES = 2;
+	private const EXIT_NO_AFFECTED_ISSUES = 0;
 
 	public function __construct(
 		private TabCreator $tabCreator,

--- a/issue-bot/src/Console/EvaluateCommand.php
+++ b/issue-bot/src/Console/EvaluateCommand.php
@@ -33,6 +33,10 @@ use function unserialize;
 class EvaluateCommand extends Command
 {
 
+	const EXIT_ERROR = 1;
+	const EXIT_AFFECTS_ISSUES = 2;
+	const EXIT_NO_AFFECTED_ISSUES = 0;
+
 	public function __construct(
 		private TabCreator $tabCreator,
 		private PostGenerator $postGenerator,
@@ -133,7 +137,9 @@ class EvaluateCommand extends Command
 			}
 		}
 
+		$exitCode = self::EXIT_AFFECTS_ISSUES;
 		if (count($toPost) === 0) {
+			$exitCode = self::EXIT_NO_AFFECTED_ISSUES;
 			$output->writeln(sprintf('No changes in results in %d code snippets from %d GitHub issues. :tada:', $totalCodeSnippets, count($issueCache->getIssues())));
 		}
 
@@ -163,7 +169,7 @@ class EvaluateCommand extends Command
 		if ($postComments) {
 			if (count($toPost) > 20) {
 				$output->writeln('Too many comments to post, something is probably wrong.');
-				return 1;
+				return self::EXIT_ERROR;
 			}
 			foreach ($toPost as ['issue' => $issue, 'hash' => $hash, 'users' => $users, 'diff' => $diff, 'details' => $details]) {
 				$text = sprintf(
@@ -191,7 +197,7 @@ class EvaluateCommand extends Command
 			}
 		}
 
-		return 0;
+		return $exitCode;
 	}
 
 	/**

--- a/issue-bot/src/Console/EvaluateCommand.php
+++ b/issue-bot/src/Console/EvaluateCommand.php
@@ -142,8 +142,6 @@ class EvaluateCommand extends Command
 			$exitCode = self::EXIT_NO_AFFECTED_ISSUES;
 			$output->writeln(sprintf('No changes in results in %d code snippets from %d GitHub issues. :tada:', $totalCodeSnippets, count($issueCache->getIssues())));
 		}
-		// XXX debug  test
-		$exitCode = self::EXIT_AFFECTS_ISSUES;
 
 		foreach ($toPost as ['issue' => $issue, 'hash' => $hash, 'users' => $users, 'diff' => $diff, 'details' => $details]) {
 			$text = sprintf(

--- a/issue-bot/src/Console/EvaluateCommand.php
+++ b/issue-bot/src/Console/EvaluateCommand.php
@@ -142,6 +142,8 @@ class EvaluateCommand extends Command
 			$exitCode = self::EXIT_NO_AFFECTED_ISSUES;
 			$output->writeln(sprintf('No changes in results in %d code snippets from %d GitHub issues. :tada:', $totalCodeSnippets, count($issueCache->getIssues())));
 		}
+		// XXX debug  test
+		$exitCode = self::EXIT_AFFECTS_ISSUES;
 
 		foreach ($toPost as ['issue' => $issue, 'hash' => $hash, 'users' => $users, 'diff' => $diff, 'details' => $details]) {
 			$text = sprintf(


### PR DESCRIPTION
with this PR we get a issue-bot 'pull request annotation' in the 'files changed' tab, which looks like:

<img width="1227" height="412" alt="grafik" src="https://github.com/user-attachments/assets/48f094a6-13c1-4070-90b1-14a72091d059" />


this annotation is only visible when issue bot finds affected issues, otherwise no annotation is showing up.
intentionally I used a message type "notice" to get a gentle hint which distracts as less as possible.

Goal: make it more obvious when issue bot has helpful results. before this PR we sometimes missed to check the issue bot results as they are hidden deep in the github.com UI

---

triggered by a discussion in https://github.com/phpstan/phpstan-src/pull/4168#issuecomment-3285074537