### PR TITLE
Added #[Covers*] attributes to tests

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -11,11 +11,13 @@ use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function extension_loaded;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class AnalyserIntegrationTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -31,6 +31,7 @@ use PHPStan\Rules\DirectRegistry as DirectRuleRegistry;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\FileTypeMapper;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use function array_map;
@@ -44,6 +45,7 @@ use function strtoupper;
 use function substr;
 use const PHP_OS;
 
+#[CoversNothing]
 class AnalyserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser;
 use Override;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function array_map;
 use function array_merge;
@@ -12,6 +13,7 @@ use function array_unique;
 use function sprintf;
 use function usort;
 
+#[CoversNothing]
 class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/AnalyserWithCheckDynamicPropertiesTest.php
+++ b/tests/PHPStan/Analyser/AnalyserWithCheckDynamicPropertiesTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use function array_merge;
 use function array_unique;
 
+#[CoversNothing]
 class AnalyserWithCheckDynamicPropertiesTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/ArgumentsNormalizerLegacyTest.php
+++ b/tests/PHPStan/Analyser/ArgumentsNormalizerLegacyTest.php
@@ -13,8 +13,10 @@ use PHPStan\Reflection\SignatureMap\NativeFunctionReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
+#[CoversNothing]
 final class ArgumentsNormalizerLegacyTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/ArgumentsNormalizerTest.php
+++ b/tests/PHPStan/Analyser/ArgumentsNormalizerTest.php
@@ -17,9 +17,11 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function count;
 
+#[CoversNothing]
 class ArgumentsNormalizerTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/ErrorTest.php
+++ b/tests/PHPStan/Analyser/ErrorTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\Analyser;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class ErrorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -10,11 +10,13 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function count;
 use function get_class;
 use function sprintf;
 
+#[CoversNothing]
 class ExpressionResultTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/Ignore/IgnoreLexerTest.php
+++ b/tests/PHPStan/Analyser/Ignore/IgnoreLexerTest.php
@@ -3,11 +3,13 @@
 namespace PHPStan\Analyser\Ignore;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_pop;
 use function substr_count;
 use const PHP_EOL;
 
+#[CoversNothing]
 class IgnoreLexerTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -16,8 +16,10 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class ScopeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -10,9 +10,11 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\StringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class StatementResultTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
@@ -4,8 +4,10 @@ namespace PHPStan\Analyser;
 
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class TypeSpecifierContextTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -36,6 +36,7 @@ use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function implode;
 use function sprintf;
@@ -43,6 +44,7 @@ use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class TypeSpecifierTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Collectors/RegistryTest.php
+++ b/tests/PHPStan/Collectors/RegistryTest.php
@@ -5,7 +5,9 @@ namespace PHPStan\Collectors;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class RegistryTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -13,6 +13,7 @@ use PHPStan\File\NullRelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -22,6 +23,7 @@ use function sprintf;
 use function stream_get_contents;
 use const DIRECTORY_SEPARATOR;
 
+#[CoversNothing]
 class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Command;
 
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -17,6 +18,7 @@ use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 
 #[Group('exec')]
+#[CoversNothing]
 class AnalyseCommandTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/AnalysisResultTest.php
+++ b/tests/PHPStan/Command/AnalysisResultTest.php
@@ -4,7 +4,9 @@ namespace PHPStan\Command;
 
 use PHPStan\Analyser\Error;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 final class AnalysisResultTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
+++ b/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
@@ -6,8 +6,10 @@ use Hoa\Compiler\Llk\Llk;
 use Hoa\File\Read;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class IgnoredRegexValidatorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/DependencyInjection/ConditionalTagsExtensionTest.php
+++ b/tests/PHPStan/DependencyInjection/ConditionalTagsExtensionTest.php
@@ -4,9 +4,11 @@ namespace PHPStan\DependencyInjection;
 
 use PHPStan\Rules\LazyRegistry;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use function array_map;
 use function get_class;
 
+#[CoversNothing]
 class ConditionalTagsExtensionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/DependencyInjection/IgnoreErrorsTest.php
+++ b/tests/PHPStan/DependencyInjection/IgnoreErrorsTest.php
@@ -3,7 +3,9 @@
 namespace PHPStan\DependencyInjection;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class IgnoreErrorsTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/DependencyInjection/InvalidIgnoredErrorExceptionTest.php
+++ b/tests/PHPStan/DependencyInjection/InvalidIgnoredErrorExceptionTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\DependencyInjection;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class InvalidIgnoredErrorExceptionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/DependencyInjection/Nette/NetteContainerTest.php
+++ b/tests/PHPStan/DependencyInjection/Nette/NetteContainerTest.php
@@ -6,7 +6,9 @@ use PHPStan\DependencyInjection\MissingServiceException;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Php\ReflectionGetAttributesMethodReturnTypeExtension;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class NetteContainerTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\File;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class FileExcluderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/File/FileHelperTest.php
+++ b/tests/PHPStan/File/FileHelperTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\File;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class FileHelperTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -15,9 +15,11 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class TemplateTypeFactoryTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -8,9 +8,11 @@ use PhpParser\Node\Stmt\Namespace_;
 use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[CoversNothing]
 class CachedParserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Parser/CleaningParserTest.php
+++ b/tests/PHPStan/Parser/CleaningParserTest.php
@@ -9,9 +9,11 @@ use PHPStan\File\FileReader;
 use PHPStan\Node\Printer\Printer;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class CleaningParserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Parser/ParserTest.php
+++ b/tests/PHPStan/Parser/ParserTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Parser;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function count;
 
+#[CoversNothing]
 class ParserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Parser/RichParserTest.php
+++ b/tests/PHPStan/Parser/RichParserTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Parser;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_EOL;
 
+#[CoversNothing]
 class RichParserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
+++ b/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
@@ -5,10 +5,12 @@ namespace PHPStan\PhpDoc;
 use Override;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use function dirname;
 use function sprintf;
 use const DIRECTORY_SEPARATOR;
 
+#[CoversNothing]
 class DefaultStubFilesProviderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/PhpDoc/PhpDocStringResolverTest.php
+++ b/tests/PHPStan/PhpDoc/PhpDocStringResolverTest.php
@@ -4,7 +4,9 @@ namespace PHPStan\PhpDoc;
 
 use PHPStan\PhpDocParser\Parser\ParserException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class PhpDocStringResolverTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/PhpDoc/TypeDescriptionTest.php
+++ b/tests/PHPStan/PhpDoc/TypeDescriptionTest.php
@@ -19,9 +19,11 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class TypeDescriptionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/PhpDoc/TypeStringResolverTest.php
+++ b/tests/PHPStan/PhpDoc/TypeStringResolverTest.php
@@ -4,7 +4,9 @@ namespace PHPStan\PhpDoc;
 
 use PHPStan\PhpDocParser\Parser\ParserException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class TypeStringResolverTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -12,11 +12,13 @@ use PHPStan\Reflection\PassedByReference;
 use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_merge;
 use function count;
 use function sprintf;
 
+#[CoversNothing]
 class AnnotationsMethodsClassReflectionExtensionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -11,9 +11,11 @@ use AnnotationsProperties\FooInterface;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class AnnotationsPropertiesClassReflectionExtensionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -16,10 +16,12 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class DeprecatedAnnotationsTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
@@ -6,8 +6,10 @@ use FinalAnnotations\FinalFoo;
 use FinalAnnotations\Foo;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class FinalAnnotationsTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
@@ -11,8 +11,10 @@ use InternalAnnotations\InternalFooTrait;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class InternalAnnotationsTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use ThrowsAnnotations\BarTrait;
@@ -14,6 +15,7 @@ use ThrowsAnnotations\FooInterface;
 use ThrowsAnnotations\FooTrait;
 use ThrowsAnnotations\PhpstanFoo;
 
+#[CoversNothing]
 class ThrowsAnnotationsTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/AttributeReflectionTest.php
+++ b/tests/PHPStan/Reflection/AttributeReflectionTest.php
@@ -7,11 +7,13 @@ use AttributeReflectionTest\MyAttr;
 use PhpParser\Node\Name;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function count;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class AttributeReflectionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
@@ -17,6 +17,7 @@ function testFunctionForLocator(): void // phpcs:disable
 	echo 'test';
 }
 
+#[\PHPUnit\Framework\Attributes\CoversNothing]
 class AutoloadSourceLocatorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
@@ -8,6 +8,7 @@ use PHPStan\BetterReflection\Reflection\Reflection;
 use PHPStan\BetterReflection\Reflector\DefaultReflector;
 use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TestDirectorySourceLocator\AFoo;
 use TestDirectorySourceLocator\EmptyClass;
@@ -15,6 +16,7 @@ use function array_map;
 use function basename;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
@@ -10,12 +10,14 @@ use PHPStan\Reflection\InitializerExprContext;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SingleFileSourceLocatorTestClass;
 use TestSingleFileSourceLocator\AFoo;
 use function array_map;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class OptimizedSingleFileSourceLocatorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/ClassReflectionPropertyHooksTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionPropertyHooksTest.php
@@ -7,11 +7,13 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function count;
 
 #[RequiresPhp('>= 8.4')]
+#[CoversNothing]
 class ClassReflectionPropertyHooksTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -30,6 +30,7 @@ use NestedTraits\NoTrait;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\IntegerType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
@@ -38,6 +39,7 @@ use WrongClassConstantFile\SecuredRouter;
 use function array_map;
 use function array_values;
 
+#[CoversNothing]
 class ClassReflectionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
+++ b/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
@@ -5,9 +5,11 @@ namespace PHPStan\Reflection\Constant;
 use PhpParser\Node\Name;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class RuntimeConstantReflectionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Deprecation/DeprecationProviderTest.php
+++ b/tests/PHPStan/Reflection/Deprecation/DeprecationProviderTest.php
@@ -15,8 +15,10 @@ use PhpParser\Node\Name\FullyQualified;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
+#[CoversNothing]
 class DeprecationProviderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/FunctionReflectionTest.php
+++ b/tests/PHPStan/Reflection/FunctionReflectionTest.php
@@ -6,9 +6,11 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class FunctionReflectionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -17,11 +17,13 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function count;
 use function get_class;
 use function sprintf;
 
+#[CoversNothing]
 class GenericParametersAcceptorResolverTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/InitializerExprTypeResolverTest.php
+++ b/tests/PHPStan/Reflection/InitializerExprTypeResolverTest.php
@@ -10,8 +10,10 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class InitializerExprTypeResolverTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/MixedTypeTest.php
+++ b/tests/PHPStan/Reflection/MixedTypeTest.php
@@ -6,8 +6,10 @@ use NativeMixedType\Foo;
 use PhpParser\Node\Name;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\MixedType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class MixedTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -32,10 +32,12 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_map;
 use function count;
 
+#[CoversNothing]
 class ParametersAcceptorSelectorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
@@ -6,8 +6,10 @@ use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use stdClass;
 
+#[CoversNothing]
 class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
@@ -13,6 +13,7 @@ use PHPStan\Php8StubsMap;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
@@ -39,6 +40,7 @@ use function trim;
 use const PHP_INT_MAX;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class ReflectionProviderGoldenTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/ReflectionProviderTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderTest.php
@@ -9,10 +9,12 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class ReflectionProviderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
@@ -5,7 +5,9 @@ namespace PHPStan\Reflection\SignatureMap;
 use Nette\Schema\Expect;
 use Nette\Schema\Processor;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class FunctionMetadataTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -34,12 +34,14 @@ use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_map;
 use function array_merge;
 use function count;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class Php8SignatureMapProviderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -28,6 +28,7 @@ use PHPStan\Type\StaticType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionParameter;
 use Throwable;
@@ -37,6 +38,7 @@ use function explode;
 use function sprintf;
 use function strpos;
 
+#[CoversNothing]
 class SignatureMapParserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
@@ -5,7 +5,9 @@ namespace PHPStan\Reflection\Type;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class IntersectionTypeMethodReflectionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
@@ -5,7 +5,9 @@ namespace PHPStan\Reflection\Type;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class UnionTypeMethodReflectionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Reflection/UnionTypesTest.php
+++ b/tests/PHPStan/Reflection/UnionTypesTest.php
@@ -7,7 +7,9 @@ use PhpParser\Node\Name;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class UnionTypesTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Rules/DirectRegistryTest.php
+++ b/tests/PHPStan/Rules/DirectRegistryTest.php
@@ -5,7 +5,9 @@ namespace PHPStan\Rules;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class DirectRegistryTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
+++ b/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
@@ -8,8 +8,10 @@ use LogicException;
 use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class DefaultExceptionTypeResolverTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/TrinaryLogicTest.php
+++ b/tests/PHPStan/TrinaryLogicTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class TrinaryLogicTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
@@ -17,9 +17,11 @@ use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class HasMethodTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
@@ -16,10 +16,12 @@ use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class HasPropertyTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -12,10 +12,12 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_map;
 use function sprintf;
 
+#[CoversNothing]
 class ArrayTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/BenevolentUnionTypeTest.php
+++ b/tests/PHPStan/Type/BenevolentUnionTypeTest.php
@@ -14,9 +14,11 @@ use PHPStan\Type\Accessory\HasPropertyType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class BenevolentUnionTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/BitwiseFlagHelperTest.php
+++ b/tests/PHPStan/Type/BitwiseFlagHelperTest.php
@@ -12,10 +12,12 @@ use PHPStan\Analyser\ScopeContext;
 use PHPStan\Analyser\ScopeFactory;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function defined;
 use function sprintf;
 
+#[CoversNothing]
 final class BitwiseFlagHelperTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/BooleanTypeTest.php
+++ b/tests/PHPStan/Type/BooleanTypeTest.php
@@ -6,9 +6,11 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class BooleanTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -16,10 +16,12 @@ use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_map;
 use function sprintf;
 
+#[CoversNothing]
 class CallableTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/ClassStringTypeTest.php
+++ b/tests/PHPStan/Type/ClassStringTypeTest.php
@@ -7,10 +7,12 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use function sprintf;
 
+#[CoversNothing]
 class ClassStringTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/ClosureTypeFactoryTest.php
+++ b/tests/PHPStan/Type/ClosureTypeFactoryTest.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type;
 
 use Closure;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_VERSION_ID;
 
 /**
  * @phpstan-consistent-constructor
  */
+#[CoversNothing]
 class ClosureTypeFactoryTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/ClosureTypeTest.php
+++ b/tests/PHPStan/Type/ClosureTypeTest.php
@@ -5,9 +5,11 @@ namespace PHPStan\Type;
 use Closure;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class ClosureTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -8,7 +8,9 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -25,10 +25,12 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_map;
 use function sprintf;
 
+#[CoversNothing]
 class ConstantArrayTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
@@ -4,8 +4,10 @@ namespace PHPStan\Type\Constant;
 
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class ConstantFloatTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
@@ -7,9 +7,11 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class ConstantIntegerTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -17,11 +17,13 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Throwable;
 use function sprintf;
 
+#[CoversNothing]
 class ConstantStringTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Constant/OversizedArrayBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/OversizedArrayBuilderTest.php
@@ -10,8 +10,10 @@ use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class OversizedArrayBuilderTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php
+++ b/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php
@@ -10,10 +10,12 @@ use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function sprintf;
 
+#[CoversNothing]
 class EnumCaseObjectTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -6,9 +6,11 @@ use DependentPhpDocs\Foo;
 use PHPStan\PhpDoc\Tag\ReturnTag;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use RuntimeException;
 use function realpath;
 
+#[CoversNothing]
 class FileTypeMapperTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/FloatTypeTest.php
+++ b/tests/PHPStan/Type/FloatTypeTest.php
@@ -7,9 +7,11 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class FloatTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
@@ -20,11 +20,13 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Throwable;
 use function sprintf;
 
+#[CoversNothing]
 class GenericClassStringTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -21,6 +21,7 @@ use PHPStan\Type\Test\E;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use stdClass;
@@ -29,6 +30,7 @@ use function array_map;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class GenericObjectTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
@@ -7,7 +7,9 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 
+#[CoversNothing]
 class TemplateTypeHelperTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Generic/TemplateTypeMapTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeMapTest.php
@@ -7,8 +7,10 @@ use InvalidArgumentException;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class TemplateTypeMapTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Generic/TemplateTypeVarianceTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeVarianceTest.php
@@ -10,9 +10,11 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class TemplateTypeVarianceTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/IntegerTypeTest.php
+++ b/tests/PHPStan/Type/IntegerTypeTest.php
@@ -7,9 +7,11 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\Constant\ConstantFloatType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class IntegerTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/IntersectionTypeTest.php
+++ b/tests/PHPStan/Type/IntersectionTypeTest.php
@@ -17,6 +17,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Test\ClassWithToString;
@@ -25,6 +26,7 @@ use function count;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class IntersectionTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -11,10 +11,12 @@ use PHPStan\Type\Generic\TemplateMixedType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function array_map;
 use function sprintf;
 
+#[CoversNothing]
 class IterableTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -13,9 +13,11 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class MixedTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -35,6 +35,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\ConstantNumericComparisonTypeTrait;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use SimpleXMLElement;
@@ -46,6 +47,7 @@ use function count;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class ObjectTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
+++ b/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
@@ -5,9 +5,11 @@ namespace PHPStan\Type;
 use InvalidArgumentException;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\TrinaryLogic;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use function sprintf;
 
+#[CoversNothing]
 class ObjectWithoutClassTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/Regex/RegexExpressionHelperTest.php
+++ b/tests/PHPStan/Type/Regex/RegexExpressionHelperTest.php
@@ -3,8 +3,10 @@
 namespace PHPStan\Type\Regex;
 
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class RegexExpressionHelperTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/SimultaneousTypeTraverserTest.php
+++ b/tests/PHPStan/Type/SimultaneousTypeTraverserTest.php
@@ -7,8 +7,10 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class SimultaneousTypeTraverserTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/StaticTypeTest.php
+++ b/tests/PHPStan/Type/StaticTypeTest.php
@@ -18,6 +18,7 @@ use PHPStan\Type\Generic\GenericStaticType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use StaticTypeTest\Base;
 use StaticTypeTest\Child;
@@ -26,6 +27,7 @@ use stdClass;
 use Traversable;
 use function sprintf;
 
+#[CoversNothing]
 class StaticTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/StringTypeTest.php
+++ b/tests/PHPStan/Type/StringTypeTest.php
@@ -11,11 +11,13 @@ use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Test\ClassWithToString;
 use function sprintf;
 
+#[CoversNothing]
 class StringTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use Throwable;
@@ -21,6 +22,7 @@ use function array_map;
 use function assert;
 use function sprintf;
 
+#[CoversNothing]
 class TemplateTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/TestDecimalOperatorTypeSpecifyingExtensionTest.php
+++ b/tests/PHPStan/Type/TestDecimalOperatorTypeSpecifyingExtensionTest.php
@@ -4,9 +4,11 @@ namespace PHPStan\Type;
 
 use PHPStan\Fixture\TestDecimal;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 
+#[CoversNothing]
 class TestDecimalOperatorTypeSpecifyingExtensionTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -48,6 +48,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RecursionCallable\Foo;
 use stdClass;
@@ -63,6 +64,7 @@ use function implode;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class TypeCombinatorTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/TypeGetFiniteTypesTest.php
+++ b/tests/PHPStan/Type/TypeGetFiniteTypesTest.php
@@ -10,8 +10,10 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class TypeGetFiniteTypesTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
+++ b/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
@@ -20,12 +20,14 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use stdClass;
 use function sprintf;
 use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
+#[CoversNothing]
 class TypeToPhpDocNodeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -27,6 +27,7 @@ use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RecursionCallable\Foo;
 use stdClass;
@@ -36,6 +37,7 @@ use function get_class;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class UnionTypeTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Type/VerbosityLevelTest.php
+++ b/tests/PHPStan/Type/VerbosityLevelTest.php
@@ -7,8 +7,10 @@ use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\Generic\TemplateTypeVariance;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[CoversNothing]
 class VerbosityLevelTest extends PHPStanTestCase
 {
 


### PR DESCRIPTION
goal: speedup the coverage generation process

refs https://github.com/paratestphp/paratest/issues/1044

before this PR
```
XDEBUG_MODE=coverage php tests/vendor/bin/paratest --coverage-xml=tmp/coverage-xml 
...
Time: 07:41.109, Memory: 618.50 MB

OK, but some tests were skipped!
Tests: 13325, Assertions: 80593, Skipped: 170.

Generating code coverage report in PHPUnit XML format ... done [00:34.753]
```

after this PR
```
XDEBUG_MODE=coverage php tests/vendor/bin/paratest --coverage-xml=tmp/coverage-xml 
...
Time: 03:37.977, Memory: 668.50 MB

OK, but some tests were skipped!
Tests: 13325, Assertions: 80593, Skipped: 170.

Generating code coverage report in PHPUnit XML format ... done [00:32.811]
```

Next: figure out whether we can utilize it and which annotations make sense where