### PR TITLE
Fix ConstantArrayType::hasOffsetValueType and ArrayType::hasOffsetValueType

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -272,6 +272,9 @@ class ArrayType implements Type
 		if ($offsetArrayKeyType instanceof ErrorType) {
 			$allowedArrayKeys = AllowedArrayKeysTypes::getType();
 			$offsetArrayKeyType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
+			if ($offsetArrayKeyType instanceof NeverType) {
+				return TrinaryLogic::createNo();
+			}
 		}
 		$offsetType = $offsetArrayKeyType;
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -586,6 +586,9 @@ class ConstantArrayType implements Type
 		if ($offsetArrayKeyType instanceof ErrorType) {
 			$allowedArrayKeys = AllowedArrayKeysTypes::getType();
 			$offsetArrayKeyType = TypeCombinator::intersect($allowedArrayKeys, $offsetType)->toArrayKey();
+			if ($offsetArrayKeyType instanceof NeverType) {
+				return TrinaryLogic::createNo();
+			}
 		}
 
 		return $this->recursiveHasOffsetValueType($offsetArrayKeyType);

--- a/tests/PHPStan/Levels/data/arrayOffsetAccess-3.json
+++ b/tests/PHPStan/Levels/data/arrayOffsetAccess-3.json
@@ -3,5 +3,10 @@
         "message": "Invalid array key type DateTimeImmutable.",
         "line": 17,
         "ignorable": true
+    },
+    {
+        "message": "Offset DateTimeImmutable does not exist on array.",
+        "line": 17,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Levels/data/arrayOffsetAccess-7.json
+++ b/tests/PHPStan/Levels/data/arrayOffsetAccess-7.json
@@ -1,7 +1,17 @@
 [
     {
+        "message": "Offset int|object might not exist on array.",
+        "line": 19,
+        "ignorable": true
+    },
+    {
         "message": "Possibly invalid array key type int|object.",
         "line": 19,
+        "ignorable": true
+    },
+    {
+        "message": "Offset object|null might not exist on array.",
+        "line": 20,
         "ignorable": true
     },
     {
@@ -10,13 +20,28 @@
         "ignorable": true
     },
     {
+        "message": "Offset DateTimeImmutable might not exist on array|ArrayAccess.",
+        "line": 26,
+        "ignorable": true
+    },
+    {
         "message": "Possibly invalid array key type DateTimeImmutable.",
         "line": 26,
         "ignorable": true
     },
     {
+        "message": "Offset int|object might not exist on array|ArrayAccess.",
+        "line": 28,
+        "ignorable": true
+    },
+    {
         "message": "Possibly invalid array key type int|object.",
         "line": 28,
+        "ignorable": true
+    },
+    {
+        "message": "Offset object|null might not exist on array|ArrayAccess.",
+        "line": 29,
         "ignorable": true
     },
     {

--- a/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
+++ b/tests/PHPStan/Levels/data/stringOffsetAccess-3.json
@@ -18,5 +18,10 @@
         "message": "Invalid array key type stdClass.",
         "line": 59,
         "ignorable": true
+    },
+    {
+        "message": "Offset stdClass does not exist on array{baz: 21}|array{foo: 17, bar: 19}.",
+        "line": 59,
+        "ignorable": true
     }
 ]

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -949,6 +949,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Offset int|object does not exist on array{baz: 21}|array{foo: 17, bar: 19}.',
 				12,
 			],
+			[
+				'Offset object does not exist on array<string, int>.',
+				21,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -269,4 +269,36 @@ class ArrayTypeTest extends PHPStanTestCase
 		);
 	}
 
+	public static function dataHasOffsetValueType(): array
+	{
+		return [
+			[
+				new ArrayType(new BenevolentUnionType([
+					new IntegerType(),
+					new StringType(),
+				]), new IntegerType()),
+				new ArrayType(new BenevolentUnionType([
+					new IntegerType(),
+					new StringType(),
+				]), new IntegerType()),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	#[DataProvider('dataHasOffsetValueType')]
+	public function testHasOffsetValueType(
+		ArrayType $type,
+		Type $offsetType,
+		TrinaryLogic $expectedResult,
+	): void
+	{
+		$actualResult = $type->hasOffsetValueType($offsetType);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> hasOffsetValueType(%s)', $type->describe(VerbosityLevel::precise()), $offsetType->describe(VerbosityLevel::precise())),
+		);
+	}
+
 }

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -1044,4 +1044,30 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 		$this->assertSame($expectedType->getNextAutoIndexes(), $actualType->getNextAutoIndexes());
 	}
 
+	public static function dataHasOffsetValueType(): array
+	{
+		return [
+			[
+				new ConstantArrayType([new ConstantIntegerType(0)], [new ConstantStringType('a')]),
+				new ConstantArrayType([new ConstantIntegerType(0)], [new ConstantStringType('a')]),
+				TrinaryLogic::createNo(),
+			],
+		];
+	}
+
+	#[DataProvider('dataHasOffsetValueType')]
+	public function testHasOffsetValueType(
+		ConstantArrayType $type,
+		Type $offsetType,
+		TrinaryLogic $expectedResult,
+	): void
+	{
+		$actualResult = $type->hasOffsetValueType($offsetType);
+		$this->assertSame(
+			$expectedResult->describe(),
+			$actualResult->describe(),
+			sprintf('%s -> hasOffsetValueType(%s)', $type->describe(VerbosityLevel::precise()), $offsetType->describe(VerbosityLevel::precise())),
+		);
+	}
+
 }


### PR DESCRIPTION
Extracted from https://github.com/phpstan/phpstan-src/pull/4385

When you merge this PR, I would recommend to wait for https://github.com/phpstan/phpstan-src/pull/4385 too in order to avoid reporting extra "duplicate" message "offset might not exist"/"offset does not exist" since we're detecting more errors with this fix.

I prefer to test hasOffsetValueType rather with errors reported by NonexistentOffsetInArrayDimFetchRule since
- https://github.com/phpstan/phpstan-src/pull/4385 will remove the message again
- But we should still check  hasOffsetValueType return NO, rather than YES (currently)