### PR TITLE
fix: checking optional properties in object shapes

### DIFF
--- a/src/Type/ObjectShapeType.php
+++ b/src/Type/ObjectShapeType.php
@@ -176,15 +176,7 @@ class ObjectShapeType implements Type
 			try {
 				$otherProperty = $type->getProperty((string) $propertyName, $scope);
 			} catch (MissingPropertyFromReflectionException) {
-				return AcceptsResult::createNo(
-					[
-						sprintf(
-							'%s does not have property $%s.',
-							$type->describe(VerbosityLevel::typeOnly()),
-							$propertyName,
-						),
-					],
-				);
+				continue;
 			}
 
 			if (!$otherProperty->isPublic()) {
@@ -281,15 +273,7 @@ class ObjectShapeType implements Type
 			try {
 				$otherProperty = $type->getProperty((string) $propertyName, $scope);
 			} catch (MissingPropertyFromReflectionException) {
-				return IsSuperTypeOfResult::createNo(
-					[
-						sprintf(
-							'%s does not have property $%s.',
-							$type->describe(VerbosityLevel::typeOnly()),
-							$propertyName,
-						),
-					],
-				);
+				continue;
 			}
 			if (!$otherProperty->isPublic()) {
 				return IsSuperTypeOfResult::createNo();

--- a/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallMethodsRuleTest.php
@@ -3666,4 +3666,13 @@ class CallMethodsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3396.php'], []);
 	}
 
+	public function testBug13511(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkNullables = true;
+		$this->checkUnionTypes = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13511.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-13511.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-13511.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Bug13511;
+
+class User
+{
+	public function __construct(
+		public string $name,
+		public string $email,
+	) {}
+}
+
+class Printer
+{
+	/** @param object{name: string, email: string, phone?: string} $object */
+	function printInfo(object $object): void
+	{
+		return;
+	}
+}
+
+function (Printer $printer, User $user): void {
+	$printer->printInfo($user);
+};


### PR DESCRIPTION
Hello!

Closes https://github.com/phpstan/phpstan/issues/13511

By the time the `getProperty()` method is called, the `$hasProperty` has already been narrowed to `maybe` or it's been determined to be optional and overridden to `yes`. We should simply continue instead of returning `no`


Thanks!