### PR TITLE
Fix time not being considered an impure function.

### DIFF
--- a/bin/functionMetadata_original.php
+++ b/bin/functionMetadata_original.php
@@ -117,6 +117,7 @@ return [
 	'str_decrement' => ['hasSideEffects' => false],
 	'str_increment' => ['hasSideEffects' => false],
 	'symlink' => ['hasSideEffects' => true],
+	'time' => ['hasSideEffects' => true],
 	'tempnam' => ['hasSideEffects' => true],
 	'tmpfile' => ['hasSideEffects' => true],
 	'touch' => ['hasSideEffects' => true],

--- a/resources/functionMetadata.php
+++ b/resources/functionMetadata.php
@@ -1737,6 +1737,7 @@ return [
 	'tan' => ['hasSideEffects' => false],
 	'tanh' => ['hasSideEffects' => false],
 	'tempnam' => ['hasSideEffects' => true],
+	'time' => ['hasSideEffects' => true],
 	'timezone_abbreviations_list' => ['hasSideEffects' => false],
 	'timezone_identifiers_list' => ['hasSideEffects' => true],
 	'timezone_location_get' => ['hasSideEffects' => true],

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -269,4 +269,9 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3387.php'], []);
 	}
 
+	public function testBug13874(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13874.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-13874.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13874.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+class Repro
+{
+	public static function func(): void
+	{
+		if (time() > 1764702390) { return; }
+		sleep(3);
+		if (time() > 1764702390) { return; }
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/13874 by marking `time()` as being impure.