### PR TITLE
Resolve bitwise not on constant integer

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -2634,8 +2634,11 @@ final class InitializerExprTypeResolver
 
 				return new IntersectionType([new StringType(), ...$accessories]);
 			}
+			if ($type instanceof ConstantIntegerType || $type instanceof ConstantFloatType) {
+				return new ConstantIntegerType(~$type->getValue());
+			}
 			if ($type->isInteger()->yes() || $type->isFloat()->yes()) {
-				return new IntegerType(); //no const types here, result depends on PHP_INT_SIZE
+				return new IntegerType();
 			}
 			return new ErrorType();
 		});

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -2635,7 +2635,7 @@ final class InitializerExprTypeResolver
 				return new IntersectionType([new StringType(), ...$accessories]);
 			}
 			if ($type instanceof ConstantIntegerType || $type instanceof ConstantFloatType) {
-				return new ConstantIntegerType(~$type->getValue());
+				return new ConstantIntegerType(~ (int) $type->getValue());
 			}
 			if ($type->isInteger()->yes() || $type->isFloat()->yes()) {
 				return new IntegerType();

--- a/tests/PHPStan/Analyser/Fiber/data/fnsr.php
+++ b/tests/PHPStan/Analyser/Fiber/data/fnsr.php
@@ -96,8 +96,8 @@ class Foo
 	{
 		assertType('int', ~$a);
 		assertNativeType('int', ~$b);
-		assertType('int', ~1);
-		assertNativeType('int', ~1);
+		assertType('-2', ~1);
+		assertNativeType('-2', ~1);
 		assertType('int', ~$b);
 		assertNativeType('int', ~$b);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bitwise-not.php
+++ b/tests/PHPStan/Analyser/nsrt/bitwise-not.php
@@ -17,5 +17,5 @@ function foo(int $int, string $string, float $float, $stringOrInt, string $nonEm
 	assertType('int', ~$float);
 	assertType('int|string', ~$stringOrInt);
 	assertType("'" . (~"abc") . "'", ~"abc");
-	assertType('int', ~1); //result is dependent on PHP_INT_SIZE
+	assertType('-2', ~1);
 }


### PR DESCRIPTION
While working on https://github.com/phpstan/phpstan-src/pull/4435 I discovered the issue https://github.com/phpstan/phpstan/issues/9384 was almost solve except for the operation with the bitwise operator not `~`.

This one generalize constant integer into integer while we could compute the value.

A comment is saying it depends on PHP_INT_SIZE but we could consider that 
- 99% operation `~` are on small number
- Relying on the PHP_INT_SIZE of the user might be good enough
- It will be consistent with other bitwise operator like `<<` https://phpstan.org/r/58bdfbb7-a047-44ff-8af3-995d976d7bb5