### PR TITLE
update PHAR compilation readme

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -4,7 +4,9 @@
 
 ```bash
 composer install
-php bin/compile
+php bin/prepare
+cd build
+php ../box/vendor/bin/box compile --no-parallel
 ```
 
 The compiled PHAR will be in `tmp/phpstan.phar`.


### PR DESCRIPTION
When I want to test how a change in PHPStan would affect a project, I compile the PHAR locally. But noticed the README was outdated. I was doing it by memory (and terminal history) 😄 This PR updates it.