### PR TITLE
Use faster case-insensitve string comparison

### DIFF
--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -18,7 +18,7 @@ use PHPStan\Rules\LazyRegistry;
 use ReflectionClass;
 use stdClass;
 use function explode;
-use function strtolower;
+use function strcasecmp;
 use function substr;
 
 final class AutowiredAttributeServicesExtension extends CompilerExtension
@@ -135,10 +135,10 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		foreach ($autowiredParameters as $autowiredParameter) {
-			if (strtolower($autowiredParameter->method) !== '__construct') {
+			if (strcasecmp($autowiredParameter->method, '__construct') !== 0) {
 				continue;
 			}
-			if (strtolower($autowiredParameter->class) !== strtolower($className)) {
+			if (strcasecmp($autowiredParameter->class, $className) !== 0) {
 				continue;
 			}
 			$ref = $autowiredParameter->attribute->ref;


### PR DESCRIPTION
this `strtolower` call is showing up in blackfire profiles

<img width="584" height="629" alt="grafik" src="https://github.com/user-attachments/assets/72bfae46-10f7-463c-9db9-b2953cf320d4" />

because we invoke it millions of times

---

local benchmarks tells me `strcasecmp` is 2x faster 

```
fec) ✗ hyperfine 'php perf.php'
Benchmark 1: php perf.php
  Time (mean ± σ):     403.3 ms ±   8.6 ms    [User: 392.5 ms, System: 8.0 ms]
  Range (min … max):   385.6 ms … 414.7 ms    10 runs
 
➜  phpstan-src git:(infec) ✗ hyperfine 'php perf.php'
Benchmark 1: php perf.php
  Time (mean ± σ):     195.8 ms ±  10.1 ms    [User: 186.0 ms, System: 7.2 ms]
  Range (min … max):   183.3 ms … 219.4 ms    16 runs
```

running

```
<?php

function generateRandomString($length = 10) {
	return substr(str_shuffle(str_repeat($x='0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil($length/strlen($x)) )),1,$length);
}

$var1 = generateRandomString();
$var2 = generateRandomString();

$x = false;
for ($i = 0; $i < 10_000_000; $i++) {
	if (strcasecmp($var1, $var2) === 0) {
	//if (strtolower($var1) === strtolower($var2)) {
		$x = true;
	}
}
```

---

working my way thru things showing up in profiles of https://github.com/phpstan/build-infection/pull/11#issuecomment-3448262310