### PR TITLE
Update stream_get_meta_data return

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -10360,7 +10360,7 @@ return [
 'stream_get_contents' => ['__benevolent<string|false>', 'source'=>'resource', 'maxlen='=>'int', 'offset='=>'int'],
 'stream_get_filters' => ['list<string>'],
 'stream_get_line' => ['string|false', 'stream'=>'resource', 'maxlen'=>'int', 'ending='=>'string'],
-'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri?:string,mediatype?:string,base64?:bool}', 'fp'=>'resource'],
+'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri?:string,mediatype?:string,base64?:bool,crypto?:array{protocol:string,cipher_name:string,cipher_bits:int,cipher_version:string,alpn_protocol?:string}}', 'fp'=>'resource'],
 'stream_get_transports' => ['list<string>'],
 'stream_get_wrappers' => ['list<string>'],
 'stream_is_local' => ['bool', 'stream'=>'resource|string'],


### PR DESCRIPTION
Per [documentation](https://www.php.net/manual/en/function.stream-get-meta-data.php#refsect1-function.stream-get-meta-data-returnvalues), the `crypto` index is added for tls://, https://, and ftps:// streams. Indices of this array aren't documented, but they're [in the source](https://github.com/php/php-src/blob/e6c6333c8e7c2f247e74d45e8b3ab442d6db3ebc/ext/openssl/xp_ssl.c#L2326)