### PR TITLE
Do not report do-while-false pseudo-loops that are interrupted by a break statement

### DIFF
--- a/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
+++ b/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
@@ -65,6 +65,13 @@ final class DoWhileLoopConstantConditionRule implements Rule
 						return [];
 					}
 				}
+			} else {
+				foreach ($node->getExitPoints() as $exitPoint) {
+					$statement = $exitPoint->getStatement();
+					if ($statement instanceof Break_) {
+						return [];
+					}
+				}
 			}
 
 			$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {

--- a/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
+++ b/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
@@ -44,24 +44,13 @@ final class DoWhileLoopConstantConditionRule implements Rule
 			if ($exprType->getValue()) {
 				foreach ($node->getExitPoints() as $exitPoint) {
 					$statement = $exitPoint->getStatement();
-					if ($statement instanceof Break_) {
-						return [];
-					}
 					if (!$statement instanceof Continue_) {
 						return [];
-					}
-					if ($statement->num === null) {
-						continue;
 					}
 					if (!$statement->num instanceof Int_) {
 						continue;
 					}
-					$value = $statement->num->value;
-					if ($value === 1) {
-						continue;
-					}
-
-					if ($value > 1) {
+					if ($statement->num->value > 1) {
 						return [];
 					}
 				}

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -44,16 +44,20 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 				46,
 			],
 			[
-				'Do-while loop condition is always false.',
-				55,
-			],
-			[
 				'Do-while loop condition is always true.',
 				64,
 			],
 			[
 				'Do-while loop condition is always false.',
 				73,
+			],
+			[
+				'Do-while loop condition is always false.',
+				105,
+			],
+			[
+				'Do-while loop condition is always false.',
+				115,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -59,6 +59,14 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 				'Do-while loop condition is always false.',
 				115,
 			],
+			[
+				'Do-while loop condition is always false.',
+				138,
+			],
+			[
+				'Do-while loop condition is always false.',
+				152,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Comparison/data/do-while-loop.php
+++ b/tests/PHPStan/Rules/Comparison/data/do-while-loop.php
@@ -52,7 +52,7 @@ class Foo
 			if (rand(0, 1)) {
 				break;
 			}
-		} while (false); // report
+		} while (false); // do not report
 	}
 
 	public function doFoo4()
@@ -93,6 +93,35 @@ class Foo
 				}
 			} while (true); // do not report
 		}
+	}
+
+	public function doFoo8(array $a)
+	{
+		foreach ($a as $v) {
+			do {
+				if (rand(0, 1)) {
+					continue 2;
+				}
+			} while (false); // report
+		}
+	}
+
+	public function doFoo9(array $a)
+	{
+		do {
+			foreach ($a as $v) {
+				break;
+			}
+		} while (false); // report
+	}
+
+	public function doFoo10(array $a)
+	{
+		do {
+			foreach ($a as $v) {
+				break 2;
+			}
+		} while (false); // do not report
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/data/do-while-loop.php
+++ b/tests/PHPStan/Rules/Comparison/data/do-while-loop.php
@@ -124,4 +124,32 @@ class Foo
 		} while (false); // do not report
 	}
 
+	public function doFoo11(array $a)
+	{
+		do {
+			throw new \Exception;
+		} while (true); // do not report
+	}
+
+	public function doFoo12(array $a)
+	{
+		do {
+			throw new \Exception;
+		} while (false); // report
+	}
+
+	public function doFoo13(array $a)
+	{
+		do {
+			exit;
+		} while (true); // do not report
+	}
+
+	public function doFoo14(array $a)
+	{
+		do {
+			exit;
+		} while (false); // report
+	}
+
 }


### PR DESCRIPTION
This enables support of the `do-break-while-false` pattern:

```php
do {
    if ($foo) {
        if ($bar) {
            $a = 'baz';
            break;
        }
     }
     $a = foobar($baz);
} while (false); // no doWhile.alwaysFalse error
```

The error is still reported when the pseudo-loop is not broken with `break`.