### PR TITLE
Fix subtype check for identical late-resolvable conditional types (bug #10942)

### DIFF
--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -67,6 +67,18 @@ trait LateResolvableTypeTrait
 			return IsSuperTypeOfResult::createYes();
 		}
 
+		if ($this->equals($type)) {
+			return IsSuperTypeOfResult::createYes();
+		}
+
+		if ($type instanceof UnionType) {
+			foreach ($type->getTypes() as $innerType) {
+				if ($this->equals($innerType)) {
+					return IsSuperTypeOfResult::createYes();
+				}
+			}
+		}
+
 		if ($type instanceof LateResolvableType) {
 			$type = $type->resolve();
 		}

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -19,6 +19,7 @@ use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\LateResolvableType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
 trait LateResolvableTypeTrait
 {
@@ -576,6 +577,18 @@ trait LateResolvableTypeTrait
 
 	public function isSubTypeOf(Type $otherType): IsSuperTypeOfResult
 	{
+		if ($this->equals($otherType)) {
+			return IsSuperTypeOfResult::createYes();
+		}
+
+		if ($otherType instanceof UnionType) {
+			foreach ($otherType->getTypes() as $innerType) {
+				if ($this->equals($innerType)) {
+					return IsSuperTypeOfResult::createYes();
+				}
+			}
+		}
+
 		$result = $this->resolve();
 
 		if ($result instanceof CompoundType) {

--- a/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php
@@ -550,6 +550,13 @@ class MethodSignatureRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10488.php'], []);
 	}
 
+	public function testBug10942(): void
+	{
+		$this->reportMaybes = true;
+		$this->reportStatic = true;
+		$this->analyse([__DIR__ . '/data/bug-10942.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.0')]
 	public function testBug12073(): void
 	{

--- a/tests/PHPStan/Rules/Methods/data/bug-10942.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-10942.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10942;
+
+class A
+{
+
+	/**
+	 * @param string|($operator is 'in' ? int : never) $sqlRight
+	 */
+	protected function _renderConditionBinary(string $operator, string $sqlLeft, $sqlRight): string
+	{
+		return 'x';
+	}
+
+}
+
+class B extends A
+{
+
+	#[\Override]
+	protected function _renderConditionBinary(string $operator, string $sqlLeft, $sqlRight): string
+	{
+		return 'y';
+	}
+
+}

--- a/tests/PHPStan/Type/LateResolvableTypeTraitTest.php
+++ b/tests/PHPStan/Type/LateResolvableTypeTraitTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\UnionType;
+use PHPUnit\Framework\TestCase;
+
+class LateResolvableTypeTraitTest extends TestCase
+{
+
+	public function testIsSuperTypeOfForConditional(): void
+	{
+		$conditional = new ConditionalTypeForParameter(
+			'$operator',
+			new ConstantStringType('in'),
+			new IntegerType(),
+			new NeverType(),
+			false,
+		);
+
+		$this->assertSame('Yes', $conditional->isSuperTypeOf($conditional)->describe());
+
+		$unionWithConditional = new UnionType([
+			new StringType(),
+			$conditional,
+		]);
+
+		$this->assertSame('Yes', $conditional->isSuperTypeOf($unionWithConditional)->describe());
+	}
+
+}

--- a/tests/PHPStan/Type/LateResolvableTypeTraitTest.php
+++ b/tests/PHPStan/Type/LateResolvableTypeTraitTest.php
@@ -3,32 +3,76 @@
 namespace PHPStan\Type;
 
 use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\ConditionalTypeForParameter;
 use PHPStan\Type\UnionType;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LateResolvableTypeTraitTest extends TestCase
 {
-
-	public function testIsSuperTypeOfForConditional(): void
+	public static function dataIsSuperTypeOf(): array
 	{
-		$conditional = new ConditionalTypeForParameter(
-			'$operator',
-			new ConstantStringType('in'),
-			new IntegerType(),
-			new NeverType(),
-			false,
+		return self::provideCases();
+	}
+
+	public static function dataIsSubTypeOf(): array
+	{
+		return self::provideCases();
+	}
+
+	private static function createConditional(
+		string $parameterName = '$operator',
+		string $targetLiteral = 'in',
+		?Type $ifType = null,
+		?Type $elseType = null,
+		bool $negated = false,
+	): ConditionalTypeForParameter
+	{
+		return new ConditionalTypeForParameter(
+			$parameterName,
+			new ConstantStringType($targetLiteral),
+			$ifType ?? new IntegerType(),
+			$elseType ?? new NeverType(),
+			$negated,
 		);
+	}
 
-		$this->assertSame('Yes', $conditional->isSuperTypeOf($conditional)->describe());
+	/**
+	 * @return list<array{Type, Type, TrinaryLogic}>
+	 */
+	private static function provideCases(): array
+	{
+		return [
+			'conditional vs same conditional' => [
+				self::createConditional(),
+				self::createConditional(),
+				TrinaryLogic::createYes(),
+			],
+			'conditional vs union containing it' => [
+				self::createConditional(),
+				new UnionType([new StringType(), self::createConditional()]),
+				TrinaryLogic::createYes(),
+			],
+		];
+	}
 
-		$unionWithConditional = new UnionType([
-			new StringType(),
-			$conditional,
-		]);
+	#[DataProvider('dataIsSuperTypeOf')]
+	public function testIsSuperTypeOf(Type $left, Type $right, TrinaryLogic $expected): void
+	{
+		$actual = $left->isSuperTypeOf($right);
+		$this->assertSame($expected->describe(), $actual->describe());
+	}
 
-		$this->assertSame('Yes', $conditional->isSuperTypeOf($unionWithConditional)->describe());
+	#[DataProvider('dataIsSubTypeOf')]
+	public function testIsSubTypeOf(Type $left, Type $right, TrinaryLogic $expected): void
+	{
+		$actual = $left->isSubTypeOf($right);
+		$this->assertSame($expected->describe(), $actual->describe());
 	}
 
 }


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/10942

・Summary

Treat identical late-resolvable conditional types as compatible before resolving them.
Short-circuit when the same conditional appears inside a union.
Add regression test for bug #10942.

・Testing

vendor/bin/phpunit tests/PHPStan/Rules/Methods/MethodSignatureRuleTest.php --filter testBug10942