### PR TITLE
Prevent reading & neon-decoding multiple times

### DIFF
--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -227,7 +227,7 @@ final class ContainerFactory
 		array $loaderParameters,
 	): array
 	{
-		$neonAdapter = new NeonAdapter([]);
+		$neonAdapter = new NeonCachedFileReader([]);
 		$phpAdapter = new PhpAdapter();
 		$allConfigFiles = [];
 		$configArray = [];
@@ -257,7 +257,7 @@ final class ContainerFactory
 	 */
 	private static function getConfigFiles(
 		FileHelper $fileHelper,
-		NeonAdapter $neonAdapter,
+		NeonCachedFileReader $neonAdapter,
 		PhpAdapter $phpAdapter,
 		string $configFile,
 		array $loaderParameters,

--- a/src/DependencyInjection/LoaderFactory.php
+++ b/src/DependencyInjection/LoaderFactory.php
@@ -24,7 +24,7 @@ final class LoaderFactory
 
 	public function createLoader(): Loader
 	{
-		$neonAdapter = new NeonAdapter($this->expandRelativePaths);
+		$neonAdapter = new NeonCachedFileReader($this->expandRelativePaths);
 
 		$loader = new NeonLoader($this->fileHelper, $this->generateBaselineFile);
 		$loader->addAdapter('dist', $neonAdapter);

--- a/src/DependencyInjection/NeonCachedFileReader.php
+++ b/src/DependencyInjection/NeonCachedFileReader.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+use Nette\DI\Config\Adapter;
+use Nette\Neon\Exception;
+use Nette\Neon\Neon;
+use Override;
+use PHPStan\File\FileReader;
+use function sprintf;
+
+final class NeonCachedFileReader implements Adapter
+{
+
+	private NeonAdapter $adapter;
+
+	/** @var array<string, mixed[]> */
+	private static array $decodedCache = [];
+
+	/**
+	 * @param list<string> $expandRelativePaths
+	 */
+	public function __construct(private array $expandRelativePaths)
+	{
+		$this->adapter = new NeonAdapter($this->expandRelativePaths);
+	}
+
+	/**
+	 * @return mixed[]
+	 */
+	#[Override]
+	public function load(string $file): array
+	{
+		try {
+			if (isset(self::$decodedCache[$file])) {
+				$neon = self::$decodedCache[$file];
+			} else {
+				$contents = FileReader::read($file);
+				$neon = (array) Neon::decode($contents);
+				self::$decodedCache[$file] = $neon;
+			}
+
+			return $this->adapter->process($neon, '', $file);
+		} catch (Exception $e) {
+			throw new Exception(sprintf('Error while loading %s: %s', $file, $e->getMessage()));
+		}
+	}
+
+}


### PR DESCRIPTION
before this PR:

```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'bin/phpstan analyze foob.php' -i
Benchmark 1: bin/phpstan analyze foob.php
  Time (mean ± σ):      1.114 s ±  0.009 s    [User: 0.752 s, System: 0.267 s]
  Range (min … max):    1.105 s …  1.128 s    10 runs
 
  Warning: Ignoring non-zero exit code.
```

after this PR:

```
➜  phpstan-src git:(neon-cache) ✗ hyperfine 'bin/phpstan analyze foob.php' -i
Benchmark 1: bin/phpstan analyze foob.php
  Time (mean ± σ):     992.7 ms ±  61.0 ms    [User: 679.0 ms, System: 265.5 ms]
  Range (min … max):   938.9 ms … 1077.7 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
```

similar to https://github.com/phpstan/phpstan-src/pull/4645

---

before this PR we read&decoded 46 NEON files in the above example.
after this PR we only need 28.