### PR TITLE
Fix PHP8.5 Warning: "unexpected NAN value was coerced to string"

### DIFF
--- a/src/Type/Constant/ConstantFloatType.php
+++ b/src/Type/Constant/ConstantFloatType.php
@@ -49,6 +49,10 @@ class ConstantFloatType extends FloatType implements ConstantScalarType
 		$precisionBackup = ini_get('precision');
 		ini_set('precision', '-1');
 		try {
+			if (is_nan($value)) {
+				return 'NAN';
+			}
+
 			$valueStr = (string) $value;
 			if (is_finite($value) && !str_contains($valueStr, '.')) {
 				$valueStr .= '.0';


### PR DESCRIPTION
Fixes PHPUnit CI Warning:

```
1) /home/runner/work/phpstan-src/phpstan-src/src/Type/Constant/ConstantFloatType.php:52
unexpected NAN value was coerced to string

Triggered by:

* PHPStan\Analyser\NodeScopeResolverTest::testFile#tests/PHPStan/Analyser/nsrt/bug-13097.php
  /home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:259

* PHPStan\Analyser\NodeScopeResolverTest::testFile#tests/PHPStan/Analyser/nsrt/pow.php
  /home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/NodeScopeResolverTest.php:259

OK, but there were issues!
Tests: 13365, Assertions: 80621, Warnings: 1, Deprecations: 6, Skipped: 63.
```

see
- https://github.com/php/php-src/pull/19573
- https://wiki.php.net/rfc/warnings-php-8-5#coercing_nan_to_other_types
