### PR TITLE
Added PHP_BUILD_DATE type (PHP 8.5+)

### DIFF
--- a/src/Analyser/ConstantResolver.php
+++ b/src/Analyser/ConstantResolver.php
@@ -159,6 +159,13 @@ final class ConstantResolver
 
 			return $this->createInteger($minVersion, $maxVersion);
 		}
+		// added in PHP 8.5
+		if ($resolvedConstantName === 'PHP_BUILD_DATE') {
+			return new IntersectionType([
+				new StringType(),
+				new AccessoryNonFalsyStringType(),
+			]);
+		}
 		if ($resolvedConstantName === 'PHP_ZTS') {
 			return new UnionType([
 				new ConstantIntegerType(0),

--- a/tests/PHPStan/Analyser/nsrt/predefined-constants-php85.php
+++ b/tests/PHPStan/Analyser/nsrt/predefined-constants-php85.php
@@ -1,0 +1,5 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+assertType('non-falsy-string', PHP_BUILD_DATE);


### PR DESCRIPTION
before this PR PHP_BUILD_DATE was inferred as a hardcoded string



see 
- https://3v4l.org/oHPdU/rfc#vgit.master
- https://phpstan.org/r/349be1d8-9544-480a-a747-14364523dafd
- https://php.watch/versions/8.5/PHP_BUILD_DATE