### PR TITLE
Narrow CURLOPT_SHARE accepting type

### DIFF
--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -394,6 +394,19 @@ final class PhpVersion
 		return $this->versionId < 80000;
 	}
 
+	/**
+	 * whether curl handles are represented as 'resource' or CurlShareHandle
+	 */
+	public function supportsCurlShareHandle(): bool
+	{
+		return $this->versionId >= 80000;
+	}
+
+	public function supportsCurlSharePersistentHandle(): bool
+	{
+		return $this->versionId >= 80500;
+	}
+
 	public function highlightStringDoesNotReturnFalse(): bool
 	{
 		return $this->versionId >= 80400;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -58,6 +58,7 @@ use function is_string;
 use function sprintf;
 use const ARRAY_FILTER_USE_BOTH;
 use const ARRAY_FILTER_USE_KEY;
+use const CURLOPT_SHARE;
 use const CURLOPT_SSL_VERIFYHOST;
 
 /**
@@ -1210,6 +1211,14 @@ final class ParametersAcceptorSelector
 			if (defined($constName) && constant($constName) === $curlOpt) {
 				return new ResourceType();
 			}
+		}
+
+		if ($curlOpt === CURLOPT_SHARE) {
+			return new UnionType([
+				new ResourceType(), // PHP 7.x
+				new ObjectType('CurlShareHandle'), // since PHP 8.0
+				new ObjectType('CurlSharePersistentHandle'), // since PHP 8.5
+			]);
 		}
 
 		// unknown constant

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -1214,11 +1214,18 @@ final class ParametersAcceptorSelector
 		}
 
 		if ($curlOpt === CURLOPT_SHARE) {
-			return new UnionType([
-				new ResourceType(), // PHP 7.x
-				new ObjectType('CurlShareHandle'), // since PHP 8.0
-				new ObjectType('CurlSharePersistentHandle'), // since PHP 8.5
-			]);
+			$phpversion = PhpVersionStaticAccessor::getInstance();
+
+			if ($phpversion->supportsCurlShareHandle()) {
+				$shareType = new ObjectType('CurlShareHandle');
+			} else {
+				$shareType = new ResourceType();
+			}
+			if ($phpversion->supportsCurlSharePersistentHandle()) {
+				$shareType = TypeCombinator::union($shareType, new ObjectType('CurlSharePersistentHandle'));
+			}
+
+			return $shareType;
 		}
 
 		// unknown constant

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1398,11 +1398,26 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #3 $value of function curl_setopt expects bool|int, int|string given.',
 				96,
 			],
-			[
-				'Parameter #3 $value of function curl_setopt expects CurlShareHandle|CurlSharePersistentHandle|resource, string given.',
-				101,
-			],
 		]);
+	}
+
+	public function testCurlSetOptInvalidShare(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$errors = [
+				['Parameter #3 $value of function curl_setopt expects resource, string given.', 8],
+			];
+		} elseif (PHP_VERSION_ID < 80500) {
+			$errors = [
+				['Parameter #3 $value of function curl_setopt expects CurlShareHandle, string given.', 8],
+			];
+		} else {
+			$errors = [
+				['Parameter #3 $value of function curl_setopt expects CurlShareHandle|CurlSharePersistentHandle, string given.', 8],
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/curl_setopt_share.php'], $errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1398,6 +1398,10 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				'Parameter #3 $value of function curl_setopt expects bool|int, int|string given.',
 				96,
 			],
+			[
+				'Parameter #3 $value of function curl_setopt expects CurlShareHandle|CurlSharePersistentHandle|resource, string given.',
+				101,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -98,7 +98,6 @@ class HelloWorld
 
 	public function curlShare() {
 		$curl = curl_init();
-		curl_setopt($curl, CURLOPT_SHARE, 'this is wrong');
 
 		$share = curl_share_init();
 		curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -101,10 +101,17 @@ class HelloWorld
 		curl_setopt($curl, CURLOPT_SHARE, 'this is wrong');
 
 		$share = curl_share_init();
+		curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+		curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+		curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
 		curl_setopt($curl, CURLOPT_SHARE, $share);
 
 		if (function_exists('curl_share_init_persistent')) {
-			$share = curl_share_init_persistent();
+			$share = curl_share_init_persistent([
+				CURL_LOCK_DATA_DNS,
+				CURL_LOCK_DATA_CONNECT,
+				CURL_LOCK_DATA_SSL_SESSION,
+			]);
 			curl_setopt($curl, CURLOPT_SHARE, $share);
 		}
 	}

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt.php
@@ -95,4 +95,17 @@ class HelloWorld
 
 		curl_setopt($curl, $var, $value);
 	}
+
+	public function curlShare() {
+		$curl = curl_init();
+		curl_setopt($curl, CURLOPT_SHARE, 'this is wrong');
+
+		$share = curl_share_init();
+		curl_setopt($curl, CURLOPT_SHARE, $share);
+
+		if (function_exists('curl_share_init_persistent')) {
+			$share = curl_share_init_persistent();
+			curl_setopt($curl, CURLOPT_SHARE, $share);
+		}
+	}
 }

--- a/tests/PHPStan/Rules/Functions/data/curl_setopt_share.php
+++ b/tests/PHPStan/Rules/Functions/data/curl_setopt_share.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CurlSetOptShare;
+
+function curlShare()
+{
+	$curl = curl_init();
+	curl_setopt($curl, CURLOPT_SHARE, 'this is wrong');
+}


### PR DESCRIPTION
since PHP8.5 there is also `CurlSharePersistentHandle` created via [curl_share_init_persistent](https://www.php.net/curl_share_init_persistent)