### PR TITLE
Fix "list type lost in for loop"

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/for-loop-expr.php
+++ b/tests/PHPStan/Analyser/nsrt/for-loop-expr.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Bug12807;
+
+use function PHPStan\debugScope;
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param non-empty-list<int> $items
+ *
+ * @return non-empty-list<int>
+ */
+function getItemsWithForLoop(array $items): array
+{
+	for ($i = 0; $i < count($items); $i++) {
+		$items[$i] = 1;
+	}
+
+	assertType('non-empty-list<int>', $items);
+	return $items;
+}
+
+/**
+ * @param non-empty-list<string> $items
+ *
+ * @return non-empty-list<string>
+ */
+function getItemsWithForLoopInvertLastCond(array $items): array
+{
+	for ($i = 0; count($items) > $i; ++$i) {
+		$items[$i] = 'hello';
+	}
+
+	assertType('non-empty-list<string>', $items);
+	return $items;
+}

--- a/tests/PHPStan/Analyser/nsrt/for-loop-expr.php
+++ b/tests/PHPStan/Analyser/nsrt/for-loop-expr.php
@@ -21,9 +21,9 @@ function getItemsWithForLoop(array $items): array
 }
 
 /**
- * @param non-empty-list<string> $items
+ * @param list<string> $items
  *
- * @return non-empty-list<string>
+ * @return list<string>
  */
 function getItemsWithForLoopInvertLastCond(array $items): array
 {
@@ -31,6 +31,22 @@ function getItemsWithForLoopInvertLastCond(array $items): array
 		$items[$i] = 'hello';
 	}
 
-	assertType('non-empty-list<string>', $items);
+	assertType('list<string>', $items);
+	return $items;
+}
+
+
+/**
+ * @param array<string> $items
+ *
+ * @return array<string>
+ */
+function getItemsArray(array $items): array
+{
+	for ($i = 0; count($items) > $i; ++$i) {
+		$items[$i] = 'hello';
+	}
+
+	assertType('array<string>', $items);
 	return $items;
 }

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -867,16 +867,7 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 	{
 		$this->reportPossiblyNonexistentGeneralArrayOffset = true;
 
-		$this->analyse([__DIR__ . '/data/bug-12406b.php'], [
-			[
-				'Offset int<0, max> might not exist on non-empty-list<array{0: string, 1: non-empty-string, 2: non-falsy-string, 3: numeric-string, 4?: numeric-string, 5?: numeric-string}>.',
-				22,
-			],
-			[
-				'Offset int<0, max> might not exist on non-empty-list<array{0: string, 1: non-empty-string, 2: non-falsy-string, 3: numeric-string, 4?: numeric-string, 5?: numeric-string}>.',
-				23,
-			],
-		]);
+		$this->analyse([__DIR__ . '/data/bug-12406b.php'], []);
 	}
 
 	public function testBug11679(): void


### PR DESCRIPTION
if the for loop is in the shape of `for($i = 0; $i < count($items); $i++) {` we can set `$items[$i]` as existing expression type.


closes https://github.com/phpstan/phpstan/issues/12807