### PR TITLE
use string instead of __stringandstringable in printf parameter error message

### DIFF
--- a/src/Rules/Functions/PrintfParameterTypeRule.php
+++ b/src/Rules/Functions/PrintfParameterTypeRule.php
@@ -106,8 +106,8 @@ final class PrintfParameterTypeRule implements Rule
 				'strict-int' => 'int',
 				'int' => 'int',
 				'float' => 'float',
-				'string' => '__stringandstringable',
-				'mixed' => '__stringandstringable',
+				'string' => 'string',
+				'mixed' => 'string',
 			]
 			: [
 				'strict-int' => 'int',

--- a/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
@@ -239,11 +239,11 @@ class PrintfParameterTypeRuleTest extends RuleTestCase
 				45,
 			],
 			[
-				'Parameter #2 of function printf is expected to be __stringandstringable by placeholder #1 ("%s"), null given.',
+				'Parameter #2 of function printf is expected to be string by placeholder #1 ("%s"), null given.',
 				47,
 			],
 			[
-				'Parameter #2 of function printf is expected to be __stringandstringable by placeholder #1 ("%s"), true given.',
+				'Parameter #2 of function printf is expected to be string by placeholder #1 ("%s"), true given.',
 				48,
 			],
 		]);


### PR DESCRIPTION
As requested here: https://github.com/phpstan/phpstan/pull/13594#issuecomment-3341869499