### PR TITLE
Fix ReflectionClassWithLazyObjects ReflectionClass stub

### DIFF
--- a/stubs/ReflectionClassWithLazyObjects.stub
+++ b/stubs/ReflectionClassWithLazyObjects.stub
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @template T of object
+ * @template-covariant T of object
  */
 class ReflectionClass
 {


### PR DESCRIPTION
I think this stub should match: https://github.com/phpstan/phpstan-src/blob/2.1.x/stubs/ReflectionClass.stub#L4C13-L4C23

See this commit for where the lazy object was introduced: https://github.com/phpstan/phpstan-src/commit/25ec5eb2db6474f95a0b9dcac1cca8210ea1a021#diff-34b8ba0664529e6e59d2c54a9a4cf3194fe2937582419c8d71516783474f4dc6

If you agree I think the same is needed for Enum. I can make a PR for that too.