### PR TITLE
Fix oversizeArrayType->isSubTypeOf

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -247,10 +247,12 @@ class IntersectionType implements CompoundType
 		}
 
 		$result = IsSuperTypeOfResult::maxMin(...array_map(static fn (Type $innerType) => $otherType->isSuperTypeOf($innerType), $this->types));
-		if ($this->isOversizedArray()->yes()) {
-			if (!$result->no()) {
-				return IsSuperTypeOfResult::createYes();
-			}
+		if (
+			!$result->no()
+			&& $this->isOversizedArray()->yes()
+			&& !$otherType->isIterableAtLeastOnce()->no()
+		) {
+			return IsSuperTypeOfResult::createYes();
 		}
 
 		return $result;

--- a/tests/PHPStan/Analyser/nsrt/bug-13509.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13509.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13509;
+
+use function PHPStan\Testing\assertType;
+
+/** @return ?array<string, mixed> */
+function alert(): ?array
+{
+	$alerts = [];
+
+	if (rand()) {
+		$alerts[] = [
+			'message'  => "Foo",
+			'details'  => "bar",
+			'duration' => rand() ?: null,
+			'severity' => 100,
+		];
+	}
+
+	if (rand()) {
+		$alerts[] = [
+			'message'  => 'Offline',
+			'duration' => rand() ?: null,
+			'severity' => 99,
+		];
+	}
+
+	if (rand()) {
+		$alerts[] = [
+			'message'  => 'Running W/O Operator',
+			'duration' => rand() ?: null,
+			'severity' => 75,
+		];
+	}
+
+	if (rand()) {
+		$alerts[] = [
+			'message'  => 'No Queue',
+			'duration' => rand() ?: null,
+			'severity' => 60,
+		];
+	}
+
+	if (rand()) {
+		if (rand()) {
+			$alerts[] = [
+				'message'  => 'Not Scheduled',
+				'duration' => null,
+				'severity' => 25,
+			];
+		}
+
+		if (rand()) {
+			$alerts[] = [
+				'message'  => 'On Lunch',
+				'duration' => rand() ?: null,
+				'severity' => 24,
+			];
+		}
+
+		if (rand()) {
+			$alerts[] = [
+				'message'  => 'On Break',
+				'duration' => rand() ?: null,
+				'severity' => 24,
+			];
+		}
+	}
+
+	if (rand()) {
+		$alerts[] = [
+			'message'  => 'Idle',
+			'duration' => rand() ?: null,
+			'severity' => 23,
+		];
+	}
+
+	if ($alerts === []) {
+		return null;
+	}
+
+	assertType('non-empty-list<non-empty-array<literal-string&lowercase-string&non-falsy-string, int|(literal-string&non-falsy-string)|null>&oversized-array>&oversized-array', $alerts);
+
+	usort($alerts, fn ($a, $b) => $b['severity'] <=> $a['severity']);
+
+	return $alerts[0];
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -5331,6 +5331,12 @@ class TypeCombinatorTest extends PHPStanTestCase
 				ObjectShapeType::class,
 				'object{foo?: int}',
 			],
+			[
+				new IntersectionType([new ArrayType(new StringType(), new StringType()), new OversizedArrayType()]),
+				new ConstantArrayType([], []),
+				IntersectionType::class,
+				'non-empty-array<string, string>&oversized-array',
+			],
 		];
 	}
 


### PR DESCRIPTION
Before `oversizeArrayType->isSubTypeOf(array{})` was considered to be YES.

So removing `array{}` to oversizeArray gives Never.

Closes https://github.com/phpstan/phpstan/issues/13509