### PR TITLE
make BcMath\Number::$value numeric-string

### DIFF
--- a/src/PhpDoc/BcMathNumberStubFilesExtension.php
+++ b/src/PhpDoc/BcMathNumberStubFilesExtension.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\PhpDoc;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Php\PhpVersion;
+
+#[AutowiredService]
+final class BcMathNumberStubFilesExtension implements StubFilesExtension
+{
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	public function getFiles(): array
+	{
+		if (!$this->phpVersion->supportsBcMathNumberOperatorOverloading()) {
+			return [];
+		}
+
+		return [__DIR__ . '/../../stubs/bcmath.stub'];
+	}
+
+}

--- a/stubs/bcmath.stub
+++ b/stubs/bcmath.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace BcMath;
+
+class Number {
+    /** @var numeric-string */
+    public readonly string $value;
+}


### PR DESCRIPTION
Fixes https://phpstan.org/r/da494451-a17d-49f9-bcb7-5b2ce11219d2

It's covered by `ReflectionProviderGoldenTest` so I didn't add any other test:

```
1) PHPStan\Reflection\ReflectionProviderGoldenTest::test with data set "PROPERTY BcMath\Number::$value" ('PROPERTY BcMath\Number::$value', 'Readonly\nVisibility: public\...string')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 'Readonly
 Visibility: public
-Read type: string
-Write type: string'
+Read type: numeric-string
+Write type: numeric-string'
```