### PR TITLE
Simplify ClassReflectionExtensions

### DIFF
--- a/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php
@@ -31,7 +31,7 @@ final class AnnotationsMethodsClassReflectionExtension implements MethodsClassRe
 			$this->methods[$classReflection->getCacheKey()][$methodName] = $method;
 		}
 
-		return isset($this->methods[$classReflection->getCacheKey()][$methodName]);
+		return true;
 	}
 
 	public function getMethod(ClassReflection $classReflection, string $methodName): ExtendedMethodReflection

--- a/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
+++ b/src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php
@@ -25,7 +25,7 @@ final class AnnotationsPropertiesClassReflectionExtension implements PropertiesC
 			$this->properties[$classReflection->getCacheKey()][$propertyName] = $property;
 		}
 
-		return isset($this->properties[$classReflection->getCacheKey()][$propertyName]);
+		return true;
 	}
 
 	public function getProperty(ClassReflection $classReflection, string $propertyName): ExtendedPropertyReflection


### PR DESCRIPTION
identified in https://github.com/phpstan/phpstan-src/pull/4372

```
------ ------------------------------------------------------------------------------------------------------------------- 
  Line   src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php                                          
 ------ ------------------------------------------------------------------------------------------------------------------- 
  34     Offset string on array<PHPStan\Reflection\ExtendedMethodReflection> in isset() always exists and is not nullable.  
         🪪  isset.offset                                                                                                   
         at src/Reflection/Annotations/AnnotationsMethodsClassReflectionExtension.php:34                                    
 ------ ------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------- 
  Line   src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php                                         
 ------ --------------------------------------------------------------------------------------------------------------------- 
  28     Offset string on array<PHPStan\Reflection\ExtendedPropertyReflection> in isset() always exists and is not nullable.  
         🪪  isset.offset                                                                                                     
         at src/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtension.php:28                                   
 ------ --------------------------------------------------------------------------------------------------------------------- 
 ```