### PR TITLE
Add regression test for bug 10942 (contravariant phpdoc union)

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1577,6 +1577,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertSame('Function Bug13714\array_find invoked with 2 parameters, 0 required.', $errors[6]->getMessage());
 	}
 
+	public function testBug10942(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-10942.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return list<Error>

--- a/tests/PHPStan/Analyser/nsrt/bug-10942.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10942.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10942;
+
+class A
+{
+
+	/**
+	 * @param string|($operator is 'in' ? int : never) $sqlRight
+	 */
+	protected function _renderConditionBinary(string $operator, string $sqlLeft, $sqlRight): string
+	{
+		return 'x';
+	}
+
+}
+
+class B extends A
+{
+
+	#[\Override]
+	protected function _renderConditionBinary(string $operator, string $sqlLeft, $sqlRight): string
+	{
+		return 'y';
+	}
+
+}


### PR DESCRIPTION

- Add the reported case to nsrt: tests/PHPStan/Analyser/nsrt/bug-10942.php
- Wire it into AnalyserIntegrationTest::testBug10942
- Verified it passes on current 2.1.x (PHP 8.3.19)

closes https://github.com/phpstan/phpstan/issues/10942

If you ran the focused test, you can mention:
vendor/bin/phpunit --filter testBug10942 tests/PHPStan/Analyser/AnalyserIntegrationTest.php