### PR TITLE
Handle impure/throw point of inherited constructors of anonymous classes

### DIFF
--- a/tests/PHPStan/Rules/DeadCode/NoopRuleTest.php
+++ b/tests/PHPStan/Rules/DeadCode/NoopRuleTest.php
@@ -158,4 +158,18 @@ class NoopRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13067.php'], []);
 	}
 
+	public function testBug13698(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13698.php'], [
+			[
+				'Expression "new class extends \Bug13698\NoConstructorClass…" on a separate line does not do anything.',
+				47,
+			],
+			[
+				'Expression "new class…" on a separate line does not do anything.',
+				50,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/DeadCode/data/bug-13698.php
+++ b/tests/PHPStan/Rules/DeadCode/data/bug-13698.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13698;
+
+class ImpureConstructorClass
+{
+	public function __construct()
+	{
+		echo 'foo';
+	}
+}
+
+class ThrowingConstructorClass
+{
+	public function __construct()
+	{
+		if (rand(0, 1) === 0) {
+			throw new \RuntimeException('Error in constructor');
+		}
+	}
+}
+
+class NoConstructorClass {}
+
+function test(): void
+{
+	new class() extends ImpureConstructorClass {
+	};
+
+	new class() extends ImpureConstructorClass {
+		public function __construct()
+		{
+			parent::__construct();
+		}
+	};
+
+	new class() extends ThrowingConstructorClass {
+	};
+
+	new class() extends ThrowingConstructorClass {
+		public function __construct()
+		{
+			parent::__construct();
+		}
+	};
+
+	new class() extends NoConstructorClass {
+	};
+
+	new class() {
+	};
+}


### PR DESCRIPTION
Improve throw point / impure point handling on anonymous classes when the anonymous class does not declare its own constructor.

Closes phpstan/phpstan#13698