### PR TITLE
add optional strict check for printf parameter types

### DIFF
--- a/conf/config.level5.neon
+++ b/conf/config.level5.neon
@@ -20,3 +20,5 @@ services:
 		class: PHPStan\Rules\Functions\ParameterCastableToNumberRule
 	-
 		class: PHPStan\Rules\Functions\PrintfParameterTypeRule
+		arguments:
+			checkStrictPrintfPlaceholderTypes: %checkStrictPrintfPlaceholderTypes%

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -66,6 +66,7 @@ parameters:
 	strictRulesInstalled: false
 	deprecationRulesInstalled: false
 	inferPrivatePropertyTypeFromConstructor: false
+	checkStrictPrintfPlaceholderTypes: false
 	reportMaybes: false
 	reportMaybesInMethodSignatures: false
 	reportMaybesInPropertyPhpDocTypes: false

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -69,6 +69,7 @@ parametersSchema:
 	strictRulesInstalled: bool()
 	deprecationRulesInstalled: bool()
 	inferPrivatePropertyTypeFromConstructor: bool()
+	checkStrictPrintfPlaceholderTypes: bool()
 
 	tips: structure([
 		discoveringSymbols: bool()

--- a/src/Rules/Functions/PrintfParameterTypeRule.php
+++ b/src/Rules/Functions/PrintfParameterTypeRule.php
@@ -42,6 +42,7 @@ final class PrintfParameterTypeRule implements Rule
 		private PrintfHelper $printfHelper,
 		private ReflectionProvider $reflectionProvider,
 		private RuleLevelHelper $ruleLevelHelper,
+		private bool $checkStrictPrintfPlaceholderTypes,
 	)
 	{
 	}
@@ -100,15 +101,23 @@ final class PrintfParameterTypeRule implements Rule
 			new NullType(),
 		);
 		// Type on the left can go to the type on the right, but not vice versa.
-		$allowedTypeNameMap = [
-			'strict-int' => 'int',
-			'int' => 'castable to int',
-			'float' => 'castable to float',
-			// These are here just for completeness. They won't be used because, these types are already enforced by
-			// CallToFunctionParametersRule.
-			'string' => 'castable to string',
-			'mixed' => 'castable to string',
-		];
+		$allowedTypeNameMap = $this->checkStrictPrintfPlaceholderTypes
+			? [
+				'strict-int' => 'int',
+				'int' => 'int',
+				'float' => 'float',
+				'string' => 'int|float|string|Stringable',
+				'mixed' => 'int|float|string|Stringable',
+			]
+			: [
+				'strict-int' => 'int',
+				'int' => 'castable to int',
+				'float' => 'castable to float',
+				// These are here just for completeness. They won't be used because, these types are already enforced by
+				// CallToFunctionParametersRule.
+				'string' => 'castable to string',
+				'mixed' => 'castable to string',
+			];
 
 		for ($i = $formatArgumentPosition + 1, $j = 0; $i < $argsCount; $i++, $j++) {
 			// Some arguments may be skipped entirely.
@@ -117,10 +126,10 @@ final class PrintfParameterTypeRule implements Rule
 					$scope,
 					$args[$i]->value,
 					'',
-					static fn (Type $t) => $placeholder->doesArgumentTypeMatchPlaceholder($t),
+					fn (Type $t) => $placeholder->doesArgumentTypeMatchPlaceholder($t, $this->checkStrictPrintfPlaceholderTypes),
 				)->getType();
 
-				if ($argType instanceof ErrorType || $placeholder->doesArgumentTypeMatchPlaceholder($argType)) {
+				if ($argType instanceof ErrorType || $placeholder->doesArgumentTypeMatchPlaceholder($argType, $this->checkStrictPrintfPlaceholderTypes)) {
 					continue;
 				}
 

--- a/src/Rules/Functions/PrintfParameterTypeRule.php
+++ b/src/Rules/Functions/PrintfParameterTypeRule.php
@@ -106,8 +106,8 @@ final class PrintfParameterTypeRule implements Rule
 				'strict-int' => 'int',
 				'int' => 'int',
 				'float' => 'float',
-				'string' => 'int|float|string|Stringable',
-				'mixed' => 'int|float|string|Stringable',
+				'string' => '__stringandstringable',
+				'mixed' => '__stringandstringable',
 			]
 			: [
 				'strict-int' => 'int',

--- a/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
@@ -14,6 +14,8 @@ use const PHP_VERSION_ID;
 class PrintfParameterTypeRuleTest extends RuleTestCase
 {
 
+	private bool $checkStrictPrintfPlaceholderTypes = false;
+
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = $this->createReflectionProvider();
@@ -30,6 +32,7 @@ class PrintfParameterTypeRuleTest extends RuleTestCase
 				true,
 				false,
 			),
+			$this->checkStrictPrintfPlaceholderTypes,
 		);
 	}
 
@@ -107,6 +110,141 @@ class PrintfParameterTypeRuleTest extends RuleTestCase
 			[
 				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%1$*d" (width)), float given.',
 				31,
+			],
+		]);
+	}
+
+	public function testStrict(): void
+	{
+		$this->checkStrictPrintfPlaceholderTypes = true;
+		$this->analyse([__DIR__ . '/data/printf-param-types.php'], [
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), PrintfParamTypes\\FooStringable given.',
+				15,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), int|PrintfParamTypes\\FooStringable given.',
+				16,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), PrintfParamTypes\\FooStringable given.',
+				17,
+			],
+			[
+				'Parameter #2 of function sprintf is expected to be int by placeholder #1 ("%d"), PrintfParamTypes\\FooStringable given.',
+				18,
+			],
+			[
+				'Parameter #3 of function fprintf is expected to be float by placeholder #1 ("%f"), PrintfParamTypes\\FooStringable given.',
+				19,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), string given.',
+				20,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), float given.',
+				21,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), SimpleXMLElement given.',
+				22,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), null given.',
+				23,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%*s" (width)), true given.',
+				24,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%.*s" (precision)), string given.',
+				25,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #2 ("%3$.*s" (precision)), string given.',
+				26,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%1$-\'X10.2f"), PrintfParamTypes\\FooStringable given.',
+				27,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #2 ("%1$*.*f" (value)), PrintfParamTypes\\FooStringable given.',
+				28,
+			],
+			[
+				'Parameter #4 of function printf is expected to be float by placeholder #1 ("%3$f"), PrintfParamTypes\\FooStringable given.',
+				29,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%1$f"), PrintfParamTypes\\FooStringable given.',
+				30,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #2 ("%1$d"), PrintfParamTypes\\FooStringable given.',
+				30,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%1$*d" (width)), float given.',
+				31,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%1$*d" (value)), float given.',
+				31,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), float given.',
+				34,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), float|int given.',
+				35,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), string given.',
+				36,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), string given.',
+				37,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), null given.',
+				38,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), true given.',
+				39,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int by placeholder #1 ("%d"), SimpleXMLElement given.',
+				40,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), string given.',
+				42,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), null given.',
+				43,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), true given.',
+				44,
+			],
+			[
+				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), SimpleXMLElement given.',
+				45,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int|float|string|Stringable by placeholder #1 ("%s"), null given.',
+				47,
+			],
+			[
+				'Parameter #2 of function printf is expected to be int|float|string|Stringable by placeholder #1 ("%s"), true given.',
+				48,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
@@ -239,11 +239,11 @@ class PrintfParameterTypeRuleTest extends RuleTestCase
 				45,
 			],
 			[
-				'Parameter #2 of function printf is expected to be int|float|string|Stringable by placeholder #1 ("%s"), null given.',
+				'Parameter #2 of function printf is expected to be __stringandstringable by placeholder #1 ("%s"), null given.',
 				47,
 			],
 			[
-				'Parameter #2 of function printf is expected to be int|float|string|Stringable by placeholder #1 ("%s"), true given.',
+				'Parameter #2 of function printf is expected to be __stringandstringable by placeholder #1 ("%s"), true given.',
 				48,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/data/printf-param-types.php
+++ b/tests/PHPStan/Rules/Functions/data/printf-param-types.php
@@ -39,7 +39,7 @@ printf('%d', null);
 printf('%d', true);
 printf('%d', new \SimpleXMLElement('<a>aaa</a>'));
 
-printf('%f', 'a');
+printf('%f', '1.2345678901234567890123456789013245678901234567989');
 printf('%f', null);
 printf('%f', true);
 printf('%f', new \SimpleXMLElement('<a>aaa</a>'));


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13496
Previous PR: https://github.com/phpstan/phpstan-src/pull/3977

Would you accept turning this on by default in phpstan-strict-rules?