### PR TITLE
`count(non-empty-array, COUNT_RECURSIVE)` is `int<1, max>`

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -686,10 +686,7 @@ class IntersectionType implements CompoundType
 		if ($arraySize instanceof IntegerRangeType) {
 			$knownOffsets = [];
 			foreach ($this->types as $type) {
-				if ($type instanceof HasOffsetValueType) {
-					$knownOffsets[$type->getOffsetType()->getValue()] = true;
-				}
-				if (!($type instanceof HasOffsetType)) {
+				if (!($type instanceof HasOffsetValueType) && !($type instanceof HasOffsetType)) {
 					continue;
 				}
 

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -53,7 +53,6 @@ use function implode;
 use function in_array;
 use function is_int;
 use function ksort;
-use function max;
 use function md5;
 use function sprintf;
 use function strcasecmp;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -53,6 +53,7 @@ use function implode;
 use function in_array;
 use function is_int;
 use function ksort;
+use function max;
 use function md5;
 use function sprintf;
 use function strcasecmp;
@@ -680,7 +681,25 @@ class IntersectionType implements CompoundType
 
 	public function getArraySize(): Type
 	{
-		return $this->intersectTypes(static fn (Type $type): Type => $type->getArraySize());
+		$arraySize = $this->intersectTypes(static fn (Type $type): Type => $type->getArraySize());
+
+		if ($arraySize instanceof IntegerRangeType) {
+			$knownOffsets = [];
+			foreach ($this->types as $type) {
+				if ($type instanceof HasOffsetValueType) {
+					$knownOffsets[$type->getOffsetType()->getValue()] = true;
+				}
+				if (!($type instanceof HasOffsetType)) {
+					continue;
+				}
+
+				$knownOffsets[$type->getOffsetType()->getValue()] = true;
+			}
+
+			return IntegerRangeType::fromInterval(max(count($knownOffsets), $arraySize->getMin()), $arraySize->getMax());
+		}
+
+		return $arraySize;
 	}
 
 	public function getIterableKeyType(): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -683,17 +683,17 @@ class IntersectionType implements CompoundType
 	{
 		$arraySize = $this->intersectTypes(static fn (Type $type): Type => $type->getArraySize());
 
-		if ($arraySize instanceof IntegerRangeType) {
-			$knownOffsets = [];
-			foreach ($this->types as $type) {
-				if (!($type instanceof HasOffsetValueType) && !($type instanceof HasOffsetType)) {
-					continue;
-				}
-
-				$knownOffsets[$type->getOffsetType()->getValue()] = true;
+		$knownOffsets = [];
+		foreach ($this->types as $type) {
+			if (!($type instanceof HasOffsetValueType) && !($type instanceof HasOffsetType)) {
+				continue;
 			}
 
-			return IntegerRangeType::fromInterval(max(count($knownOffsets), $arraySize->getMin()), $arraySize->getMax());
+			$knownOffsets[$type->getOffsetType()->getValue()] = true;
+		}
+
+		if ($knownOffsets !== []) {
+			return TypeCombinator::intersect($arraySize, IntegerRangeType::fromInterval(count($knownOffsets), null));
 		}
 
 		return $arraySize;

--- a/src/Type/Php/CountFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CountFunctionReturnTypeExtension.php
@@ -13,7 +13,7 @@ use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
 use function count;
 use function in_array;
-use const COUNT_RECURSIVE;
+use const COUNT_NORMAL;
 
 #[AutowiredService]
 final class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -30,11 +30,12 @@ final class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 		Scope $scope,
 	): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 1) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
 		if (!$this->isNormalCount($functionCall, $arrayType, $scope)->yes()) {
 			if ($arrayType->isIterableAtLeastOnce()->yes()) {
 				return IntegerRangeType::fromInterval(1, null);
@@ -42,10 +43,10 @@ final class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 			return null;
 		}
 
-		return $scope->getType($functionCall->getArgs()[0]->value)->getArraySize();
+		return $scope->getType($args[0]->value)->getArraySize();
 	}
 
-	private function isNormalCount(FuncCall $countFuncCall, Type $countedType, Scope $scope,): TrinaryLogic
+	private function isNormalCount(FuncCall $countFuncCall, Type $countedType, Scope $scope): TrinaryLogic
 	{
 		if (count($countFuncCall->getArgs()) === 1) {
 			$isNormalCount = TrinaryLogic::createYes();

--- a/src/Type/Php/CountFunctionReturnTypeExtension.php
+++ b/src/Type/Php/CountFunctionReturnTypeExtension.php
@@ -6,8 +6,10 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\Type;
 use function count;
 use function in_array;
@@ -32,14 +34,26 @@ final class CountFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 			return null;
 		}
 
-		if (count($functionCall->getArgs()) > 1) {
-			$mode = $scope->getType($functionCall->getArgs()[1]->value);
-			if ($mode->isSuperTypeOf(new ConstantIntegerType(COUNT_RECURSIVE))->yes()) {
-				return null;
+		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		if (!$this->isNormalCount($functionCall, $arrayType, $scope)->yes()) {
+			if ($arrayType->isIterableAtLeastOnce()->yes()) {
+				return IntegerRangeType::fromInterval(1, null);
 			}
+			return null;
 		}
 
 		return $scope->getType($functionCall->getArgs()[0]->value)->getArraySize();
+	}
+
+	private function isNormalCount(FuncCall $countFuncCall, Type $countedType, Scope $scope,): TrinaryLogic
+	{
+		if (count($countFuncCall->getArgs()) === 1) {
+			$isNormalCount = TrinaryLogic::createYes();
+		} else {
+			$mode = $scope->getType($countFuncCall->getArgs()[1]->value);
+			$isNormalCount = (new ConstantIntegerType(COUNT_NORMAL))->isSuperTypeOf($mode)->result->or($countedType->getIterableValueType()->isArray()->negate());
+		}
+		return $isNormalCount;
 	}
 
 }

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -2464,7 +2464,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'count($arrayOfIntegers)',
 			],
 			[
-				'int<0, max>',
+				'3',
 				'count($arrayOfIntegers, \COUNT_RECURSIVE)',
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace CountRecursive;
+
 use function PHPStan\Testing\assertType;
 
 class HelloWorld

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -116,14 +116,36 @@ class HelloWorld
 		assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
 
 		$arr = [1, 2, 3, $anotherArray];
+		assertType('array{1, 2, 3, array}', $arr);
 		assertType('4', count($arr));
 		assertType('4', count($arr, COUNT_NORMAL));
 		assertType('int<1, max>', count($arr, COUNT_RECURSIVE)); // could be int<4, max>
 
 		$arr = [1, 2, 3] + $anotherArray;
 		assertType('non-empty-array&hasOffsetValue(0, 1)&hasOffsetValue(1, 2)&hasOffsetValue(2, 3)', $arr);
-		assertType('int<1, max>', count($arr)); // could be int<3, max>
-		assertType('int<1, max>', count($arr, COUNT_NORMAL));  // could be int<3, max>
-		assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
+		assertType('int<3, max>', count($arr));
+		assertType('int<3, max>', count($arr, COUNT_NORMAL));
+		assertType('int<1, max>', count($arr, COUNT_RECURSIVE)); // could be int<3, max>
+	}
+
+	public function countAfterKeyExists(array $array, int $i): void {
+		if (array_key_exists(5, $array)) {
+			assertType('non-empty-array&hasOffset(5)', $array);
+			assertType('int<1, max>', count($array));
+		}
+
+		if ($array !== []) {
+			assertType('non-empty-array', $array);
+			assertType('int<1, max>', count($array));
+			if (array_key_exists(5, $array)) {
+				assertType('non-empty-array&hasOffset(5)', $array);
+				assertType('int<1, max>', count($array));
+
+				if (array_key_exists(15, $array)) {
+					assertType('non-empty-array&hasOffset(15)&hasOffset(5)', $array);
+					assertType('int<2, max>', count($array));
+				}
+			}
+		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -36,6 +36,17 @@ class HelloWorld
 		}
 	}
 
+	public function countArrayUnionMode(array $arr): void
+	{
+		$mode = rand(0,1) ? COUNT_NORMAL : COUNT_RECURSIVE;
+		if (count($arr, $mode) > 2) {
+			assertType('non-empty-array', $arr);
+			assertType('int<3, max>', count($arr, $mode));
+			assertType('int<1, max>', count($arr, COUNT_NORMAL));
+			assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
 	/** @param list<int> $list */
 	public function countList($list): void
 	{

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -1,0 +1,66 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function countArray(array $arr): void
+	{
+		if (count($arr) > 2) {
+			assertType('non-empty-array', $arr);
+			assertType('int<3, max>', count($arr));
+			assertType('int<1, max>', count($arr, COUNT_NORMAL)); // could be int<3, max>
+			assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
+	public function countArrayNormal(array $arr): void
+	{
+		if (count($arr, COUNT_NORMAL) > 2) {
+			assertType('non-empty-array', $arr);
+			assertType('int<1, max>', count($arr)); // could be int<3, max>
+			assertType('int<3, max>', count($arr, COUNT_NORMAL));
+			assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
+	public function countArrayRecursive(array $arr): void
+	{
+		if (count($arr, COUNT_RECURSIVE) > 2) {
+			assertType('non-empty-array', $arr);
+			assertType('int<1, max>', count($arr));
+			assertType('int<1, max>', count($arr, COUNT_NORMAL));
+			assertType('int<3, max>', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
+	/** @param list<int> $list */
+	public function countList($list): void
+	{
+		if (count($list) > 2) {
+			assertType('int<3, max>', count($list));
+			assertType('int<1, max>', count($list, COUNT_NORMAL));
+			assertType('int<1, max>', count($list, COUNT_RECURSIVE));
+		}
+	}
+
+	/** @param list<int> $list */
+	public function countListNormal($list): void
+	{
+		if (count($list, COUNT_NORMAL) > 2) {
+			assertType('int<1, max>', count($list));
+			assertType('int<3, max>', count($list, COUNT_NORMAL));
+			assertType('int<1, max>', count($list, COUNT_RECURSIVE));
+		}
+	}
+
+	/** @param list<int> $list */
+	public function countListRecursive($list): void
+	{
+		if (count($list, COUNT_RECURSIVE) > 2) {
+			assertType('int<1, max>', count($list));
+			assertType('int<1, max>', count($list, COUNT_NORMAL));
+			assertType('int<3, max>', count($list, COUNT_RECURSIVE));
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -121,6 +121,14 @@ class HelloWorld
 		assertType('4', count($arr, COUNT_NORMAL));
 		assertType('int<1, max>', count($arr, COUNT_RECURSIVE)); // could be int<4, max>
 
+		if (rand(0,1)) {
+			$arr[] = 10;
+		}
+		assertType('array{0: 1, 1: 2, 2: 3, 3: array, 4?: 10}', $arr);
+		assertType('int<4, 5>', count($arr));
+		assertType('int<4, 5>', count($arr, COUNT_NORMAL));
+		assertType('int<1, max>', count($arr, COUNT_RECURSIVE)); // could be int<4, max>
+
 		$arr = [1, 2, 3] + $anotherArray;
 		assertType('non-empty-array&hasOffsetValue(0, 1)&hasOffsetValue(1, 2)&hasOffsetValue(2, 3)', $arr);
 		assertType('int<3, max>', count($arr));

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -99,6 +99,27 @@ class HelloWorld
 		}
 	}
 
+	public function countImplicitNormal($mode): void
+	{
+		$arr = [1, 2, 3];
+		if (count($arr, $mode) > 2) {
+			assertType('3', count($arr));
+			assertType('3', count($arr, $mode));
+			assertType('3', count($arr, COUNT_NORMAL));
+			assertType('3', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
+	public function countMixed($arr, $mode): void
+	{
+		if (count($arr, $mode) > 2) {
+			assertType('int<0, max>', count($arr));
+			assertType('int<3, max>', count($arr, $mode));
+			assertType('int<0, max>', count($arr, COUNT_NORMAL));
+			assertType('int<0, max>', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
 	/** @param list<int> $list */
 	public function countListRecursive($list): void
 	{

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -210,4 +210,20 @@ class HelloWorld
 			}
 		}
 	}
+
+	public function countMaybeCountable(array $arr, bool $b, int $i) {
+		$c = rand(0,1) ? $arr : $b;
+		assertType('array|bool', $c);
+		assertType('int<0, max>', count($c, $i));
+
+		if ($arr === []) {
+			return;
+		}
+		assertType('int<1, max>', count($arr, $i));
+
+		$c = rand(0,1) ? $arr : $b;
+		assertType('non-empty-array|bool', $c);
+		assertType('int<0, max>', count($c, $i));
+
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -130,6 +130,24 @@ class HelloWorld
 		}
 	}
 
+	/** @param arary<int> $array */
+	public function countListRecursiveOnUnionOfRanges($array): void
+	{
+		if (!array_key_exists(5, $array)) {
+			return;
+		}
+		assertType('non-empty-array&hasOffset(5)', $array);
+		assertType('int<1, max>', count($array));
+
+		if (
+			(count($array) > 2 && count($array) < 5)
+			|| (count($array) > 20 && count($array) < 50)
+		) {
+			assertType('int<3, 4>|int<21, 49>', count($array));
+		}
+	}
+
+
 	public function countConstantArray(array $anotherArray): void {
 		$arr = [1, 2, 3, [4, 5]];
 		assertType('4', count($arr));
@@ -174,6 +192,21 @@ class HelloWorld
 					assertType('non-empty-array&hasOffset(15)&hasOffset(5)', $array);
 					assertType('int<2, max>', count($array));
 				}
+			}
+		}
+	}
+
+	public function unionIntegerCountAfterKeyExists(array $array, int $i): void {
+		if ($array === []) {
+			return;
+		}
+
+		assertType('non-empty-array', $array);
+		if (count($array) === 3 || count($array) === 4) {
+			assertType('3|4', count($array));
+			if (array_key_exists(5, $array)) {
+				assertType('non-empty-array&hasOffset(5)', $array);
+				assertType('3|4', count($array));
 			}
 		}
 	}

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -108,4 +108,22 @@ class HelloWorld
 			assertType('int<3, max>', count($list, COUNT_RECURSIVE));
 		}
 	}
+
+	public function countConstantArray(array $anotherArray): void {
+		$arr = [1, 2, 3, [4, 5]];
+		assertType('4', count($arr));
+		assertType('4', count($arr, COUNT_NORMAL));
+		assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
+
+		$arr = [1, 2, 3, $anotherArray];
+		assertType('4', count($arr));
+		assertType('4', count($arr, COUNT_NORMAL));
+		assertType('int<1, max>', count($arr, COUNT_RECURSIVE)); // could be int<4, max>
+
+		$arr = [1, 2, 3] + $anotherArray;
+		assertType('non-empty-array&hasOffsetValue(0, 1)&hasOffsetValue(1, 2)&hasOffsetValue(2, 3)', $arr);
+		assertType('int<1, max>', count($arr)); // could be int<3, max>
+		assertType('int<1, max>', count($arr, COUNT_NORMAL));  // could be int<3, max>
+		assertType('int<1, max>', count($arr, COUNT_RECURSIVE));
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -6,6 +6,24 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
+	public function countUnknownArray(array $arr): void
+	{
+		assertType('array', $arr);
+		assertType('int<0, max>', count($arr));
+		assertType('int<0, max>', count($arr, COUNT_NORMAL));
+		assertType('int<0, max>', count($arr, COUNT_RECURSIVE));
+	}
+
+	public function countEmptyArray(array $arr): void
+	{
+		if (count($arr) == 0) {
+			assertType('array{}', $arr);
+			assertType('0', count($arr));
+			assertType('0', count($arr, COUNT_NORMAL));
+			assertType('0', count($arr, COUNT_RECURSIVE));
+		}
+	}
+
 	public function countArray(array $arr): void
 	{
 		if (count($arr) > 2) {

--- a/tests/PHPStan/Analyser/nsrt/count-recursive.php
+++ b/tests/PHPStan/Analyser/nsrt/count-recursive.php
@@ -6,6 +6,20 @@ use function PHPStan\Testing\assertType;
 
 class HelloWorld
 {
+	/**
+	 * @param array<array<mixed>> $muliDimArr
+	 * @return void
+	 */
+	public function countMultiDim(array $muliDimArr, $mixed): void
+	{
+		if (count($muliDimArr, $mixed) > 2) {
+			assertType('int<1, max>', count($muliDimArr));
+			assertType('int<3, max>', count($muliDimArr, $mixed));
+			assertType('int<1, max>', count($muliDimArr, COUNT_NORMAL));
+			assertType('int<1, max>', count($muliDimArr, COUNT_RECURSIVE));
+		}
+	}
+
 	public function countUnknownArray(array $arr): void
 	{
 		assertType('array', $arr);


### PR DESCRIPTION
Before this PR it was taken as `int<0, max>`