### PR TITLE
Inherit PHPDoc return type in child method with narrower native return type

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -7025,6 +7025,23 @@ final class NodeScopeResolver
 			return $phpDocReturnType;
 		}
 
+		if ($phpDocReturnType instanceof UnionType) {
+			$types = [];
+			foreach ($phpDocReturnType->getTypes() as $innerType) {
+				if (!$nativeReturnType->isSuperTypeOf($innerType)->yes()) {
+					continue;
+				}
+
+				$types[] = $innerType;
+			}
+
+			if (count($types) === 0) {
+				return null;
+			}
+
+			return TypeCombinator::union(...$types);
+		}
+
 		return null;
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -172,6 +172,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield __DIR__ . '/../Rules/Arrays/data/slevomat-foreach-unset-bug.php';
 		yield __DIR__ . '/../Rules/Arrays/data/slevomat-foreach-array-key-exists-bug.php';
 
+		yield __DIR__ . '/../Rules/Methods/data/inherit-phpdoc-return-type-with-narrower-native-return-type.php';
+
 		if (PHP_VERSION_ID >= 80000) {
 			yield __DIR__ . '/../Rules/Comparison/data/bug-7898.php';
 		}

--- a/tests/PHPStan/Analyser/nsrt/inherit-phpdoc-return-type-with-narrower-native-return-type-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/inherit-phpdoc-return-type-with-narrower-native-return-type-php8.php
@@ -1,0 +1,32 @@
+<?php // lint >= 8.0
+
+namespace InheritPhpDocReturnTypeWithNarrowerNativeReturnTypePhp8;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @return array<string>|positive-int|null
+	 */
+	public function doFoo(): array|int|null
+	{
+
+	}
+
+}
+
+class Bar extends Foo
+{
+
+	public function doFoo(): array|int
+	{
+
+	}
+
+}
+
+function (Bar $bar): void {
+	assertType('array<string>|int<1, max>', $bar->doFoo());
+};

--- a/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodReturnTypehintRuleTest.php
@@ -118,4 +118,9 @@ class MissingMethodReturnTypehintRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9657.php'], []);
 	}
 
+	public function testInheritPhpDocReturnTypeWithNarrowerNativeReturnType(): void
+	{
+		$this->analyse([__DIR__ . '/data/inherit-phpdoc-return-type-with-narrower-native-return-type.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/inherit-phpdoc-return-type-with-narrower-native-return-type.php
+++ b/tests/PHPStan/Rules/Methods/data/inherit-phpdoc-return-type-with-narrower-native-return-type.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace InheritPhpDocReturnTypeWithNarrowerNativeReturnType;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+
+	/**
+	 * @return array<string>|null
+	 */
+	public function doFoo(): ?array
+	{
+
+	}
+
+}
+
+class Bar extends Foo
+{
+
+	public function doFoo(): array
+	{
+
+	}
+
+}
+
+function (Bar $bar): void {
+	assertType('array<string>', $bar->doFoo());
+};


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/12481
Closes https://github.com/phpstan/phpstan/issues/11364
Closes https://github.com/phpstan/phpstan/issues/10600
Closes https://github.com/phpstan/phpstan/issues/13588