### PR TITLE
Upgrade ondram/ci-detector to 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"nette/schema": "^1.2.2",
 		"nette/utils": "^3.2.5",
 		"nikic/php-parser": "^5.6.2",
-		"ondram/ci-detector": "^3.4.0",
+		"ondram/ci-detector": "^4.0",
 		"ondrejmirtes/better-reflection": "6.65.0.0",
 		"ondrejmirtes/composer-attribute-collector": "^1.1.1",
 		"ondrejmirtes/php-merge": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65184e399cfac1d3b189462535646fae",
+    "content-hash": "e0509e01f7391c29ae7422428b0bba85",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -2104,29 +2104,29 @@
         },
         {
             "name": "ondram/ci-detector",
-            "version": "3.5.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OndraM/ci-detector.git",
-                "reference": "594e61252843b68998bddd48078c5058fe9028bd"
+                "reference": "8b0223b5ed235fd377c75fdd1bfcad05c0f168b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OndraM/ci-detector/zipball/594e61252843b68998bddd48078c5058fe9028bd",
-                "reference": "594e61252843b68998bddd48078c5058fe9028bd",
+                "url": "https://api.github.com/repos/OndraM/ci-detector/zipball/8b0223b5ed235fd377c75fdd1bfcad05c0f168b8",
+                "reference": "8b0223b5ed235fd377c75fdd1bfcad05c0f168b8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.2",
-                "lmc/coding-standard": "^1.3 || ^2.0",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpstan/extension-installer": "^1.0.3",
-                "phpstan/phpstan": "^0.12.0",
-                "phpstan/phpstan-phpunit": "^0.12.1",
-                "phpunit/phpunit": "^7.1 || ^8.0 || ^9.0"
+                "ergebnis/composer-normalize": "^2.13.2",
+                "lmc/coding-standard": "^3.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.1.0",
+                "phpstan/phpstan": "^1.2.0",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpunit/phpunit": "^9.6.13"
             },
             "type": "library",
             "autoload": {
@@ -2153,6 +2153,9 @@
                 "appveyor",
                 "aws",
                 "aws codebuild",
+                "azure",
+                "azure devops",
+                "azure pipelines",
                 "bamboo",
                 "bitbucket",
                 "buddy",
@@ -2160,19 +2163,22 @@
                 "codebuild",
                 "continuous integration",
                 "continuousphp",
+                "devops",
                 "drone",
                 "github",
                 "gitlab",
                 "interface",
                 "jenkins",
+                "pipelines",
+                "sourcehut",
                 "teamcity",
                 "travis"
             ],
             "support": {
                 "issues": "https://github.com/OndraM/ci-detector/issues",
-                "source": "https://github.com/OndraM/ci-detector/tree/main"
+                "source": "https://github.com/OndraM/ci-detector/tree/4.2.0"
             },
-            "time": "2020-09-04T11:21:14+00:00"
+            "time": "2024-03-12T13:22:30+00:00"
         },
         {
             "name": "ondrejmirtes/better-reflection",


### PR DESCRIPTION
infection is using ondram/ci-detector 4.x and has class-loading problems when the project-under-test uses a older version of this lib, see https://github.com/infection/infection/issues/2671

upgrading to 4.x allows us to run infection from within build-infection:
```
➜  phpstan-src git:(upd) ✗ php build-infection/vendor/bin/infection -vvv
Xdebug: [Step Debug] Could not connect to debugging client. Tried: 127.0.0.1:9003 (through xdebug.client_host/xdebug.client_port).
[debug] Checking INFECTION_ALLOW_XDEBUG
[debug] The Xdebug extension is loaded (3.5.0) xdebug.mode=debug
[debug] Process restarting (INFECTION_ALLOW_XDEBUG=internal|3.5.0|1|*|*)
[debug] Running: [/opt/homebrew/Cellar/php@8.3/8.3.28/bin/php, build-infection/vendor/bin/infection, -vvv]
[debug] Checking INFECTION_ALLOW_XDEBUG
[debug] Restarted (47 ms). The Xdebug extension is not loaded

    ____      ____          __  _
   /  _/___  / __/__  _____/ /_(_)___  ____
   / // __ \/ /_/ _ \/ ___/ __/ / __ \/ __ \
 _/ // / / / __/  __/ /__/ /_/ / /_/ / / / /
/___/_/ /_/_/  \___/\___/\__/_/\____/_/ /_/

#StandWithUkraine

Infection - PHP Mutation Testing Framework version 0.31.9
```

before this PR, this step errored with:
```
➜  phpstan-src git:(2.1.x) ✗ php build-infection/vendor/bin/infection -vvv 

In Container.php line 147:
                                                                  
  [DIContainer\Exception]                                         
  Unknown service "Infection\Configuration\ConfigurationFactory"  
                                                                  

Exception trace:
  at /Users/staabm/workspace/phpstan-src/build-infection/vendor/sanmai/di-container/src/Container.php:147
 DIContainer\Container->get() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Container.php:1045
 Infection\Container->getConfigurationFactory() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Container.php:643
 Infection\Container::Infection\{closure}() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/sanmai/di-container/src/Container.php:139
 DIContainer\Container->get() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Container.php:890
 Infection\Container->getConfiguration() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Command/RunCommand.php:599
 Infection\Command\RunCommand->installTestFrameworkIfNeeded() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Command/RunCommand.php:630
 Infection\Command\RunCommand->startUp() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Command/RunCommand.php:419
 Infection\Command\RunCommand->executeCommand() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/src/Command/BaseCommand.php:75
 Infection\Command\BaseCommand->execute() at /Users/staabm/workspace/phpstan-src/vendor/symfony/console/Command/Command.php:298
 Symfony\Component\Console\Command\Command->run() at /Users/staabm/workspace/phpstan-src/vendor/symfony/console/Application.php:1040
 Symfony\Component\Console\Application->doRunCommand() at /Users/staabm/workspace/phpstan-src/vendor/symfony/console/Application.php:301
 Symfony\Component\Console\Application->doRun() at /Users/staabm/workspace/phpstan-src/vendor/symfony/console/Application.php:171
 Symfony\Component\Console\Application->run() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/infection/infection/bin/infection:94
 include() at /Users/staabm/workspace/phpstan-src/build-infection/vendor/bin/infection:119

run [--test-framework TEST-FRAMEWORK] [--static-analysis-tool STATIC-ANALYSIS-TOOL] [--test-framework-options TEST-FRAMEWORK-OPTIONS] [--static-analysis-tool-options STATIC-ANALYSIS-TOOL-OPTIONS] [-j|--threads THREADS] [--with-uncovered] [-s|--show-mutations [SHOW-MUTATIONS]] [--no-progress] [--force-progress] [-c|--configuration CONFIGURATION] [--coverage COVERAGE] [--mutators MUTATORS] [--filter FILTER] [--formatter FORMATTER] [--git-diff-filter GIT-DIFF-FILTER] [--git-diff-lines] [--git-diff-base GIT-DIFF-BASE] [--logger-github [LOGGER-GITHUB]] [--id ID] [--map-source-class-to-test [MAP-SOURCE-CLASS-TO-TEST]] [--logger-gitlab [LOGGER-GITLAB]] [--logger-project-root-directory LOGGER-PROJECT-ROOT-DIRECTORY] [--logger-html LOGGER-HTML] [--logger-text LOGGER-TEXT] [--noop] [--only-covering-test-cases] [--min-msi MIN-MSI] [--min-covered-msi MIN-COVERED-MSI] [--log-verbosity LOG-VERBOSITY] [--initial-tests-php-options INITIAL-TESTS-PHP-OPTIONS] [--skip-initial-tests] [--ignore-msi-with-no-mutations] [--debug] [--dry-run]                                                                       
```

so while the root problem should be addressed in the infection application, it does not hurt for us to upgrade ondram/ci-detector to 4.x - which requires PHP 7.4+. this is fine for PHPStan 2.x as we are also requiring 7.4+

---

[breaking changes of 4.x](https://github.com/OndraM/ci-detector/blob/HEAD/CHANGELOG.md#400---2021-02-02) seem to not affect us