### PR TITLE
Reduce ContainerFactory::postInitializeContainer() calls

### DIFF
--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -31,6 +31,7 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\Finder\Finder;
 use function array_map;
 use function array_merge;
@@ -56,33 +57,34 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 	protected static function createNodeScopeResolver(): NodeScopeResolver|GeneratorNodeScopeResolver
 	{
 		$reflectionProvider = self::createReflectionProvider();
-		$typeSpecifier = self::getContainer()->getService('typeSpecifier');
+		$container = self::getContainer();
+		$typeSpecifier = $container->getService('typeSpecifier');
 
 		return new NodeScopeResolver(
 			$reflectionProvider,
-			self::getContainer()->getByType(InitializerExprTypeResolver::class),
+			$container->getByType(InitializerExprTypeResolver::class),
 			self::getReflector(),
-			self::getContainer()->getByType(ClassReflectionFactory::class),
-			self::getContainer()->getByType(ParameterOutTypeExtensionProvider::class),
+			$container->getByType(ClassReflectionFactory::class),
+			$container->getByType(ParameterOutTypeExtensionProvider::class),
 			self::getParser(),
-			self::getContainer()->getByType(FileTypeMapper::class),
-			self::getContainer()->getByType(PhpVersion::class),
-			self::getContainer()->getByType(PhpDocInheritanceResolver::class),
-			self::getContainer()->getByType(FileHelper::class),
+			$container->getByType(FileTypeMapper::class),
+			$container->getByType(PhpVersion::class),
+			$container->getByType(PhpDocInheritanceResolver::class),
+			$container->getByType(FileHelper::class),
 			$typeSpecifier,
-			self::getContainer()->getByType(DynamicThrowTypeExtensionProvider::class),
-			self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class),
-			self::getContainer()->getByType(ParameterClosureThisExtensionProvider::class),
-			self::getContainer()->getByType(ParameterClosureTypeExtensionProvider::class),
+			$container->getByType(DynamicThrowTypeExtensionProvider::class),
+			$container->getByType(ReadWritePropertiesExtensionProvider::class),
+			$container->getByType(ParameterClosureThisExtensionProvider::class),
+			$container->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
-			self::getContainer()->getParameter('polluteScopeWithLoopInitialAssignments'),
-			self::getContainer()->getParameter('polluteScopeWithAlwaysIterableForeach'),
-			self::getContainer()->getParameter('polluteScopeWithBlock'),
+			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
+			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
+			$container->getParameter('polluteScopeWithBlock'),
 			static::getEarlyTerminatingMethodCalls(),
 			static::getEarlyTerminatingFunctionCalls(),
-			self::getContainer()->getParameter('exceptions')['implicitThrows'],
-			self::getContainer()->getParameter('treatPhpDocTypesAsCertain'),
-			self::getContainer()->getParameter('narrowMethodScopeFromConstructor'),
+			$container->getParameter('exceptions')['implicitThrows'],
+			$container->getParameter('treatPhpDocTypesAsCertain'),
+			$container->getParameter('narrowMethodScopeFromConstructor'),
 		);
 	}
 

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -31,7 +31,6 @@ use PHPStan\Type\ConstantScalarType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\Finder\Finder;
 use function array_map;
 use function array_merge;

--- a/tests/PHPStan/Analyser/Generator/GeneratorNodeScopeResolverRuleTest.php
+++ b/tests/PHPStan/Analyser/Generator/GeneratorNodeScopeResolverRuleTest.php
@@ -180,9 +180,10 @@ class GeneratorNodeScopeResolverRuleTest extends RuleTestCase
 
 	protected function createNodeScopeResolver(): GeneratorNodeScopeResolver
 	{
+		$container = self::getContainer();
 		return new GeneratorNodeScopeResolver(
-			self::getContainer()->getByType(ExprPrinter::class),
-			self::getContainer(),
+			$container->getByType(ExprPrinter::class),
+			$container,
 		);
 	}
 

--- a/tests/PHPStan/Rules/Classes/ClassAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassAttributesRuleTest.php
@@ -28,6 +28,7 @@ class ClassAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ClassAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -43,9 +44,9 @@ class ClassAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Classes/ClassConstantAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantAttributesRuleTest.php
@@ -23,6 +23,7 @@ class ClassConstantAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ClassConstantAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class ClassConstantAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ClassConstantRuleTest.php
@@ -24,14 +24,15 @@ class ClassConstantRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ClassConstantRule(
 			$reflectionProvider,
 			new RuleLevelHelper($reflectionProvider, true, false, true, true, true, false, true),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new PhpVersion($this->phpVersion),
 			true,

--- a/tests/PHPStan/Rules/Classes/ExistingClassInClassExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInClassExtendsRuleTest.php
@@ -18,12 +18,13 @@ class ExistingClassInClassExtendsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassInClassExtendsRule(
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			$reflectionProvider,
 			true,

--- a/tests/PHPStan/Rules/Classes/ExistingClassInInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInInstanceOfRuleTest.php
@@ -19,13 +19,14 @@ class ExistingClassInInstanceOfRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassInInstanceOfRule(
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			true,
 			true,

--- a/tests/PHPStan/Rules/Classes/ExistingClassInTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassInTraitUseRuleTest.php
@@ -18,12 +18,13 @@ class ExistingClassInTraitUseRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassInTraitUseRule(
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			$reflectionProvider,
 			true,

--- a/tests/PHPStan/Rules/Classes/ExistingClassesInClassImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassesInClassImplementsRuleTest.php
@@ -18,12 +18,13 @@ class ExistingClassesInClassImplementsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInClassImplementsRule(
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			$reflectionProvider,
 			true,

--- a/tests/PHPStan/Rules/Classes/ExistingClassesInEnumImplementsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassesInEnumImplementsRuleTest.php
@@ -19,12 +19,13 @@ class ExistingClassesInEnumImplementsRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new ExistingClassesInEnumImplementsRule(
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			$reflectionProvider,
 			true,

--- a/tests/PHPStan/Rules/Classes/ExistingClassesInInterfaceExtendsRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ExistingClassesInInterfaceExtendsRuleTest.php
@@ -18,12 +18,13 @@ class ExistingClassesInInterfaceExtendsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInInterfaceExtendsRule(
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			$reflectionProvider,
 			true,

--- a/tests/PHPStan/Rules/Classes/ForbiddenNameCheckExtensionRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ForbiddenNameCheckExtensionRuleTest.php
@@ -23,15 +23,16 @@ class ForbiddenNameCheckExtensionRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new InstantiationRule(
-			self::getContainer(),
+			$container,
 			$reflectionProvider,
 			new FunctionCallParametersCheck(new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true), new NullsafeCheck(), new UnresolvableTypeHelper(), new PropertyReflectionFinder(), true, true, true, true),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new ConsistentConstructorHelper(),
 			true,

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -23,15 +23,16 @@ class InstantiationRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new InstantiationRule(
-			self::getContainer(),
+			$container,
 			$reflectionProvider,
 			new FunctionCallParametersCheck(new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true), new NullsafeCheck(), new UnresolvableTypeHelper(), new PropertyReflectionFinder(), true, true, true, true),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new ConsistentConstructorHelper(),
 			true,

--- a/tests/PHPStan/Rules/Classes/LocalTypeAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeAliasesRuleTest.php
@@ -23,17 +23,18 @@ class LocalTypeAliasesRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new LocalTypeAliasesRule(
 			new LocalTypeAliasesCheck(
 				['GlobalTypeAlias' => 'int|string'],
 				self::createReflectionProvider(),
-				self::getContainer()->getByType(TypeNodeResolver::class),
+				$container->getByType(TypeNodeResolver::class),
 				new MissingTypehintCheck(true, []),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new GenericObjectTypeCheck(),

--- a/tests/PHPStan/Rules/Classes/LocalTypeTraitAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeTraitAliasesRuleTest.php
@@ -22,17 +22,18 @@ class LocalTypeTraitAliasesRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new LocalTypeTraitAliasesRule(
 			new LocalTypeAliasesCheck(
 				['GlobalTypeAlias' => 'int|string'],
 				self::createReflectionProvider(),
-				self::getContainer()->getByType(TypeNodeResolver::class),
+				$container->getByType(TypeNodeResolver::class),
 				new MissingTypehintCheck(true, []),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new GenericObjectTypeCheck(),

--- a/tests/PHPStan/Rules/Classes/LocalTypeTraitUseAliasesRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/LocalTypeTraitUseAliasesRuleTest.php
@@ -22,17 +22,18 @@ class LocalTypeTraitUseAliasesRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new LocalTypeTraitUseAliasesRule(
 			new LocalTypeAliasesCheck(
 				['GlobalTypeAlias' => 'int|string'],
 				self::createReflectionProvider(),
-				self::getContainer()->getByType(TypeNodeResolver::class),
+				$container->getByType(TypeNodeResolver::class),
 				new MissingTypehintCheck(true, []),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new GenericObjectTypeCheck(),

--- a/tests/PHPStan/Rules/Classes/MethodTagRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MethodTagRuleTest.php
@@ -21,14 +21,15 @@ class MethodTagRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new MethodTagRule(
 			new MethodTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/MethodTagTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MethodTagTraitRuleTest.php
@@ -21,14 +21,15 @@ class MethodTagTraitRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new MethodTagTraitRule(
 			new MethodTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/MethodTagTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MethodTagTraitUseRuleTest.php
@@ -22,14 +22,15 @@ class MethodTagTraitUseRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new MethodTagTraitUseRule(
 			new MethodTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/MixinRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinRuleTest.php
@@ -22,14 +22,15 @@ class MixinRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new MixinRule(
 			new MixinCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/MixinTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinTraitRuleTest.php
@@ -21,14 +21,15 @@ class MixinTraitRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new MixinTraitRule(
 			new MixinCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/MixinTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/MixinTraitUseRuleTest.php
@@ -21,14 +21,15 @@ class MixinTraitUseRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new MixinTraitUseRule(
 			new MixinCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/PropertyTagRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/PropertyTagRuleTest.php
@@ -21,14 +21,15 @@ class PropertyTagRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new PropertyTagRule(
 			new PropertyTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/PropertyTagTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/PropertyTagTraitRuleTest.php
@@ -21,14 +21,15 @@ class PropertyTagTraitRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new PropertyTagTraitRule(
 			new PropertyTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Classes/PropertyTagTraitUseRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/PropertyTagTraitUseRuleTest.php
@@ -21,14 +21,15 @@ class PropertyTagTraitUseRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new PropertyTagTraitUseRule(
 			new PropertyTagCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/Constants/ConstantAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ConstantAttributesRuleTest.php
@@ -29,6 +29,7 @@ class ConstantAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ConstantAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -44,9 +45,9 @@ class ConstantAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/EnumCases/EnumCaseAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/EnumCases/EnumCaseAttributesRuleTest.php
@@ -24,6 +24,7 @@ class EnumCaseAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new EnumCaseAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -39,9 +40,9 @@ class EnumCaseAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Exceptions/CaughtExceptionExistenceRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CaughtExceptionExistenceRuleTest.php
@@ -17,13 +17,14 @@ class CaughtExceptionExistenceRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new CaughtExceptionExistenceRule(
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			true,
 			true,

--- a/tests/PHPStan/Rules/Functions/ArrowFunctionAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ArrowFunctionAttributesRuleTest.php
@@ -23,6 +23,7 @@ class ArrowFunctionAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ArrowFunctionAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class ArrowFunctionAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Functions/ClosureAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ClosureAttributesRuleTest.php
@@ -23,6 +23,7 @@ class ClosureAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ClosureAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class ClosureAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInArrowFunctionTypehintsRuleTest.php
@@ -25,14 +25,15 @@ class ExistingClassesInArrowFunctionTypehintsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInArrowFunctionTypehintsRule(
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new PhpVersion($this->phpVersionId),

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInClosureTypehintsRuleTest.php
@@ -25,14 +25,15 @@ class ExistingClassesInClosureTypehintsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInClosureTypehintsRule(
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new PhpVersion($this->phpVersionId),

--- a/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ExistingClassesInTypehintsRuleTest.php
@@ -25,14 +25,15 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInTypehintsRule(
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new PhpVersion($this->phpVersionId),

--- a/tests/PHPStan/Rules/Functions/FunctionAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/FunctionAttributesRuleTest.php
@@ -23,6 +23,7 @@ class FunctionAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new FunctionAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class FunctionAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Functions/ParamAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ParamAttributesRuleTest.php
@@ -23,6 +23,7 @@ class ParamAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ParamAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class ParamAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/ClassTemplateTypeRuleTest.php
@@ -20,14 +20,15 @@ class ClassTemplateTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new ClassTemplateTypeRule(
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				$typeAliasResolver,

--- a/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/FunctionTemplateTypeRuleTest.php
@@ -20,15 +20,16 @@ class FunctionTemplateTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new FunctionTemplateTypeRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				$typeAliasResolver,

--- a/tests/PHPStan/Rules/Generics/InterfaceTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/InterfaceTemplateTypeRuleTest.php
@@ -19,14 +19,15 @@ class InterfaceTemplateTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new InterfaceTemplateTypeRule(
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				$typeAliasResolver,

--- a/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeRuleTest.php
@@ -20,16 +20,17 @@ class MethodTagTemplateTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new MethodTagTemplateTypeRule(
 			new MethodTagTemplateTypeCheck(
-				self::getContainer()->getByType(FileTypeMapper::class),
+				$container->getByType(FileTypeMapper::class),
 				new TemplateTypeCheck(
 					$reflectionProvider,
 					new ClassNameCheck(
 						new ClassCaseSensitivityCheck($reflectionProvider, true),
-						new ClassForbiddenNameCheck(self::getContainer()),
+						new ClassForbiddenNameCheck($container),
 						$reflectionProvider,
-						self::getContainer(),
+						$container,
 					),
 					new GenericObjectTypeCheck(),
 					$typeAliasResolver,

--- a/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeTraitRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodTagTemplateTypeTraitRuleTest.php
@@ -20,16 +20,17 @@ class MethodTagTemplateTypeTraitRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new MethodTagTemplateTypeTraitRule(
 			new MethodTagTemplateTypeCheck(
-				self::getContainer()->getByType(FileTypeMapper::class),
+				$container->getByType(FileTypeMapper::class),
 				new TemplateTypeCheck(
 					$reflectionProvider,
 					new ClassNameCheck(
 						new ClassCaseSensitivityCheck($reflectionProvider, true),
-						new ClassForbiddenNameCheck(self::getContainer()),
+						new ClassForbiddenNameCheck($container),
 						$reflectionProvider,
-						self::getContainer(),
+						$container,
 					),
 					new GenericObjectTypeCheck(),
 					$typeAliasResolver,

--- a/tests/PHPStan/Rules/Generics/MethodTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/MethodTemplateTypeRuleTest.php
@@ -20,15 +20,16 @@ class MethodTemplateTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new MethodTemplateTypeRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				$typeAliasResolver,

--- a/tests/PHPStan/Rules/Generics/TraitTemplateTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generics/TraitTemplateTypeRuleTest.php
@@ -20,15 +20,16 @@ class TraitTemplateTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new TraitTemplateTypeRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			new TemplateTypeCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new GenericObjectTypeCheck(),
 				$typeAliasResolver,

--- a/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallStaticMethodsRuleTest.php
@@ -33,15 +33,16 @@ class CallStaticMethodsRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$ruleLevelHelper = new RuleLevelHelper($reflectionProvider, true, $this->checkThisOnly, true, $this->checkExplicitMixed, $this->checkImplicitMixed, false, true);
+		$container = self::getContainer();
 		return new CallStaticMethodsRule(
 			new StaticMethodCallCheck(
 				$reflectionProvider,
 				$ruleLevelHelper,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 				true,

--- a/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ConsistentConstructorRuleTest.php
@@ -13,10 +13,11 @@ class ConsistentConstructorRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new ConsistentConstructorRule(
 			new ConsistentConstructorHelper(),
-			self::getContainer()->getByType(MethodParameterComparisonHelper::class),
-			self::getContainer()->getByType(MethodVisibilityComparisonHelper::class),
+			$container->getByType(MethodParameterComparisonHelper::class),
+			$container->getByType(MethodVisibilityComparisonHelper::class),
 		);
 	}
 

--- a/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/ExistingClassesInTypehintsRuleTest.php
@@ -25,14 +25,15 @@ class ExistingClassesInTypehintsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInTypehintsRule(
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new PhpVersion($this->phpVersionId),

--- a/tests/PHPStan/Rules/Methods/MethodAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodAttributesRuleTest.php
@@ -23,6 +23,7 @@ class MethodAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new MethodAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class MethodAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/StaticMethodCallableRuleTest.php
@@ -25,15 +25,16 @@ class StaticMethodCallableRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$ruleLevelHelper = new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true);
 
+		$container = self::getContainer();
 		return new StaticMethodCallableRule(
 			new StaticMethodCallCheck(
 				$reflectionProvider,
 				$ruleLevelHelper,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 				true,

--- a/tests/PHPStan/Rules/Namespaces/ExistingNamesInGroupUseRuleTest.php
+++ b/tests/PHPStan/Rules/Namespaces/ExistingNamesInGroupUseRuleTest.php
@@ -17,13 +17,14 @@ class ExistingNamesInGroupUseRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingNamesInGroupUseRule(
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			true,
 			true,

--- a/tests/PHPStan/Rules/Namespaces/ExistingNamesInUseRuleTest.php
+++ b/tests/PHPStan/Rules/Namespaces/ExistingNamesInUseRuleTest.php
@@ -17,13 +17,14 @@ class ExistingNamesInUseRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingNamesInUseRule(
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			true,
 			true,

--- a/tests/PHPStan/Rules/PhpDoc/FunctionAssertRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/FunctionAssertRuleTest.php
@@ -19,14 +19,15 @@ class FunctionAssertRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new FunctionAssertRule(new AssertRuleHelper(
 			$reflectionProvider,
 			new UnresolvableTypeHelper(),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new MissingTypehintCheck(true, []),
 			new GenericObjectTypeCheck(),

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePhpDocTypeRuleTest.php
@@ -23,8 +23,9 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new IncompatiblePhpDocTypeRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			new IncompatiblePhpDocTypeCheck(
 				new GenericObjectTypeCheck(),
 				new UnresolvableTypeHelper(),
@@ -33,9 +34,9 @@ class IncompatiblePhpDocTypeRuleTest extends RuleTestCase
 						$reflectionProvider,
 						new ClassNameCheck(
 							new ClassCaseSensitivityCheck($reflectionProvider, true),
-							new ClassForbiddenNameCheck(self::getContainer()),
+							new ClassForbiddenNameCheck($container),
 							$reflectionProvider,
-							self::getContainer(),
+							$container,
 						),
 						new GenericObjectTypeCheck(),
 						$typeAliasResolver,

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyHookPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyHookPhpDocTypeRuleTest.php
@@ -23,8 +23,9 @@ class IncompatiblePropertyHookPhpDocTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver([], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new IncompatiblePropertyHookPhpDocTypeRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			new IncompatiblePhpDocTypeCheck(
 				new GenericObjectTypeCheck(),
 				new UnresolvableTypeHelper(),
@@ -33,9 +34,9 @@ class IncompatiblePropertyHookPhpDocTypeRuleTest extends RuleTestCase
 						$reflectionProvider,
 						new ClassNameCheck(
 							new ClassCaseSensitivityCheck($reflectionProvider, true),
-							new ClassForbiddenNameCheck(self::getContainer()),
+							new ClassForbiddenNameCheck($container),
 							$reflectionProvider,
-							self::getContainer(),
+							$container,
 						),
 						new GenericObjectTypeCheck(),
 						$typeAliasResolver,

--- a/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/IncompatiblePropertyPhpDocTypeRuleTest.php
@@ -22,6 +22,7 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends RuleTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$typeAliasResolver = $this->createTypeAliasResolver(['TypeAlias' => 'int'], $reflectionProvider);
 
+		$container = self::getContainer();
 		return new IncompatiblePropertyPhpDocTypeRule(
 			new GenericObjectTypeCheck(),
 			new UnresolvableTypeHelper(),
@@ -30,9 +31,9 @@ class IncompatiblePropertyPhpDocTypeRuleTest extends RuleTestCase
 					$reflectionProvider,
 					new ClassNameCheck(
 						new ClassCaseSensitivityCheck($reflectionProvider, true),
-						new ClassForbiddenNameCheck(self::getContainer()),
+						new ClassForbiddenNameCheck($container),
 						$reflectionProvider,
-						self::getContainer(),
+						$container,
 					),
 					new GenericObjectTypeCheck(),
 					$typeAliasResolver,

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPHPStanDocTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPHPStanDocTagRuleTest.php
@@ -16,9 +16,10 @@ class InvalidPHPStanDocTagRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new InvalidPHPStanDocTagRule(
-			self::getContainer()->getByType(Lexer::class),
-			self::getContainer()->getByType(PhpDocParser::class),
+			$container->getByType(Lexer::class),
+			$container->getByType(PhpDocParser::class),
 		);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocTagValueRuleTest.php
@@ -16,9 +16,10 @@ class InvalidPhpDocTagValueRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new InvalidPhpDocTagValueRule(
-			self::getContainer()->getByType(Lexer::class),
-			self::getContainer()->getByType(PhpDocParser::class),
+			$container->getByType(Lexer::class),
+			$container->getByType(PhpDocParser::class),
 		);
 	}
 

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -21,14 +21,15 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new InvalidPhpDocVarTagTypeRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new GenericObjectTypeCheck(),
 			new MissingTypehintCheck(true, []),

--- a/tests/PHPStan/Rules/PhpDoc/MethodAssertRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/MethodAssertRuleTest.php
@@ -19,14 +19,15 @@ class MethodAssertRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new MethodAssertRule(new AssertRuleHelper(
 			$reflectionProvider,
 			new UnresolvableTypeHelper(),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new MissingTypehintCheck(true, []),
 			new GenericObjectTypeCheck(),

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionClassRuleTest.php
@@ -19,13 +19,14 @@ class RequireExtendsDefinitionClassRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new RequireExtendsDefinitionClassRule(
 			new RequireExtendsCheck(
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 				true,

--- a/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireExtendsDefinitionTraitRuleTest.php
@@ -19,14 +19,15 @@ class RequireExtendsDefinitionTraitRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new RequireExtendsDefinitionTraitRule(
 			$reflectionProvider,
 			new RequireExtendsCheck(
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 				true,

--- a/tests/PHPStan/Rules/PhpDoc/RequireImplementsDefinitionTraitRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/RequireImplementsDefinitionTraitRuleTest.php
@@ -19,13 +19,14 @@ class RequireImplementsDefinitionTraitRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new RequireImplementsDefinitionTraitRule(
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			true,
 			true,

--- a/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/SealedDefinitionClassRuleTest.php
@@ -19,12 +19,13 @@ class SealedDefinitionClassRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
+		$container = self::getContainer();
 		return new SealedDefinitionClassRule(
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			true,
 			true,

--- a/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/VarTagChangedExpressionTypeRuleTest.php
@@ -15,9 +15,10 @@ class VarTagChangedExpressionTypeRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new VarTagChangedExpressionTypeRule(new VarTagTypeRuleHelper(
-			self::getContainer()->getByType(TypeNodeResolver::class),
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(TypeNodeResolver::class),
+			$container->getByType(FileTypeMapper::class),
 			self::createReflectionProvider(),
 			true,
 			true,

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -21,11 +21,12 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new WrongVariableNameInVarTagRule(
-			self::getContainer()->getByType(FileTypeMapper::class),
+			$container->getByType(FileTypeMapper::class),
 			new VarTagTypeRuleHelper(
-				self::getContainer()->getByType(TypeNodeResolver::class),
-				self::getContainer()->getByType(FileTypeMapper::class),
+				$container->getByType(TypeNodeResolver::class),
+				$container->getByType(FileTypeMapper::class),
 				self::createReflectionProvider(),
 				$this->checkTypeAgainstPhpDocType,
 				$this->strictWideningCheck,

--- a/tests/PHPStan/Rules/Playground/PromoteParameterRuleTest.php
+++ b/tests/PHPStan/Rules/Playground/PromoteParameterRuleTest.php
@@ -16,12 +16,13 @@ class PromoteParameterRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new PromoteParameterRule(
 			new UninitializedPropertyRule(new ConstructorsHelper(
-				self::getContainer(),
+				$container,
 				[],
 			)),
-			self::getContainer(),
+			$container,
 			ClassPropertiesNode::class,
 			false,
 			'checkUninitializedProperties',

--- a/tests/PHPStan/Rules/Playground/PromoteParameterRuleWithOriginalRuleTest.php
+++ b/tests/PHPStan/Rules/Playground/PromoteParameterRuleWithOriginalRuleTest.php
@@ -21,17 +21,18 @@ class PromoteParameterRuleWithOriginalRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new PromoteParameterRule(
 			new OverridingMethodRule(
-				self::getContainer()->getByType(PhpVersion::class),
-				self::getContainer()->getByType(MethodSignatureRule::class),
+				$container->getByType(PhpVersion::class),
+				$container->getByType(MethodSignatureRule::class),
 				true,
-				self::getContainer()->getByType(MethodParameterComparisonHelper::class),
-				self::getContainer()->getByType(MethodVisibilityComparisonHelper::class),
-				self::getContainer()->getByType(MethodPrototypeFinder::class),
+				$container->getByType(MethodParameterComparisonHelper::class),
+				$container->getByType(MethodVisibilityComparisonHelper::class),
+				$container->getByType(MethodPrototypeFinder::class),
 				true,
 			),
-			self::getContainer(),
+			$container,
 			InClassMethodNode::class,
 			false,
 			'checkMissingOverrideMethodAttribute',

--- a/tests/PHPStan/Rules/Properties/ExistingClassesInPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ExistingClassesInPropertiesRuleTest.php
@@ -23,13 +23,14 @@ class ExistingClassesInPropertiesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInPropertiesRule(
 			$reflectionProvider,
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
-				new ClassForbiddenNameCheck(self::getContainer()),
+				new ClassForbiddenNameCheck($container),
 				$reflectionProvider,
-				self::getContainer(),
+				$container,
 			),
 			new UnresolvableTypeHelper(),
 			new PhpVersion($this->phpVersion),

--- a/tests/PHPStan/Rules/Properties/ExistingClassesInPropertyHookTypehintsRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ExistingClassesInPropertyHookTypehintsRuleTest.php
@@ -22,14 +22,15 @@ class ExistingClassesInPropertyHookTypehintsRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new ExistingClassesInPropertyHookTypehintsRule(
 			new FunctionDefinitionCheck(
 				$reflectionProvider,
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, true),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				new UnresolvableTypeHelper(),
 				new PhpVersion(PHP_VERSION_ID),

--- a/tests/PHPStan/Rules/Properties/PropertyAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyAttributesRuleTest.php
@@ -25,6 +25,7 @@ class PropertyAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new PropertyAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -40,9 +41,9 @@ class PropertyAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Properties/PropertyHookAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/PropertyHookAttributesRuleTest.php
@@ -23,6 +23,7 @@ class PropertyHookAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new PropertyHookAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -38,9 +39,9 @@ class PropertyHookAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Traits/TraitAttributesRuleTest.php
+++ b/tests/PHPStan/Rules/Traits/TraitAttributesRuleTest.php
@@ -30,6 +30,7 @@ class TraitAttributesRuleTest extends RuleTestCase
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
+		$container = self::getContainer();
 		return new TraitAttributesRule(
 			new AttributesCheck(
 				$reflectionProvider,
@@ -45,9 +46,9 @@ class TraitAttributesRuleTest extends RuleTestCase
 				),
 				new ClassNameCheck(
 					new ClassCaseSensitivityCheck($reflectionProvider, false),
-					new ClassForbiddenNameCheck(self::getContainer()),
+					new ClassForbiddenNameCheck($container),
 					$reflectionProvider,
-					self::getContainer(),
+					$container,
 				),
 				true,
 			),

--- a/tests/PHPStan/Rules/Variables/UnsetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/UnsetRuleTest.php
@@ -18,9 +18,10 @@ class UnsetRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
+		$container = self::getContainer();
 		return new UnsetRule(
-			self::getContainer()->getByType(PropertyReflectionFinder::class),
-			self::getContainer()->getByType(PhpVersion::class),
+			$container->getByType(PropertyReflectionFinder::class),
+			$container->getByType(PhpVersion::class),
 		);
 	}
 


### PR DESCRIPTION
prevents duplicate work in data-providers

before this PR
```
➜  phpstan-src git:(pstint) ✗ hyperfine '../phpunit/phpunit --list-suites'
Benchmark 1: ../phpunit/phpunit --list-suites
  Time (mean ± σ):     10.575 s ±  0.160 s    [User: 9.804 s, System: 0.759 s]
  Range (min … max):   10.218 s … 10.711 s    10 runs
```

after this PR:
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine '../phpunit/phpunit --list-suites'
Benchmark 1: ../phpunit/phpunit --list-suites
  Time (mean ± σ):     10.397 s ±  0.151 s    [User: 9.655 s, System: 0.725 s]
  Range (min … max):   10.187 s … 10.623 s    10 runs
```