### PR TITLE
False positive "non-empty-array<int, int> might not be a list" when change existing list key

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5610,7 +5610,10 @@ final class NodeScopeResolver
 					$varForSetOffsetValue = $var->var;
 				}
 
-				if ($scope->hasExpressionType($var)->yes()) {
+				if (
+					$var === $originalVar
+					&& $scope->hasExpressionType($var)->yes()
+				) {
 					$assignedPropertyExpr = new SetExistingOffsetValueTypeExpr(
 						$varForSetOffsetValue,
 						$var->dim,

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5609,11 +5609,20 @@ final class NodeScopeResolver
 				} else {
 					$varForSetOffsetValue = $var->var;
 				}
-				$assignedPropertyExpr = new SetOffsetValueTypeExpr(
-					$varForSetOffsetValue,
-					$var->dim,
-					$assignedPropertyExpr,
-				);
+
+				if ($scope->hasExpressionType($var)->yes()) {
+					$assignedPropertyExpr = new SetExistingOffsetValueTypeExpr(
+						$varForSetOffsetValue,
+						$var->dim,
+						$assignedPropertyExpr,
+					);
+				} else {
+					$assignedPropertyExpr = new SetOffsetValueTypeExpr(
+						$varForSetOffsetValue,
+						$var->dim,
+						$assignedPropertyExpr,
+					);
+				}
 				$dimFetchStack[] = $var;
 				$var = $var->var;
 			}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5612,6 +5612,7 @@ final class NodeScopeResolver
 
 				if (
 					$var === $originalVar
+					&& $var->dim !== null
 					&& $scope->hasExpressionType($var)->yes()
 				) {
 					$assignedPropertyExpr = new SetExistingOffsetValueTypeExpr(

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -935,4 +935,11 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11777.php'], []);
 	}
 
+	public function testBug13035(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkImplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13035.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-13035.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13035.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bug13035;
+
+use function PHPStan\debugScope;
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @var list<int>
+	 */
+	public array $list = [];
+
+	public function bug(int $offset): void
+	{
+		if (isset($this->list[$offset])) {
+			$this->list[$offset] = 123;
+		}
+	}
+}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/13035