### PR TITLE
relax strict printf parameter check

### DIFF
--- a/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParameterTypeRuleTest.php
@@ -223,10 +223,6 @@ class PrintfParameterTypeRuleTest extends RuleTestCase
 				40,
 			],
 			[
-				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), string given.',
-				42,
-			],
-			[
 				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), null given.',
 				43,
 			],
@@ -237,10 +233,6 @@ class PrintfParameterTypeRuleTest extends RuleTestCase
 			[
 				'Parameter #2 of function printf is expected to be float by placeholder #1 ("%f"), SimpleXMLElement given.',
 				45,
-			],
-			[
-				'Parameter #2 of function printf is expected to be string by placeholder #1 ("%s"), null given.',
-				47,
 			],
 			[
 				'Parameter #2 of function printf is expected to be string by placeholder #1 ("%s"), true given.',

--- a/tests/PHPStan/Rules/Functions/data/printf-param-types.php
+++ b/tests/PHPStan/Rules/Functions/data/printf-param-types.php
@@ -39,12 +39,12 @@ printf('%d', null);
 printf('%d', true);
 printf('%d', new \SimpleXMLElement('<a>aaa</a>'));
 
-printf('%f', '1.2345678901234567890123456789013245678901234567989');
+
 printf('%f', null);
 printf('%f', true);
 printf('%f', new \SimpleXMLElement('<a>aaa</a>'));
 
-printf('%s', null);
+
 printf('%s', true);
 
 // Error, but already reported by CallToFunctionParametersRule
@@ -54,6 +54,10 @@ printf('%s', []);
 // Error, but already reported by PrintfParametersRule
 printf('%s');
 printf('%s', 1, 2);
+
+// Arguable
+printf('%f', '1.2345678901234567890123456789013245678901234567989');
+printf('%s', null);
 
 // OK
 printf('%s', 'a');


### PR DESCRIPTION
I relaxed the strict printf parameter check as described in [this comment](https://github.com/phpstan/phpstan-src/pull/4349#discussion_r2381919959).

IMO `checkStrictPrintfPlaceholderTypes: true` should mean precisely the level of strictness that's appropriate for phpstan-strict-rules.

Beyond that it may be desirable to configure it to be more/less strict. But for now, those who want it less strict will have to set it to `false` and they will be no worse off than before I introduced it. Those who want it more strict can keep it turned on and they'll be at least somewhat better off than before I introduced it.