### PR TITLE
Fix ArrayCountValuesDynamicReturnTypeExtension

### DIFF
--- a/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
@@ -10,9 +10,11 @@ use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
@@ -44,17 +46,11 @@ final class ArrayCountValuesDynamicReturnTypeExtension implements DynamicFunctio
 		$arrayTypes = $inputType->getArrays();
 
 		$outputTypes = [];
+		$allowedValues = new UnionType([new IntegerType(), new StringType()]);
 
 		foreach ($arrayTypes as $arrayType) {
-			$itemType = $arrayType->getItemType();
-
-			if ($itemType instanceof UnionType) {
-				$itemType = $itemType->filterTypes(
-					static fn ($type) => !$type->toArrayKey() instanceof ErrorType,
-				);
-			}
-
-			if ($itemType->toArrayKey() instanceof ErrorType) {
+			$itemType = TypeCombinator::intersect($arrayType->getItemType(), $allowedValues);
+			if ($itemType instanceof NeverType) {
 				continue;
 			}
 

--- a/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCountValuesDynamicReturnTypeExtension.php
@@ -55,7 +55,7 @@ final class ArrayCountValuesDynamicReturnTypeExtension implements DynamicFunctio
 			}
 
 			$outputTypes[] = new IntersectionType([
-				new ArrayType($itemType, IntegerRangeType::fromInterval(1, null)),
+				new ArrayType($itemType->toArrayKey(), IntegerRangeType::fromInterval(1, null)),
 				new NonEmptyArrayType(),
 			]);
 		}

--- a/tests/PHPStan/Analyser/nsrt/array-count-values.php
+++ b/tests/PHPStan/Analyser/nsrt/array-count-values.php
@@ -41,3 +41,8 @@ class StringableObject
 $stringable = array_count_values([new StringableObject(), 'string', 1]);
 
 assertType('non-empty-array<1|\'string\', int<1, max>>', $stringable);
+
+// Booleans, floats and null are ignored by array_count_values even if they can be cast to array key.
+$scalar = array_count_values([true, 1.0, false, 0.0, null]);
+
+assertType('array{}', $scalar);

--- a/tests/PHPStan/Analyser/nsrt/array-count-values.php
+++ b/tests/PHPStan/Analyser/nsrt/array-count-values.php
@@ -46,3 +46,7 @@ assertType('non-empty-array<1|\'string\', int<1, max>>', $stringable);
 $scalar = array_count_values([true, 1.0, false, 0.0, null]);
 
 assertType('array{}', $scalar);
+
+$intAsString = array_count_values(['1', '2', '2', '3']);
+
+assertType("non-empty-array<1|2|3, int<1, max>>", $intAsString);


### PR DESCRIPTION
`$type->toArrayKey() instanceof ErrorType` is not the right check cause `true, false, 1.0, null, ...` are ignored by the function. It has to be an int or a string.

And numeric string wasn't casted into int when used as array key.