### PR TITLE
Simplify *StatementWithoutImpurePointsRule

### DIFF
--- a/src/Rules/DeadCode/CallToMethodStatementWithoutImpurePointsRule.php
+++ b/src/Rules/DeadCode/CallToMethodStatementWithoutImpurePointsRule.php
@@ -30,10 +30,6 @@ final class CallToMethodStatementWithoutImpurePointsRule implements Rule
 		foreach ($node->get(MethodWithoutImpurePointsCollector::class) as $collected) {
 			foreach ($collected as [$className, $methodName, $classDisplayName]) {
 				$className = strtolower($className);
-
-				if (!array_key_exists($className, $methods)) {
-					$methods[$className] = [];
-				}
 				$methods[$className][strtolower($methodName)] = $classDisplayName . '::' . $methodName;
 			}
 		}

--- a/src/Rules/DeadCode/CallToStaticMethodStatementWithoutImpurePointsRule.php
+++ b/src/Rules/DeadCode/CallToStaticMethodStatementWithoutImpurePointsRule.php
@@ -30,10 +30,6 @@ final class CallToStaticMethodStatementWithoutImpurePointsRule implements Rule
 		foreach ($node->get(MethodWithoutImpurePointsCollector::class) as $collected) {
 			foreach ($collected as [$className, $methodName, $classDisplayName]) {
 				$lowerClassName = strtolower($className);
-
-				if (!array_key_exists($lowerClassName, $methods)) {
-					$methods[$lowerClassName] = [];
-				}
 				$methods[$lowerClassName][strtolower($methodName)] = $classDisplayName . '::' . $methodName;
 			}
 		}


### PR DESCRIPTION
identified in https://github.com/phpstan/phpstan-src/pull/4372

```
 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Rules/DeadCode/CallToMethodStatementWithoutImpurePointsRule.php                                                            
 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  34     Call to function array_key_exists() with non-falsy-string and array<non-falsy-string, *NEVER*> will always evaluate to false.  
         🪪  function.impossibleType                                                                                                    
         at src/Rules/DeadCode/CallToMethodStatementWithoutImpurePointsRule.php:34                                                      

 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/Rules/DeadCode/CallToStaticMethodStatementWithoutImpurePointsRule.php                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------- 
  34     Call to function array_key_exists() with non-falsy-string and array<non-falsy-string, *NEVER*> will always evaluate to false.  
         🪪  function.impossibleType                                                                                                    
         at src/Rules/DeadCode/CallToStaticMethodStatementWithoutImpurePointsRule.php:34                                                
```