### PR TITLE
Don't loose known offset-types in array_merge()

### DIFF
--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -53,10 +53,7 @@ class HasOffsetType implements CompoundType, AccessoryType
 	{
 	}
 
-	/**
-	 * @return ConstantStringType|ConstantIntegerType
-	 */
-	public function getOffsetType(): Type
+	public function getOffsetType(): ConstantStringType|ConstantIntegerType
 	{
 		return $this->offsetType;
 	}

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -23,6 +23,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function array_keys;
+use function array_values;
 use function count;
 use function in_array;
 
@@ -163,7 +164,7 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			$arrayType = TypeCombinator::intersect($arrayType, new AccessoryArrayListType());
 		}
 		if ($offsetTypes !== []) {
-			$arrayType = TypeCombinator::intersect($arrayType, ...$offsetTypes);
+			$arrayType = TypeCombinator::intersect($arrayType, ...array_values($offsetTypes));
 		}
 
 		return $arrayType;

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -8,6 +8,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\HasOffsetType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -73,26 +74,40 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			static fn (Type $argType) => $argType->isConstantArray(),
 		);
 
+		$nonOptionalConstKeys = [];
+		$newArrayBuilder = null;
 		if ($allConstant->yes()) {
 			$newArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-			foreach ($argTypes as $argType) {
-				/** @var array<int|string, ConstantIntegerType|ConstantStringType> $keyTypes */
-				$keyTypes = [];
-				foreach ($argType->getConstantArrays() as $constantArray) {
-					foreach ($constantArray->getKeyTypes() as $keyType) {
-						$keyTypes[$keyType->getValue()] = $keyType;
-					}
-				}
+		}
+		foreach ($argTypes as $argType) {
+			/** @var array<int|string, ConstantIntegerType|ConstantStringType> $keyTypes */
+			$keyTypes = [];
+			foreach ($argType->getConstantArrays() as $constantArray) {
+				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+					$keyTypes[$keyType->getValue()] = $keyType;
 
-				foreach ($keyTypes as $keyType) {
-					$newArrayBuilder->setOffsetValueType(
-						$keyType instanceof ConstantIntegerType ? null : $keyType,
-						$argType->getOffsetValueType($keyType),
-						!$argType->hasOffsetValueType($keyType)->yes(),
-					);
+					if ($constantArray->isOptionalKey($i)) {
+						continue;
+					}
+
+					$nonOptionalConstKeys[] = $keyType;
 				}
 			}
 
+			if ($newArrayBuilder === null) {
+				continue;
+			}
+
+			foreach ($keyTypes as $keyType) {
+				$newArrayBuilder->setOffsetValueType(
+					$keyType instanceof ConstantIntegerType ? null : $keyType,
+					$argType->getOffsetValueType($keyType),
+					!$argType->hasOffsetValueType($keyType)->yes(),
+				);
+			}
+		}
+
+		if ($newArrayBuilder !== null) {
 			return $newArrayBuilder->getArray();
 		}
 
@@ -121,6 +136,11 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			return new ConstantArrayType([], []);
 		}
 
+		$offsetTypes = [];
+		foreach ($nonOptionalConstKeys as $constKey) {
+			$offsetTypes[] = new HasOffsetType($constKey);
+		}
+
 		$arrayType = new ArrayType(
 			$keyType,
 			TypeCombinator::union(...$valueTypes),
@@ -131,6 +151,9 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 		}
 		if ($isList) {
 			$arrayType = TypeCombinator::intersect($arrayType, new AccessoryArrayListType());
+		}
+		if ($offsetTypes !== []) {
+			$arrayType = TypeCombinator::intersect($arrayType, ...$offsetTypes);
 		}
 
 		return $arrayType;

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -23,9 +23,10 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function array_keys;
-use function array_values;
 use function count;
 use function in_array;
+use function is_int;
+use function is_string;
 
 #[AutowiredService]
 final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -93,8 +94,16 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 						continue;
 					}
 
-					$offsetTypes[$keyType->getValue()] = new HasOffsetType($keyType);
+					$offsetValueType = $constantArray->getOffsetValueType($keyType);
+					$offsetTypes[$keyType->getValue()] = [false, $offsetValueType];
 				}
+			}
+
+			if ($keyTypes === []) {
+				foreach ($offsetTypes as [&$generalize, $offsetType]) {
+					$generalize = true;
+				}
+				unset($generalize);
 			}
 
 			if ($newArrayBuilder === null) {
@@ -107,8 +116,8 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 					}
 
 					$offsetType = $accessoryType->getOffsetType();
-					$offsetTypes[$offsetType->getValue()] = new HasOffsetType($offsetType);
-
+					$offsetValueType = $argType->getOffsetValueType($offsetType);
+					$offsetTypes[$offsetType->getValue()] = [false, $offsetValueType];
 				}
 
 				continue;
@@ -164,7 +173,32 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			$arrayType = TypeCombinator::intersect($arrayType, new AccessoryArrayListType());
 		}
 		if ($offsetTypes !== []) {
-			$arrayType = TypeCombinator::intersect($arrayType, ...array_values($offsetTypes));
+			$knownOffsetValues = [];
+			foreach ($offsetTypes as $key => [$generalize, $offsetType]) {
+				if (is_int($key)) {
+					// int keys will be appended and renumbered.
+					// at this point we can't reason about them, because unknown arrays are in the mix.
+					continue;
+				}
+				$keyType = new ConstantStringType($key);
+
+				if (!$generalize && is_string($key)) {
+					// the last string-keyed offset will overwrite previous values
+					$hasOffsetType = new HasOffsetValueType(
+						$keyType,
+						$offsetType,
+					);
+				} else {
+					$hasOffsetType = new HasOffsetType(
+						$keyType,
+					);
+				}
+
+				$knownOffsetValues[] = $hasOffsetType;
+			}
+			if ($knownOffsetValues !== []) {
+				$arrayType = TypeCombinator::intersect($arrayType, ...$knownOffsetValues);
+			}
 		}
 
 		return $arrayType;

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -9,6 +9,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\HasOffsetType;
+use PHPStan\Type\Accessory\HasOffsetValueType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -20,6 +21,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 use function array_keys;
 use function count;
 use function in_array;
@@ -74,7 +76,7 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			static fn (Type $argType) => $argType->isConstantArray(),
 		);
 
-		$nonOptionalConstKeys = [];
+		$offsetTypes = [];
 		$newArrayBuilder = null;
 		if ($allConstant->yes()) {
 			$newArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
@@ -90,11 +92,24 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 						continue;
 					}
 
-					$nonOptionalConstKeys[] = $keyType;
+					$offsetTypes[$keyType->getValue()] = new HasOffsetType($keyType);
 				}
 			}
 
 			if ($newArrayBuilder === null) {
+				foreach (TypeUtils::getAccessoryTypes($argType) as $accessoryType) {
+					if (
+						!($accessoryType instanceof HasOffsetType)
+						&& !($accessoryType instanceof HasOffsetValueType)
+					) {
+						continue;
+					}
+
+					$offsetType = $accessoryType->getOffsetType();
+					$offsetTypes[$offsetType->getValue()] = new HasOffsetType($offsetType);
+
+				}
+
 				continue;
 			}
 
@@ -134,11 +149,6 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 		$keyType = TypeCombinator::union(...$keyTypes);
 		if ($keyType instanceof NeverType) {
 			return new ConstantArrayType([], []);
-		}
-
-		$offsetTypes = [];
-		foreach ($nonOptionalConstKeys as $constKey) {
-			$offsetTypes[] = new HasOffsetType($constKey);
 		}
 
 		$arrayType = new ArrayType(

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -18,6 +18,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -86,21 +87,23 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			/** @var array<int|string, ConstantIntegerType|ConstantStringType> $keyTypes */
 			$keyTypes = [];
 			foreach ($argType->getConstantArrays() as $constantArray) {
-				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+				foreach ($constantArray->getKeyTypes() as $keyType) {
 					$keyTypes[$keyType->getValue()] = $keyType;
 
-					if ($constantArray->isOptionalKey($i)) {
-						continue;
-					}
-
-					$offsetValueType = $constantArray->getOffsetValueType($keyType);
-					$offsetTypes[$keyType->getValue()] = [false, $offsetValueType];
+					$hasOffsetValue = TrinaryLogic::createFromBoolean($argType->hasOffsetValueType($keyType)->yes());
+					$offsetTypes[$keyType->getValue()] = [
+						$hasOffsetValue,
+						$argType->getOffsetValueType($keyType),
+					];
 				}
 			}
 
 			if ($keyTypes === []) {
-				foreach ($offsetTypes as $key => [$generalize, $offsetValueType]) {
-					$offsetTypes[$key][0] = true;
+				foreach ($offsetTypes as $key => [$hasOffsetValue, $offsetValueType]) {
+					$offsetTypes[$key] = [
+						$hasOffsetValue->and(TrinaryLogic::createMaybe()),
+						new MixedType(),
+					];
 				}
 			}
 
@@ -113,8 +116,10 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 				}
 
 				$offsetType = $accessoryType->getOffsetType();
-				$offsetValueType = $argType->getOffsetValueType($offsetType);
-				$offsetTypes[$offsetType->getValue()] = [false, $offsetValueType];
+				$offsetTypes[$offsetType->getValue()] = [
+					TrinaryLogic::createYes(),
+					$argType->getOffsetValueType($offsetType),
+				];
 			}
 
 			if ($newArrayBuilder === null) {
@@ -172,7 +177,7 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 		}
 		if ($offsetTypes !== []) {
 			$knownOffsetValues = [];
-			foreach ($offsetTypes as $key => [$generalize, $offsetType]) {
+			foreach ($offsetTypes as $key => [$hasOffsetValue, $offsetType]) {
 				if (is_int($key)) {
 					// int keys will be appended and renumbered.
 					// at this point we can't reason about them, because unknown arrays are in the mix.
@@ -180,16 +185,18 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 				}
 				$keyType = new ConstantStringType($key);
 
-				if (!$generalize) {
+				if ($hasOffsetValue->yes()) {
 					// the last string-keyed offset will overwrite previous values
 					$hasOffsetType = new HasOffsetValueType(
 						$keyType,
 						$offsetType,
 					);
-				} else {
+				} elseif ($hasOffsetValue->maybe()) {
 					$hasOffsetType = new HasOffsetType(
 						$keyType,
 					);
+				} else {
+					continue;
 				}
 
 				$knownOffsetValues[] = $hasOffsetType;

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -26,7 +26,6 @@ use function array_keys;
 use function count;
 use function in_array;
 use function is_int;
-use function is_string;
 
 #[AutowiredService]
 final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -100,26 +99,25 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			}
 
 			if ($keyTypes === []) {
-				foreach ($offsetTypes as [&$generalize, $offsetType]) {
-					$generalize = true;
+				foreach ($offsetTypes as $key => [$generalize, $offsetValueType]) {
+					$offsetTypes[$key][0] = true;
 				}
-				unset($generalize);
+			}
+
+			foreach (TypeUtils::getAccessoryTypes($argType) as $accessoryType) {
+				if (
+					!($accessoryType instanceof HasOffsetType)
+					&& !($accessoryType instanceof HasOffsetValueType)
+				) {
+					continue;
+				}
+
+				$offsetType = $accessoryType->getOffsetType();
+				$offsetValueType = $argType->getOffsetValueType($offsetType);
+				$offsetTypes[$offsetType->getValue()] = [false, $offsetValueType];
 			}
 
 			if ($newArrayBuilder === null) {
-				foreach (TypeUtils::getAccessoryTypes($argType) as $accessoryType) {
-					if (
-						!($accessoryType instanceof HasOffsetType)
-						&& !($accessoryType instanceof HasOffsetValueType)
-					) {
-						continue;
-					}
-
-					$offsetType = $accessoryType->getOffsetType();
-					$offsetValueType = $argType->getOffsetValueType($offsetType);
-					$offsetTypes[$offsetType->getValue()] = [false, $offsetValueType];
-				}
-
 				continue;
 			}
 
@@ -182,7 +180,7 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 				}
 				$keyType = new ConstantStringType($key);
 
-				if (!$generalize && is_string($key)) {
+				if (!$generalize) {
 					// the last string-keyed offset will overwrite previous values
 					$hasOffsetType = new HasOffsetValueType(
 						$keyType,

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -78,27 +78,42 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 			static fn (Type $argType) => $argType->isConstantArray(),
 		);
 
-		$offsetTypes = [];
-		$newArrayBuilder = null;
 		if ($allConstant->yes()) {
 			$newArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-		}
-		foreach ($argTypes as $argType) {
-			/** @var array<int|string, ConstantIntegerType|ConstantStringType> $keyTypes */
-			$keyTypes = [];
-			foreach ($argType->getConstantArrays() as $constantArray) {
-				foreach ($constantArray->getKeyTypes() as $keyType) {
-					$keyTypes[$keyType->getValue()] = $keyType;
+			foreach ($argTypes as $argType) {
+				/** @var array<int|string, ConstantIntegerType|ConstantStringType> $keyTypes */
+				$keyTypes = [];
+				foreach ($argType->getConstantArrays() as $constantArray) {
+					foreach ($constantArray->getKeyTypes() as $keyType) {
+						$keyTypes[$keyType->getValue()] = $keyType;
+					}
+				}
 
-					$hasOffsetValue = TrinaryLogic::createFromBoolean($argType->hasOffsetValueType($keyType)->yes());
-					$offsetTypes[$keyType->getValue()] = [
-						$hasOffsetValue,
+				foreach ($keyTypes as $keyType) {
+					$newArrayBuilder->setOffsetValueType(
+						$keyType instanceof ConstantIntegerType ? null : $keyType,
 						$argType->getOffsetValueType($keyType),
-					];
+						!$argType->hasOffsetValueType($keyType)->yes(),
+					);
 				}
 			}
 
-			if ($keyTypes === []) {
+			return $newArrayBuilder->getArray();
+		}
+
+		$offsetTypes = [];
+		foreach ($argTypes as $argType) {
+			if ($argType->isConstantArray()->yes()) {
+				foreach ($argType->getConstantArrays() as $constantArray) {
+					foreach ($constantArray->getKeyTypes() as $keyType) {
+						$hasOffsetValue = TrinaryLogic::createFromBoolean($argType->hasOffsetValueType($keyType)->yes());
+						$offsetTypes[$keyType->getValue()] = [
+							$hasOffsetValue,
+							$argType->getOffsetValueType($keyType),
+						];
+					}
+				}
+			} else {
 				foreach ($offsetTypes as $key => [$hasOffsetValue, $offsetValueType]) {
 					$offsetTypes[$key] = [
 						$hasOffsetValue->and(TrinaryLogic::createMaybe()),
@@ -121,22 +136,6 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 					$argType->getOffsetValueType($offsetType),
 				];
 			}
-
-			if ($newArrayBuilder === null) {
-				continue;
-			}
-
-			foreach ($keyTypes as $keyType) {
-				$newArrayBuilder->setOffsetValueType(
-					$keyType instanceof ConstantIntegerType ? null : $keyType,
-					$argType->getOffsetValueType($keyType),
-					!$argType->hasOffsetValueType($keyType)->yes(),
-				);
-			}
-		}
-
-		if ($newArrayBuilder !== null) {
-			return $newArrayBuilder->getArray();
 		}
 
 		$keyTypes = [];

--- a/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMergeFunctionDynamicReturnTypeExtension.php
@@ -103,8 +103,9 @@ final class ArrayMergeFunctionDynamicReturnTypeExtension implements DynamicFunct
 
 		$offsetTypes = [];
 		foreach ($argTypes as $argType) {
-			if ($argType->isConstantArray()->yes()) {
-				foreach ($argType->getConstantArrays() as $constantArray) {
+			$constArrays = $argType->getConstantArrays();
+			if ($constArrays !== []) {
+				foreach ($constArrays as $constantArray) {
 					foreach ($constantArray->getKeyTypes() as $keyType) {
 						$hasOffsetValue = TrinaryLogic::createFromBoolean($argType->hasOffsetValueType($keyType)->yes());
 						$offsetTypes[$keyType->getValue()] = [

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4697,11 +4697,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_merge($generalStringKeys, $generalDateTimeValues)',
 			],
 			[
-				'non-empty-array<1|string, int|stdClass>',
+				"non-empty-array<1|string, int|stdClass>&hasOffset('foo')&hasOffset(1)",
 				'array_merge($generalStringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				'non-empty-array<1|string, int|stdClass>',
+				"non-empty-array<1|string, int|stdClass>&hasOffset('foo')&hasOffset(1)",
 				'array_merge($stringOrIntegerKeys, $generalStringKeys)',
 			],
 			[

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -4697,11 +4697,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'array_merge($generalStringKeys, $generalDateTimeValues)',
 			],
 			[
-				"non-empty-array<1|string, int|stdClass>&hasOffset('foo')&hasOffset(1)",
+				"non-empty-array<1|string, int|stdClass>&hasOffsetValue('foo', stdClass)",
 				'array_merge($generalStringKeys, $stringOrIntegerKeys)',
 			],
 			[
-				"non-empty-array<1|string, int|stdClass>&hasOffset('foo')&hasOffset(1)",
+				"non-empty-array<1|string, int|stdClass>&hasOffset('foo')",
 				'array_merge($stringOrIntegerKeys, $generalStringKeys)',
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -26,3 +26,17 @@ function doFooInts(array $array): void {
 function floatKey(array $array): void {
 	assertType("non-empty-array<string>&hasOffset('a')&hasOffset('c')&hasOffset(3)&hasOffset(4)", array_merge([4.23 => 'd'], $array, ['a' => '1', 3 => 'false', 'c' => 'e']));
 }
+
+function doOptKeys(array $array, array $arr2): void {
+	if (rand(0, 1)) {
+		$array['abc'] = 'def';
+	}
+	assertType("array", array_merge($arr2, $array));
+}
+
+/**
+ * @param array{a?: 1, b: 2} $array
+ */
+function doOptShapeKeys(array $array, array $arr2): void {
+	assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
+}

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -50,11 +50,18 @@ function hasOffsetKeys(array $array, array $arr2): void {
 	}
 }
 
-function hasOffsetValueKeys(array $array, array $arr2): void {
-	$array['b'] = 123;
+function hasOffsetValueKeys(array $hasB, array $mixedArray, array $hasC): void {
+	$hasB['b'] = 123;
+	$hasC['c'] = 'def';
 
-	assertType("non-empty-array&hasOffsetValue('b', 123)", array_merge($arr2, $array));
-	assertType("non-empty-array&hasOffset('b')", array_merge($array, $arr2));
+	assertType("non-empty-array&hasOffsetValue('b', 123)", array_merge($mixedArray, $hasB));
+	assertType("non-empty-array&hasOffset('b')", array_merge($hasB, $mixedArray));
+
+	assertType("non-empty-array&hasOffset('b')&hasOffsetValue('c', 'def')", array_merge($mixedArray, $hasB, $hasC));
+	assertType("non-empty-array&hasOffset('b')&hasOffsetValue('c', 'def')", array_merge($hasB, $mixedArray, $hasC));
+
+	assertType("non-empty-array&hasOffset('c')&hasOffsetValue('b', 123)", array_merge($hasC, $mixedArray, $hasB));
+	assertType("non-empty-array&hasOffset('b')&hasOffset('c')", array_merge($hasC, $hasB, $mixedArray));
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -5,26 +5,26 @@ namespace ArrayMergeConstNonConst;
 use function PHPStan\Testing\assertType;
 
 function doFoo(array $post): void {
-	assertType("non-empty-array&hasOffset('a')&hasOffset('b')", array_merge(['a' => 1, 'b' => false], $post));
+	assertType("non-empty-array&hasOffset('a')&hasOffset('b')", array_merge(['a' => 1, 'b' => false, 10 => 99], $post));
 }
 
 function doBar(array $array): void {
-	assertType("non-empty-array&hasOffset('a')&hasOffset('b')", array_merge($array, ['a' => 1, 'b' => false]));
+	assertType("non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('b', false)", array_merge($array, ['a' => 1, 'b' => false, 10 => 99]));
 }
 
 function doFooBar(array $array): void {
-	assertType("non-empty-array&hasOffset('a')&hasOffset('b')&hasOffset('c')", array_merge(['c' => 'd'], $array, ['a' => 1, 'b' => false, 'c' => 'e']));
+	assertType("non-empty-array&hasOffset('x')&hasOffsetValue('a', 1)&hasOffsetValue('b', false)&hasOffsetValue('c', 'e')", array_merge(['c' => 'd', 'x' => 'y'], $array, ['a' => 1, 'b' => false, 'c' => 'e']));
 }
 
 function doFooInts(array $array): void {
-	assertType("non-empty-array&hasOffset('a')&hasOffset('c')&hasOffset(1)&hasOffset(3)", array_merge([1 => 'd'], $array, ['a' => 1, 3 => false, 'c' => 'e']));
+	assertType("non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('c', 'e')", array_merge([1 => 'd'], $array, ['a' => 1, 3 => false, 'c' => 'e']));
 }
 
 /**
  * @param array<string> $array
  */
 function floatKey(array $array): void {
-	assertType("non-empty-array<string>&hasOffset('a')&hasOffset('c')&hasOffset(3)&hasOffset(4)", array_merge([4.23 => 'd'], $array, ['a' => '1', 3 => 'false', 'c' => 'e']));
+	assertType("non-empty-array<string>&hasOffsetValue('a', '1')&hasOffsetValue('c', 'e')", array_merge([4.23 => 'd'], $array, ['a' => '1', 3 => 'false', 'c' => 'e']));
 }
 
 function doOptKeys(array $array, array $arr2): void {
@@ -38,17 +38,25 @@ function doOptKeys(array $array, array $arr2): void {
  * @param array{a?: 1, b: 2} $array
  */
 function doOptShapeKeys(array $array, array $arr2): void {
-	assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
+	assertType("non-empty-array&hasOffsetValue('b', 2)", array_merge($arr2, $array));
 }
 
 function hasOffsetKeys(array $array, array $arr2): void {
 	if (array_key_exists('b', $array)) {
-		assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
+		assertType("non-empty-array&hasOffsetValue('b', mixed)", array_merge($arr2, $array));
 	}
 }
 
 function hasOffsetValueKeys(array $array, array $arr2): void {
 	$array['b'] = 123;
 
-	assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
+	assertType("non-empty-array&hasOffsetValue('b', 123)", array_merge($arr2, $array));
+}
+
+/**
+ * @param array{a?: 1, b?: 2} $allOptional
+ */
+function doAllOptional(array $allOptional, array $arr2): void {
+	assertType("array", array_merge($arr2, $allOptional));
+	assertType("array", array_merge($allOptional, $arr2));
 }

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ArrayMergeConstNonConst;
+
+use function PHPStan\Testing\assertType;
+
+function doFoo(array $post): void {
+	assertType("non-empty-array&hasOffset('a')&hasOffset('b')", array_merge(['a' => 1, 'b' => false], $post));
+}
+
+function doBar(array $array): void {
+	assertType("non-empty-array&hasOffset('a')&hasOffset('b')", array_merge($array, ['a' => 1, 'b' => false]));
+}
+
+function doFooBar(array $array): void {
+	assertType("non-empty-array&hasOffset('a')&hasOffset('b')&hasOffset('c')", array_merge(['c' => 'd'], $array, ['a' => 1, 'b' => false, 'c' => 'e']));
+}
+
+function doFooInts(array $array): void {
+	assertType("non-empty-array&hasOffset('a')&hasOffset('c')&hasOffset(1)&hasOffset(3)", array_merge([1 => 'd'], $array, ['a' => 1, 3 => false, 'c' => 'e']));
+}
+
+/**
+ * @param array<string> $array
+ */
+function floatKey(array $array): void {
+	assertType("non-empty-array<string>&hasOffset('a')&hasOffset('c')&hasOffset(3)&hasOffset(4)", array_merge([4.23 => 'd'], $array, ['a' => '1', 3 => 'false', 'c' => 'e']));
+}

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -32,6 +32,7 @@ function doOptKeys(array $array, array $arr2): void {
 		$array['abc'] = 'def';
 	}
 	assertType("array", array_merge($arr2, $array));
+	assertType("array", array_merge($array, $arr2));
 }
 
 /**
@@ -39,11 +40,13 @@ function doOptKeys(array $array, array $arr2): void {
  */
 function doOptShapeKeys(array $array, array $arr2): void {
 	assertType("non-empty-array&hasOffsetValue('b', 2)", array_merge($arr2, $array));
+	assertType("non-empty-array&hasOffset('b')", array_merge($array, $arr2));
 }
 
 function hasOffsetKeys(array $array, array $arr2): void {
 	if (array_key_exists('b', $array)) {
 		assertType("non-empty-array&hasOffsetValue('b', mixed)", array_merge($arr2, $array));
+		assertType("non-empty-array&hasOffset('b')", array_merge($array, $arr2));
 	}
 }
 
@@ -51,6 +54,7 @@ function hasOffsetValueKeys(array $array, array $arr2): void {
 	$array['b'] = 123;
 
 	assertType("non-empty-array&hasOffsetValue('b', 123)", array_merge($arr2, $array));
+	assertType("non-empty-array&hasOffset('b')", array_merge($array, $arr2));
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -26,6 +26,7 @@ function doFooBar(array $array): void {
 }
 
 function doFooInts(array $array): void {
+	// int keys will be renumbered therefore we can't reason about them in case we don't know all arrays involved
 	assertType(
 		"non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('c', 'e')",
 		array_merge([1 => 'd'], $array, ['a' => 1, 3 => false, 'c' => 'e'])

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -5,26 +5,41 @@ namespace ArrayMergeConstNonConst;
 use function PHPStan\Testing\assertType;
 
 function doFoo(array $post): void {
-	assertType("non-empty-array&hasOffset('a')&hasOffset('b')", array_merge(['a' => 1, 'b' => false, 10 => 99], $post));
+	assertType(
+		"non-empty-array&hasOffset('a')&hasOffset('b')",
+		array_merge(['a' => 1, 'b' => false, 10 => 99], $post)
+	);
 }
 
 function doBar(array $array): void {
-	assertType("non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('b', false)", array_merge($array, ['a' => 1, 'b' => false, 10 => 99]));
+	assertType(
+		"non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('b', false)",
+		array_merge($array, ['a' => 1, 'b' => false, 10 => 99])
+	);
 }
 
 function doFooBar(array $array): void {
-	assertType("non-empty-array&hasOffset('x')&hasOffsetValue('a', 1)&hasOffsetValue('b', false)&hasOffsetValue('c', 'e')", array_merge(['c' => 'd', 'x' => 'y'], $array, ['a' => 1, 'b' => false, 'c' => 'e']));
+	assertType(
+		"non-empty-array&hasOffset('x')&hasOffsetValue('a', 1)&hasOffsetValue('b', false)&hasOffsetValue('c', 'e')",
+		array_merge(['c' => 'd', 'x' => 'y'], $array, ['a' => 1, 'b' => false, 'c' => 'e'])
+	);
 }
 
 function doFooInts(array $array): void {
-	assertType("non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('c', 'e')", array_merge([1 => 'd'], $array, ['a' => 1, 3 => false, 'c' => 'e']));
+	assertType(
+		"non-empty-array&hasOffsetValue('a', 1)&hasOffsetValue('c', 'e')",
+		array_merge([1 => 'd'], $array, ['a' => 1, 3 => false, 'c' => 'e'])
+	);
 }
 
 /**
  * @param array<string> $array
  */
 function floatKey(array $array): void {
-	assertType("non-empty-array<string>&hasOffsetValue('a', '1')&hasOffsetValue('c', 'e')", array_merge([4.23 => 'd'], $array, ['a' => '1', 3 => 'false', 'c' => 'e']));
+	assertType(
+		"non-empty-array<string>&hasOffsetValue('a', '1')&hasOffsetValue('c', 'e')",
+		array_merge([4.23 => 'd'], $array, ['a' => '1', 3 => 'false', 'c' => 'e'])
+	);
 }
 
 function doOptKeys(array $array, array $arr2): void {
@@ -57,11 +72,23 @@ function hasOffsetValueKeys(array $hasB, array $mixedArray, array $hasC): void {
 	assertType("non-empty-array&hasOffsetValue('b', 123)", array_merge($mixedArray, $hasB));
 	assertType("non-empty-array&hasOffset('b')", array_merge($hasB, $mixedArray));
 
-	assertType("non-empty-array&hasOffset('b')&hasOffsetValue('c', 'def')", array_merge($mixedArray, $hasB, $hasC));
-	assertType("non-empty-array&hasOffset('b')&hasOffsetValue('c', 'def')", array_merge($hasB, $mixedArray, $hasC));
+	assertType(
+		"non-empty-array&hasOffset('b')&hasOffsetValue('c', 'def')",
+		array_merge($mixedArray, $hasB, $hasC)
+	);
+	assertType(
+		"non-empty-array&hasOffset('b')&hasOffsetValue('c', 'def')",
+		array_merge($hasB, $mixedArray, $hasC)
+	);
 
-	assertType("non-empty-array&hasOffset('c')&hasOffsetValue('b', 123)", array_merge($hasC, $mixedArray, $hasB));
-	assertType("non-empty-array&hasOffset('b')&hasOffset('c')", array_merge($hasC, $hasB, $mixedArray));
+	assertType(
+		"non-empty-array&hasOffset('c')&hasOffsetValue('b', 123)",
+		array_merge($hasC, $mixedArray, $hasB)
+	);
+	assertType(
+		"non-empty-array&hasOffset('b')&hasOffset('c')",
+		array_merge($hasC, $hasB, $mixedArray)
+	);
 
 	if (rand(0, 1)) {
 		$hasBorC = ['b' => 1];

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -65,6 +65,16 @@ function hasOffsetKeys(array $array, array $arr2): void {
 	}
 }
 
+function maybeHasOffsetKeys(array $array): void {
+	$arr2 = [];
+	if (rand(0,1)) {
+		$arr2 ['ab'] = 'def';
+	}
+
+	assertType("array", array_merge($arr2, $array));
+	assertType("array", array_merge($array, $arr2));
+}
+
 function hasOffsetValueKeys(array $hasB, array $mixedArray, array $hasC): void {
 	$hasB['b'] = 123;
 	$hasC['c'] = 'def';

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -40,3 +40,15 @@ function doOptKeys(array $array, array $arr2): void {
 function doOptShapeKeys(array $array, array $arr2): void {
 	assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
 }
+
+function hasOffsetKeys(array $array, array $arr2): void {
+	if (array_key_exists('b', $array)) {
+		assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
+	}
+}
+
+function hasOffsetValueKeys(array $array, array $arr2): void {
+	$array['b'] = 123;
+
+	assertType("non-empty-array&hasOffset('b')", array_merge($arr2, $array));
+}

--- a/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
+++ b/tests/PHPStan/Analyser/nsrt/array-merge-const-non-const.php
@@ -62,6 +62,29 @@ function hasOffsetValueKeys(array $hasB, array $mixedArray, array $hasC): void {
 
 	assertType("non-empty-array&hasOffset('c')&hasOffsetValue('b', 123)", array_merge($hasC, $mixedArray, $hasB));
 	assertType("non-empty-array&hasOffset('b')&hasOffset('c')", array_merge($hasC, $hasB, $mixedArray));
+
+	if (rand(0, 1)) {
+		$hasBorC = ['b' => 1];
+	} else {
+		$hasBorC = ['c' => 2];
+	}
+	assertType('array{b: 1}|array{c: 2}', $hasBorC);
+	assertType("non-empty-array", array_merge($mixedArray, $hasBorC));
+	assertType("non-empty-array", array_merge($hasBorC, $mixedArray));
+
+	if (rand(0, 1)) {
+		$differentCs = ['c' => 10];
+	} else {
+		$differentCs = ['c' => 20];
+	}
+	assertType('array{c: 10}|array{c: 20}', $differentCs);
+	assertType("non-empty-array&hasOffsetValue('c', 10|20)", array_merge($mixedArray, $differentCs));
+	assertType("non-empty-array&hasOffset('c')", array_merge($differentCs, $mixedArray));
+
+	assertType("non-empty-array&hasOffsetValue('c', 10|20)", array_merge($mixedArray, $hasBorC, $differentCs));
+	assertType("non-empty-array", array_merge($differentCs, $mixedArray, $hasBorC)); // could be non-empty-array&hasOffset('c')
+	assertType("non-empty-array&hasOffsetValue('c', 10|20)", array_merge($hasBorC, $mixedArray, $differentCs));
+	assertType("non-empty-array", array_merge($differentCs, $hasBorC, $mixedArray)); // could be non-empty-array&hasOffset('c')
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/bug-2911.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-2911.php
@@ -49,23 +49,23 @@ final class ArrayItemRemoval
 	private function getResultSettings(array $settings): array
 	{
 		$settings = array_merge(self::DEFAULT_SETTINGS, $settings);
-		assertType('non-empty-array<string, mixed>', $settings);
+		assertType("non-empty-array<string, mixed>&hasOffset('limit')&hasOffset('remove')", $settings);
 
 		if (!is_string($settings['remove'])) {
 			throw $this->configException($settings, 'remove');
 		}
 
-		assertType("non-empty-array<string, mixed>&hasOffsetValue('remove', string)", $settings);
+		assertType("non-empty-array<string, mixed>&hasOffset('limit')&hasOffsetValue('remove', string)", $settings);
 
 		$settings['remove'] = strtolower($settings['remove']);
 
-		assertType("non-empty-array<string, mixed>&hasOffsetValue('remove', lowercase-string)", $settings);
+		assertType("non-empty-array<string, mixed>&hasOffset('limit')&hasOffsetValue('remove', lowercase-string)", $settings);
 
 		if (!in_array($settings['remove'], ['first', 'last', 'all'], true)) {
 			throw $this->configException($settings, 'remove');
 		}
 
-		assertType("non-empty-array<string, mixed>&hasOffsetValue('remove', 'all'|'first'|'last')", $settings);
+		assertType("non-empty-array<string, mixed>&hasOffset('limit')&hasOffsetValue('remove', 'all'|'first'|'last')", $settings);
 
 		if (!is_numeric($settings['limit']) || $settings['limit'] < 1) {
 			throw $this->configException($settings, 'limit');
@@ -110,13 +110,13 @@ final class ArrayItemRemoval2
 	{
 		$settings = array_merge(self::DEFAULT_SETTINGS, $settings);
 
-		assertType('non-empty-array<string, mixed>', $settings);
+		assertType("non-empty-array<string, mixed>&hasOffset('limit')&hasOffset('remove')", $settings);
 
 		if (!is_string($settings['remove'])) {
 			throw new Exception();
 		}
 
-		assertType("non-empty-array<string, mixed>&hasOffsetValue('remove', string)", $settings);
+		assertType("non-empty-array<string, mixed>&hasOffset('limit')&hasOffsetValue('remove', string)", $settings);
 
 		if (!is_int($settings['limit'])) {
 			throw new Exception();

--- a/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ReturnTypeRuleTest.php
@@ -1281,4 +1281,9 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11160.php'], []);
 	}
 
+	public function testBug8438(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8438.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/data/bug-8438.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-8438.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug8438;
+
+class HelloWorld
+{
+	/**
+	 * @param array<string, string> $array
+	 *
+	 * @return array{expr: mixed, ...}
+	 */
+	protected function foo(array $array): array
+	{
+		$rnd = mt_rand();
+		if ($rnd === 0) {
+			return ['expr' => 'test'];
+		} elseif ($rnd === 1) {
+			// no error with checkBenevolentUnionTypes: false (default even with l9 + strict rules)
+			return ['expr' => 'test', 1 => 'ok'];
+		} else {
+			// phpstan must understand 'expr' key is always present in the result,
+			// then there will be no error here neither
+			return array_merge($array, ['expr' => 'test', 1 => 'ok']);
+		}
+	}
+}


### PR DESCRIPTION
the result of `array_merge` will always contain all `string` keys we see along the way.
~~we can't reason about the values when not all arrays are constant, but we can remember the keys.~~
since string keys overwrite each other, we know the value of the last string keys in the chain.
of other string based offsets we at least know about their existance.

best [reviewed with whitespaces ignored](https://github.com/phpstan/phpstan-src/pull/4554/files?w=1)

Followup could be doing the same for 
- the `+` operator when merging arrays
- `array_replace`
- spread operator