### PR TITLE
Narrow string type when `ctype_*` functions return true

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -147,6 +147,7 @@ parameters:
 		- ../stubs/file.stub
 		- ../stubs/stream_socket_client.stub
 		- ../stubs/stream_socket_server.stub
+		- ../stubs/ctype.stub
 	earlyTerminatingMethodCalls: []
 	earlyTerminatingFunctionCalls: []
 	resultCachePath: %tmpDir%/resultCache.php

--- a/stubs/ctype.stub
+++ b/stubs/ctype.stub
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-empty-string : int) $text
+ */
+function ctype_alnum(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-falsy-string : int) $text
+ */
+function ctype_alpha(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-falsy-string : int) $text
+ */
+function ctype_cntrl(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-falsy-string : int) $text
+ */
+function ctype_lower(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-empty-string : int) $text
+ */
+function ctype_graph(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-empty-string : int) $text
+ */
+function ctype_print(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-falsy-string : int) $text
+ */
+function ctype_punct(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-falsy-string : int) $text
+ */
+function ctype_space(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-falsy-string : int) $text
+ */
+function ctype_upper(mixed $text): bool {}
+
+/**
+ * @phpstan-assert-if-true =($text is string ? non-empty-string : int) $text
+ */
+function ctype_xdigit(mixed $text): bool {}

--- a/tests/PHPStan/Analyser/nsrt/ctype.php
+++ b/tests/PHPStan/Analyser/nsrt/ctype.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ctype;
+
+use function ctype_alnum;
+use function ctype_alpha;
+use function ctype_cntrl;
+use function ctype_graph;
+use function ctype_lower;
+use function ctype_print;
+use function ctype_punct;
+use function ctype_space;
+use function ctype_upper;
+use function ctype_xdigit;
+use function PHPStan\Testing\assertType;
+
+function test(string $str): void
+{
+	// functions asserting non-falsy-string
+
+	if (ctype_alpha($str)) {
+		assertType('non-falsy-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_cntrl($str)) {
+		assertType('non-falsy-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_lower($str)) {
+		assertType('non-falsy-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_upper($str)) {
+		assertType('non-falsy-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_punct($str)) {
+		assertType('non-falsy-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_space($str)) {
+		assertType('non-falsy-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	// functions asserting non-empty-string
+	// ctype_digit is tested in another file
+
+	if (ctype_alnum($str)) {
+		assertType('non-empty-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_graph($str)) {
+		assertType('non-empty-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_print($str)) {
+		assertType('non-empty-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+
+	if (ctype_xdigit($str)) {
+		assertType('non-empty-string', $str);
+	} else {
+		assertType('string', $str);
+	}
+}
+
+function testInt(int $int): void
+{
+	if (ctype_alpha($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_cntrl($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_lower($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_upper($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_punct($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_space($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	// functions asserting non-empty-string
+	// ctype_digit is tested in another file
+
+	if (ctype_alnum($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_graph($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_print($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+
+	if (ctype_xdigit($int)) {
+		assertType('int', $int);
+	} else {
+		assertType('int', $int);
+	}
+}


### PR DESCRIPTION
Closes phpstan/phpstan#13089

Some ctype functions asserts non-falsy-string, while others asserts non-empty-string.

<details><summary>Test script to see the functions' return value when `''` or `'0'` given</summary>

```php
<?php

$ctypeFuncs = array_filter(
	get_defined_functions()['internal'],
	fn (string $name) => str_starts_with($name, 'ctype_'),
);

echo "func name   \t''\t'0'\n";
foreach ($ctypeFuncs as $func) {
	printf(
		"%-12s\t%s\t%s\n",
		$func,
		var_export($func(''), true),
		var_export($func('0'), true),
	);
}
```
</details>

Result:

```
func name       ''      '0'
ctype_alnum     false   true
ctype_alpha     false   false
ctype_cntrl     false   false
ctype_digit     false   true
ctype_lower     false   false
ctype_graph     false   true
ctype_print     false   true
ctype_punct     false   false
ctype_space     false   false
ctype_upper     false   false
ctype_xdigit    false   true
```