### PR TITLE
Tests: Use Stubs instead of Mocks

### DIFF
--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -62,7 +62,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 
 		$symfonyOutput = new SymfonyOutput(
 			$output,
-			new \PHPStan\Command\Symfony\SymfonyStyle(new SymfonyStyle($this->createMock(InputInterface::class), $output)),
+			new \PHPStan\Command\Symfony\SymfonyStyle(new SymfonyStyle($this->createStub(InputInterface::class), $output)),
 		);
 
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), __DIR__, [], DIRECTORY_SEPARATOR);
@@ -88,7 +88,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 			null,
 			null,
 			null,
-			$this->createMock(InputInterface::class),
+			$this->createStub(InputInterface::class),
 		);
 		$statusCode = $errorFormatter->formatErrors($analysisResult, $symfonyOutput);
 

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -9,7 +9,6 @@ use PHPStan\File\FileHelper;
 use PHPStan\File\FileReader;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 
 class CachedParserTest extends PHPStanTestCase

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -10,6 +10,7 @@ use PHPStan\File\FileReader;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 
 class CachedParserTest extends PHPStanTestCase
 {
@@ -21,7 +22,7 @@ class CachedParserTest extends PHPStanTestCase
 	): void
 	{
 		$parser = new CachedParser(
-			$this->getParserMock(),
+			$this->getParserStub(),
 			$cachedNodesByStringCountMax,
 		);
 
@@ -62,19 +63,19 @@ class CachedParserTest extends PHPStanTestCase
 		];
 	}
 
-	private function getParserMock(): Parser&MockObject
+	private function getParserStub(): Parser&Stub
 	{
-		$mock = $this->createMock(Parser::class);
+		$mock = $this->createStub(Parser::class);
 
-		$mock->method('parseFile')->willReturn([$this->getPhpParserNodeMock()]);
-		$mock->method('parseString')->willReturn([$this->getPhpParserNodeMock()]);
+		$mock->method('parseFile')->willReturn([$this->getPhpParserNodeStub()]);
+		$mock->method('parseString')->willReturn([$this->getPhpParserNodeStub()]);
 
 		return $mock;
 	}
 
-	private function getPhpParserNodeMock(): Node&MockObject
+	private function getPhpParserNodeStub(): Node&Stub
 	{
-		return $this->createMock(Node::class);
+		return $this->createStub(Node::class);
 	}
 
 	public function testParseTheSameFileWithDifferentMethod(): void

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -966,7 +966,7 @@ class AnnotationsMethodsClassReflectionExtensionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canCallMethod')->willReturn(true);

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -280,7 +280,7 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canAccessProperty')->willReturn(true);

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -101,7 +101,7 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canAccessProperty')->willReturn(true);

--- a/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
@@ -45,7 +45,7 @@ class FinalAnnotationsTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canAccessProperty')->willReturn(true);

--- a/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
@@ -126,7 +126,7 @@ class InternalAnnotationsTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canAccessProperty')->willReturn(true);

--- a/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
@@ -76,7 +76,7 @@ class ThrowsAnnotationsTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 
 		foreach ($throwsAnnotations as $methodName => $type) {
 			$methodAnnotation = $class->getMethod($methodName, $scope);

--- a/tests/PHPStan/Reflection/FunctionReflectionTest.php
+++ b/tests/PHPStan/Reflection/FunctionReflectionTest.php
@@ -119,7 +119,7 @@ class FunctionReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canAccessProperty')->willReturn(true);
@@ -180,7 +180,7 @@ class FunctionReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('isInClass')->willReturn(true);
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canAccessProperty')->willReturn(true);

--- a/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
@@ -38,7 +38,7 @@ class IntersectionTypeMethodReflectionTest extends PHPStanTestCase
 
 	private function createDeprecatedMethod(TrinaryLogic $deprecated, ?string $deprecationText): ExtendedMethodReflection
 	{
-		$method = $this->createMock(ExtendedMethodReflection::class);
+		$method = $this->createStub(ExtendedMethodReflection::class);
 		$method->method('isDeprecated')->willReturn($deprecated);
 		$method->method('getDeprecatedDescription')->willReturn($deprecationText);
 		return $method;

--- a/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
@@ -38,7 +38,7 @@ class UnionTypeMethodReflectionTest extends PHPStanTestCase
 
 	private function createDeprecatedMethod(TrinaryLogic $deprecated, ?string $deprecationText): ExtendedMethodReflection
 	{
-		$method = $this->createMock(ExtendedMethodReflection::class);
+		$method = $this->createStub(ExtendedMethodReflection::class);
 		$method->method('isDeprecated')->willReturn($deprecated);
 		$method->method('getDeprecatedDescription')->willReturn($deprecationText);
 		return $method;

--- a/tests/PHPStan/Rules/Api/ApiRuleHelperTest.php
+++ b/tests/PHPStan/Rules/Api/ApiRuleHelperTest.php
@@ -144,7 +144,7 @@ class ApiRuleHelperTest extends TestCase
 	): void
 	{
 		$rule = new ApiRuleHelper();
-		$scope = $this->createMock(Scope::class);
+		$scope = $this->createStub(Scope::class);
 		$scope->method('getNamespace')->willReturn($scopeNamespace);
 		$scope->method('getFile')->willReturn($scopeFile);
 		$this->assertSame($expected, $rule->isPhpStanCode($scope, $nameToCheck, $declaringFileNameToCheck));


### PR DESCRIPTION
No expectations were configured for the mock object for XY. You should refactor your test code and use a test stub instead.