### PR TITLE
Rely on RuleLevelHelper in InvalidKeyInArrayItemRule

### DIFF
--- a/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayItemRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/InvalidKeyInArrayItemRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Arrays;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
@@ -12,9 +13,15 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 class InvalidKeyInArrayItemRuleTest extends RuleTestCase
 {
 
+	private bool $checkExplicitMixed = false;
+
+	private bool $checkImplicitMixed = false;
+
 	protected function getRule(): Rule
 	{
-		return new InvalidKeyInArrayItemRule(true);
+		$ruleLevelHelper = new RuleLevelHelper(self::createReflectionProvider(), true, false, true, $this->checkExplicitMixed, $this->checkImplicitMixed, false, true);
+
+		return new InvalidKeyInArrayItemRule($ruleLevelHelper);
 	}
 
 	public function testInvalidKey(): void
@@ -31,6 +38,31 @@ class InvalidKeyInArrayItemRuleTest extends RuleTestCase
 			[
 				'Possibly invalid array key type stdClass|string.',
 				15,
+			],
+		]);
+	}
+
+	public function testInvalidMixedKey(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkImplicitMixed = true;
+
+		$this->analyse([__DIR__ . '/data/invalid-key-array-item.php'], [
+			[
+				'Invalid array key type DateTimeImmutable.',
+				13,
+			],
+			[
+				'Invalid array key type array.',
+				14,
+			],
+			[
+				'Possibly invalid array key type stdClass|string.',
+				15,
+			],
+			[
+				'Possibly invalid array key type mixed.',
+				22,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Arrays/data/invalid-key-array-item.php
+++ b/tests/PHPStan/Rules/Arrays/data/invalid-key-array-item.php
@@ -14,3 +14,10 @@ $a = [
 	[] => 'bbb',
 	$stringOrObject => 'aaa',
 ];
+
+/** @var mixed $mixed */
+$mixed = doFoo();
+
+$b = [
+	$mixed => 'foo',
+];


### PR DESCRIPTION
This change is extracted from https://github.com/phpstan/phpstan-src/pull/4012

I feel like it will help for https://github.com/phpstan/phpstan/issues/13592 @ondrejmirtes by having a consistent behavior in code like
https://phpstan.org/r/43149492-9d7a-4d88-9f19-208b12d262b3 (currently mixed is reported only for one rule but not the other)

Similar to https://github.com/phpstan/phpstan-src/pull/4166