### PR TITLE
Add ArrayCountValuesDynamicReturnTypeExtension.

### DIFF
--- a/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\IntegerRangeType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use function count;
+
+#[AutowiredService]
+final class ArrayCountValuesDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+	public function isFunctionSupported(FunctionReflection $functionReflection): bool
+	{
+		return $functionReflection->getName() === 'array_count_values';
+	}
+
+	public function getTypeFromFunctionCall(
+		FunctionReflection $functionReflection,
+		FuncCall $functionCall,
+		Scope $scope,
+	): ?Type
+	{
+		$args = $functionCall->getArgs();
+
+		if (!isset($args[0])) {
+			return null;
+		}
+
+		$inputType = $scope->getType($args[0]->value);
+
+		$arrayTypes = $inputType->getArrays();
+
+		$outputTypes = [];
+
+		foreach ($arrayTypes as $arrayType) {
+			$itemType = $arrayType->getItemType();
+
+			if ($itemType instanceof UnionType) {
+				$itemType = $itemType->filterTypes(
+					static fn ($type) => !$type->toArrayKey() instanceof ErrorType,
+				);
+			}
+
+			if ($itemType->toArrayKey() instanceof ErrorType) {
+				continue;
+			}
+
+			$outputTypes[] = new ArrayType(
+				$itemType,
+				IntegerRangeType::fromInterval(1, null),
+			);
+		}
+
+		if (count($outputTypes) === 0) {
+			return new ConstantArrayType([], []);
+		}
+
+		return TypeCombinator::union(...$outputTypes);
+	}
+
+}

--- a/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
@@ -56,9 +57,9 @@ final class ArrayCountValuesDynamicReturnTypeExtension implements DynamicFunctio
 				continue;
 			}
 
-			$outputTypes[] = new ArrayType(
-				$itemType,
-				IntegerRangeType::fromInterval(1, null),
+			$outputTypes[] = TypeCombinator::intersect(
+				new ArrayType($itemType, IntegerRangeType::fromInterval(1, null)),
+				new NonEmptyArrayType(),
 			);
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/array-count-values.php
+++ b/tests/PHPStan/Analyser/nsrt/array-count-values.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ArrayCountValues;
+
+use function PHPStan\Testing\assertType;
+
+$ints = array_count_values([1, 2, 2, 3]);
+
+assertType('array<1|2|3, int<1, max>>', $ints);
+
+$strings = array_count_values(['one', 'two', 'two', 'three']);
+
+assertType('array<\'one\'|\'three\'|\'two\', int<1, max>>', $strings);
+
+$objects = array_count_values([new \stdClass()]);
+
+assertType('array{}', $objects);
+
+/**
+ * @return array<int, string|object>
+ */
+function returnsStringOrObjectArray(): array
+{
+
+}
+
+// Objects are ignored by array_count_values, with a warning emitted.
+assertType('array<string, int<1, max>>', array_count_values(returnsStringOrObjectArray()));
+
+class StringableObject
+{
+
+	public function __toString(): string
+	{
+		return 'string';
+	}
+
+}
+
+// Stringable objects are ignored by array_count_values, with a warning emitted.
+$stringable = array_count_values([new StringableObject(), 'string', 1]);
+
+assertType('array<1|\'string\', int<1, max>>', $stringable);

--- a/tests/PHPStan/Analyser/nsrt/array-count-values.php
+++ b/tests/PHPStan/Analyser/nsrt/array-count-values.php
@@ -6,11 +6,11 @@ use function PHPStan\Testing\assertType;
 
 $ints = array_count_values([1, 2, 2, 3]);
 
-assertType('array<1|2|3, int<1, max>>', $ints);
+assertType('non-empty-array<1|2|3, int<1, max>>', $ints);
 
 $strings = array_count_values(['one', 'two', 'two', 'three']);
 
-assertType('array<\'one\'|\'three\'|\'two\', int<1, max>>', $strings);
+assertType('non-empty-array<\'one\'|\'three\'|\'two\', int<1, max>>', $strings);
 
 $objects = array_count_values([new \stdClass()]);
 
@@ -25,7 +25,7 @@ function returnsStringOrObjectArray(): array
 }
 
 // Objects are ignored by array_count_values, with a warning emitted.
-assertType('array<string, int<1, max>>', array_count_values(returnsStringOrObjectArray()));
+assertType('non-empty-array<string, int<1, max>>', array_count_values(returnsStringOrObjectArray()));
 
 class StringableObject
 {
@@ -40,4 +40,4 @@ class StringableObject
 // Stringable objects are ignored by array_count_values, with a warning emitted.
 $stringable = array_count_values([new StringableObject(), 'string', 1]);
 
-assertType('array<1|\'string\', int<1, max>>', $stringable);
+assertType('non-empty-array<1|\'string\', int<1, max>>', $stringable);


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13816

The issue states that stringable objects are accepted, but it turns out that this is not the case:
https://3v4l.org/07vKm#v8.4.15