### PR TITLE
Mutation Testing: Create coverage in parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,6 +232,10 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress"
 
+      - name: "Install Tests dependencies"
+        working-directory: "tests"
+        run: "composer install --no-interaction --no-progress"
+
       - name: "Install build-infection dependencies"
         working-directory: "build-infection"
         run: "composer install --no-interaction --no-progress"
@@ -259,7 +263,7 @@ jobs:
 
       - name: "Create coverage in parallel"
         run: |
-          php -d pcov.enabled=1 vendor/bin/paratest \
+          php -d pcov.enabled=1 tests/vendor/bin/paratest \
             --passthru-php="'-d' 'pcov.enabled=1'" \
             --runner WrapperRunner \
             --coverage-xml=coverage-xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -259,10 +259,10 @@ jobs:
 
       - name: "Create coverage"
         run: |
-          php -d pcov.enabled=1 tests/vendor/bin/paratest \
+          php -d pcov.enabled=1 vendor/bin/paratest \
             --passthru-php="'-d' 'pcov.enabled=1'" \
             --runner WrapperRunner \
-            --coverage-xml=coverage.xml
+            --coverage-xml=coverage-xml
 
       - name: "Run infection"
         run: |
@@ -270,7 +270,7 @@ jobs:
           infection \
             --git-diff-base=origin/${{ steps.default-branch.outputs.name }} \
             --git-diff-lines \
-            --coverage=coverage.xml \
+            --coverage=coverage-xml \
             --skip-initial-tests \
             --ignore-msi-with-no-mutations \
             --min-msi=100 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,16 +229,15 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: ds,mbstring
 
-      - name: "Install dependencies"
-        run: "composer install --no-interaction --no-progress"
+      - uses: "ramsey/composer-install@v3"
 
-      - name: "Install Tests dependencies"
-        working-directory: "tests"
-        run: "composer install --no-interaction --no-progress"
+      - uses: "ramsey/composer-install@v3"
+        with:
+          working-directory: "tests/"
 
-      - name: "Install build-infection dependencies"
-        working-directory: "build-infection"
-        run: "composer install --no-interaction --no-progress"
+      - uses: "ramsey/composer-install@v3"
+        with:
+          working-directory: "build-infection/"
 
       - name: "Configure infection"
         run: |
@@ -261,12 +260,13 @@ jobs:
           restore-keys: |
             result-cache-v1-${{ matrix.php-version }}-
 
+      # see https://infection.github.io/guide/command-line-options.html#coverage
       - name: "Create coverage in parallel"
         run: |
           php -d pcov.enabled=1 tests/vendor/bin/paratest \
             --passthru-php="'-d' 'pcov.enabled=1'" \
             --runner WrapperRunner \
-            --coverage-xml=coverage-xml
+            --coverage-xml=tmp/coverage/coverage-xml --log-junit=tmp/coverage/junit.xml
 
       - name: "Run infection"
         run: |
@@ -274,7 +274,7 @@ jobs:
           infection \
             --git-diff-base=origin/${{ steps.default-branch.outputs.name }} \
             --git-diff-lines \
-            --coverage=coverage-xml \
+            --coverage=tmp/coverage \
             --skip-initial-tests \
             --ignore-msi-with-no-mutations \
             --min-msi=100 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
   mutation-testing:
     name: "Mutation Testing"
     runs-on: "ubuntu-latest"
-    needs: ["tests"]
+    #needs: ["tests"]
     if: github.event_name == 'pull_request'
 
     strategy:
@@ -257,7 +257,7 @@ jobs:
           restore-keys: |
             result-cache-v1-${{ matrix.php-version }}-
 
-      - name: "Create coverage"
+      - name: "Create coverage in parallel"
         run: |
           php -d pcov.enabled=1 vendor/bin/paratest \
             --passthru-php="'-d' 'pcov.enabled=1'" \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,7 +258,11 @@ jobs:
             result-cache-v1-${{ matrix.php-version }}-
 
       - name: "Create coverage"
-        run: php -d pcov.enabled=1 tests/vendor/bin/paratest --passthru-php="'-d' 'pcov.enabled=1'" --runner WrapperRunner
+        run: |
+          php -d pcov.enabled=1 tests/vendor/bin/paratest \
+            --passthru-php="'-d' 'pcov.enabled=1'" \
+            --runner WrapperRunner \
+            --coverage-xml=coverage.xml
 
       - name: "Run infection"
         run: |
@@ -266,6 +270,7 @@ jobs:
           infection \
             --git-diff-base=origin/${{ steps.default-branch.outputs.name }} \
             --git-diff-lines \
+            --coverage=coverage.xml \
             --skip-initial-tests \
             --ignore-msi-with-no-mutations \
             --min-msi=100 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
   mutation-testing:
     name: "Mutation Testing"
     runs-on: "ubuntu-latest"
-    #needs: ["tests"]
+    needs: ["tests"]
     if: github.event_name == 'pull_request'
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -257,12 +257,16 @@ jobs:
           restore-keys: |
             result-cache-v1-${{ matrix.php-version }}-
 
+      - name: "Create coverage"
+        run: php -d pcov.enabled=1 tests/vendor/bin/paratest --passthru-php="'-d' 'pcov.enabled=1'" --runner WrapperRunner
+
       - name: "Run infection"
         run: |
           git fetch --depth=1 origin ${{ steps.default-branch.outputs.name }}
           infection \
             --git-diff-base=origin/${{ steps.default-branch.outputs.name }} \
             --git-diff-lines \
+            --skip-initial-tests \
             --ignore-msi-with-no-mutations \
             --min-msi=100 \
             --min-covered-msi=100 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -265,7 +265,6 @@ jobs:
         run: |
           php -d pcov.enabled=1 tests/vendor/bin/paratest \
             --passthru-php="'-d' 'pcov.enabled=1'" \
-            --runner WrapperRunner \
             --coverage-xml=tmp/coverage/coverage-xml --log-junit=tmp/coverage/junit.xml
 
       - name: "Run infection"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,5 +15,10 @@
       <group>levels</group>
     </exclude>
   </groups>
+  <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
   <logging/>
 </phpunit>

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -46,6 +46,7 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 		$callback = $functionCall->getArgs()[0]->value;
 		$callableType = $scope->getType($callback);
 		$callableIsNull = $callableType->isNull()->yes();
+		$x = $callableType->isNull()->yes();
 
 		if ($callableType->isCallable()->yes()) {
 			$valueType = $scope->getType(new FuncCall(

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -46,7 +46,6 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 		$callback = $functionCall->getArgs()[0]->value;
 		$callableType = $scope->getType($callback);
 		$callableIsNull = $callableType->isNull()->yes();
-		$x = $callableType->isNull()->yes();
 
 		if ($callableType->isCallable()->yes()) {
 			$valueType = $scope->getType(new FuncCall(


### PR DESCRIPTION
the initial test-run takes 15m 36s on GitHub Actions, since infection natively runs it on a single process.
<img width="1125" height="276" alt="grafik" src="https://github.com/user-attachments/assets/218ab201-ac47-43fe-972b-a975a988052e" />

with this PR we create the coverage beforhand with ParaUnit, which should be faster:
<img width="1130" height="547" alt="grafik" src="https://github.com/user-attachments/assets/bfad6d00-6227-499a-b7ef-b540a50e49b4" />

so 15m 36s => 12m 26s