### PR TITLE
Update theseer/tokenizer to 1.3.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6649,16 +6649,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -6687,7 +6687,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -6695,7 +6695,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
@@ -6713,5 +6713,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -2732,16 +2732,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -2770,7 +2770,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -2778,7 +2778,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
@@ -2791,5 +2791,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
running PHPUnit 11.5.23 on phpstan-src@5a24138b9a with
`time XDEBUG_MODE=coverage blackfire run php vendor/bin/phpunit --coverage-xml=tmp/coverage-xml tests/PHPStan/Rules/Api/`

---

using theseer/tokenizer 1.2.3

```
➜  phpstan-src git:(2.1.x) ✗ time XDEBUG_MODE=coverage blackfire run php vendor/bin/phpunit --coverage-xml=tmp/coverage-xml tests/PHPStan/Rules/Api/
The profile will be stored in your Personal environment. The "--environment" option can be used to specify the target environment.
PHPUnit 11.5.43 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.27 with Xdebug 3.4.7
Configuration: /Users/staabm/workspace/phpstan-src/phpunit.xml
Random Seed:   1763446832

.............................................                     45 / 45 (100%)

Time: 00:34.220, Memory: 230.50 MB

OK (45 tests, 45 assertions)

Generating code coverage report in PHPUnit XML format ... done [00:42.036]
```

---

using theseer/tokenizer 1.3.1

```
➜  phpstan-src git:(2.1.x) ✗ time XDEBUG_MODE=coverage blackfire run php vendor/bin/phpunit --coverage-xml=tmp/coverage-xml tests/PHPStan/Rules/Api/
The profile will be stored in your Personal environment. The "--environment" option can be used to specify the target environment.
PHPUnit 11.5.43 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.27 with Xdebug 3.4.7
Configuration: /Users/staabm/workspace/phpstan-src/phpunit.xml
Random Seed:   1763446937

.............................................                     45 / 45 (100%)

Time: 00:34.075, Memory: 232.50 MB

OK (45 tests, 45 assertions)

Generating code coverage report in PHPUnit XML format ... done [00:24.117]
```

=>
```diff
- Generating code coverage report in PHPUnit XML format ... done [00:42.036]
+ Generating code coverage report in PHPUnit XML format ... done [00:24.117]
```

the perf benefit seems to only happen on blackfire builds though :-/