### PR TITLE
`array_key_exist` inference is lost when adding a false condition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,6 +240,7 @@ jobs:
         run: |
           php build-infection/bin/infection-config.php \
             --source-directory='build/PHPStan/Build' \
+            --timeout=180 \
           > infection.json5
           cat infection.json5 | jq
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,7 +240,6 @@ jobs:
         run: |
           php build-infection/bin/infection-config.php \
             --source-directory='build/PHPStan/Build' \
-            --timeout=300 \
           > infection.json5
           cat infection.json5 | jq
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,7 +240,7 @@ jobs:
         run: |
           php build-infection/bin/infection-config.php \
             --source-directory='build/PHPStan/Build' \
-            --timeout=180 \
+            --timeout=300 \
           > infection.json5
           cat infection.json5 | jq
 

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -663,7 +663,25 @@ final class TypeSpecifier
 			$leftTypes = $this->specifyTypesInCondition($scope, $expr->left, $context)->setRootExpr($expr);
 			$rightScope = $scope->filterByFalseyValue($expr->left);
 			$rightTypes = $this->specifyTypesInCondition($rightScope, $expr->right, $context)->setRootExpr($expr);
-			$types = $context->true() ? $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($rightScope)) : $leftTypes->unionWith($rightTypes);
+
+			if ($context->true()) {
+				if (
+					$scope->getType($expr->left)->isFalse()->yes()
+					|| $scope->getType($expr->right)->isTrue()->yes()
+				) {
+					$types = $rightTypes->normalize($rightScope);
+				} elseif (
+					$scope->getType($expr->left)->isTrue()->yes()
+					|| $scope->getType($expr->right)->isFalse()->yes()
+				) {
+					$types = $leftTypes->normalize($scope);
+				} else {
+					$types = $leftTypes->normalize($scope)->intersectWith($rightTypes->normalize($rightScope));
+				}
+			} else {
+				$types = $leftTypes->unionWith($rightTypes);
+			}
+
 			if ($context->true()) {
 				return (new SpecifiedTypes(
 					$types->getSureTypes(),

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -667,7 +667,6 @@ final class TypeSpecifier
 			if ($context->true()) {
 				if (
 					$scope->getType($expr->left)->isFalse()->yes()
-					|| $scope->getType($expr->right)->isTrue()->yes()
 				) {
 					$types = $rightTypes->normalize($rightScope);
 				} elseif (

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -666,12 +666,12 @@ final class TypeSpecifier
 
 			if ($context->true()) {
 				if (
-					$scope->getType($expr->left)->isFalse()->yes()
+					$scope->getType($expr->left)->toBoolean()->isFalse()->yes()
 				) {
 					$types = $rightTypes->normalize($rightScope);
 				} elseif (
-					$scope->getType($expr->left)->isTrue()->yes()
-					|| $scope->getType($expr->right)->isFalse()->yes()
+					$scope->getType($expr->left)->toBoolean()->isTrue()->yes()
+					|| $scope->getType($expr->right)->toBoolean()->isFalse()->yes()
 				) {
 					$types = $leftTypes->normalize($scope);
 				} else {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -353,7 +353,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					self::createFunctionCall('is_int', 'foo'),
 					self::createFunctionCall('is_string', 'bar'),
 				),
-				[],
+				['$foo' => 'int'],
 				['$foo' => '~int', '$bar' => '~string'],
 			],
 			[
@@ -652,7 +652,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 			[
 				new Expr\Empty_(new Variable('array')),
 				[
-					'$array' => 'array{}|null',
+					'$array' => 'array{}',
 				],
 				[
 					'$array' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
@@ -664,7 +664,7 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$array' => '~0|0.0|\'\'|\'0\'|array{}|false|null',
 				],
 				[
-					'$array' => 'array{}|null',
+					'$array' => 'array{}',
 				],
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/bug-11276.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11276.php
@@ -14,11 +14,27 @@ function doFoo(int $i, int $j, $arr): void
 		assertType('non-empty-array', $arr);
 	}
 
+	if ("0" || array_key_exists($i, $arr)) {
+		assertType('non-empty-array', $arr);
+	}
+
+	if (array_key_exists($i, $arr) || "0") {
+		assertType('non-empty-array', $arr);
+	}
+
 	if (true || array_key_exists($i, $arr)) {
 		assertType('mixed', $arr);
 	}
 
 	if (array_key_exists($i, $arr) || true) {
+		assertType('mixed', $arr);
+	}
+
+	if ("1" || array_key_exists($i, $arr)) {
+		assertType('mixed', $arr);
+	}
+
+	if (array_key_exists($i, $arr) || "1") {
 		assertType('mixed', $arr);
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11276.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11276.php
@@ -42,7 +42,7 @@ function doFoo(int $i, int $j, $arr): void
 	}
 }
 
-function doBar($j, $arr) {
+function doBar($j, array $arr) {
 	$i = 1;
 	if (!array_key_exists($i, $arr)) {
 		if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {

--- a/tests/PHPStan/Analyser/nsrt/bug-11276.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11276.php
@@ -1,0 +1,26 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+function sayEqualArrayShape(int $i, $arr): void
+{
+	if (false || array_key_exists($i, $arr)) {
+		assertType('non-empty-array', $arr);
+	}
+
+	if (array_key_exists($i, $arr) || false) {
+		assertType('non-empty-array', $arr);
+	}
+
+	if (true || array_key_exists($i, $arr)) {
+		assertType('mixed', $arr);
+	}
+
+	if (array_key_exists($i, $arr) || true) {
+		assertType('mixed', $arr);
+	}
+
+	if (array_key_exists($i, $arr)) {
+		assertType('non-empty-array', $arr);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-11276.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11276.php
@@ -41,18 +41,3 @@ function doFoo(int $i, int $j, $arr): void
 		assertType('non-empty-array', $arr);
 	}
 }
-
-function doBar($j, array $arr) {
-	$i = 1;
-	if (!array_key_exists($i, $arr)) {
-		if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {
-			assertType('non-empty-array<mixed~1, mixed>', $arr);
-		}
-	}
-
-	if (!array_key_exists($i, $arr)) {
-		if (array_key_exists($j, $arr) || array_key_exists($i, $arr)) {
-			assertType('non-empty-array<mixed~1, mixed>', $arr);
-		}
-	}
-}

--- a/tests/PHPStan/Analyser/nsrt/bug-11276.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11276.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace Bug11276;
+
 use function PHPStan\Testing\assertType;
 
-function sayEqualArrayShape(int $i, $arr): void
+function doFoo(int $i, int $j, $arr): void
 {
 	if (false || array_key_exists($i, $arr)) {
 		assertType('non-empty-array', $arr);
@@ -20,7 +22,37 @@ function sayEqualArrayShape(int $i, $arr): void
 		assertType('mixed', $arr);
 	}
 
+	if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {
+		assertType('non-empty-array', $arr);
+	}
+
+	if (!array_key_exists($j, $arr)) {
+		if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {
+			assertType('non-empty-array', $arr);
+		}
+	}
+	if (!array_key_exists($i, $arr)) {
+		if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {
+			assertType('non-empty-array', $arr);
+		}
+	}
+
 	if (array_key_exists($i, $arr)) {
 		assertType('non-empty-array', $arr);
+	}
+}
+
+function doBar($j, $arr) {
+	$i = 1;
+	if (!array_key_exists($i, $arr)) {
+		if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {
+			assertType('non-empty-array<mixed~1, mixed>', $arr);
+		}
+	}
+
+	if (!array_key_exists($i, $arr)) {
+		if (array_key_exists($j, $arr) || array_key_exists($i, $arr)) {
+			assertType('non-empty-array<mixed~1, mixed>', $arr);
+		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11276b.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11276b.php
@@ -1,0 +1,20 @@
+<?php // lint >= 8.0
+
+namespace Bug11276b;
+
+use function PHPStan\Testing\assertType;
+
+function doBar($j, array $arr) {
+	$i = 1;
+	if (!array_key_exists($i, $arr)) {
+		if (array_key_exists($i, $arr) || array_key_exists($j, $arr)) {
+			assertType('non-empty-array<mixed~1, mixed>', $arr);
+		}
+	}
+
+	if (!array_key_exists($i, $arr)) {
+		if (array_key_exists($j, $arr) || array_key_exists($i, $arr)) {
+			assertType('non-empty-array<mixed~1, mixed>', $arr);
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -1132,4 +1132,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6209.php'], []);
 	}
 
+	public function testBug11276(): void
+	{
+		$this->reportPossiblyNonexistentConstantArrayOffset = true;
+		$this->analyse([__DIR__ . '/data/bug-11276.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-11276.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-11276.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Bug11276;
+
+class HelloWorld
+{
+	/**
+	 * @param array{from: string, to: string} $expected
+	 */
+	public function testLanguagesMatchingRegex(string $url, ?array $expected): void
+	{
+		preg_match('#\/(?<from>[a-z]{2})-(?<to>[a-z]{1}[a-z0-9]{1})\/#', $url, $matches);
+
+		foreach ($expected as $key => $value) {
+			if ($matches instanceof ArrayAccess || \array_key_exists($key, $matches)) {
+				$matches[$key];
+			}
+		}
+
+		foreach ($expected as $key => $value) {
+			if (\array_key_exists($key, $matches) || $matches instanceof ArrayAccess) {
+				$matches[$key];
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -239,7 +239,6 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 			[
 				'Right side of || is always true.',
 				33,
-				$tipText,
 			],
 		]);
 	}


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/11276

fixes https://github.com/phpstan/phpstan-phpunit/issues/100