### PR TITLE
Fix `UnionType::getObjectClassReflections`

### DIFF
--- a/src/Rules/PhpDoc/RequireExtendsCheck.php
+++ b/src/Rules/PhpDoc/RequireExtendsCheck.php
@@ -7,17 +7,15 @@ use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\PhpDoc\Tag\RequireExtendsTag;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\ClassNameCheck;
 use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\VerbosityLevel;
-use function array_column;
-use function array_map;
 use function array_merge;
 use function count;
-use function sort;
 use function sprintf;
 use function strtolower;
 
@@ -26,6 +24,7 @@ final class RequireExtendsCheck
 {
 
 	public function __construct(
+		private ReflectionProvider $reflectionProvider,
 		private ClassNameCheck $classCheck,
 		#[AutowiredParameter]
 		private bool $checkClassCaseSensitivity,
@@ -59,12 +58,8 @@ final class RequireExtendsCheck
 				continue;
 			}
 
-			sort($classNames);
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
-			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
-				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;
-				if ($referencedClassReflection === null) {
+				if (!$this->reflectionProvider->hasClass($class)) {
 					$errorBuilder = RuleErrorBuilder::message(sprintf('PHPDoc tag @phpstan-require-extends contains unknown class %s.', $class))
 						->identifier('class.notFound');
 
@@ -76,16 +71,17 @@ final class RequireExtendsCheck
 					continue;
 				}
 
-				if ($referencedClassReflection->isInterface()) {
+				$reflection = $this->reflectionProvider->getClass($class);
+				if ($reflection->isInterface()) {
 					$errors[] = RuleErrorBuilder::message(sprintf('PHPDoc tag @phpstan-require-extends cannot contain an interface %s, expected a class.', $class))
 						->tip('If you meant an interface, use @phpstan-require-implements instead.')
 						->identifier('requireExtends.interface')
 						->build();
-				} elseif (!$referencedClassReflection->isClass()) {
+				} elseif (!$reflection->isClass()) {
 					$errors[] = RuleErrorBuilder::message(sprintf('PHPDoc tag @phpstan-require-extends cannot contain non-class type %s.', $class))
-						->identifier(sprintf('requireExtends.%s', strtolower($referencedClassReflection->getClassTypeDescription())))
+						->identifier(sprintf('requireExtends.%s', strtolower($reflection->getClassTypeDescription())))
 						->build();
-				} elseif ($referencedClassReflection->isFinal()) {
+				} elseif ($reflection->isFinal()) {
 					$errors[] = RuleErrorBuilder::message(sprintf('PHPDoc tag @phpstan-require-extends cannot contain final class %s.', $class))
 						->identifier('requireExtends.finalClass')
 						->build();

--- a/src/Rules/PhpDoc/RequireExtendsCheck.php
+++ b/src/Rules/PhpDoc/RequireExtendsCheck.php
@@ -12,6 +12,7 @@ use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_column;
 use function array_map;
@@ -59,8 +60,18 @@ final class RequireExtendsCheck
 				continue;
 			}
 
+			if ($type instanceof UnionType) {
+				$classReflections = [];
+				foreach ($type->getTypes() as $subType) {
+					$classReflections[] = $subType->getObjectClassReflections();
+				}
+				$classReflections = array_merge(...$classReflections);
+			} else {
+				$classReflections = $type->getObjectClassReflections();
+			}
+
 			sort($classNames);
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
+			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $classReflections);
 			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
 				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;

--- a/src/Rules/PhpDoc/RequireExtendsCheck.php
+++ b/src/Rules/PhpDoc/RequireExtendsCheck.php
@@ -12,7 +12,6 @@ use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_column;
 use function array_map;
@@ -60,18 +59,8 @@ final class RequireExtendsCheck
 				continue;
 			}
 
-			if ($type instanceof UnionType) {
-				$classReflections = [];
-				foreach ($type->getTypes() as $subType) {
-					$classReflections[] = $subType->getObjectClassReflections();
-				}
-				$classReflections = array_merge(...$classReflections);
-			} else {
-				$classReflections = $type->getObjectClassReflections();
-			}
-
 			sort($classNames);
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $classReflections);
+			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
 			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
 				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;

--- a/src/Rules/PhpDoc/RequireImplementsDefinitionTraitRule.php
+++ b/src/Rules/PhpDoc/RequireImplementsDefinitionTraitRule.php
@@ -12,7 +12,6 @@ use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_column;
 use function array_map;
@@ -67,17 +66,7 @@ final class RequireImplementsDefinitionTraitRule implements Rule
 				continue;
 			}
 
-			if ($type instanceof UnionType) {
-				$classReflections = [];
-				foreach ($type->getTypes() as $subType) {
-					$classReflections[] = $subType->getObjectClassReflections();
-				}
-				$classReflections = array_merge(...$classReflections);
-			} else {
-				$classReflections = $type->getObjectClassReflections();
-			}
-
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $classReflections);
+			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
 			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
 				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;

--- a/src/Rules/PhpDoc/RequireImplementsDefinitionTraitRule.php
+++ b/src/Rules/PhpDoc/RequireImplementsDefinitionTraitRule.php
@@ -12,6 +12,7 @@ use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_column;
 use function array_map;
@@ -66,7 +67,17 @@ final class RequireImplementsDefinitionTraitRule implements Rule
 				continue;
 			}
 
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
+			if ($type instanceof UnionType) {
+				$classReflections = [];
+				foreach ($type->getTypes() as $subType) {
+					$classReflections[] = $subType->getObjectClassReflections();
+				}
+				$classReflections = array_merge(...$classReflections);
+			} else {
+				$classReflections = $type->getObjectClassReflections();
+			}
+
+			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $classReflections);
 			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
 				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;

--- a/src/Rules/PhpDoc/SealedDefinitionClassRule.php
+++ b/src/Rules/PhpDoc/SealedDefinitionClassRule.php
@@ -12,7 +12,6 @@ use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_column;
 use function array_map;
@@ -70,17 +69,7 @@ final class SealedDefinitionClassRule implements Rule
 				continue;
 			}
 
-			if ($type instanceof UnionType) {
-				$classReflections = [];
-				foreach ($type->getTypes() as $subType) {
-					$classReflections[] = $subType->getObjectClassReflections();
-				}
-				$classReflections = array_merge(...$classReflections);
-			} else {
-				$classReflections = $type->getObjectClassReflections();
-			}
-
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $classReflections);
+			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
 			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
 				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;

--- a/src/Rules/PhpDoc/SealedDefinitionClassRule.php
+++ b/src/Rules/PhpDoc/SealedDefinitionClassRule.php
@@ -12,6 +12,7 @@ use PHPStan\Rules\ClassNameNodePair;
 use PHPStan\Rules\ClassNameUsageLocation;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function array_column;
 use function array_map;
@@ -69,7 +70,17 @@ final class SealedDefinitionClassRule implements Rule
 				continue;
 			}
 
-			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $type->getObjectClassReflections());
+			if ($type instanceof UnionType) {
+				$classReflections = [];
+				foreach ($type->getTypes() as $subType) {
+					$classReflections[] = $subType->getObjectClassReflections();
+				}
+				$classReflections = array_merge(...$classReflections);
+			} else {
+				$classReflections = $type->getObjectClassReflections();
+			}
+
+			$referencedClassReflections = array_map(static fn ($reflection) => [$reflection, $reflection->getName()], $classReflections);
 			$referencedClassReflectionsMap = array_column($referencedClassReflections, 0, 1);
 			foreach ($classNames as $class) {
 				$referencedClassReflection = $referencedClassReflectionsMap[$class] ?? null;

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -162,14 +162,10 @@ class UnionType implements CompoundType
 
 	public function getObjectClassReflections(): array
 	{
-		$reflections = [];
-		foreach ($this->types as $type) {
-			foreach ($type->getObjectClassReflections() as $reflection) {
-				$reflections[] = $reflection;
-			}
-		}
-
-		return $reflections;
+		return $this->pickFromTypes(
+			static fn (Type $type) => $type->getObjectClassReflections(),
+			static fn (Type $type) => $type->isObject()->yes(),
+		);
 	}
 
 	public function getArrays(): array

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -162,10 +162,14 @@ class UnionType implements CompoundType
 
 	public function getObjectClassReflections(): array
 	{
-		return $this->pickFromTypes(
-			static fn (Type $type) => $type->getObjectClassReflections(),
-			static fn (Type $type) => $type->isObject()->yes(),
-		);
+		$reflections = [];
+		foreach ($this->types as $type) {
+			foreach ($type->getObjectClassReflections() as $reflection) {
+				$reflections[] = $reflection;
+			}
+		}
+
+		return $reflections;
 	}
 
 	public function getArrays(): array

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
@@ -22,6 +22,7 @@ class RequireExtendsDefinitionClassRuleTest extends RuleTestCase
 		$container = self::getContainer();
 		return new RequireExtendsDefinitionClassRule(
 			new RequireExtendsCheck(
+				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
 					new ClassForbiddenNameCheck($container),

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
@@ -86,11 +86,6 @@ class RequireExtendsDefinitionClassRuleTest extends RuleTestCase
 				183,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
-			[
-				'PHPDoc tag @phpstan-require-extends contains unknown class IncompatibleRequireExtends\SomeClass.',
-				183,
-				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
@@ -56,11 +56,6 @@ class RequireExtendsDefinitionTraitRuleTest extends RuleTestCase
 				192,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
-			[
-				'PHPDoc tag @phpstan-require-extends contains unknown class IncompatibleRequireExtends\SomeClass.',
-				192,
-				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
-			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
@@ -23,6 +23,7 @@ class RequireExtendsDefinitionTraitRuleTest extends RuleTestCase
 		return new RequireExtendsDefinitionTraitRule(
 			$reflectionProvider,
 			new RequireExtendsCheck(
+				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
 					new ClassForbiddenNameCheck($container),

--- a/tests/PHPStan/Rules/PhpDoc/RequireImplementsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireImplementsDefinitionTraitRuleTest.php
@@ -62,6 +62,11 @@ class RequireImplementsDefinitionTraitRuleTest extends RuleTestCase
 				'PHPDoc tag @phpstan-require-implements contains non-object type *NEVER*.',
 				34,
 			],
+			[
+				'PHPDoc tag @phpstan-require-implements contains unknown class IncompatibleRequireImplements\TypeDoesNotExist.',
+				175,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
 		];
 
 		$this->analyse([__DIR__ . '/data/incompatible-require-implements.php'], $expectedErrors);

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -50,6 +50,11 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 				26,
 				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
 			],
+			[
+				'PHPDoc tag @phpstan-sealed contains unknown class IncompatibleSealed\UnknownClass.',
+				46,
+				'Learn more at https://phpstan.org/user-guide/discovering-symbols',
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -21,6 +21,7 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 
 		$container = self::getContainer();
 		return new SealedDefinitionClassRule(
+			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
 				new ClassForbiddenNameCheck($container),

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-implements.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-require-implements.php
@@ -168,3 +168,8 @@ new class implements RequiredInterface {
 new class {
 	use ValidPsalmTrait;
 };
+
+/**
+ * @phpstan-require-implements RequiredInterface|TypeDoesNotExist
+ */
+trait InvalidTraitWithUnknown {}

--- a/tests/PHPStan/Rules/PhpDoc/data/incompatible-sealed.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/incompatible-sealed.php
@@ -39,3 +39,8 @@ interface ValidInterface {}
  * @phpstan-sealed SomeInterface
  */
 interface ValidInterface2 {}
+
+/**
+ * @phpstan-sealed UnknownClass|SomeClass
+ */
+class InvalidClassWithUnion {}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13777

The issue is that `UnionType::getObjectClassReflections` was returning `[]` as soon as one of subtypes returns `[]`...