### PR TITLE
Improve inference on FuncCall === FuncCall

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -2250,11 +2250,23 @@ final class TypeSpecifier
 
 	public function resolveIdentical(Expr\BinaryOp\Identical $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		$specifiedTypes = $this->resolveNormalizedIdentical($expr, $scope, $context);
-
-		// merge result of fn1() === fn2() and fn2() === fn1()
 		$leftExpr = $expr->left;
 		$rightExpr = $expr->right;
+
+		// Normalize to: fn() === expr
+		if ($rightExpr instanceof FuncCall && !$leftExpr instanceof FuncCall) {
+			$specifiedTypes = $this->resolveNormalizedIdentical(new Expr\BinaryOp\Identical(
+				$rightExpr,
+				$leftExpr,
+			), $scope, $context);
+		} else {
+			$specifiedTypes = $this->resolveNormalizedIdentical(new Expr\BinaryOp\Identical(
+				$leftExpr,
+				$rightExpr,
+			), $scope, $context);
+		}
+
+		// merge result of fn1() === fn2() and fn2() === fn1()
 		if ($rightExpr instanceof FuncCall && $leftExpr instanceof FuncCall) {
 			return $specifiedTypes->unionWith(
 				$this->resolveNormalizedIdentical(new Expr\BinaryOp\Identical(
@@ -2269,12 +2281,8 @@ final class TypeSpecifier
 
 	private function resolveNormalizedIdentical(Expr\BinaryOp\Identical $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		// Normalize to: fn() === expr
 		$leftExpr = $expr->left;
 		$rightExpr = $expr->right;
-		if ($rightExpr instanceof FuncCall && !$leftExpr instanceof FuncCall) {
-			[$leftExpr, $rightExpr] = [$rightExpr, $leftExpr];
-		}
 
 		$unwrappedLeftExpr = $leftExpr;
 		if ($leftExpr instanceof AlwaysRememberedExpr) {

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -2250,6 +2250,25 @@ final class TypeSpecifier
 
 	public function resolveIdentical(Expr\BinaryOp\Identical $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
+		$specifiedTypes = $this->resolveNormalizedIdentical($expr, $scope, $context);
+
+		// merge result of fn1() === fn2() and fn2() === fn1()
+		$leftExpr = $expr->left;
+		$rightExpr = $expr->right;
+		if ($rightExpr instanceof FuncCall && $leftExpr instanceof FuncCall) {
+			return $specifiedTypes->unionWith(
+				$this->resolveNormalizedIdentical(new Expr\BinaryOp\Identical(
+					$rightExpr,
+					$leftExpr,
+				), $scope, $context),
+			);
+		}
+
+		return $specifiedTypes;
+	}
+
+	private function resolveNormalizedIdentical(Expr\BinaryOp\Identical $expr, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+	{
 		// Normalize to: fn() === expr
 		$leftExpr = $expr->left;
 		$rightExpr = $expr->right;

--- a/tests/PHPStan/Analyser/nsrt/bug-13749.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13749.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13749;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param non-empty-string $nonES
+	 */
+	public function sayNonEmpty(string $s, string $nonES): void
+	{
+		if (strlen($nonES) === strlen($s)) {
+			assertType('non-empty-string', $s);
+		}
+		if (strlen($nonES) >= strlen($s)) {
+			assertType('string', $s); // could be non-empty-string
+		}
+
+		if (strlen($s) === strlen($nonES)) {
+			assertType('non-empty-string', $s);
+		}
+		if (strlen($s) >= strlen($nonES)) {
+			assertType('non-empty-string', $s);
+		}
+	}
+
+	/**
+	 * @param non-falsy-string $nonFalsy
+	 */
+	public function sayNonFalsy(string $s, string $nonFalsy): void
+	{
+		if (strlen($nonFalsy) === strlen($s)) {
+			assertType('non-empty-string', $s);
+		}
+		if (strlen($nonFalsy) >= strlen($s)) {
+			assertType('string', $s); // could be non-empty-string
+		}
+
+		if (strlen($s) === strlen($nonFalsy)) {
+			assertType('non-empty-string', $s);
+		}
+		if (strlen($s) >= strlen($nonFalsy)) {
+			assertType('non-empty-string', $s);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13749.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13749.php
@@ -46,4 +46,24 @@ class HelloWorld
 		}
 	}
 
+	/**
+	 * @param non-empty-array $nonEmptyArr
+	 */
+	public function sayCount(array $arr, array $nonEmptyArr): void
+	{
+		if (count($arr) === count($nonEmptyArr)) {
+			assertType('non-empty-array', $arr);
+			assertType('non-empty-array', $nonEmptyArr);
+		}
+		assertType('array', $arr);
+		assertType('non-empty-array', $nonEmptyArr);
+
+		if (count($nonEmptyArr) === count($arr)) {
+			assertType('non-empty-array', $arr);
+			assertType('non-empty-array', $nonEmptyArr);
+		}
+		assertType('array', $arr);
+		assertType('non-empty-array', $nonEmptyArr);
+	}
+
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/13749

if one of the involved function calls got already narrowed, switching the operands can lead to more precise types.