### PR TITLE
Improve support of FILTER_REQUIRE_ARRAY

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/discussion-9134.php
+++ b/tests/PHPStan/Analyser/nsrt/discussion-9134.php
@@ -6,7 +6,7 @@ use function PHPStan\Testing\assertType;
 
 $var = $_GET["data"];
 $res = filter_var($var, FILTER_VALIDATE_INT, FILTER_REQUIRE_ARRAY);
-assertType('array<int>|false', $res);
+assertType('array<int|false>|false', $res);
 if (is_array($res) === false) {
 	throw new \RuntimeException();
 }

--- a/tests/PHPStan/Analyser/nsrt/filter-var.php
+++ b/tests/PHPStan/Analyser/nsrt/filter-var.php
@@ -23,10 +23,10 @@ class FilterVar
 		assertType('null', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('false', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
 		assertType('null', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
-		assertType('array<int>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
-		assertType('array<int>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
-		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
-		assertType('array<string, int>|null', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<int|false>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
+		assertType('array<int|null>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<string, int|false>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY]));
+		assertType('array<string, int|null>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_NULL_ON_FAILURE]));
 
 		assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY]));
 		assertType('array<17>', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
@@ -41,10 +41,10 @@ class FilterVar
 		assertType('null', filter_var(17, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 		assertType('false', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
 		assertType('null', filter_var('foo', FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
-		assertType('array<int>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
-		assertType('array<int>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
-		assertType('array<string, int>|false', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
-		assertType('array<string, int>|null', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<int|false>|false', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
+		assertType('array<int|null>|null', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
+		assertType('array<string, int|false>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY]));
+		assertType('array<string, int|null>', filter_var($stringMixedMap, FILTER_VALIDATE_INT, ['flags' => FILTER_REQUIRE_ARRAY|FILTER_FORCE_ARRAY|FILTER_NULL_ON_FAILURE]));
 
 		assertType('0|int<17, 19>', filter_var($mixed, FILTER_VALIDATE_INT, ['options' => ['default' => 0, 'min_range' => 17, 'max_range' => 19]]));
 

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -2329,6 +2329,11 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13434.php'], []);
 	}
 
+	public function testBug11863(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-11863.php'], []);
+	}
+
 	public function testBug13556(): void
 	{
 		$this->checkExplicitMixed = true;

--- a/tests/PHPStan/Rules/Functions/data/bug-11863.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-11863.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bug11863;
+
+$ips = ['0.0.0.0', '1.2.3.4', '10.0.0.1'];
+
+$ips = array_filter(
+	filter_var(
+		$ips,
+		FILTER_VALIDATE_IP,
+		FILTER_REQUIRE_ARRAY
+	)
+);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/11863

After this merge I'll work on https://github.com/phpstan/phpstan/issues/11485
I think it will require to change `hasFlag` signature to return a TrinaryLogic

cc @herndlm 