### PR TITLE
feat: add GenericClassStringType::getObjectClassNames

### DIFF
--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -40,6 +40,11 @@ class GenericClassStringType extends ClassStringType
 		return $this->type->getReferencedClasses();
 	}
 
+	public function getObjectClassNames(): array
+	{
+		return $this->type->getObjectClassNames();
+	}
+
 	public function getGenericType(): Type
 	{
 		return $this->type;


### PR DESCRIPTION
Hello!

This forwards the call to the underlying type. I had a `class-string<User>`, and calling `->getObjectClassNames` was returning an empty array despite it knowing about the inner User type.

Thanks!