### PR TITLE
Enable FileCacheStorage for OptimizedDirectorySourceLocatorFactory in tests

### DIFF
--- a/src/Testing/TestCase.neon
+++ b/src/Testing/TestCase.neon
@@ -11,11 +11,6 @@ services:
 			fileExtensions: %fileExtensions%
 			excludePaths: %excludePaths%
 
-	# overrides service from services.neon
-	cacheStorage:
-		class: PHPStan\Cache\MemoryCacheStorage
-		arguments!: []
-
 	# overrides service from parsers.neon
 	currentPhpVersionSimpleParser!:
 		factory: @currentPhpVersionRichParser


### PR DESCRIPTION
the caching in

https://github.com/phpstan/phpstan-src/blob/1a8a65748ffe77f7e8c7291da596caf6aaa03ecb/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php#L57-L76

re-valides the cache contents via sha1_file() hashes. I think we can utilize this cache also for our test-suite.

---

running `php tests/vendor/bin/paratest`..

before this PR:
```
Time: 00:46.365, Memory: 636.50 MB

OK, but some tests were skipped!
Tests: 13381, Assertions: 80652, Skipped: 170.
```

after this PR:
```
...
Time: 00:41.428, Memory: 618.50 MB

OK, but some tests were skipped!
Tests: 13381, Assertions: 80652, Skipped: 170.
```

<img width="406" height="802" alt="grafik" src="https://github.com/user-attachments/assets/126aa6aa-6922-455f-94f0-9d0b5cf79a06" />

---

this will NOT solve https://github.com/phpstan/phpstan/discussions/13852 as it only affects the test-suite