### PR TITLE
Cache files in OptimizedDirectorySourceLocatorFactory

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
+++ b/src/Reflection/BetterReflection/SourceLocator/ComposerJsonAndInstalledJsonSourceLocatorMaker.php
@@ -129,7 +129,7 @@ final class ComposerJsonAndInstalledJsonSourceLocatorMaker
 		}
 
 		if (count($files) > 0) {
-			$locators[] = $this->optimizedDirectorySourceLocatorFactory->createByFiles($files);
+			$locators[] = $this->optimizedDirectorySourceLocatorFactory->createByFiles($files, 'odsl-installed-files');
 		}
 
 		$binDir = ComposerHelper::getBinDirFromComposerConfig($projectInstallationPath, $composer);

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -57,6 +57,10 @@ final class OptimizedDirectorySourceLocatorFactory
 		return $this->createCachedDirectorySourceLocator($fileHashes, $cacheKey);
 	}
 
+	/**
+	 * @param array<string, string> $fileHashes
+	 * @param non-empty-string $cacheKey
+	 */
 	public function createCachedDirectorySourceLocator(array $fileHashes, string $cacheKey): OptimizedDirectorySourceLocator
 	{
 		$variableCacheKey = 'v1';

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -61,7 +61,7 @@ final class OptimizedDirectorySourceLocatorFactory
 	 * @param array<string, string> $fileHashes
 	 * @param non-empty-string $cacheKey
 	 */
-	public function createCachedDirectorySourceLocator(array $fileHashes, string $cacheKey): OptimizedDirectorySourceLocator
+	private function createCachedDirectorySourceLocator(array $fileHashes, string $cacheKey): OptimizedDirectorySourceLocator
 	{
 		$variableCacheKey = 'v1';
 

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -10,11 +10,13 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstantNameHelper;
 use function array_key_exists;
 use function count;
+use function implode;
 use function in_array;
 use function ltrim;
 use function php_strip_whitespace;
 use function preg_match_all;
 use function preg_replace;
+use function sha1;
 use function sha1_file;
 use function sprintf;
 use function strtolower;
@@ -52,6 +54,11 @@ final class OptimizedDirectorySourceLocatorFactory
 		}
 
 		$cacheKey = sprintf('odsl-%s', $directory);
+		return $this->createCachedDirectorySourceLocator($fileHashes, $cacheKey);
+	}
+
+	public function createCachedDirectorySourceLocator(array $fileHashes, string $cacheKey): OptimizedDirectorySourceLocator
+	{
 		$variableCacheKey = 'v1';
 
 		/** @var array<string, array{string, string[], string[], string[]}>|null $cached */
@@ -96,20 +103,17 @@ final class OptimizedDirectorySourceLocatorFactory
 	 */
 	public function createByFiles(array $files): OptimizedDirectorySourceLocator
 	{
-		$symbols = [];
+		$fileHashes = [];
 		foreach ($files as $file) {
-			[$newClasses, $newFunctions, $newConstants] = $this->findSymbols($file);
-			$symbols[$file] = ['', $newClasses, $newFunctions, $newConstants];
+			$hash = sha1_file($file);
+			if ($hash === false) {
+				continue;
+			}
+			$fileHashes[$file] = $hash;
 		}
 
-		[$classToFile, $functionToFiles, $constantToFile] = $this->changeStructure($symbols);
-
-		return new OptimizedDirectorySourceLocator(
-			$this->fileNodesFetcher,
-			$classToFile,
-			$functionToFiles,
-			$constantToFile,
-		);
+		$cacheKey = sprintf('odsl-files-%s', sha1(implode(',', $files)));
+		return $this->createCachedDirectorySourceLocator($fileHashes, $cacheKey);
 	}
 
 	/**

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -10,13 +10,11 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstantNameHelper;
 use function array_key_exists;
 use function count;
-use function implode;
 use function in_array;
 use function ltrim;
 use function php_strip_whitespace;
 use function preg_match_all;
 use function preg_replace;
-use function sha1;
 use function sha1_file;
 use function sprintf;
 use function strtolower;
@@ -104,8 +102,9 @@ final class OptimizedDirectorySourceLocatorFactory
 
 	/**
 	 * @param string[] $files
+	 * @param non-empty-string&literal-string $uniqueCacheIdentifier
 	 */
-	public function createByFiles(array $files): OptimizedDirectorySourceLocator
+	public function createByFiles(array $files, string $uniqueCacheIdentifier): OptimizedDirectorySourceLocator
 	{
 		$fileHashes = [];
 		foreach ($files as $file) {
@@ -116,8 +115,7 @@ final class OptimizedDirectorySourceLocatorFactory
 			$fileHashes[$file] = $hash;
 		}
 
-		$cacheKey = sprintf('odsl-files-%s', sha1(implode(',', $files)));
-		return $this->createCachedDirectorySourceLocator($fileHashes, $cacheKey);
+		return $this->createCachedDirectorySourceLocator($fileHashes, $uniqueCacheIdentifier);
 	}
 
 	/**

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
@@ -307,7 +307,7 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 	public function testBug5525(): void
 	{
 		$factory = self::getContainer()->getByType(OptimizedDirectorySourceLocatorFactory::class);
-		$locator = $factory->createByFiles([__DIR__ . '/data/bug-5525.php']);
+		$locator = $factory->createByFiles([__DIR__ . '/data/bug-5525.php'], 'bug5525-odsl-installed-files');
 		$reflector = new DefaultReflector($locator);
 
 		$class = $reflector->reflectClass('Faker\\Provider\\nl_BE\\Text');


### PR DESCRIPTION
shot in the dark for the problem seen in https://github.com/phpstan/phpstan/discussions/13852

---

This PR adds caching when called with a array of files. 

Before this PR the existing caching did only work for directories. 

I tried this PR on the phpunit codebase, which proofed that with this change the numer pf `findSymbols` calls will be reduced to the files actually changed. Unrelated files (like bootstrap files) will no longer be processed for symbols)

---

this PR combined with https://github.com/phpstan/phpstan-src/pull/4576 I can see the phpstan test-suite running with `php tests/vendor/bin/paratest ` in 38-40 seconds