### PR TITLE
Remove path normalizing from NodeDependencies

### DIFF
--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -492,7 +492,7 @@ final class DependencyResolver
 			}
 		}
 
-		return new NodeDependencies($this->fileHelper, $dependenciesReflections, $this->exportedNodeResolver->resolve($scope->getFile(), $node));
+		return new NodeDependencies($dependenciesReflections, $this->exportedNodeResolver->resolve($scope->getFile(), $node));
 	}
 
 	public function resolveUsedTraitDependencies(InClassNode $inClassNode): NodeDependencies
@@ -502,7 +502,7 @@ final class DependencyResolver
 			$dependenciesReflections[] = $trait;
 		}
 
-		return new NodeDependencies($this->fileHelper, $dependenciesReflections, null);
+		return new NodeDependencies($dependenciesReflections, null);
 	}
 
 	private function considerArrayForCallableTest(Scope $scope, Array_ $arrayNode): bool

--- a/src/Dependency/DependencyResolver.php
+++ b/src/Dependency/DependencyResolver.php
@@ -12,7 +12,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Broker\ClassNotFoundException;
 use PHPStan\Broker\FunctionNotFoundException;
 use PHPStan\DependencyInjection\AutowiredService;
-use PHPStan\File\FileHelper;
 use PHPStan\Node\ClassPropertyNode;
 use PHPStan\Node\FunctionCallableNode;
 use PHPStan\Node\InClassMethodNode;
@@ -38,7 +37,6 @@ final class DependencyResolver
 {
 
 	public function __construct(
-		private FileHelper $fileHelper,
 		private ReflectionProvider $reflectionProvider,
 		private ExportedNodeResolver $exportedNodeResolver,
 		private FileTypeMapper $fileTypeMapper,

--- a/src/Dependency/NodeDependencies.php
+++ b/src/Dependency/NodeDependencies.php
@@ -42,7 +42,6 @@ final class NodeDependencies
 			if ($dependencyFile === null) {
 				continue;
 			}
-			$dependencyFile = $this->fileHelper->normalizePath($dependencyFile);
 
 			if ($currentFile === $dependencyFile) {
 				continue;

--- a/src/Dependency/NodeDependencies.php
+++ b/src/Dependency/NodeDependencies.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Dependency;
 
-use PHPStan\File\FileHelper;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\FunctionReflection;
 use function array_values;
@@ -14,7 +13,6 @@ final class NodeDependencies
 	 * @param array<int, ClassReflection|FunctionReflection> $reflections
 	 */
 	public function __construct(
-		private FileHelper $fileHelper,
 		private array $reflections,
 		private ?RootExportedNode $exportedNode,
 	)

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -842,7 +842,7 @@ class AnalyserTest extends PHPStanTestCase
 				$container,
 				new IgnoreLexer(),
 			),
-			new DependencyResolver($fileHelper, $reflectionProvider, new ExportedNodeResolver($reflectionProvider, $fileTypeMapper, new ExprPrinter(new Printer())), $fileTypeMapper),
+			new DependencyResolver($reflectionProvider, new ExportedNodeResolver($reflectionProvider, $fileTypeMapper, new ExprPrinter(new Printer())), $fileTypeMapper),
 			new IgnoreErrorExtensionProvider(new NetteContainer(new Container([]))),
 			$container->getByType(RuleErrorTransformer::class),
 			new LocalIgnoresProcessor(),


### PR DESCRIPTION
in NodeDependencies the same file paths are normalized over and over, as can be seen in blackfire profiles

<img width="400" height="841" alt="grafik" src="https://github.com/user-attachments/assets/fda55dd7-f49d-43e6-a727-1c2a05fbfb06" />

