### PR TITLE
Add option to prohibit bool to string coercion

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -14,3 +14,4 @@ parameters:
 		rawMessageInBaseline: true
 		reportNestedTooWideType: false
 		assignToByRefForeachExpr: true
+		checkTypeCoercions: true

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -38,6 +38,7 @@ parameters:
 		rawMessageInBaseline: false
 		reportNestedTooWideType: false
 		assignToByRefForeachExpr: false
+		checkTypeCoercions: false
 	fileExtensions:
 		- php
 	checkAdvancedIsset: false
@@ -221,6 +222,8 @@ parameters:
 		- [parameters, memoryLimitFile]
 		- [parameters, pro]
 		- parametersSchema
+	allowedTypeCoercions:
+		boolToString: true
 
 extensions:
 	rules: PHPStan\DependencyInjection\RulesExtension

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -41,6 +41,7 @@ parametersSchema:
 		rawMessageInBaseline: bool()
 		reportNestedTooWideType: bool()
 		assignToByRefForeachExpr: bool()
+		checkTypeCoercions: bool()
 	])
 	fileExtensions: listOf(string())
 	checkAdvancedIsset: bool()
@@ -163,6 +164,9 @@ parametersSchema:
 		string(),
 		listOf(string()),
 	)))
+	allowedTypeCoercions: structure([
+		boolToString: bool()
+	])
 
 	# playground mode
 	sourceLocatorPlaygroundMode: bool()

--- a/src/Rules/Cast/InvalidPartOfEncapsedStringRule.php
+++ b/src/Rules/Cast/InvalidPartOfEncapsedStringRule.php
@@ -9,6 +9,7 @@ use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Rules\TypeCoercionRuleHelper;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
@@ -24,6 +25,7 @@ final class InvalidPartOfEncapsedStringRule implements Rule
 	public function __construct(
 		private ExprPrinter $exprPrinter,
 		private RuleLevelHelper $ruleLevelHelper,
+		private TypeCoercionRuleHelper $typeCoercionRuleHelper,
 	)
 	{
 	}
@@ -45,14 +47,14 @@ final class InvalidPartOfEncapsedStringRule implements Rule
 				$scope,
 				$part,
 				'',
-				static fn (Type $type): bool => !$type->toString() instanceof ErrorType,
+				fn (Type $type): bool => !$this->typeCoercionRuleHelper->coerceToString($type) instanceof ErrorType,
 			);
 			$partType = $typeResult->getType();
 			if ($partType instanceof ErrorType) {
 				continue;
 			}
 
-			$stringPartType = $partType->toString();
+			$stringPartType = $this->typeCoercionRuleHelper->coerceToString($partType);
 			if (!$stringPartType instanceof ErrorType) {
 				continue;
 			}

--- a/src/Rules/TypeCoercionRuleHelper.php
+++ b/src/Rules/TypeCoercionRuleHelper.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules;
+
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+
+#[AutowiredService]
+final class TypeCoercionRuleHelper
+{
+
+	public function __construct(
+		#[AutowiredParameter(ref: '%featureToggles.checkTypeCoercions%')]
+		private readonly bool $checkTypeCoercions,
+		#[AutowiredParameter(ref: '%allowedTypeCoercions.boolToString%')]
+		private readonly bool $allowBoolToString,
+	)
+	{
+	}
+
+	public function coerceToString(Type $type): Type
+	{
+		if (!$this->checkTypeCoercions) {
+			return $type->toString();
+		}
+		if (!$this->allowBoolToString && !$type->isBoolean()->no()) {
+			return new ErrorType();
+		}
+		return $type->toString();
+	}
+
+}

--- a/tests/PHPStan/Rules/Cast/InvalidPartOfEncapsedStringRuleTest.php
+++ b/tests/PHPStan/Rules/Cast/InvalidPartOfEncapsedStringRuleTest.php
@@ -6,6 +6,7 @@ use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Node\Printer\Printer;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Rules\TypeCoercionRuleHelper;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
@@ -15,11 +16,14 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 class InvalidPartOfEncapsedStringRuleTest extends RuleTestCase
 {
 
+	private ?TypeCoercionRuleHelper $typeCoercionRuleHelper = null;
+
 	protected function getRule(): Rule
 	{
 		return new InvalidPartOfEncapsedStringRule(
 			new ExprPrinter(new Printer()),
 			new RuleLevelHelper(self::createReflectionProvider(), true, false, true, false, false, false, true),
+			$this->typeCoercionRuleHelper ?? new TypeCoercionRuleHelper(true, true),
 		);
 	}
 
@@ -37,6 +41,37 @@ class InvalidPartOfEncapsedStringRuleTest extends RuleTestCase
 			[
 				'Part $std (stdClass|string) of encapsed string cannot be cast to string.',
 				56,
+			],
+			[
+				'Part $array (array|string) of encapsed string cannot be cast to string.',
+				60,
+			],
+		]);
+	}
+
+	public function testRuleWithStrictCoercions(): void
+	{
+		$this->typeCoercionRuleHelper = new TypeCoercionRuleHelper(true, false);
+		$this->analyse([__DIR__ . '/data/invalid-encapsed-part.php'], [
+			[
+				'Part $std (stdClass) of encapsed string cannot be cast to string.',
+				26,
+			],
+			[
+				'Part $bool (bool) of encapsed string cannot be cast to string.',
+				27,
+			],
+			[
+				'Part $array (array) of encapsed string cannot be cast to string.',
+				30,
+			],
+			[
+				'Part $std (stdClass|string) of encapsed string cannot be cast to string.',
+				56,
+			],
+			[
+				'Part $bool (bool|string) of encapsed string cannot be cast to string.',
+				57,
 			],
 			[
 				'Part $array (array|string) of encapsed string cannot be cast to string.',

--- a/tests/PHPStan/Rules/Cast/InvalidPartOfEncapsedStringRuleTest.php
+++ b/tests/PHPStan/Rules/Cast/InvalidPartOfEncapsedStringRuleTest.php
@@ -28,7 +28,19 @@ class InvalidPartOfEncapsedStringRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/invalid-encapsed-part.php'], [
 			[
 				'Part $std (stdClass) of encapsed string cannot be cast to string.',
-				8,
+				26,
+			],
+			[
+				'Part $array (array) of encapsed string cannot be cast to string.',
+				30,
+			],
+			[
+				'Part $std (stdClass|string) of encapsed string cannot be cast to string.',
+				56,
+			],
+			[
+				'Part $array (array|string) of encapsed string cannot be cast to string.',
+				60,
 			],
 		]);
 	}
@@ -40,6 +52,25 @@ class InvalidPartOfEncapsedStringRuleTest extends RuleTestCase
 			[
 				'Part $bar?->obj (stdClass|null) of encapsed string cannot be cast to string.',
 				11,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.1')]
+	public function testRuleWithEnum(): void
+	{
+		$this->analyse([__DIR__ . '/data/invalid-encapsed-part-enum.php'], [
+			[
+				'Part $unitEnum (InvalidEncapsedPartEnum\\FooUnitEnum) of encapsed string cannot be cast to string.',
+				21,
+			],
+			[
+				'Part $intEnum (InvalidEncapsedPartEnum\\IntEnum) of encapsed string cannot be cast to string.',
+				22,
+			],
+			[
+				'Part $stringEnum (InvalidEncapsedPartEnum\\StringEnum) of encapsed string cannot be cast to string.',
+				23,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Cast/data/invalid-encapsed-part-enum.php
+++ b/tests/PHPStan/Rules/Cast/data/invalid-encapsed-part-enum.php
@@ -1,0 +1,24 @@
+<?php // lint >= 8.1
+
+namespace InvalidEncapsedPartEnum;
+
+enum FooUnitEnum
+{
+	case A;
+}
+
+enum IntEnum: int
+{
+	case A = 1;
+}
+
+enum StringEnum: string
+{
+	case A = 'a';
+}
+
+function doFoo(FooUnitEnum $unitEnum, IntEnum $intEnum, StringEnum $stringEnum) {
+	"{$unitEnum}";
+	"{$intEnum}";
+	"{$stringEnum}";
+}

--- a/tests/PHPStan/Rules/Cast/data/invalid-encapsed-part.php
+++ b/tests/PHPStan/Rules/Cast/data/invalid-encapsed-part.php
@@ -1,9 +1,64 @@
 <?php
 
-function (
+namespace InvalidPartOfEncapsedString;
+
+class ClassWithToString
+{
+	public function __toString(): string
+	{
+		return 'str';
+	}
+}
+
+function foo(
 	string $str,
-	\stdClass $std
+	\stdClass $std,
+	bool $bool,
+	int $int,
+	float $float,
+	array $array,
+	ClassWithToString $objectWithToString
 ) {
+	$null = null;
+	$resource = fopen('php://input');
+	assert($resource !== false);
 	"$str bar";
 	"$std bar";
-};
+	"$bool bar";
+	"$int bar";
+	"$float bar";
+	"$array bar";
+	"$objectWithToString bar";
+	"$null bar";
+	"$resource bar";
+}
+
+/**
+ * @param string|\stdClass $std
+ * @param string|bool $bool
+ * @param string|int $int
+ * @param string|float $float
+ * @param string|array $array
+ * @param string|ClassWithToString $objectWithToString
+ * @param string|null $null
+ * @param string|resource $resource
+ */
+function checkUnions(
+	$std,
+	$bool,
+	$int,
+	$float,
+	$array,
+	$objectWithToString,
+	$null,
+	$resource
+) {
+	"$std bar";
+	"$bool bar";
+	"$int bar";
+	"$float bar";
+	"$array bar";
+	"$objectWithToString bar";
+	"$null bar";
+	"$resource bar";
+}


### PR DESCRIPTION
I'd like to know your opinion on this approach before I go too far with it.

It's a follow up to [this comment](https://github.com/phpstan/phpstan-src/pull/4349#discussion_r2381919959) (specifically the part about disabling "{$bool}" etc in phpstan-strict-rules).

The idea is to eventually (separate PRs) add all pairs of types which make sense to prohibit (e.g. it makes sense to prohibit coercing `null` to `string` (not necessarily in phpstan-strict-rules), but it probably doesn't make sense to prohibit coercing `int` to `string`). Note that the configuration is only meant to prohibit type coercions (i.e. implicit), not explicit type casts. This could then replace things like:

- `booleansInConditions` and `numericOperandsInArithmeticOperators` from phpstan-strict-rules: the rules would be moved to phpstan and they'd be enabled by `allowedTypeCoercions.XToY`.
- `forbidNullInInterpolatedString` and `forbidNullInBinaryOperations` from [shipmonk/phpstan-rules](https://github.com/shipmonk-rnd/phpstan-rules): it would be handled by existing phpstan rules and enabled by `allowedTypeCoercions.nullToY`.
- `checkStrictPrintfPlaceholderTypes`: it would be removed and instead it would be configured by `allowedTypeCoercions.XToY`. phpstan-strict-rules would set the flags to preserve the current default behavior.

The benefit of this approach is that it would be configured in one place and applied consistently across the rules. The downside is that it would make it harder to enable `XToY` in one rule, but prohibit it in another. Given the discussion in the strict printf parameter check PR, I guess it's safe to assume that there will be users with strong opinions on how it should behave for them. The DI container could pass a different `TypeCoercionRuleHelper` to every rule, so it has a possible solution, but there would have to be a sane way to configure it (ultimately the `RuleLevelHelper` has the same limitation).