### PR TITLE
Quality of life improvement, PHPStorm error identifiers

### DIFF
--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -44,15 +44,13 @@ final class CheckstyleErrorFormatter implements ErrorFormatter
 
 			foreach ($errors as $error) {
 
-				$identifier = null !== $error->getIdentifier()
-					? "  // @phpstan-ignore {$error->getIdentifier()}" :
-					'';
+				$identifier = $error->getIdentifier();
 
 				$output->writeRaw(sprintf(
 					'  <error line="%d" column="1" severity="error" message="%s"%s />',
 					$this->escape((string) $error->getLine()),
-					$this->escape($error->getMessage() . $identifier),
-					$error->getIdentifier() !== null ? sprintf(' source="%s"', $this->escape($error->getIdentifier())) : '',
+					$this->escape($error->getMessage() . ($identifier !== null ? sprintf('  // @phpstan-ignore %s', $identifier) : '')),
+					$identifier !== null ? sprintf(' source="%s"', $this->escape($identifier)) : '',
 				));
 				$output->writeLineFormatted('');
 			}

--- a/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
+++ b/src/Command/ErrorFormatter/CheckstyleErrorFormatter.php
@@ -43,10 +43,15 @@ final class CheckstyleErrorFormatter implements ErrorFormatter
 			$output->writeLineFormatted('');
 
 			foreach ($errors as $error) {
+
+				$identifier = null !== $error->getIdentifier()
+					? "  // @phpstan-ignore {$error->getIdentifier()}" :
+					'';
+
 				$output->writeRaw(sprintf(
 					'  <error line="%d" column="1" severity="error" message="%s"%s />',
 					$this->escape((string) $error->getLine()),
-					$this->escape($error->getMessage()),
+					$this->escape($error->getMessage() . $identifier),
 					$error->getIdentifier() !== null ? sprintf(' source="%s"', $this->escape($error->getIdentifier())) : '',
 				));
 				$output->writeLineFormatted('');

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -186,7 +186,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 		), $this->getOutput());
 		$this->assertXmlStringEqualsXmlString('<checkstyle>
 	<file name="Foo.php">
-		<error column="1" line="5" message="Foo" severity="error" source="argument.type" />
+		<error column="1" line="5" message="Foo  // @phpstan-ignore argument.type" severity="error" source="argument.type" />
 	</file>
 </checkstyle>', $this->getOutputContent());
 	}


### PR DESCRIPTION
ref: https://github.com/phpstan/phpstan/discussions/13646

I left the actual source attribute untouched in case someone is using it for any other tools. If Jetbrains ever gets this sorted on their end we can revert the change without affecting anything else.

Edit: failures seem unrelated