### PR TITLE
add bcround function signature for php8.4

### DIFF
--- a/resources/functionMap_php84delta.php
+++ b/resources/functionMap_php84delta.php
@@ -15,6 +15,7 @@
  */
 return [
 	'new' => [
+		'bcround' => ['numeric-string', 'num'=>'numeric-string', 'precision='=>'int', 'mode='=>'RoundingMode'],
 		'http_get_last_response_headers' => ['list<string>|null'],
 		'http_clear_last_response_headers' => ['void'],
 		'mb_lcfirst' => ['string', 'string'=>'string', 'encoding='=>'string'],


### PR DESCRIPTION
Add signature for bcround so phpstan knows that it accepts & returns `numeric-string` instead of a raw `string`. 

phpdoc link: https://www.php.net/manual/en/function.bcround.php

Related: https://github.com/phpstan/phpstan/discussions/13364