### PR TITLE
Fix return type of pcntl_signal_get_handler

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -7612,7 +7612,7 @@ return [
 'pcntl_setpriority' => ['bool', 'priority'=>'int', 'pid='=>'int', 'process_identifier='=>'int'],
 'pcntl_signal' => ['bool', 'signo'=>'int', 'handle'=>'callable|int', 'restart_syscalls='=>'bool'],
 'pcntl_signal_dispatch' => ['bool'],
-'pcntl_signal_get_handler' => ['int|string', 'signo'=>'int'],
+'pcntl_signal_get_handler' => ['(callable(): mixed)|int', 'signo'=>'int'],
 'pcntl_sigprocmask' => ['bool', 'how'=>'int', 'set'=>'array', '&w_oldset='=>'array'],
 'pcntl_sigtimedwait' => ['int|false', 'set'=>'array', '&w_siginfo='=>'array', 'seconds='=>'int', 'nanoseconds='=>'int'],
 'pcntl_sigwaitinfo' => ['int|false', 'set'=>'array', '&w_siginfo='=>'array'],


### PR DESCRIPTION
`pcntl_signal_get_handler` returns the defined callable or `SIG_DFL` / `SIG_IGN` if none has been defined via `pcntl_signal`.

https://www.php.net/manual/en/function.pcntl-signal-get-handler.php
https://github.com/php/php-src/blob/e97c0dc340be7387498b92b182b9356b960a3bd0/ext/pcntl/pcntl.c#L863

https://phpstan.org/r/7632586d-bc04-4b97-865f-3cb5125037a8