### PR TITLE
Fix typo in GNSR

### DIFF
--- a/src/Analyser/Generator/ExprHandler/ClosureHandler.php
+++ b/src/Analyser/Generator/ExprHandler/ClosureHandler.php
@@ -126,8 +126,8 @@ final class ClosureHandler implements ExprHandler
 					$inAssignRightSideVariableName === $use->var->name
 					&& $inAssignRightSideExpr !== null
 				) {
-					$inAssignRighSideExprTypeResult = yield new TypeExprRequest($inAssignRightSideExpr);
-					$inAssignRightSideType = $inAssignRighSideExprTypeResult->type;
+					$inAssignRightSideExprTypeResult = yield new TypeExprRequest($inAssignRightSideExpr);
+					$inAssignRightSideType = $inAssignRightSideExprTypeResult->type;
 					if ($inAssignRightSideType instanceof ClosureType) {
 						$variableType = $inAssignRightSideType;
 					} else {
@@ -138,7 +138,7 @@ final class ClosureHandler implements ExprHandler
 							$variableType = TypeCombinator::union($scope->getVariableType($inAssignRightSideVariableName), $inAssignRightSideType);
 						}
 					}
-					$inAssignRightSideNativeType = $inAssignRighSideExprTypeResult->nativeType;
+					$inAssignRightSideNativeType = $inAssignRightSideExprTypeResult->nativeType;
 					if ($inAssignRightSideNativeType instanceof ClosureType) {
 						$variableNativeType = $inAssignRightSideNativeType;
 					} else {


### PR DESCRIPTION
```
./typos
jq: jq-1.7
$ ./typos README.md src/
Warning: "Righ" should be "Right".
Warning: "Righ" should be "Right".
Warning: "Righ" should be "Right".
error: `Righ` should be `Right`
    ╭▸ src/Analyser/Generator/ExprHandler/ClosureHandler.php:129:15
    │
129 │                     $inAssignRighSideExprTypeResult = yield new TypeExprRequest($inAssignRightSideExpr);
    ╰╴                             ━━━━
error: `Righ` should be `Right`
    ╭▸ src/Analyser/Generator/ExprHandler/ClosureHandler.php:130:40
    │
130 │                     $inAssignRightSideType = $inAssignRighSideExprTypeResult->type;
    ╰╴                                                      ━━━━
error: `Righ` should be `Right`
    ╭▸ src/Analyser/Generator/ExprHandler/ClosureHandler.php:141:46
    │
141 │                     $inAssignRightSideNativeType = $inAssignRighSideExprTypeResult->nativeType;
    ╰╴                                                            ━━━━
```