### PR TITLE
Use template-covariant in CompositeRule

### DIFF
--- a/src/Testing/CompositeRule.php
+++ b/src/Testing/CompositeRule.php
@@ -22,7 +22,7 @@ final class CompositeRule implements Rule
 	private DirectRegistry $registry;
 
 	/**
-	 * @template T of Node
+	 * @template-covariant T of Node
 	 * @param array<Rule<T>> $rules
 	 *
 	 * @api


### PR DESCRIPTION
shot in the dark. this will hopefully fix

```
------ ----------------------------------------------------------------------- 
  Line   tests/Rules/PHPUnit/DataProviderDataRuleTest.php                       
 ------ ----------------------------------------------------------------------- 
  24     Parameter #1 $rules of class PHPStan\Testing\CompositeRule             
         constructor expects array<PHPStan\Rules\Rule<PhpParser\Node>>, array{  
         PHPStan\Rules\PHPUnit\DataProviderDataRule,                            
         PHPStan\Rules\Methods\CallMethodsRule} given.                          
         🪪  argument.type                                                      
         💡  Template type TNodeType on class PHPStan\Rules\Rule is not         
         covariant. Learn more: https://phpstan.org/blog/whats-up-with-templat  
         e-covariant                                                            
 ------ ----------------------------------------------------------------------- 
```

in https://github.com/phpstan/phpstan-phpunit/pull/238