### PR TITLE
fix build

### DIFF
--- a/tests/PHPStan/Rules/DeadCode/data/call-to-static-method-without-impure-points-pipe.php
+++ b/tests/PHPStan/Rules/DeadCode/data/call-to-static-method-without-impure-points-pipe.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.5
 
 namespace CallToStaticMethodWithoutImpurePointsPipe;
 


### PR DESCRIPTION
not sure about those remaining errors in tests, whether there are intentional errors or not

```
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/DeadCode/data/call-to-static-method-without-impure-points-pipe.php:17
    15| function (): void {
    16| 	5 |> Foo::doFoo(...);
  > 17| 	5 |> fn ($x) => Foo::doFoo($x);
    18| };
Arrow functions on the right hand side of |> must be parenthesized
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/DeadCode/data/call-to-function-without-impure-points-pipe.php:10
     8| 
     9| 5 |> myFunc(...);
  > 10| 5 |> fn ($x) => myFunc($x);
Arrow functions on the right hand side of |> must be parenthesized
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/DeadCode/data/call-to-method-without-impure-points-pipe.php:18
    16| 	$foo = new Foo();
    17| 	5 |> $foo->maybePure(...);
  > 18| 	5 |> fn ($x) => $foo->maybePure($x);
    19| };
Arrow functions on the right hand side of |> must be parenthesized
```