### PR TITLE
Fix "Offset (int|string) might not exist on array" after `array_keys($arr)`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6521,6 +6521,23 @@ final class NodeScopeResolver
 			}
 		}
 
+		if (
+			$stmt->expr instanceof FuncCall
+			&& $stmt->expr->name instanceof Name
+			&& $stmt->expr->name->toLowerString() === 'array_keys'
+			&& $stmt->valueVar instanceof Variable
+		) {
+			$args = $stmt->expr->getArgs();
+			if (count($args) >= 1) {
+				$arrayArg = $args[0]->value;
+				$scope = $scope->assignExpression(
+					new ArrayDimFetch($arrayArg, $stmt->valueVar),
+					$scope->getType($arrayArg)->getIterableValueType(),
+					$scope->getNativeType($arrayArg)->getIterableValueType(),
+				);
+			}
+		}
+
 		return $this->processVarAnnotation($scope, $vars, $stmt);
 	}
 

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -1000,4 +1000,11 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12926(): void
+	{
+		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
+
+		$this->analyse([__DIR__ . '/data/bug-12926.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-12926.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-12926.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
+namespace Bug12926;
 
 class HelloWorld
 {

--- a/tests/PHPStan/Rules/Arrays/data/bug-12926.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-12926.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+class HelloWorld
+{
+	public function sayHello(array $arr): void
+	{
+		foreach (array_keys($arr) as $key) {
+			var_dump($arr[$key]);
+		}
+	}
+}


### PR DESCRIPTION
found while investigating https://github.com/phpstan/phpstan-src/pull/4372

closes https://github.com/phpstan/phpstan/issues/12926