### PR TITLE
Use isSuperTypeOf() instead of equals() in Bound check

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1564,7 +1564,7 @@ final class TypeSpecifier
 					static function (Type $type, callable $traverse) use ($templateTypeMap, &$containsUnresolvedTemplate) {
 						if ($type instanceof TemplateType && $type->getScope()->getClassName() !== null) {
 							$resolvedType = $templateTypeMap->getType($type->getName());
-							if ($resolvedType === null || $type->getBound()->equals($resolvedType)) {
+							if ($resolvedType === null || $resolvedType->isSuperTypeOf($type->getBound())->yes()) {
 								$containsUnresolvedTemplate = true;
 								return $type;
 							}


### PR DESCRIPTION
I just have a gut feeling that this code should use `isSuperTypeOf()` instead of `equals()` - like most other code which handles `Bound`s in the codebase