### PR TITLE
Faster code downgrade to speedup CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "${{ matrix.php-version }}"
+          php-version: "8.4"
 
       - name: "Downgrade PHPUnit"
         if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
@@ -53,6 +53,12 @@ jobs:
           composer install --no-interaction --no-progress --working-dir=compiler
           ./compiler/vendor/bin/simple-downgrade downgrade -c build/downgrade.php ${{ matrix.php-version }}
           composer dump
+
+      - name: "Change to runtime PHP version"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
 
       - name: "Validate Composer"
         run: "composer validate"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.4"
+          php-version: "${{ matrix.php-version }}"
 
       - name: "Downgrade PHPUnit"
         if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
@@ -47,6 +47,13 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"
 
+      - name: "Change to simple-downgrade PHP version"
+        if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "8.4"
+
       - name: "Transform source code"
         if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         run: |
@@ -54,7 +61,8 @@ jobs:
           ./compiler/vendor/bin/simple-downgrade downgrade -c build/downgrade.php ${{ matrix.php-version }}
           composer dump
 
-      - name: "Change to runtime PHP version"
+      - name: "Re-store PHP version"
+        if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -45,7 +45,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.4"
+          php-version: "${{ matrix.php-version }}"
           ini-file: development
           extensions: mbstring
 
@@ -57,6 +57,14 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"
 
+      - name: "Change to simple-downgrade PHP version"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "8.4"
+          ini-file: development
+          extensions: mbstring
+
       - name: "Transform source code"
         if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         shell: bash
@@ -65,7 +73,8 @@ jobs:
           ./compiler/vendor/bin/simple-downgrade downgrade -c build/downgrade.php ${{ matrix.php-version }}
           composer dump
 
-      - name: "Change to runtime PHP version"
+      - name: "Re-store PHP version"
+        if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -45,7 +45,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "${{ matrix.php-version }}"
+          php-version: "8.4"
           ini-file: development
           extensions: mbstring
 
@@ -64,6 +64,14 @@ jobs:
           composer install --no-interaction --no-progress --working-dir=compiler
           ./compiler/vendor/bin/simple-downgrade downgrade -c build/downgrade.php ${{ matrix.php-version }}
           composer dump
+
+      - name: "Change to runtime PHP version"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          ini-file: development
+          extensions: mbstring
 
       - name: "PHPStan"
         run: "make phpstan"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -58,6 +58,7 @@ jobs:
         run: "composer install --no-interaction --no-progress"
 
       - name: "Change to simple-downgrade PHP version"
+        if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "${{ matrix.php-version }}"
+          php-version: "8.4"
           tools: pecl
           extensions: ds,mbstring
           ini-file: development
@@ -193,6 +193,16 @@ jobs:
           composer install --no-interaction --no-progress --working-dir=compiler
           ./compiler/vendor/bin/simple-downgrade downgrade -c build/downgrade.php ${{ matrix.php-version }}
           composer dump
+
+      - name: "Change to runtime PHP version"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: pecl
+          extensions: ds,mbstring
+          ini-file: development
+          ini-values: memory_limit=2G
 
       - name: "Tests"
         run: "make tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.4"
+          php-version: "${{ matrix.php-version }}"
           tools: pecl
           extensions: ds,mbstring
           ini-file: development
@@ -187,6 +187,17 @@ jobs:
         shell: bash
         run: "composer require --dev phpunit/phpunit:^9.6 brianium/paratest:^6.5 symfony/console:^5.4 symfony/process:^5.4 --update-with-dependencies --ignore-platform-reqs --working-dir=tests"
 
+      - name: "Change to simple-downgrade PHP version"
+        if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "8.4"
+          tools: pecl
+          extensions: ds,mbstring
+          ini-file: development
+          ini-values: memory_limit=2G
+
       - name: "Transform source code"
         shell: bash
         run: |
@@ -194,7 +205,8 @@ jobs:
           ./compiler/vendor/bin/simple-downgrade downgrade -c build/downgrade.php ${{ matrix.php-version }}
           composer dump
 
-      - name: "Change to runtime PHP version"
+      - name: "Re-store PHP version"
+        if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"

--- a/compiler/composer.json
+++ b/compiler/composer.json
@@ -4,9 +4,9 @@
     "description": "PHAR Compiler for PHPStan",
     "license": ["MIT"],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "nette/neon": "^3.0.0",
-        "ondrejmirtes/simple-downgrader": "^2.2.1",
+        "ondrejmirtes/simple-downgrader": "^2.2.2",
         "seld/phar-utils": "^1.2",
         "symfony/console": "^5.4.43",
         "symfony/filesystem": "^5.4.43",
@@ -30,7 +30,7 @@
     },
 	"config": {
 		"platform": {
-			"php": "8.0.99"
+			"php": "8.2.99"
 		},
 		"platform-check": false,
 		"sort-packages": true

--- a/compiler/composer.lock
+++ b/compiler/composer.lock
@@ -4,56 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce39326567575644f63f099981a3cd73",
+    "content-hash": "421cae13caa4a836476ab23b026961de",
     "packages": [
-        {
-            "name": "jetbrains/phpstorm-stubs",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "dee3c94edb5adde5834e42c3d660a2cc89d367ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/dee3c94edb5adde5834e42c3d660a2cc89d367ea",
-                "reference": "dee3c94edb5adde5834e42c3d660a2cc89d367ea",
-                "shasum": ""
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.64.0",
-                "nikic/php-parser": "^v5.3.1",
-                "phpdocumentor/reflection-docblock": "^5.6.0",
-                "phpunit/phpunit": "^11.4.3"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "PhpStormStubsMap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "PHP runtime & extensions header files for PhpStorm",
-            "homepage": "https://www.jetbrains.com/phpstorm",
-            "keywords": [
-                "autocomplete",
-                "code",
-                "inference",
-                "inspection",
-                "jetbrains",
-                "phpstorm",
-                "stubs",
-                "type"
-            ],
-            "support": {
-                "source": "https://github.com/JetBrains/phpstorm-stubs/tree/master"
-            },
-            "time": "2025-07-08T09:17:06+00:00"
-        },
         {
             "name": "nette/neon",
             "version": "v3.4.4",
@@ -267,95 +219,23 @@
             "time": "2025-07-27T20:03:57+00:00"
         },
         {
-            "name": "ondrejmirtes/better-reflection",
-            "version": "6.57.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ondrejmirtes/BetterReflection.git",
-                "reference": "dcc22b90a63497f3450dd5eed62197bc46937297"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ondrejmirtes/BetterReflection/zipball/dcc22b90a63497f3450dd5eed62197bc46937297",
-                "reference": "dcc22b90a63497f3450dd5eed62197bc46937297",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "dev-master#dfcad4524db603bd20bdec3aab1a31c5f5128ea3",
-                "nikic/php-parser": "^5.4.0",
-                "php": "^7.4 || ^8.0"
-            },
-            "conflict": {
-                "thecodingmachine/safe": "<1.1.3"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^12.0.0",
-                "phpstan/phpstan": "^1.10.60",
-                "phpstan/phpstan-phpunit": "^1.3.16",
-                "phpunit/phpunit": "^11.5.7",
-                "rector/rector": "1.2.10"
-            },
-            "suggest": {
-                "composer/composer": "Required to use the ComposerSourceLocator"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\BetterReflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "James Titcumb",
-                    "email": "james@asgrim.com",
-                    "homepage": "https://github.com/asgrim"
-                },
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                },
-                {
-                    "name": "Gary Hockin",
-                    "email": "gary@roave.com",
-                    "homepage": "https://github.com/geeh"
-                },
-                {
-                    "name": "Jaroslav Hanslík",
-                    "email": "kukulich@kukulich.cz",
-                    "homepage": "https://github.com/kukulich"
-                }
-            ],
-            "description": "Better Reflection - an improved code reflection API",
-            "support": {
-                "source": "https://github.com/ondrejmirtes/BetterReflection/tree/6.57.0.0"
-            },
-            "time": "2025-02-12T21:16:38+00:00"
-        },
-        {
             "name": "ondrejmirtes/simple-downgrader",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ondrejmirtes/simple-downgrader.git",
-                "reference": "f91211786fcb75966ccba69406926db89cea8956"
+                "reference": "5de54eaa47dac5142e36b4085a12e5103e93366c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ondrejmirtes/simple-downgrader/zipball/f91211786fcb75966ccba69406926db89cea8956",
-                "reference": "f91211786fcb75966ccba69406926db89cea8956",
+                "url": "https://api.github.com/repos/ondrejmirtes/simple-downgrader/zipball/5de54eaa47dac5142e36b4085a12e5103e93366c",
+                "reference": "5de54eaa47dac5142e36b4085a12e5103e93366c",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2.5",
                 "nikic/php-parser": "^5.5.0",
-                "ondrejmirtes/better-reflection": "^6.57",
-                "php": "^7.4|^8.0",
+                "php": "^8.2",
                 "phpstan/phpdoc-parser": "^2.0",
                 "symfony/console": "^5.4.47",
                 "symfony/finder": "^5.4.45",
@@ -384,9 +264,9 @@
             "description": "Simple Downgrader",
             "support": {
                 "issues": "https://github.com/ondrejmirtes/simple-downgrader/issues",
-                "source": "https://github.com/ondrejmirtes/simple-downgrader/tree/2.2.1"
+                "source": "https://github.com/ondrejmirtes/simple-downgrader/tree/2.2.2"
             },
-            "time": "2025-07-13T11:49:36+00:00"
+            "time": "2025-09-20T18:37:56+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -3371,11 +3251,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": "^8.2"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.2.99"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWideMethodReturnTypehintRuleTest.php
@@ -208,12 +208,14 @@ class TooWideMethodReturnTypehintRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10312b.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.1')]
 	public function testBug10312c(): void
 	{
 		$this->checkProtectedAndPublicMethods = true;
 		$this->analyse([__DIR__ . '/data/bug-10312c.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.1')]
 	public function testBug10312d(): void
 	{
 		$this->checkProtectedAndPublicMethods = true;


### PR DESCRIPTION
make use of https://github.com/ondrejmirtes/simple-downgrader/pull/14

downgrading phpstan-src in CI before this PR took ~10min (windows) and ~4m30s (ubuntu)

we are now down to ~15-25 seconds