### PR TITLE
fix null coalesce false positive for multi-dimensional array in loop

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -983,7 +983,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug7903(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7903.php');
-		$this->assertCount(23, $errors);
+		$this->assertCount(24, $errors);
 	}
 
 	public function testBug7901(): void

--- a/tests/PHPStan/Analyser/nsrt/bug-optionalArrayKeyInMultiDimArrayLoop.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-optionalArrayKeyInMultiDimArrayLoop.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace OptionalArrayKeyInMultiDimArrayLoop;
+
+/**
+ * @param array<int, array{1: int, 2: int, 3: float}> $rows
+ */
+function foo(array $rows): mixed
+{
+	$itemMap = [];
+
+	foreach ($rows as $row) {
+		$x = $row[1];
+		$month = $row[2];
+
+		$itemMap[$x][$month]['foo'] ??= 5;
+		$itemMap[$x][$month]['bar'] ??= 5;
+
+		\PHPStan\Testing\assertType('array{foo: 5, bar: 5, amount?: 0.0}', $itemMap[$x][$month]);
+		$itemMap[$x][$month]['amount'] ??= 0.0;
+	}
+
+	return $itemMap;
+}

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -337,6 +337,11 @@ class NullCoalesceRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12553.php'], []);
 	}
 
+	public function testBugMultiDimLoop(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-nullCoalesceMultiDimLoop.php'], []);
+	}
+
 	public function testIssetAfterRememberedConstructor(): void
 	{
 		$this->analyse([__DIR__ . '/data/isset-after-remembered-constructor.php'], [

--- a/tests/PHPStan/Rules/Variables/data/bug-nullCoalesceMultiDimLoop.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-nullCoalesceMultiDimLoop.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace BugNullCoalesceMultiDimLoop;
+
+/**
+ * @param array<int, array{1: int, 2: int, 3: float}> $rows
+ */
+function foo(array $rows): mixed
+{
+	$itemMap = [];
+
+	foreach ($rows as $row) {
+		$x = $row[1];
+		$month = $row[2];
+
+		$itemMap[$x][$month]['foo'] ??= 5;
+		$itemMap[$x][$month]['bar'] ??= 5;
+
+		$itemMap[$x][$month]['amount'] ??= 0.0;
+	}
+
+	return $itemMap;
+}


### PR DESCRIPTION
Fixes: https://phpstan.org/r/9e10fb00-443f-4c05-9506-da40bf191f8e

The bug is triggered the second time the loop is processed on line 17 of the test file in `produceArrayDimFetchAssignValueToWrite`:

```
$valueToWrite = $offsetValueType->setExistingOffsetValueType($offsetType, $valueToWrite);
```

Original `$valueToWrite`: `array{foo: 5, bar: 5, amount?: 0.0}`
`$offserValueType`: `non-empty-array<int, array{foo: 5, bar: 5, amount: 0.0}|array{foo: 5}>`

The original version of `setExistingOffsetValueType` disregards optional keys, so it results in new `$valueTypeToWrite`: `non-empty-array<int, array{foo: 5, bar: 5, amount: 0.0}>`