### PR TITLE
Fix non-existent offset when guarding

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -307,7 +307,7 @@ final class TypeSpecifier
 							$argType->getIterableValueType(),
 							TypeSpecifierContext::createTrue(),
 							$scope,
-						)->setRootExpr($expr)
+						)
 					);
 				}
 

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -273,7 +273,8 @@ final class TypeSpecifier
 				&& in_array(strtolower((string) $expr->right->name), ['count', 'sizeof'], true)
 				&& $leftType->isInteger()->yes()
 			) {
-				$argType = $scope->getType($expr->right->getArgs()[0]->value);
+				$argExpr = $expr->right->getArgs()[0]->value;
+				$argType = $scope->getType($argExpr);
 
 				if ($leftType instanceof ConstantIntegerType) {
 					if ($orEqual) {
@@ -295,10 +296,11 @@ final class TypeSpecifier
 					$context->true()
 					&& $expr instanceof Node\Expr\BinaryOp\Smaller
 				    && $argType->isList()->yes()
+					&& $argExpr instanceof Expr\Variable
 					&& IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($leftType)->yes()
 				) {
 					$dimFetch = new ArrayDimFetch(
-						$expr->right->getArgs()[0]->value,
+						$argExpr,
 						$expr->left,
 					);
 					$result = $result->unionWith(

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -291,6 +291,25 @@ final class TypeSpecifier
 				if ($specifiedTypes !== null) {
 					$result = $result->unionWith($specifiedTypes);
 				}
+				if (
+					$context->true()
+					&& $expr instanceof Node\Expr\BinaryOp\Smaller
+				    && $argType->isList()->yes()
+					&& IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($leftType)->yes()
+				) {
+					$dimFetch = new ArrayDimFetch(
+						$expr->right->getArgs()[0]->value,
+						$expr->left,
+					);
+					$result = $result->unionWith(
+						$this->create(
+							$dimFetch,
+							$argType->getIterableValueType(),
+							TypeSpecifierContext::createTrue(),
+							$scope,
+						)->setRootExpr($expr)
+					);
+				}
 
 				if (
 					$context->true() && (IntegerRangeType::createAllGreaterThanOrEqualTo(1 - $offset)->isSuperTypeOf($leftType)->yes())

--- a/tests/PHPStan/Analyser/nsrt/bug-10264.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10264.php
@@ -33,7 +33,7 @@ class A
 		assertType('list<int>', $c);
 		if (count($c) > 0) {
 			$c = array_map(fn() => new stdClass(), $c);
-			assertType('non-empty-list<stdClass>', $c);
+			assertType('non-empty-list<stdClass>&hasOffsetValue(0, stdClass)', $c);
 		} else {
 			assertType('array{}', $c);
 		}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -712,6 +712,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Offset int<0, max> might not exist on array<int, int>.',
 				100
 			],
+			[
+				'Offset int<0, max> might not exist on array<int<min, 4>|int<6, max>, int>.',
+				112
+			],
 		]];
 		yield [true, true, [
 			[
@@ -733,6 +737,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Offset int<0, max> might not exist on array<int, int>.',
 				100
+			],
+			[
+				'Offset int<0, max> might not exist on array<int<min, 4>|int<6, max>, int>.',
+				112
 			],
 		]];
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -704,6 +704,14 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				'Offset int might not exist on list<int>.',
 				77
 			],
+			[
+				'Offset int<0, max> might not exist on list<int>.',
+				88
+			],
+			[
+				'Offset int<0, max> might not exist on array<int, int>.',
+				100
+			],
 		]];
 		yield [true, true, [
 			[
@@ -717,6 +725,14 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Offset int might not exist on list<int>.',
 				77
+			],
+			[
+				'Offset int<0, max> might not exist on list<int>.',
+				88
+			],
+			[
+				'Offset int<0, max> might not exist on array<int, int>.',
+				100
 			],
 		]];
 	}

--- a/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/NonexistentOffsetInArrayDimFetchRuleTest.php
@@ -700,6 +700,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 				"Offset 'foo' might not exist on array.",
 				9,
 			],
+			[
+				'Offset int might not exist on list<int>.',
+				77
+			],
 		]];
 		yield [true, true, [
 			[
@@ -709,6 +713,10 @@ class NonexistentOffsetInArrayDimFetchRuleTest extends RuleTestCase
 			[
 				'Offset string might not exist on array{foo: 1}.',
 				20,
+			],
+			[
+				'Offset int might not exist on list<int>.',
+				77
 			],
 		]];
 	}

--- a/tests/PHPStan/Rules/Arrays/data/report-possibly-nonexistent-array-offset.php
+++ b/tests/PHPStan/Rules/Arrays/data/report-possibly-nonexistent-array-offset.php
@@ -59,7 +59,7 @@ class Feature7553
 
 	/**
 	 * @param list<int> $array
-	 * @param positive-int $index
+	 * @param non-negative-int $index
 	 */
 	public function guard(array $array, int $index) {
 		if ($index < count($array)) {
@@ -72,8 +72,31 @@ class Feature7553
 	/**
 	 * @param list<int> $array
 	 */
-	public function guardNotSafe(array $array, int $index) {
+	public function guardNotSafeLowerBound(array $array, int $index) {
 		if ($index < count($array)) {
+			return $array[$index];
+		}
+		return null;
+	}
+
+	/**
+	 * @param list<int> $array
+	 * @param non-negative-int $index
+	 */
+	public function guardNotSafeUpperBound(array $array, int $index) {
+		if ($index <= count($array)) {
+			return $array[$index];
+		}
+		return null;
+	}
+
+
+	/**
+	 * @param array<int, int> $array
+	 * @param non-negative-int $index
+	 */
+	public function guardNotSafeArray(array $array, int $index) {
+		if ($index <= count($array)) {
 			return $array[$index];
 		}
 		return null;

--- a/tests/PHPStan/Rules/Arrays/data/report-possibly-nonexistent-array-offset.php
+++ b/tests/PHPStan/Rules/Arrays/data/report-possibly-nonexistent-array-offset.php
@@ -57,4 +57,25 @@ class Feature7553
 		echo $a[0];
 	}
 
+	/**
+	 * @param list<int> $array
+	 * @param positive-int $index
+	 */
+	public function guard(array $array, int $index) {
+		if ($index < count($array)) {
+			return $array[$index];
+		}
+		return null;
+	}
+
+
+	/**
+	 * @param list<int> $array
+	 */
+	public function guardNotSafe(array $array, int $index) {
+		if ($index < count($array)) {
+			return $array[$index];
+		}
+		return null;
+	}
 }

--- a/tests/PHPStan/Rules/Arrays/data/report-possibly-nonexistent-array-offset.php
+++ b/tests/PHPStan/Rules/Arrays/data/report-possibly-nonexistent-array-offset.php
@@ -101,4 +101,16 @@ class Feature7553
 		}
 		return null;
 	}
+
+	/**
+	 * @param array<int, int> $array
+	 * @param non-negative-int $index
+	 */
+	public function guardNotSafeBecauseRewrite(array $array, int $index) {
+		if ($index <= count($array)) {
+			unset($array[5]);
+			return $array[$index];
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
This pr is trying to fix a false positive.

```
/**
 * @param list<int> $array
 * @param positive-int $index
 */
public function guardNotSafeLowerBound(array $array, int $index) {
    if ($index < count($array)) { // index is within 0..count(array)-1
        return $array[$index]; // phpstan reports a potentially unsafe array access
    }
    return null;
}
```
Note that 1) $array is a list 2) $index is positive (or at least >= 0)