### PR TITLE
Ignore by identifier instead of regex error pattern

### DIFF
--- a/build/phpstan.neon
+++ b/build/phpstan.neon
@@ -117,7 +117,7 @@ parameters:
 			message: "#^Parameter \\#1 (?:\\$argument|\\$objectOrClass) of class ReflectionClass constructor expects class\\-string\\<PHPStan\\\\ExtensionInstaller\\\\GeneratedConfig\\>\\|PHPStan\\\\ExtensionInstaller\\\\GeneratedConfig, string given\\.$#"
 			count: 1
 			path: ../src/Diagnose/PHPStanDiagnoseExtension.php
-		- '#^Short ternary operator is not allowed#'
+		- identifier: ternary.shortNotAllowed
 	reportStaticMethodSignatures: true
 	tmpDir: %rootDir%/tmp
 	stubFiles:


### PR DESCRIPTION
regex re-validation/AST-parsing currently is the slowest parts in some tests.

can be seen in 

```
➜  cat foo.php 
<?php

class Foo
{

        public function doFoo(DateTimeImmutable $d): void
        {
                $a = $d->format('j. n. Y');
        }

}

➜  blackfire run /opt/homebrew/bin/php bin/phpstan analyze foo.php --debug 
```

<img width="424" height="533" alt="grafik" src="https://github.com/user-attachments/assets/566abd52-21f5-42c1-8379-4eb17ab6330f" />
