### PR TITLE
Support union types in curl_setopt validation

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -128,35 +128,30 @@ final class ParametersAcceptorSelector
 			if (count($args) >= 3 && (bool) $args[0]->getAttribute(CurlSetOptArgVisitor::ATTRIBUTE_NAME)) {
 				$optType = $scope->getType($args[1]->value);
 
-				$optValueType = null;
+				$valueTypes = [];
 				foreach ($optType->getConstantScalarValues() as $scalarValue) {
 					if (!is_int($scalarValue)) {
-						$optValueType = null;
+						$valueTypes = [];
 						break;
 					}
 
 					$valueType = self::getCurlOptValueType($scalarValue);
 					if ($valueType === null) {
-						$optValueType = null;
+						$valueTypes = [];
 						break;
 					}
 
-					if ($optValueType === null) {
-						$optValueType = $valueType;
-						continue;
-					}
-
-					$optValueType = TypeCombinator::union($optValueType, $valueType);
+					$valueTypes[] = $valueType;
 				}
 
-				if ($optValueType !== null) {
+				if (count($valueTypes) !== 0) {
 					$acceptor = $parametersAcceptors[0];
 					$parameters = $acceptor->getParameters();
 
 					$parameters[2] = new NativeParameterReflection(
 						$parameters[2]->getName(),
 						$parameters[2]->isOptional(),
-						$optValueType,
+						TypeCombinator::union(...$valueTypes),
 						$parameters[2]->passedByReference(),
 						$parameters[2]->isVariadic(),
 						$parameters[2]->getDefaultValue(),

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -50,6 +50,7 @@ use function array_values;
 use function constant;
 use function count;
 use function defined;
+use function is_int;
 use function is_string;
 use function sprintf;
 use const ARRAY_FILTER_USE_BOTH;
@@ -126,33 +127,51 @@ final class ParametersAcceptorSelector
 
 			if (count($args) >= 3 && (bool) $args[0]->getAttribute(CurlSetOptArgVisitor::ATTRIBUTE_NAME)) {
 				$optType = $scope->getType($args[1]->value);
-				if ($optType instanceof ConstantIntegerType) {
-					$optValueType = self::getCurlOptValueType($optType->getValue());
 
-					if ($optValueType !== null) {
-						$acceptor = $parametersAcceptors[0];
-						$parameters = $acceptor->getParameters();
-
-						$parameters[2] = new NativeParameterReflection(
-							$parameters[2]->getName(),
-							$parameters[2]->isOptional(),
-							$optValueType,
-							$parameters[2]->passedByReference(),
-							$parameters[2]->isVariadic(),
-							$parameters[2]->getDefaultValue(),
-						);
-
-						$parametersAcceptors = [
-							new FunctionVariant(
-								$acceptor->getTemplateTypeMap(),
-								$acceptor->getResolvedTemplateTypeMap(),
-								array_values($parameters),
-								$acceptor->isVariadic(),
-								$acceptor->getReturnType(),
-								$acceptor instanceof ExtendedParametersAcceptor ? $acceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
-							),
-						];
+				$optValueType = null;
+				foreach ($optType->getConstantScalarValues() as $scalarValue) {
+					if (!is_int($scalarValue)) {
+						$optValueType = null;
+						break;
 					}
+
+					$valueType = self::getCurlOptValueType($scalarValue);
+					if ($valueType === null) {
+						$optValueType = null;
+						break;
+					}
+
+					if ($optValueType === null) {
+						$optValueType = $valueType;
+						continue;
+					}
+
+					$optValueType = TypeCombinator::union($optValueType, $valueType);
+				}
+
+				if ($optValueType !== null) {
+					$acceptor = $parametersAcceptors[0];
+					$parameters = $acceptor->getParameters();
+
+					$parameters[2] = new NativeParameterReflection(
+						$parameters[2]->getName(),
+						$parameters[2]->isOptional(),
+						$optValueType,
+						$parameters[2]->passedByReference(),
+						$parameters[2]->isVariadic(),
+						$parameters[2]->getDefaultValue(),
+					);
+
+					$parametersAcceptors = [
+						new FunctionVariant(
+							$acceptor->getTemplateTypeMap(),
+							$acceptor->getResolvedTemplateTypeMap(),
+							array_values($parameters),
+							$acceptor->isVariadic(),
+							$acceptor->getReturnType(),
+							$acceptor instanceof ExtendedParametersAcceptor ? $acceptor->getCallSiteVarianceMap() : TemplateTypeVarianceMap::createEmpty(),
+						),
+					];
 				}
 			}
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1375,6 +1375,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #3 $value of function curl_setopt expects array<int, string>, array<string, string> given.',
 				77,
 			],
+			[
+				'Parameter #3 $value of function curl_setopt expects bool|int, int|string given.',
+				96,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -81,4 +81,18 @@ class HelloWorld
 		];
 		curl_setopt($curl, CURLOPT_HTTPHEADER, $header_list);
 	}
+
+	public function unionType() {
+		$curl = curl_init();
+
+		if (rand(0,1)) {
+			$var = CURLOPT_AUTOREFERER;
+			$value = 'yes'; // invalid, should be bool
+		} else {
+			$var = CURLOPT_TIMEOUT;
+			$value = 1;
+		}
+
+		curl_setopt($curl, $var, $value);
+	}
 }


### PR DESCRIPTION
while working on https://github.com/phpstan/phpstan-src/pull/4395 I realized there is a low hanging fruit by getting rid of `instanceof ConstantIntegerType`