### PR TITLE
Do not report dead catch with `treatPhpDocTypesAsCertain: false`

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -4305,7 +4305,16 @@ final class NodeScopeResolver
 
 				$throwType = $extension->getThrowTypeFromFunctionCall($functionReflection, $normalizedFuncCall, $scope);
 				if ($throwType === null) {
-					return null;
+					if ($this->treatPhpDocTypesAsCertain) {
+						return null;
+					}
+
+					$nativeThrowType = $extension->getThrowTypeFromFunctionCall($functionReflection, $normalizedFuncCall, $scope->doNotTreatPhpDocTypesAsCertain());
+					if ($nativeThrowType === null) {
+						return null;
+					}
+
+					return ThrowPoint::createImplicit($scope, $funcCall);
 				}
 
 				return ThrowPoint::createExplicit($scope, $throwType, $funcCall, false);
@@ -4363,7 +4372,16 @@ final class NodeScopeResolver
 
 				$throwType = $extension->getThrowTypeFromMethodCall($methodReflection, $normalizedMethodCall, $scope);
 				if ($throwType === null) {
-					return null;
+					if ($this->treatPhpDocTypesAsCertain) {
+						return null;
+					}
+
+					$nativeThrowType = $extension->getThrowTypeFromMethodCall($methodReflection, $normalizedMethodCall, $scope->doNotTreatPhpDocTypesAsCertain());
+					if ($nativeThrowType === null) {
+						return null;
+					}
+
+					return ThrowPoint::createImplicit($scope, $methodCall);
 				}
 
 				return ThrowPoint::createExplicit($scope, $throwType, $methodCall, false);
@@ -4407,7 +4425,16 @@ final class NodeScopeResolver
 
 				$throwType = $extension->getThrowTypeFromStaticMethodCall($constructorReflection, $normalizedMethodCall, $scope);
 				if ($throwType === null) {
-					return null;
+					if ($this->treatPhpDocTypesAsCertain) {
+						return null;
+					}
+
+					$nativeThrowType = $extension->getThrowTypeFromStaticMethodCall($constructorReflection, $normalizedMethodCall, $scope->doNotTreatPhpDocTypesAsCertain());
+					if ($nativeThrowType === null) {
+						return null;
+					}
+
+					return ThrowPoint::createImplicit($scope, $new);
 				}
 
 				return ThrowPoint::createExplicit($scope, $throwType, $new, false);
@@ -4439,7 +4466,16 @@ final class NodeScopeResolver
 
 				$throwType = $extension->getThrowTypeFromStaticMethodCall($methodReflection, $normalizedMethodCall, $scope);
 				if ($throwType === null) {
-					return null;
+					if ($this->treatPhpDocTypesAsCertain) {
+						return null;
+					}
+
+					$nativeThrowType = $extension->getThrowTypeFromStaticMethodCall($methodReflection, $normalizedMethodCall, $scope->doNotTreatPhpDocTypesAsCertain());
+					if ($nativeThrowType === null) {
+						return null;
+					}
+
+					return ThrowPoint::createImplicit($scope, $methodCall);
 				}
 
 				return ThrowPoint::createExplicit($scope, $throwType, $methodCall, false);

--- a/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionDeadCatchPhpDocNotCertainTest.php
+++ b/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionDeadCatchPhpDocNotCertainTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Rules\Exceptions\CatchWithUnthrownExceptionRule;
+use PHPStan\Rules\Rule as TRule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CatchWithUnthrownExceptionRule>
+ */
+class DynamicMethodThrowTypeExtensionDeadCatchPhpDocNotCertainTest extends RuleTestCase
+{
+
+	protected function getRule(): TRule
+	{
+		return self::getContainer()->getByType(CatchWithUnthrownExceptionRule::class);
+	}
+
+	public function testDynamicMethodThrowTypeExtension(): void
+	{
+		$this->analyse([__DIR__ . '/data/dynamic-method-throw-type-extension.php'], [
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				102,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				124,
+			],
+		]);
+	}
+
+	protected function shouldTreatPhpDocTypesAsCertain(): bool
+	{
+		return false;
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/dynamic-throw-type-extension.neon',
+			__DIR__ . '/do-not-treat-php-doc-type-as-certain.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionDeadCatchTest.php
+++ b/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionDeadCatchTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Rules\Exceptions\CatchWithUnthrownExceptionRule;
+use PHPStan\Rules\Rule as TRule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<CatchWithUnthrownExceptionRule>
+ */
+class DynamicMethodThrowTypeExtensionDeadCatchTest extends RuleTestCase
+{
+
+	protected function getRule(): TRule
+	{
+		return self::getContainer()->getByType(CatchWithUnthrownExceptionRule::class);
+	}
+
+	public function testMixedUnknownType(): void
+	{
+		$this->analyse([__DIR__ . '/data/dynamic-method-throw-type-extension.php'], [
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				102,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				124,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				148,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				172,
+			],
+		]);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/dynamic-throw-type-extension.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionPhpDocNotCertainTest.php
+++ b/tests/PHPStan/Analyser/DynamicMethodThrowTypeExtensionPhpDocNotCertainTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use const PHP_VERSION_ID;
+
+class DynamicMethodThrowTypeExtensionPhpDocNotCertainTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		if (PHP_VERSION_ID < 80000) {
+			return [];
+		}
+
+		yield from self::gatherAssertTypes(__DIR__ . '/data/dynamic-method-throw-type-extension.php');
+		yield from self::gatherAssertTypes(__DIR__ . '/data/dynamic-method-throw-type-extension-named-args-fixture.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataFileAsserts')]
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/dynamic-throw-type-extension.neon',
+			__DIR__ . '/do-not-treat-php-doc-type-as-certain.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/dynamic-method-throw-type-extension.php
+++ b/tests/PHPStan/Analyser/data/dynamic-method-throw-type-extension.php
@@ -28,11 +28,11 @@ class MethodThrowTypeExtension implements DynamicMethodThrowTypeExtension
 		}
 
 		$argType = $scope->getType($methodCall->args[0]->value);
-		if ((new ConstantBooleanType(true))->isSuperTypeOf($argType)->yes()) {
-			return $methodReflection->getThrowType();
+		if ((new ConstantBooleanType(false))->isSuperTypeOf($argType)->yes()) {
+			return null;
 		}
 
-		return null;
+		return $methodReflection->getThrowType();
 	}
 
 }
@@ -52,11 +52,11 @@ class StaticMethodThrowTypeExtension implements DynamicStaticMethodThrowTypeExte
 		}
 
 		$argType = $scope->getType($methodCall->args[0]->value);
-		if ((new ConstantBooleanType(true))->isSuperTypeOf($argType)->yes()) {
-			return $methodReflection->getThrowType();
+		if ((new ConstantBooleanType(false))->isSuperTypeOf($argType)->yes()) {
+			return null;
 		}
 
-		return null;
+		return $methodReflection->getThrowType();
 	}
 
 }
@@ -88,6 +88,8 @@ class Foo
 	{
 		try {
 			$result = $this->throwOrNot(true);
+		} catch (\Exception) {
+
 		} finally {
 			assertVariableCertainty(TrinaryLogic::createMaybe(), $result);
 		}
@@ -97,6 +99,8 @@ class Foo
 	{
 		try {
 			$result = $this->throwOrNot(false);
+		} catch (\Exception) { // DeadCatch
+
 		} finally {
 			assertVariableCertainty(TrinaryLogic::createYes(), $result);
 		}
@@ -106,6 +110,8 @@ class Foo
 	{
 		try {
 			$result = self::staticThrowOrNot(true);
+		} catch (\Exception) {
+
 		} finally {
 			assertVariableCertainty(TrinaryLogic::createMaybe(), $result);
 		}
@@ -115,6 +121,56 @@ class Foo
 	{
 		try {
 			$result = self::staticThrowOrNot(false);
+		} catch (\Exception) { // DeadCatch
+
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createYes(), $result);
+		}
+	}
+
+	/** @param true $value */
+	public function doFooPhpdoc1(bool $value)
+	{
+		try {
+			$result = $this->throwOrNot($value);
+		} catch (\Exception) {
+
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createMaybe(), $result);
+		}
+	}
+
+	/** @param false $value */
+	public function doFooPhpdoc2(bool $value)
+	{
+		try {
+			$result = $this->throwOrNot($value);
+		} catch (\Exception) { // DeadCatch if phpdoc is trusted
+
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createYes(), $result);
+		}
+	}
+
+	/** @param true $value */
+	public function doFooPhpdoc3(bool $value)
+	{
+		try {
+			$result = self::staticThrowOrNot($value);
+		} catch (\Exception) {
+
+		} finally {
+			assertVariableCertainty(TrinaryLogic::createMaybe(), $result);
+		}
+	}
+
+	/** @param false $value */
+	public function doFooPhpdoc4(bool $value)
+	{
+		try {
+			$result = self::staticThrowOrNot($value);
+		} catch (\Exception) { // DeadCatch if phpdoc is trusted
+
 		} finally {
 			assertVariableCertainty(TrinaryLogic::createYes(), $result);
 		}

--- a/tests/PHPStan/Analyser/do-not-treat-php-doc-type-as-certain.neon
+++ b/tests/PHPStan/Analyser/do-not-treat-php-doc-type-as-certain.neon
@@ -1,0 +1,2 @@
+parameters:
+	treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
I'd like to move https://github.com/phpstan/phpstan-src/pull/4156 forward, and kinda disagree with your request change from calling `getType` to `getNativeType` inside `BackedEnumFromDynamicStaticMethodThrowTypeExtension`.

Because when using the exception analysis, PHPStan will still ask for a `@throws` tag while I know there is not because I trust my phpdoc (value-of<...>).

Also, when looking at all the existing `DynamicMethodThrowTypeExtension` they are using `getType`.

So I tried to find a solution you will agree with.
- When the throw type extension return NULL
-> If I trust the phpdoc, I consider it doesn't throw an exception.
-> If I don't, I check the throw type extension with the native type
--> If I don't have an exception with the native type I can still return NULL
--> If I have one, I had an implicit ThrowPoint.

The benefit of the implicit throwpoint is that:
- It won't report the catch as a dead catch
- It won't force people to add `@throws` tag on the method

which is a similar behavior of `treatPhpDocTypesAsCertain: false` which allow extra safety check but doesn't enforce them.

I didn't know how to correctly write test about this but the current one I wrote/updated should show the new behavior.