### PR TITLE
Prevent unnecessary scope merging

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4816,7 +4816,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 	public function mergeWith(?self $otherScope): self
 	{
-		if ($otherScope === null) {
+		if ($otherScope === null || $this === $otherScope) {
 			return $this;
 		}
 		$ourExpressionTypes = $this->expressionTypes;


### PR DESCRIPTION
In the profiles of https://github.com/phpstan/phpstan-src/pull/4628#issuecomment-3674032038 we can see `MutatingScope->createConditionalExpressions` as one of the most expensive calls (which gets called via `MutatingScope->merge()`):

<img width="565" height="853" alt="grafik" src="https://github.com/user-attachments/assets/b2b22c21-a318-4bb5-b6cc-d188907d65a1" />

After this PR, we can see `PHPSTAN_FNSR=1 php bin/phpstan analyse src/Analyser/NodeScopeResolver.php -vvv --debug` taking the `return $this;` fast path ~180 times.

It seems `make test` is 0.5-1 second faster
