### PR TITLE
Add `#[CoversNothing]`

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -11,11 +11,13 @@ use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function extension_loaded;
 use function sprintf;
 use const PHP_VERSION_ID;
 
+#[CoversNothing]
 class AnalyserIntegrationTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Analyser;
 use Override;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use function array_map;
 use function array_merge;
@@ -12,6 +13,7 @@ use function array_unique;
 use function sprintf;
 use function usort;
 
+#[CoversNothing]
 class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -13,6 +13,7 @@ use PHPStan\File\NullRelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -22,6 +23,7 @@ use function sprintf;
 use function stream_get_contents;
 use const DIRECTORY_SEPARATOR;
 
+#[CoversNothing]
 class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Command;
 
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -17,6 +18,7 @@ use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
 
 #[Group('exec')]
+#[CoversNothing]
 class AnalyseCommandTest extends PHPStanTestCase
 {
 

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Command;
 
 use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -16,6 +17,7 @@ use function stream_get_contents;
 use const DIRECTORY_SEPARATOR;
 
 #[Group('exec')]
+#[CoversNothing]
 class CommandHelperTest extends TestCase
 {
 

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Command\ErrorFormatter;
 
 use Nette\Utils\Json;
 use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use function array_sum;
@@ -17,6 +18,7 @@ use function unlink;
 use const PHP_BINARY;
 
 #[Group('exec')]
+#[CoversNothing]
 class BaselineNeonErrorFormatterIntegrationTest extends TestCase
 {
 

--- a/tests/PHPStan/Generics/GenericsIntegrationTest.php
+++ b/tests/PHPStan/Generics/GenericsIntegrationTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Generics;
 
 use PHPStan\Testing\LevelsTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('levels')]
+#[CoversNothing]
 class GenericsIntegrationTest extends LevelsTestCase
 {
 

--- a/tests/PHPStan/Levels/InferPrivatePropertyTypeFromConstructorIntegrationTest.php
+++ b/tests/PHPStan/Levels/InferPrivatePropertyTypeFromConstructorIntegrationTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Levels;
 
 use PHPStan\Testing\LevelsTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('levels')]
+#[CoversNothing]
 class InferPrivatePropertyTypeFromConstructorIntegrationTest extends LevelsTestCase
 {
 

--- a/tests/PHPStan/Levels/LevelsIntegrationTest.php
+++ b/tests/PHPStan/Levels/LevelsIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Levels;
 
 use PHPStan\Testing\LevelsTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use const PHP_VERSION_ID;
 

--- a/tests/PHPStan/Levels/LevelsIntegrationTest.php
+++ b/tests/PHPStan/Levels/LevelsIntegrationTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Group;
 use const PHP_VERSION_ID;
 
 #[Group('levels')]
+#[CoversNothing]
 class LevelsIntegrationTest extends LevelsTestCase
 {
 

--- a/tests/PHPStan/Levels/NamedArgumentsIntegrationTest.php
+++ b/tests/PHPStan/Levels/NamedArgumentsIntegrationTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Levels;
 
 use PHPStan\Testing\LevelsTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('levels')]
+#[CoversNothing]
 class NamedArgumentsIntegrationTest extends LevelsTestCase
 {
 

--- a/tests/PHPStan/Levels/StubValidatorIntegrationTest.php
+++ b/tests/PHPStan/Levels/StubValidatorIntegrationTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Levels;
 
 use PHPStan\Testing\LevelsTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('levels')]
+#[CoversNothing]
 class StubValidatorIntegrationTest extends LevelsTestCase
 {
 

--- a/tests/PHPStan/Levels/StubsIntegrationTest.php
+++ b/tests/PHPStan/Levels/StubsIntegrationTest.php
@@ -3,9 +3,11 @@
 namespace PHPStan\Levels;
 
 use PHPStan\Testing\LevelsTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 
 #[Group('levels')]
+#[CoversNothing]
 class StubsIntegrationTest extends LevelsTestCase
 {
 

--- a/tests/PHPStan/Parallel/ParallelAnalyserIntegrationTest.php
+++ b/tests/PHPStan/Parallel/ParallelAnalyserIntegrationTest.php
@@ -6,6 +6,7 @@ use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 use PHPStan\File\FileHelper;
 use PHPStan\ShouldNotHappenException;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -21,6 +22,7 @@ use function uniqid;
 use const PHP_BINARY;
 
 #[Group('exec')]
+#[CoversNothing]
 class ParallelAnalyserIntegrationTest extends TestCase
 {
 


### PR DESCRIPTION
In https://github.com/phpstan/phpstan-src/pull/4527 we found out that `#[CoversNothing]` can speedup the coverage generation process.

We can only add this attributes to tests which are not relevant for mutation testing, because infection would not see these tests when they are no longer part of the coverage report.

---

tbh: I cannot believe the results running
(its reproducible though)

```
XDEBUG_MODE=coverage php tests/vendor/bin/paratest \
          --coverage-xml=tmp/coverage/coverage-xml \
          --log-junit=tmp/coverage/junit.xml

ParaTest v7.8.4 upon PHPUnit 11.5.43 by Sebastian Bergmann and contributors.

Warming cache for static analysis ... [00:00.051]
Processes:     14
Runtime:       PHP 8.3.27 with Xdebug 3.4.7
Configuration: /Users/staabm/workspace/phpstan-src/phpunit.xml
Random Seed:   1762589403

...................SS.....................S...S...........S    59 / 13334 (  0%)
...........................................................   118 / 13334 (  0%)
..
```

before this PR:
```
Time: 07:57.258, Memory: 618.50 MB

OK, but some tests were skipped!
Tests: 13334, Assertions: 80601, Skipped: 171.

Generating code coverage report in PHPUnit XML format ... done [00:34.829]
```

after this PR:
```
Time: 03:44.550, Memory: 660.50 MB

OK, but some tests were skipped!
Tests: 13334, Assertions: 80601, Skipped: 171.

Generating code coverage report in PHPUnit XML format ... done [00:32.989]
```

on macbook m4 pro
