### PR TITLE
Prevent reading & json-decoding composer.json multiple times

### DIFF
--- a/src/Internal/ComposerHelper.php
+++ b/src/Internal/ComposerHelper.php
@@ -21,9 +21,16 @@ final class ComposerHelper
 
 	private static ?string $phpstanVersion = null;
 
+	/** @var array<string, mixed[]> */
+	private static array $decodedCache = [];
+
 	/** @return array<string, mixed>|null */
 	public static function getComposerConfig(string $root): ?array
 	{
+		if (isset(self::$decodedCache[$root])) {
+			return self::$decodedCache[$root];
+		}
+
 		$composerJsonPath = self::getComposerJsonPath($root);
 		if ($composerJsonPath === null) {
 			return null;
@@ -32,7 +39,7 @@ final class ComposerHelper
 		try {
 			$composerJsonContents = FileReader::read($composerJsonPath);
 
-			return Json::decode($composerJsonContents, Json::FORCE_ARRAY);
+			return self::$decodedCache[$root] ??= Json::decode($composerJsonContents, Json::FORCE_ARRAY);
 		} catch (CouldNotReadFileException | JsonException) {
 			return null;
 		}

--- a/src/Php/PhpVersionFactoryFactory.php
+++ b/src/Php/PhpVersionFactoryFactory.php
@@ -2,16 +2,12 @@
 
 namespace PHPStan\Php;
 
-use Nette\Utils\Json;
-use Nette\Utils\JsonException;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
-use PHPStan\File\CouldNotReadFileException;
-use PHPStan\File\FileReader;
+use PHPStan\Internal\ComposerHelper;
 use function count;
 use function end;
 use function is_array;
-use function is_file;
 use function is_int;
 use function is_string;
 
@@ -36,17 +32,12 @@ final class PhpVersionFactoryFactory
 	{
 		$composerPhpVersion = null;
 		if (count($this->composerAutoloaderProjectPaths) > 0) {
-			$composerJsonPath = end($this->composerAutoloaderProjectPaths) . '/composer.json';
-			if (is_file($composerJsonPath)) {
-				try {
-					$composerJsonContents = FileReader::read($composerJsonPath);
-					$composer = Json::decode($composerJsonContents, Json::FORCE_ARRAY);
-					$platformVersion = $composer['config']['platform']['php'] ?? null;
-					if (is_string($platformVersion)) {
-						$composerPhpVersion = $platformVersion;
-					}
-				} catch (CouldNotReadFileException | JsonException) {
-					// pass
+			$composerJsonPath = end($this->composerAutoloaderProjectPaths);
+			$composer = ComposerHelper::getComposerConfig($composerJsonPath);
+			if ($composer !== null) {
+				$platformVersion = $composer['config']['platform']['php'] ?? null;
+				if (is_string($platformVersion)) {
+					$composerPhpVersion = $platformVersion;
 				}
 			}
 		}


### PR DESCRIPTION
before this PR, when invoking

```
bin/phpstan analyze foob.php --xdebug --debug
```

you can see `composer.json` beeing read from disc and json decoded 5 times.
after this PR we read and decode `composer.json` only once.