### PR TITLE
Fix PHP8.5 lint errors

### DIFF
--- a/tests/PHPStan/Rules/DeadCode/data/call-to-function-without-impure-points-pipe.php
+++ b/tests/PHPStan/Rules/DeadCode/data/call-to-function-without-impure-points-pipe.php
@@ -7,4 +7,4 @@ function myFunc()
 }
 
 5 |> myFunc(...);
-5 |> fn ($x) => myFunc($x);
+5 |> (fn ($x) => myFunc($x));

--- a/tests/PHPStan/Rules/DeadCode/data/call-to-method-without-impure-points-pipe.php
+++ b/tests/PHPStan/Rules/DeadCode/data/call-to-method-without-impure-points-pipe.php
@@ -15,5 +15,5 @@ class Foo
 function (): void {
 	$foo = new Foo();
 	5 |> $foo->maybePure(...);
-	5 |> fn ($x) => $foo->maybePure($x);
+	5 |> (fn ($x) => $foo->maybePure($x));
 };

--- a/tests/PHPStan/Rules/DeadCode/data/call-to-static-method-without-impure-points-pipe.php
+++ b/tests/PHPStan/Rules/DeadCode/data/call-to-static-method-without-impure-points-pipe.php
@@ -14,5 +14,5 @@ class Foo
 
 function (): void {
 	5 |> Foo::doFoo(...);
-	5 |> fn ($x) => Foo::doFoo($x);
+	5 |> (fn ($x) => Foo::doFoo($x));
 };


### PR DESCRIPTION
fixes

```
Parse error: tests/PHPStan/Rules/DeadCode/data/call-to-static-method-without-impure-points-pipe.php:17
    15| function (): void {
    16| 	5 |> Foo::doFoo(...);
  > 17| 	5 |> fn ($x) => Foo::doFoo($x);
    18| };
Arrow functions on the right hand side of |> must be parenthesized
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/DeadCode/data/call-to-function-without-impure-points-pipe.php:10
     8| 
     9| 5 |> myFunc(...);
  > 10| 5 |> fn ($x) => myFunc($x);
Arrow functions on the right hand side of |> must be parenthesized
------------------------------------------------------------
Parse error: tests/PHPStan/Rules/DeadCode/data/call-to-method-without-impure-points-pipe.php:18
    16| 	$foo = new Foo();
    17| 	5 |> $foo->maybePure(...);
  > 18| 	5 |> fn ($x) => $foo->maybePure($x);
    19| };
Arrow functions on the right hand side of |> must be parenthesized
```

as it seems [they will not get rid of this caveats](https://github.com/php/php-src/pull/19533#issuecomment-3442822119)