### PR TITLE
[PHP 8.5] add support for FILTER_THROW_ON_FAILURE for filter_var

### DIFF
--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntegerType;
@@ -129,6 +130,10 @@ final class FilterFunctionReturnTypeHelper
 		$inputIsArray = $inputType->isArray();
 		$hasRequireArrayFlag = $this->hasFlag('FILTER_REQUIRE_ARRAY', $flagsType);
 		if ($inputIsArray->no() && $hasRequireArrayFlag) {
+			if ($this->hasFlag('FILTER_THROW_ON_FAILURE', $flagsType)) {
+				return new ErrorType();
+			}
+
 			return $defaultType;
 		}
 
@@ -172,6 +177,10 @@ final class FilterFunctionReturnTypeHelper
 
 		if (!$hasRequireArrayFlag && $hasForceArrayFlag) {
 			return new ArrayType($inputArrayKeyType ?? $mixedType, $type);
+		}
+
+		if ($this->hasFlag('FILTER_THROW_ON_FAILURE', $flagsType)) {
+			$type = TypeCombinator::remove($type, $defaultType);
 		}
 
 		return $type;

--- a/src/Type/Php/FilterVarThrowTypeExtension.php
+++ b/src/Type/Php/FilterVarThrowTypeExtension.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicFunctionThrowTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+#[AutowiredService]
+final class FilterVarThrowTypeExtension implements DynamicFunctionThrowTypeExtension
+{
+
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+	)
+	{
+	}
+
+	public function isFunctionSupported(
+		FunctionReflection $functionReflection,
+	): bool
+	{
+		return $functionReflection->getName() === 'filter_var'
+			&& $this->reflectionProvider->hasConstant(new Name\FullyQualified('FILTER_THROW_ON_FAILURE'), null);
+	}
+
+	public function getThrowTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $funcCall,
+		Scope $scope,
+	): ?Type
+	{
+		if (!isset($funcCall->getArgs()[3])) {
+			return null;
+		}
+
+		$flagsExpr = $funcCall->getArgs()[3]->value;
+		$flagsType = $scope->getType($flagsExpr);
+
+		if ($flagsType->isConstantArray()->yes()) {
+			$flagsType = $flagsType->getOffsetValueType(new ConstantStringType('flags'));
+		}
+
+		$flag = $this->getConstant();
+
+		if ($flag !== null && $flagsType instanceof ConstantIntegerType && ($flagsType->getValue() & $flag) === $flag) {
+			return new ObjectType('Filter\FilterFailedException');
+		}
+
+		return null;
+	}
+
+	private function getConstant(): ?int
+	{
+		$constant = $this->reflectionProvider->getConstant(new Name('FILTER_THROW_ON_FAILURE'), null);
+		$valueType = $constant->getValueType();
+		if (!$valueType instanceof ConstantIntegerType) {
+			return null;
+		}
+
+		return $valueType->getValue();
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/filter-var-php85.php
+++ b/tests/PHPStan/Analyser/nsrt/filter-var-php85.php
@@ -1,0 +1,26 @@
+<?php // lint >= 8.5
+
+declare(strict_types=1);
+
+namespace FilterVarPHP85;
+
+use PHPStan\TrinaryLogic;
+use function PHPStan\Testing\assertType;
+use function PHPStan\Testing\assertVariableCertainty;
+
+class FilterVarPHP85
+{
+
+	public function doFoo($mixed): void
+	{
+		try {
+			filter_var($mixed, FILTER_VALIDATE_INT, FILTER_THROW_ON_FAILURE);
+			$foo = 1;
+		} catch (\Filter\FilterFailedException $e) {
+			assertVariableCertainty(TrinaryLogic::createNo(), $foo);
+		}
+
+		assertType('int', filter_var($mixed, FILTER_VALIDATE_INT, FILTER_THROW_ON_FAILURE));
+		assertType('int', filter_var($mixed, FILTER_VALIDATE_INT, ['flags' => FILTER_THROW_ON_FAILURE]));
+	}
+}


### PR DESCRIPTION
Adds support for `FILTER_THROW_ON_FAILURE` for `filter_var`. There are still stuff I need to figure out:

- [ ] How to better test the throw type extension?
- [ ] Should we add the `@throws` tag to function in phpstorm-stubs repo? Or anywhere in PHPStan. Couldn't figure out how to conditionally add it only for PHP 8.5 in phpstorm-stubs repo.
- [ ] Combining `FILTER_THROW_ON_FAILURE` and `FILTER_NULL_ON_FAILURE` is not allowed. Should we have a new rule for that?

If anyone can help me with those questions, that'd be helpful!