### PR TITLE
Don't report already assigned errors when setting or unsetting an offset on array access objects set as class properties.

### DIFF
--- a/src/Node/ClassPropertiesNode.php
+++ b/src/Node/ClassPropertiesNode.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Node;
 
+use ArrayAccess;
 use Override;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
@@ -13,6 +14,8 @@ use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\NodeAbstract;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\Expr\PropertyInitializationExpr;
+use PHPStan\Node\Expr\SetOffsetValueTypeExpr;
+use PHPStan\Node\Expr\UnsetOffsetExpr;
 use PHPStan\Node\Method\MethodCall;
 use PHPStan\Node\Property\PropertyAssign;
 use PHPStan\Node\Property\PropertyRead;
@@ -22,6 +25,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\NeverType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeUtils;
 use function array_diff_key;
 use function array_key_exists;
@@ -211,6 +215,19 @@ final class ClassPropertiesNode extends NodeAbstract implements VirtualNode
 
 			if ($usage instanceof PropertyWrite) {
 				if (array_key_exists($propertyName, $initializedPropertiesMap)) {
+					$originalNode = $usage->getOriginalNode();
+
+					if ($originalNode instanceof PropertyAssignNode) {
+						$assignedExpr = $originalNode->getAssignedExpr();
+
+						if (
+							($assignedExpr instanceof SetOffsetValueTypeExpr || $assignedExpr instanceof UnsetOffsetExpr)
+							&& (new ObjectType(ArrayAccess::class))->isSuperTypeOf($scope->getType($assignedExpr->getVar()))->yes()
+						) {
+							continue;
+						}
+					}
+
 					$hasInitialization = $initializedPropertiesMap[$propertyName]->or($usageScope->hasExpressionType(new PropertyInitializationExpr($propertyName)));
 					if (
 						!$hasInitialization->no()

--- a/src/Node/ClassStatementsGatherer.php
+++ b/src/Node/ClassStatementsGatherer.php
@@ -156,6 +156,7 @@ final class ClassStatementsGatherer
 					new PropertyFetch(new Expr\Variable('this'), new Identifier($node->getName())),
 					$scope,
 					true,
+					$node,
 				);
 			}
 			return;
@@ -200,7 +201,7 @@ final class ClassStatementsGatherer
 			return;
 		}
 		if ($node instanceof PropertyAssignNode) {
-			$this->propertyUsages[] = new PropertyWrite($node->getPropertyFetch(), $scope, false);
+			$this->propertyUsages[] = new PropertyWrite($node->getPropertyFetch(), $scope, false, $node);
 			$this->propertyAssigns[] = new PropertyAssign($node, $scope);
 			return;
 		}
@@ -218,7 +219,7 @@ final class ClassStatementsGatherer
 			}
 
 			$this->propertyUsages[] = new PropertyRead($node->expr, $scope);
-			$this->propertyUsages[] = new PropertyWrite($node->expr, $scope, false);
+			$this->propertyUsages[] = new PropertyWrite($node->expr, $scope, false, $node);
 			return;
 		}
 		if ($node instanceof FunctionCallableNode) {

--- a/src/Node/Property/PropertyWrite.php
+++ b/src/Node/Property/PropertyWrite.php
@@ -2,9 +2,12 @@
 
 namespace PHPStan\Node\Property;
 
+use PhpParser\Node\Expr\AssignRef;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Node\PropertyAssignNode;
 
 /**
  * @api
@@ -12,7 +15,7 @@ use PHPStan\Analyser\Scope;
 final class PropertyWrite
 {
 
-	public function __construct(private PropertyFetch|StaticPropertyFetch $fetch, private Scope $scope, private bool $promotedPropertyWrite)
+	public function __construct(private PropertyFetch|StaticPropertyFetch $fetch, private Scope $scope, private bool $promotedPropertyWrite, private ClassPropertyNode|PropertyAssignNode|AssignRef|null $originalNode = null)
 	{
 	}
 
@@ -32,6 +35,11 @@ final class PropertyWrite
 	public function isPromotedPropertyWrite(): bool
 	{
 		return $this->promotedPropertyWrite;
+	}
+
+	public function getOriginalNode(): ClassPropertyNode|PropertyAssignNode|AssignRef|null
+	{
+		return $this->originalNode;
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -342,4 +342,25 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11828.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.1')]
+	public function testBug13856(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13856.php'], [
+			[
+				'Readonly property Bug13856\foo2::$store is already assigned.',
+				27,
+			],
+		]);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return array_merge(
+			parent::getAdditionalConfigFiles(),
+			[
+				__DIR__ . '/../../../../src/Testing/narrowMethodScopeFromConstructor.neon',
+			],
+		);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -348,7 +348,7 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13856.php'], [
 			[
 				'Readonly property Bug13856\foo2::$store is already assigned.',
-				27,
+				28,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/MissingReadOnlyPropertyAssignRuleTest.php
@@ -350,17 +350,11 @@ class MissingReadOnlyPropertyAssignRuleTest extends RuleTestCase
 				'Readonly property Bug13856\foo2::$store is already assigned.',
 				28,
 			],
-		]);
-	}
-
-	public static function getAdditionalConfigFiles(): array
-	{
-		return array_merge(
-			parent::getAdditionalConfigFiles(),
 			[
-				__DIR__ . '/../../../../src/Testing/narrowMethodScopeFromConstructor.neon',
+				'Readonly property Bug13856\foo3::$store is already assigned.',
+				39,
 			],
-		);
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-13856.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13856.php
@@ -1,0 +1,29 @@
+<?php // lint >= 8.1
+
+namespace Bug13856;
+
+use SplObjectStorage;
+
+class foo
+{
+	/** @var SplObjectStorage<object, mixed> */
+    private readonly SplObjectStorage $store;
+
+    public function __construct()
+    {
+        $this->store = new SplObjectStorage();
+        $this->store[(object) ['foo' => 'bar']] = true;
+    }
+}
+
+class foo2
+{
+    /** @var array<int, bool> */
+    private readonly array $store;
+
+    public function __construct()
+    {
+        $this->store[1] = true;
+        $this->store[2] = false;
+    }
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13856.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13856.php
@@ -28,3 +28,15 @@ class foo2
         $this->store[2] = false;
     }
 }
+
+class foo3
+{
+    private readonly object $store;
+
+    public function __construct()
+    {
+        $this->store = new SplObjectStorage();
+        $this->store[(object) ['foo' => 'bar']] = true;
+        unset($this->store[(object) ['foo' => 'bar']]);
+    }
+}

--- a/tests/PHPStan/Rules/Properties/data/bug-13856.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-13856.php
@@ -13,6 +13,7 @@ class foo
     {
         $this->store = new SplObjectStorage();
         $this->store[(object) ['foo' => 'bar']] = true;
+        unset($this->store[(object) ['foo' => 'bar']]);
     }
 }
 


### PR DESCRIPTION
fixes https://github.com/phpstan/phpstan/issues/13856

Took inspiration from https://github.com/phpstan/phpstan-src/pull/3817 when implementing the fix.

Not entirely 100% sure about the proposed changes here, as passing through the `$originalNode` to the `PropertyWrite` constructor feels a little heavy handed, considering i only need one of the 3 types that it could be, and also it has to be null because of the parent constructor case, so open to suggestions there.

