### PR TITLE
Faster AutowiredAttributeServicesExtension->processParameters()

### DIFF
--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -19,6 +19,7 @@ use ReflectionClass;
 use stdClass;
 use function explode;
 use function strcasecmp;
+use function strtolower;
 use function substr;
 
 final class AutowiredAttributeServicesExtension extends CompilerExtension
@@ -44,8 +45,9 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			if (strcasecmp($parameter->method, '__construct') !== 0) {
 				continue;
 			}
-			$constructorParameters[$parameter->class] ??= [];
-			$constructorParameters[$parameter->class][] = $parameter;
+			$lowerClass = strtolower($parameter->class);
+			$constructorParameters[$lowerClass] ??= [];
+			$constructorParameters[$lowerClass][] = $parameter;
 		}
 
 		foreach (Attributes::findTargetClasses(AutowiredService::class) as $class) {
@@ -137,12 +139,12 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 
 	/**
 	 * @param class-string $className
-	 * @param array<class-string, non-empty-list<TargetMethodParameter<AutowiredParameter>>> $constructorParameters
+	 * @param array<lowercase-string, non-empty-list<TargetMethodParameter<AutowiredParameter>>> $constructorParameters
 	 */
 	private function processConstructorParameters(string $className, ServiceDefinition $definition, array $constructorParameters): void
 	{
 		$builder = $this->getContainerBuilder();
-		foreach ($constructorParameters[$className] ?? [] as $autowiredParameter) {
+		foreach ($constructorParameters[strtolower($className)] ?? [] as $autowiredParameter) {
 			$ref = $autowiredParameter->attribute->ref;
 			if ($ref === null) {
 				$argument = Helpers::expand(

--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -135,7 +135,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		foreach ($autowiredParameters as $autowiredParameter) {
-			if ($autowiredParameter->method === '' || $autowiredParameter->method[0] !== '_') {
+			if ($autowiredParameter->method[0] !== '_') {
 				continue;
 			}
 

--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -135,6 +135,10 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 	{
 		$builder = $this->getContainerBuilder();
 		foreach ($autowiredParameters as $autowiredParameter) {
+			if ($autowiredParameter->method === '' || $autowiredParameter->method[0] !== '_') {
+				continue;
+			}
+
 			if (strcasecmp($autowiredParameter->method, '__construct') !== 0) {
 				continue;
 			}

--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -40,7 +40,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 
 		$autowiredParameters = Attributes::findTargetMethodParameters(AutowiredParameter::class);
 		$constructorParameters = [];
-		foreach($autowiredParameters as $parameter) {
+		foreach ($autowiredParameters as $parameter) {
 			if (strcasecmp($parameter->method, '__construct') !== 0) {
 				continue;
 			}
@@ -142,7 +142,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 	private function processParameters(string $className, ServiceDefinition $definition, array $constructorParameters): void
 	{
 		$builder = $this->getContainerBuilder();
-		foreach($constructorParameters[$className] ?? [] as $autowiredParameter) {
+		foreach ($constructorParameters[$className] ?? [] as $autowiredParameter) {
 			$ref = $autowiredParameter->attribute->ref;
 			if ($ref === null) {
 				$argument = Helpers::expand(

--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -61,7 +61,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				$definition->setFactory(new Statement([new Reference(substr($ref, 1)), $method]));
 			}
 
-			$this->processParameters($class->name, $definition, $constructorParameters);
+			$this->processConstructorParameters($class->name, $definition, $constructorParameters);
 
 			foreach (ValidateServiceTagsExtension::INTERFACE_TAG_MAPPING as $interface => $tag) {
 				if (!$reflection->implementsInterface($interface)) {
@@ -84,7 +84,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				$definition->setFactory(new Statement([new Reference(substr($ref, 1)), $method]));
 			}
 
-			$this->processParameters($class->name, $definition, $constructorParameters);
+			$this->processConstructorParameters($class->name, $definition, $constructorParameters);
 		}
 
 		foreach (Attributes::findTargetClasses(GenerateFactory::class) as $class) {
@@ -97,7 +97,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			}
 
 			$resultDefinition = $definition->getResultDefinition();
-			$this->processParameters($class->name, $resultDefinition, $constructorParameters);
+			$this->processConstructorParameters($class->name, $resultDefinition, $constructorParameters);
 		}
 
 		/** @var stdClass&object{level: int|null} $config */
@@ -117,7 +117,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				->setAutowired($class->name)
 				->addTag(LazyRegistry::RULE_TAG);
 
-			$this->processParameters($class->name, $definition, $constructorParameters);
+			$this->processConstructorParameters($class->name, $definition, $constructorParameters);
 		}
 
 		foreach (Attributes::findTargetClasses(RegisteredCollector::class) as $class) {
@@ -131,7 +131,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				->setAutowired($class->name)
 				->addTag(RegistryFactory::COLLECTOR_TAG);
 
-			$this->processParameters($class->name, $definition, $constructorParameters);
+			$this->processConstructorParameters($class->name, $definition, $constructorParameters);
 		}
 	}
 
@@ -139,7 +139,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 	 * @param class-string $className
 	 * @param array<class-string, non-empty-list<TargetMethodParameter<AutowiredParameter>>> $constructorParameters
 	 */
-	private function processParameters(string $className, ServiceDefinition $definition, array $constructorParameters): void
+	private function processConstructorParameters(string $className, ServiceDefinition $definition, array $constructorParameters): void
 	{
 		$builder = $this->getContainerBuilder();
 		foreach ($constructorParameters[$className] ?? [] as $autowiredParameter) {

--- a/src/DependencyInjection/AutowiredAttributeServicesExtension.php
+++ b/src/DependencyInjection/AutowiredAttributeServicesExtension.php
@@ -39,6 +39,14 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 
 		$autowiredParameters = Attributes::findTargetMethodParameters(AutowiredParameter::class);
+		$constructorParameters = [];
+		foreach($autowiredParameters as $parameter) {
+			if (strcasecmp($parameter->method, '__construct') !== 0) {
+				continue;
+			}
+			$constructorParameters[$parameter->class] ??= [];
+			$constructorParameters[$parameter->class][] = $parameter;
+		}
 
 		foreach (Attributes::findTargetClasses(AutowiredService::class) as $class) {
 			$reflection = new ReflectionClass($class->name);
@@ -53,7 +61,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				$definition->setFactory(new Statement([new Reference(substr($ref, 1)), $method]));
 			}
 
-			$this->processParameters($class->name, $definition, $autowiredParameters);
+			$this->processParameters($class->name, $definition, $constructorParameters);
 
 			foreach (ValidateServiceTagsExtension::INTERFACE_TAG_MAPPING as $interface => $tag) {
 				if (!$reflection->implementsInterface($interface)) {
@@ -76,7 +84,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				$definition->setFactory(new Statement([new Reference(substr($ref, 1)), $method]));
 			}
 
-			$this->processParameters($class->name, $definition, $autowiredParameters);
+			$this->processParameters($class->name, $definition, $constructorParameters);
 		}
 
 		foreach (Attributes::findTargetClasses(GenerateFactory::class) as $class) {
@@ -89,7 +97,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 			}
 
 			$resultDefinition = $definition->getResultDefinition();
-			$this->processParameters($class->name, $resultDefinition, $autowiredParameters);
+			$this->processParameters($class->name, $resultDefinition, $constructorParameters);
 		}
 
 		/** @var stdClass&object{level: int|null} $config */
@@ -109,7 +117,7 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				->setAutowired($class->name)
 				->addTag(LazyRegistry::RULE_TAG);
 
-			$this->processParameters($class->name, $definition, $autowiredParameters);
+			$this->processParameters($class->name, $definition, $constructorParameters);
 		}
 
 		foreach (Attributes::findTargetClasses(RegisteredCollector::class) as $class) {
@@ -123,28 +131,18 @@ final class AutowiredAttributeServicesExtension extends CompilerExtension
 				->setAutowired($class->name)
 				->addTag(RegistryFactory::COLLECTOR_TAG);
 
-			$this->processParameters($class->name, $definition, $autowiredParameters);
+			$this->processParameters($class->name, $definition, $constructorParameters);
 		}
 	}
 
 	/**
 	 * @param class-string $className
-	 * @param TargetMethodParameter<AutowiredParameter>[] $autowiredParameters
+	 * @param array<class-string, non-empty-list<TargetMethodParameter<AutowiredParameter>>> $constructorParameters
 	 */
-	private function processParameters(string $className, ServiceDefinition $definition, array $autowiredParameters): void
+	private function processParameters(string $className, ServiceDefinition $definition, array $constructorParameters): void
 	{
 		$builder = $this->getContainerBuilder();
-		foreach ($autowiredParameters as $autowiredParameter) {
-			if ($autowiredParameter->method[0] !== '_') {
-				continue;
-			}
-
-			if (strcasecmp($autowiredParameter->method, '__construct') !== 0) {
-				continue;
-			}
-			if (strcasecmp($autowiredParameter->class, $className) !== 0) {
-				continue;
-			}
+		foreach($constructorParameters[$className] ?? [] as $autowiredParameter) {
 			$ref = $autowiredParameter->attribute->ref;
 			if ($ref === null) {
 				$argument = Helpers::expand(


### PR DESCRIPTION
even after https://github.com/phpstan/phpstan-src/pull/4482 we still see this method call on the hot path.

<img width="295" height="493" alt="grafik" src="https://github.com/user-attachments/assets/ce34cceb-f898-4c64-8916-0adfca3daf8c" />

---

running PHPStan on the PHPStan-PHPUnit extension tests show this path as the slowest part of the run:

<img width="472" height="167" alt="grafik" src="https://github.com/user-attachments/assets/2b21e00d-678a-4132-a734-703206077717" />
