### PR TITLE
Skip deep expression when root expression changes while scope generalization

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -162,12 +162,14 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
+use function str_contains;
 use function str_decrement;
 use function str_increment;
 use function str_starts_with;
 use function strlen;
 use function strtolower;
 use function substr;
+use function uksort;
 use function usort;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
@@ -5296,12 +5298,7 @@ final class MutatingScope implements Scope
 		array $otherVariableTypeHolders,
 	): array
 	{
-		$sortByExprStringLength = static function (string $exprA, string $exprB): int {
-			return strlen($exprA) <=> strlen($exprB);
-		};
-
-		uksort($variableTypeHolders, $sortByExprStringLength);
-		uksort($otherVariableTypeHolders, $sortByExprStringLength);
+		uksort($variableTypeHolders, static fn (string $exprA, string $exprB): int => strlen($exprA) <=> strlen($exprB));
 
 		$changedArrays = [];
 		foreach ($variableTypeHolders as $variableExprString => $variableTypeHolder) {
@@ -5309,17 +5306,20 @@ final class MutatingScope implements Scope
 				continue;
 			}
 
-			foreach($changedArrays as $changedExpr) {
-				if (str_starts_with($variableExprString, $changedExpr)) {
+			foreach ($changedArrays as $changedExpr) {
+				if (
+					str_contains($variableExprString, $changedExpr . '[')
+					|| str_contains($variableExprString, '[' . $changedExpr . ']')
+				) {
+					unset($variableTypeHolders[$variableExprString]);
 					continue 2;
 				}
 			}
 
 			$generalizedType = $this->generalizeType($variableTypeHolder->getType(), $otherVariableTypeHolders[$variableExprString]->getType(), 0);
 			if (
-				$generalizedType->isArray()->yes() &&
-				!$generalizedType->equals($variableTypeHolder->getType()))
-			{
+				!$generalizedType->equals($variableTypeHolder->getType())
+			) {
 				$changedArrays[] = $variableExprString;
 			}
 			$variableTypeHolders[$variableExprString] = new ExpressionTypeHolder(

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5296,14 +5296,35 @@ final class MutatingScope implements Scope
 		array $otherVariableTypeHolders,
 	): array
 	{
+		$sortByExprStringLength = static function (string $exprA, string $exprB): int {
+			return strlen($exprA) <=> strlen($exprB);
+		};
+
+		uksort($variableTypeHolders, $sortByExprStringLength);
+		uksort($otherVariableTypeHolders, $sortByExprStringLength);
+
+		$changedArrays = [];
 		foreach ($variableTypeHolders as $variableExprString => $variableTypeHolder) {
 			if (!isset($otherVariableTypeHolders[$variableExprString])) {
 				continue;
 			}
 
+			foreach($changedArrays as $changedExpr) {
+				if (str_starts_with($variableExprString, $changedExpr)) {
+					continue 2;
+				}
+			}
+
+			$generalizedType = $this->generalizeType($variableTypeHolder->getType(), $otherVariableTypeHolders[$variableExprString]->getType(), 0);
+			if (
+				$generalizedType->isArray()->yes() &&
+				!$generalizedType->equals($variableTypeHolder->getType()))
+			{
+				$changedArrays[] = $variableExprString;
+			}
 			$variableTypeHolders[$variableExprString] = new ExpressionTypeHolder(
 				$variableTypeHolder->getExpr(),
-				$this->generalizeType($variableTypeHolder->getType(), $otherVariableTypeHolders[$variableExprString]->getType(), 0),
+				$generalizedType,
 				$variableTypeHolder->getCertainty(),
 			);
 		}

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5300,13 +5300,13 @@ final class MutatingScope implements Scope
 	{
 		uksort($variableTypeHolders, static fn (string $exprA, string $exprB): int => strlen($exprA) <=> strlen($exprB));
 
-		$changedArrays = [];
+		$generalizedExpressions = [];
 		foreach ($variableTypeHolders as $variableExprString => $variableTypeHolder) {
 			if (!isset($otherVariableTypeHolders[$variableExprString])) {
 				continue;
 			}
 
-			foreach ($changedArrays as $changedExpr) {
+			foreach ($generalizedExpressions as $changedExpr) {
 				if (
 					str_contains($variableExprString, $changedExpr . '[')
 					|| str_contains($variableExprString, '[' . $changedExpr . ']')
@@ -5320,7 +5320,7 @@ final class MutatingScope implements Scope
 			if (
 				!$generalizedType->equals($variableTypeHolder->getType())
 			) {
-				$changedArrays[] = $variableExprString;
+				$generalizedExpressions[] = $variableExprString;
 			}
 			$variableTypeHolders[$variableExprString] = new ExpressionTypeHolder(
 				$variableTypeHolder->getExpr(),

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -5302,8 +5302,8 @@ final class MutatingScope implements Scope
 		$generalizedExpressions = [];
 		$newVariableTypeHolders = [];
 		foreach ($variableTypeHolders as $variableExprString => $variableTypeHolder) {
-			foreach ($generalizedExpressions as $generalizedExprString => $generalizedTypeHolder) {
-				if (!$this->shouldInvalidateExpression($generalizedExprString, $generalizedTypeHolder->getExpr(), $variableTypeHolder->getExpr())) {
+			foreach ($generalizedExpressions as $generalizedExprString => $generalizedExpr) {
+				if (!$this->shouldInvalidateExpression($generalizedExprString, $generalizedExpr, $variableTypeHolder->getExpr())) {
 					continue;
 				}
 
@@ -5318,7 +5318,7 @@ final class MutatingScope implements Scope
 			if (
 				!$generalizedType->equals($variableTypeHolder->getType())
 			) {
-				$generalizedExpressions[$variableExprString] = $variableTypeHolder;
+				$generalizedExpressions[$variableExprString] = $variableTypeHolder->getExpr();
 			}
 			$newVariableTypeHolders[$variableExprString] = new ExpressionTypeHolder(
 				$variableTypeHolder->getExpr(),

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -162,7 +162,6 @@ use function is_string;
 use function ltrim;
 use function md5;
 use function sprintf;
-use function str_contains;
 use function str_decrement;
 use function str_increment;
 use function str_starts_with;
@@ -5301,35 +5300,34 @@ final class MutatingScope implements Scope
 		uksort($variableTypeHolders, static fn (string $exprA, string $exprB): int => strlen($exprA) <=> strlen($exprB));
 
 		$generalizedExpressions = [];
+		$newVariableTypeHolders = [];
 		foreach ($variableTypeHolders as $variableExprString => $variableTypeHolder) {
-			if (!isset($otherVariableTypeHolders[$variableExprString])) {
-				continue;
-			}
-
-			foreach ($generalizedExpressions as $changedExpr) {
-				if (
-					str_contains($variableExprString, $changedExpr . '[')
-					|| str_contains($variableExprString, '[' . $changedExpr . ']')
-				) {
-					unset($variableTypeHolders[$variableExprString]);
-					continue 2;
+			foreach ($generalizedExpressions as $generalizedExprString => $generalizedTypeHolder) {
+				if (!$this->shouldInvalidateExpression($generalizedExprString, $generalizedTypeHolder->getExpr(), $variableTypeHolder->getExpr())) {
+					continue;
 				}
+
+				continue 2;
+			}
+			if (!isset($otherVariableTypeHolders[$variableExprString])) {
+				$newVariableTypeHolders[$variableExprString] = $variableTypeHolder;
+				continue;
 			}
 
 			$generalizedType = $this->generalizeType($variableTypeHolder->getType(), $otherVariableTypeHolders[$variableExprString]->getType(), 0);
 			if (
 				!$generalizedType->equals($variableTypeHolder->getType())
 			) {
-				$generalizedExpressions[] = $variableExprString;
+				$generalizedExpressions[$variableExprString] = $variableTypeHolder;
 			}
-			$variableTypeHolders[$variableExprString] = new ExpressionTypeHolder(
+			$newVariableTypeHolders[$variableExprString] = new ExpressionTypeHolder(
 				$variableTypeHolder->getExpr(),
 				$generalizedType,
 				$variableTypeHolder->getCertainty(),
 			);
 		}
 
-		return $variableTypeHolders;
+		return $newVariableTypeHolders;
 	}
 
 	private function generalizeType(Type $a, Type $b, int $depth): Type

--- a/tests/PHPStan/Analyser/nsrt/pr-4372.php
+++ b/tests/PHPStan/Analyser/nsrt/pr-4372.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PR4372;
+
+use function PHPStan\debugScope;
+use function PHPStan\Testing\assertType;
+
+function (string $s): void {
+	$locations = [];
+	for ($i = 0; $i < 10; $i++) {
+		$locations[$i] = [];
+		for ($j = 0; $j < 10; $j++) {
+			$locations[$i][$j] = $s;
+		}
+	}
+
+	assertType('non-empty-array<int<0, 9>, non-empty-array<int<0, 9>, string>>', $locations);
+	assertType('non-empty-array<int<0, 9>, string>>', $locations[0]);
+};

--- a/tests/PHPStan/Analyser/nsrt/pr-4390.php
+++ b/tests/PHPStan/Analyser/nsrt/pr-4390.php
@@ -2,7 +2,6 @@
 
 namespace PR4390;
 
-use function PHPStan\debugScope;
 use function PHPStan\Testing\assertType;
 
 function (string $s): void {

--- a/tests/PHPStan/Analyser/nsrt/pr-4390.php
+++ b/tests/PHPStan/Analyser/nsrt/pr-4390.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PR4372;
+namespace PR4390;
 
 use function PHPStan\debugScope;
 use function PHPStan\Testing\assertType;
@@ -15,5 +15,5 @@ function (string $s): void {
 	}
 
 	assertType('non-empty-array<int<0, 9>, non-empty-array<int<0, 9>, string>>', $locations);
-	assertType('non-empty-array<int<0, 9>, string>>', $locations[0]);
+	assertType('non-empty-array<int<0, 9>, string>', $locations[0]);
 };


### PR DESCRIPTION
implement the idea described in https://github.com/phpstan/phpstan-src/pull/4372#issuecomment-3345672871

it does not fix the problem we see the wrong types we see from https://phpstan.org/r/16197474-84cb-43ad-b983-ad78371fba02 though