### PR TITLE
More precise `hrtime()` return type

### DIFF
--- a/src/Type/Php/HrtimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/HrtimeFunctionReturnTypeExtension.php
@@ -12,7 +12,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\FloatType;
-use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -28,8 +28,13 @@ final class HrtimeFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		$arrayType = new ConstantArrayType([new ConstantIntegerType(0), new ConstantIntegerType(1)], [new IntegerType(), new IntegerType()], [2], isList: TrinaryLogic::createYes());
-		$numberType = new BenevolentUnionType([new IntegerType(), new FloatType()]);
+		$arrayType = new ConstantArrayType(
+			[new ConstantIntegerType(0), new ConstantIntegerType(1)],
+			[IntegerRangeType::fromInterval(1, null), IntegerRangeType::fromInterval(0, 999999999)],
+			[2],
+			isList: TrinaryLogic::createYes(),
+		);
+		$numberType = new BenevolentUnionType([IntegerRangeType::fromInterval(1, null), new FloatType()]);
 
 		if (count($functionCall->getArgs()) < 1) {
 			return $arrayType;

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -8684,19 +8684,19 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_key_last($constantArrayOptionalKeys3)',
 			],
 			[
-				'array{int, int}',
+				'array{int<1, max>, int<0, 999999999>}',
 				'$hrtime1',
 			],
 			[
-				'array{int, int}',
+				'array{int<1, max>, int<0, 999999999>}',
 				'$hrtime2',
 			],
 			[
-				'(float|int)',
+				'(float|int<1, max>)',
 				'$hrtime3',
 			],
 			[
-				'array{int, int}|float|int',
+				'array{int<1, max>, int<0, 999999999>}|float|int<1, max>',
 				'$hrtime4',
 			],
 		];


### PR DESCRIPTION
`hrtime(true)` always returns positive-int.
`hrtime(false)` returns an array of `[second, nanosecond]`, where second is positive-int and nanosecond is between 0 and 10⁹-1 (because 10⁹ nanosecond = 1 second)

## Another solution
I tried to remove the return type extension and add a stub like this:
```php
/**
 * @template T of bool
 * @param T $as_number
 * @return (T is true ? __benevolent<float|positive-int> : array{positive-int, int<0, 999999999>})
 */
function hrtime(bool $as_number = false): array|int|float {}
```

but this doesn't work:
```php
dumpType(hrtime()); // array{int<1, max>, int<0, 999999999>}|false
dumpType(hrtime(true)); // float|int<1, max>|false
```

`false` seems to come from phpstan/php-8-stubs.
https://github.com/phpstan/php-8-stubs/blob/0.4.30/stubs/ext/standard/hrtime.php

---

I also tried this stub:
```php
/**
 * @template T of bool
 * @param T $as_number
 * @return (T is true ? __benevolent<float|positive-int> : (T is false ? array{positive-int, int<0, 999999999>} : false))
 */
function hrtime(bool $as_number = false): array|int|float|false {}
```

This works in most cases, but we see `false` when argument is not bool:
```php
// before: array{int, int}|float|int
// after:  array{int<1, max>, int<0, 999999999>}|float|int<1, max>|false
dumpType(hrtime(1));
```