### PR TITLE
Use self:: over $this-> for PHPUnit assertions

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -24,40 +24,40 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testUndefinedVariableFromAssignErrorHasLine(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/undefined-variable-assign.php');
-		$this->assertCount(2, $errors);
+		self::assertCount(2, $errors);
 		$error = $errors[0];
-		$this->assertSame('Undefined variable: $bar', $error->getMessage());
-		$this->assertSame(3, $error->getLine());
+		self::assertSame('Undefined variable: $bar', $error->getMessage());
+		self::assertSame(3, $error->getLine());
 
 		$error = $errors[1];
-		$this->assertSame('Variable $foo might not be defined.', $error->getMessage());
-		$this->assertSame(6, $error->getLine());
+		self::assertSame('Variable $foo might not be defined.', $error->getMessage());
+		self::assertSame(6, $error->getLine());
 	}
 
 	public function testMissingPropertyAndMethod(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../../notAutoloaded/Foo.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testMissingClassErrorAboutMisconfiguredAutoloader(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../../notAutoloaded/Bar.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testMissingFunctionErrorAboutMisconfiguredAutoloader(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../../notAutoloaded/functionFoo.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Function doSomething not found.', $errors[0]->getMessage());
-		$this->assertSame(7, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Function doSomething not found.', $errors[0]->getMessage());
+		self::assertSame(7, $errors[0]->getLine());
 	}
 
 	public function testAnonymousClassWithInheritedConstructor(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/anonymous-class-with-inherited-constructor.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testNestedFunctionCallsDoNotCauseExcessiveFunctionNesting(): void
@@ -66,57 +66,57 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			$this->markTestSkipped('This test takes too long with Xdebug enabled.');
 		}
 		$errors = $this->runAnalyse(__DIR__ . '/data/nested-functions.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testExtendingUnknownClass(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/extending-unknown-class.php');
-		$this->assertCount(1, $errors);
+		self::assertCount(1, $errors);
 
-		$this->assertSame(5, $errors[0]->getLine());
-		$this->assertSame('Class ExtendingUnknownClass\Foo extends unknown class ExtendingUnknownClass\Bar.', $errors[0]->getMessage());
+		self::assertSame(5, $errors[0]->getLine());
+		self::assertSame('Class ExtendingUnknownClass\Foo extends unknown class ExtendingUnknownClass\Bar.', $errors[0]->getMessage());
 	}
 
 	public function testExtendingKnownClassWithCheck(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/extending-known-class-with-check.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 
 		$reflectionProvider = self::createReflectionProvider();
-		$this->assertTrue($reflectionProvider->hasClass(Foo::class));
+		self::assertTrue($reflectionProvider->hasClass(Foo::class));
 	}
 
 	public function testInfiniteRecursionWithCallable(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/Foo-callable.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testClassThatExtendsUnknownClassIn3rdPartyPropertyTypeShouldNotCauseAutoloading(): void
 	{
 		// no error about PHPStan\Tests\Baz not being able to be autoloaded
 		$errors = $this->runAnalyse(__DIR__ . '/data/ExtendsClassWithUnknownPropertyType.php');
-		$this->assertCount(1, $errors);
-		//$this->assertSame(11, $errors[0]->getLine());
-		$this->assertSame('Call to an undefined method ExtendsClassWithUnknownPropertyType::foo().', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		//self::assertSame(11, $errors[0]->getLine());
+		self::assertSame('Call to an undefined method ExtendsClassWithUnknownPropertyType::foo().', $errors[0]->getMessage());
 	}
 
 	public function testAnonymousClassesWithComments(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/AnonymousClassesWithComments.php');
-		$this->assertCount(3, $errors);
+		self::assertCount(3, $errors);
 		foreach ($errors as $error) {
-			$this->assertStringContainsString('Call to an undefined method', $error->getMessage());
+			self::assertStringContainsString('Call to an undefined method', $error->getMessage());
 		}
 	}
 
 	public function testUniversalObjectCrateIssue(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/universal-object-crate.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #1 $i of method UniversalObjectCrate\Foo::doBaz() expects int, string given.', $errors[0]->getMessage());
-		$this->assertSame(19, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #1 $i of method UniversalObjectCrate\Foo::doBaz() expects int, string given.', $errors[0]->getMessage());
+		self::assertSame(19, $errors[0]->getLine());
 	}
 
 	public function testCustomFunctionWithNameEquivalentInSignatureMap(): void
@@ -127,289 +127,289 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		}
 		require_once __DIR__ . '/data/custom-function-in-signature-map.php';
 		$errors = $this->runAnalyse(__DIR__ . '/data/custom-function-in-signature-map.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testAnonymousClassWithWrongFilename(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/anonymous-class-wrong-filename-regression.php');
-		$this->assertCount(5, $errors);
-		$this->assertStringContainsString('Method', $errors[0]->getMessage());
-		$this->assertStringContainsString('has invalid return type', $errors[0]->getMessage());
-		$this->assertSame(16, $errors[0]->getLine());
-		$this->assertStringContainsString('Method', $errors[1]->getMessage());
-		$this->assertStringContainsString('has invalid return type', $errors[1]->getMessage());
-		$this->assertSame(16, $errors[1]->getLine());
-		$this->assertSame('Instantiated class AnonymousClassWrongFilename\Bar not found.', $errors[2]->getMessage());
-		$this->assertSame(18, $errors[2]->getLine());
-		$this->assertStringContainsString('Parameter #1 $test of method', $errors[3]->getMessage());
-		$this->assertStringContainsString('$this(AnonymousClassWrongFilename\Foo) given', $errors[3]->getMessage());
-		$this->assertSame(23, $errors[3]->getLine());
-		$this->assertSame('Call to method test() on an unknown class AnonymousClassWrongFilename\Bar.', $errors[4]->getMessage());
-		$this->assertSame(24, $errors[4]->getLine());
+		self::assertCount(5, $errors);
+		self::assertStringContainsString('Method', $errors[0]->getMessage());
+		self::assertStringContainsString('has invalid return type', $errors[0]->getMessage());
+		self::assertSame(16, $errors[0]->getLine());
+		self::assertStringContainsString('Method', $errors[1]->getMessage());
+		self::assertStringContainsString('has invalid return type', $errors[1]->getMessage());
+		self::assertSame(16, $errors[1]->getLine());
+		self::assertSame('Instantiated class AnonymousClassWrongFilename\Bar not found.', $errors[2]->getMessage());
+		self::assertSame(18, $errors[2]->getLine());
+		self::assertStringContainsString('Parameter #1 $test of method', $errors[3]->getMessage());
+		self::assertStringContainsString('$this(AnonymousClassWrongFilename\Foo) given', $errors[3]->getMessage());
+		self::assertSame(23, $errors[3]->getLine());
+		self::assertSame('Call to method test() on an unknown class AnonymousClassWrongFilename\Bar.', $errors[4]->getMessage());
+		self::assertSame(24, $errors[4]->getLine());
 	}
 
 	public function testExtendsPdoStatementCrash(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/extends-pdo-statement.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12803(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12803.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testArrayDestructuringArrayDimFetch(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/array-destructuring-array-dim-fetch.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testNestedNamespaces(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/nested-namespaces.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Property y\x::$baz has unknown class x\baz as its type.', $errors[0]->getMessage());
-		$this->assertSame(15, $errors[0]->getLine());
-		$this->assertSame('Parameter $baz of method y\x::__construct() has invalid type x\baz.', $errors[1]->getMessage());
-		$this->assertSame(16, $errors[1]->getLine());
+		self::assertCount(2, $errors);
+		self::assertSame('Property y\x::$baz has unknown class x\baz as its type.', $errors[0]->getMessage());
+		self::assertSame(15, $errors[0]->getLine());
+		self::assertSame('Parameter $baz of method y\x::__construct() has invalid type x\baz.', $errors[1]->getMessage());
+		self::assertSame(16, $errors[1]->getLine());
 	}
 
 	public function testClassExistsAutoloadingError(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/class-exists.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testCollectWarnings(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/declaration-warning.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #1 $i of method DeclarationWarning\Bar::doFoo() is not optional.', $errors[0]->getMessage());
-		$this->assertSame(22, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #1 $i of method DeclarationWarning\Bar::doFoo() is not optional.', $errors[0]->getMessage());
+		self::assertSame(22, $errors[0]->getLine());
 	}
 
 	public function testPropertyAssignIntersectionStaticTypeBug(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/property-assign-intersection-static-type-bug.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug2823(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-2823.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug13424(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13424.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Instantiated class Bug13424\Hello not found.', $errors[0]->getMessage());
-		$this->assertSame(14, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Instantiated class Bug13424\Hello not found.', $errors[0]->getMessage());
+		self::assertSame(14, $errors[0]->getLine());
 	}
 
 	public function testTwoSameClassesInSingleFile(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/two-same-classes.php');
-		$this->assertCount(5, $errors);
+		self::assertCount(5, $errors);
 
 		$error = $errors[0];
-		$this->assertSame('Property TwoSame\Foo::$prop (string) does not accept default value of type int.', $error->getMessage());
-		$this->assertSame(9, $error->getLine());
+		self::assertSame('Property TwoSame\Foo::$prop (string) does not accept default value of type int.', $error->getMessage());
+		self::assertSame(9, $error->getLine());
 
 		$error = $errors[1];
-		$this->assertSame('Access to undefined constant TwoSame\Foo::FOO_CONST.', $error->getMessage());
-		$this->assertSame(13, $error->getLine());
+		self::assertSame('Access to undefined constant TwoSame\Foo::FOO_CONST.', $error->getMessage());
+		self::assertSame(13, $error->getLine());
 
 		$error = $errors[2];
-		$this->assertSame('If condition is always false.', $error->getMessage());
-		$this->assertSame(26, $error->getLine());
+		self::assertSame('If condition is always false.', $error->getMessage());
+		self::assertSame(26, $error->getLine());
 
 		$error = $errors[3];
-		$this->assertSame('Property TwoSame\Foo::$prop (int) does not accept default value of type string.', $error->getMessage());
-		$this->assertSame(33, $error->getLine());
+		self::assertSame('Property TwoSame\Foo::$prop (int) does not accept default value of type string.', $error->getMessage());
+		self::assertSame(33, $error->getLine());
 
 		$error = $errors[4];
-		$this->assertSame('Property TwoSame\Foo::$prop2 (int) does not accept default value of type string.', $error->getMessage());
-		$this->assertSame(36, $error->getLine());
+		self::assertSame('Property TwoSame\Foo::$prop2 (int) does not accept default value of type string.', $error->getMessage());
+		self::assertSame(36, $error->getLine());
 	}
 
 	public function testBug6936(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6936.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3405(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3405.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Magic constant __TRAIT__ is always empty outside a trait.', $errors[0]->getMessage());
-		$this->assertSame(16, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Magic constant __TRAIT__ is always empty outside a trait.', $errors[0]->getMessage());
+		self::assertSame(16, $errors[0]->getLine());
 	}
 
 	public function testBug3415(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Methods/data/bug-3415.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3415Two(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Methods/data/bug-3415-2.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3468(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3468.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3686(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3686.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug13352(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13352.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3379(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-3379.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Constant SOME_UNKNOWN_CONST not found.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Constant SOME_UNKNOWN_CONST not found.', $errors[0]->getMessage());
 	}
 
 	public function testBug13685(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13685.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3798(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3798.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3909(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3909.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug4097(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4097.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug4300(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4300.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Comparison operation ">" between 0 and 0 is always false.', $errors[0]->getMessage());
-		$this->assertSame(13, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Comparison operation ">" between 0 and 0 is always false.', $errors[0]->getMessage());
+		self::assertSame(13, $errors[0]->getLine());
 	}
 
 	public function testBug4513(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4513.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug1871(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1871.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3309(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3309.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug11649(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11649.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug6872(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6872.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3769(): void
 	{
 		require_once __DIR__ . '/../Rules/Generics/data/bug-3769.php';
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Generics/data/bug-3769.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6301(): void
 	{
 		require_once __DIR__ . '/../Rules/Generics/data/bug-6301.php';
 		$errors = $this->runAnalyse(__DIR__ . '/../Rules/Generics/data/bug-6301.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3922(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3922-integration.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug1843(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1843.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug9711(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9711.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Function in_array invoked with 1 parameter, 2-3 required.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Function in_array invoked with 1 parameter, 2-3 required.', $errors[0]->getMessage());
 	}
 
 	public function testBug4713(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4713.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Method Bug4713\Service::createInstance() should return Bug4713\Service but returns object.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Method Bug4713\Service::createInstance() should return Bug4713\Service but returns object.', $errors[0]->getMessage());
 
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(Service::class);
 		$parameter = $class->getNativeMethod('createInstance')->getOnlyVariant()->getParameters()[0];
 		$defaultValue = $parameter->getDefaultValue();
-		$this->assertInstanceOf(ConstantStringType::class, $defaultValue);
-		$this->assertSame(Service::class, $defaultValue->getValue());
+		self::assertInstanceOf(ConstantStringType::class, $defaultValue);
+		self::assertSame(Service::class, $defaultValue->getValue());
 	}
 
 	public function testBug4288(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4288.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(MyClass::class);
 		$parameter = $class->getNativeMethod('paginate')->getOnlyVariant()->getParameters()[0];
 		$defaultValue = $parameter->getDefaultValue();
-		$this->assertInstanceOf(ConstantIntegerType::class, $defaultValue);
-		$this->assertSame(10, $defaultValue->getValue());
+		self::assertInstanceOf(ConstantIntegerType::class, $defaultValue);
+		self::assertSame(10, $defaultValue->getValue());
 
 		$nativeProperty = $class->getNativeReflection()->getProperty('test');
 		$initializerExprTypeResolver = self::getContainer()->getByType(InitializerExprTypeResolver::class);
@@ -417,142 +417,142 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			$nativeProperty->getDefaultValueExpression(),
 			InitializerExprContext::fromClassReflection($class->getNativeProperty('test')->getDeclaringClass()),
 		);
-		$this->assertInstanceOf(ConstantIntegerType::class, $defaultValueType);
-		$this->assertSame(10, $defaultValueType->getValue());
+		self::assertInstanceOf(ConstantIntegerType::class, $defaultValueType);
+		self::assertSame(10, $defaultValueType->getValue());
 	}
 
 	public function testBug4702(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4702.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testFunctionThatExistsOn72AndLater(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/ldap-exop-passwd.php');
 		if (PHP_VERSION_ID < 80100) {
-			$this->assertNoErrors($errors);
+			self::assertNoErrors($errors);
 			return;
 		}
 
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #1 $ldap of function ldap_exop_passwd expects LDAP\Connection, resource given.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #1 $ldap of function ldap_exop_passwd expects LDAP\Connection, resource given.', $errors[0]->getMessage());
 	}
 
 	public function testBug4715(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4715.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.2')]
 	public function testBug4734(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4734.php');
-		$this->assertCount(5, $errors); // could be 3
+		self::assertCount(5, $errors); // could be 3
 
-		$this->assertSame('Static property Bug4734\Foo::$httpMethodParameterOverride (bool) is never assigned false so the property type can be changed to true.', $errors[0]->getMessage()); // should not error
-		$this->assertSame('Property Bug4734\Foo::$httpMethodParameterOverride2 (bool) is never assigned false so the property type can be changed to true.', $errors[1]->getMessage()); // should not error
-		$this->assertSame('Unsafe access to private property Bug4734\Foo::$httpMethodParameterOverride through static::.', $errors[2]->getMessage());
-		$this->assertSame('Access to an undefined static property static(Bug4734\Foo)::$httpMethodParameterOverride3.', $errors[3]->getMessage());
-		$this->assertSame('Access to an undefined property Bug4734\Foo::$httpMethodParameterOverride4.', $errors[4]->getMessage());
+		self::assertSame('Static property Bug4734\Foo::$httpMethodParameterOverride (bool) is never assigned false so the property type can be changed to true.', $errors[0]->getMessage()); // should not error
+		self::assertSame('Property Bug4734\Foo::$httpMethodParameterOverride2 (bool) is never assigned false so the property type can be changed to true.', $errors[1]->getMessage()); // should not error
+		self::assertSame('Unsafe access to private property Bug4734\Foo::$httpMethodParameterOverride through static::.', $errors[2]->getMessage());
+		self::assertSame('Access to an undefined static property static(Bug4734\Foo)::$httpMethodParameterOverride3.', $errors[3]->getMessage());
+		self::assertSame('Access to an undefined property Bug4734\Foo::$httpMethodParameterOverride4.', $errors[4]->getMessage());
 	}
 
 	public function testBug5231(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5231.php');
-		$this->assertNotEmpty($errors);
+		self::assertNotEmpty($errors);
 	}
 
 	public function testBug5231Two(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5231_2.php');
-		$this->assertNotEmpty($errors);
+		self::assertNotEmpty($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug12512(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12512.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug13218(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13218.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug5529(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-5529.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug5527(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5527.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug5639(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5639.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug5657(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5657.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug5951(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5951.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testEnums(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/enums-integration.php');
-		$this->assertCount(3, $errors);
-		$this->assertSame('Access to an undefined property EnumIntegrationTest\Foo::TWO::$value.', $errors[0]->getMessage());
-		$this->assertSame(22, $errors[0]->getLine());
-		$this->assertSame('Access to undefined constant EnumIntegrationTest\Bar::NONEXISTENT.', $errors[1]->getMessage());
-		$this->assertSame(49, $errors[1]->getLine());
-		$this->assertSame('Strict comparison using === between EnumIntegrationTest\Foo::ONE and EnumIntegrationTest\Foo::TWO will always evaluate to false.', $errors[2]->getMessage());
-		$this->assertSame(79, $errors[2]->getLine());
+		self::assertCount(3, $errors);
+		self::assertSame('Access to an undefined property EnumIntegrationTest\Foo::TWO::$value.', $errors[0]->getMessage());
+		self::assertSame(22, $errors[0]->getLine());
+		self::assertSame('Access to undefined constant EnumIntegrationTest\Bar::NONEXISTENT.', $errors[1]->getMessage());
+		self::assertSame(49, $errors[1]->getLine());
+		self::assertSame('Strict comparison using === between EnumIntegrationTest\Foo::ONE and EnumIntegrationTest\Foo::TWO will always evaluate to false.', $errors[2]->getMessage());
+		self::assertSame(79, $errors[2]->getLine());
 	}
 
 	public function testBug6255(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6255.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6300(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6300.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Call to an undefined method Bug6300\Bar::get().', $errors[0]->getMessage());
-		$this->assertSame(27, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Call to an undefined method Bug6300\Bar::get().', $errors[0]->getMessage());
+		self::assertSame(27, $errors[0]->getLine());
 	}
 
 	public function testBug6466(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6466.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug6494(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6494.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6253(): void
@@ -565,168 +565,168 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 				__DIR__ . '/data/bug-6253-collection-trait.php',
 			],
 		);
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6442(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6442.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Dumped type: \'Bug6442\\\B\'', $errors[0]->getMessage());
-		$this->assertSame(9, $errors[0]->getLine());
-		$this->assertSame('Dumped type: \'Bug6442\\\A\'', $errors[1]->getMessage());
-		$this->assertSame(9, $errors[1]->getLine());
+		self::assertCount(2, $errors);
+		self::assertSame('Dumped type: \'Bug6442\\\B\'', $errors[0]->getMessage());
+		self::assertSame(9, $errors[0]->getLine());
+		self::assertSame('Dumped type: \'Bug6442\\\A\'', $errors[1]->getMessage());
+		self::assertSame(9, $errors[1]->getLine());
 	}
 
 	public function testBug13057(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13057.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6375(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6375.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6501(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6501.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('PHPDoc tag @var with type R of Exception|stdClass is not subtype of native type stdClass.', $errors[0]->getMessage());
-		$this->assertSame(24, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('PHPDoc tag @var with type R of Exception|stdClass is not subtype of native type stdClass.', $errors[0]->getMessage());
+		self::assertSame(24, $errors[0]->getLine());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug6114(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6114.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6681(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6681.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6212(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6212.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6740(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6740-b.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6866(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6866.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6649(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6649.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12778(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12778.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6842(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6842.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Generator expects value type T of DateTimeInterface, DateTime|DateTimeImmutable|T of DateTimeInterface given.', $errors[0]->getMessage());
-		$this->assertSame(28, $errors[0]->getLine());
+		self::assertCount(2, $errors);
+		self::assertSame('Generator expects value type T of DateTimeInterface, DateTime|DateTimeImmutable|T of DateTimeInterface given.', $errors[0]->getMessage());
+		self::assertSame(28, $errors[0]->getLine());
 
-		$this->assertSame('Generator expects value type T of DateTimeInterface, DateTime|DateTimeImmutable|T of DateTimeInterface given.', $errors[1]->getMessage());
-		$this->assertSame(54, $errors[1]->getLine());
+		self::assertSame('Generator expects value type T of DateTimeInterface, DateTime|DateTimeImmutable|T of DateTimeInterface given.', $errors[1]->getMessage());
+		self::assertSame(54, $errors[1]->getLine());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug6896(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6896.php');
-		$this->assertCount(4, $errors);
-		$this->assertSame('Generic type IteratorIterator<(int|string), mixed> in PHPDoc tag @return does not specify all template types of class IteratorIterator: TKey, TValue, TIterator', $errors[0]->getMessage());
-		$this->assertSame(38, $errors[0]->getLine());
-		$this->assertSame('Generic type LimitIterator<(int|string), mixed> in PHPDoc tag @return does not specify all template types of class LimitIterator: TKey, TValue, TIterator', $errors[1]->getMessage());
-		$this->assertSame(38, $errors[1]->getLine());
-		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() return type with generic class Bug6896\XIterator does not specify its types: TKey, TValue', $errors[2]->getMessage());
-		$this->assertSame(38, $errors[2]->getLine());
-		$this->assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() should return array<TRandKey of (int|string), TRandVal>|Bug6896\XIterator<TRandKey of (int|string), TRandVal>|IteratorIterator<TRandKey of (int|string), TRandVal>|LimitIterator<TRandKey of (int|string), TRandVal> but returns TRandList of array<TRandKey of (int|string), TRandVal>|Traversable<TRandKey of (int|string), TRandVal>.', $errors[3]->getMessage());
-		$this->assertSame(42, $errors[3]->getLine());
+		self::assertCount(4, $errors);
+		self::assertSame('Generic type IteratorIterator<(int|string), mixed> in PHPDoc tag @return does not specify all template types of class IteratorIterator: TKey, TValue, TIterator', $errors[0]->getMessage());
+		self::assertSame(38, $errors[0]->getLine());
+		self::assertSame('Generic type LimitIterator<(int|string), mixed> in PHPDoc tag @return does not specify all template types of class LimitIterator: TKey, TValue, TIterator', $errors[1]->getMessage());
+		self::assertSame(38, $errors[1]->getLine());
+		self::assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() return type with generic class Bug6896\XIterator does not specify its types: TKey, TValue', $errors[2]->getMessage());
+		self::assertSame(38, $errors[2]->getLine());
+		self::assertSame('Method Bug6896\RandHelper::getPseudoRandomWithUrl() should return array<TRandKey of (int|string), TRandVal>|Bug6896\XIterator<TRandKey of (int|string), TRandVal>|IteratorIterator<TRandKey of (int|string), TRandVal>|LimitIterator<TRandKey of (int|string), TRandVal> but returns TRandList of array<TRandKey of (int|string), TRandVal>|Traversable<TRandKey of (int|string), TRandVal>.', $errors[3]->getMessage());
+		self::assertSame(42, $errors[3]->getLine());
 	}
 
 	public function testBug6940(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6940.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Loose comparison using == between array{} and array{} will always evaluate to true.', $errors[0]->getMessage());
-		$this->assertSame(12, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Loose comparison using == between array{} and array{} will always evaluate to true.', $errors[0]->getMessage());
+		self::assertSame(12, $errors[0]->getLine());
 	}
 
 	public function testBug1447(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1447.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug5081(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5081.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug1388(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-1388.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug4308(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4308.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug4732(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-4732.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6160(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6160.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Parameter #1 $flags of static method Bug6160\HelloWorld::split() expects 0|1|2, 94561 given.', $errors[0]->getMessage());
-		$this->assertSame(19, $errors[0]->getLine());
-		$this->assertSame('Parameter #1 $flags of static method Bug6160\HelloWorld::split() expects 0|1|2, \'sdf\' given.', $errors[1]->getMessage());
-		$this->assertSame(23, $errors[1]->getLine());
+		self::assertCount(2, $errors);
+		self::assertSame('Parameter #1 $flags of static method Bug6160\HelloWorld::split() expects 0|1|2, 94561 given.', $errors[0]->getMessage());
+		self::assertSame(19, $errors[0]->getLine());
+		self::assertSame('Parameter #1 $flags of static method Bug6160\HelloWorld::split() expects 0|1|2, \'sdf\' given.', $errors[1]->getMessage());
+		self::assertSame(23, $errors[1]->getLine());
 	}
 
 	public function testBug6979(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6979.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7030(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7030.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('PHPDoc tag @method has invalid value (array  getItemsForID($id, $quantity, $shippingPostCode = null, $wholesalerList = null, $shippingLatitude =
+		self::assertCount(1, $errors);
+		self::assertSame('PHPDoc tag @method has invalid value (array  getItemsForID($id, $quantity, $shippingPostCode = null, $wholesalerList = null, $shippingLatitude =
 	null, $shippingLongitude = null, $shippingNeutralShipping = null)): Unexpected token "\n * ", expected type at offset 193 on line 6', $errors[0]->getMessage());
 	}
 
@@ -734,460 +734,460 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug7012(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7012.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug6192(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6192.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7068(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-7068.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testDiscussion6993(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-6993.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #1 $specificable of method Bug6993\AndSpecificationValidator<Bug6993\TestSpecification,Bug6993\Foo>::isSatisfiedBy() expects Bug6993\Foo, Bug6993\Bar given.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #1 $specificable of method Bug6993\AndSpecificationValidator<Bug6993\TestSpecification,Bug6993\Foo>::isSatisfiedBy() expects Bug6993\Foo, Bug6993\Bar given.', $errors[0]->getMessage());
 	}
 
 	public function testBug7077(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7077.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug7078(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-7078.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug7116(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7116.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug3853(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-3853.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug7135(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7135.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Cannot create callable from the new operator.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Cannot create callable from the new operator.', $errors[0]->getMessage());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testDiscussion7124(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/discussion-7124.php');
-		$this->assertCount(4, $errors);
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, 0|1|2=): bool, Closure(int, bool): bool given.', $errors[0]->getMessage());
-		$this->assertSame(38, $errors[0]->getLine());
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, 0|1|2=): bool, Closure(int): bool given.', $errors[1]->getMessage());
-		$this->assertSame(45, $errors[1]->getLine());
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(0|1|2): bool, Closure(bool): bool given.', $errors[2]->getMessage());
-		$this->assertSame(52, $errors[2]->getLine());
-		$this->assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool): bool, Closure(int): bool given.', $errors[3]->getMessage());
-		$this->assertSame(59, $errors[3]->getLine());
+		self::assertCount(4, $errors);
+		self::assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, 0|1|2=): bool, Closure(int, bool): bool given.', $errors[0]->getMessage());
+		self::assertSame(38, $errors[0]->getLine());
+		self::assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool, 0|1|2=): bool, Closure(int): bool given.', $errors[1]->getMessage());
+		self::assertSame(45, $errors[1]->getLine());
+		self::assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(0|1|2): bool, Closure(bool): bool given.', $errors[2]->getMessage());
+		self::assertSame(52, $errors[2]->getLine());
+		self::assertSame('Parameter #2 $callback of function Discussion7124\filter expects callable(bool): bool, Closure(int): bool given.', $errors[3]->getMessage());
+		self::assertSame(59, $errors[3]->getLine());
 	}
 
 	public function testBug7214(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7214.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Method Bug7214\HelloWorld::getFoo() has no return type specified.', $errors[0]->getMessage());
-		$this->assertSame(6, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Method Bug7214\HelloWorld::getFoo() has no return type specified.', $errors[0]->getMessage());
+		self::assertSame(6, $errors[0]->getLine());
 	}
 
 	public function testBug12327(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12327.php');
-		$this->assertCount(1, $errors);
+		self::assertCount(1, $errors);
 
-		$this->assertSame('Class Bug12327\DoesNotMatter uses unknown trait Bug12327\ThisTriggersTheIssue.', $errors[0]->getMessage());
-		$this->assertSame(15, $errors[0]->getLine());
+		self::assertSame('Class Bug12327\DoesNotMatter uses unknown trait Bug12327\ThisTriggersTheIssue.', $errors[0]->getMessage());
+		self::assertSame(15, $errors[0]->getLine());
 	}
 
 	public function testBug7215(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7215.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7094(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7094.php');
-		$this->assertCount(6, $errors);
+		self::assertCount(6, $errors);
 
-		$this->assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() contains unresolvable type.', $errors[0]->getMessage());
-		$this->assertSame(74, $errors[0]->getLine());
-		$this->assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() expects string, int given.', $errors[1]->getMessage());
-		$this->assertSame(75, $errors[1]->getLine());
-		$this->assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() expects 5|6|7, 3 given.', $errors[2]->getMessage());
-		$this->assertSame(76, $errors[2]->getLine());
-		$this->assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() expects string, int given.', $errors[3]->getMessage());
-		$this->assertSame(78, $errors[3]->getLine());
-		$this->assertSame('Return type of call to method Bug7094\Foo::getAttribute() contains unresolvable type.', $errors[4]->getMessage());
-		$this->assertSame(79, $errors[4]->getLine());
+		self::assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() contains unresolvable type.', $errors[0]->getMessage());
+		self::assertSame(74, $errors[0]->getLine());
+		self::assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() expects string, int given.', $errors[1]->getMessage());
+		self::assertSame(75, $errors[1]->getLine());
+		self::assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() expects 5|6|7, 3 given.', $errors[2]->getMessage());
+		self::assertSame(76, $errors[2]->getLine());
+		self::assertSame('Parameter #2 $val of method Bug7094\Foo::setAttribute() expects string, int given.', $errors[3]->getMessage());
+		self::assertSame(78, $errors[3]->getLine());
+		self::assertSame('Return type of call to method Bug7094\Foo::getAttribute() contains unresolvable type.', $errors[4]->getMessage());
+		self::assertSame(79, $errors[4]->getLine());
 
-		$this->assertSame('Parameter #1 $attr of method Bug7094\Foo::setAttributes() expects array{foo?: string, bar?: 5|6|7, baz?: bool}, non-empty-array<\'bar\'|\'baz\'|\'foo\'|K of string, 5|6|7|bool|string> given.', $errors[5]->getMessage());
-		$this->assertSame(29, $errors[5]->getLine());
+		self::assertSame('Parameter #1 $attr of method Bug7094\Foo::setAttributes() expects array{foo?: string, bar?: 5|6|7, baz?: bool}, non-empty-array<\'bar\'|\'baz\'|\'foo\'|K of string, 5|6|7|bool|string> given.', $errors[5]->getMessage());
+		self::assertSame(29, $errors[5]->getLine());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testOffsetAccess(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/offset-access.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('PHPDoc tag @return contains unresolvable type.', $errors[0]->getMessage());
-		$this->assertSame(42, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('PHPDoc tag @return contains unresolvable type.', $errors[0]->getMessage());
+		self::assertSame(42, $errors[0]->getLine());
 	}
 
 	public function testUnresolvableParameter(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/unresolvable-parameter.php');
-		$this->assertCount(3, $errors);
-		$this->assertSame('Parameter #2 $array of function array_map expects array, list<string>|false given.', $errors[0]->getMessage());
-		$this->assertSame(18, $errors[0]->getLine());
-		$this->assertSame('Method UnresolvableParameter\Collection::pipeInto() has parameter $class with no type specified.', $errors[1]->getMessage());
-		$this->assertSame(30, $errors[1]->getLine());
-		$this->assertSame('PHPDoc tag @param for parameter $class contains unresolvable type.', $errors[2]->getMessage());
-		$this->assertSame(30, $errors[2]->getLine());
+		self::assertCount(3, $errors);
+		self::assertSame('Parameter #2 $array of function array_map expects array, list<string>|false given.', $errors[0]->getMessage());
+		self::assertSame(18, $errors[0]->getLine());
+		self::assertSame('Method UnresolvableParameter\Collection::pipeInto() has parameter $class with no type specified.', $errors[1]->getMessage());
+		self::assertSame(30, $errors[1]->getLine());
+		self::assertSame('PHPDoc tag @param for parameter $class contains unresolvable type.', $errors[2]->getMessage());
+		self::assertSame(30, $errors[2]->getLine());
 	}
 
 	public function testBug7248(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7248.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7351(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7351.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7381(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7381.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7153(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/bug-7153.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7275(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7275.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7500(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7500.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12767(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12767.php');
-		$this->assertCount(3, $errors);
+		self::assertCount(3, $errors);
 
-		$this->assertSame('Expected type int, actual: *ERROR*', $errors[0]->getMessage());
-		$this->assertSame('Undefined variable: $field1', $errors[1]->getMessage());
-		$this->assertSame('Undefined variable: $field2', $errors[2]->getMessage());
+		self::assertSame('Expected type int, actual: *ERROR*', $errors[0]->getMessage());
+		self::assertSame('Undefined variable: $field1', $errors[1]->getMessage());
+		self::assertSame('Undefined variable: $field2', $errors[2]->getMessage());
 	}
 
 	public function testBug7554(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7554.php');
-		$this->assertCount(2, $errors);
+		self::assertCount(2, $errors);
 
-		$this->assertSame(sprintf('Parameter #1 $%s of function count expects array|Countable, list<array<int, int<0, max>|string>>|false given.', PHP_VERSION_ID < 80000 ? 'var' : 'value'), $errors[0]->getMessage());
-		$this->assertSame(26, $errors[0]->getLine());
+		self::assertSame(sprintf('Parameter #1 $%s of function count expects array|Countable, list<array<int, int<0, max>|string>>|false given.', PHP_VERSION_ID < 80000 ? 'var' : 'value'), $errors[0]->getMessage());
+		self::assertSame(26, $errors[0]->getLine());
 
-		$this->assertSame('Cannot access offset int<1, max> on list<array{non-empty-string, int<0, max>}>|false.', $errors[1]->getMessage());
-		$this->assertSame(27, $errors[1]->getLine());
+		self::assertSame('Cannot access offset int<1, max> on list<array{non-empty-string, int<0, max>}>|false.', $errors[1]->getMessage());
+		self::assertSame(27, $errors[1]->getLine());
 	}
 
 	public function testBug7637(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7637.php');
-		$this->assertCount(3, $errors);
+		self::assertCount(3, $errors);
 
-		$this->assertSame('Method Bug7637\HelloWorld::getProperty() has invalid return type Bug7637\rex_backend_login.', $errors[0]->getMessage());
-		$this->assertSame(54, $errors[0]->getLine());
+		self::assertSame('Method Bug7637\HelloWorld::getProperty() has invalid return type Bug7637\rex_backend_login.', $errors[0]->getMessage());
+		self::assertSame(54, $errors[0]->getLine());
 
-		$this->assertSame('Method Bug7637\HelloWorld::getProperty() has invalid return type Bug7637\rex_timer.', $errors[1]->getMessage());
-		$this->assertSame(54, $errors[1]->getLine());
+		self::assertSame('Method Bug7637\HelloWorld::getProperty() has invalid return type Bug7637\rex_timer.', $errors[1]->getMessage());
+		self::assertSame(54, $errors[1]->getLine());
 
-		$this->assertSame('Call to function is_string() with string will always evaluate to true.', $errors[2]->getMessage());
-		$this->assertSame(57, $errors[2]->getLine());
+		self::assertSame('Call to function is_string() with string will always evaluate to true.', $errors[2]->getMessage());
+		self::assertSame(57, $errors[2]->getLine());
 	}
 
 	public function testBug12671(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12671.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7737(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7737.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7762(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7762.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Function json_decode invoked with 0 parameters, 1-4 required.', $errors[0]->getMessage());
-		$this->assertSame('Function json_encode invoked with 0 parameters, 1-3 required.', $errors[1]->getMessage());
+		self::assertCount(2, $errors);
+		self::assertSame('Function json_decode invoked with 0 parameters, 1-4 required.', $errors[0]->getMessage());
+		self::assertSame('Function json_encode invoked with 0 parameters, 1-3 required.', $errors[1]->getMessage());
 	}
 
 	public function testPrestashopInfiniteRunXmlLoaderBug(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/prestashop-xml-loader.php');
-		$this->assertCount(4, $errors);
-		$this->assertSame('Property PrestaShopBundleInfiniteRunBug\XmlLoader::$data_path has no type specified.', $errors[0]->getMessage());
-		$this->assertSame('Method PrestaShopBundleInfiniteRunBug\XmlLoader::getEntityInfo() has no return type specified.', $errors[1]->getMessage());
-		$this->assertSame('Method PrestaShopBundleInfiniteRunBug\XmlLoader::getEntityInfo() has parameter $entity with no type specified.', $errors[2]->getMessage());
-		$this->assertSame('Method PrestaShopBundleInfiniteRunBug\XmlLoader::getEntityInfo() has parameter $exists with no type specified.', $errors[3]->getMessage());
+		self::assertCount(4, $errors);
+		self::assertSame('Property PrestaShopBundleInfiniteRunBug\XmlLoader::$data_path has no type specified.', $errors[0]->getMessage());
+		self::assertSame('Method PrestaShopBundleInfiniteRunBug\XmlLoader::getEntityInfo() has no return type specified.', $errors[1]->getMessage());
+		self::assertSame('Method PrestaShopBundleInfiniteRunBug\XmlLoader::getEntityInfo() has parameter $entity with no type specified.', $errors[2]->getMessage());
+		self::assertSame('Method PrestaShopBundleInfiniteRunBug\XmlLoader::getEntityInfo() has parameter $exists with no type specified.', $errors[3]->getMessage());
 	}
 
 	public function testBug7320(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7320.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #1 $c of function Bug7320\foo expects callable(int=): void, Closure(int): void given.', $errors[0]->getMessage());
-		$this->assertSame(13, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #1 $c of function Bug7320\foo expects callable(int=): void, Closure(int): void given.', $errors[0]->getMessage());
+		self::assertSame(13, $errors[0]->getLine());
 	}
 
 	public function testBug7581(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7581.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7903(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7903.php');
-		$this->assertCount(24, $errors);
+		self::assertCount(24, $errors);
 	}
 
 	public function testBug7901(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7901.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7918(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7918.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7140(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7140.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testArrayUnion(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/array-union.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6948(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6948.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7963(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7963.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7963Two(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7963-two.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug8078(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8078.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug8072(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8072.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug7787(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7787.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Reflection error: Circular reference to class "Bug7787\TestClass"', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Reflection error: Circular reference to class "Bug7787\TestClass"', $errors[0]->getMessage());
 	}
 
 	public function testBug3865(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-3865.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('The @extends tag of class Bug3865\RecursiveClass describes Bug3865\RecursiveClass but the class extends Bug3865\EntityRepository.', $errors[0]->getMessage());
-		$this->assertSame(14, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('The @extends tag of class Bug3865\RecursiveClass describes Bug3865\RecursiveClass but the class extends Bug3865\EntityRepository.', $errors[0]->getMessage());
+		self::assertSame(14, $errors[0]->getLine());
 	}
 
 	public function testBug5312(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5312.php');
-		$this->assertCount(3, $errors);
-		$this->assertSame('Parameter $object of method Bug5312\Updatable::update() has invalid type Bug5312\T.', $errors[0]->getMessage());
-		$this->assertSame(13, $errors[0]->getLine());
-		$this->assertSame('Type Bug5312\T in generic type Bug5312\Updatable<Bug5312\T> in PHPDoc tag @param for parameter $object is not subtype of template type T of Bug5312\Updatable<Bug5312\T> of interface Bug5312\Updatable.', $errors[1]->getMessage());
-		$this->assertSame(13, $errors[1]->getLine());
-		$this->assertSame('Type Bug5312\T in generic type Bug5312\Updatable<Bug5312\T> in PHPDoc tag @param for parameter $object is not subtype of template type T of Bug5312\Updatable<Bug5312\T> of interface Bug5312\Updatable.', $errors[2]->getMessage());
-		$this->assertSame(13, $errors[2]->getLine());
+		self::assertCount(3, $errors);
+		self::assertSame('Parameter $object of method Bug5312\Updatable::update() has invalid type Bug5312\T.', $errors[0]->getMessage());
+		self::assertSame(13, $errors[0]->getLine());
+		self::assertSame('Type Bug5312\T in generic type Bug5312\Updatable<Bug5312\T> in PHPDoc tag @param for parameter $object is not subtype of template type T of Bug5312\Updatable<Bug5312\T> of interface Bug5312\Updatable.', $errors[1]->getMessage());
+		self::assertSame(13, $errors[1]->getLine());
+		self::assertSame('Type Bug5312\T in generic type Bug5312\Updatable<Bug5312\T> in PHPDoc tag @param for parameter $object is not subtype of template type T of Bug5312\Updatable<Bug5312\T> of interface Bug5312\Updatable.', $errors[2]->getMessage());
+		self::assertSame(13, $errors[2]->getLine());
 	}
 
 	public function testBug5390(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5390.php');
-		$this->assertCount(3, $errors);
-		$this->assertSame('Property Bug5390\A::$b is never written, only read.', $errors[0]->getMessage());
-		$this->assertSame(9, $errors[0]->getLine());
-		$this->assertSame('Method Bug5390\A::infiniteRecursion() has no return type specified.', $errors[1]->getMessage());
-		$this->assertSame(11, $errors[1]->getLine());
-		$this->assertSame('Call to an undefined method Bug5390\B::someMethod().', $errors[2]->getMessage());
-		$this->assertSame(12, $errors[2]->getLine());
+		self::assertCount(3, $errors);
+		self::assertSame('Property Bug5390\A::$b is never written, only read.', $errors[0]->getMessage());
+		self::assertSame(9, $errors[0]->getLine());
+		self::assertSame('Method Bug5390\A::infiniteRecursion() has no return type specified.', $errors[1]->getMessage());
+		self::assertSame(11, $errors[1]->getLine());
+		self::assertSame('Call to an undefined method Bug5390\B::someMethod().', $errors[2]->getMessage());
+		self::assertSame(12, $errors[2]->getLine());
 	}
 
 	public function testBug7110(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7110.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #1 $s of function Bug7110\takesInt expects int, string given.', $errors[0]->getMessage());
-		$this->assertSame(34, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #1 $s of function Bug7110\takesInt expects int, string given.', $errors[0]->getMessage());
+		self::assertSame(34, $errors[0]->getLine());
 	}
 
 	public function testBug8376(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8376.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.2')]
 	public function testAssertDocblock(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/nsrt/assert-docblock.php');
-		$this->assertCount(4, $errors);
-		$this->assertSame('Call to method AssertDocblock\A::testInt() with string will always evaluate to false.', $errors[0]->getMessage());
-		$this->assertSame(218, $errors[0]->getLine());
-		$this->assertSame('Call to method AssertDocblock\A::testNotInt() with string will always evaluate to true.', $errors[1]->getMessage());
-		$this->assertSame(224, $errors[1]->getLine());
-		$this->assertSame('Call to method AssertDocblock\A::testInt() with int will always evaluate to true.', $errors[2]->getMessage());
-		$this->assertSame(232, $errors[2]->getLine());
-		$this->assertSame('Call to method AssertDocblock\A::testNotInt() with int will always evaluate to false.', $errors[3]->getMessage());
-		$this->assertSame(238, $errors[3]->getLine());
+		self::assertCount(4, $errors);
+		self::assertSame('Call to method AssertDocblock\A::testInt() with string will always evaluate to false.', $errors[0]->getMessage());
+		self::assertSame(218, $errors[0]->getLine());
+		self::assertSame('Call to method AssertDocblock\A::testNotInt() with string will always evaluate to true.', $errors[1]->getMessage());
+		self::assertSame(224, $errors[1]->getLine());
+		self::assertSame('Call to method AssertDocblock\A::testInt() with int will always evaluate to true.', $errors[2]->getMessage());
+		self::assertSame(232, $errors[2]->getLine());
+		self::assertSame('Call to method AssertDocblock\A::testNotInt() with int will always evaluate to false.', $errors[3]->getMessage());
+		self::assertSame(238, $errors[3]->getLine());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug8147(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8147.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug12934(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12934.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testConditionalExpressionInfiniteLoop(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/conditional-expression-infinite-loop.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testPr2030(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/pr-2030.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug6265(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-6265.php');
-		$this->assertNotEmpty($errors);
+		self::assertNotEmpty($errors);
 	}
 
 	public function testBug8503(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8503.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug8537(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8537.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug7927(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-7927.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Enum case Bug7927\Test::One does not have a value but the enum is backed with the "int" type.', $errors[0]->getMessage());
-		$this->assertSame('Enum case Bug7927\Test::Two does not have a value but the enum is backed with the "int" type.', $errors[1]->getMessage());
+		self::assertCount(2, $errors);
+		self::assertSame('Enum case Bug7927\Test::One does not have a value but the enum is backed with the "int" type.', $errors[0]->getMessage());
+		self::assertSame('Enum case Bug7927\Test::Two does not have a value but the enum is backed with the "int" type.', $errors[1]->getMessage());
 	}
 
 	public function testBug8146(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8146b.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug8215(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8215.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug8146a(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8146a.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public static function getAdditionalConfigFiles(): array
@@ -1201,351 +1201,351 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 	public function testBug8004(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8004.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Strict comparison using !== between null and DateTimeInterface|string will always evaluate to true.', $errors[0]->getMessage());
-		$this->assertSame(49, $errors[0]->getLine());
+		self::assertCount(2, $errors);
+		self::assertSame('Strict comparison using !== between null and DateTimeInterface|string will always evaluate to true.', $errors[0]->getMessage());
+		self::assertSame(49, $errors[0]->getLine());
 
-		$this->assertSame('Strict comparison using !== between null and DateTimeInterface|string will always evaluate to true.', $errors[1]->getMessage());
-		$this->assertSame(59, $errors[1]->getLine());
+		self::assertSame('Strict comparison using !== between null and DateTimeInterface|string will always evaluate to true.', $errors[1]->getMessage());
+		self::assertSame(59, $errors[1]->getLine());
 	}
 
 	public function testSkipCheckNoGenericClasses(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/skip-check-no-generic-classes.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Method SkipCheckNoGenericClasses\Foo::doFoo() has parameter $i with generic class LimitIterator but does not specify its types: TKey, TValue, TIterator', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Method SkipCheckNoGenericClasses\Foo::doFoo() has parameter $i with generic class LimitIterator but does not specify its types: TKey, TValue, TIterator', $errors[0]->getMessage());
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug8983(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-8983.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug9008(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9008.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug5091(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5091.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug13507(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13507.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug9459(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9459.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('PHPDoc tag @var with type callable(): array<mixed> is not subtype of native type Closure(): array{}.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('PHPDoc tag @var with type callable(): array<mixed> is not subtype of native type Closure(): array{}.', $errors[0]->getMessage());
 	}
 
 	public function testBug9573(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9573.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug9039(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9039.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Constant Bug9039\Test::RULES is unused.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Constant Bug9039\Test::RULES is unused.', $errors[0]->getMessage());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testDiscussion9053(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/discussion-9053.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug13492(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13492.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testProcessCalledMethodInfiniteLoop(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/process-called-method-infinite-loop.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug9428(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9428.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug9690(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9690.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testIgnoreIdentifiers(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/ignore-identifiers.php');
-		$this->assertCount(5, $errors);
+		self::assertCount(5, $errors);
 
-		$this->assertSame('No error with identifier wrong.id is reported on line 12.', $errors[0]->getMessage());
-		$this->assertSame(12, $errors[0]->getLine());
+		self::assertSame('No error with identifier wrong.id is reported on line 12.', $errors[0]->getMessage());
+		self::assertSame(12, $errors[0]->getLine());
 
-		$this->assertSame('Undefined variable: $foo', $errors[1]->getMessage());
-		$this->assertSame(12, $errors[1]->getLine());
+		self::assertSame('Undefined variable: $foo', $errors[1]->getMessage());
+		self::assertSame(12, $errors[1]->getLine());
 
-		$this->assertSame('Undefined variable: $bar', $errors[2]->getMessage());
-		$this->assertSame(14, $errors[2]->getLine());
+		self::assertSame('Undefined variable: $bar', $errors[2]->getMessage());
+		self::assertSame(14, $errors[2]->getLine());
 
-		$this->assertSame('Undefined variable: $foo', $errors[3]->getMessage());
-		$this->assertSame(14, $errors[3]->getLine());
+		self::assertSame('Undefined variable: $foo', $errors[3]->getMessage());
+		self::assertSame(14, $errors[3]->getLine());
 
-		$this->assertSame('Undefined variable: $bar', $errors[4]->getMessage());
-		$this->assertSame(16, $errors[4]->getLine());
+		self::assertSame('Undefined variable: $bar', $errors[4]->getMessage());
+		self::assertSame(16, $errors[4]->getLine());
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug9994(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-9994.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Negated boolean expression is always false.', $errors[0]->getMessage());
-		$this->assertSame('Parameter #2 $callback of function array_filter expects (callable(1|2|3|null): bool)|null, false given.', $errors[1]->getMessage());
+		self::assertCount(2, $errors);
+		self::assertSame('Negated boolean expression is always false.', $errors[0]->getMessage());
+		self::assertSame('Parameter #2 $callback of function array_filter expects (callable(1|2|3|null): bool)|null, false given.', $errors[1]->getMessage());
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug10049(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10049-recursive.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug10086(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10086.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug10147(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10147.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.2')]
 	public function testBug10302(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10302.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug10358(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10358.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Cannot use Ns\Foo2 as Foo because the name is already in use', $errors[0]->getMessage());
-		$this->assertSame(6, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Cannot use Ns\Foo2 as Foo because the name is already in use', $errors[0]->getMessage());
+		self::assertSame(6, $errors[0]->getLine());
 	}
 
 	public function testBug10509(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10509.php');
-		$this->assertCount(2, $errors);
-		$this->assertSame('Method Bug10509\Foo::doFoo() has no return type specified.', $errors[0]->getMessage());
-		$this->assertSame('PHPDoc tag @return contains unresolvable type.', $errors[1]->getMessage());
+		self::assertCount(2, $errors);
+		self::assertSame('Method Bug10509\Foo::doFoo() has no return type specified.', $errors[0]->getMessage());
+		self::assertSame('PHPDoc tag @return contains unresolvable type.', $errors[1]->getMessage());
 	}
 
 	public function testBug10538(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10538.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug10847(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10847.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug10772(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10772.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug10985(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10985.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug10979(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10979.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug11026(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11026.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug10867(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-10867.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug11263(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11263.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug11147(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11147.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Method Bug11147\RedisAdapter::createConnection() has invalid return type Bug11147\NonExistentClass.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Method Bug11147\RedisAdapter::createConnection() has invalid return type Bug11147\NonExistentClass.', $errors[0]->getMessage());
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug11283(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11283.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug11292(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11292.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
 	public function testBug11297(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11297.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug5597(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-5597.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug11511(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11511.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Access to an undefined property object::$bar.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Access to an undefined property object::$bar.', $errors[0]->getMessage());
 	}
 
 	public function testBug12214(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12214.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug11640(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11640.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.0')]
 	public function testBug11709(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11709.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug11913(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11913.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.3')]
 	public function testBug12549(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12549.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12627(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12627.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.3')]
 	public function testBug12159(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12159.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12787(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12787.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12800(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12800.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.3')]
 	public function testBug12949(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12949.php');
-		$this->assertCount(3, $errors);
-		$this->assertSame('Call to an undefined method object::0().', $errors[0]->getMessage());
-		$this->assertSame('Call to an undefined static method object::0().', $errors[1]->getMessage());
-		$this->assertSame('Access to undefined constant object::0.', $errors[2]->getMessage());
+		self::assertCount(3, $errors);
+		self::assertSame('Call to an undefined method object::0().', $errors[0]->getMessage());
+		self::assertSame('Call to an undefined static method object::0().', $errors[1]->getMessage());
+		self::assertSame('Access to undefined constant object::0.', $errors[2]->getMessage());
 	}
 
 	public function testBug12979(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12979.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug12095(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-12095.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug13279(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13279.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Parameter #2 $offset of function array_splice expects int, string given.', $errors[0]->getMessage());
+		self::assertCount(1, $errors);
+		self::assertSame('Parameter #2 $offset of function array_splice expects int, string given.', $errors[0]->getMessage());
 	}
 
 	public function testBug13310(): void
@@ -1554,20 +1554,20 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		require_once __DIR__ . '/data/bug-13310.php';
 
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13310.php');
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testBug13714(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13714.php');
-		$this->assertCount(7, $errors);
-		$this->assertSame('Function Bug13714\curl_setopt invoked with 3 parameters, 0 required.', $errors[0]->getMessage());
-		$this->assertSame('Function Bug13714\curl_setopt_array invoked with 2 parameters, 0 required.', $errors[1]->getMessage());
-		$this->assertSame('Function Bug13714\implode invoked with 2 parameters, 0 required.', $errors[2]->getMessage());
-		$this->assertSame('Function Bug13714\array_map invoked with 2 parameters, 0 required.', $errors[3]->getMessage());
-		$this->assertSame('Function Bug13714\array_filter invoked with 2 parameters, 0 required.', $errors[4]->getMessage());
-		$this->assertSame('Function Bug13714\array_walk invoked with 2 parameters, 0 required.', $errors[5]->getMessage());
-		$this->assertSame('Function Bug13714\array_find invoked with 2 parameters, 0 required.', $errors[6]->getMessage());
+		self::assertCount(7, $errors);
+		self::assertSame('Function Bug13714\curl_setopt invoked with 3 parameters, 0 required.', $errors[0]->getMessage());
+		self::assertSame('Function Bug13714\curl_setopt_array invoked with 2 parameters, 0 required.', $errors[1]->getMessage());
+		self::assertSame('Function Bug13714\implode invoked with 2 parameters, 0 required.', $errors[2]->getMessage());
+		self::assertSame('Function Bug13714\array_map invoked with 2 parameters, 0 required.', $errors[3]->getMessage());
+		self::assertSame('Function Bug13714\array_filter invoked with 2 parameters, 0 required.', $errors[4]->getMessage());
+		self::assertSame('Function Bug13714\array_walk invoked with 2 parameters, 0 required.', $errors[5]->getMessage());
+		self::assertSame('Function Bug13714\array_find invoked with 2 parameters, 0 required.', $errors[6]->getMessage());
 	}
 
 	/**
@@ -1586,7 +1586,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 			true,
 		)->getErrors();
 		foreach ($errors as $error) {
-			$this->assertSame($file, $error->getFilePath());
+			self::assertSame($file, $error->getFilePath());
 		}
 
 		return $errors;

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -48,7 +48,7 @@ class AnalyserTest extends PHPStanTestCase
 	public function testReturnErrorIfIgnoredMessagesDoesNotOccur(): void
 	{
 		$result = $this->runAnalyser(['#Unknown error#'], true, __DIR__ . '/data/empty/empty.php', false);
-		$this->assertSame([
+		self::assertSame([
 			'Ignored error pattern #Unknown error# was not matched in reported errors.',
 		], $result);
 	}
@@ -56,107 +56,107 @@ class AnalyserTest extends PHPStanTestCase
 	public function testDoNotReturnErrorIfIgnoredMessagesDoesNotOccurWithReportUnmatchedIgnoredErrorsOff(): void
 	{
 		$result = $this->runAnalyser(['#Unknown error#'], false, __DIR__ . '/data/empty/empty.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testDoNotReturnErrorIfIgnoredMessagesDoNotOccurWhileAnalysingIndividualFiles(): void
 	{
 		$result = $this->runAnalyser(['#Unknown error#'], true, __DIR__ . '/data/empty/empty.php', true);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredError(): void
 	{
 		$result = $this->runAnalyser(['#Fail\.#'], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredErrorMessage(): void
 	{
 		$result = $this->runAnalyser([['message' => '#Fail\.#']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredErrorRawMessage(): void
 	{
 		$result = $this->runAnalyser([['rawMessage' => 'Fail.']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredErrorMessageAndWrongIdentifier(): void
 	{
 		$result = $this->runAnalyser([['message' => '#Fail\.#', 'identifier' => 'wrong.identifier']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(2, $result);
+		self::assertCount(2, $result);
 		assert($result[0] instanceof Error);
-		$this->assertSame('Fail.', $result[0]->getMessage());
+		self::assertSame('Fail.', $result[0]->getMessage());
 		assert(is_string($result[1]));
-		$this->assertSame('Ignored error pattern #Fail\.# (wrong.identifier) was not matched in reported errors.', $result[1]);
+		self::assertSame('Ignored error pattern #Fail\.# (wrong.identifier) was not matched in reported errors.', $result[1]);
 	}
 
 	public function testFileWithAnIgnoredErrorRawMessageAndWrongIdentifier(): void
 	{
 		$result = $this->runAnalyser([['rawMessage' => 'Fail.', 'identifier' => 'wrong.identifier']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(2, $result);
+		self::assertCount(2, $result);
 		assert($result[0] instanceof Error);
-		$this->assertSame('Fail.', $result[0]->getMessage());
+		self::assertSame('Fail.', $result[0]->getMessage());
 		assert(is_string($result[1]));
-		$this->assertSame('Ignored error pattern "Fail." (wrong.identifier) was not matched in reported errors.', $result[1]);
+		self::assertSame('Ignored error pattern "Fail." (wrong.identifier) was not matched in reported errors.', $result[1]);
 	}
 
 	public function testFileWithAnIgnoredWrongIdentifier(): void
 	{
 		$result = $this->runAnalyser([['identifier' => 'wrong.identifier']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(2, $result);
+		self::assertCount(2, $result);
 		assert($result[0] instanceof Error);
-		$this->assertSame('Fail.', $result[0]->getMessage());
+		self::assertSame('Fail.', $result[0]->getMessage());
 		assert(is_string($result[1]));
-		$this->assertSame('Ignored error pattern wrong.identifier was not matched in reported errors.', $result[1]);
+		self::assertSame('Ignored error pattern wrong.identifier was not matched in reported errors.', $result[1]);
 	}
 
 	public function testFileWithAnIgnoredErrorMessageAndCorrectIdentifier(): void
 	{
 		$result = $this->runAnalyser([['message' => '#Fail\.#', 'identifier' => 'tests.alwaysFail']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredErrorRawMessageAndCorrectIdentifier(): void
 	{
 		$result = $this->runAnalyser([['rawMessage' => 'Fail.', 'identifier' => 'tests.alwaysFail']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredErrorIdentifier(): void
 	{
 		$result = $this->runAnalyser([['identifier' => 'tests.alwaysFail']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEmpty($result);
+		self::assertEmpty($result);
 	}
 
 	public function testFileWithAnIgnoredErrorMessages(): void
 	{
 		$result = $this->runAnalyser([['messages' => ['#Fail\.#']]], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertEquals([], $result);
+		self::assertEquals([], $result);
 	}
 
 	public function testFileWithAnIgnoredErrorIdentifiers(): void
 	{
 		$result = $this->runAnalyser([['identifiers' => ['tests.alwaysFail']]], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testFileWithAnIgnoredErrorIdentifiersWithPath(): void
 	{
 		$result = $this->runAnalyser([['identifiers' => ['tests.alwaysFail'], 'path' => __DIR__ . '/data/bootstrap-error.php']], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testFileWithAnIgnoredErrorIdentifiersWithWrongIdentifier(): void
 	{
 		$result = $this->runAnalyser([['identifiers' => ['wrong.identifier']]], true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(2, $result);
-		$this->assertInstanceOf(Error::class, $result[0]);
-		$this->assertSame('Fail.', $result[0]->getMessage());
+		self::assertCount(2, $result);
+		self::assertInstanceOf(Error::class, $result[0]);
+		self::assertSame('Fail.', $result[0]->getMessage());
 		assert(is_string($result[1]));
-		$this->assertSame('Ignored error pattern wrong.identifier was not matched in reported errors.', $result[1]);
+		self::assertSame('Ignored error pattern wrong.identifier was not matched in reported errors.', $result[1]);
 	}
 
 	public function testIgnoreErrorByPath(): void
@@ -168,7 +168,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorMultiByPath(): void
@@ -183,7 +183,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-different-fails.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public static function dataIgnoreErrorByPathAndCount(): iterable
@@ -260,7 +260,7 @@ class AnalyserTest extends PHPStanTestCase
 	public function testIgnoreErrorByPathAndCount(array $ignoreErrors): void
 	{
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-fails.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public static function dataTrueAndFalse(): array
@@ -292,7 +292,7 @@ class AnalyserTest extends PHPStanTestCase
 			__DIR__ . '/data/two-different-fails.php',
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, $filesToAnalyze, $onlyFiles);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	#[DataProvider('dataTrueAndFalse')]
@@ -306,22 +306,22 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-fails.php', $onlyFiles);
-		$this->assertCount(3, $result);
-		$this->assertInstanceOf(Error::class, $result[0]);
-		$this->assertSame('Fail.', $result[0]->getMessage());
-		$this->assertSame(6, $result[0]->getLine());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[0]->getFile());
+		self::assertCount(3, $result);
+		self::assertInstanceOf(Error::class, $result[0]);
+		self::assertSame('Fail.', $result[0]->getMessage());
+		self::assertSame(6, $result[0]->getLine());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[0]->getFile());
 
-		$this->assertInstanceOf(Error::class, $result[1]);
-		$this->assertSame('Fail.', $result[1]->getMessage());
-		$this->assertSame(7, $result[1]->getLine());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[1]->getFile());
+		self::assertInstanceOf(Error::class, $result[1]);
+		self::assertSame('Fail.', $result[1]->getMessage());
+		self::assertSame(7, $result[1]->getLine());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[1]->getFile());
 
-		$this->assertInstanceOf(Error::class, $result[2]);
-		$this->assertStringContainsString('Ignored error pattern #Fail\.#', $result[2]->getMessage());
-		$this->assertStringContainsString('is expected to occur 1 time, but occurred 3 times.', $result[2]->getMessage());
-		$this->assertSame(5, $result[2]->getLine());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[2]->getFile());
+		self::assertInstanceOf(Error::class, $result[2]);
+		self::assertStringContainsString('Ignored error pattern #Fail\.#', $result[2]->getMessage());
+		self::assertStringContainsString('is expected to occur 1 time, but occurred 3 times.', $result[2]->getMessage());
+		self::assertSame(5, $result[2]->getLine());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[2]->getFile());
 	}
 
 	#[DataProvider('dataTrueAndFalse')]
@@ -335,12 +335,12 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-fails.php', $onlyFiles);
-		$this->assertCount(1, $result);
-		$this->assertInstanceOf(Error::class, $result[0]);
-		$this->assertStringContainsString('Ignored error pattern #Fail\.#', $result[0]->getMessage());
-		$this->assertStringContainsString('is expected to occur 4 times, but occurred only 3 times.', $result[0]->getMessage());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[0]->getFile());
-		$this->assertSame(5, $result[0]->getLine());
+		self::assertCount(1, $result);
+		self::assertInstanceOf(Error::class, $result[0]);
+		self::assertStringContainsString('Ignored error pattern #Fail\.#', $result[0]->getMessage());
+		self::assertStringContainsString('is expected to occur 4 times, but occurred only 3 times.', $result[0]->getMessage());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[0]->getFile());
+		self::assertSame(5, $result[0]->getLine());
 	}
 
 	public function testIgnoreErrorByPathAndCountMissing(): void
@@ -353,26 +353,26 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-fails.php', false);
-		$this->assertCount(4, $result);
-		$this->assertInstanceOf(Error::class, $result[0]);
-		$this->assertSame('Fail.', $result[0]->getMessage());
-		$this->assertSame(5, $result[0]->getLine());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[0]->getFile());
+		self::assertCount(4, $result);
+		self::assertInstanceOf(Error::class, $result[0]);
+		self::assertSame('Fail.', $result[0]->getMessage());
+		self::assertSame(5, $result[0]->getLine());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[0]->getFile());
 
-		$this->assertInstanceOf(Error::class, $result[1]);
-		$this->assertSame('Fail.', $result[1]->getMessage());
-		$this->assertSame(6, $result[1]->getLine());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[1]->getFile());
+		self::assertInstanceOf(Error::class, $result[1]);
+		self::assertSame('Fail.', $result[1]->getMessage());
+		self::assertSame(6, $result[1]->getLine());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[1]->getFile());
 
-		$this->assertInstanceOf(Error::class, $result[2]);
-		$this->assertSame('Fail.', $result[2]->getMessage());
-		$this->assertSame(7, $result[2]->getLine());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[2]->getFile());
+		self::assertInstanceOf(Error::class, $result[2]);
+		self::assertSame('Fail.', $result[2]->getMessage());
+		self::assertSame(7, $result[2]->getLine());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[2]->getFile());
 
-		$this->assertInstanceOf(Error::class, $result[3]);
-		$this->assertStringContainsString('Ignored error pattern #Some custom error\.# in path', $result[3]->getMessage());
-		$this->assertStringContainsString('was not matched in reported errors.', $result[3]->getMessage());
-		$this->assertSamePaths(__DIR__ . '/data/two-fails.php', $result[2]->getFile());
+		self::assertInstanceOf(Error::class, $result[3]);
+		self::assertStringContainsString('Ignored error pattern #Some custom error\.# in path', $result[3]->getMessage());
+		self::assertStringContainsString('was not matched in reported errors.', $result[3]->getMessage());
+		self::assertSamePaths(__DIR__ . '/data/two-fails.php', $result[2]->getFile());
 	}
 
 	public function testIgnoreErrorByPaths(): void
@@ -384,7 +384,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorRawByPaths(): void
@@ -396,7 +396,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorMultiByPaths(): void
@@ -411,7 +411,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/two-different-fails.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorByPathsMultipleUnmatched(): void
@@ -423,10 +423,10 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(1, $result);
-		$this->assertIsString($result[0]);
-		$this->assertStringContainsString('Ignored error pattern #Fail\.# in paths: ', $result[0]);
-		$this->assertStringContainsString('was not matched in reported errors', $result[0]);
+		self::assertCount(1, $result);
+		self::assertIsString($result[0]);
+		self::assertStringContainsString('Ignored error pattern #Fail\.# in paths: ', $result[0]);
+		self::assertStringContainsString('was not matched in reported errors', $result[0]);
 	}
 
 	public function testIgnoreErrorByPathsUnmatched(): void
@@ -438,10 +438,10 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(1, $result);
-		$this->assertIsString($result[0]);
-		$this->assertStringContainsString('Ignored error pattern #Fail\.# in path ', $result[0]);
-		$this->assertStringContainsString('was not matched in reported errors', $result[0]);
+		self::assertCount(1, $result);
+		self::assertIsString($result[0]);
+		self::assertStringContainsString('Ignored error pattern #Fail\.# in path ', $result[0]);
+		self::assertStringContainsString('was not matched in reported errors', $result[0]);
 	}
 
 	public function testIgnoreErrorByPathsUnmatchedExplicitReportUnmatched(): void
@@ -454,10 +454,10 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/bootstrap-error.php', false);
-		$this->assertCount(1, $result);
-		$this->assertIsString($result[0]);
-		$this->assertStringContainsString('Ignored error pattern #Fail\.# in path ', $result[0]);
-		$this->assertStringContainsString('was not matched in reported errors', $result[0]);
+		self::assertCount(1, $result);
+		self::assertIsString($result[0]);
+		self::assertStringContainsString('Ignored error pattern #Fail\.# in path ', $result[0]);
+		self::assertStringContainsString('was not matched in reported errors', $result[0]);
 	}
 
 	public function testIgnoreErrorNotFoundInPath(): void
@@ -469,8 +469,8 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/empty/empty.php', false);
-		$this->assertCount(1, $result);
-		$this->assertSame('Ignored error pattern #Fail\.# in path ' . __DIR__ . '/data/not-existent-path.php was not matched in reported errors.', $result[0]);
+		self::assertCount(1, $result);
+		self::assertSame('Ignored error pattern #Fail\.# in path ' . __DIR__ . '/data/not-existent-path.php was not matched in reported errors.', $result[0]);
 	}
 
 	public function testIgnoreErrorNotFoundInPathExplicitReportUnmatched(): void
@@ -483,8 +483,8 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/empty/empty.php', false);
-		$this->assertCount(1, $result);
-		$this->assertSame('Ignored error pattern #Fail\.# in path ' . __DIR__ . '/data/not-existent-path.php was not matched in reported errors.', $result[0]);
+		self::assertCount(1, $result);
+		self::assertSame('Ignored error pattern #Fail\.# in path ' . __DIR__ . '/data/not-existent-path.php was not matched in reported errors.', $result[0]);
 	}
 
 	public static function dataIgnoreErrorInTraitUsingClassFilePath(): array
@@ -512,7 +512,7 @@ class AnalyserTest extends PHPStanTestCase
 			__DIR__ . '/data/traits-ignore/Foo.php',
 			__DIR__ . '/data/traits-ignore/FooTrait.php',
 		], true);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	#[DataProvider('dataIgnoreErrorInTraitUsingClassFilePath')]
@@ -527,7 +527,7 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser($ignoreErrors, true, [
 			__DIR__ . '/data/traits-ignore/Foo.php',
 		], true);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoredErrorMissingMessage(): void
@@ -545,24 +545,24 @@ class AnalyserTest extends PHPStanTestCase
 		}
 
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/empty/empty.php', false);
-		$this->assertCount(1, $result);
-		$this->assertSame('Ignored error {"path":"' . $expectedPath . '/data/empty/empty.php"} is missing a message or an identifier.', $result[0]);
+		self::assertCount(1, $result);
+		self::assertSame('Ignored error {"path":"' . $expectedPath . '/data/empty/empty.php"} is missing a message or an identifier.', $result[0]);
 	}
 
 	public function testReportMultipleParserErrorsAtOnce(): void
 	{
 		$result = $this->runAnalyser([], false, __DIR__ . '/data/multipleParseErrors.php', false);
-		$this->assertCount(2, $result);
+		self::assertCount(2, $result);
 
 		/** @var Error $errorOne */
 		$errorOne = $result[0];
-		$this->assertSame('Syntax error, unexpected T_IS_EQUAL, expecting T_VARIABLE on line 3', $errorOne->getMessage());
-		$this->assertSame(3, $errorOne->getLine());
+		self::assertSame('Syntax error, unexpected T_IS_EQUAL, expecting T_VARIABLE on line 3', $errorOne->getMessage());
+		self::assertSame(3, $errorOne->getLine());
 
 		/** @var Error $errorTwo */
 		$errorTwo = $result[1];
-		$this->assertSame('Syntax error, unexpected EOF on line 10', $errorTwo->getMessage());
-		$this->assertSame(10, $errorTwo->getLine());
+		self::assertSame('Syntax error, unexpected EOF on line 10', $errorTwo->getMessage());
+		self::assertSame(10, $errorTwo->getLine());
 	}
 
 	#[DataProvider('dataTrueAndFalse')]
@@ -581,7 +581,7 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser($ignoreErrors, true, [
 			__DIR__ . '/data/two-fails.php',
 		], $onlyFiles);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	#[DataProvider('dataTrueAndFalse')]
@@ -602,7 +602,7 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser($ignoreErrors, true, [
 			__DIR__ . '/data/two-fails.php',
 		], $onlyFiles);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreNextLine(): void
@@ -610,12 +610,12 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser([], false, [
 			__DIR__ . '/data/ignore-next-line.php',
 		], true);
-		$this->assertCount(5, $result);
+		self::assertCount(5, $result);
 		foreach ([10, 20, 24, 31, 50] as $i => $line) {
-			$this->assertArrayHasKey($i, $result);
-			$this->assertInstanceOf(Error::class, $result[$i]);
-			$this->assertSame('Fail.', $result[$i]->getMessage());
-			$this->assertSame($line, $result[$i]->getLine());
+			self::assertArrayHasKey($i, $result);
+			self::assertInstanceOf(Error::class, $result[$i]);
+			self::assertSame('Fail.', $result[$i]->getMessage());
+			self::assertSame($line, $result[$i]->getLine());
 		}
 	}
 
@@ -624,12 +624,12 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser([], true, [
 			__DIR__ . '/data/ignore-next-line-unmatched.php',
 		], true);
-		$this->assertCount(2, $result);
+		self::assertCount(2, $result);
 		foreach ([11, 15] as $i => $line) {
-			$this->assertArrayHasKey($i, $result);
-			$this->assertInstanceOf(Error::class, $result[$i]);
-			$this->assertStringContainsString('No error to ignore is reported on line', $result[$i]->getMessage());
-			$this->assertSame($line, $result[$i]->getLine());
+			self::assertArrayHasKey($i, $result);
+			self::assertInstanceOf(Error::class, $result[$i]);
+			self::assertStringContainsString('No error to ignore is reported on line', $result[$i]->getMessage());
+			self::assertSame($line, $result[$i]->getLine());
 		}
 	}
 
@@ -639,22 +639,22 @@ class AnalyserTest extends PHPStanTestCase
 		$result = $this->runAnalyser([], $reportUnmatchedIgnoredErrors, [
 			__DIR__ . '/data/ignore-line.php',
 		], true);
-		$this->assertCount($reportUnmatchedIgnoredErrors ? 4 : 3, $result);
+		self::assertCount($reportUnmatchedIgnoredErrors ? 4 : 3, $result);
 		foreach ([10, 19, 22] as $i => $line) {
-			$this->assertArrayHasKey($i, $result);
-			$this->assertInstanceOf(Error::class, $result[$i]);
-			$this->assertSame('Fail.', $result[$i]->getMessage());
-			$this->assertSame($line, $result[$i]->getLine());
+			self::assertArrayHasKey($i, $result);
+			self::assertInstanceOf(Error::class, $result[$i]);
+			self::assertSame('Fail.', $result[$i]->getMessage());
+			self::assertSame($line, $result[$i]->getLine());
 		}
 
 		if (!$reportUnmatchedIgnoredErrors) {
 			return;
 		}
 
-		$this->assertArrayHasKey(3, $result);
-		$this->assertInstanceOf(Error::class, $result[3]);
-		$this->assertSame('No error to ignore is reported on line 26.', $result[3]->getMessage());
-		$this->assertSame(26, $result[3]->getLine());
+		self::assertArrayHasKey(3, $result);
+		self::assertInstanceOf(Error::class, $result[3]);
+		self::assertSame('No error to ignore is reported on line 26.', $result[3]->getMessage());
+		self::assertSame(26, $result[3]->getLine());
 	}
 
 	public function testIgnoreErrorExplicitReportUnmatchedDisable(): void
@@ -666,7 +666,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorExplicitReportUnmatchedDisableRaw(): void
@@ -678,7 +678,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorExplicitReportUnmatchedDisableMulti(): void
@@ -690,7 +690,7 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, true, __DIR__ . '/data/bootstrap.php', false);
-		$this->assertNoErrors($result);
+		self::assertNoErrors($result);
 	}
 
 	public function testIgnoreErrorExplicitReportUnmatchedEnable(): void
@@ -702,8 +702,8 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/bootstrap.php', false);
-		$this->assertCount(1, $result);
-		$this->assertSame('Ignored error pattern #Fail# was not matched in reported errors.', $result[0]);
+		self::assertCount(1, $result);
+		self::assertSame('Ignored error pattern #Fail# was not matched in reported errors.', $result[0]);
 	}
 
 	public function testIgnoreErrorExplicitReportUnmatchedEnableRaw(): void
@@ -715,8 +715,8 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/bootstrap.php', false);
-		$this->assertCount(1, $result);
-		$this->assertSame('Ignored error pattern "Fail." was not matched in reported errors.', $result[0]);
+		self::assertCount(1, $result);
+		self::assertSame('Ignored error pattern "Fail." was not matched in reported errors.', $result[0]);
 	}
 
 	public function testIgnoreErrorExplicitReportUnmatchedEnableMulti(): void
@@ -728,8 +728,8 @@ class AnalyserTest extends PHPStanTestCase
 			],
 		];
 		$result = $this->runAnalyser($ignoreErrors, false, __DIR__ . '/data/bootstrap.php', false);
-		$this->assertCount(1, $result);
-		$this->assertSame('Ignored error pattern #Fail# was not matched in reported errors.', $result[0]);
+		self::assertCount(1, $result);
+		self::assertSame('Ignored error pattern #Fail# was not matched in reported errors.', $result[0]);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTraitsIntegrationTest.php
@@ -31,7 +31,7 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 			__DIR__ . '/traits/Foo.php',
 			__DIR__ . '/traits/FooTrait.php',
 		]);
-		$this->assertEmpty($errors);
+		self::assertEmpty($errors);
 	}
 
 	public function testMethodDoesNotExist(): void
@@ -40,14 +40,14 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 			__DIR__ . '/traits/Bar.php',
 			__DIR__ . '/traits/FooTrait.php',
 		]);
-		$this->assertCount(1, $errors);
+		self::assertCount(1, $errors);
 		$error = $errors[0];
-		$this->assertSame('Call to an undefined method AnalyseTraits\Bar::doFoo().', $error->getMessage());
-		$this->assertSame(
+		self::assertSame('Call to an undefined method AnalyseTraits\Bar::doFoo().', $error->getMessage());
+		self::assertSame(
 			sprintf('%s (in context of class AnalyseTraits\Bar)', $this->fileHelper->normalizePath(__DIR__ . '/traits/FooTrait.php')),
 			$error->getFile(),
 		);
-		$this->assertSame(10, $error->getLine());
+		self::assertSame(10, $error->getLine());
 	}
 
 	public function testNestedTraits(): void
@@ -57,51 +57,51 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 			__DIR__ . '/traits/NestedFooTrait.php',
 			__DIR__ . '/traits/FooTrait.php',
 		]);
-		$this->assertCount(2, $errors);
+		self::assertCount(2, $errors);
 		$firstError = $errors[0];
-		$this->assertSame('Call to an undefined method AnalyseTraits\NestedBar::doFoo().', $firstError->getMessage());
-		$this->assertSame(
+		self::assertSame('Call to an undefined method AnalyseTraits\NestedBar::doFoo().', $firstError->getMessage());
+		self::assertSame(
 			sprintf('%s (in context of class AnalyseTraits\NestedBar)', $this->fileHelper->normalizePath(__DIR__ . '/traits/FooTrait.php')),
 			$firstError->getFile(),
 		);
-		$this->assertSame(10, $firstError->getLine());
+		self::assertSame(10, $firstError->getLine());
 
 		$secondError = $errors[1];
-		$this->assertSame('Call to an undefined method AnalyseTraits\NestedBar::doNestedFoo().', $secondError->getMessage());
-		$this->assertSame(
+		self::assertSame('Call to an undefined method AnalyseTraits\NestedBar::doNestedFoo().', $secondError->getMessage());
+		self::assertSame(
 			sprintf('%s (in context of class AnalyseTraits\NestedBar)', $this->fileHelper->normalizePath(__DIR__ . '/traits/NestedFooTrait.php')),
 			$secondError->getFile(),
 		);
-		$this->assertSame(12, $secondError->getLine());
+		self::assertSame(12, $secondError->getLine());
 	}
 
 	public function testTraitsAreNotAnalysedDirectly(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/FooTrait.php']);
-		$this->assertEmpty($errors);
+		self::assertEmpty($errors);
 		$errors = $this->runAnalyse([__DIR__ . '/traits/NestedFooTrait.php']);
-		$this->assertEmpty($errors);
+		self::assertEmpty($errors);
 	}
 
 	public function testClassAndTraitInTheSameFile(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/classAndTrait.php']);
-		$this->assertEmpty($errors);
+		self::assertEmpty($errors);
 	}
 
 	public function testTraitMethodAlias(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/trait-aliases.php']);
-		$this->assertEmpty($errors);
+		self::assertEmpty($errors);
 	}
 
 	public function testFindErrorsInTrait(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/trait-error.php']);
-		$this->assertCount(3, $errors);
-		$this->assertSame('Undefined variable: $undefined', $errors[0]->getMessage());
-		$this->assertSame('Call to an undefined method TraitErrors\MyClass::undefined().', $errors[1]->getMessage());
-		$this->assertSame('Undefined variable: $undefined', $errors[2]->getMessage());
+		self::assertCount(3, $errors);
+		self::assertSame('Undefined variable: $undefined', $errors[0]->getMessage());
+		self::assertSame('Call to an undefined method TraitErrors\MyClass::undefined().', $errors[1]->getMessage());
+		self::assertSame('Undefined variable: $undefined', $errors[2]->getMessage());
 	}
 
 	public function testTraitInAnonymousClass(): void
@@ -112,56 +112,56 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 				__DIR__ . '/traits/TraitWithTypeSpecification.php',
 			],
 		);
-		$this->assertCount(1, $errors);
-		$this->assertStringContainsString('Access to an undefined property', $errors[0]->getMessage());
-		$this->assertSame(18, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertStringContainsString('Access to an undefined property', $errors[0]->getMessage());
+		self::assertSame(18, $errors[0]->getLine());
 	}
 
 	public function testDuplicateMethodDefinition(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/duplicateMethod/Lesson.php']);
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testWrongPropertyType(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/wrongProperty/Foo.php']);
-		$this->assertCount(2, $errors);
-		$this->assertSame(15, $errors[0]->getLine());
-		$this->assertSame(
+		self::assertCount(2, $errors);
+		self::assertSame(15, $errors[0]->getLine());
+		self::assertSame(
 			$this->fileHelper->normalizePath(__DIR__ . '/traits/wrongProperty/Foo.php'),
 			$errors[0]->getFile(),
 		);
-		$this->assertSame('Property TraitsWrongProperty\Foo::$id (int) does not accept string.', $errors[0]->getMessage());
+		self::assertSame('Property TraitsWrongProperty\Foo::$id (int) does not accept string.', $errors[0]->getMessage());
 
-		$this->assertSame(17, $errors[1]->getLine());
-		$this->assertSame(
+		self::assertSame(17, $errors[1]->getLine());
+		self::assertSame(
 			$this->fileHelper->normalizePath(__DIR__ . '/traits/wrongProperty/Foo.php'),
 			$errors[1]->getFile(),
 		);
-		$this->assertSame('Property TraitsWrongProperty\Foo::$bar (Ipsum) does not accept int.', $errors[1]->getMessage());
+		self::assertSame('Property TraitsWrongProperty\Foo::$bar (Ipsum) does not accept int.', $errors[1]->getMessage());
 	}
 
 	public function testReturnThis(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/returnThis/Bar.php']);
-		$this->assertCount(2, $errors);
-		$this->assertSame(10, $errors[0]->getLine());
-		$this->assertSame('Call to an undefined method TraitsReturnThis\Foo::doFoo().', $errors[0]->getMessage());
-		$this->assertSame(11, $errors[1]->getLine());
-		$this->assertSame('Call to an undefined method TraitsReturnThis\Foo::doFoo().', $errors[1]->getMessage());
+		self::assertCount(2, $errors);
+		self::assertSame(10, $errors[0]->getLine());
+		self::assertSame('Call to an undefined method TraitsReturnThis\Foo::doFoo().', $errors[0]->getMessage());
+		self::assertSame(11, $errors[1]->getLine());
+		self::assertSame('Call to an undefined method TraitsReturnThis\Foo::doFoo().', $errors[1]->getMessage());
 	}
 
 	public function testTraitInEval(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/TraitInEvalUse.php']);
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testParameterNotFoundCrash(): void
 	{
 		$errors = $this->runAnalyse([__DIR__ . '/traits/parameter-not-found.php']);
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	public function testMissingReturnInAbstractTraitMethod(): void
@@ -170,7 +170,7 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 			__DIR__ . '/traits/TraitWithAbstractMethod.php',
 			__DIR__ . '/traits/ClassImplementingTraitWithAbstractMethod.php',
 		]);
-		$this->assertNoErrors($errors);
+		self::assertNoErrors($errors);
 	}
 
 	#[RequiresPhp('>= 8.1')]
@@ -180,24 +180,24 @@ class AnalyserTraitsIntegrationTest extends PHPStanTestCase
 			__DIR__ . '/traits/uninitializedProperty/FooClass.php',
 			__DIR__ . '/traits/uninitializedProperty/FooTrait.php',
 		]);
-		$this->assertCount(3, $errors);
+		self::assertCount(3, $errors);
 		usort($errors, static fn (Error $a, Error $b) => $a->getLine() <=> $b->getLine());
 		$expectedFile = sprintf('%s (in context of class TraitsUnititializedProperty\FooClass)', $this->fileHelper->normalizePath(__DIR__ . '/traits/uninitializedProperty/FooTrait.php'));
 
 		$error = $errors[0];
-		$this->assertSame('Access to an uninitialized readonly property TraitsUnititializedProperty\FooClass::$x.', $error->getMessage());
-		$this->assertSame(15, $error->getLine());
-		$this->assertSame($expectedFile, $error->getFile());
+		self::assertSame('Access to an uninitialized readonly property TraitsUnititializedProperty\FooClass::$x.', $error->getMessage());
+		self::assertSame(15, $error->getLine());
+		self::assertSame($expectedFile, $error->getFile());
 
 		$error = $errors[1];
-		$this->assertSame('Access to an uninitialized @readonly property TraitsUnititializedProperty\FooClass::$y.', $error->getMessage());
-		$this->assertSame(16, $error->getLine());
-		$this->assertSame($expectedFile, $error->getFile());
+		self::assertSame('Access to an uninitialized @readonly property TraitsUnititializedProperty\FooClass::$y.', $error->getMessage());
+		self::assertSame(16, $error->getLine());
+		self::assertSame($expectedFile, $error->getFile());
 
 		$error = $errors[2];
-		$this->assertSame('Access to an uninitialized property TraitsUnititializedProperty\FooClass::$z.', $error->getMessage());
-		$this->assertSame(17, $error->getLine());
-		$this->assertSame($expectedFile, $error->getFile());
+		self::assertSame('Access to an uninitialized property TraitsUnititializedProperty\FooClass::$z.', $error->getMessage());
+		self::assertSame(17, $error->getLine());
+		self::assertSame($expectedFile, $error->getFile());
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/AnalyserWithCheckDynamicPropertiesTest.php
+++ b/tests/PHPStan/Analyser/AnalyserWithCheckDynamicPropertiesTest.php
@@ -12,9 +12,9 @@ class AnalyserWithCheckDynamicPropertiesTest extends PHPStanTestCase
 	public function testBug13529(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13529.php');
-		$this->assertCount(1, $errors);
-		$this->assertSame('Access to an undefined property object::$bar.', $errors[0]->getMessage());
-		$this->assertSame(8, $errors[0]->getLine());
+		self::assertCount(1, $errors);
+		self::assertSame('Access to an undefined property object::$bar.', $errors[0]->getMessage());
+		self::assertSame(8, $errors[0]->getLine());
 	}
 
 	/**
@@ -32,7 +32,7 @@ class AnalyserWithCheckDynamicPropertiesTest extends PHPStanTestCase
 			true,
 		)->getErrors();
 		foreach ($errors as $error) {
-			$this->assertSame($file, $error->getFilePath());
+			self::assertSame($file, $error->getFilePath());
 		}
 
 		return $errors;

--- a/tests/PHPStan/Analyser/ArgumentsNormalizerLegacyTest.php
+++ b/tests/PHPStan/Analyser/ArgumentsNormalizerLegacyTest.php
@@ -45,16 +45,16 @@ final class ArgumentsNormalizerLegacyTest extends PHPStanTestCase
 		$funcCall = new FuncCall($funcName, $args);
 
 		$funcCall = ArgumentsNormalizer::reorderFuncArguments($parameterAcceptor, $funcCall);
-		$this->assertNotNull($funcCall);
+		self::assertNotNull($funcCall);
 		$reorderedArgs = $funcCall->getArgs();
-		$this->assertCount(2, $reorderedArgs);
+		self::assertCount(2, $reorderedArgs);
 
-		$this->assertNull($reorderedArgs[0]->name, 'named-arg turned into regular numeric arg');
-		$this->assertInstanceOf(String_::class, $reorderedArgs[0]->value, 'value-arg at the right position');
+		self::assertNull($reorderedArgs[0]->name, 'named-arg turned into regular numeric arg');
+		self::assertInstanceOf(String_::class, $reorderedArgs[0]->value, 'value-arg at the right position');
 
-		$this->assertNull($reorderedArgs[1]->name, 'named-arg turned into regular numeric arg');
-		$this->assertInstanceOf(LNumber::class, $reorderedArgs[1]->value, 'flags-arg at the right position');
-		$this->assertSame(0, $reorderedArgs[1]->value->value);
+		self::assertNull($reorderedArgs[1]->name, 'named-arg turned into regular numeric arg');
+		self::assertInstanceOf(LNumber::class, $reorderedArgs[1]->value, 'flags-arg at the right position');
+		self::assertSame(0, $reorderedArgs[1]->value->value);
 	}
 
 	/**
@@ -84,21 +84,21 @@ final class ArgumentsNormalizerLegacyTest extends PHPStanTestCase
 		$funcCall = new FuncCall($funcName, $args);
 
 		$funcCall = ArgumentsNormalizer::reorderFuncArguments($parameterAcceptor, $funcCall);
-		$this->assertNotNull($funcCall);
+		self::assertNotNull($funcCall);
 		$reorderedArgs = $funcCall->getArgs();
-		$this->assertCount(3, $reorderedArgs);
+		self::assertCount(3, $reorderedArgs);
 
-		$this->assertNull($reorderedArgs[0]->name, 'named-arg turned into regular numeric arg');
-		$this->assertInstanceOf(String_::class, $reorderedArgs[0]->value, 'value-arg at the right position');
+		self::assertNull($reorderedArgs[0]->name, 'named-arg turned into regular numeric arg');
+		self::assertInstanceOf(String_::class, $reorderedArgs[0]->value, 'value-arg at the right position');
 
-		$this->assertNull($reorderedArgs[1]->name, 'named-arg turned into regular numeric arg');
-		$this->assertInstanceOf(TypeExpr::class, $reorderedArgs[1]->value, 'flags-arg at the right position');
-		$this->assertInstanceOf(ConstantIntegerType::class, $reorderedArgs[1]->value->getExprType());
-		$this->assertSame(0, $reorderedArgs[1]->value->getExprType()->getValue(), 'flags-arg with default value');
+		self::assertNull($reorderedArgs[1]->name, 'named-arg turned into regular numeric arg');
+		self::assertInstanceOf(TypeExpr::class, $reorderedArgs[1]->value, 'flags-arg at the right position');
+		self::assertInstanceOf(ConstantIntegerType::class, $reorderedArgs[1]->value->getExprType());
+		self::assertSame(0, $reorderedArgs[1]->value->getExprType()->getValue(), 'flags-arg with default value');
 
-		$this->assertNull($reorderedArgs[2]->name, 'named-arg turned into regular numeric arg');
-		$this->assertInstanceOf(LNumber::class, $reorderedArgs[2]->value, 'depth-arg at the right position');
-		$this->assertSame(128, $reorderedArgs[2]->value->value);
+		self::assertNull($reorderedArgs[2]->name, 'named-arg turned into regular numeric arg');
+		self::assertInstanceOf(LNumber::class, $reorderedArgs[2]->value, 'depth-arg at the right position');
+		self::assertSame(128, $reorderedArgs[2]->value->value);
 	}
 
 	#[RequiresPhp('>= 8.0')]
@@ -120,7 +120,7 @@ final class ArgumentsNormalizerLegacyTest extends PHPStanTestCase
 		];
 		$funcCall = new FuncCall($funcName, $args);
 
-		$this->assertNull(ArgumentsNormalizer::reorderFuncArguments($parameterAcceptor, $funcCall));
+		self::assertNull(ArgumentsNormalizer::reorderFuncArguments($parameterAcceptor, $funcCall));
 	}
 
 	public function testLeaveRegularCallAsIs(): void
@@ -144,13 +144,13 @@ final class ArgumentsNormalizerLegacyTest extends PHPStanTestCase
 		$funcCall = new FuncCall($funcName, $args);
 
 		$funcCall = ArgumentsNormalizer::reorderFuncArguments($parameterAcceptor, $funcCall);
-		$this->assertNotNull($funcCall);
+		self::assertNotNull($funcCall);
 		$reorderedArgs = $funcCall->getArgs();
-		$this->assertCount(2, $reorderedArgs);
+		self::assertCount(2, $reorderedArgs);
 
-		$this->assertInstanceOf(String_::class, $reorderedArgs[0]->value, 'value-arg at unchanged position');
-		$this->assertInstanceOf(LNumber::class, $reorderedArgs[1]->value, 'flags-arg at unchanged position');
-		$this->assertSame(0, $reorderedArgs[1]->value->value);
+		self::assertInstanceOf(String_::class, $reorderedArgs[0]->value, 'value-arg at unchanged position');
+		self::assertInstanceOf(LNumber::class, $reorderedArgs[1]->value, 'flags-arg at unchanged position');
+		self::assertSame(0, $reorderedArgs[1]->value->value);
 	}
 
 }

--- a/tests/PHPStan/Analyser/ArgumentsNormalizerTest.php
+++ b/tests/PHPStan/Analyser/ArgumentsNormalizerTest.php
@@ -284,15 +284,15 @@ class ArgumentsNormalizerTest extends PHPStanTestCase
 			),
 			new FuncCall(new Name('foo'), $arguments),
 		);
-		$this->assertNotNull($normalized);
+		self::assertNotNull($normalized);
 
 		$actualArguments = $normalized->getArgs();
-		$this->assertCount(count($expectedArgumentTypes), $actualArguments);
+		self::assertCount(count($expectedArgumentTypes), $actualArguments);
 		foreach ($actualArguments as $i => $actualArgument) {
-			$this->assertNull($actualArgument->name);
+			self::assertNull($actualArgument->name);
 			$value = $actualArgument->value;
-			$this->assertInstanceOf(TypeExpr::class, $value);
-			$this->assertSame(
+			self::assertInstanceOf(TypeExpr::class, $value);
+			self::assertSame(
 				$expectedArgumentTypes[$i]->describe(VerbosityLevel::precise()),
 				$value->getExprType()->describe(VerbosityLevel::precise()),
 			);
@@ -362,7 +362,7 @@ class ArgumentsNormalizerTest extends PHPStanTestCase
 			),
 			new FuncCall(new Name('foo'), $arguments),
 		);
-		$this->assertNull($normalized);
+		self::assertNull($normalized);
 	}
 
 }

--- a/tests/PHPStan/Analyser/Bug13813IntegrationTest.php
+++ b/tests/PHPStan/Analyser/Bug13813IntegrationTest.php
@@ -28,24 +28,24 @@ class Bug13813IntegrationTest extends PHPStanTestCase
 		} finally {
 			error_reporting($oldReporting);
 		}
-		$this->assertCount(2, $analyzerResult->getAllPhpErrors());
-		$this->assertCount(2, $analyzerResult->getFilteredPhpErrors());
+		self::assertCount(2, $analyzerResult->getAllPhpErrors());
+		self::assertCount(2, $analyzerResult->getFilteredPhpErrors());
 
 		if (PHP_VERSION_ID >= 80000) {
-			$this->assertSame(
+			self::assertSame(
 				'Warning: Undefined variable $x',
 				$analyzerResult->getAllPhpErrors()[0]->getMessage(),
 			);
-			$this->assertSame(
+			self::assertSame(
 				'Warning: Undefined variable $x',
 				$analyzerResult->getAllPhpErrors()[1]->getMessage(),
 			);
 		} else {
-			$this->assertSame(
+			self::assertSame(
 				'Notice: Undefined variable: x',
 				$analyzerResult->getAllPhpErrors()[0]->getMessage(),
 			);
-			$this->assertSame(
+			self::assertSame(
 				'Notice: Undefined variable: x',
 				$analyzerResult->getAllPhpErrors()[1]->getMessage(),
 			);

--- a/tests/PHPStan/Analyser/ErrorTest.php
+++ b/tests/PHPStan/Analyser/ErrorTest.php
@@ -11,9 +11,9 @@ class ErrorTest extends PHPStanTestCase
 	public function testError(): void
 	{
 		$error = new Error('Message', 'file', 10);
-		$this->assertSame('Message', $error->getMessage());
-		$this->assertSame('file', $error->getFile());
-		$this->assertSame(10, $error->getLine());
+		self::assertSame('Message', $error->getMessage());
+		self::assertSame('file', $error->getFile());
+		self::assertSame(10, $error->getLine());
 	}
 
 	public static function dataValidIdentifier(): iterable
@@ -33,7 +33,7 @@ class ErrorTest extends PHPStanTestCase
 	#[DataProvider('dataValidIdentifier')]
 	public function testValidIdentifier(string $identifier): void
 	{
-		$this->assertTrue(Error::validateIdentifier($identifier));
+		self::assertTrue(Error::validateIdentifier($identifier));
 	}
 
 	public static function dataInvalidIdentifier(): iterable
@@ -50,7 +50,7 @@ class ErrorTest extends PHPStanTestCase
 	#[DataProvider('dataInvalidIdentifier')]
 	public function testInvalidIdentifier(string $identifier): void
 	{
-		$this->assertFalse(Error::validateIdentifier($identifier));
+		self::assertFalse(Error::validateIdentifier($identifier));
 	}
 
 }

--- a/tests/PHPStan/Analyser/ExpressionResultTest.php
+++ b/tests/PHPStan/Analyser/ExpressionResultTest.php
@@ -213,7 +213,7 @@ class ExpressionResultTest extends PHPStanTestCase
 			},
 			ExpressionContext::createTopLevel(),
 		);
-		$this->assertSame($expectedIsAlwaysTerminating, $result->isAlwaysTerminating());
+		self::assertSame($expectedIsAlwaysTerminating, $result->isAlwaysTerminating());
 	}
 
 }

--- a/tests/PHPStan/Analyser/Ignore/IgnoreLexerTest.php
+++ b/tests/PHPStan/Analyser/Ignore/IgnoreLexerTest.php
@@ -90,8 +90,8 @@ class IgnoreLexerTest extends PHPStanTestCase
 		$tokens = $lexer->tokenize($input);
 		$lastToken = array_pop($tokens);
 
-		$this->assertSame(['', IgnoreLexer::TOKEN_END, substr_count($input, PHP_EOL) + 1], $lastToken);
-		$this->assertSame($expectedTokens, $tokens);
+		self::assertSame(['', IgnoreLexer::TOKEN_END, substr_count($input, PHP_EOL) + 1], $lastToken);
+		self::assertSame($expectedTokens, $tokens);
 	}
 
 }

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -43,25 +43,25 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				return;
 			}
 
-			$this->assertSame('SomeNodeScopeResolverNamespace', $scope->getNamespace());
-			$this->assertTrue($scope->isInClass());
-			$this->assertSame(Foo::class, $scope->getClassReflection()->getName());
-			$this->assertSame('doFoo', $scope->getFunctionName());
-			$this->assertSame('$this(SomeNodeScopeResolverNamespace\Foo)', $scope->getVariableType('this')->describe(VerbosityLevel::precise()));
-			$this->assertTrue($scope->hasVariableType('baz')->yes());
-			$this->assertTrue($scope->hasVariableType('lorem')->yes());
-			$this->assertFalse($scope->hasVariableType('ipsum')->yes());
-			$this->assertTrue($scope->hasVariableType('i')->yes());
-			$this->assertTrue($scope->hasVariableType('val')->yes());
-			$this->assertSame('SomeNodeScopeResolverNamespace\InvalidArgumentException', $scope->getVariableType('exception')->describe(VerbosityLevel::precise()));
-			$this->assertTrue($scope->hasVariableType('staticVariable')->yes());
-			$this->assertSame($scope->getVariableType('staticVariable')->describe(VerbosityLevel::precise()), 'mixed');
-			$this->assertTrue($scope->hasVariableType('staticVariableWithPhpDocType')->yes());
-			$this->assertSame($scope->getVariableType('staticVariableWithPhpDocType')->describe(VerbosityLevel::precise()), 'string');
-			$this->assertTrue($scope->hasVariableType('staticVariableWithPhpDocType2')->yes());
-			$this->assertSame($scope->getVariableType('staticVariableWithPhpDocType2')->describe(VerbosityLevel::precise()), 'int');
-			$this->assertTrue($scope->hasVariableType('staticVariableWithPhpDocType3')->yes());
-			$this->assertSame($scope->getVariableType('staticVariableWithPhpDocType3')->describe(VerbosityLevel::precise()), 'float');
+			self::assertSame('SomeNodeScopeResolverNamespace', $scope->getNamespace());
+			self::assertTrue($scope->isInClass());
+			self::assertSame(Foo::class, $scope->getClassReflection()->getName());
+			self::assertSame('doFoo', $scope->getFunctionName());
+			self::assertSame('$this(SomeNodeScopeResolverNamespace\Foo)', $scope->getVariableType('this')->describe(VerbosityLevel::precise()));
+			self::assertTrue($scope->hasVariableType('baz')->yes());
+			self::assertTrue($scope->hasVariableType('lorem')->yes());
+			self::assertFalse($scope->hasVariableType('ipsum')->yes());
+			self::assertTrue($scope->hasVariableType('i')->yes());
+			self::assertTrue($scope->hasVariableType('val')->yes());
+			self::assertSame('SomeNodeScopeResolverNamespace\InvalidArgumentException', $scope->getVariableType('exception')->describe(VerbosityLevel::precise()));
+			self::assertTrue($scope->hasVariableType('staticVariable')->yes());
+			self::assertSame($scope->getVariableType('staticVariable')->describe(VerbosityLevel::precise()), 'mixed');
+			self::assertTrue($scope->hasVariableType('staticVariableWithPhpDocType')->yes());
+			self::assertSame($scope->getVariableType('staticVariableWithPhpDocType')->describe(VerbosityLevel::precise()), 'string');
+			self::assertTrue($scope->hasVariableType('staticVariableWithPhpDocType2')->yes());
+			self::assertSame($scope->getVariableType('staticVariableWithPhpDocType2')->describe(VerbosityLevel::precise()), 'int');
+			self::assertTrue($scope->hasVariableType('staticVariableWithPhpDocType3')->yes());
+			self::assertSame($scope->getVariableType('staticVariableWithPhpDocType3')->describe(VerbosityLevel::precise()), 'float');
 		});
 	}
 
@@ -96,7 +96,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/catch-union.php',
 			$description,
 			$expression,
@@ -219,7 +219,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/union-intersection.php',
 			$description,
 			$expression,
@@ -745,7 +745,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		?string $iterableValueTypeDescription = null,
 	): void
 	{
-		$this->assertVariables(
+		self::assertVariables(
 			$scope,
 			$variableName,
 			$expectedCertainty,
@@ -879,7 +879,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $typeDescription,
 	): void
 	{
-		$this->assertVariables(
+		self::assertVariables(
 			$scope,
 			$variableName,
 			TrinaryLogic::createYes(),
@@ -897,7 +897,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		$certainty = $scope->hasVariableType($variableName);
-		$this->assertTrue(
+		self::assertTrue(
 			$expectedCertainty->equals($certainty),
 			sprintf(
 				'Certainty of %s is %s, expected %s',
@@ -911,14 +911,14 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$this->fail(sprintf('Missing expected type for defined variable $%s.', $variableName));
 			}
 
-			$this->assertSame(
+			self::assertSame(
 				$typeDescription,
 				$scope->getVariableType($variableName)->describe(VerbosityLevel::precise()),
 				sprintf('Type of variable $%s does not match the expected one.', $variableName),
 			);
 
 			if ($iterableValueTypeDescription !== null) {
-				$this->assertSame(
+				self::assertSame(
 					$iterableValueTypeDescription,
 					$scope->getVariableType($variableName)->getIterableValueType()->describe(VerbosityLevel::precise()),
 					sprintf('Iterable value type of variable $%s does not match the expected one.', $variableName),
@@ -1211,7 +1211,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-destructuring.php',
 			$description,
 			$expression,
@@ -1290,7 +1290,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/typehints.php',
 			$typeClass,
 			$expression,
@@ -1349,7 +1349,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/typehints-anonymous-function.php',
 			$description,
 			$expression,
@@ -1428,13 +1428,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/var-annotations.php',
 			$description,
 			$expression,
-			'die',
-			[],
-			false,
+			useCache: false,
 		);
 	}
 
@@ -1582,7 +1580,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/casts.php',
 			$desciptiion,
 			$expression,
@@ -1710,7 +1708,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/function-definitions.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/deducted-types.php',
 			$description,
 			$expression,
@@ -1853,7 +1851,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/properties.php',
 			$description,
 			$expression,
@@ -3168,7 +3166,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/binary.php',
 			$description,
 			$expression,
@@ -3191,7 +3189,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/var-stmt-annotation.php',
 			$description,
 			$expression,
@@ -3214,7 +3212,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/clone.php',
 			$description,
 			$expression,
@@ -3265,7 +3263,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/literal-arrays.php',
 			$description,
 			$expression,
@@ -3340,7 +3338,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpressionType,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/literal-arrays-keys.php',
 			$description,
 			'$key',
@@ -3380,7 +3378,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/string-array-access.php',
 			$description,
 			$expression,
@@ -3555,7 +3553,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/functionPhpDocs.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/functionPhpDocs.php',
 			$description,
 			$expression,
@@ -3580,7 +3578,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/functionPhpDocs-psalmPrefix.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/functionPhpDocs-psalmPrefix.php',
 			$description,
 			$expression,
@@ -3595,7 +3593,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/functionPhpDocs-phpstanPrefix.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/functionPhpDocs-phpstanPrefix.php',
 			$description,
 			$expression,
@@ -3610,7 +3608,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/functionPhpDocs-phanPrefix.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/functionPhpDocs-phanPrefix.php',
 			$description,
 			$expression,
@@ -3766,7 +3764,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs.php',
 			$description,
 			$expression,
@@ -3789,7 +3787,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooPsalmPrefix';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-psalmPrefix.php',
 			$description,
 			$expression,
@@ -3815,7 +3813,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooPhpstanPrefix';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-phpstanPrefix.php',
 			$description,
 			$expression,
@@ -3838,7 +3836,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooPhanPrefix';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-phanPrefix.php',
 			$description,
 			$expression,
@@ -3861,7 +3859,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooWithTrait';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-trait.php',
 			$description,
 			$expression,
@@ -3884,7 +3882,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooInheritDocChildWithoutCurly';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/method-phpDocs-inheritdoc-without-curly-braces.php',
 			$description,
 			$expression,
@@ -3907,7 +3905,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooWithRecursiveTrait';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-recursiveTrait.php',
 			$description,
 			$expression,
@@ -3930,7 +3928,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-traitInSameFileAsClass.php',
 			$description,
 			$expression,
@@ -3953,7 +3951,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooInheritDocChild';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/method-phpDocs-inheritdoc.php',
 			$description,
 			$expression,
@@ -3976,7 +3974,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				$description = 'MethodPhpDocsNamespace\FooPhpDocsImplicitInheritanceChild';
 			}
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/methodPhpDocs-implicitInheritance.php',
 			$description,
 			$expression,
@@ -3985,7 +3983,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function testNotSwitchInstanceof(): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/switch-instanceof-not.php',
 			'*NEVER*',
 			'$foo',
@@ -4016,7 +4014,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/switch-instanceof.php',
 			$description,
 			$expression,
@@ -4029,7 +4027,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/switch-instanceof-truthy.php',
 			$description,
 			$expression,
@@ -4059,7 +4057,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/switch-get-class.php',
 			$description,
 			$expression,
@@ -4083,7 +4081,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/switch-instanceof-fallthrough.php',
 			$description,
 			$expression,
@@ -4106,7 +4104,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/switch-type-elimination.php',
 			$description,
 			$expression,
@@ -4141,7 +4139,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpressionType,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/overwritingVariable.php',
 			$description,
 			$expression,
@@ -4205,7 +4203,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/negated-instanceof.php',
 			$description,
 			$expression,
@@ -4240,7 +4238,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/anonymous-function.php',
 			$description,
 			$expression,
@@ -4375,7 +4373,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			$file,
 			$description,
 			$expression,
@@ -4400,7 +4398,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			$file,
 			$description,
 			$expression,
@@ -4457,7 +4455,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			$file,
 			$description,
 			$expression,
@@ -5182,7 +5180,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-functions.php',
 			$description,
 			$expression,
@@ -5514,7 +5512,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/functions.php',
 			$description,
 			$expression,
@@ -5540,7 +5538,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		if (!function_exists('dio_stat')) {
 			$this->markTestSkipped('This test requires DIO extension.');
 		}
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/dio-functions.php',
 			$description,
 			$expression,
@@ -5563,7 +5561,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/ssh2-functions.php',
 			$description,
 			$expression,
@@ -5634,7 +5632,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/range-function.php',
 			$description,
 			$expression,
@@ -5789,7 +5787,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/specifiedTypesUsingIsFunctions.php',
 			$description,
 			$expression,
@@ -5952,7 +5950,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/iterable.php',
 			$description,
 			$expression,
@@ -5987,7 +5985,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-accessable.php',
 			$description,
 			$expression,
@@ -6018,7 +6016,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/void.php',
 			$description,
 			$expression,
@@ -6053,7 +6051,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/nullable-returnTypes.php',
 			$description,
 			$expression,
@@ -6096,7 +6094,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/ternary.php',
 			$description,
 			$expression,
@@ -6123,7 +6121,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/heredoc.php',
 			$description,
 			$expression,
@@ -6293,7 +6291,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/type-elimination.php',
 			$description,
 			$expression,
@@ -6325,7 +6323,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/misleading-types.php',
 			$description,
 			$expression,
@@ -6352,7 +6350,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/misleading-types-without-namespace.php',
 			$description,
 			$expression,
@@ -6383,7 +6381,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/unresolvable-types.php',
 			$description,
 			$expression,
@@ -6410,7 +6408,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/combine-types.php',
 			$description,
 			$expression,
@@ -6447,7 +6445,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/constants.php',
 			$description,
 			$expression,
@@ -6474,7 +6472,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/finally.php',
 			$description,
 			$expression,
@@ -6487,7 +6485,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/finally-with-early-termination.php',
 			$description,
 			$expression,
@@ -6510,7 +6508,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-from-interface.php',
 			$description,
 			$expression,
@@ -6523,7 +6521,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-without-curly-braces-from-interface.php',
 			$description,
 			$expression,
@@ -6547,7 +6545,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/inheritdoc-from-interface2-definition.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-from-interface2.php',
 			$description,
 			$expression,
@@ -6561,7 +6559,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		require_once __DIR__ . '/data/inheritdoc-without-curly-braces-from-interface2-definition.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-without-curly-braces-from-interface2.php',
 			$description,
 			$expression,
@@ -6584,7 +6582,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-from-trait.php',
 			$description,
 			$expression,
@@ -6597,7 +6595,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-without-curly-braces-from-trait.php',
 			$description,
 			$expression,
@@ -6622,7 +6620,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		require_once __DIR__ . '/data/inheritdoc-from-trait2-definition.php';
 		require_once __DIR__ . '/data/inheritdoc-from-trait2-definition2.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-from-trait2.php',
 			$description,
 			$expression,
@@ -6637,7 +6635,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	{
 		require_once __DIR__ . '/data/inheritdoc-without-curly-braces-from-trait2-definition.php';
 		require_once __DIR__ . '/data/inheritdoc-without-curly-braces-from-trait2-definition2.php';
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/inheritdoc-without-curly-braces-from-trait2.php',
 			$description,
 			$expression,
@@ -6676,7 +6674,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/resolve-static.php',
 			$description,
 			$expression,
@@ -6905,7 +6903,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/foreach-loop-variables.php',
 			$description,
 			$expression,
@@ -6921,7 +6919,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/while-loop-variables.php',
 			$description,
 			$expression,
@@ -6937,7 +6935,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/for-loop-variables.php',
 			$description,
 			$expression,
@@ -7044,7 +7042,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/do-while-loop-variables.php',
 			$description,
 			$expression,
@@ -7075,7 +7073,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/multiple-classes-per-file.php',
 			$description,
 			$expression,
@@ -7103,7 +7101,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/calling-multiple-classes-per-file.php',
 			$description,
 			$expression,
@@ -7142,7 +7140,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/explode.php',
 			$description,
 			$expression,
@@ -7233,7 +7231,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-pointer-functions.php',
 			$description,
 			$expression,
@@ -7308,7 +7306,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/replaceFunctions.php',
 			$description,
 			$expression,
@@ -7470,7 +7468,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/filterVar.php',
 			$description,
 			$expression,
@@ -7580,7 +7578,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/closure-passed-by-reference.php',
 			$description,
 			$expression,
@@ -7604,7 +7602,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/closure-passed-by-reference-in-call.php',
 			$description,
 			$expression,
@@ -7653,7 +7651,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/static-closure.php',
 			$description,
 			$expression,
@@ -7667,7 +7665,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/closure-passed-by-reference-return.php',
 			$description,
 			$expression,
@@ -7695,13 +7693,11 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/closure-inferred-typehint.php',
 			$description,
 			$expression,
-			'die',
-			[],
-			false,
+			useCache: false,
 		);
 	}
 
@@ -7801,7 +7797,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/traits/traits.php',
 			$description,
 			$expression,
@@ -7832,7 +7828,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/passed-by-reference.php',
 			$description,
 			$expression,
@@ -7875,7 +7871,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/callables.php',
 			$description,
 			$expression,
@@ -7930,7 +7926,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-keys-branches.php',
 			$description,
 			$expression,
@@ -7975,7 +7971,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/specified-function-call.php',
 			$description,
 			$expression,
@@ -8015,7 +8011,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/mixed-elements.php',
 			$description,
 			$expression,
@@ -8042,7 +8038,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/case-insensitive-phpdocs.php',
 			$description,
 			$expression,
@@ -8122,7 +8118,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/constant-types-duplicate-condition.php',
 			$description,
 			$expression,
@@ -8173,7 +8169,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/anonymous-class-name.php',
 			$description,
 			$expression,
@@ -8197,7 +8193,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/anonymous-class-name-in-trait.php',
 			$description,
 			$expression,
@@ -8232,7 +8228,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/anonymous-class-name-same-line.php',
 			$description,
 			$expression,
@@ -8280,7 +8276,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/dynamic-constant.php',
 			$description,
 			$expression,
@@ -8323,7 +8319,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/dynamic-constant-native-types.php',
 			$description,
 			$expression,
@@ -8407,7 +8403,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/isset.php',
 			$description,
 			$expression,
@@ -8452,7 +8448,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/property-array.php',
 			$description,
 			$expression,
@@ -8541,7 +8537,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression = 'die',
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/get-parent-class.php',
 			$description,
 			$expression,
@@ -8572,7 +8568,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/is_countable.php',
 			$description,
 			$expression,
@@ -8708,7 +8704,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/php73_functions.php',
 			$description,
 			$expression,
@@ -8735,7 +8731,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/union-methods.php',
 			$description,
 			$expression,
@@ -8758,7 +8754,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/union-properties.php',
 			$description,
 			$expression,
@@ -8781,7 +8777,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/assignment-in-condition.php',
 			$description,
 			$expression,
@@ -8804,7 +8800,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/generalize-scope.php',
 			$description,
 			$expression,
@@ -8827,7 +8823,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/generalize-scope-recursive.php',
 			$description,
 			$expression,
@@ -8858,7 +8854,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-shapes.php',
 			$description,
 			$expression,
@@ -8909,7 +8905,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/infer-private-property-type-from-constructor.php',
 			$description,
 			$expression,
@@ -8940,7 +8936,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/property-native-types.php',
 			$description,
 			$expression,
@@ -8971,7 +8967,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/arrow-functions.php',
 			$description,
 			$expression,
@@ -9002,7 +8998,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/arrow-functions-inside.php',
 			$description,
 			$expression,
@@ -9057,7 +9053,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/coalesce-assign.php',
 			$description,
 			$expression,
@@ -9104,7 +9100,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/array-spread.php',
 			$description,
 			$expression,
@@ -9127,7 +9123,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $expression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/die-74.php',
 			$description,
 			$expression,
@@ -9162,13 +9158,12 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 		string $evaluatedPointExpression,
 	): void
 	{
-		$this->assertTypes(
+		self::assertTypes(
 			__DIR__ . '/data/try-catch-scope.php',
 			$description,
 			$expression,
 			$evaluatedPointExpression,
-			[],
-			false,
+			useCache: false,
 		);
 	}
 
@@ -9188,7 +9183,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 			/** @var Node\Stmt\Expression $expressionNode */
 			$expressionNode = $this->getParser()->parseString(sprintf('<?php %s;', $expression))[0];
 			$type = $scope->getType($expressionNode->expr);
-			$this->assertTypeDescribe(
+			self::assertTypeDescribe(
 				$description,
 				$type,
 				sprintf('%s at %s', $expression, $evaluatedPointExpression),
@@ -9253,7 +9248,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				return;
 			}
 
-			$this->assertSame($result, $scope->isDeclareStrictTypes());
+			self::assertSame($result, $scope->isDeclareStrictTypes());
 		});
 	}
 
@@ -9264,9 +9259,9 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				return;
 			}
 
-			$this->assertTrue($scope->hasVariableType('something')->yes());
-			$this->assertTrue($scope->hasVariableType('var')->yes());
-			$this->assertTrue($scope->hasVariableType('foo')->no());
+			self::assertTrue($scope->hasVariableType('something')->yes());
+			self::assertTrue($scope->hasVariableType('var')->yes());
+			self::assertTrue($scope->hasVariableType('foo')->no());
 		});
 	}
 
@@ -9292,7 +9287,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	): void
 	{
 		$actualDescription = $actualType->describe(VerbosityLevel::precise());
-		$this->assertSame(
+		self::assertSame(
 			$expectedDescription,
 			$actualDescription,
 			$label,

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -38,7 +38,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function testClassMethodScope(): void
 	{
-		self::processFile(__DIR__ . '/data/class.php', function (Node $node, Scope $scope): void {
+		self::processFile(__DIR__ . '/data/class.php', static function (Node $node, Scope $scope): void {
 			if (!($node instanceof Exit_)) {
 				return;
 			}
@@ -9243,7 +9243,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 	#[DataProvider('dataDeclareStrictTypes')]
 	public function testDeclareStrictTypes(string $file, bool $result): void
 	{
-		self::processFile($file, function (Node $node, Scope $scope) use ($result): void {
+		self::processFile($file, static function (Node $node, Scope $scope) use ($result): void {
 			if (!($node instanceof Exit_)) {
 				return;
 			}
@@ -9254,7 +9254,7 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 
 	public function testEarlyTermination(): void
 	{
-		self::processFile(__DIR__ . '/data/early-termination.php', function (Node $node, Scope $scope): void {
+		self::processFile(__DIR__ . '/data/early-termination.php', static function (Node $node, Scope $scope): void {
 			if (!($node instanceof Exit_)) {
 				return;
 			}

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -265,7 +265,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 	public function testFile(string $file): void
 	{
 		$asserts = self::gatherAssertTypes($file);
-		$this->assertNotCount(0, $asserts, sprintf('File %s has no asserts.', $file));
+		self::assertNotCount(0, $asserts, sprintf('File %s has no asserts.', $file));
 		$failures = [];
 
 		foreach ($asserts as $args) {

--- a/tests/PHPStan/Analyser/ScopePhpVersionTest.php
+++ b/tests/PHPStan/Analyser/ScopePhpVersionTest.php
@@ -28,7 +28,7 @@ class ScopePhpVersionTest extends TypeInferenceTestCase
 	#[DataProvider('dataTestPhpVersion')]
 	public function testPhpVersion(string $expected, string $file): void
 	{
-		self::processFile($file, function (Node $node, Scope $scope) use ($expected): void {
+		self::processFile($file, static function (Node $node, Scope $scope) use ($expected): void {
 			if (!($node instanceof Exit_)) {
 				return;
 			}

--- a/tests/PHPStan/Analyser/ScopePhpVersionTest.php
+++ b/tests/PHPStan/Analyser/ScopePhpVersionTest.php
@@ -32,7 +32,7 @@ class ScopePhpVersionTest extends TypeInferenceTestCase
 			if (!($node instanceof Exit_)) {
 				return;
 			}
-			$this->assertSame(
+			self::assertSame(
 				$expected,
 				$scope->getPhpVersion()->getType()->describe(VerbosityLevel::precise()),
 			);

--- a/tests/PHPStan/Analyser/ScopeTest.php
+++ b/tests/PHPStan/Analyser/ScopeTest.php
@@ -236,7 +236,7 @@ class ScopeTest extends PHPStanTestCase
 		$scopeA = $scopeFactory->create(ScopeContext::create('file.php'))->assignVariable('a', $a, $a, TrinaryLogic::createYes());
 		$scopeB = $scopeFactory->create(ScopeContext::create('file.php'))->assignVariable('a', $b, $b, TrinaryLogic::createYes());
 		$resultScope = $scopeA->generalizeWith($scopeB);
-		$this->assertSame($expectedTypeDescription, $resultScope->getVariableType('a')->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedTypeDescription, $resultScope->getVariableType('a')->describe(VerbosityLevel::precise()));
 	}
 
 	public function testGetConstantType(): void
@@ -246,7 +246,7 @@ class ScopeTest extends PHPStanTestCase
 		$scope = $scopeFactory->create(ScopeContext::create(__DIR__ . '/data/compiler-halt-offset.php'));
 		$node = new ConstFetch(new FullyQualified('__COMPILER_HALT_OFFSET__'));
 		$type = $scope->getType($node);
-		$this->assertSame('int<1, max>', $type->describe(VerbosityLevel::precise()));
+		self::assertSame('int<1, max>', $type->describe(VerbosityLevel::precise()));
 	}
 
 	public function testDefinedVariables(): void
@@ -257,7 +257,7 @@ class ScopeTest extends PHPStanTestCase
 			->assignVariable('a', new ConstantStringType('a'), new StringType(), TrinaryLogic::createYes())
 			->assignVariable('b', new ConstantStringType('b'), new StringType(), TrinaryLogic::createMaybe());
 
-		$this->assertSame(['a'], $scope->getDefinedVariables());
+		self::assertSame(['a'], $scope->getDefinedVariables());
 	}
 
 	public function testMaybeDefinedVariables(): void
@@ -268,7 +268,7 @@ class ScopeTest extends PHPStanTestCase
 			->assignVariable('a', new ConstantStringType('a'), new StringType(), TrinaryLogic::createYes())
 			->assignVariable('b', new ConstantStringType('b'), new StringType(), TrinaryLogic::createMaybe());
 
-		$this->assertSame(['b'], $scope->getMaybeDefinedVariables());
+		self::assertSame(['b'], $scope->getMaybeDefinedVariables());
 	}
 
 }

--- a/tests/PHPStan/Analyser/StatementResultTest.php
+++ b/tests/PHPStan/Analyser/StatementResultTest.php
@@ -539,7 +539,7 @@ class StatementResultTest extends PHPStanTestCase
 			},
 			StatementContext::createTopLevel(),
 		);
-		$this->assertSame($expectedIsAlwaysTerminating, $result->isAlwaysTerminating());
+		self::assertSame($expectedIsAlwaysTerminating, $result->isAlwaysTerminating());
 	}
 
 }

--- a/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierContextTest.php
@@ -41,11 +41,11 @@ class TypeSpecifierContextTest extends PHPStanTestCase
 	#[DataProvider('dataContext')]
 	public function testContext(TypeSpecifierContext $context, array $results): void
 	{
-		$this->assertSame($results[0], $context->true());
-		$this->assertSame($results[1], $context->truthy());
-		$this->assertSame($results[2], $context->false());
-		$this->assertSame($results[3], $context->falsey());
-		$this->assertSame($results[4], $context->null());
+		self::assertSame($results[0], $context->true());
+		self::assertSame($results[1], $context->truthy());
+		self::assertSame($results[2], $context->false());
+		self::assertSame($results[3], $context->falsey());
+		self::assertSame($results[4], $context->null());
 	}
 
 	public static function dataNegate(): array
@@ -76,11 +76,11 @@ class TypeSpecifierContextTest extends PHPStanTestCase
 	#[DataProvider('dataNegate')]
 	public function testNegate(TypeSpecifierContext $context, array $results): void
 	{
-		$this->assertSame($results[0], $context->true());
-		$this->assertSame($results[1], $context->truthy());
-		$this->assertSame($results[2], $context->false());
-		$this->assertSame($results[3], $context->falsey());
-		$this->assertSame($results[4], $context->null());
+		self::assertSame($results[0], $context->true());
+		self::assertSame($results[1], $context->truthy());
+		self::assertSame($results[2], $context->false());
+		self::assertSame($results[3], $context->falsey());
+		self::assertSame($results[4], $context->null());
 	}
 
 	public function testNegateNull(): void

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -91,11 +91,11 @@ class TypeSpecifierTest extends PHPStanTestCase
 	{
 		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this->scope, $expr, TypeSpecifierContext::createTruthy());
 		$actualResult = $this->toReadableResult($specifiedTypes);
-		$this->assertSame($expectedPositiveResult, $actualResult, sprintf('if (%s)', $this->printer->prettyPrintExpr($expr)));
+		self::assertSame($expectedPositiveResult, $actualResult, sprintf('if (%s)', $this->printer->prettyPrintExpr($expr)));
 
 		$specifiedTypes = $this->typeSpecifier->specifyTypesInCondition($this->scope, $expr, TypeSpecifierContext::createFalsey());
 		$actualResult = $this->toReadableResult($specifiedTypes);
-		$this->assertSame($expectedNegatedResult, $actualResult, sprintf('if not (%s)', $this->printer->prettyPrintExpr($expr)));
+		self::assertSame($expectedNegatedResult, $actualResult, sprintf('if not (%s)', $this->printer->prettyPrintExpr($expr)));
 	}
 
 	public static function dataCondition(): iterable

--- a/tests/PHPStan/Collectors/RegistryTest.php
+++ b/tests/PHPStan/Collectors/RegistryTest.php
@@ -18,10 +18,10 @@ class RegistryTest extends PHPStanTestCase
 		]);
 
 		$collectors = $registry->getCollectors(Node\Expr\FuncCall::class);
-		$this->assertCount(1, $collectors);
-		$this->assertSame($collector, $collectors[0]);
+		self::assertCount(1, $collectors);
+		self::assertSame($collector, $collectors[0]);
 
-		$this->assertCount(0, $registry->getCollectors(Node\Expr\MethodCall::class));
+		self::assertCount(0, $registry->getCollectors(Node\Expr\MethodCall::class));
 	}
 
 	public function testGetCollectorsWithTwoDifferentInstances(): void
@@ -35,11 +35,11 @@ class RegistryTest extends PHPStanTestCase
 		]);
 
 		$collectors = $registry->getCollectors(Node\Expr\FuncCall::class);
-		$this->assertCount(2, $collectors);
-		$this->assertSame($fooCollector, $collectors[0]);
-		$this->assertSame($barCollector, $collectors[1]);
+		self::assertCount(2, $collectors);
+		self::assertSame($fooCollector, $collectors[0]);
+		self::assertSame($barCollector, $collectors[1]);
 
-		$this->assertCount(0, $registry->getCollectors(Node\Expr\MethodCall::class));
+		self::assertCount(0, $registry->getCollectors(Node\Expr\MethodCall::class));
 	}
 
 }

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -30,14 +30,14 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 	public function testExecuteOnAFile(): void
 	{
 		$output = $this->runPath(__DIR__ . '/data/file-without-errors.php', 0);
-		$this->assertStringContainsString('No errors', $output);
+		self::assertStringContainsString('No errors', $output);
 	}
 
 	public function testExecuteOnANonExistentPath(): void
 	{
 		$path = __DIR__ . '/foo';
 		$output = $this->runPath($path, 1);
-		$this->assertStringContainsString(sprintf(
+		self::assertStringContainsString(sprintf(
 			'File %s does not exist.',
 			$path,
 		), $output);
@@ -47,7 +47,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 	{
 		$path = __DIR__ . '/../Rules/Functions/data/nonexistent-function.php';
 		$output = $this->runPath($path, 1);
-		$this->assertStringContainsString('Function foobarNonExistentFunction not found.', $output);
+		self::assertStringContainsString('Function foobarNonExistentFunction not found.', $output);
 	}
 
 	private function runPath(string $path, int $expectedStatusCode): string
@@ -95,7 +95,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 		rewind($output->getStream());
 
 		$contents = stream_get_contents($output->getStream());
-		$this->assertSame($expectedStatusCode, $statusCode, $contents);
+		self::assertSame($expectedStatusCode, $statusCode, $contents);
 
 		return $contents;
 	}

--- a/tests/PHPStan/Command/AnalyseCommandTest.php
+++ b/tests/PHPStan/Command/AnalyseCommandTest.php
@@ -33,7 +33,7 @@ class AnalyseCommandTest extends PHPStanTestCase
 
 		try {
 			$output = $this->runCommand(1);
-			$this->assertStringContainsString('Note: Using configuration file ' . $file . '.', $output);
+			self::assertStringContainsString('Note: Using configuration file ' . $file . '.', $output);
 		} catch (Throwable $e) {
 			chdir($originalDir);
 			throw $e;
@@ -46,7 +46,7 @@ class AnalyseCommandTest extends PHPStanTestCase
 		$autoloadFile = $dir . DIRECTORY_SEPARATOR . 'phpstan.123456789.php';
 
 		$output = $this->runCommand(1, ['--autoload-file' => $autoloadFile]);
-		$this->assertSame(sprintf('Autoload file "%s" not found.' . PHP_EOL, $autoloadFile), $output);
+		self::assertSame(sprintf('Autoload file "%s" not found.' . PHP_EOL, $autoloadFile), $output);
 	}
 
 	public function testValidAutoloadFile(): void
@@ -62,9 +62,9 @@ class AnalyseCommandTest extends PHPStanTestCase
 
 		try {
 			$output = $this->runCommand(0, ['--autoload-file' => $autoloadFile]);
-			$this->assertStringContainsString('[OK] No errors', $output);
-			$this->assertStringNotContainsString(sprintf('Autoload file "%s" not found.' . PHP_EOL, $autoloadFile), $output);
-			$this->assertSame('magic value', SOME_CONSTANT_IN_AUTOLOAD_FILE);
+			self::assertStringContainsString('[OK] No errors', $output);
+			self::assertStringNotContainsString(sprintf('Autoload file "%s" not found.' . PHP_EOL, $autoloadFile), $output);
+			self::assertSame('magic value', SOME_CONSTANT_IN_AUTOLOAD_FILE);
 		} catch (Throwable $e) {
 			chdir($originalDir);
 			throw $e;
@@ -128,7 +128,7 @@ class AnalyseCommandTest extends PHPStanTestCase
 			'--debug' => true,
 		] + $parameters, ['debug' => true]);
 
-		$this->assertSame($expectedStatusCode, $commandTester->getStatusCode(), $commandTester->getDisplay());
+		self::assertSame($expectedStatusCode, $commandTester->getStatusCode(), $commandTester->getDisplay());
 
 		return $commandTester->getDisplay();
 	}

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -145,16 +145,16 @@ class CommandHelperTest extends TestCase
 		rewind($output->getStream());
 
 		$contents = stream_get_contents($output->getStream());
-		$this->assertStringContainsString($expectedOutput, $contents);
+		self::assertStringContainsString($expectedOutput, $contents);
 
 		if (isset($result)) {
 			$parameters = $result->getContainer()->getParameters();
 			foreach ($expectedParameters as $name => $expectedValue) {
-				$this->assertArrayHasKey($name, $parameters);
-				$this->assertSame($expectedValue, $parameters[$name]);
+				self::assertArrayHasKey($name, $parameters);
+				self::assertSame($expectedValue, $parameters[$name]);
 			}
 		} else {
-			$this->assertCount(0, $expectedParameters);
+			self::assertCount(0, $expectedParameters);
 		}
 	}
 
@@ -314,8 +314,8 @@ class CommandHelperTest extends TestCase
 		);
 		$parameters = $result->getContainer()->getParameters();
 		foreach ($expectedParameters as $name => $expectedValue) {
-			$this->assertArrayHasKey($name, $parameters);
-			$this->assertSame($expectedValue, $parameters[$name]);
+			self::assertArrayHasKey($name, $parameters);
+			self::assertSame($expectedValue, $parameters[$name]);
 		}
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterIntegrationTest.php
@@ -26,8 +26,8 @@ class BaselineNeonErrorFormatterIntegrationTest extends TestCase
 	{
 		$output = $this->runPhpStan(__DIR__ . '/data/', __DIR__ . '/empty.neon');
 		$errors = Json::decode($output, Json::FORCE_ARRAY);
-		$this->assertSame(10, array_sum($errors['totals']));
-		$this->assertCount(6, $errors['files']);
+		self::assertSame(10, array_sum($errors['totals']));
+		self::assertCount(6, $errors['files']);
 	}
 
 	public function testGenerateBaselineAndRunAgainWithIt(): void
@@ -38,24 +38,24 @@ class BaselineNeonErrorFormatterIntegrationTest extends TestCase
 		$output = $this->runPhpStan(__DIR__ . '/data/', $baselineFile);
 		@unlink($baselineFile);
 		$errors = Json::decode($output, Json::FORCE_ARRAY);
-		$this->assertSame(0, array_sum($errors['totals']));
-		$this->assertCount(0, $errors['files']);
+		self::assertSame(0, array_sum($errors['totals']));
+		self::assertCount(0, $errors['files']);
 	}
 
 	public function testRunWindowsFileWithUnixBaseline(): void
 	{
 		$output = $this->runPhpStan(__DIR__ . '/data/WindowsNewlines.php', __DIR__ . '/data/unixBaseline.neon');
 		$errors = Json::decode($output, Json::FORCE_ARRAY);
-		$this->assertSame(0, array_sum($errors['totals']));
-		$this->assertCount(0, $errors['files']);
+		self::assertSame(0, array_sum($errors['totals']));
+		self::assertCount(0, $errors['files']);
 	}
 
 	public function testRunUnixFileWithWindowsBaseline(): void
 	{
 		$output = $this->runPhpStan(__DIR__ . '/data/UnixNewlines.php', __DIR__ . '/data/windowsBaseline.neon');
 		$errors = Json::decode($output, Json::FORCE_ARRAY);
-		$this->assertSame(0, array_sum($errors['totals']));
-		$this->assertCount(0, $errors['files']);
+		self::assertSame(0, array_sum($errors['totals']));
+		self::assertCount(0, $errors['files']);
 	}
 
 	private function runPhpStan(

--- a/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselineNeonErrorFormatterTest.php
@@ -161,13 +161,13 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = new BaselineNeonErrorFormatter(new SimpleRelativePathHelper(self::DIRECTORY_PATH), $useRawMessage);
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 			'',
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertSame(trim(Neon::encode(['parameters' => ['ignoreErrors' => $expected]], Neon::BLOCK)), trim($this->getOutputContent()), sprintf('%s: output do not match', $message));
+		self::assertSame(trim(Neon::encode(['parameters' => ['ignoreErrors' => $expected]], Neon::BLOCK)), trim($this->getOutputContent()), sprintf('%s: output do not match', $message));
 	}
 
 	public function testFormatErrorMessagesRegexEscape(): void
@@ -689,7 +689,7 @@ class BaselineNeonErrorFormatterTest extends ErrorFormatterTestCase
 			'',
 		);
 
-		$this->assertSame($expectedOutput, Neon::decode($this->getOutputContent()));
+		self::assertSame($expectedOutput, Neon::decode($this->getOutputContent()));
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/BaselinePhpErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/BaselinePhpErrorFormatterTest.php
@@ -238,7 +238,7 @@ return ['parameters' => ['ignoreErrors' => \$ignoreErrors]];
 			$this->getOutput(),
 		);
 
-		$this->assertSame($expectedOutput, $this->getOutputContent());
+		self::assertSame($expectedOutput, $this->getOutputContent());
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/CheckstyleErrorFormatterTest.php
@@ -122,14 +122,14 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = new CheckstyleErrorFormatter(new SimpleRelativePathHelper(self::DIRECTORY_PATH));
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 		), sprintf('%s: response code do not match', $message));
 
 		$outputContent = $this->getOutputContent();
-		$this->assertXmlStringEqualsXmlString($expected, $outputContent, sprintf('%s: XML do not match', $message));
-		$this->assertStringStartsWith('<?xml', $outputContent);
+		self::assertXmlStringEqualsXmlString($expected, $outputContent, sprintf('%s: XML do not match', $message));
+		self::assertStringStartsWith('<?xml', $outputContent);
 	}
 
 	public function testTraitPath(): void
@@ -155,7 +155,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 			false,
 			[],
 		), $this->getOutput());
-		$this->assertXmlStringEqualsXmlString('<checkstyle>
+		self::assertXmlStringEqualsXmlString('<checkstyle>
 	<file name="FooTrait.php">
 		<error column="1" line="5" message="Foo" severity="error"/>
 	</file>
@@ -184,7 +184,7 @@ class CheckstyleErrorFormatterTest extends ErrorFormatterTestCase
 			true,
 			[],
 		), $this->getOutput());
-		$this->assertXmlStringEqualsXmlString('<checkstyle>
+		self::assertXmlStringEqualsXmlString('<checkstyle>
 	<file name="Foo.php">
 		<error column="1" line="5" message="Foo" severity="error" source="argument.type" />
 	</file>

--- a/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GithubErrorFormatterTest.php
@@ -102,12 +102,12 @@ class GithubErrorFormatterTest extends ErrorFormatterTestCase
 			$relativePathHelper,
 		);
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertSame($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+		self::assertSame($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/GitlabErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/GitlabErrorFormatterTest.php
@@ -333,12 +333,12 @@ class GitlabErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = new GitlabErrorFormatter(new SimpleRelativePathHelper('/data/folder'));
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertJsonStringEqualsJsonString($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+		self::assertJsonStringEqualsJsonString($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JsonErrorFormatterTest.php
@@ -205,12 +205,12 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = new JsonErrorFormatter(true);
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 		), $message);
 
-		$this->assertJsonStringEqualsJsonString($expected, $this->getOutputContent());
+		self::assertJsonStringEqualsJsonString($expected, $this->getOutputContent());
 	}
 
 	#[DataProvider('dataFormatterOutputProvider')]
@@ -224,12 +224,12 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		$formatter = new JsonErrorFormatter(false);
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertJsonStringEqualsJsonString($expected, $this->getOutputContent(), sprintf('%s: JSON do not match', $message));
+		self::assertJsonStringEqualsJsonString($expected, $this->getOutputContent(), sprintf('%s: JSON do not match', $message));
 	}
 
 	public static function dataFormatTip(): iterable
@@ -249,7 +249,7 @@ class JsonErrorFormatterTest extends ErrorFormatterTestCase
 
 		$content = $this->getOutputContent();
 		$json = Json::decode($content, Json::FORCE_ARRAY);
-		$this->assertSame($expectedTip, $json['files']['/foo/bar.php']['messages'][0]['tip']);
+		self::assertSame($expectedTip, $json['files']['/foo/bar.php']['messages'][0]['tip']);
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/JunitErrorFormatterTest.php
@@ -142,7 +142,7 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 		string $expected,
 	): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$exitCode,
 			$this->formatter->formatErrors(
 				$this->getAnalysisResult($numFileErrors, $numGeneralErrors),
@@ -154,12 +154,12 @@ class JunitErrorFormatterTest extends ErrorFormatterTestCase
 		$xml = new DOMDocument();
 		$xml->loadXML($this->getOutputContent());
 
-		$this->assertTrue(
+		self::assertTrue(
 			$xml->schemaValidate(__DIR__ . '/junit-schema.xsd'),
 			'Schema do not validate',
 		);
 
-		$this->assertXmlStringEqualsXmlString(
+		self::assertXmlStringEqualsXmlString(
 			$expected,
 			$this->getOutputContent(),
 			'XML do not match',

--- a/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/RawErrorFormatterTest.php
@@ -117,12 +117,12 @@ Bar2
 	{
 		$formatter = new RawErrorFormatter();
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(false, $verbose),
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertSame($expected, $this->getOutputContent(false, $verbose), sprintf('%s: output do not match', $message));
+		self::assertSame($expected, $this->getOutputContent(false, $verbose), sprintf('%s: output do not match', $message));
 	}
 
 }

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -285,12 +285,12 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			putenv($envVar);
 		}
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(false, $verbose),
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertSame($expected, $this->getOutputContent(false, $verbose), sprintf('%s: output do not match', $message));
+		self::assertSame($expected, $this->getOutputContent(false, $verbose), sprintf('%s: output do not match', $message));
 	}
 
 	public function testEditorUrlWithTrait(): void
@@ -299,7 +299,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		$error = new Error('Test', 'Foo.php (in context of trait)', 12, filePath: 'Foo.php', traitFilePath: 'Bar.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput());
 
-		$this->assertStringContainsString('Bar.php', $this->getOutputContent());
+		self::assertStringContainsString('Bar.php', $this->getOutputContent());
 	}
 
 	public function testEditorUrlWithRelativePath(): void
@@ -308,7 +308,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		$error = new Error('Test', 'Foo.php', 12, filePath: self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput(true));
 
-		$this->assertStringContainsString('editor://custom/path/rel/Foo.php', $this->getOutputContent(true));
+		self::assertStringContainsString('editor://custom/path/rel/Foo.php', $this->getOutputContent(true));
 	}
 
 	public function testEditorUrlWithCustomTitle(): void
@@ -317,7 +317,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		$error = new Error('Test', 'Foo.php', 12, filePath: self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput(true));
 
-		$this->assertStringContainsString('rel/Foo.php:12', $this->getOutputContent(true));
+		self::assertStringContainsString('rel/Foo.php:12', $this->getOutputContent(true));
 	}
 
 	public function testBug6727(): void
@@ -406,7 +406,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			),
 			$this->getOutput(),
 		);
-		$this->assertSame(
+		self::assertSame(
 			<<<'TABLE'
  ------ -------------------------------------------------------------------------------------------------------------------------------------------------
   Line   bla.php
@@ -445,7 +445,7 @@ TABLE,
 		$error = new Error('Test', 'Foo.php', 12, filePath: self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput(true));
 
-		$this->assertStringContainsString('at rel/Foo.php:12', $this->getOutputContent(true));
+		self::assertStringContainsString('at rel/Foo.php:12', $this->getOutputContent(true));
 	}
 
 	private function createErrorFormatter(?string $editorUrl, ?string $editorUrlTitle = null): TableErrorFormatter

--- a/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TeamcityErrorFormatterTest.php
@@ -109,12 +109,12 @@ class TeamcityErrorFormatterTest extends ErrorFormatterTestCase
 			$relativePathHelper,
 		);
 
-		$this->assertSame($exitCode, $formatter->formatErrors(
+		self::assertSame($exitCode, $formatter->formatErrors(
 			$this->getAnalysisResult($numFileErrors, $numGenericErrors),
 			$this->getOutput(),
 		), sprintf('%s: response code do not match', $message));
 
-		$this->assertSame($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
+		self::assertSame($expected, $this->getOutputContent(), sprintf('%s: output do not match', $message));
 	}
 
 }

--- a/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
+++ b/tests/PHPStan/Command/IgnoredRegexValidatorTest.php
@@ -168,9 +168,9 @@ class IgnoredRegexValidatorTest extends PHPStanTestCase
 		$validator = new IgnoredRegexValidator($parser, self::getContainer()->getByType(TypeStringResolver::class));
 
 		$result = $validator->validate($regex);
-		$this->assertSame($expectedTypes, $result->getIgnoredTypes());
-		$this->assertSame($expectedHasAnchors, $result->hasAnchorsInTheMiddle());
-		$this->assertSame($expectAllErrorsIgnored, $result->areAllErrorsIgnored());
+		self::assertSame($expectedTypes, $result->getIgnoredTypes());
+		self::assertSame($expectedHasAnchors, $result->hasAnchorsInTheMiddle());
+		self::assertSame($expectAllErrorsIgnored, $result->areAllErrorsIgnored());
 	}
 
 }

--- a/tests/PHPStan/Composer/AutoloadFilesTest.php
+++ b/tests/PHPStan/Composer/AutoloadFilesTest.php
@@ -77,7 +77,7 @@ class AutoloadFilesTest extends TestCase
 		$expectedFiles = array_map(static fn (string $path): string => $fileHelper->normalizePath($path), $expectedFiles);
 		sort($expectedFiles);
 
-		$this->assertSame($expectedFiles, $autoloadFiles);
+		self::assertSame($expectedFiles, $autoloadFiles);
 	}
 
 }

--- a/tests/PHPStan/DependencyInjection/ConditionalTagsExtensionTest.php
+++ b/tests/PHPStan/DependencyInjection/ConditionalTagsExtensionTest.php
@@ -14,16 +14,16 @@ class ConditionalTagsExtensionTest extends PHPStanTestCase
 	{
 		$enabledServices = self::getContainer()->getServicesByTag(LazyRegistry::RULE_TAG);
 		$enabledServices = array_map(static fn ($service) => get_class($service), $enabledServices);
-		$this->assertNotContains(TestedConditionalServiceDisabled::class, $enabledServices);
-		$this->assertContains(TestedConditionalServiceEnabled::class, $enabledServices);
-		$this->assertContains(TestedConditionalServiceNotDisabled::class, $enabledServices);
-		$this->assertNotContains(TestedConditionalServiceNotEnabled::class, $enabledServices);
-		$this->assertNotContains(TestedConditionalServiceDisabledDisabled::class, $enabledServices);
-		$this->assertNotContains(TestedConditionalServiceDisabledEnabled::class, $enabledServices);
-		$this->assertNotContains(TestedConditionalServiceEnabledDisabled::class, $enabledServices);
-		$this->assertContains(TestedConditionalServiceEnabledEnabled::class, $enabledServices);
-		$this->assertContains(TestedConditionalServiceEnabledNotDisabled::class, $enabledServices);
-		$this->assertNotContains(TestedConditionalServiceEnabledNotEnabled::class, $enabledServices);
+		self::assertNotContains(TestedConditionalServiceDisabled::class, $enabledServices);
+		self::assertContains(TestedConditionalServiceEnabled::class, $enabledServices);
+		self::assertContains(TestedConditionalServiceNotDisabled::class, $enabledServices);
+		self::assertNotContains(TestedConditionalServiceNotEnabled::class, $enabledServices);
+		self::assertNotContains(TestedConditionalServiceDisabledDisabled::class, $enabledServices);
+		self::assertNotContains(TestedConditionalServiceDisabledEnabled::class, $enabledServices);
+		self::assertNotContains(TestedConditionalServiceEnabledDisabled::class, $enabledServices);
+		self::assertContains(TestedConditionalServiceEnabledEnabled::class, $enabledServices);
+		self::assertContains(TestedConditionalServiceEnabledNotDisabled::class, $enabledServices);
+		self::assertNotContains(TestedConditionalServiceEnabledNotEnabled::class, $enabledServices);
 	}
 
 	/**

--- a/tests/PHPStan/DependencyInjection/IgnoreErrorsTest.php
+++ b/tests/PHPStan/DependencyInjection/IgnoreErrorsTest.php
@@ -9,7 +9,7 @@ class IgnoreErrorsTest extends PHPStanTestCase
 
 	public function testIgnoreErrors(): void
 	{
-		$this->assertCount(16, self::getContainer()->getParameter('ignoreErrors'));
+		self::assertCount(16, self::getContainer()->getParameter('ignoreErrors'));
 	}
 
 	/**

--- a/tests/PHPStan/File/FileExcluderTest.php
+++ b/tests/PHPStan/File/FileExcluderTest.php
@@ -22,7 +22,7 @@ class FileExcluderTest extends PHPStanTestCase
 
 		$fileExcluder = new FileExcluder($this->getFileHelper(), $analyseExcludes);
 
-		$this->assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
+		self::assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
 	}
 
 	public static function dataExcludeOnWindows(): array
@@ -130,7 +130,7 @@ class FileExcluderTest extends PHPStanTestCase
 
 		$fileExcluder = new FileExcluder($this->getFileHelper(), $analyseExcludes);
 
-		$this->assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
+		self::assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
 	}
 
 	public static function dataExcludeOnUnix(): array
@@ -253,7 +253,7 @@ class FileExcluderTest extends PHPStanTestCase
 
 		$fileExcluder = new FileExcluder($this->getFileHelper(), $analyseExcludes);
 
-		$this->assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
+		self::assertSame($isExcluded, $fileExcluder->isExcludedFromAnalysing($filePath));
 	}
 
 }

--- a/tests/PHPStan/File/FileHelperTest.php
+++ b/tests/PHPStan/File/FileHelperTest.php
@@ -31,7 +31,7 @@ class FileHelperTest extends PHPStanTestCase
 	{
 		$this->skipIfNotOnWindows();
 		$fileHelper = new FileHelper('C:\abcd');
-		$this->assertSame($absolutePath, $fileHelper->absolutizePath($path));
+		self::assertSame($absolutePath, $fileHelper->absolutizePath($path));
 	}
 
 	/**
@@ -58,7 +58,7 @@ class FileHelperTest extends PHPStanTestCase
 	{
 		$this->skipIfNotOnUnix();
 		$fileHelper = new FileHelper('/abcd');
-		$this->assertSame($absolutePath, $fileHelper->absolutizePath($path));
+		self::assertSame($absolutePath, $fileHelper->absolutizePath($path));
 	}
 
 	/**
@@ -82,7 +82,7 @@ class FileHelperTest extends PHPStanTestCase
 	public function testNormalizePathOnWindows(string $path, string $normalizedPath): void
 	{
 		$this->skipIfNotOnWindows();
-		$this->assertSame($normalizedPath, self::getContainer()->getByType(FileHelper::class)->normalizePath($path));
+		self::assertSame($normalizedPath, self::getContainer()->getByType(FileHelper::class)->normalizePath($path));
 	}
 
 	/**
@@ -108,7 +108,7 @@ class FileHelperTest extends PHPStanTestCase
 	public function testNormalizePathOnLinuxOrMac(string $path, string $normalizedPath): void
 	{
 		$this->skipIfNotOnUnix();
-		$this->assertSame($normalizedPath, self::getContainer()->getByType(FileHelper::class)->normalizePath($path));
+		self::assertSame($normalizedPath, self::getContainer()->getByType(FileHelper::class)->normalizePath($path));
 	}
 
 }

--- a/tests/PHPStan/File/ParentDirectoryRelativePathHelperTest.php
+++ b/tests/PHPStan/File/ParentDirectoryRelativePathHelperTest.php
@@ -112,7 +112,7 @@ class ParentDirectoryRelativePathHelperTest extends TestCase
 	): void
 	{
 		$helper = new ParentDirectoryRelativePathHelper($parentDirectory);
-		$this->assertSame(
+		self::assertSame(
 			$expectedRelativePath,
 			$helper->getRelativePath($filename),
 		);

--- a/tests/PHPStan/File/RelativePathHelperTest.php
+++ b/tests/PHPStan/File/RelativePathHelperTest.php
@@ -192,7 +192,7 @@ class RelativePathHelperTest extends TestCase
 	): void
 	{
 		$helper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), $currentWorkingDirectory, $analysedPaths, '/');
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$helper->getRelativePath($filenameToRelativize),
 		);
@@ -217,7 +217,7 @@ class RelativePathHelperTest extends TestCase
 			return str_replace('/', '\\', $path);
 		};
 		$helper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), $sanitize($currentWorkingDirectory), array_map($sanitize, $analysedPaths), '\\');
-		$this->assertSame(
+		self::assertSame(
 			$sanitize($expectedResult),
 			$helper->getRelativePath($sanitize($filenameToRelativize)),
 		);
@@ -259,7 +259,7 @@ class RelativePathHelperTest extends TestCase
 	): void
 	{
 		$helper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), $currentWorkingDirectory, $analysedPaths, '\\');
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$helper->getRelativePath($filenameToRelativize),
 		);

--- a/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
+++ b/tests/PHPStan/Generics/TemplateTypeFactoryTest.php
@@ -91,7 +91,7 @@ class TemplateTypeFactoryTest extends PHPStanTestCase
 			TemplateTypeVariance::createInvariant(),
 		);
 
-		$this->assertTrue(
+		self::assertTrue(
 			$expectedBound->equals($templateType->getBound()),
 			sprintf('%s -> equals(%s)', $expectedBound->describe(VerbosityLevel::precise()), $templateType->getBound()->describe(VerbosityLevel::precise())),
 		);

--- a/tests/PHPStan/Internal/ArrayHelperTest.php
+++ b/tests/PHPStan/Internal/ArrayHelperTest.php
@@ -21,7 +21,7 @@ class ArrayHelperTest extends TestCase
 
 		ArrayHelper::unsetKeyAtPath($array, ['dep1a', 'dep2a', 'dep3a']);
 
-		$this->assertSame([
+		self::assertSame([
 			'dep1a' => [
 				'dep2a' => [],
 				'dep2b' => null,
@@ -31,7 +31,7 @@ class ArrayHelperTest extends TestCase
 
 		ArrayHelper::unsetKeyAtPath($array, ['dep1a', 'dep2a']);
 
-		$this->assertSame([
+		self::assertSame([
 			'dep1a' => [
 				'dep2b' => null,
 			],
@@ -40,13 +40,13 @@ class ArrayHelperTest extends TestCase
 
 		ArrayHelper::unsetKeyAtPath($array, ['dep1a']);
 
-		$this->assertSame([
+		self::assertSame([
 			'dep1b' => null,
 		], $array);
 
 		ArrayHelper::unsetKeyAtPath($array, ['dep1b']);
 
-		$this->assertSame([], $array);
+		self::assertSame([], $array);
 	}
 
 	public function testUnsetKeyAtPathEmpty(): void
@@ -55,7 +55,7 @@ class ArrayHelperTest extends TestCase
 
 		ArrayHelper::unsetKeyAtPath($array, ['foo', 'bar']);
 
-		$this->assertSame([], $array);
+		self::assertSame([], $array);
 	}
 
 }

--- a/tests/PHPStan/Parallel/ParallelAnalyserIntegrationTest.php
+++ b/tests/PHPStan/Parallel/ParallelAnalyserIntegrationTest.php
@@ -61,7 +61,7 @@ class ParallelAnalyserIntegrationTest extends TestCase
 
 		$fileHelper = new FileHelper(__DIR__);
 		$filePath = $fileHelper->normalizePath(__DIR__ . '/data/trait-definition.php');
-		$this->assertJsonStringEqualsJsonString(Json::encode([
+		self::assertJsonStringEqualsJsonString(Json::encode([
 			'totals' => [
 				'errors' => 0,
 				'file_errors' => 4,
@@ -106,7 +106,7 @@ class ParallelAnalyserIntegrationTest extends TestCase
 			],
 			'errors' => [],
 		]), $output);
-		$this->assertSame(1, $exitCode);
+		self::assertSame(1, $exitCode);
 	}
 
 }

--- a/tests/PHPStan/Parallel/SchedulerTest.php
+++ b/tests/PHPStan/Parallel/SchedulerTest.php
@@ -93,9 +93,9 @@ class SchedulerTest extends TestCase
 		$scheduler = new Scheduler($jobSize, $maximumNumberOfProcesses, $minimumNumberOfJobsPerProcess);
 		$schedule = $scheduler->scheduleWork($cpuCores, $files);
 
-		$this->assertSame($expectedNumberOfProcesses, $schedule->getNumberOfProcesses());
+		self::assertSame($expectedNumberOfProcesses, $schedule->getNumberOfProcesses());
 		$jobSizes = array_map(static fn (array $job): int => count($job), $schedule->getJobs());
-		$this->assertSame($expectedJobSizes, $jobSizes);
+		self::assertSame($expectedJobSizes, $jobSizes);
 	}
 
 }

--- a/tests/PHPStan/Parser/CachedParserTest.php
+++ b/tests/PHPStan/Parser/CachedParserTest.php
@@ -25,7 +25,7 @@ class CachedParserTest extends PHPStanTestCase
 			$cachedNodesByStringCountMax,
 		);
 
-		$this->assertSame(
+		self::assertSame(
 			$cachedNodesByStringCountMax,
 			$parser->getCachedNodesByStringCountMax(),
 		);
@@ -35,12 +35,12 @@ class CachedParserTest extends PHPStanTestCase
 			$parser->parseString('string' . $i);
 		}
 
-		$this->assertSame(
+		self::assertSame(
 			$cachedNodesByStringCountExpected,
 			$parser->getCachedNodesByStringCount(),
 		);
 
-		$this->assertCount(
+		self::assertCount(
 			$cachedNodesByStringCountExpected,
 			$parser->getCachedNodesByString(),
 		);
@@ -92,35 +92,35 @@ class CachedParserTest extends PHPStanTestCase
 		$pathRoutingParser->setAnalysedFiles([$path]);
 		$contents = FileReader::read($path);
 		$stmts = $parser->parseString($contents);
-		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
-		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
-		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
-		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
-		$this->assertNull($stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+		self::assertInstanceOf(Namespace_::class, $stmts[0]);
+		self::assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		self::assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		self::assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		self::assertNull($stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
 
 		$stmts = $parser->parseFile($path);
-		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
-		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
-		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
-		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
-		$this->assertSame(1, $stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+		self::assertInstanceOf(Namespace_::class, $stmts[0]);
+		self::assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		self::assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		self::assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		self::assertSame(1, $stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
 
-		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[1]);
-		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[1]->expr);
-		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[1]->expr->expr);
-		$this->assertSame(2, $stmts[0]->stmts[1]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+		self::assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[1]);
+		self::assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[1]->expr);
+		self::assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[1]->expr->expr);
+		self::assertSame(2, $stmts[0]->stmts[1]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
 
 		$stmts = $parser->parseString($contents);
-		$this->assertInstanceOf(Namespace_::class, $stmts[0]);
-		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
-		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
-		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
-		$this->assertSame(1, $stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+		self::assertInstanceOf(Namespace_::class, $stmts[0]);
+		self::assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[0]);
+		self::assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[0]->expr);
+		self::assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[0]->expr->expr);
+		self::assertSame(1, $stmts[0]->stmts[0]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
 
-		$this->assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[1]);
-		$this->assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[1]->expr);
-		$this->assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[1]->expr->expr);
-		$this->assertSame(2, $stmts[0]->stmts[1]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
+		self::assertInstanceOf(Node\Stmt\Expression::class, $stmts[0]->stmts[1]);
+		self::assertInstanceOf(Node\Expr\Assign::class, $stmts[0]->stmts[1]->expr);
+		self::assertInstanceOf(Node\Expr\New_::class, $stmts[0]->stmts[1]->expr->expr);
+		self::assertSame(2, $stmts[0]->stmts[1]->expr->expr->class->getAttribute(AnonymousClassVisitor::ATTRIBUTE_LINE_INDEX));
 	}
 
 }

--- a/tests/PHPStan/Parser/CleaningParserTest.php
+++ b/tests/PHPStan/Parser/CleaningParserTest.php
@@ -79,7 +79,7 @@ class CleaningParserTest extends PHPStanTestCase
 		);
 		$printer = new Printer();
 		$ast = $parser->parseFile($beforeFile);
-		$this->assertSame(FileReader::read($afterFile), "<?php\n" . $printer->prettyPrint($ast) . "\n");
+		self::assertSame(FileReader::read($afterFile), "<?php\n" . $printer->prettyPrint($ast) . "\n");
 	}
 
 }

--- a/tests/PHPStan/Parser/ParserTest.php
+++ b/tests/PHPStan/Parser/ParserTest.php
@@ -66,11 +66,11 @@ class ParserTest extends PHPStanTestCase
 		$parser = self::getContainer()->getService('currentPhpVersionSimpleParser');
 		$ast = $parser->parseFile($file);
 		$variadics = $ast[0]->getAttribute($attributeName);
-		$this->assertIsArray($variadics);
-		$this->assertCount(count($expectedVariadics), $variadics);
+		self::assertIsArray($variadics);
+		self::assertCount(count($expectedVariadics), $variadics);
 		foreach ($expectedVariadics as $key => $expectedVariadic) {
-			$this->assertArrayHasKey($key, $variadics);
-			$this->assertSame($expectedVariadic, $variadics[$key]);
+			self::assertArrayHasKey($key, $variadics);
+			self::assertSame($expectedVariadic, $variadics[$key]);
 		}
 	}
 
@@ -85,11 +85,11 @@ class ParserTest extends PHPStanTestCase
 		$parser = self::getContainer()->getService('currentPhpVersionRichParser');
 		$ast = $parser->parseFile($file);
 		$variadics = $ast[0]->getAttribute($attributeName);
-		$this->assertIsArray($variadics);
-		$this->assertCount(count($expectedVariadics), $variadics);
+		self::assertIsArray($variadics);
+		self::assertCount(count($expectedVariadics), $variadics);
 		foreach ($expectedVariadics as $key => $expectedVariadic) {
-			$this->assertArrayHasKey($key, $variadics);
-			$this->assertSame($expectedVariadic, $variadics[$key]);
+			self::assertArrayHasKey($key, $variadics);
+			self::assertSame($expectedVariadic, $variadics[$key]);
 		}
 	}
 

--- a/tests/PHPStan/Parser/RichParserTest.php
+++ b/tests/PHPStan/Parser/RichParserTest.php
@@ -323,8 +323,8 @@ class RichParserTest extends PHPStanTestCase
 		$parser = self::getContainer()->getService('currentPhpVersionRichParser');
 		$ast = $parser->parseString($code);
 		$lines = $ast[0]->getAttribute('linesToIgnore');
-		$this->assertNull($ast[0]->getAttribute('linesToIgnoreParseErrors'));
-		$this->assertSame($expectedLines, $lines);
+		self::assertNull($ast[0]->getAttribute('linesToIgnoreParseErrors'));
+		self::assertSame($expectedLines, $lines);
 	}
 
 	public static function dataLinesToIgnoreParseErrors(): iterable
@@ -536,12 +536,12 @@ class RichParserTest extends PHPStanTestCase
 		$parser = self::getContainer()->getService('currentPhpVersionRichParser');
 		$ast = $parser->parseString($code);
 		$errors = $ast[0]->getAttribute('linesToIgnoreParseErrors');
-		$this->assertIsArray($errors);
-		$this->assertSame($expectedErrors, $errors);
+		self::assertIsArray($errors);
+		self::assertSame($expectedErrors, $errors);
 
 		$lines = $ast[0]->getAttribute('linesToIgnore');
-		$this->assertIsArray($lines);
-		$this->assertCount(0, $lines);
+		self::assertIsArray($lines);
+		self::assertCount(0, $lines);
 	}
 
 }

--- a/tests/PHPStan/Php/PhpVersionFactoryTest.php
+++ b/tests/PHPStan/Php/PhpVersionFactoryTest.php
@@ -109,13 +109,13 @@ class PhpVersionFactoryTest extends TestCase
 	{
 		$factory = new PhpVersionFactory($versionId, $composerPhpVersion);
 		$phpVersion = $factory->create();
-		$this->assertSame($expectedVersion, $phpVersion->getVersionId());
+		self::assertSame($expectedVersion, $phpVersion->getVersionId());
 
 		if ($expectedVersionString === null) {
 			return;
 		}
 
-		$this->assertSame($expectedVersionString, $phpVersion->getVersionString());
+		self::assertSame($expectedVersionString, $phpVersion->getVersionString());
 	}
 
 }

--- a/tests/PHPStan/Php/PhpVersionsTest.php
+++ b/tests/PHPStan/Php/PhpVersionsTest.php
@@ -17,7 +17,7 @@ class PhpVersionsTest extends TestCase
 	public function testProducesWarningForFinalPrivateMethods(TrinaryLogic $expected, Type $versionType): void
 	{
 		$phpVersions = new PhpVersions($versionType);
-		$this->assertSame(
+		self::assertSame(
 			$expected->describe(),
 			$phpVersions->producesWarningForFinalPrivateMethods()->describe(),
 		);

--- a/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
+++ b/tests/PHPStan/PhpDoc/DefaultStubFilesProviderTest.php
@@ -27,8 +27,8 @@ class DefaultStubFilesProviderTest extends PHPStanTestCase
 		$stubFiles = $defaultStubFilesProvider->getStubFiles();
 
 		$fileHelper = new FileHelper(__DIR__);
-		$this->assertContains($fileHelper->normalizePath('/projectStub.stub'), $stubFiles);
-		$this->assertContains($fileHelper->normalizePath($thirdPartyStubFile), $stubFiles);
+		self::assertContains($fileHelper->normalizePath('/projectStub.stub'), $stubFiles);
+		self::assertContains($fileHelper->normalizePath($thirdPartyStubFile), $stubFiles);
 	}
 
 	public function testGetProjectStubFiles(): void
@@ -39,11 +39,11 @@ class DefaultStubFilesProviderTest extends PHPStanTestCase
 		$projectStubFiles = $defaultStubFilesProvider->getProjectStubFiles();
 
 		$fileHelper = new FileHelper(__DIR__);
-		$this->assertContains($fileHelper->normalizePath('/projectStub.stub'), $projectStubFiles);
-		$this->assertNotContains($thirdPartyStubFile, $projectStubFiles);
-		$this->assertNotContains($fileHelper->normalizePath($thirdPartyStubFile), $projectStubFiles);
-		$this->assertNotContains($firstPartyStubFile, $projectStubFiles);
-		$this->assertNotContains($fileHelper->normalizePath($firstPartyStubFile), $projectStubFiles);
+		self::assertContains($fileHelper->normalizePath('/projectStub.stub'), $projectStubFiles);
+		self::assertNotContains($thirdPartyStubFile, $projectStubFiles);
+		self::assertNotContains($fileHelper->normalizePath($thirdPartyStubFile), $projectStubFiles);
+		self::assertNotContains($firstPartyStubFile, $projectStubFiles);
+		self::assertNotContains($fileHelper->normalizePath($firstPartyStubFile), $projectStubFiles);
 	}
 
 	public function testGetProjectStubFilesWhenPathContainsWindowsSeparator(): void
@@ -53,9 +53,9 @@ class DefaultStubFilesProviderTest extends PHPStanTestCase
 		$projectStubFiles = $defaultStubFilesProvider->getProjectStubFiles();
 
 		$fileHelper = new FileHelper(__DIR__);
-		$this->assertContains($fileHelper->normalizePath('/projectStub.stub'), $projectStubFiles);
-		$this->assertNotContains($thirdPartyStubFile, $projectStubFiles);
-		$this->assertNotContains($fileHelper->normalizePath($thirdPartyStubFile), $projectStubFiles);
+		self::assertContains($fileHelper->normalizePath('/projectStub.stub'), $projectStubFiles);
+		self::assertNotContains($thirdPartyStubFile, $projectStubFiles);
+		self::assertNotContains($fileHelper->normalizePath($thirdPartyStubFile), $projectStubFiles);
 	}
 
 	/**

--- a/tests/PHPStan/PhpDoc/TypeDescriptionTest.php
+++ b/tests/PHPStan/PhpDoc/TypeDescriptionTest.php
@@ -75,21 +75,21 @@ class TypeDescriptionTest extends PHPStanTestCase
 	{
 		$typeStringResolver = self::getContainer()->getByType(TypeStringResolver::class);
 		$type = $typeStringResolver->resolve($description);
-		$this->assertTrue($expectedType->equals($type), sprintf('Parsing %s did not result in %s, but in %s', $description, $expectedType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())));
+		self::assertTrue($expectedType->equals($type), sprintf('Parsing %s did not result in %s, but in %s', $description, $expectedType->describe(VerbosityLevel::value()), $type->describe(VerbosityLevel::value())));
 
 		$newDescription = $type->describe(VerbosityLevel::value());
 		$newType = $typeStringResolver->resolve($newDescription);
-		$this->assertTrue($type->equals($newType), sprintf('Parsing %s again did not result in %s, but in %s', $newDescription, $type->describe(VerbosityLevel::value()), $newType->describe(VerbosityLevel::value())));
+		self::assertTrue($type->equals($newType), sprintf('Parsing %s again did not result in %s, but in %s', $newDescription, $type->describe(VerbosityLevel::value()), $newType->describe(VerbosityLevel::value())));
 	}
 
 	#[DataProvider('dataTest')]
 	public function testDesiredTypeDescription(string $description, Type $expectedType): void
 	{
-		$this->assertSame($description, $expectedType->describe(VerbosityLevel::value()));
+		self::assertSame($description, $expectedType->describe(VerbosityLevel::value()));
 
 		$typeStringResolver = self::getContainer()->getByType(TypeStringResolver::class);
 		$type = $typeStringResolver->resolve($description);
-		$this->assertSame($description, $type->describe(VerbosityLevel::value()));
+		self::assertSame($description, $type->describe(VerbosityLevel::value()));
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsMethodsClassReflectionExtensionTest.php
@@ -971,52 +971,52 @@ class AnnotationsMethodsClassReflectionExtensionTest extends PHPStanTestCase
 		$scope->method('getClassReflection')->willReturn($class);
 		$scope->method('canCallMethod')->willReturn(true);
 		foreach ($methods as $methodName => $expectedMethodData) {
-			$this->assertTrue($class->hasMethod($methodName), sprintf('Method %s() not found in class %s.', $methodName, $className));
+			self::assertTrue($class->hasMethod($methodName), sprintf('Method %s() not found in class %s.', $methodName, $className));
 
 			$method = $class->getMethod($methodName, $scope);
 			$selectedParametersAcceptor = $method->getOnlyVariant();
-			$this->assertSame(
+			self::assertSame(
 				$expectedMethodData['class'],
 				$method->getDeclaringClass()->getName(),
 				sprintf('Declaring class of method %s() does not match.', $methodName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedMethodData['returnType'],
 				$selectedParametersAcceptor->getReturnType()->describe(VerbosityLevel::precise()),
 				sprintf('Return type of method %s::%s() does not match', $className, $methodName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedMethodData['isStatic'],
 				$method->isStatic(),
 				sprintf('Scope of method %s::%s() does not match', $className, $methodName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedMethodData['isVariadic'],
 				$selectedParametersAcceptor->isVariadic(),
 				sprintf('Method %s::%s() does not match expected variadicity', $className, $methodName),
 			);
-			$this->assertCount(
+			self::assertCount(
 				count($expectedMethodData['parameters']),
 				$selectedParametersAcceptor->getParameters(),
 				sprintf('Method %s::%s() does not match expected count of parameters', $className, $methodName),
 			);
 			foreach ($selectedParametersAcceptor->getParameters() as $i => $parameter) {
-				$this->assertSame(
+				self::assertSame(
 					$expectedMethodData['parameters'][$i]['name'],
 					$parameter->getName(),
 				);
-				$this->assertSame(
+				self::assertSame(
 					$expectedMethodData['parameters'][$i]['type'],
 					$parameter->getType()->describe(VerbosityLevel::precise()),
 				);
-				$this->assertTrue(
+				self::assertTrue(
 					$expectedMethodData['parameters'][$i]['passedByReference']->equals($parameter->passedByReference()),
 				);
-				$this->assertSame(
+				self::assertSame(
 					$expectedMethodData['parameters'][$i]['isOptional'],
 					$parameter->isOptional(),
 				);
-				$this->assertSame(
+				self::assertSame(
 					$expectedMethodData['parameters'][$i]['isVariadic'],
 					$parameter->isVariadic(),
 				);
@@ -1028,8 +1028,8 @@ class AnnotationsMethodsClassReflectionExtensionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(Bar::class);
-		$this->assertTrue($class->hasNativeMethod('overridenMethodWithAnnotation'));
-		$this->assertInstanceOf(PhpMethodReflection::class, $class->getNativeMethod('overridenMethodWithAnnotation'));
+		self::assertTrue($class->hasNativeMethod('overridenMethodWithAnnotation'));
+		self::assertInstanceOf(PhpMethodReflection::class, $class->getNativeMethod('overridenMethodWithAnnotation'));
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Annotations/AnnotationsPropertiesClassReflectionExtensionTest.php
@@ -287,33 +287,33 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends PHPStanTestCase
 		$scope->method('canReadProperty')->willReturn(true);
 		$scope->method('canWriteProperty')->willReturn(true);
 		foreach ($properties as $propertyName => $expectedPropertyData) {
-			$this->assertTrue(
+			self::assertTrue(
 				$class->hasInstanceProperty($propertyName),
 				sprintf('Class %s does not define property %s.', $className, $propertyName),
 			);
 
 			$property = $class->getInstanceProperty($propertyName, $scope);
-			$this->assertSame(
+			self::assertSame(
 				$expectedPropertyData['class'],
 				$property->getDeclaringClass()->getName(),
 				sprintf('Declaring class of property $%s does not match.', $propertyName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedPropertyData['readableType'],
 				$property->getReadableType()->describe(VerbosityLevel::precise()),
 				sprintf('Readable type of property %s::$%s does not match.', $property->getDeclaringClass()->getName(), $propertyName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedPropertyData['writableType'],
 				$property->getWritableType()->describe(VerbosityLevel::precise()),
 				sprintf('Writable type of property %s::$%s does not match.', $property->getDeclaringClass()->getName(), $propertyName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedPropertyData['readable'],
 				$property->isReadable(),
 				sprintf('Property %s::$%s readability is not as expected.', $property->getDeclaringClass()->getName(), $propertyName),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedPropertyData['writable'],
 				$property->isWritable(),
 				sprintf('Property %s::$%s writability is not as expected.', $property->getDeclaringClass()->getName(), $propertyName),
@@ -325,8 +325,8 @@ class AnnotationsPropertiesClassReflectionExtensionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(Bar::class);
-		$this->assertTrue($class->hasNativeProperty('overridenPropertyWithAnnotation'));
-		$this->assertSame('AnnotationsProperties\Foo', $class->getNativeProperty('overridenPropertyWithAnnotation')->getReadableType()->describe(VerbosityLevel::precise()));
+		self::assertTrue($class->hasNativeProperty('overridenPropertyWithAnnotation'));
+		self::assertSame('AnnotationsProperties\Foo', $class->getNativeProperty('overridenPropertyWithAnnotation')->getReadableType()->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/DeprecatedAnnotationsTest.php
@@ -108,31 +108,31 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 		$scope->method('canReadProperty')->willReturn(true);
 		$scope->method('canWriteProperty')->willReturn(true);
 
-		$this->assertSame($deprecated, $class->isDeprecated());
-		$this->assertSame($classDeprecation, $class->getDeprecatedDescription());
+		self::assertSame($deprecated, $class->isDeprecated());
+		self::assertSame($classDeprecation, $class->getDeprecatedDescription());
 
 		foreach ($deprecatedAnnotations['method'] ?? [] as $methodName => $deprecatedMessage) {
 			$methodAnnotation = $class->getMethod($methodName, $scope);
-			$this->assertSame($deprecated, $methodAnnotation->isDeprecated()->yes());
-			$this->assertSame($deprecatedMessage, $methodAnnotation->getDeprecatedDescription());
+			self::assertSame($deprecated, $methodAnnotation->isDeprecated()->yes());
+			self::assertSame($deprecatedMessage, $methodAnnotation->getDeprecatedDescription());
 		}
 
 		foreach ($deprecatedAnnotations['property'] ?? [] as $propertyName => $deprecatedMessage) {
 			$propertyAnnotation = $class->getInstanceProperty($propertyName, $scope);
-			$this->assertSame($deprecated, $propertyAnnotation->isDeprecated()->yes());
-			$this->assertSame($deprecatedMessage, $propertyAnnotation->getDeprecatedDescription());
+			self::assertSame($deprecated, $propertyAnnotation->isDeprecated()->yes());
+			self::assertSame($deprecatedMessage, $propertyAnnotation->getDeprecatedDescription());
 		}
 
 		foreach ($deprecatedAnnotations['staticProperty'] ?? [] as $propertyName => $deprecatedMessage) {
 			$propertyAnnotation = $class->getStaticProperty($propertyName);
-			$this->assertSame($deprecated, $propertyAnnotation->isDeprecated()->yes());
-			$this->assertSame($deprecatedMessage, $propertyAnnotation->getDeprecatedDescription());
+			self::assertSame($deprecated, $propertyAnnotation->isDeprecated()->yes());
+			self::assertSame($deprecatedMessage, $propertyAnnotation->getDeprecatedDescription());
 		}
 
 		foreach ($deprecatedAnnotations['constant'] ?? [] as $constantName => $deprecatedMessage) {
 			$constantAnnotation = $class->getConstant($constantName);
-			$this->assertSame($deprecated, $constantAnnotation->isDeprecated()->yes());
-			$this->assertSame($deprecatedMessage, $constantAnnotation->getDeprecatedDescription());
+			self::assertSame($deprecated, $constantAnnotation->isDeprecated()->yes());
+			self::assertSame($deprecatedMessage, $constantAnnotation->getDeprecatedDescription());
 		}
 	}
 
@@ -142,33 +142,33 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertFalse($reflectionProvider->getFunction(new Name\FullyQualified('DeprecatedAnnotations\foo'), null)->isDeprecated()->yes());
-		$this->assertTrue($reflectionProvider->getFunction(new Name\FullyQualified('DeprecatedAnnotations\deprecatedFoo'), null)->isDeprecated()->yes());
+		self::assertFalse($reflectionProvider->getFunction(new Name\FullyQualified('DeprecatedAnnotations\foo'), null)->isDeprecated()->yes());
+		self::assertTrue($reflectionProvider->getFunction(new Name\FullyQualified('DeprecatedAnnotations\deprecatedFoo'), null)->isDeprecated()->yes());
 	}
 
 	public function testNonDeprecatedNativeFunctions(): void
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertFalse($reflectionProvider->getFunction(new Name('str_replace'), null)->isDeprecated()->yes());
-		$this->assertFalse($reflectionProvider->getFunction(new Name('get_class'), null)->isDeprecated()->yes());
-		$this->assertFalse($reflectionProvider->getFunction(new Name('function_exists'), null)->isDeprecated()->yes());
+		self::assertFalse($reflectionProvider->getFunction(new Name('str_replace'), null)->isDeprecated()->yes());
+		self::assertFalse($reflectionProvider->getFunction(new Name('get_class'), null)->isDeprecated()->yes());
+		self::assertFalse($reflectionProvider->getFunction(new Name('function_exists'), null)->isDeprecated()->yes());
 	}
 
 	public function testDeprecatedMethodsFromInterface(): void
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(DeprecatedBar::class);
-		$this->assertTrue($class->getNativeMethod('superDeprecated')->isDeprecated()->yes());
+		self::assertTrue($class->getNativeMethod('superDeprecated')->isDeprecated()->yes());
 	}
 
 	public function testNotDeprecatedChildMethods(): void
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertTrue($reflectionProvider->getClass(BazInterface::class)->getNativeMethod('superDeprecated')->isDeprecated()->yes());
-		$this->assertTrue($reflectionProvider->getClass(SubBazInterface::class)->getNativeMethod('superDeprecated')->isDeprecated()->no());
-		$this->assertTrue($reflectionProvider->getClass(Baz::class)->getNativeMethod('superDeprecated')->isDeprecated()->no());
+		self::assertTrue($reflectionProvider->getClass(BazInterface::class)->getNativeMethod('superDeprecated')->isDeprecated()->yes());
+		self::assertTrue($reflectionProvider->getClass(SubBazInterface::class)->getNativeMethod('superDeprecated')->isDeprecated()->no());
+		self::assertTrue($reflectionProvider->getClass(Baz::class)->getNativeMethod('superDeprecated')->isDeprecated()->no());
 	}
 
 	public static function dataDeprecatedAttributeAboveFunction(): iterable
@@ -210,8 +210,8 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 
 		$reflectionProvider = self::createReflectionProvider();
 		$function = $reflectionProvider->getFunction(new Name($functionName), null);
-		$this->assertSame($isDeprecated->describe(), $function->isDeprecated()->describe());
-		$this->assertSame($deprecatedDescription, $function->getDeprecatedDescription());
+		self::assertSame($isDeprecated->describe(), $function->isDeprecated()->describe());
+		self::assertSame($deprecatedDescription, $function->getDeprecatedDescription());
 	}
 
 	public static function dataDeprecatedAttributeAboveMethod(): iterable
@@ -248,8 +248,8 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
 		$method = $class->getNativeMethod($methodName);
-		$this->assertSame($isDeprecated->describe(), $method->isDeprecated()->describe());
-		$this->assertSame($deprecatedDescription, $method->getDeprecatedDescription());
+		self::assertSame($isDeprecated->describe(), $method->isDeprecated()->describe());
+		self::assertSame($deprecatedDescription, $method->getDeprecatedDescription());
 	}
 
 	public static function dataDeprecatedAttributeAboveClassConstant(): iterable
@@ -309,8 +309,8 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
 		$constant = $class->getConstant($constantName);
-		$this->assertSame($isDeprecated->describe(), $constant->isDeprecated()->describe());
-		$this->assertSame($deprecatedDescription, $constant->getDeprecatedDescription());
+		self::assertSame($isDeprecated->describe(), $constant->isDeprecated()->describe());
+		self::assertSame($deprecatedDescription, $constant->getDeprecatedDescription());
 	}
 
 	public static function dataDeprecatedAttributeAboveEnumCase(): iterable
@@ -342,8 +342,8 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass($className);
 		$case = $class->getEnumCase($caseName);
-		$this->assertSame($isDeprecated->describe(), $case->isDeprecated()->describe());
-		$this->assertSame($deprecatedDescription, $case->getDeprecatedDescription());
+		self::assertSame($isDeprecated->describe(), $case->isDeprecated()->describe());
+		self::assertSame($deprecatedDescription, $case->getDeprecatedDescription());
 	}
 
 	public static function dataDeprecatedAttributeAbovePropertyHook(): iterable
@@ -396,8 +396,8 @@ class DeprecatedAnnotationsTest extends PHPStanTestCase
 		$class = $reflectionProvider->getClass($className);
 		$property = $class->getNativeProperty($propertyName);
 		$hook = $property->getHook($hookName);
-		$this->assertSame($isDeprecated->describe(), $hook->isDeprecated()->describe());
-		$this->assertSame($deprecatedDescription, $hook->getDeprecatedDescription());
+		self::assertSame($isDeprecated->describe(), $hook->isDeprecated()->describe());
+		self::assertSame($deprecatedDescription, $hook->getDeprecatedDescription());
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/FinalAnnotationsTest.php
@@ -52,11 +52,11 @@ class FinalAnnotationsTest extends PHPStanTestCase
 		$scope->method('canReadProperty')->willReturn(true);
 		$scope->method('canWriteProperty')->willReturn(true);
 
-		$this->assertSame($final, $class->isFinal());
+		self::assertSame($final, $class->isFinal());
 
 		foreach ($finalAnnotations['method'] ?? [] as $methodName) {
 			$methodAnnotation = $class->getMethod($methodName, $scope);
-			$this->assertSame($final, $methodAnnotation->isFinal()->yes());
+			self::assertSame($final, $methodAnnotation->isFinal()->yes());
 		}
 	}
 

--- a/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/InternalAnnotationsTest.php
@@ -133,26 +133,26 @@ class InternalAnnotationsTest extends PHPStanTestCase
 		$scope->method('canReadProperty')->willReturn(true);
 		$scope->method('canWriteProperty')->willReturn(true);
 
-		$this->assertSame($internal, $class->isInternal());
+		self::assertSame($internal, $class->isInternal());
 
 		foreach ($internalAnnotations['method'] ?? [] as $methodName) {
 			$methodAnnotation = $class->getMethod($methodName, $scope);
-			$this->assertSame($internal, $methodAnnotation->isInternal()->yes());
+			self::assertSame($internal, $methodAnnotation->isInternal()->yes());
 		}
 
 		foreach ($internalAnnotations['property'] ?? [] as $propertyName) {
 			$propertyAnnotation = $class->getInstanceProperty($propertyName, $scope);
-			$this->assertSame($internal, $propertyAnnotation->isInternal()->yes());
+			self::assertSame($internal, $propertyAnnotation->isInternal()->yes());
 		}
 
 		foreach ($internalAnnotations['staticProperty'] ?? [] as $propertyName) {
 			$propertyAnnotation = $class->getStaticProperty($propertyName);
-			$this->assertSame($internal, $propertyAnnotation->isInternal()->yes());
+			self::assertSame($internal, $propertyAnnotation->isInternal()->yes());
 		}
 
 		foreach ($internalAnnotations['constant'] ?? [] as $constantName) {
 			$constantAnnotation = $class->getConstant($constantName);
-			$this->assertSame($internal, $constantAnnotation->isInternal()->yes());
+			self::assertSame($internal, $constantAnnotation->isInternal()->yes());
 		}
 	}
 
@@ -162,8 +162,8 @@ class InternalAnnotationsTest extends PHPStanTestCase
 
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertFalse($reflectionProvider->getFunction(new Name\FullyQualified('InternalAnnotations\foo'), null)->isInternal()->yes());
-		$this->assertTrue($reflectionProvider->getFunction(new Name\FullyQualified('InternalAnnotations\internalFoo'), null)->isInternal()->yes());
+		self::assertFalse($reflectionProvider->getFunction(new Name\FullyQualified('InternalAnnotations\foo'), null)->isInternal()->yes());
+		self::assertTrue($reflectionProvider->getFunction(new Name\FullyQualified('InternalAnnotations\internalFoo'), null)->isInternal()->yes());
 	}
 
 }

--- a/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
+++ b/tests/PHPStan/Reflection/Annotations/ThrowsAnnotationsTest.php
@@ -81,7 +81,7 @@ class ThrowsAnnotationsTest extends PHPStanTestCase
 		foreach ($throwsAnnotations as $methodName => $type) {
 			$methodAnnotation = $class->getMethod($methodName, $scope);
 			$throwType = $methodAnnotation->getThrowType();
-			$this->assertSame($type, $throwType !== null ? $throwType->describe(VerbosityLevel::typeOnly()) : null);
+			self::assertSame($type, $throwType !== null ? $throwType->describe(VerbosityLevel::typeOnly()) : null);
 		}
 	}
 
@@ -91,11 +91,11 @@ class ThrowsAnnotationsTest extends PHPStanTestCase
 
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertNull($reflectionProvider->getFunction(new Name\FullyQualified('ThrowsAnnotations\withoutThrows'), null)->getThrowType());
+		self::assertNull($reflectionProvider->getFunction(new Name\FullyQualified('ThrowsAnnotations\withoutThrows'), null)->getThrowType());
 
 		$throwType = $reflectionProvider->getFunction(new Name\FullyQualified('ThrowsAnnotations\throwsRuntime'), null)->getThrowType();
-		$this->assertNotNull($throwType);
-		$this->assertSame(RuntimeException::class, $throwType->describe(VerbosityLevel::typeOnly()));
+		self::assertNotNull($throwType);
+		self::assertSame(RuntimeException::class, $throwType->describe(VerbosityLevel::typeOnly()));
 	}
 
 }

--- a/tests/PHPStan/Reflection/AttributeReflectionTest.php
+++ b/tests/PHPStan/Reflection/AttributeReflectionTest.php
@@ -269,17 +269,17 @@ class AttributeReflectionTest extends PHPStanTestCase
 		array $expectations,
 	): void
 	{
-		$this->assertCount(count($expectations), $attributeReflections);
+		self::assertCount(count($expectations), $attributeReflections);
 		foreach ($expectations as $i => [$name, $argumentTypes]) {
 			$attribute = $attributeReflections[$i];
-			$this->assertSame($name, $attribute->getName());
+			self::assertSame($name, $attribute->getName());
 
 			$attributeArgumentTypes = $attribute->getArgumentTypes();
-			$this->assertCount(count($argumentTypes), $attributeArgumentTypes);
+			self::assertCount(count($argumentTypes), $attributeArgumentTypes);
 
 			foreach ($argumentTypes as $argumentName => $argumentType) {
-				$this->assertArrayHasKey($argumentName, $attributeArgumentTypes);
-				$this->assertSame($argumentType, $attributeArgumentTypes[$argumentName]->describe(VerbosityLevel::precise()));
+				self::assertArrayHasKey($argumentName, $attributeArgumentTypes);
+				self::assertSame($argumentType, $attributeArgumentTypes[$argumentName]->describe(VerbosityLevel::precise()));
 			}
 		}
 	}

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/AutoloadSourceLocatorTest.php
@@ -25,48 +25,48 @@ class AutoloadSourceLocatorTest extends PHPStanTestCase
 		$locator = new AutoloadSourceLocator(self::getContainer()->getByType(FileNodesFetcher::class), true);
 		$reflector = new DefaultReflector($locator);
 		$aFoo = $reflector->reflectClass(AFoo::class);
-		$this->assertNotNull($aFoo->getFileName());
-		$this->assertSame('a.php', basename($aFoo->getFileName()));
+		self::assertNotNull($aFoo->getFileName());
+		self::assertSame('a.php', basename($aFoo->getFileName()));
 
 		$testFunctionReflection = $reflector->reflectFunction('PHPStan\\Reflection\\BetterReflection\\SourceLocator\testFunctionForLocator');
-		$this->assertSame(str_replace('\\', '/', __FILE__), $testFunctionReflection->getFileName());
+		self::assertSame(str_replace('\\', '/', __FILE__), $testFunctionReflection->getFileName());
 
 		$someConstant = $reflector->reflectConstant('TestSingleFileSourceLocator\\SOME_CONSTANT');
-		$this->assertNotNull($someConstant->getFileName());
-		$this->assertSame('a.php', basename($someConstant->getFileName()));
+		self::assertNotNull($someConstant->getFileName());
+		self::assertSame('a.php', basename($someConstant->getFileName()));
 
 		$initializerExprTypeResolver = self::getContainer()->getByType(InitializerExprTypeResolver::class);
 		$someConstantValue = $initializerExprTypeResolver->getType(
 			$someConstant->getValueExpression(),
 			InitializerExprContext::fromGlobalConstant($someConstant),
 		);
-		$this->assertInstanceOf(ConstantIntegerType::class, $someConstantValue);
-		$this->assertSame(1, $someConstantValue->getValue());
+		self::assertInstanceOf(ConstantIntegerType::class, $someConstantValue);
+		self::assertSame(1, $someConstantValue->getValue());
 
 		$anotherConstant = $reflector->reflectConstant('TestSingleFileSourceLocator\\ANOTHER_CONSTANT');
-		$this->assertNotNull($anotherConstant->getFileName());
-		$this->assertSame('a.php', basename($anotherConstant->getFileName()));
+		self::assertNotNull($anotherConstant->getFileName());
+		self::assertSame('a.php', basename($anotherConstant->getFileName()));
 		$anotherConstantValue = $initializerExprTypeResolver->getType(
 			$anotherConstant->getValueExpression(),
 			InitializerExprContext::fromGlobalConstant($anotherConstant),
 		);
-		$this->assertInstanceOf(ConstantIntegerType::class, $anotherConstantValue);
-		$this->assertSame(2, $anotherConstantValue->getValue());
+		self::assertInstanceOf(ConstantIntegerType::class, $anotherConstantValue);
+		self::assertSame(2, $anotherConstantValue->getValue());
 
 		$doFooFunctionReflection = $reflector->reflectFunction('TestSingleFileSourceLocator\\doFoo');
-		$this->assertSame('TestSingleFileSourceLocator\\doFoo', $doFooFunctionReflection->getName());
-		$this->assertNotNull($doFooFunctionReflection->getFileName());
-		$this->assertSame('a.php', basename($doFooFunctionReflection->getFileName()));
+		self::assertSame('TestSingleFileSourceLocator\\doFoo', $doFooFunctionReflection->getName());
+		self::assertNotNull($doFooFunctionReflection->getFileName());
+		self::assertSame('a.php', basename($doFooFunctionReflection->getFileName()));
 
 		class_exists(InCondition::class);
 		$classInCondition = $reflector->reflectClass(InCondition::class);
 		$classInConditionFilename = $classInCondition->getFileName();
-		$this->assertNotNull($classInConditionFilename);
-		$this->assertSame('a.php', basename($classInConditionFilename));
-		$this->assertSame(InCondition::class, $classInCondition->getName());
-		$this->assertSame(25, $classInCondition->getStartLine());
-		$this->assertInstanceOf(ReflectionClass::class, $classInCondition->getParentClass());
-		$this->assertSame(AFoo::class, $classInCondition->getParentClass()->getName());
+		self::assertNotNull($classInConditionFilename);
+		self::assertSame('a.php', basename($classInConditionFilename));
+		self::assertSame(InCondition::class, $classInCondition->getName());
+		self::assertSame(25, $classInCondition->getStartLine());
+		self::assertInstanceOf(ReflectionClass::class, $classInCondition->getParentClass());
+		self::assertSame(AFoo::class, $classInCondition->getParentClass()->getName());
 	}
 
 	public function testClassAlias(): void
@@ -75,7 +75,7 @@ class AutoloadSourceLocatorTest extends PHPStanTestCase
 		$locator = new AutoloadSourceLocator(self::getContainer()->getByType(FileNodesFetcher::class), true);
 		$reflector = new DefaultReflector($locator);
 		$class = $reflector->reflectClass('A_Foo');
-		$this->assertSame(AFoo::class, $class->getName());
+		self::assertSame(AFoo::class, $class->getName());
 	}
 
 }

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorTest.php
@@ -78,9 +78,9 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 		$locator = $factory->createByDirectory(__DIR__ . '/data/directory');
 		$reflector = new DefaultReflector($locator);
 		$classReflection = $reflector->reflectClass($className);
-		$this->assertSame($expectedClassName, $classReflection->getName());
-		$this->assertNotNull($classReflection->getFileName());
-		$this->assertSame($file, basename($classReflection->getFileName()));
+		self::assertSame($expectedClassName, $classReflection->getName());
+		self::assertNotNull($classReflection->getFileName());
+		self::assertSame($file, basename($classReflection->getFileName()));
 	}
 
 	public static function dataFunctionExists(): array
@@ -136,9 +136,9 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 		$locator = $factory->createByDirectory(__DIR__ . '/data/directory');
 		$reflector = new DefaultReflector($locator);
 		$functionReflection = $reflector->reflectFunction($functionName);
-		$this->assertSame($expectedFunctionName, $functionReflection->getName());
-		$this->assertNotNull($functionReflection->getFileName());
-		$this->assertSame($file, basename($functionReflection->getFileName()));
+		self::assertSame($expectedFunctionName, $functionReflection->getName());
+		self::assertNotNull($functionReflection->getFileName());
+		self::assertSame($file, basename($functionReflection->getFileName()));
 	}
 
 	public static function dataConstant(): iterable
@@ -212,8 +212,8 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 		} else {
 			$constantReflection = $reflector->reflectConstant($constantName);
 
-			$this->assertNotNull($constantReflection->getFileName());
-			$this->assertSame($expectedFile, basename($constantReflection->getFileName()));
+			self::assertNotNull($constantReflection->getFileName());
+			self::assertSame($expectedFile, basename($constantReflection->getFileName()));
 		}
 	}
 
@@ -244,7 +244,7 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 		}
 
 		$actualClasses = array_map(static fn (Reflection $reflection) => $reflection->getName(), $classIdentifiers);
-		$this->assertEqualsCanonicalizing($expectedClasses, $actualClasses);
+		self::assertEqualsCanonicalizing($expectedClasses, $actualClasses);
 
 		$functionIdentifiers = $locator->locateIdentifiersByType(
 			$reflector,
@@ -253,7 +253,7 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 
 		$actualFunctions = array_map(static fn (Reflection $reflection) => $reflection->getName(), $functionIdentifiers);
 
-		$this->assertEqualsCanonicalizing([
+		self::assertEqualsCanonicalizing([
 			'TestDirectorySourceLocator\doLorem',
 			'OptimizedDirectory\doBar',
 			'OptimizedDirectory\doBaz',
@@ -269,7 +269,7 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 
 		$actualConstants = array_map(static fn (Reflection $reflection) => $reflection->getName(), $constantIdentifiers);
 
-		$this->assertEqualsCanonicalizing([
+		self::assertEqualsCanonicalizing([
 			'NOTHING',
 			'OptimizedDirectory\SOMETHING',
 			'OptimizedDirectory2\ANYTHING',
@@ -314,7 +314,7 @@ class OptimizedDirectorySourceLocatorTest extends PHPStanTestCase
 
 		/** @var string $className */
 		$className = $class->getName();
-		$this->assertSame('Faker\\Provider\\nl_BE\\Text', $className);
+		self::assertSame('Faker\\Provider\\nl_BE\\Text', $className);
 	}
 
 }

--- a/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
+++ b/tests/PHPStan/Reflection/BetterReflection/SourceLocator/OptimizedSingleFileSourceLocatorTest.php
@@ -135,7 +135,7 @@ class OptimizedSingleFileSourceLocatorTest extends PHPStanTestCase
 		$locator = $factory->create($file);
 		$reflector = new DefaultReflector($locator);
 		$classReflection = $reflector->reflectClass($className);
-		$this->assertSame($expectedClassName, $classReflection->getName());
+		self::assertSame($expectedClassName, $classReflection->getName());
 	}
 
 	public static function dataFunction(): array
@@ -171,7 +171,7 @@ class OptimizedSingleFileSourceLocatorTest extends PHPStanTestCase
 		$locator = $factory->create($file);
 		$reflector = new DefaultReflector($locator);
 		$functionReflection = $reflector->reflectFunction($functionName);
-		$this->assertSame($expectedFunctionName, $functionReflection->getName());
+		self::assertSame($expectedFunctionName, $functionReflection->getName());
 	}
 
 	public static function dataConst(): array
@@ -207,14 +207,14 @@ class OptimizedSingleFileSourceLocatorTest extends PHPStanTestCase
 		$locator = $factory->create(__DIR__ . '/data/const.php');
 		$reflector = new DefaultReflector($locator);
 		$constant = $reflector->reflectConstant($constantName);
-		$this->assertSame($constantName, $constant->getName());
+		self::assertSame($constantName, $constant->getName());
 
 		$initializerExprTypeResolver = self::getContainer()->getByType(InitializerExprTypeResolver::class);
 		$valueType = $initializerExprTypeResolver->getType(
 			$constant->getValueExpression(),
 			InitializerExprContext::fromGlobalConstant($constant),
 		);
-		$this->assertSame($valueTypeDescription, $valueType->describe(VerbosityLevel::precise()));
+		self::assertSame($valueTypeDescription, $valueType->describe(VerbosityLevel::precise()));
 	}
 
 	public static function dataConstUnknown(): array
@@ -255,7 +255,7 @@ class OptimizedSingleFileSourceLocatorTest extends PHPStanTestCase
 		);
 
 		$actualIdentifiers = array_map(static fn (Reflection $reflection) => $reflection->getName(), $reflections);
-		$this->assertEqualsCanonicalizing($expectedIdentifiers, $actualIdentifiers);
+		self::assertEqualsCanonicalizing($expectedIdentifiers, $actualIdentifiers);
 	}
 
 }

--- a/tests/PHPStan/Reflection/ClassReflectionPropertyHooksTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionPropertyHooksTest.php
@@ -342,15 +342,15 @@ class ClassReflectionPropertyHooksTest extends PHPStanTestCase
 	): void
 	{
 		$propertyReflection = $classReflection->getNativeProperty($propertyName);
-		$this->assertSame($isVirtual, $propertyReflection->isVirtual()->yes());
+		self::assertSame($isVirtual, $propertyReflection->isVirtual()->yes());
 
 		$hookReflection = $propertyReflection->getHook($hookName);
 		$hookVariant = $hookReflection->getOnlyVariant();
-		$this->assertSame($returnType, $hookVariant->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertCount(count($parameterTypes), $hookVariant->getParameters());
+		self::assertSame($returnType, $hookVariant->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertCount(count($parameterTypes), $hookVariant->getParameters());
 
 		foreach ($hookVariant->getParameters() as $i => $parameter) {
-			$this->assertSame($parameterTypes[$i], $parameter->getType()->describe(VerbosityLevel::precise()));
+			self::assertSame($parameterTypes[$i], $parameter->getType()->describe(VerbosityLevel::precise()));
 		}
 	}
 

--- a/tests/PHPStan/Reflection/ClassReflectionTest.php
+++ b/tests/PHPStan/Reflection/ClassReflectionTest.php
@@ -58,7 +58,7 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$classReflection = $reflectionProvider->getClass($className);
-		$this->assertSame($has, $classReflection->hasTraitUse(FooTrait::class));
+		self::assertSame($has, $classReflection->hasTraitUse(FooTrait::class));
 	}
 
 	public static function dataClassHierarchyDistances(): array
@@ -105,7 +105,7 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$classReflection = $reflectionProvider->getClass($class);
-		$this->assertSame(
+		self::assertSame(
 			$expectedDistances,
 			$classReflection->getClassHierarchyDistances(),
 		);
@@ -117,7 +117,7 @@ class ClassReflectionTest extends PHPStanTestCase
 		$fooReflection = $reflectionProvider->getClass(Foo::class);
 		$variadicMethod = $fooReflection->getNativeMethod('variadicMethod');
 		$methodVariant = $variadicMethod->getOnlyVariant();
-		$this->assertTrue($methodVariant->isVariadic());
+		self::assertTrue($methodVariant->isVariadic());
 	}
 
 	public function testGenericInheritance(): void
@@ -125,14 +125,14 @@ class ClassReflectionTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$reflection = $reflectionProvider->getClass(C::class);
 
-		$this->assertSame('GenericInheritance\\C', $reflection->getDisplayName());
+		self::assertSame('GenericInheritance\\C', $reflection->getDisplayName());
 
 		$parent = $reflection->getParentClass();
-		$this->assertNotNull($parent);
+		self::assertNotNull($parent);
 
-		$this->assertSame('GenericInheritance\\C0<DateTime>', $parent->getDisplayName());
+		self::assertSame('GenericInheritance\\C0<DateTime>', $parent->getDisplayName());
 
-		$this->assertSame([
+		self::assertSame([
 			'GenericInheritance\\I<DateTime>',
 			'GenericInheritance\\I0<DateTime>',
 			'GenericInheritance\\I1<int>',
@@ -143,7 +143,7 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$reflection = $reflectionProvider->getClass(ReflectionClass::class);
-		$this->assertTrue($reflection->isGeneric());
+		self::assertTrue($reflection->isGeneric());
 	}
 
 	public static function dataIsAttributeClass(): array
@@ -176,11 +176,11 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$reflection = $reflectionProvider->getClass($className);
-		$this->assertSame($expected, $reflection->isAttributeClass());
+		self::assertSame($expected, $reflection->isAttributeClass());
 		if (!$expected) {
 			return;
 		}
-		$this->assertSame($expectedFlags, $reflection->getAttributeClassFlags());
+		self::assertSame($expectedFlags, $reflection->getAttributeClassFlags());
 	}
 
 	public function testDeprecatedConstantFromAnotherFile(): void
@@ -188,7 +188,7 @@ class ClassReflectionTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$reflection = $reflectionProvider->getClass(SecuredRouter::class);
 		$constant = $reflection->getConstant('SECURED');
-		$this->assertTrue($constant->isDeprecated()->yes());
+		self::assertTrue($constant->isDeprecated()->yes());
 	}
 
 	/**
@@ -200,7 +200,7 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertSame(
+		self::assertSame(
 			array_map(
 				static fn (ClassReflection $classReflection): string => $classReflection->getNativeReflection()->getName(),
 				$reflectionProvider->getClass($className)->getTraits($recursive),
@@ -289,12 +289,12 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$enum = $reflectionProvider->getClass('PHPStan\Fixture\TestEnum');
-		$this->assertTrue($enum->isEnum());
+		self::assertTrue($enum->isEnum());
 
 		// @phpstan-ignore-next-line Exact error differs on PHP 7.4 and others
-		$this->assertInstanceOf('ReflectionEnum', $enum->getNativeReflection());
-		$this->assertTrue($enum->isFinal());
-		$this->assertTrue($enum->isFinalByKeyword());
+		self::assertInstanceOf('ReflectionEnum', $enum->getNativeReflection());
+		self::assertTrue($enum->isFinal());
+		self::assertTrue($enum->isFinalByKeyword());
 	}
 
 	#[RequiresPhp('>= 8.1')]
@@ -302,7 +302,7 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$enum = $reflectionProvider->getClass('PHPStan\Fixture\TestEnum');
-		$this->assertInstanceOf(IntegerType::class, $enum->getBackedEnumType());
+		self::assertInstanceOf(IntegerType::class, $enum->getBackedEnumType());
 	}
 
 	public function testIs(): void
@@ -312,10 +312,10 @@ class ClassReflectionTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$classReflection = $reflectionProvider->getClass($className);
 
-		$this->assertTrue($classReflection->is($className));
-		$this->assertTrue($classReflection->is(PHPStanTestCase::class));
-		$this->assertTrue($classReflection->is(TestCase::class));
-		$this->assertFalse($classReflection->is(RuleTestCase::class));
+		self::assertTrue($classReflection->is($className));
+		self::assertTrue($classReflection->is(PHPStanTestCase::class));
+		self::assertTrue($classReflection->is(TestCase::class));
+		self::assertFalse($classReflection->is(RuleTestCase::class));
 	}
 
 	public static function dataDeprecatedAttribute(): iterable
@@ -329,7 +329,7 @@ class ClassReflectionTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$classReflection = $reflectionProvider->getClass($className);
-		$this->assertSame($expected, $classReflection->isDeprecated());
+		self::assertSame($expected, $classReflection->isDeprecated());
 	}
 
 }

--- a/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
+++ b/tests/PHPStan/Reflection/Constant/RuntimeConstantReflectionTest.php
@@ -49,9 +49,9 @@ class RuntimeConstantReflectionTest extends PHPStanTestCase
 
 		$reflectionProvider = self::createReflectionProvider();
 
-		$this->assertTrue($reflectionProvider->hasConstant($constName, null));
-		$this->assertSame($isDeprecated->describe(), $reflectionProvider->getConstant($constName, null)->isDeprecated()->describe());
-		$this->assertSame($deprecationMessage, $reflectionProvider->getConstant($constName, null)->getDeprecatedDescription());
+		self::assertTrue($reflectionProvider->hasConstant($constName, null));
+		self::assertSame($isDeprecated->describe(), $reflectionProvider->getConstant($constName, null)->isDeprecated()->describe());
+		self::assertSame($deprecationMessage, $reflectionProvider->getConstant($constName, null)->getDeprecatedDescription());
 	}
 
 }

--- a/tests/PHPStan/Reflection/FunctionReflectionTest.php
+++ b/tests/PHPStan/Reflection/FunctionReflectionTest.php
@@ -47,7 +47,7 @@ class FunctionReflectionTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 
 		$functionReflection = $reflectionProvider->getFunction(new Node\Name($functionName), null);
-		$this->assertSame($expectedDoc, $functionReflection->getDocComment());
+		self::assertSame($expectedDoc, $functionReflection->getDocComment());
 	}
 
 	public static function dataPhpdocMethods(): iterable
@@ -128,7 +128,7 @@ class FunctionReflectionTest extends PHPStanTestCase
 		$classReflection = $reflectionProvider->getClass($className);
 
 		$methodReflection = $classReflection->getMethod($methodName, $scope);
-		$this->assertSame($expectedDocComment, $methodReflection->getDocComment());
+		self::assertSame($expectedDocComment, $methodReflection->getDocComment());
 	}
 
 	public static function dataFunctionReturnsByReference(): iterable
@@ -150,7 +150,7 @@ class FunctionReflectionTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 
 		$functionReflection = $reflectionProvider->getFunction(new Node\Name($functionName), null);
-		$this->assertSame($expectedReturnsByRef, $functionReflection->returnsByReference());
+		self::assertSame($expectedReturnsByRef, $functionReflection->returnsByReference());
 	}
 
 	public static function dataMethodReturnsByReference(): iterable
@@ -189,7 +189,7 @@ class FunctionReflectionTest extends PHPStanTestCase
 		$classReflection = $reflectionProvider->getClass($className);
 
 		$methodReflection = $classReflection->getMethod($methodName, $scope);
-		$this->assertSame($expectedReturnsByRef, $methodReflection->returnsByReference());
+		self::assertSame($expectedReturnsByRef, $methodReflection->returnsByReference());
 	}
 
 	/**

--- a/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
+++ b/tests/PHPStan/Reflection/GenericParametersAcceptorResolverTest.php
@@ -434,12 +434,12 @@ class GenericParametersAcceptorResolverTest extends PHPStanTestCase
 			$parametersAcceptor,
 		);
 
-		$this->assertInstanceOf(
+		self::assertInstanceOf(
 			get_class($expectedResult->getReturnType()),
 			$result->getReturnType(),
 			'Unexpected return type',
 		);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->getReturnType()->describe(VerbosityLevel::precise()),
 			$result->getReturnType()->describe(VerbosityLevel::precise()),
 			'Unexpected return type',
@@ -448,15 +448,15 @@ class GenericParametersAcceptorResolverTest extends PHPStanTestCase
 		$resultParameters = $result->getParameters();
 		$expectedParameters = $expectedResult->getParameters();
 
-		$this->assertCount(count($expectedParameters), $resultParameters);
+		self::assertCount(count($expectedParameters), $resultParameters);
 
 		foreach ($expectedParameters as $i => $param) {
-			$this->assertInstanceOf(
+			self::assertInstanceOf(
 				get_class($param->getType()),
 				$resultParameters[$i]->getType(),
 				sprintf('Unexpected parameter %d', $i + 1),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$param->getType()->describe(VerbosityLevel::precise()),
 				$resultParameters[$i]->getType()->describe(VerbosityLevel::precise()),
 				sprintf('Unexpected parameter %d', $i + 1),

--- a/tests/PHPStan/Reflection/InitializerExprTypeResolverTest.php
+++ b/tests/PHPStan/Reflection/InitializerExprTypeResolverTest.php
@@ -115,7 +115,7 @@ class InitializerExprTypeResolverTest extends PHPStanTestCase
 			$right,
 			$callback,
 		);
-		$this->assertInstanceOf($resultClass, $result);
+		self::assertInstanceOf($resultClass, $result);
 
 		if (!($result instanceof NeverType)) {
 			return;
@@ -124,7 +124,7 @@ class InitializerExprTypeResolverTest extends PHPStanTestCase
 		if ($resultIsExplicit === null) {
 			throw new ShouldNotHappenException();
 		}
-		$this->assertSame($resultIsExplicit, $result->isExplicit());
+		self::assertSame($resultIsExplicit, $result->isExplicit());
 	}
 
 }

--- a/tests/PHPStan/Reflection/MixedTypeTest.php
+++ b/tests/PHPStan/Reflection/MixedTypeTest.php
@@ -20,28 +20,28 @@ class MixedTypeTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(Foo::class);
 		$propertyType = $class->getNativeProperty('fooProp')->getNativeType();
-		$this->assertInstanceOf(MixedType::class, $propertyType);
-		$this->assertTrue($propertyType->isExplicitMixed());
+		self::assertInstanceOf(MixedType::class, $propertyType);
+		self::assertTrue($propertyType->isExplicitMixed());
 
 		$method = $class->getNativeMethod('doFoo');
 		$methodVariant = $method->getOnlyVariant();
 		$methodReturnType = $methodVariant->getReturnType();
-		$this->assertInstanceOf(MixedType::class, $methodReturnType);
-		$this->assertTrue($methodReturnType->isExplicitMixed());
+		self::assertInstanceOf(MixedType::class, $methodReturnType);
+		self::assertTrue($methodReturnType->isExplicitMixed());
 
 		$methodParameterType = $methodVariant->getParameters()[0]->getType();
-		$this->assertInstanceOf(MixedType::class, $methodParameterType);
-		$this->assertTrue($methodParameterType->isExplicitMixed());
+		self::assertInstanceOf(MixedType::class, $methodParameterType);
+		self::assertTrue($methodParameterType->isExplicitMixed());
 
 		$function = $reflectionProvider->getFunction(new Name('NativeMixedType\doFoo'), null);
 		$functionVariant = $function->getOnlyVariant();
 		$functionReturnType = $functionVariant->getReturnType();
-		$this->assertInstanceOf(MixedType::class, $functionReturnType);
-		$this->assertTrue($functionReturnType->isExplicitMixed());
+		self::assertInstanceOf(MixedType::class, $functionReturnType);
+		self::assertTrue($functionReturnType->isExplicitMixed());
 
 		$functionParameterType = $functionVariant->getParameters()[0]->getType();
-		$this->assertInstanceOf(MixedType::class, $functionParameterType);
-		$this->assertTrue($functionParameterType->isExplicitMixed());
+		self::assertInstanceOf(MixedType::class, $functionParameterType);
+		self::assertTrue($functionParameterType->isExplicitMixed());
 	}
 
 }

--- a/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
+++ b/tests/PHPStan/Reflection/ParametersAcceptorSelectorTest.php
@@ -483,43 +483,43 @@ class ParametersAcceptorSelectorTest extends PHPStanTestCase
 	): void
 	{
 		$selectedAcceptor = ParametersAcceptorSelector::selectFromTypes($types, $variants, $unpack);
-		$this->assertCount(count($expected->getParameters()), $selectedAcceptor->getParameters());
+		self::assertCount(count($expected->getParameters()), $selectedAcceptor->getParameters());
 		foreach ($selectedAcceptor->getParameters() as $i => $parameter) {
 			$expectedParameter = $expected->getParameters()[$i];
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameter->getName(),
 				$parameter->getName(),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameter->isOptional(),
 				$parameter->isOptional(),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameter->getType()->describe(VerbosityLevel::precise()),
 				$parameter->getType()->describe(VerbosityLevel::precise()),
 			);
-			$this->assertTrue(
+			self::assertTrue(
 				$expectedParameter->passedByReference()->equals($parameter->passedByReference()),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameter->isVariadic(),
 				$parameter->isVariadic(),
 			);
 			if ($expectedParameter->getDefaultValue() === null) {
-				$this->assertNull($parameter->getDefaultValue());
+				self::assertNull($parameter->getDefaultValue());
 			} else {
-				$this->assertSame(
+				self::assertSame(
 					$expectedParameter->getDefaultValue()->describe(VerbosityLevel::precise()),
 					$parameter->getDefaultValue() !== null ? $parameter->getDefaultValue()->describe(VerbosityLevel::precise()) : null,
 				);
 			}
 		}
 
-		$this->assertSame(
+		self::assertSame(
 			$expected->getReturnType()->describe(VerbosityLevel::precise()),
 			$selectedAcceptor->getReturnType()->describe(VerbosityLevel::precise()),
 		);
-		$this->assertSame($expected->isVariadic(), $selectedAcceptor->isVariadic());
+		self::assertSame($expected->isVariadic(), $selectedAcceptor->isVariadic());
 	}
 
 }

--- a/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
+++ b/tests/PHPStan/Reflection/Php/UniversalObjectCratesClassReflectionExtensionTest.php
@@ -19,7 +19,7 @@ class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 			['NonexistentClass', 'stdClass'],
 			new AnnotationsPropertiesClassReflectionExtension(),
 		);
-		$this->assertTrue($extension->hasProperty($reflectionProvider->getClass(stdClass::class), 'foo'));
+		self::assertTrue($extension->hasProperty($reflectionProvider->getClass(stdClass::class), 'foo'));
 	}
 
 	public function testDifferentGetSetType(): void
@@ -33,13 +33,13 @@ class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 			new AnnotationsPropertiesClassReflectionExtension(),
 		);
 
-		$this->assertEquals(
+		self::assertEquals(
 			new ObjectType('UniversalObjectCreates\DifferentGetSetTypesValue'),
 			$extension
 				->getProperty($reflectionProvider->getClass('UniversalObjectCreates\DifferentGetSetTypes'), 'foo')
 				->getReadableType(),
 		);
-		$this->assertEquals(
+		self::assertEquals(
 			new StringType(),
 			$extension
 				->getProperty($reflectionProvider->getClass('UniversalObjectCreates\DifferentGetSetTypes'), 'foo')
@@ -59,13 +59,13 @@ class UniversalObjectCratesClassReflectionExtensionTest extends PHPStanTestCase
 			new AnnotationsPropertiesClassReflectionExtension(),
 		);
 
-		$this->assertEquals(
+		self::assertEquals(
 			new StringType(),
 			$extension
 				->getProperty($reflectionProvider->getClass($className), 'foo')
 				->getReadableType(),
 		);
-		$this->assertEquals(
+		self::assertEquals(
 			new StringType(),
 			$extension
 				->getProperty($reflectionProvider->getClass($className), 'foo')

--- a/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderGoldenTest.php
@@ -70,7 +70,7 @@ class ReflectionProviderGoldenTest extends PHPStanTestCase
 	{
 		$output = self::generateSymbolDescription($input);
 		$output = trim($output);
-		$this->assertSame($expectedOutput, $output);
+		self::assertSame($expectedOutput, $output);
 	}
 
 	private static function generateSymbolDescription(string $symbol): string

--- a/tests/PHPStan/Reflection/ReflectionProviderTest.php
+++ b/tests/PHPStan/Reflection/ReflectionProviderTest.php
@@ -61,11 +61,11 @@ class ReflectionProviderTest extends PHPStanTestCase
 		$function = $reflectionProvider->getFunction(new Name($functionName), null);
 		$throwType = $function->getThrowType();
 		if ($expectedThrowType === null) {
-			$this->assertNull($throwType);
+			self::assertNull($throwType);
 			return;
 		}
-		$this->assertNotNull($throwType);
-		$this->assertSame(
+		self::assertNotNull($throwType);
+		self::assertSame(
 			$expectedThrowType->describe(VerbosityLevel::precise()),
 			$throwType->describe(VerbosityLevel::precise()),
 		);
@@ -105,7 +105,7 @@ class ReflectionProviderTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$function = $reflectionProvider->getFunction(new Name($functionName), null);
-		$this->assertEquals(TrinaryLogic::createFromBoolean($isDeprecated), $function->isDeprecated());
+		self::assertEquals(TrinaryLogic::createFromBoolean($isDeprecated), $function->isDeprecated());
 	}
 
 	public static function dataConstantDeprecated(): iterable
@@ -135,7 +135,7 @@ class ReflectionProviderTest extends PHPStanTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$constant = $reflectionProvider->getConstant(new Name($constantName), null);
-		$this->assertSame(TrinaryLogic::createFromBoolean($isDeprecated)->describe(), $constant->isDeprecated()->describe());
+		self::assertSame(TrinaryLogic::createFromBoolean($isDeprecated)->describe(), $constant->isDeprecated()->describe());
 	}
 
 	public static function dataMethodThrowType(): array
@@ -162,11 +162,11 @@ class ReflectionProviderTest extends PHPStanTestCase
 		$method = $class->getNativeMethod($methodName);
 		$throwType = $method->getThrowType();
 		if ($expectedThrowType === null) {
-			$this->assertNull($throwType);
+			self::assertNull($throwType);
 			return;
 		}
-		$this->assertNotNull($throwType);
-		$this->assertSame(
+		self::assertNotNull($throwType);
+		self::assertSame(
 			$expectedThrowType->describe(VerbosityLevel::precise()),
 			$throwType->describe(VerbosityLevel::precise()),
 		);
@@ -180,7 +180,7 @@ class ReflectionProviderTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass('NativeClassConstantInEvaledClass\\Foo');
 		$constant = $class->getConstant('FOO');
-		$this->assertSame('int', $constant->getValueType()->describe(VerbosityLevel::precise()));
+		self::assertSame('int', $constant->getValueType()->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/FunctionMetadataTest.php
@@ -12,7 +12,7 @@ class FunctionMetadataTest extends PHPStanTestCase
 	public function testSchema(): void
 	{
 		$data = require __DIR__ . '/../../../../resources/functionMetadata.php';
-		$this->assertIsArray($data);
+		self::assertIsArray($data);
 
 		$processor = new Processor();
 		$processor->process(Expect::arrayOf(

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -147,8 +147,8 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 		$provider = $this->createProvider();
 		$reflector = self::getContainer()->getByType(Reflector::class);
 		$signatures = $provider->getFunctionSignatures($functionName, null, new ReflectionFunction($reflector->reflectFunction($functionName)))['positional'];
-		$this->assertCount(1, $signatures);
-		$this->assertSignature($parameters, $returnType, $nativeReturnType, $variadic, $signatures[0]);
+		self::assertCount(1, $signatures);
+		self::assertSignature($parameters, $returnType, $nativeReturnType, $variadic, $signatures[0]);
 	}
 
 	private function createProvider(): Php8SignatureMapProvider
@@ -277,14 +277,14 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 	{
 		$provider = $this->createProvider();
 		$signatures = $provider->getMethodSignatures($className, $methodName, null)['positional'];
-		$this->assertCount(1, $signatures);
-		$this->assertSignature($parameters, $returnType, $nativeReturnType, $variadic, $signatures[0]);
+		self::assertCount(1, $signatures);
+		self::assertSignature($parameters, $returnType, $nativeReturnType, $variadic, $signatures[0]);
 	}
 
 	/**
 	 * @param mixed[] $expectedParameters
 	 */
-	private function assertSignature(
+	static private function assertSignature(
 		array $expectedParameters,
 		Type $expectedReturnType,
 		Type $expectedNativeReturnType,
@@ -292,20 +292,20 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 		FunctionSignature $actualSignature,
 	): void
 	{
-		$this->assertCount(count($expectedParameters), $actualSignature->getParameters());
+		self::assertCount(count($expectedParameters), $actualSignature->getParameters());
 		foreach ($expectedParameters as $i => $expectedParameter) {
 			$actualParameter = $actualSignature->getParameters()[$i];
-			$this->assertSame($expectedParameter['name'], $actualParameter->getName());
-			$this->assertSame($expectedParameter['optional'], $actualParameter->isOptional());
-			$this->assertSame($expectedParameter['type']->describe(VerbosityLevel::precise()), $actualParameter->getType()->describe(VerbosityLevel::precise()));
-			$this->assertSame($expectedParameter['nativeType']->describe(VerbosityLevel::precise()), $actualParameter->getNativeType()->describe(VerbosityLevel::precise()));
-			$this->assertTrue($expectedParameter['passedByReference']->equals($actualParameter->passedByReference()));
-			$this->assertSame($expectedParameter['variadic'], $actualParameter->isVariadic());
+			self::assertSame($expectedParameter['name'], $actualParameter->getName());
+			self::assertSame($expectedParameter['optional'], $actualParameter->isOptional());
+			self::assertSame($expectedParameter['type']->describe(VerbosityLevel::precise()), $actualParameter->getType()->describe(VerbosityLevel::precise()));
+			self::assertSame($expectedParameter['nativeType']->describe(VerbosityLevel::precise()), $actualParameter->getNativeType()->describe(VerbosityLevel::precise()));
+			self::assertTrue($expectedParameter['passedByReference']->equals($actualParameter->passedByReference()));
+			self::assertSame($expectedParameter['variadic'], $actualParameter->isVariadic());
 		}
 
-		$this->assertSame($expectedReturnType->describe(VerbosityLevel::precise()), $actualSignature->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertSame($expectedNativeReturnType->describe(VerbosityLevel::precise()), $actualSignature->getNativeReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertSame($expectedVariadic, $actualSignature->isVariadic());
+		self::assertSame($expectedReturnType->describe(VerbosityLevel::precise()), $actualSignature->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedNativeReturnType->describe(VerbosityLevel::precise()), $actualSignature->getNativeReturnType()->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedVariadic, $actualSignature->isVariadic());
 	}
 
 	public static function dataParseAll(): array

--- a/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/Php8SignatureMapProviderTest.php
@@ -284,7 +284,7 @@ class Php8SignatureMapProviderTest extends PHPStanTestCase
 	/**
 	 * @param mixed[] $expectedParameters
 	 */
-	static private function assertSignature(
+	private static function assertSignature(
 		array $expectedParameters,
 		Type $expectedReturnType,
 		Type $expectedNativeReturnType,

--- a/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
+++ b/tests/PHPStan/Reflection/SignatureMap/SignatureMapParserTest.php
@@ -437,7 +437,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 		/** @var SignatureMapParser $parser */
 		$parser = self::getContainer()->getByType(SignatureMapParser::class);
 		$functionSignature = $parser->getFunctionSignature($map, $className);
-		$this->assertCount(
+		self::assertCount(
 			count($expectedSignature->getParameters()),
 			$functionSignature->getParameters(),
 			'Number of parameters does not match.',
@@ -445,38 +445,38 @@ class SignatureMapParserTest extends PHPStanTestCase
 
 		foreach ($functionSignature->getParameters() as $i => $parameterSignature) {
 			$expectedParameterSignature = $expectedSignature->getParameters()[$i];
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameterSignature->getName(),
 				$parameterSignature->getName(),
 				sprintf('Name of parameter #%d does not match.', $i),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameterSignature->isOptional(),
 				$parameterSignature->isOptional(),
 				sprintf('Optionality of parameter $%s does not match.', $parameterSignature->getName()),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameterSignature->getType()->describe(VerbosityLevel::precise()),
 				$parameterSignature->getType()->describe(VerbosityLevel::precise()),
 				sprintf('Type of parameter $%s does not match.', $parameterSignature->getName()),
 			);
-			$this->assertTrue(
+			self::assertTrue(
 				$expectedParameterSignature->passedByReference()->equals($parameterSignature->passedByReference()),
 				sprintf('Passed-by-reference of parameter $%s does not match.', $parameterSignature->getName()),
 			);
-			$this->assertSame(
+			self::assertSame(
 				$expectedParameterSignature->isVariadic(),
 				$parameterSignature->isVariadic(),
 				sprintf('Variadicity of parameter $%s does not match.', $parameterSignature->getName()),
 			);
 		}
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedSignature->getReturnType()->describe(VerbosityLevel::precise()),
 			$functionSignature->getReturnType()->describe(VerbosityLevel::precise()),
 			'Return type does not match.',
 		);
-		$this->assertSame(
+		self::assertSame(
 			$expectedSignature->isVariadic(),
 			$functionSignature->isVariadic(),
 			'Variadicity does not match.',
@@ -554,7 +554,7 @@ class SignatureMapParserTest extends PHPStanTestCase
 			}
 		}
 
-		$this->assertGreaterThan(0, $count);
+		self::assertGreaterThan(0, $count);
 	}
 
 }

--- a/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/IntersectionTypeMethodReflectionTest.php
@@ -20,7 +20,7 @@ class IntersectionTypeMethodReflectionTest extends PHPStanTestCase
 			],
 		);
 
-		$this->assertSame('Deprecated', $reflection->getDeprecatedDescription());
+		self::assertSame('Deprecated', $reflection->getDeprecatedDescription());
 	}
 
 	public function testMultipleDeprecationsAreJoined(): void
@@ -33,7 +33,7 @@ class IntersectionTypeMethodReflectionTest extends PHPStanTestCase
 			],
 		);
 
-		$this->assertSame('Deprecated #1 Deprecated #2', $reflection->getDeprecatedDescription());
+		self::assertSame('Deprecated #1 Deprecated #2', $reflection->getDeprecatedDescription());
 	}
 
 	private function createDeprecatedMethod(TrinaryLogic $deprecated, ?string $deprecationText): ExtendedMethodReflection

--- a/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
+++ b/tests/PHPStan/Reflection/Type/UnionTypeMethodReflectionTest.php
@@ -20,7 +20,7 @@ class UnionTypeMethodReflectionTest extends PHPStanTestCase
 			],
 		);
 
-		$this->assertSame('Deprecated', $reflection->getDeprecatedDescription());
+		self::assertSame('Deprecated', $reflection->getDeprecatedDescription());
 	}
 
 	public function testMultipleDeprecationsAreJoined(): void
@@ -33,7 +33,7 @@ class UnionTypeMethodReflectionTest extends PHPStanTestCase
 			],
 		);
 
-		$this->assertSame('Deprecated #1 Deprecated #2', $reflection->getDeprecatedDescription());
+		self::assertSame('Deprecated #1 Deprecated #2', $reflection->getDeprecatedDescription());
 	}
 
 	private function createDeprecatedMethod(TrinaryLogic $deprecated, ?string $deprecationText): ExtendedMethodReflection

--- a/tests/PHPStan/Reflection/UnionTypesTest.php
+++ b/tests/PHPStan/Reflection/UnionTypesTest.php
@@ -18,28 +18,28 @@ class UnionTypesTest extends PHPStanTestCase
 		$reflectionProvider = self::createReflectionProvider();
 		$class = $reflectionProvider->getClass(Foo::class);
 		$propertyType = $class->getNativeProperty('fooProp')->getNativeType();
-		$this->assertInstanceOf(UnionType::class, $propertyType);
-		$this->assertSame('bool|int', $propertyType->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf(UnionType::class, $propertyType);
+		self::assertSame('bool|int', $propertyType->describe(VerbosityLevel::precise()));
 
 		$method = $class->getNativeMethod('doFoo');
 		$methodVariant = $method->getOnlyVariant();
 		$methodReturnType = $methodVariant->getReturnType();
-		$this->assertInstanceOf(UnionType::class, $methodReturnType);
-		$this->assertSame('NativeUnionTypes\\Bar|NativeUnionTypes\\Foo', $methodReturnType->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf(UnionType::class, $methodReturnType);
+		self::assertSame('NativeUnionTypes\\Bar|NativeUnionTypes\\Foo', $methodReturnType->describe(VerbosityLevel::precise()));
 
 		$methodParameterType = $methodVariant->getParameters()[0]->getType();
-		$this->assertInstanceOf(UnionType::class, $methodParameterType);
-		$this->assertSame('bool|int', $methodParameterType->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf(UnionType::class, $methodParameterType);
+		self::assertSame('bool|int', $methodParameterType->describe(VerbosityLevel::precise()));
 
 		$function = $reflectionProvider->getFunction(new Name('NativeUnionTypes\doFoo'), null);
 		$functionVariant = $function->getOnlyVariant();
 		$functionReturnType = $functionVariant->getReturnType();
-		$this->assertInstanceOf(UnionType::class, $functionReturnType);
-		$this->assertSame('NativeUnionTypes\\Bar|NativeUnionTypes\\Foo', $functionReturnType->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf(UnionType::class, $functionReturnType);
+		self::assertSame('NativeUnionTypes\\Bar|NativeUnionTypes\\Foo', $functionReturnType->describe(VerbosityLevel::precise()));
 
 		$functionParameterType = $functionVariant->getParameters()[0]->getType();
-		$this->assertInstanceOf(UnionType::class, $functionParameterType);
-		$this->assertSame('bool|int', $functionParameterType->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf(UnionType::class, $functionParameterType);
+		self::assertSame('bool|int', $functionParameterType->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Rules/Api/ApiRuleHelperTest.php
+++ b/tests/PHPStan/Rules/Api/ApiRuleHelperTest.php
@@ -147,7 +147,7 @@ class ApiRuleHelperTest extends TestCase
 		$scope = $this->createStub(Scope::class);
 		$scope->method('getNamespace')->willReturn($scopeNamespace);
 		$scope->method('getFile')->willReturn($scopeFile);
-		$this->assertSame($expected, $rule->isPhpStanCode($scope, $nameToCheck, $declaringFileNameToCheck));
+		self::assertSame($expected, $rule->isPhpStanCode($scope, $nameToCheck, $declaringFileNameToCheck));
 	}
 
 }

--- a/tests/PHPStan/Rules/DirectRegistryTest.php
+++ b/tests/PHPStan/Rules/DirectRegistryTest.php
@@ -18,10 +18,10 @@ class DirectRegistryTest extends PHPStanTestCase
 		]);
 
 		$rules = $registry->getRules(Node\Expr\FuncCall::class);
-		$this->assertCount(1, $rules);
-		$this->assertSame($rule, $rules[0]);
+		self::assertCount(1, $rules);
+		self::assertSame($rule, $rules[0]);
 
-		$this->assertCount(0, $registry->getRules(Node\Expr\MethodCall::class));
+		self::assertCount(0, $registry->getRules(Node\Expr\MethodCall::class));
 	}
 
 	public function testGetRulesWithTwoDifferentInstances(): void
@@ -39,11 +39,11 @@ class DirectRegistryTest extends PHPStanTestCase
 		]);
 
 		$rules = $registry->getRules(Node\Expr\FuncCall::class);
-		$this->assertCount(2, $rules);
-		$this->assertSame($fooRule, $rules[0]);
-		$this->assertSame($barRule, $rules[1]);
+		self::assertCount(2, $rules);
+		self::assertSame($fooRule, $rules[0]);
+		self::assertSame($barRule, $rules[1]);
 
-		$this->assertCount(0, $registry->getRules(Node\Expr\MethodCall::class));
+		self::assertCount(0, $registry->getRules(Node\Expr\MethodCall::class));
 	}
 
 }

--- a/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
+++ b/tests/PHPStan/Rules/Exceptions/DefaultExceptionTypeResolverTest.php
@@ -144,7 +144,7 @@ class DefaultExceptionTypeResolverTest extends PHPStanTestCase
 	): void
 	{
 		$resolver = new DefaultExceptionTypeResolver(self::createReflectionProvider(), $uncheckedExceptionRegexes, $uncheckedExceptionClasses, $checkedExceptionRegexes, $checkedExceptionClasses);
-		$this->assertSame($expectedResult, $resolver->isCheckedException($className, self::getContainer()->getByType(ScopeFactory::class)->create(ScopeContext::create(__DIR__))));
+		self::assertSame($expectedResult, $resolver->isCheckedException($className, self::getContainer()->getByType(ScopeFactory::class)->create(ScopeContext::create(__DIR__))));
 	}
 
 }

--- a/tests/PHPStan/Rules/Methods/AbstractMethodInNonAbstractClassRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/AbstractMethodInNonAbstractClassRuleTest.php
@@ -47,8 +47,8 @@ class AbstractMethodInNonAbstractClassRuleTest extends RuleTestCase
 	{
 		$reflectionProvider = self::createReflectionProvider();
 		$reflection = $reflectionProvider->getClass(ClassFoo::class);
-		$this->assertSame(AbstractFoo::class, $reflection->getNativeMethod('myFoo')->getDeclaringClass()->getName());
-		$this->assertSame(ClassFoo::class, $reflection->getNativeMethod('myBar')->getDeclaringClass()->getName());
+		self::assertSame(AbstractFoo::class, $reflection->getNativeMethod('myFoo')->getDeclaringClass()->getName());
+		self::assertSame(ClassFoo::class, $reflection->getNativeMethod('myBar')->getDeclaringClass()->getName());
 	}
 
 	public function testbug3406AnotherCase(): void

--- a/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidThrowsPhpDocValueRuleTest.php
@@ -133,8 +133,8 @@ class InvalidThrowsPhpDocValueRuleTest extends RuleTestCase
 		$reflection = $reflectionProvider->getClass($className);
 		$method = $reflection->getNativeMethod($method);
 		$throwsType = $method->getThrowType();
-		$this->assertNotNull($throwsType);
-		$this->assertSame($expectedType, $throwsType->describe(VerbosityLevel::precise()));
+		self::assertNotNull($throwsType);
+		self::assertSame($expectedType, $throwsType->describe(VerbosityLevel::precise()));
 	}
 
 	#[RequiresPhp('>= 8.4')]

--- a/tests/PHPStan/Rules/RuleErrorBuilderTest.php
+++ b/tests/PHPStan/Rules/RuleErrorBuilderTest.php
@@ -11,39 +11,39 @@ class RuleErrorBuilderTest extends TestCase
 	{
 		$builder = RuleErrorBuilder::message('Foo');
 		$ruleError = $builder->build();
-		$this->assertSame('Foo', $ruleError->getMessage());
+		self::assertSame('Foo', $ruleError->getMessage());
 	}
 
 	public function testMessageAndLineAndBuild(): void
 	{
 		$builder = RuleErrorBuilder::message('Foo')->line(25);
 		$ruleError = $builder->build();
-		$this->assertSame('Foo', $ruleError->getMessage());
+		self::assertSame('Foo', $ruleError->getMessage());
 
-		$this->assertInstanceOf(LineRuleError::class, $ruleError); // @phpstan-ignore method.alreadyNarrowedType
-		$this->assertSame(25, $ruleError->getLine());
+		self::assertInstanceOf(LineRuleError::class, $ruleError); // @phpstan-ignore staticMethod.alreadyNarrowedType
+		self::assertSame(25, $ruleError->getLine());
 	}
 
 	public function testMessageAndFileAndBuild(): void
 	{
 		$builder = RuleErrorBuilder::message('Foo')->file(__FILE__);
 		$ruleError = $builder->build();
-		$this->assertSame('Foo', $ruleError->getMessage());
+		self::assertSame('Foo', $ruleError->getMessage());
 
-		$this->assertInstanceOf(FileRuleError::class, $ruleError); // @phpstan-ignore method.alreadyNarrowedType
-		$this->assertSame(__FILE__, $ruleError->getFile());
+		self::assertInstanceOf(FileRuleError::class, $ruleError); // @phpstan-ignore staticMethod.alreadyNarrowedType
+		self::assertSame(__FILE__, $ruleError->getFile());
 	}
 
 	public function testMessageAndLineAndFileAndBuild(): void
 	{
 		$builder = RuleErrorBuilder::message('Foo')->line(25)->file(__FILE__);
 		$ruleError = $builder->build();
-		$this->assertSame('Foo', $ruleError->getMessage());
+		self::assertSame('Foo', $ruleError->getMessage());
 
-		$this->assertInstanceOf(LineRuleError::class, $ruleError); // @phpstan-ignore method.alreadyNarrowedType
-		$this->assertInstanceOf(FileRuleError::class, $ruleError);  // @phpstan-ignore method.alreadyNarrowedType
-		$this->assertSame(25, $ruleError->getLine());
-		$this->assertSame(__FILE__, $ruleError->getFile());
+		self::assertInstanceOf(LineRuleError::class, $ruleError); // @phpstan-ignore staticMethod.alreadyNarrowedType
+		self::assertInstanceOf(FileRuleError::class, $ruleError);  // @phpstan-ignore staticMethod.alreadyNarrowedType
+		self::assertSame(25, $ruleError->getLine());
+		self::assertSame(__FILE__, $ruleError->getFile());
 	}
 
 }

--- a/tests/PHPStan/Testing/NonexistentAnalysedClassRuleTest.php
+++ b/tests/PHPStan/Testing/NonexistentAnalysedClassRuleTest.php
@@ -55,7 +55,7 @@ class NonexistentAnalysedClassRuleTest extends RuleTestCase
 			if ($e->getComparisonFailure() === null) {
 				throw $e;
 			}
-			$this->assertStringContainsString('not found in ReflectionProvider', $e->getComparisonFailure()->getDiff());
+			self::assertStringContainsString('not found in ReflectionProvider', $e->getComparisonFailure()->getDiff());
 		}
 	}
 

--- a/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
+++ b/tests/PHPStan/Testing/TypeInferenceTestCaseTest.php
@@ -117,8 +117,8 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 
 		[$variableAssert, $offsetAssert] = array_values(self::gatherAssertTypes($filePath));
 
-		$this->assertSame('variable $context', $variableAssert[4]);
-		$this->assertSame("offset 'email'", $offsetAssert[4]);
+		self::assertSame('variable $context', $variableAssert[4]);
+		self::assertSame("offset 'email'", $offsetAssert[4]);
 	}
 
 	public function testSuperType(): void
@@ -159,7 +159,7 @@ final class TypeInferenceTestCaseTest extends TypeInferenceTestCase
 
 			$this->fail('Should have failed');
 		} catch (AssertionFailedError $e) {
-			$this->assertStringContainsString('not found in ReflectionProvider', $e->getMessage());
+			self::assertStringContainsString('not found in ReflectionProvider', $e->getMessage());
 		}
 	}
 

--- a/tests/PHPStan/TrinaryLogicTest.php
+++ b/tests/PHPStan/TrinaryLogicTest.php
@@ -36,7 +36,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 		TrinaryLogic ...$operands,
 	): void
 	{
-		$this->assertTrue($expectedResult->equals($value->and(...$operands)));
+		self::assertTrue($expectedResult->equals($value->and(...$operands)));
 	}
 
 	#[DataProvider('dataAnd')]
@@ -46,7 +46,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 		TrinaryLogic ...$operands,
 	): void
 	{
-		$this->assertTrue($expectedResult->equals($value->lazyAnd($operands, static fn (TrinaryLogic $result) => $result)));
+		self::assertTrue($expectedResult->equals($value->lazyAnd($operands, static fn (TrinaryLogic $result) => $result)));
 	}
 
 	public static function dataOr(): array
@@ -77,7 +77,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 		TrinaryLogic ...$operands,
 	): void
 	{
-		$this->assertTrue($expectedResult->equals($value->or(...$operands)));
+		self::assertTrue($expectedResult->equals($value->or(...$operands)));
 	}
 
 	#[DataProvider('dataOr')]
@@ -87,7 +87,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 		TrinaryLogic ...$operands,
 	): void
 	{
-		$this->assertTrue($expectedResult->equals($value->lazyOr($operands, static fn (TrinaryLogic $result) => $result)));
+		self::assertTrue($expectedResult->equals($value->lazyOr($operands, static fn (TrinaryLogic $result) => $result)));
 	}
 
 	public static function dataNegate(): array
@@ -102,7 +102,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 	#[DataProvider('dataNegate')]
 	public function testNegate(TrinaryLogic $expectedResult, TrinaryLogic $operand): void
 	{
-		$this->assertTrue($expectedResult->equals($operand->negate()));
+		self::assertTrue($expectedResult->equals($operand->negate()));
 	}
 
 	public static function dataCompareTo(): array
@@ -147,7 +147,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 	#[DataProvider('dataCompareTo')]
 	public function testCompareTo(TrinaryLogic $first, TrinaryLogic $second, ?TrinaryLogic $expected): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expected,
 			$first->compareTo($second),
 		);
@@ -156,7 +156,7 @@ class TrinaryLogicTest extends PHPStanTestCase
 	#[DataProvider('dataCompareTo')]
 	public function testCompareToInversed(TrinaryLogic $first, TrinaryLogic $second, ?TrinaryLogic $expected): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expected,
 			$second->compareTo($first),
 		);

--- a/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasMethodTypeTest.php
@@ -141,7 +141,7 @@ class HasMethodTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(HasMethodType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -189,7 +189,7 @@ class HasMethodTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOf(HasMethodType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSubTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -200,7 +200,7 @@ class HasMethodTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOfInversed(HasMethodType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
+++ b/tests/PHPStan/Type/Accessory/HasPropertyTypeTest.php
@@ -107,7 +107,7 @@ class HasPropertyTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(HasPropertyType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -150,7 +150,7 @@ class HasPropertyTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOf(HasPropertyType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSubTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -161,7 +161,7 @@ class HasPropertyTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOfInversed(HasPropertyType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/ArrayTypeTest.php
+++ b/tests/PHPStan/Type/ArrayTypeTest.php
@@ -90,7 +90,7 @@ class ArrayTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ArrayType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -154,7 +154,7 @@ class ArrayTypeTest extends PHPStanTestCase
 	): void
 	{
 		$actualResult = $acceptingType->accepts($acceptedType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $acceptingType->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),
@@ -180,7 +180,7 @@ class ArrayTypeTest extends PHPStanTestCase
 		string $expectedDescription,
 	): void
 	{
-		$this->assertSame($expectedDescription, $type->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedDescription, $type->describe(VerbosityLevel::precise()));
 	}
 
 	public static function dataInferTemplateTypes(): array
@@ -263,7 +263,7 @@ class ArrayTypeTest extends PHPStanTestCase
 	{
 		$result = $template->inferTemplateTypes($received);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypes,
 			array_map(static fn (Type $type): string => $type->describe(VerbosityLevel::precise()), $result->getTypes()),
 		);
@@ -294,7 +294,7 @@ class ArrayTypeTest extends PHPStanTestCase
 	): void
 	{
 		$actualResult = $type->hasOffsetValueType($offsetType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasOffsetValueType(%s)', $type->describe(VerbosityLevel::precise()), $offsetType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/BenevolentUnionTypeTest.php
+++ b/tests/PHPStan/Type/BenevolentUnionTypeTest.php
@@ -45,7 +45,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testCanAccessProperties(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->canAccessProperties();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> canAccessProperties()', $type->describe(VerbosityLevel::precise())),
@@ -86,7 +86,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testHasInstanceProperty(BenevolentUnionType $type, string $propertyName, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->hasInstanceProperty($propertyName);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasProperty()', $type->describe(VerbosityLevel::precise())),
@@ -118,7 +118,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testCanCanCallMethods(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->canCallMethods();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> canCallMethods()', $type->describe(VerbosityLevel::precise())),
@@ -156,7 +156,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testHasMethod(BenevolentUnionType $type, string $methodName, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->hasMethod($methodName);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasMethod()', $type->describe(VerbosityLevel::precise())),
@@ -188,7 +188,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testCanAccessConstants(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->canAccessConstants();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> canAccessConstants()', $type->describe(VerbosityLevel::precise())),
@@ -226,7 +226,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsIterable(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isIterable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isIterable()', $type->describe(VerbosityLevel::precise())),
@@ -264,7 +264,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsIterableAtLeastOnce(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isIterableAtLeastOnce();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isIterableAtLeastOnce()', $type->describe(VerbosityLevel::precise())),
@@ -296,7 +296,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsArray(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isArray();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isArray()', $type->describe(VerbosityLevel::precise())),
@@ -331,7 +331,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsString(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isString();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isString()', $type->describe(VerbosityLevel::precise())),
@@ -365,7 +365,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsNumericString(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isNumericString();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isNumericString()', $type->describe(VerbosityLevel::precise())),
@@ -399,7 +399,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsNonFalsyString(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isNonFalsyString();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isNonFalsyString()', $type->describe(VerbosityLevel::precise())),
@@ -433,7 +433,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsLiteralString(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isLiteralString();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isLiteralString()', $type->describe(VerbosityLevel::precise())),
@@ -471,7 +471,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsOffsetAccessible(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isOffsetAccessible();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isOffsetAccessible()', $type->describe(VerbosityLevel::precise())),
@@ -512,7 +512,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testHasOffsetValue(BenevolentUnionType $type, Type $offsetType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->hasOffsetValueType($offsetType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasOffsetValueType()', $type->describe(VerbosityLevel::precise())),
@@ -544,7 +544,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsCallable(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isCallable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCallable()', $type->describe(VerbosityLevel::precise())),
@@ -576,7 +576,7 @@ class BenevolentUnionTypeTest extends PHPStanTestCase
 	public function testIsCloneable(BenevolentUnionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isCloneable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCloneable()', $type->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/BitwiseFlagHelperTest.php
+++ b/tests/PHPStan/Type/BitwiseFlagHelperTest.php
@@ -138,7 +138,7 @@ final class BitwiseFlagHelperTest extends PHPStanTestCase
 
 		$analyser = new BitwiseFlagHelper(self::createReflectionProvider());
 		$actual = $analyser->bitwiseOrContainsConstant($expr, $scope, $constName);
-		$this->assertTrue($expected->equals($actual), sprintf('Expected Trinary::%s but got Trinary::%s.', $expected->describe(), $actual->describe()));
+		self::assertTrue($expected->equals($actual), sprintf('Expected Trinary::%s but got Trinary::%s.', $expected->describe(), $actual->describe()));
 	}
 
 }

--- a/tests/PHPStan/Type/BooleanTypeTest.php
+++ b/tests/PHPStan/Type/BooleanTypeTest.php
@@ -52,7 +52,7 @@ class BooleanTypeTest extends PHPStanTestCase
 	public function testAccepts(BooleanType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -96,7 +96,7 @@ class BooleanTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(BooleanType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -148,7 +148,7 @@ class BooleanTypeTest extends PHPStanTestCase
 	public function testEquals(BooleanType $type, Type $otherType, bool $expectedResult): void
 	{
 		$actualResult = $type->equals($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$actualResult,
 			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/CallableTypeTest.php
+++ b/tests/PHPStan/Type/CallableTypeTest.php
@@ -66,7 +66,7 @@ class CallableTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(CallableType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -143,7 +143,7 @@ class CallableTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOf(CallableType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSubTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -154,7 +154,7 @@ class CallableTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOfInversed(CallableType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),
@@ -269,7 +269,7 @@ class CallableTypeTest extends PHPStanTestCase
 	{
 		$result = $template->inferTemplateTypes($received);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypes,
 			array_map(static fn (Type $type): string => $type->describe(VerbosityLevel::precise()), $result->getTypes()),
 		);
@@ -414,7 +414,7 @@ class CallableTypeTest extends PHPStanTestCase
 		TrinaryLogic $expectedResult,
 	): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$type->accepts($acceptedType, true)->result->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/ClassStringTypeTest.php
+++ b/tests/PHPStan/Type/ClassStringTypeTest.php
@@ -44,7 +44,7 @@ class ClassStringTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ClassStringType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -106,7 +106,7 @@ class ClassStringTypeTest extends PHPStanTestCase
 	public function testAccepts(ClassStringType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -133,7 +133,7 @@ class ClassStringTypeTest extends PHPStanTestCase
 	public function testEquals(ClassStringType $type, Type $otherType, bool $expectedResult): void
 	{
 		$actualResult = $type->equals($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$actualResult,
 			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/ClosureTypeFactoryTest.php
+++ b/tests/PHPStan/Type/ClosureTypeFactoryTest.php
@@ -43,7 +43,7 @@ class ClosureTypeFactoryTest extends PHPStanTestCase
 	{
 		$closureType = $this->getClosureType($closure);
 
-		$this->assertSame($returnType, $closureType->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertSame($returnType, $closureType->getReturnType()->describe(VerbosityLevel::precise()));
 	}
 
 	public static function dataFromClosureObjectParameter(): array
@@ -70,8 +70,8 @@ class ClosureTypeFactoryTest extends PHPStanTestCase
 	{
 		$closureType = $this->getClosureType($closure);
 
-		$this->assertArrayHasKey($index, $closureType->getParameters());
-		$this->assertSame($type, $closureType->getParameters()[$index]->getType()->describe(VerbosityLevel::precise()));
+		self::assertArrayHasKey($index, $closureType->getParameters());
+		self::assertSame($type, $closureType->getParameters()[$index]->getType()->describe(VerbosityLevel::precise()));
 	}
 
 	/**

--- a/tests/PHPStan/Type/ClosureTypeTest.php
+++ b/tests/PHPStan/Type/ClosureTypeTest.php
@@ -100,7 +100,7 @@ class ClosureTypeTest extends PHPStanTestCase
 	): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php
@@ -18,44 +18,44 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		$builder->setOffsetValueType(null, new ConstantIntegerType(1));
 
 		$array1 = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array1);
-		$this->assertSame('array{1}', $array1->describe(VerbosityLevel::precise()));
-		$this->assertSame([1], $array1->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array1);
+		self::assertSame('array{1}', $array1->describe(VerbosityLevel::precise()));
+		self::assertSame([1], $array1->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(2), true);
 		$array2 = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array2);
-		$this->assertSame('array{0: 1, 1?: 2}', $array2->describe(VerbosityLevel::precise()));
-		$this->assertSame([1, 2], $array2->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array2);
+		self::assertSame('array{0: 1, 1?: 2}', $array2->describe(VerbosityLevel::precise()));
+		self::assertSame([1, 2], $array2->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(3));
 		$array3 = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array3);
-		$this->assertSame('array{0: 1, 1: 2|3, 2?: 3}', $array3->describe(VerbosityLevel::precise()));
-		$this->assertSame([2, 3], $array3->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array3);
+		self::assertSame('array{0: 1, 1: 2|3, 2?: 3}', $array3->describe(VerbosityLevel::precise()));
+		self::assertSame([2, 3], $array3->getNextAutoIndexes());
 
-		$this->assertTrue($array3->isKeysSupersetOf($array2));
+		self::assertTrue($array3->isKeysSupersetOf($array2));
 		$array2MergedWith3 = $array3->mergeWith($array2);
-		$this->assertSame('array{0: 1, 1?: 2|3, 2?: 3}', $array2MergedWith3->describe(VerbosityLevel::precise()));
-		$this->assertSame([1, 2, 3], $array2MergedWith3->getNextAutoIndexes());
+		self::assertSame('array{0: 1, 1?: 2|3, 2?: 3}', $array2MergedWith3->describe(VerbosityLevel::precise()));
+		self::assertSame([1, 2, 3], $array2MergedWith3->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(4));
 		$array4 = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array4);
-		$this->assertSame('array{0: 1, 1: 2|3, 2: 3|4, 3?: 4}', $array4->describe(VerbosityLevel::precise()));
-		$this->assertSame([3, 4], $array4->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array4);
+		self::assertSame('array{0: 1, 1: 2|3, 2: 3|4, 3?: 4}', $array4->describe(VerbosityLevel::precise()));
+		self::assertSame([3, 4], $array4->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(3), new ConstantIntegerType(5), true);
 		$array5 = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array5);
-		$this->assertSame('array{0: 1, 1: 2|3, 2: 3|4, 3?: 4|5}', $array5->describe(VerbosityLevel::precise()));
-		$this->assertSame([3, 4], $array5->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array5);
+		self::assertSame('array{0: 1, 1: 2|3, 2: 3|4, 3?: 4|5}', $array5->describe(VerbosityLevel::precise()));
+		self::assertSame([3, 4], $array5->getNextAutoIndexes());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(3), new ConstantIntegerType(6));
 		$array6 = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array6);
-		$this->assertSame('array{1, 2|3, 3|4, 6}', $array6->describe(VerbosityLevel::precise()));
-		$this->assertSame([4], $array6->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array6);
+		self::assertSame('array{1, 2|3, 3|4, 6}', $array6->describe(VerbosityLevel::precise()));
+		self::assertSame([4], $array6->getNextAutoIndexes());
 	}
 
 	public function testNextAutoIndex(): void
@@ -67,9 +67,9 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		));
 		$builder->setOffsetValueType(new ConstantIntegerType(0), new ConstantStringType('bar'));
 		$array = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array);
-		$this->assertSame('array{\'bar\'}', $array->describe(VerbosityLevel::precise()));
-		$this->assertSame([1], $array->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array);
+		self::assertSame('array{\'bar\'}', $array->describe(VerbosityLevel::precise()));
+		self::assertSame([1], $array->getNextAutoIndexes());
 	}
 
 	public function testNextAutoIndexAnother(): void
@@ -81,9 +81,9 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		));
 		$builder->setOffsetValueType(new ConstantIntegerType(1), new ConstantStringType('bar'));
 		$array = $builder->getArray();
-		$this->assertInstanceOf(ConstantArrayType::class, $array);
-		$this->assertSame('array{\'foo\', \'bar\'}', $array->describe(VerbosityLevel::precise()));
-		$this->assertSame([2], $array->getNextAutoIndexes());
+		self::assertInstanceOf(ConstantArrayType::class, $array);
+		self::assertSame('array{\'foo\', \'bar\'}', $array->describe(VerbosityLevel::precise()));
+		self::assertSame([2], $array->getNextAutoIndexes());
 	}
 
 	public function testAppendingOptionalKeys(): void
@@ -91,13 +91,13 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 
 		$builder->setOffsetValueType(null, new BooleanType(), true);
-		$this->assertSame('array{0?: bool}', $builder->getArray()->describe(VerbosityLevel::precise()));
+		self::assertSame('array{0?: bool}', $builder->getArray()->describe(VerbosityLevel::precise()));
 
 		$builder->setOffsetValueType(null, new NullType(), true);
-		$this->assertSame('array{0?: bool|null, 1?: null}', $builder->getArray()->describe(VerbosityLevel::precise()));
+		self::assertSame('array{0?: bool|null, 1?: null}', $builder->getArray()->describe(VerbosityLevel::precise()));
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(17));
-		$this->assertSame('array{0: 17|bool|null, 1?: 17|null, 2?: 17}', $builder->getArray()->describe(VerbosityLevel::precise()));
+		self::assertSame('array{0: 17|bool|null, 1?: 17|null, 2?: 17}', $builder->getArray()->describe(VerbosityLevel::precise()));
 	}
 
 	public function testDegradedArrayIsNotAlwaysOversized(): void
@@ -109,7 +109,7 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		}
 
 		$array = $builder->getArray();
-		$this->assertSame('non-empty-array<string, string>', $array->describe(VerbosityLevel::precise()));
+		self::assertSame('non-empty-array<string, string>', $array->describe(VerbosityLevel::precise()));
 	}
 
 	public function testIsList(): void
@@ -117,16 +117,16 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(0));
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(0), new NullType());
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(1), new NullType(), true);
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(2), new NullType(), true);
-		$this->assertFalse($builder->isList());
+		self::assertFalse($builder->isList());
 	}
 
 	public function testIsListWithUnion(): void
@@ -134,16 +134,16 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 
 		$builder->setOffsetValueType(null, new ConstantIntegerType(0));
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(0), new NullType());
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(1), new NullType());
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$builder->setOffsetValueType(new ConstantIntegerType(2), new NullType());
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$oneOrZero = TypeCombinator::union(
 			new ConstantIntegerType(0),
@@ -151,7 +151,7 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		);
 
 		$builder->setOffsetValueType($oneOrZero, new NullType());
-		$this->assertTrue($builder->isList());
+		self::assertTrue($builder->isList());
 
 		$oneOrFour = TypeCombinator::union(
 			new ConstantIntegerType(1),
@@ -159,7 +159,7 @@ class ConstantArrayTypeBuilderTest extends PHPStanTestCase
 		);
 
 		$builder->setOffsetValueType($oneOrFour, new NullType());
-		$this->assertFalse($builder->isList());
+		self::assertFalse($builder->isList());
 	}
 
 }

--- a/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantArrayTypeTest.php
@@ -414,7 +414,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 	public function testAccepts(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -696,7 +696,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ConstantArrayType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -815,7 +815,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 	{
 		$result = $template->inferTemplateTypes($received);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypes,
 			array_map(static fn (Type $type): string => $type->describe(VerbosityLevel::precise()), $result->getTypes()),
 		);
@@ -825,7 +825,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 	public function testIsCallable(ConstantArrayType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isCallable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCallable()', $type->describe(VerbosityLevel::precise())),
@@ -1039,9 +1039,9 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 			$actualType->describe(VerbosityLevel::precise()),
 			$expectedType->describe(VerbosityLevel::precise()),
 		);
-		$this->assertTrue($expectedType->equals($actualType), $message);
-		$this->assertSame($expectedType->isList(), $actualType->isList());
-		$this->assertSame($expectedType->getNextAutoIndexes(), $actualType->getNextAutoIndexes());
+		self::assertTrue($expectedType->equals($actualType), $message);
+		self::assertSame($expectedType->isList(), $actualType->isList());
+		self::assertSame($expectedType->getNextAutoIndexes(), $actualType->getNextAutoIndexes());
 	}
 
 	public static function dataHasOffsetValueType(): array
@@ -1063,7 +1063,7 @@ class ConstantArrayTypeTest extends PHPStanTestCase
 	): void
 	{
 		$actualResult = $type->hasOffsetValueType($offsetType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasOffsetValueType(%s)', $type->describe(VerbosityLevel::precise()), $offsetType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantFloatTypeTest.php
@@ -45,7 +45,7 @@ class ConstantFloatTypeTest extends PHPStanTestCase
 		string $expectedDescription,
 	): void
 	{
-		$this->assertSame($expectedDescription, $type->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedDescription, $type->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantIntegerTypeTest.php
@@ -38,7 +38,7 @@ class ConstantIntegerTypeTest extends PHPStanTestCase
 	public function testAccepts(ConstantIntegerType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -70,7 +70,7 @@ class ConstantIntegerTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ConstantIntegerType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -141,7 +141,7 @@ class ConstantStringTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ConstantStringType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -150,39 +150,39 @@ class ConstantStringTypeTest extends PHPStanTestCase
 
 	public function testGeneralize(): void
 	{
-		$this->assertSame('literal-string&non-falsy-string', (new ConstantStringType('NonexistentClass'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string', (new ConstantStringType(''))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string', (new ConstantStringType('a'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&non-falsy-string&uppercase-string', (new ConstantStringType('A'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-empty-string&numeric-string&uppercase-string', (new ConstantStringType('0'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string', (new ConstantStringType('1.123'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string&uppercase-string', (new ConstantStringType('    1       1   '))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string', (new ConstantStringType('+1'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string&uppercase-string', (new ConstantStringType('+1+1'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string&numeric-string', (new ConstantStringType('1e9'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&lowercase-string&non-falsy-string', (new ConstantStringType('1e91e9'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('string', (new ConstantStringType(''))->generalize(GeneralizePrecision::lessSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('string', (new ConstantStringType('a'))->generalize(GeneralizePrecision::lessSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('literal-string&non-falsy-string', (new ConstantStringType(stdClass::class))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('class-string', (new ConstantStringType(stdClass::class, true))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
-		$this->assertSame('class-string', (new ConstantStringType('NonexistentClass', true))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&non-falsy-string', (new ConstantStringType('NonexistentClass'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string', (new ConstantStringType(''))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string', (new ConstantStringType('a'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&non-falsy-string&uppercase-string', (new ConstantStringType('A'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-empty-string&numeric-string&uppercase-string', (new ConstantStringType('0'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string', (new ConstantStringType('1.123'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string&uppercase-string', (new ConstantStringType('    1       1   '))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string&numeric-string&uppercase-string', (new ConstantStringType('+1'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string&uppercase-string', (new ConstantStringType('+1+1'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string&numeric-string', (new ConstantStringType('1e9'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&lowercase-string&non-falsy-string', (new ConstantStringType('1e91e9'))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('string', (new ConstantStringType(''))->generalize(GeneralizePrecision::lessSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('string', (new ConstantStringType('a'))->generalize(GeneralizePrecision::lessSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('literal-string&non-falsy-string', (new ConstantStringType(stdClass::class))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('class-string', (new ConstantStringType(stdClass::class, true))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
+		self::assertSame('class-string', (new ConstantStringType('NonexistentClass', true))->generalize(GeneralizePrecision::moreSpecific())->describe(VerbosityLevel::precise()));
 	}
 
 	public function testTextInvalidEncoding(): void
 	{
-		$this->assertSame("'\xc3Lorem ipsum dolor s\u{2026}'", (new ConstantStringType("\xc3Lorem ipsum dolor sit"))->describe(VerbosityLevel::value()));
+		self::assertSame("'\xc3Lorem ipsum dolor s\u{2026}'", (new ConstantStringType("\xc3Lorem ipsum dolor sit"))->describe(VerbosityLevel::value()));
 	}
 
 	public function testShortTextInvalidEncoding(): void
 	{
-		$this->assertSame("'\xc3Lorem ipsum dolor'", (new ConstantStringType("\xc3Lorem ipsum dolor"))->describe(VerbosityLevel::value()));
+		self::assertSame("'\xc3Lorem ipsum dolor'", (new ConstantStringType("\xc3Lorem ipsum dolor"))->describe(VerbosityLevel::value()));
 	}
 
 	public function testSetInvalidValue(): void
 	{
 		$string = new ConstantStringType('internal:/node/add');
 		$result = $string->setOffsetValueType(new ConstantIntegerType(0), new NullType());
-		$this->assertInstanceOf(ErrorType::class, $result);
+		self::assertInstanceOf(ErrorType::class, $result);
 	}
 
 }

--- a/tests/PHPStan/Type/Constant/OversizedArrayBuilderTest.php
+++ b/tests/PHPStan/Type/Constant/OversizedArrayBuilderTest.php
@@ -69,15 +69,15 @@ class OversizedArrayBuilderTest extends PHPStanTestCase
 		$parser = self::getParser();
 		$ast = $parser->parseString('<?php ' . $sourceCode . ';');
 		$expr = $ast[0];
-		$this->assertInstanceOf(Expression::class, $expr);
+		self::assertInstanceOf(Expression::class, $expr);
 
 		$array = $expr->expr;
-		$this->assertInstanceOf(Array_::class, $array);
+		self::assertInstanceOf(Array_::class, $array);
 
 		$builder = new OversizedArrayBuilder();
 		$initializerExprTypeResolver = self::getContainer()->getByType(InitializerExprTypeResolver::class);
 		$arrayType = $builder->build($array, static fn (Expr $expr): Type => $initializerExprTypeResolver->getType($expr, InitializerExprContext::createEmpty()));
-		$this->assertSame($expectedTypeDescription, $arrayType->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedTypeDescription, $arrayType->describe(VerbosityLevel::precise()));
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php
+++ b/tests/PHPStan/Type/Enum/EnumCaseObjectTypeTest.php
@@ -108,7 +108,7 @@ class EnumCaseObjectTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -209,7 +209,7 @@ class EnumCaseObjectTypeTest extends PHPStanTestCase
 		TrinaryLogic $expectedResult,
 	): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$type->accepts($acceptedType, true)->result->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/FileTypeMapperTest.php
+++ b/tests/PHPStan/Type/FileTypeMapperTest.php
@@ -29,78 +29,78 @@ class FileTypeMapperTest extends PHPStanTestCase
  * @method Image rotate(float $angle, $backgroundColor)
  * @method int | float paramMultipleTypesWithExtraSpaces(string | null $string, stdClass | null $object)
  */');
-		$this->assertCount(0, $resolvedA->getVarTags());
-		$this->assertCount(0, $resolvedA->getParamTags());
-		$this->assertCount(2, $resolvedA->getPropertyTags());
-		$this->assertArrayHasKey('numericBazBazProperty', $resolvedA->getPropertyTags());
-		$this->assertNull($resolvedA->getReturnTag());
-		$this->assertNotNull($resolvedA->getPropertyTags()['numericBazBazProperty']->getReadableType());
-		$this->assertNotNull($resolvedA->getPropertyTags()['numericBazBazProperty']->getWritableType());
-		$this->assertSame('float|int', $resolvedA->getPropertyTags()['numericBazBazProperty']->getReadableType()->describe(VerbosityLevel::precise()));
-		$this->assertSame('float|int', $resolvedA->getPropertyTags()['numericBazBazProperty']->getWritableType()->describe(VerbosityLevel::precise()));
-		$this->assertArrayHasKey('singleLetterObjectName', $resolvedA->getPropertyTags());
-		$this->assertNotNull($resolvedA->getPropertyTags()['singleLetterObjectName']->getReadableType());
-		$this->assertNotNull($resolvedA->getPropertyTags()['singleLetterObjectName']->getWritableType());
-		$this->assertSame('TestAnnotations\\X', $resolvedA->getPropertyTags()['singleLetterObjectName']->getReadableType()->describe(VerbosityLevel::precise()));
-		$this->assertSame('TestAnnotations\\X', $resolvedA->getPropertyTags()['singleLetterObjectName']->getWritableType()->describe(VerbosityLevel::precise()));
+		self::assertCount(0, $resolvedA->getVarTags());
+		self::assertCount(0, $resolvedA->getParamTags());
+		self::assertCount(2, $resolvedA->getPropertyTags());
+		self::assertArrayHasKey('numericBazBazProperty', $resolvedA->getPropertyTags());
+		self::assertNull($resolvedA->getReturnTag());
+		self::assertNotNull($resolvedA->getPropertyTags()['numericBazBazProperty']->getReadableType());
+		self::assertNotNull($resolvedA->getPropertyTags()['numericBazBazProperty']->getWritableType());
+		self::assertSame('float|int', $resolvedA->getPropertyTags()['numericBazBazProperty']->getReadableType()->describe(VerbosityLevel::precise()));
+		self::assertSame('float|int', $resolvedA->getPropertyTags()['numericBazBazProperty']->getWritableType()->describe(VerbosityLevel::precise()));
+		self::assertArrayHasKey('singleLetterObjectName', $resolvedA->getPropertyTags());
+		self::assertNotNull($resolvedA->getPropertyTags()['singleLetterObjectName']->getReadableType());
+		self::assertNotNull($resolvedA->getPropertyTags()['singleLetterObjectName']->getWritableType());
+		self::assertSame('TestAnnotations\\X', $resolvedA->getPropertyTags()['singleLetterObjectName']->getReadableType()->describe(VerbosityLevel::precise()));
+		self::assertSame('TestAnnotations\\X', $resolvedA->getPropertyTags()['singleLetterObjectName']->getWritableType()->describe(VerbosityLevel::precise()));
 
-		$this->assertCount(6, $resolvedA->getMethodTags());
-		$this->assertArrayNotHasKey('complicatedParameters', $resolvedA->getMethodTags()); // ambiguous parameter types
-		$this->assertArrayHasKey('simpleMethod', $resolvedA->getMethodTags());
+		self::assertCount(6, $resolvedA->getMethodTags());
+		self::assertArrayNotHasKey('complicatedParameters', $resolvedA->getMethodTags()); // ambiguous parameter types
+		self::assertArrayHasKey('simpleMethod', $resolvedA->getMethodTags());
 		$simpleMethod = $resolvedA->getMethodTags()['simpleMethod'];
-		$this->assertSame('void', $simpleMethod->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertFalse($simpleMethod->isStatic());
-		$this->assertCount(0, $simpleMethod->getParameters());
+		self::assertSame('void', $simpleMethod->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertFalse($simpleMethod->isStatic());
+		self::assertCount(0, $simpleMethod->getParameters());
 
-		$this->assertArrayHasKey('returningMethod', $resolvedA->getMethodTags());
+		self::assertArrayHasKey('returningMethod', $resolvedA->getMethodTags());
 		$returningMethod = $resolvedA->getMethodTags()['returningMethod'];
-		$this->assertSame('string', $returningMethod->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertFalse($returningMethod->isStatic());
-		$this->assertCount(0, $returningMethod->getParameters());
+		self::assertSame('string', $returningMethod->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertFalse($returningMethod->isStatic());
+		self::assertCount(0, $returningMethod->getParameters());
 
-		$this->assertArrayHasKey('returningNullableScalar', $resolvedA->getMethodTags());
+		self::assertArrayHasKey('returningNullableScalar', $resolvedA->getMethodTags());
 		$returningNullableScalar = $resolvedA->getMethodTags()['returningNullableScalar'];
-		$this->assertSame('float|null', $returningNullableScalar->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertFalse($returningNullableScalar->isStatic());
-		$this->assertCount(0, $returningNullableScalar->getParameters());
+		self::assertSame('float|null', $returningNullableScalar->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertFalse($returningNullableScalar->isStatic());
+		self::assertCount(0, $returningNullableScalar->getParameters());
 
-		$this->assertArrayHasKey('returningNullableObject', $resolvedA->getMethodTags());
+		self::assertArrayHasKey('returningNullableObject', $resolvedA->getMethodTags());
 		$returningNullableObject = $resolvedA->getMethodTags()['returningNullableObject'];
-		$this->assertSame('stdClass|null', $returningNullableObject->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertFalse($returningNullableObject->isStatic());
-		$this->assertCount(0, $returningNullableObject->getParameters());
+		self::assertSame('stdClass|null', $returningNullableObject->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertFalse($returningNullableObject->isStatic());
+		self::assertCount(0, $returningNullableObject->getParameters());
 
-		$this->assertArrayHasKey('rotate', $resolvedA->getMethodTags());
+		self::assertArrayHasKey('rotate', $resolvedA->getMethodTags());
 		$rotate = $resolvedA->getMethodTags()['rotate'];
-		$this->assertSame('TestAnnotations\\Image', $rotate->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertFalse($rotate->isStatic());
-		$this->assertCount(2, $rotate->getParameters());
-		$this->assertArrayHasKey('angle', $rotate->getParameters());
-		$this->assertSame('float', $rotate->getParameters()['angle']->getType()->describe(VerbosityLevel::precise()));
-		$this->assertTrue($rotate->getParameters()['angle']->passedByReference()->no());
-		$this->assertFalse($rotate->getParameters()['angle']->isOptional());
-		$this->assertFalse($rotate->getParameters()['angle']->isVariadic());
-		$this->assertArrayHasKey('backgroundColor', $rotate->getParameters());
-		$this->assertSame('mixed', $rotate->getParameters()['backgroundColor']->getType()->describe(VerbosityLevel::precise()));
-		$this->assertTrue($rotate->getParameters()['backgroundColor']->passedByReference()->no());
-		$this->assertFalse($rotate->getParameters()['backgroundColor']->isOptional());
-		$this->assertFalse($rotate->getParameters()['backgroundColor']->isVariadic());
+		self::assertSame('TestAnnotations\\Image', $rotate->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertFalse($rotate->isStatic());
+		self::assertCount(2, $rotate->getParameters());
+		self::assertArrayHasKey('angle', $rotate->getParameters());
+		self::assertSame('float', $rotate->getParameters()['angle']->getType()->describe(VerbosityLevel::precise()));
+		self::assertTrue($rotate->getParameters()['angle']->passedByReference()->no());
+		self::assertFalse($rotate->getParameters()['angle']->isOptional());
+		self::assertFalse($rotate->getParameters()['angle']->isVariadic());
+		self::assertArrayHasKey('backgroundColor', $rotate->getParameters());
+		self::assertSame('mixed', $rotate->getParameters()['backgroundColor']->getType()->describe(VerbosityLevel::precise()));
+		self::assertTrue($rotate->getParameters()['backgroundColor']->passedByReference()->no());
+		self::assertFalse($rotate->getParameters()['backgroundColor']->isOptional());
+		self::assertFalse($rotate->getParameters()['backgroundColor']->isVariadic());
 
-		$this->assertArrayHasKey('paramMultipleTypesWithExtraSpaces', $resolvedA->getMethodTags());
+		self::assertArrayHasKey('paramMultipleTypesWithExtraSpaces', $resolvedA->getMethodTags());
 		$paramMultipleTypesWithExtraSpaces = $resolvedA->getMethodTags()['paramMultipleTypesWithExtraSpaces'];
-		$this->assertSame('float|int', $paramMultipleTypesWithExtraSpaces->getReturnType()->describe(VerbosityLevel::precise()));
-		$this->assertFalse($paramMultipleTypesWithExtraSpaces->isStatic());
-		$this->assertCount(2, $paramMultipleTypesWithExtraSpaces->getParameters());
-		$this->assertArrayHasKey('string', $paramMultipleTypesWithExtraSpaces->getParameters());
-		$this->assertSame('string|null', $paramMultipleTypesWithExtraSpaces->getParameters()['string']->getType()->describe(VerbosityLevel::precise()));
-		$this->assertTrue($paramMultipleTypesWithExtraSpaces->getParameters()['string']->passedByReference()->no());
-		$this->assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['string']->isOptional());
-		$this->assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['string']->isVariadic());
-		$this->assertArrayHasKey('object', $paramMultipleTypesWithExtraSpaces->getParameters());
-		$this->assertSame('TestAnnotations\\stdClass|null', $paramMultipleTypesWithExtraSpaces->getParameters()['object']->getType()->describe(VerbosityLevel::precise()));
-		$this->assertTrue($paramMultipleTypesWithExtraSpaces->getParameters()['object']->passedByReference()->no());
-		$this->assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['object']->isOptional());
-		$this->assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['object']->isVariadic());
+		self::assertSame('float|int', $paramMultipleTypesWithExtraSpaces->getReturnType()->describe(VerbosityLevel::precise()));
+		self::assertFalse($paramMultipleTypesWithExtraSpaces->isStatic());
+		self::assertCount(2, $paramMultipleTypesWithExtraSpaces->getParameters());
+		self::assertArrayHasKey('string', $paramMultipleTypesWithExtraSpaces->getParameters());
+		self::assertSame('string|null', $paramMultipleTypesWithExtraSpaces->getParameters()['string']->getType()->describe(VerbosityLevel::precise()));
+		self::assertTrue($paramMultipleTypesWithExtraSpaces->getParameters()['string']->passedByReference()->no());
+		self::assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['string']->isOptional());
+		self::assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['string']->isVariadic());
+		self::assertArrayHasKey('object', $paramMultipleTypesWithExtraSpaces->getParameters());
+		self::assertSame('TestAnnotations\\stdClass|null', $paramMultipleTypesWithExtraSpaces->getParameters()['object']->getType()->describe(VerbosityLevel::precise()));
+		self::assertTrue($paramMultipleTypesWithExtraSpaces->getParameters()['object']->passedByReference()->no());
+		self::assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['object']->isOptional());
+		self::assertFalse($paramMultipleTypesWithExtraSpaces->getParameters()['object']->isVariadic());
 	}
 
 	public function testFileWithDependentPhpDocs(): void
@@ -121,9 +121,9 @@ class FileTypeMapperTest extends PHPStanTestCase
 			'/** @param Foo[]|Foo|\Iterator $pages */',
 		);
 
-		$this->assertCount(1, $resolved->getParamTags());
-		$this->assertArrayHasKey('pages', $resolved->getParamTags());
-		$this->assertSame(
+		self::assertCount(1, $resolved->getParamTags());
+		self::assertArrayHasKey('pages', $resolved->getParamTags());
+		self::assertSame(
 			'(DependentPhpDocs\Foo&iterable<DependentPhpDocs\Foo>)|(iterable<DependentPhpDocs\Foo>&Iterator)',
 			$resolved->getParamTags()['pages']->getType()->describe(VerbosityLevel::precise()),
 		);
@@ -143,8 +143,8 @@ class FileTypeMapperTest extends PHPStanTestCase
  * @throws RuntimeException
  */');
 
-		$this->assertNotNull($resolved->getThrowsTag());
-		$this->assertSame(
+		self::assertNotNull($resolved->getThrowsTag());
+		self::assertSame(
 			RuntimeException::class,
 			$resolved->getThrowsTag()->getType()->describe(VerbosityLevel::precise()),
 		);
@@ -153,8 +153,8 @@ class FileTypeMapperTest extends PHPStanTestCase
  * @throws RuntimeException|LogicException
  */');
 
-		$this->assertNotNull($resolved->getThrowsTag());
-		$this->assertSame(
+		self::assertNotNull($resolved->getThrowsTag());
+		self::assertSame(
 			'LogicException|RuntimeException',
 			$resolved->getThrowsTag()->getType()->describe(VerbosityLevel::precise()),
 		);
@@ -164,8 +164,8 @@ class FileTypeMapperTest extends PHPStanTestCase
  * @throws LogicException
  */');
 
-		$this->assertNotNull($resolved->getThrowsTag());
-		$this->assertSame(
+		self::assertNotNull($resolved->getThrowsTag());
+		self::assertSame(
 			'LogicException|RuntimeException',
 			$resolved->getThrowsTag()->getType()->describe(VerbosityLevel::precise()),
 		);
@@ -193,7 +193,7 @@ class FileTypeMapperTest extends PHPStanTestCase
 
 		/** @var ReturnTag $returnTag */
 		$returnTag = $resolved->getReturnTag();
-		$this->assertSame('CyclicPhpDocs\Foo|iterable<CyclicPhpDocs\Foo>', $returnTag->getType()->describe(VerbosityLevel::precise()));
+		self::assertSame('CyclicPhpDocs\Foo|iterable<CyclicPhpDocs\Foo>', $returnTag->getType()->describe(VerbosityLevel::precise()));
 	}
 
 	public function testFilesWithIdenticalPhpDocsUsingDifferentAliases(): void
@@ -204,10 +204,10 @@ class FileTypeMapperTest extends PHPStanTestCase
 		$doc1 = $fileTypeMapper->getResolvedPhpDoc(__DIR__ . '/data/alias-collision1.php', null, null, null, '/** @var Foo $x */');
 		$doc2 = $fileTypeMapper->getResolvedPhpDoc(__DIR__ . '/data/alias-collision2.php', null, null, null, '/** @var Foo $x */');
 
-		$this->assertArrayHasKey('x', $doc1->getVarTags());
-		$this->assertSame('AliasCollisionNamespace1\Foo', $doc1->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
-		$this->assertArrayHasKey('x', $doc2->getVarTags());
-		$this->assertSame('AliasCollisionNamespace2\Foo', $doc2->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
+		self::assertArrayHasKey('x', $doc1->getVarTags());
+		self::assertSame('AliasCollisionNamespace1\Foo', $doc1->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
+		self::assertArrayHasKey('x', $doc2->getVarTags());
+		self::assertSame('AliasCollisionNamespace2\Foo', $doc2->getVarTags()['x']->getType()->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/FloatTypeTest.php
+++ b/tests/PHPStan/Type/FloatTypeTest.php
@@ -66,7 +66,7 @@ class FloatTypeTest extends PHPStanTestCase
 	{
 		$type = new FloatType();
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -123,7 +123,7 @@ class FloatTypeTest extends PHPStanTestCase
 	public function testEquals(FloatType $type, Type $otherType, bool $expectedResult): void
 	{
 		$actualResult = $type->equals($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$actualResult,
 			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericClassStringTypeTest.php
@@ -163,7 +163,7 @@ class GenericClassStringTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(GenericClassStringType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -282,7 +282,7 @@ class GenericClassStringTypeTest extends PHPStanTestCase
 	): void
 	{
 		$actualResult = $acceptingType->accepts($acceptedType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $acceptingType->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),
@@ -325,14 +325,14 @@ class GenericClassStringTypeTest extends PHPStanTestCase
 		$otherTypeDescription = $otherType->describe($verbosityLevel);
 
 		$actual = $type->equals($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expected,
 			$actual,
 			sprintf('%s -> equals(%s)', $typeDescription, $otherTypeDescription),
 		);
 
 		$actual = $otherType->equals($type);
-		$this->assertSame(
+		self::assertSame(
 			$expected,
 			$actual,
 			sprintf('%s -> equals(%s)', $otherTypeDescription, $typeDescription),

--- a/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
+++ b/tests/PHPStan/Type/Generic/GenericObjectTypeTest.php
@@ -267,7 +267,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -339,7 +339,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 	): void
 	{
 		$actualResult = $acceptingType->accepts($acceptedType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $acceptingType->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),
@@ -453,7 +453,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 	{
 		$result = $template->inferTemplateTypes($received);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypes,
 			array_map(static fn (Type $type): string => $type->describe(VerbosityLevel::precise()), $result->getTypes()),
 		);
@@ -974,7 +974,7 @@ class GenericObjectTypeTest extends PHPStanTestCase
 			'positionVariance' => $ref->getPositionVariance()->describe(),
 		], $expectedReferences);
 
-		$this->assertSame($comparableExpect, $comparableResult);
+		self::assertSame($comparableExpect, $comparableResult);
 	}
 
 }

--- a/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeHelperTest.php
@@ -29,7 +29,7 @@ class TemplateTypeHelperTest extends PHPStanTestCase
 			TemplateTypeVariance::createInvariant(),
 		);
 
-		$this->assertSame(
+		self::assertSame(
 			'T (function a(), parameter)',
 			$type->describe(VerbosityLevel::precise()),
 		);
@@ -46,7 +46,7 @@ class TemplateTypeHelperTest extends PHPStanTestCase
 			TemplateTypeVariance::createInvariant(),
 		);
 
-		$this->assertSame(
+		self::assertSame(
 			'DateTime&T (function a(), parameter)',
 			$type->describe(VerbosityLevel::precise()),
 		);

--- a/tests/PHPStan/Type/Generic/TemplateTypeMapTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeMapTest.php
@@ -59,10 +59,10 @@ class TemplateTypeMapTest extends PHPStanTestCase
 	#[DataProvider('dataUnionWithLowerBoundTypes')]
 	public function testUnionWithLowerBoundTypes(TemplateTypeMap $map, string $expectedTDescription): void
 	{
-		$this->assertFalse($map->isEmpty());
+		self::assertFalse($map->isEmpty());
 		$t = $map->getType('T');
-		$this->assertNotNull($t);
-		$this->assertSame($expectedTDescription, $t->describe(VerbosityLevel::precise()));
+		self::assertNotNull($t);
+		self::assertSame($expectedTDescription, $t->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/Generic/TemplateTypeVarianceTest.php
+++ b/tests/PHPStan/Type/Generic/TemplateTypeVarianceTest.php
@@ -87,12 +87,12 @@ class TemplateTypeVarianceTest extends PHPStanTestCase
 	): void
 	{
 		$templateType = TemplateTypeFactory::create(TemplateTypeScope::createWithFunction('foo'), 'T', null, $variance);
-		$this->assertSame(
+		self::assertSame(
 			$expected->describe(),
 			$variance->isValidVariance($templateType, $a, $b)->result->describe(),
 			sprintf('%s->isValidVariance(%s, %s)', $variance->describe(), $a->describe(VerbosityLevel::precise()), $b->describe(VerbosityLevel::precise())),
 		);
-		$this->assertSame(
+		self::assertSame(
 			$expectedInversed->describe(),
 			$variance->isValidVariance($templateType, $b, $a)->result->describe(),
 			sprintf('%s->isValidVariance(%s, %s)', $variance->describe(), $b->describe(VerbosityLevel::precise()), $a->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/IntegerTypeTest.php
+++ b/tests/PHPStan/Type/IntegerTypeTest.php
@@ -53,7 +53,7 @@ class IntegerTypeTest extends PHPStanTestCase
 	public function testAccepts(IntegerType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -97,7 +97,7 @@ class IntegerTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(IntegerType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -154,7 +154,7 @@ class IntegerTypeTest extends PHPStanTestCase
 	public function testEquals(IntegerType $type, Type $otherType, bool $expectedResult): void
 	{
 		$actualResult = $type->equals($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$actualResult,
 			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/IntersectionTypeTest.php
+++ b/tests/PHPStan/Type/IntersectionTypeTest.php
@@ -76,7 +76,7 @@ class IntersectionTypeTest extends PHPStanTestCase
 	public function testAccepts(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -117,7 +117,7 @@ class IntersectionTypeTest extends PHPStanTestCase
 	public function testIsCallable(IntersectionType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isCallable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCallable()', $type->describe(VerbosityLevel::precise())),
@@ -241,7 +241,7 @@ class IntersectionTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(IntersectionType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -342,7 +342,7 @@ class IntersectionTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOf(IntersectionType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSubTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -353,7 +353,7 @@ class IntersectionTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOfInversed(IntersectionType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),
@@ -363,7 +363,7 @@ class IntersectionTypeTest extends PHPStanTestCase
 	public function testToBooleanCrash(): void
 	{
 		$type = new IntersectionType([new NeverType(), new NonEmptyArrayType()]);
-		$this->assertSame('true', $type->toBoolean()->describe(VerbosityLevel::precise()));
+		self::assertSame('true', $type->toBoolean()->describe(VerbosityLevel::precise()));
 	}
 
 	public static function dataGetEnumCases(): iterable
@@ -396,10 +396,10 @@ class IntersectionTypeTest extends PHPStanTestCase
 	): void
 	{
 		$enumCases = $type->getEnumCases();
-		$this->assertCount(count($expectedEnumCases), $enumCases);
+		self::assertCount(count($expectedEnumCases), $enumCases);
 		foreach ($enumCases as $i => $enumCase) {
 			$expectedEnumCase = $expectedEnumCases[$i];
-			$this->assertTrue($expectedEnumCase->equals($enumCase), sprintf('%s->equals(%s)', $expectedEnumCase->describe(VerbosityLevel::precise()), $enumCase->describe(VerbosityLevel::precise())));
+			self::assertTrue($expectedEnumCase->equals($enumCase), sprintf('%s->equals(%s)', $expectedEnumCase->describe(VerbosityLevel::precise()), $enumCase->describe(VerbosityLevel::precise())));
 		}
 	}
 

--- a/tests/PHPStan/Type/IterableTypeTest.php
+++ b/tests/PHPStan/Type/IterableTypeTest.php
@@ -63,7 +63,7 @@ class IterableTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(IterableType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -160,7 +160,7 @@ class IterableTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOf(IterableType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSubTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -171,7 +171,7 @@ class IterableTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOfInversed(IterableType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),
@@ -237,7 +237,7 @@ class IterableTypeTest extends PHPStanTestCase
 	{
 		$result = $template->inferTemplateTypes($received);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypes,
 			array_map(static fn (Type $type): string => $type->describe(VerbosityLevel::precise()), $result->getTypes()),
 		);
@@ -285,7 +285,7 @@ class IterableTypeTest extends PHPStanTestCase
 	{
 		$result = $type->describe(VerbosityLevel::typeOnly());
 
-		$this->assertSame($expect, $result);
+		self::assertSame($expect, $result);
 	}
 
 	public static function dataAccepts(): array
@@ -321,7 +321,7 @@ class IterableTypeTest extends PHPStanTestCase
 	public function testAccepts(IterableType $iterableType, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $iterableType->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $iterableType->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/MixedTypeTest.php
+++ b/tests/PHPStan/Type/MixedTypeTest.php
@@ -164,7 +164,7 @@ class MixedTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(MixedType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -231,7 +231,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isArray();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isArray()', $subtracted->describe(VerbosityLevel::precise())),
@@ -303,7 +303,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isConstantArray();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isConstantArray()', $subtracted->describe(VerbosityLevel::precise())),
@@ -353,7 +353,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isString();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isString()', $subtracted->describe(VerbosityLevel::precise())),
@@ -403,7 +403,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isNumericString();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isNumericString()', $subtracted->describe(VerbosityLevel::precise())),
@@ -461,7 +461,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isNonEmptyString();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isNonEmptyString()', $subtracted->describe(VerbosityLevel::precise())),
@@ -519,7 +519,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isNonFalsyString();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isNonFalsyString()', $subtracted->describe(VerbosityLevel::precise())),
@@ -585,7 +585,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isClassString();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isClassStringType()', $subtracted->describe(VerbosityLevel::precise())),
@@ -627,7 +627,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isVoid();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isVoid()', $subtracted->describe(VerbosityLevel::precise())),
@@ -656,7 +656,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isScalar();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isScalar()', $subtracted->describe(VerbosityLevel::precise())),
@@ -685,7 +685,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isLiteralString();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isLiteralString()', $subtracted->describe(VerbosityLevel::precise())),
@@ -737,7 +737,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isBoolean();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isBoolean()', $subtracted->describe(VerbosityLevel::precise())),
@@ -776,7 +776,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isFalse();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isFalse()', $subtracted->describe(VerbosityLevel::precise())),
@@ -815,7 +815,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isNull();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isNull()', $subtracted->describe(VerbosityLevel::precise())),
@@ -859,7 +859,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isTrue();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isTrue()', $subtracted->describe(VerbosityLevel::precise())),
@@ -898,7 +898,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isFloat();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isFloat()', $subtracted->describe(VerbosityLevel::precise())),
@@ -932,7 +932,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isInteger();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isInteger()', $subtracted->describe(VerbosityLevel::precise())),
@@ -966,7 +966,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isIterable();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isIterable()', $subtracted->describe(VerbosityLevel::precise())),
@@ -1019,7 +1019,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isOffsetAccessible();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isOffsetAccessible()', $subtracted->describe(VerbosityLevel::precise())),
@@ -1064,7 +1064,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->isOffsetAccessLegal();
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isOffsetAccessLegal()', $subtracted->describe(VerbosityLevel::precise())),
@@ -1122,7 +1122,7 @@ class MixedTypeTest extends PHPStanTestCase
 		$subtracted = $mixedType->subtract($typeToSubtract);
 		$actualResult = $subtracted->hasOffsetValueType($offsetType);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasOffsetValueType()', $subtracted->describe(VerbosityLevel::precise())),
@@ -1132,7 +1132,7 @@ class MixedTypeTest extends PHPStanTestCase
 	#[DataProvider('dataEquals')]
 	public function testEquals(MixedType $mixedType, Type $typeToCompare, bool $expectedResult): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$mixedType->equals($typeToCompare),
 			sprintf('%s -> equals(%s)', $mixedType->describe(VerbosityLevel::precise()), $typeToCompare->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -63,7 +63,7 @@ class ObjectTypeTest extends PHPStanTestCase
 	public function testIsIterable(ObjectType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isIterable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isIterable()', $type->describe(VerbosityLevel::precise())),
@@ -90,7 +90,7 @@ class ObjectTypeTest extends PHPStanTestCase
 	public function testIsEnum(ObjectType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isEnum();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isEnum()', $type->describe(VerbosityLevel::precise())),
@@ -110,7 +110,7 @@ class ObjectTypeTest extends PHPStanTestCase
 	public function testIsCallable(ObjectType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isCallable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCallable()', $type->describe(VerbosityLevel::precise())),
@@ -485,7 +485,7 @@ class ObjectTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ObjectType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -550,7 +550,7 @@ class ObjectTypeTest extends PHPStanTestCase
 		TrinaryLogic $expectedResult,
 	): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$type->accepts($acceptedType, true)->result->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),
@@ -588,7 +588,7 @@ class ObjectTypeTest extends PHPStanTestCase
 	public function testHasConstant(ObjectType $type, string $constantName, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->hasConstant($constantName);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> hasConstant("%s")', $type->describe(VerbosityLevel::precise()), $constantName),
@@ -599,8 +599,8 @@ class ObjectTypeTest extends PHPStanTestCase
 	{
 		$objectType = new ObjectType(Traversable::class);
 		$classReflection = $objectType->getClassReflection();
-		$this->assertNotNull($classReflection);
-		$this->assertSame('Traversable<mixed,mixed>', $classReflection->getDisplayName());
+		self::assertNotNull($classReflection);
+		self::assertSame('Traversable<mixed,mixed>', $classReflection->getDisplayName());
 	}
 
 	public static function dataHasOffsetValueType(): array
@@ -666,7 +666,7 @@ class ObjectTypeTest extends PHPStanTestCase
 		TrinaryLogic $expectedResult,
 	): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$type->hasOffsetValueType($offsetType)->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $offsetType->describe(VerbosityLevel::precise())),
@@ -716,10 +716,10 @@ class ObjectTypeTest extends PHPStanTestCase
 	): void
 	{
 		$enumCases = $type->getEnumCases();
-		$this->assertCount(count($expectedEnumCases), $enumCases);
+		self::assertCount(count($expectedEnumCases), $enumCases);
 		foreach ($enumCases as $i => $enumCase) {
 			$expectedEnumCase = $expectedEnumCases[$i];
-			$this->assertTrue($expectedEnumCase->equals($enumCase), sprintf('%s->equals(%s)', $expectedEnumCase->describe(VerbosityLevel::precise()), $enumCase->describe(VerbosityLevel::precise())));
+			self::assertTrue($expectedEnumCase->equals($enumCase), sprintf('%s->equals(%s)', $expectedEnumCase->describe(VerbosityLevel::precise()), $enumCase->describe(VerbosityLevel::precise())));
 		}
 	}
 
@@ -727,22 +727,22 @@ class ObjectTypeTest extends PHPStanTestCase
 	{
 		$type = new ObjectType(GenericClass::class);
 		$classReflection = $type->getClassReflection();
-		$this->assertNotNull($classReflection);
+		self::assertNotNull($classReflection);
 		$tModlel = $classReflection->getActiveTemplateTypeMap()->getType('TModlel');
-		$this->assertNotNull($tModlel);
-		$this->assertSame(BaseModel::class, $tModlel->describe(VerbosityLevel::precise()));
+		self::assertNotNull($tModlel);
+		self::assertSame(BaseModel::class, $tModlel->describe(VerbosityLevel::precise()));
 	}
 
 	public function testClassReflectionParentWithTemplateBound(): void
 	{
 		$type = new ObjectType(ChildGenericGenericClass::class);
 		$classReflection = $type->getClassReflection();
-		$this->assertNotNull($classReflection);
+		self::assertNotNull($classReflection);
 		$ancestor = $classReflection->getAncestorWithClassName(GenericClass::class);
-		$this->assertNotNull($ancestor);
+		self::assertNotNull($ancestor);
 		$tModlel = $ancestor->getActiveTemplateTypeMap()->getType('TModlel');
-		$this->assertNotNull($tModlel);
-		$this->assertSame(Model::class, $tModlel->describe(VerbosityLevel::precise()));
+		self::assertNotNull($tModlel);
+		self::assertSame(Model::class, $tModlel->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
+++ b/tests/PHPStan/Type/ObjectWithoutClassTypeTest.php
@@ -66,7 +66,7 @@ class ObjectWithoutClassTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(ObjectWithoutClassType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/Regex/RegexExpressionHelperTest.php
+++ b/tests/PHPStan/Type/Regex/RegexExpressionHelperTest.php
@@ -51,7 +51,7 @@ class RegexExpressionHelperTest extends PHPStanTestCase
 	{
 		$regexExpressionHelper = self::getContainer()->getByType(RegexExpressionHelper::class);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedPatternWithoutDelimiter,
 			$regexExpressionHelper->removeDelimitersAndModifiers($inputPattern),
 		);

--- a/tests/PHPStan/Type/SimultaneousTypeTraverserTest.php
+++ b/tests/PHPStan/Type/SimultaneousTypeTraverserTest.php
@@ -86,7 +86,7 @@ class SimultaneousTypeTraverserTest extends PHPStanTestCase
 			return $right;
 		};
 		$actualType = SimultaneousTypeTraverser::map($left, $right, $cb);
-		$this->assertSame($expectedTypeDescription, $actualType->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedTypeDescription, $actualType->describe(VerbosityLevel::precise()));
 	}
 
 	public static function dataDescriptionBased(): iterable
@@ -152,7 +152,7 @@ class SimultaneousTypeTraverserTest extends PHPStanTestCase
 		$leftType = $typeStringResolver->resolve($left);
 		$rightType = $typeStringResolver->resolve($right);
 		$actualType = SimultaneousTypeTraverser::map($leftType, $rightType, $callback);
-		$this->assertSame($expectedTypeDescription, $actualType->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedTypeDescription, $actualType->describe(VerbosityLevel::precise()));
 	}
 
 }

--- a/tests/PHPStan/Type/StaticTypeTest.php
+++ b/tests/PHPStan/Type/StaticTypeTest.php
@@ -44,7 +44,7 @@ class StaticTypeTest extends PHPStanTestCase
 	public function testIsIterable(StaticType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isIterable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isIterable()', $type->describe(VerbosityLevel::precise())),
@@ -65,7 +65,7 @@ class StaticTypeTest extends PHPStanTestCase
 	public function testIsCallable(StaticType $type, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isCallable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCallable()', $type->describe(VerbosityLevel::precise())),
@@ -292,7 +292,7 @@ class StaticTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(Type $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -330,8 +330,8 @@ class StaticTypeTest extends PHPStanTestCase
 	#[DataProvider('dataEquals')]
 	public function testEquals(StaticType $type, StaticType $otherType, bool $expected): void
 	{
-		$this->assertSame($expected, $type->equals($otherType));
-		$this->assertSame($expected, $otherType->equals($type));
+		self::assertSame($expected, $type->equals($otherType));
+		self::assertSame($expected, $otherType->equals($type));
 	}
 
 	public static function dataAccepts(): iterable
@@ -452,7 +452,7 @@ class StaticTypeTest extends PHPStanTestCase
 	public function testAccepts(StaticType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->accepts($otherType, true);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->result->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/StringTypeTest.php
+++ b/tests/PHPStan/Type/StringTypeTest.php
@@ -98,10 +98,10 @@ class StringTypeTest extends PHPStanTestCase
 	#[DataProvider('dataIsSuperTypeOf')]
 	public function testIsSuperTypeOf(Type $stringType, Type $otherType, TrinaryLogic $expectedResult): void
 	{
-		$this->assertInstanceOf(StringType::class, $stringType);
+		self::assertInstanceOf(StringType::class, $stringType);
 
 		$actualResult = $stringType->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $stringType->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -178,10 +178,10 @@ class StringTypeTest extends PHPStanTestCase
 	#[DataProvider('dataAccepts')]
 	public function testAccepts(Type $stringType, Type $otherType, TrinaryLogic $expectedResult): void
 	{
-		$this->assertInstanceOf(StringType::class, $stringType);
+		self::assertInstanceOf(StringType::class, $stringType);
 
 		$actualResult = $stringType->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $stringType->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -228,7 +228,7 @@ class StringTypeTest extends PHPStanTestCase
 	public function testEquals(StringType $type, Type $otherType, bool $expectedResult): void
 	{
 		$actualResult = $type->equals($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult,
 			$actualResult,
 			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),

--- a/tests/PHPStan/Type/TemplateTypeTest.php
+++ b/tests/PHPStan/Type/TemplateTypeTest.php
@@ -108,7 +108,7 @@ class TemplateTypeTest extends PHPStanTestCase
 		assert($type instanceof TemplateType);
 
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedAccept->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -117,7 +117,7 @@ class TemplateTypeTest extends PHPStanTestCase
 		$type = $type->toArgument();
 
 		$actualResult = $type->accepts($otherType, true)->result;
-		$this->assertSame(
+		self::assertSame(
 			$expectedAcceptArg->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> accepts(%s) (Argument strategy)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -295,14 +295,14 @@ class TemplateTypeTest extends PHPStanTestCase
 		assert($type instanceof TemplateType);
 
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedIsSuperType->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
 		);
 
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedIsSuperTypeInverse->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),
@@ -365,7 +365,7 @@ class TemplateTypeTest extends PHPStanTestCase
 	{
 		$result = $template->inferTemplateTypes($received);
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypes,
 			array_map(static fn (Type $type): string => $type->describe(VerbosityLevel::precise()), $result->getTypes()),
 		);

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -139,8 +139,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 	): void
 	{
 		$result = TypeCombinator::addNull($type);
-		$this->assertSame($expectedTypeDescription, $result->describe(VerbosityLevel::precise()));
-		$this->assertInstanceOf($expectedTypeClass, $result);
+		self::assertSame($expectedTypeDescription, $result->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf($expectedTypeClass, $result);
 	}
 
 	/**
@@ -154,8 +154,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 	): void
 	{
 		$result = TypeCombinator::union($type, new NullType());
-		$this->assertSame($expectedTypeDescription, $result->describe(VerbosityLevel::precise()));
-		$this->assertInstanceOf($expectedTypeClass, $result);
+		self::assertSame($expectedTypeDescription, $result->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf($expectedTypeClass, $result);
 	}
 
 	public static function dataRemoveNull(): array
@@ -257,8 +257,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 	): void
 	{
 		$result = TypeCombinator::removeNull($type);
-		$this->assertSame($expectedTypeDescription, $result->describe(VerbosityLevel::precise()));
-		$this->assertInstanceOf($expectedTypeClass, $result);
+		self::assertSame($expectedTypeDescription, $result->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf($expectedTypeClass, $result);
 	}
 
 	public static function dataUnion(): iterable
@@ -2835,7 +2835,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 			}
 		}
 
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypeDescription,
 			$actualTypeDescription,
 			sprintf('union(%s)', implode(', ', array_map(
@@ -2844,7 +2844,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 			))),
 		);
 
-		$this->assertInstanceOf($expectedTypeClass, $actualType);
+		self::assertInstanceOf($expectedTypeClass, $actualType);
 
 		$hasSubtraction = false;
 		foreach ($types as $type) {
@@ -2891,7 +2891,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				$actualTypeDescription .= '=final';
 			}
 		}
-		$this->assertSame(
+		self::assertSame(
 			$expectedTypeDescription,
 			$actualTypeDescription,
 			sprintf('union(%s)', implode(', ', array_map(
@@ -2899,7 +2899,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 				$types,
 			))),
 		);
-		$this->assertInstanceOf($expectedTypeClass, $actualType);
+		self::assertInstanceOf($expectedTypeClass, $actualType);
 	}
 
 	public static function dataIntersect(): iterable
@@ -4798,8 +4798,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 			}
 		}
 
-		$this->assertSame($expectedTypeDescription, $actualTypeDescription);
-		$this->assertInstanceOf($expectedTypeClass, $actualType);
+		self::assertSame($expectedTypeDescription, $actualTypeDescription);
+		self::assertInstanceOf($expectedTypeClass, $actualType);
 	}
 
 	/**
@@ -4840,8 +4840,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 				$actualTypeDescription .= '=final';
 			}
 		}
-		$this->assertSame($expectedTypeDescription, $actualTypeDescription);
-		$this->assertInstanceOf($expectedTypeClass, $actualType);
+		self::assertSame($expectedTypeDescription, $actualTypeDescription);
+		self::assertInstanceOf($expectedTypeClass, $actualType);
 	}
 
 	public static function dataRemove(): array
@@ -5368,8 +5368,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 				$actualTypeDescription .= '=implicit';
 			}
 		}
-		$this->assertSame($expectedTypeDescription, $actualTypeDescription);
-		$this->assertInstanceOf($expectedTypeClass, $result);
+		self::assertSame($expectedTypeDescription, $actualTypeDescription);
+		self::assertInstanceOf($expectedTypeClass, $result);
 	}
 
 	public function testSpecificUnionConstantArray(): void
@@ -5387,8 +5387,8 @@ class TypeCombinatorTest extends PHPStanTestCase
 			}
 		}
 		$resultType = TypeCombinator::union(...$arrays);
-		$this->assertInstanceOf(ConstantArrayType::class, $resultType);
-		$this->assertSame('array{0: string, 1?: string, 2?: string, 3?: string, 4?: string, test?: string}', $resultType->describe(VerbosityLevel::precise()));
+		self::assertInstanceOf(ConstantArrayType::class, $resultType);
+		self::assertSame('array{0: string, 1?: string, 2?: string, 3?: string, 4?: string, test?: string}', $resultType->describe(VerbosityLevel::precise()));
 	}
 
 	#[DataProvider('dataContainsNull')]
@@ -5397,7 +5397,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 		bool $expectedResult,
 	): void
 	{
-		$this->assertSame($expectedResult, TypeCombinator::containsNull($type));
+		self::assertSame($expectedResult, TypeCombinator::containsNull($type));
 	}
 
 	public static function dataContainsNull(): iterable

--- a/tests/PHPStan/Type/TypeGetFiniteTypesTest.php
+++ b/tests/PHPStan/Type/TypeGetFiniteTypesTest.php
@@ -133,7 +133,7 @@ class TypeGetFiniteTypesTest extends PHPStanTestCase
 		array $expectedTypes,
 	): void
 	{
-		$this->assertEquals($expectedTypes, $type->getFiniteTypes());
+		self::assertEquals($expectedTypes, $type->getFiniteTypes());
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
+++ b/tests/PHPStan/Type/TypeToPhpDocNodeTest.php
@@ -441,11 +441,11 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 		$phpDocNode = $type->toPhpDocNode();
 
 		$typeString = (string) $phpDocNode;
-		$this->assertSame($expected, $typeString);
+		self::assertSame($expected, $typeString);
 
 		$typeStringResolver = self::getContainer()->getByType(TypeStringResolver::class);
 		$parsedType = $typeStringResolver->resolve($typeString);
-		$this->assertTrue($type->equals($parsedType), sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $parsedType->describe(VerbosityLevel::precise())));
+		self::assertTrue($type->equals($parsedType), sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $parsedType->describe(VerbosityLevel::precise())));
 	}
 
 	public static function dataToPhpDocNodeWithoutCheckingEquals(): iterable
@@ -522,7 +522,7 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 		$phpDocNode = $type->toPhpDocNode();
 
 		$typeString = (string) $phpDocNode;
-		$this->assertSame($expected, $typeString);
+		self::assertSame($expected, $typeString);
 
 		$typeStringResolver = self::getContainer()->getByType(TypeStringResolver::class);
 		$typeStringResolver->resolve($typeString);
@@ -550,10 +550,10 @@ class TypeToPhpDocNodeTest extends PHPStanTestCase
 	{
 		$typeStringResolver = self::getContainer()->getByType(TypeStringResolver::class);
 		$type = $typeStringResolver->resolve($typeString);
-		$this->assertSame($typeString, (string) $type->toPhpDocNode());
+		self::assertSame($typeString, (string) $type->toPhpDocNode());
 
 		$typeAgain = $typeStringResolver->resolve((string) $type->toPhpDocNode());
-		$this->assertTrue($type->equals($typeAgain));
+		self::assertTrue($type->equals($typeAgain));
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -79,10 +79,10 @@ class UnionTypeTest extends PHPStanTestCase
 	#[DataProvider('dataIsCallable')]
 	public function testIsCallable(Type $unionType, TrinaryLogic $expectedResult): void
 	{
-		$this->assertInstanceOf(UnionType::class, $unionType);
+		self::assertInstanceOf(UnionType::class, $unionType);
 
 		$actualResult = $unionType->isCallable();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isCallable()', $unionType->describe(VerbosityLevel::precise())),
@@ -155,16 +155,16 @@ class UnionTypeTest extends PHPStanTestCase
 	public function testSelfCompare(Type $type): void
 	{
 		$description = $type->describe(VerbosityLevel::precise());
-		$this->assertTrue(
+		self::assertTrue(
 			$type->equals($type),
 			sprintf('%s -> equals(itself)', $description),
 		);
-		$this->assertSame(
+		self::assertSame(
 			'Yes',
 			$type->isSuperTypeOf($type)->describe(),
 			sprintf('%s -> isSuperTypeOf(itself)', $description),
 		);
-		$this->assertInstanceOf(
+		self::assertInstanceOf(
 			get_class($type),
 			TypeCombinator::union($type, $type),
 			sprintf('%s -> union with itself is same type', $description),
@@ -465,7 +465,7 @@ class UnionTypeTest extends PHPStanTestCase
 	public function testIsSuperTypeOf(UnionType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSuperTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -638,7 +638,7 @@ class UnionTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOf(UnionType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $type->isSubTypeOf($otherType);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSubTypeOf(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
@@ -649,7 +649,7 @@ class UnionTypeTest extends PHPStanTestCase
 	public function testIsSubTypeOfInversed(UnionType $type, Type $otherType, TrinaryLogic $expectedResult): void
 	{
 		$actualResult = $otherType->isSuperTypeOf($type);
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isSuperTypeOf(%s)', $otherType->describe(VerbosityLevel::precise()), $type->describe(VerbosityLevel::precise())),
@@ -711,10 +711,10 @@ class UnionTypeTest extends PHPStanTestCase
 	#[DataProvider('dataIsScalar')]
 	public function testIsScalar(Type $unionType, TrinaryLogic $expectedResult): void
 	{
-		$this->assertInstanceOf(UnionType::class, $unionType);
+		self::assertInstanceOf(UnionType::class, $unionType);
 
 		$actualResult = $unionType->isScalar();
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$actualResult->describe(),
 			sprintf('%s -> isScalar()', $unionType->describe(VerbosityLevel::precise())),
@@ -973,10 +973,10 @@ class UnionTypeTest extends PHPStanTestCase
 		string $expectedTypeOnlyDescription,
 	): void
 	{
-		$this->assertSame($expectedCacheDescription, $type->describe(VerbosityLevel::cache()));
-		$this->assertSame($expectedPreciseDescription, $type->describe(VerbosityLevel::precise()));
-		$this->assertSame($expectedValueDescription, $type->describe(VerbosityLevel::value()));
-		$this->assertSame($expectedTypeOnlyDescription, $type->describe(VerbosityLevel::typeOnly()));
+		self::assertSame($expectedCacheDescription, $type->describe(VerbosityLevel::cache()));
+		self::assertSame($expectedPreciseDescription, $type->describe(VerbosityLevel::precise()));
+		self::assertSame($expectedValueDescription, $type->describe(VerbosityLevel::value()));
+		self::assertSame($expectedTypeOnlyDescription, $type->describe(VerbosityLevel::typeOnly()));
 	}
 
 	public static function dataAccepts(): iterable
@@ -1327,7 +1327,7 @@ class UnionTypeTest extends PHPStanTestCase
 		TrinaryLogic $expectedResult,
 	): void
 	{
-		$this->assertSame(
+		self::assertSame(
 			$expectedResult->describe(),
 			$type->accepts($acceptedType, true)->result->describe(),
 			sprintf('%s -> accepts(%s)', $type->describe(VerbosityLevel::precise()), $acceptedType->describe(VerbosityLevel::precise())),
@@ -1367,7 +1367,7 @@ class UnionTypeTest extends PHPStanTestCase
 		TrinaryLogic $expectedResult,
 	): void
 	{
-		$this->assertSame($expectedResult->describe(), $type->hasMethod($methodName)->describe());
+		self::assertSame($expectedResult->describe(), $type->hasMethod($methodName)->describe());
 	}
 
 	public function testSorting(): void
@@ -1398,13 +1398,13 @@ class UnionTypeTest extends PHPStanTestCase
 		$type1 = new UnionType($types);
 		$type2 = new UnionType(array_reverse($types));
 
-		$this->assertSame(
+		self::assertSame(
 			$type1->describe(VerbosityLevel::precise()),
 			$type2->describe(VerbosityLevel::precise()),
 			'UnionType sorting always produces the same order',
 		);
 
-		$this->assertTrue(
+		self::assertTrue(
 			$type1->equals($type2),
 			'UnionType sorting always produces the same order',
 		);
@@ -1428,7 +1428,7 @@ class UnionTypeTest extends PHPStanTestCase
 			$actualDescriptions[] = $constantArray->describe(VerbosityLevel::precise());
 		}
 
-		$this->assertSame($expectedDescriptions, $actualDescriptions);
+		self::assertSame($expectedDescriptions, $actualDescriptions);
 	}
 
 	public static function dataGetConstantArrays(): iterable
@@ -1489,7 +1489,7 @@ class UnionTypeTest extends PHPStanTestCase
 			$actualDescriptions[] = $constantString->describe(VerbosityLevel::precise());
 		}
 
-		$this->assertSame($expectedDescriptions, $actualDescriptions);
+		self::assertSame($expectedDescriptions, $actualDescriptions);
 	}
 
 	public static function dataGetConstantStrings(): iterable
@@ -1556,7 +1556,7 @@ class UnionTypeTest extends PHPStanTestCase
 		array $expectedObjectClassNames,
 	): void
 	{
-		$this->assertSame($expectedObjectClassNames, $unionType->getObjectClassNames());
+		self::assertSame($expectedObjectClassNames, $unionType->getObjectClassNames());
 	}
 
 	public static function dataGetObjectClassNames(): iterable
@@ -1605,7 +1605,7 @@ class UnionTypeTest extends PHPStanTestCase
 			$actualDescriptions[] = $arrayType->describe(VerbosityLevel::precise());
 		}
 
-		$this->assertSame($expectedDescriptions, $actualDescriptions);
+		self::assertSame($expectedDescriptions, $actualDescriptions);
 	}
 
 	public static function dataGetArrays(): iterable

--- a/tests/PHPStan/Type/VerbosityLevelTest.php
+++ b/tests/PHPStan/Type/VerbosityLevelTest.php
@@ -50,7 +50,7 @@ class VerbosityLevelTest extends PHPStanTestCase
 	{
 		$level = VerbosityLevel::getRecommendedLevelByType($acceptingType, $acceptedType);
 
-		$this->assertSame($expected->getLevelValue(), $level->getLevelValue());
+		self::assertSame($expected->getLevelValue(), $level->getLevelValue());
 	}
 
 }


### PR DESCRIPTION
with static calls assertion-calls do not affect remembered non-static properties.

in addition assertion methods are declared `static` so we don't need to process ignored errors for these lines

---

before PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'bin/phpstan analyze tests/PHPStan/Analyser/AnalyserIntegrationTest.php' --runs=5
Benchmark 1: bin/phpstan analyze tests/PHPStan/Analyser/AnalyserIntegrationTest.php
  Time (mean ± σ):      2.537 s ±  0.047 s    [User: 2.224 s, System: 0.279 s]
  Range (min … max):    2.508 s …  2.620 s    5 runs
```

after PR
```
➜  phpstan-src git:(this-self) ✗ hyperfine 'bin/phpstan analyze tests/PHPStan/Analyser/AnalyserIntegrationTest.php' --runs=5
Benchmark 1: bin/phpstan analyze tests/PHPStan/Analyser/AnalyserIntegrationTest.php
  Time (mean ± σ):      2.526 s ±  0.016 s    [User: 2.220 s, System: 0.281 s]
  Range (min … max):    2.513 s …  2.554 s    5 runs
```