### PR TITLE
[PHP 8.5] add new rule for filter_var

### DIFF
--- a/src/Rules/Functions/FilterVarRule.php
+++ b/src/Rules/Functions/FilterVarRule.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Php\FilterFunctionReturnTypeHelper;
+use function count;
+
+/**
+ * @implements Rule<Node\Expr\FuncCall>
+ */
+#[RegisteredRule(level: 0)]
+final class FilterVarRule implements Rule
+{
+
+	public function __construct(
+		private ReflectionProvider $reflectionProvider,
+		private FilterFunctionReturnTypeHelper $filterFunctionReturnTypeHelper,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!($node->name instanceof Node\Name)) {
+			return [];
+		}
+
+		if ($this->reflectionProvider->resolveFunctionName($node->name, $scope) !== 'filter_var') {
+			return [];
+		}
+
+		$args = $node->getArgs();
+
+		if ($this->reflectionProvider->hasConstant(new Name\FullyQualified('FILTER_THROW_ON_FAILURE'), null)) {
+			if (count($args) < 3) {
+				return [];
+			}
+
+			$flagsType = $scope->getType($args[2]->value);
+
+			if ($this->filterFunctionReturnTypeHelper->hasFlag('FILTER_NULL_ON_FAILURE', $flagsType)
+				->and($this->filterFunctionReturnTypeHelper->hasFlag('FILTER_THROW_ON_FAILURE', $flagsType))
+				->yes()
+			) {
+				return [
+					RuleErrorBuilder::message('Cannot use both FILTER_NULL_ON_FAILURE and FILTER_THROW_ON_FAILURE.')
+						->identifier('filterVar.nullOnFailureAndThrowOnFailure')
+						->build(),
+				];
+			}
+		}
+
+		return [];
+	}
+
+}

--- a/src/Type/Php/FilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/FilterFunctionReturnTypeHelper.php
@@ -484,7 +484,7 @@ final class FilterFunctionReturnTypeHelper
 	/**
 	 * @param non-empty-string $flagName
 	 */
-	private function hasFlag(string $flagName, ?Type $flagsType): TrinaryLogic
+	public function hasFlag(string $flagName, ?Type $flagsType): TrinaryLogic
 	{
 		$flag = $this->getConstant($flagName);
 		if ($flag === null) {

--- a/tests/PHPStan/Rules/Functions/FilterVarRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/FilterVarRuleTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStan\Type\Php\FilterFunctionReturnTypeHelper;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+/** @extends RuleTestCase<FilterVarRule> */
+class FilterVarRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new FilterVarRule(
+			self::createReflectionProvider(),
+			self::getContainer()->getByType(FilterFunctionReturnTypeHelper::class),
+		);
+	}
+
+	#[RequiresPhp('8.5')]
+	public function testRule(): void
+	{
+		$this->analyse([__DIR__ . '/data/filter_var_null_and_throw.php'], [
+			['Cannot use both FILTER_NULL_ON_FAILURE and FILTER_THROW_ON_FAILURE.', 5],
+			['Cannot use both FILTER_NULL_ON_FAILURE and FILTER_THROW_ON_FAILURE.', 8],
+			['Cannot use both FILTER_NULL_ON_FAILURE and FILTER_THROW_ON_FAILURE.', 10],
+		]);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/filter_var_null_and_throw.php
+++ b/tests/PHPStan/Rules/Functions/data/filter_var_null_and_throw.php
@@ -1,0 +1,17 @@
+<?php // lint >= 8.5
+
+namespace FilterVarNullAndThrow;
+
+filter_var('foo@bar.test', FILTER_VALIDATE_EMAIL, FILTER_THROW_ON_FAILURE|FILTER_NULL_ON_FAILURE);
+
+$flag = FILTER_NULL_ON_FAILURE|FILTER_THROW_ON_FAILURE;
+filter_var(100, FILTER_VALIDATE_INT, $flag);
+
+filter_var(
+	'johndoe',
+	FILTER_VALIDATE_REGEXP,
+	['options' => ['regexp' => '/^[a-z]+$/'], 'flags' => FILTER_THROW_ON_FAILURE|FILTER_NULL_ON_FAILURE]
+);
+filter_var('foo@bar.test', FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE);
+filter_var('foo@bar.test', FILTER_VALIDATE_EMAIL, FILTER_THROW_ON_FAILURE);
+


### PR DESCRIPTION
Follow up to #4495 

In PHP 8.5 using both `FILTER_THROW_ON_FAILURE` and `FILTER_NULL_ON_FAILURE` at same time is not allowed. https://3v4l.org/Ibd4B/rfc#vgit.master_jit

Not sure about the rule level and the message.