### PR TITLE
Remove PHP version constraint from the `#[\Override]` attribute rules

### DIFF
--- a/src/Rules/Methods/OverridingMethodRule.php
+++ b/src/Rules/Methods/OverridingMethodRule.php
@@ -87,7 +87,7 @@ final class OverridingMethodRule implements Rule
 				}
 			}
 
-			if ($this->phpVersion->supportsOverrideAttribute() && $this->hasOverrideAttribute($node->getOriginalNode())) {
+			if ($this->hasOverrideAttribute($node->getOriginalNode())) {
 				return [
 					RuleErrorBuilder::message(sprintf(
 						'Method %s::%s() has #[\Override] attribute but does not override any method.',
@@ -111,8 +111,7 @@ final class OverridingMethodRule implements Rule
 
 		$messages = [];
 		if (
-			$this->phpVersion->supportsOverrideAttribute()
-			&& $this->checkMissingOverrideMethodAttribute
+			$this->checkMissingOverrideMethodAttribute
 			&& !$scope->isInTrait()
 			&& !$this->hasOverrideAttribute($node->getOriginalNode())
 		) {

--- a/src/Rules/Properties/OverridingPropertyRule.php
+++ b/src/Rules/Properties/OverridingPropertyRule.php
@@ -47,10 +47,7 @@ final class OverridingPropertyRule implements Rule
 		$classReflection = $node->getClassReflection();
 		$prototype = $this->findPrototype($classReflection, $node->getName());
 		if ($prototype === null) {
-			if (
-				$this->phpVersion->supportsOverrideAttribute()
-				&& $this->hasOverrideAttribute($node->getAttrGroups())
-			) {
+			if ($this->hasOverrideAttribute($node->getAttrGroups())) {
 				$originalNode = $node->getOriginalNode();
 				if ($originalNode instanceof Node\Stmt\Property) {
 					/** @var Node\Stmt\Property $originalNode */
@@ -77,8 +74,7 @@ final class OverridingPropertyRule implements Rule
 
 		$errors = [];
 		if (
-			$this->phpVersion->supportsOverrideAttributeOnProperty()
-			&& $this->checkMissingOverridePropertyAttribute
+			$this->checkMissingOverridePropertyAttribute
 			&& !$scope->isInTrait()
 			&& !$this->hasOverrideAttribute($node->getAttrGroups())
 		) {

--- a/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
@@ -726,7 +726,6 @@ class OverridingMethodRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/overriding-trait-methods.php'], $errors);
 	}
 
-	#[RequiresPhp('>= 8.3')]
 	public function testOverrideAttribute(): void
 	{
 		$this->phpVersionId = PHP_VERSION_ID;
@@ -745,7 +744,16 @@ class OverridingMethodRuleTest extends RuleTestCase
 	public static function dataCheckMissingOverrideAttribute(): iterable
 	{
 		yield [false, 80000, []];
-		yield [true, 80000, []];
+		yield [true, 80000, [
+			[
+				'Method CheckMissingOverrideAttr\Bar::doFoo() overrides method CheckMissingOverrideAttr\Foo::doFoo() but is missing the #[\Override] attribute.',
+				18,
+			],
+			[
+				'Method CheckMissingOverrideAttr\ChildOfParentWithAbstractConstructor::__construct() overrides method CheckMissingOverrideAttr\ParentWithAbstractConstructor::__construct() but is missing the #[\Override] attribute.',
+				49,
+			],
+		]];
 		yield [false, 80300, []];
 		yield [true, 80300, [
 			[
@@ -785,7 +793,6 @@ class OverridingMethodRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10153.php'], $errors);
 	}
 
-	#[RequiresPhp('>= 8.3')]
 	public function testBug12471(): void
 	{
 		$this->checkMissingOverrideMethodAttribute = true;
@@ -812,7 +819,6 @@ class OverridingMethodRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/simple-xml-element-child.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.3')]
 	public function testFixOverride(): void
 	{
 		$this->phpVersionId = PHP_VERSION_ID;
@@ -820,7 +826,6 @@ class OverridingMethodRuleTest extends RuleTestCase
 		$this->fix(__DIR__ . '/data/fix-override-attribute.php', __DIR__ . '/data/fix-override-attribute.php.fixed');
 	}
 
-	#[RequiresPhp('>= 8.3')]
 	public function testFixWithTabs(): void
 	{
 		$this->phpVersionId = PHP_VERSION_ID;

--- a/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/OverridingMethodRuleTest.php
@@ -687,15 +687,12 @@ class OverridingMethodRuleTest extends RuleTestCase
 	public function testBug10149(): void
 	{
 		$this->phpVersionId = PHP_VERSION_ID;
-		$errors = [];
-		if (PHP_VERSION_ID >= 80300) {
-			$errors = [
-				[
-					'Method Bug10149\StdSat::__get() has #[\Override] attribute but does not override any method.',
-					10,
-				],
-			];
-		}
+		$errors = [
+			[
+				'Method Bug10149\StdSat::__get() has #[\Override] attribute but does not override any method.',
+				10,
+			],
+		];
 		$this->analyse([__DIR__ . '/data/bug-10149.php'], $errors);
 	}
 

--- a/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/OverridingPropertyRuleTest.php
@@ -286,7 +286,6 @@ class OverridingPropertyRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.5')]
 	public function testOverrideAttribute(): void
 	{
 		$this->checkMissingOverridePropertyAttribute = true;
@@ -307,7 +306,6 @@ class OverridingPropertyRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.5')]
 	public function testFixMissingOverrideAttribute(): void
 	{
 		$this->checkMissingOverridePropertyAttribute = true;


### PR DESCRIPTION
There are two PHPStan rules relating to use of the `#[\Override]` attribute on methods:

1. `method.missingOverride` which detects when a method overrides another but is missing the `#[\Override]` attribute. This rule is operational only when the `checkMissingOverrideMethodAttribute` config option is set to true.
2. `method.override` which detects when `#[\Override]` is used on a method which does not override a method.

Currently these rules are triggered when PHP 8.3 or higher is in use, because that's the version that introduced support for this attribute.

However both of these rules are opt-in and therefore don't need to be constrained by PHP version. The former is explicitly opt-in via the `checkMissingOverrideMethodAttribute` config option and the latter is implicitly opt-in via the existence of an `#[\Override]` attribute on a method.

This PR proposes removing the PHP version constraint from these rules so they can be applied to a codebase which supports versions of PHP older than 8.3 and still benefit from static analysis by PHPStan.

## What's the use case?

I work on codebases which support PHP 7.4 to 8.5. I want to make use of the `#[\Override]` attribute on methods and have PHPStan confirm that their usage is correct. The fact that the codebase is compatible with PHP < 8.3 should be of no concern to these rules.

Currently if the following PHP version range config is in `phpstan.neon` then the `#[\Override]` attribute rules don't apply and PHPStan won't check their correctness.

```neon
phpVersion:
	min: 70400
	max: 80500
```

## Is this a breaking change?

I don't believe this should be considered a breaking change, however there may be codebases that are using `#[\Override]` attributes and a supported version of PHP lower than 8.3 that don't realise these rules are not currently being applied. These rule changes may cause previously passing incorrect use of `#[\Override]` to now fail, which arguably is a bugfix.
