### PR TITLE
Remember resolved types after pushInFunctionCall

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2927,7 +2927,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		$stack = $this->inFunctionCallsStack;
 		$stack[] = [$reflection, $parameter];
 
-		return $this->scopeFactory->create(
+		$functionScope = $this->scopeFactory->create(
 			$this->context,
 			$this->isDeclareStrictTypes(),
 			$this->getFunction(),

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2922,7 +2922,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 	/**
 	 * @param MethodReflection|FunctionReflection|null $reflection
 	 */
-	public function pushInFunctionCall($reflection, ?ParameterReflection $parameter): self
+	public function pushInFunctionCall($reflection, ?ParameterReflection $parameter, bool $rememberTypes): self
 	{
 		$stack = $this->inFunctionCallsStack;
 		$stack[] = [$reflection, $parameter];
@@ -2945,7 +2945,11 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			$this->parentScope,
 			$this->nativeTypesPromoted,
 		);
-		$functionScope->resolvedTypes = $this->resolvedTypes;
+
+		if ($rememberTypes) {
+			$functionScope->resolvedTypes = $this->resolvedTypes;
+		}
+
 		return $functionScope;
 	}
 
@@ -2972,7 +2976,9 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			$this->parentScope,
 			$this->nativeTypesPromoted,
 		);
+
 		$parentScope->resolvedTypes = $this->resolvedTypes;
+
 		return $parentScope;
 	}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2945,6 +2945,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			$this->parentScope,
 			$this->nativeTypesPromoted,
 		);
+		$functionScope->resolvedTypes = $this->resolvedTypes;
+		return $functionScope;
 	}
 
 	public function popInFunctionCall(): self

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -2954,7 +2954,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		$stack = $this->inFunctionCallsStack;
 		array_pop($stack);
 
-		return $this->scopeFactory->create(
+		$parentScope = $this->scopeFactory->create(
 			$this->context,
 			$this->isDeclareStrictTypes(),
 			$this->getFunction(),
@@ -2972,6 +2972,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			$this->parentScope,
 			$this->nativeTypesPromoted,
 		);
+		$parentScope->resolvedTypes = $this->resolvedTypes;
+		return $parentScope;
 	}
 
 	/** @api */

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5604,7 +5604,7 @@ class NodeScopeResolver
 			}
 
 			if ($calleeReflection !== null) {
-				$scope = $scope->pushInFunctionCall($calleeReflection, $parameter);
+				$scope = $scope->pushInFunctionCall($calleeReflection, $parameter, true);
 			}
 
 			$originalArg = $arg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $arg;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5603,11 +5603,12 @@ class NodeScopeResolver
 				}
 			}
 
+			$originalArg = $arg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $arg;
 			if ($calleeReflection !== null) {
-				$scope = $scope->pushInFunctionCall($calleeReflection, $parameter, true);
+				$rememberTypes = !$originalArg->value instanceof Expr\Closure && !$originalArg->value instanceof Expr\ArrowFunction;
+				$scope = $scope->pushInFunctionCall($calleeReflection, $parameter, $rememberTypes);
 			}
 
-			$originalArg = $arg->getAttribute(ArgumentsNormalizer::ORIGINAL_ARG_ATTRIBUTE) ?? $arg;
 			$this->callNodeCallback($nodeCallback, $originalArg, $scope, $storage);
 
 			$originalScope = $scope;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -499,7 +499,7 @@ final class ParametersAcceptorSelector
 			}
 
 			if ($parameter !== null && $scope instanceof MutatingScope) {
-				$scope = $scope->pushInFunctionCall(null, $parameter);
+				$scope = $scope->pushInFunctionCall(null, $parameter, true);
 			}
 
 			$type = $scope->getType($originalArg->value);

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -499,7 +499,8 @@ final class ParametersAcceptorSelector
 			}
 
 			if ($parameter !== null && $scope instanceof MutatingScope) {
-				$scope = $scope->pushInFunctionCall(null, $parameter, true);
+				$rememberTypes = !$originalArg->value instanceof Node\Expr\Closure && !$originalArg->value instanceof Node\Expr\ArrowFunction;
+				$scope = $scope->pushInFunctionCall(null, $parameter, $rememberTypes);
 			}
 
 			$type = $scope->getType($originalArg->value);

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -319,7 +319,8 @@ final class FunctionCallParametersCheck
 
 			if ($argumentValueType === null) {
 				if ($scope instanceof MutatingScope) {
-					$scope = $scope->pushInFunctionCall(null, $parameter);
+					$rememberTypes = !$argumentValue instanceof Expr\Closure && !$argumentValue instanceof Expr\ArrowFunction;
+					$scope = $scope->pushInFunctionCall(null, $parameter, $rememberTypes);
 				}
 				$argumentValueType = $scope->getType($argumentValue);
 


### PR DESCRIPTION
prevents duplicate work, as MethodCalls will re-calculated one less time.

analysing 

```php
<?php

class Foo
{

	public function doFoo(DateTimeImmutable $d): void
	{
		$a = $d->format('j. n. Y');
	}

}
```

before this PR reaches “if ($node instanceof MethodCall) {“ in MutatingScope.php:2161 4 times.
after the PR only 3 times.

with `PHPSTAN_FNSR=1 php bin/phpstan analyze foo.php --debug` after PR its only 2 times.

---

```
➜  phpstan-src git:(push-resolve) ✗ hyperfine -i 'php bin/phpstan analyze foo.php --debug'
Benchmark 1: php bin/phpstan analyze foo.php --debug
  Time (mean ± σ):     743.8 ms ±   1.8 ms    [User: 578.3 ms, System: 161.6 ms]
  Range (min … max):   741.5 ms … 747.1 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
➜  phpstan-src git:(push-resolve) ✗ hyperfine -i 'php bin/phpstan analyze foo.php'        
Benchmark 1: php bin/phpstan analyze foo.php
  Time (mean ± σ):      1.047 s ±  0.005 s    [User: 0.777 s, System: 0.255 s]
  Range (min … max):    1.039 s …  1.054 s    10 runs
 
  Warning: Ignoring non-zero exit code.
  
➜  phpstan-src git:(2.1.x) ✗ hyperfine -i 'php bin/phpstan analyze foo.php --debug'
Benchmark 1: php bin/phpstan analyze foo.php --debug
  Time (mean ± σ):     754.9 ms ±   3.3 ms    [User: 587.2 ms, System: 164.1 ms]
  Range (min … max):   752.6 ms … 761.7 ms    10 runs
 
  Warning: Ignoring non-zero exit code.
 
➜  phpstan-src git:(2.1.x) ✗ hyperfine -i 'php bin/phpstan analyze foo.php'        
Benchmark 1: php bin/phpstan analyze foo.php
  Time (mean ± σ):      1.119 s ±  0.054 s    [User: 0.792 s, System: 0.260 s]
  Range (min … max):    1.055 s …  1.166 s    10 runs
 
  Warning: Ignoring non-zero exit code.

 ```