### PR TITLE
Use template-covariant in CompositeRule

### DIFF
--- a/src/Testing/CompositeRule.php
+++ b/src/Testing/CompositeRule.php
@@ -12,6 +12,8 @@ use function get_class;
 /**
  * Allows testing of rules which delegate work to NodeCallbackInvoker.
  *
+ * @template-covariant N of Node = Node
+ * @template-covariant R = Rule<N>
  * @implements Rule<Node>
  *
  * @api
@@ -22,8 +24,7 @@ final class CompositeRule implements Rule
 	private DirectRegistry $registry;
 
 	/**
-	 * @template T of Node
-	 * @param array<Rule<T>> $rules
+	 * @param array<R> $rules
 	 *
 	 * @api
 	 */


### PR DESCRIPTION
Fixes

```
------ ----------------------------------------------------------------------- 
  Line   tests/Rules/PHPUnit/DataProviderDataRuleTest.php                       
 ------ ----------------------------------------------------------------------- 
  24     Parameter #1 $rules of class PHPStan\Testing\CompositeRule             
         constructor expects array<PHPStan\Rules\Rule<PhpParser\Node>>, array{  
         PHPStan\Rules\PHPUnit\DataProviderDataRule,                            
         PHPStan\Rules\Methods\CallMethodsRule} given.                          
         🪪  argument.type                                                      
         💡  Template type TNodeType on class PHPStan\Rules\Rule is not         
         covariant. Learn more: https://phpstan.org/blog/whats-up-with-templat  
         e-covariant                                                            
 ------ ----------------------------------------------------------------------- 
```

in https://github.com/phpstan/phpstan-phpunit/pull/238