### PR TITLE
Infer mixed~array<mixed> | array<string>

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -580,7 +580,7 @@ final class TypeCombinator
 		Type $b,
 	): Type
 	{
-		if ($a->getSubtractedType() === null) {
+		if ($a->getSubtractedType() === null || $b instanceof NeverType) {
 			return $a;
 		}
 
@@ -621,7 +621,10 @@ final class TypeCombinator
 			} elseif ($isBAlreadySubtracted->yes()) {
 				$subtractedType = self::remove($a->getSubtractedType(), $b);
 
-				if ($subtractedType instanceof NeverType) {
+				if (
+					$subtractedType instanceof NeverType
+					|| !$subtractedType->isSuperTypeOf($b)->no()
+				) {
 					$subtractedType = null;
 				}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1100,6 +1100,12 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10394.php'], []);
 	}
 
+	public function testBug12930(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-12930.php'], []);
+	}
+
 	public function testBug13628(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1100,6 +1100,12 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10394.php'], []);
 	}
 
+	public function testBug13628(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-13628.php'], []);
+	}
+
 	public function testBug9666(): void
 	{
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';

--- a/tests/PHPStan/Rules/Comparison/data/bug-12930.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-12930.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12930;
+
+/** @return mixed */
+function getMixed() {return \stdClass::class;}
+
+$val = getMixed();
+if (is_string($val) && !is_a($val, \stdClass::class, true)) {
+	throw new \Exception();
+}
+
+echo is_string($val) ? 'string' : 'something else';

--- a/tests/PHPStan/Rules/Comparison/data/bug-13628.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13628.php
@@ -2,7 +2,11 @@
 
 namespace Bug13628;
 
-function test(mixed $param): string {
+/**
+ * @param mixed $param
+ * @return string
+ */
+function test($param) {
 
 	$a = is_array($param) ? array_filter($param) : $param;
 	if ($a && is_array($a)) {

--- a/tests/PHPStan/Rules/Comparison/data/bug-13628.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13628.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13628;
+
+function test(mixed $param): string {
+
+	$a = is_array($param) ? array_filter($param) : $param;
+	if ($a && is_array($a)) {
+		return 'array';
+	}
+	else {
+		return 'not-array';
+	}
+
+}

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2136,7 +2136,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 			[
 				[
 					new ArrayType(new MixedType(), new StringType()),
-					new MixedType(false, new ArrayType(new MixedType(), new MixedType())),
+					new MixedType(subtractedType: new ArrayType(new MixedType(), new MixedType())),
 				],
 				MixedType::class,
 				'mixed=implicit',

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2133,6 +2133,14 @@ class TypeCombinatorTest extends PHPStanTestCase
 				MixedType::class,
 				'mixed=implicit',
 			],
+			[
+				[
+					new ArrayType(new MixedType(), new StringType()),
+					new MixedType(false, new ArrayType(new MixedType(), new MixedType())),
+				],
+				MixedType::class,
+				'mixed=implicit',
+			],
 		];
 
 		if (PHP_VERSION_ID < 80100) {


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13628
Closes https://github.com/phpstan/phpstan/issues/12930

Original bug was 
```
array<mixed~(0|0.0|''|'0'|array{}|false|null)>|mixed~array<mixed, mixed>
```
resolved into `mixed~non-empty-array`.

Same exists with something simpler like
```
array<string>|mixed~array<mixed, mixed>
```

Because it was converted to `mixed ~ (remove(array<mixed, mixed>, array<string>)`

While it's true that `remove(array<mixed, mixed>, array<string>` is a non-empty-array,
it's untrue that `array<string>|mixed~array<mixed, mixed>` is mixed~non-empty-array.