### PR TITLE
Cache ast-parsing in RegexGroupParser

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -44,6 +44,9 @@ final class RegexGroupParser
 
 	private static ?Parser $parser = null;
 
+	/** @var array<string, TreeNode> */
+	private static array $parsedAst = [];
+
 	public function __construct(
 		private PhpVersion $phpVersion,
 		private RegexExpressionHelper $regexExpressionHelper,
@@ -77,7 +80,7 @@ final class RegexGroupParser
 
 		$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);
 		try {
-			$ast = self::$parser->parse($rawRegex);
+			$ast = self::$parsedAst[$rawRegex] ??= self::$parser->parse($rawRegex);
 		} catch (Exception) {
 			return null;
 		}

--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -21,6 +21,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use function array_key_exists;
 use function array_values;
 use function count;
 use function in_array;
@@ -44,7 +45,7 @@ final class RegexGroupParser
 
 	private static ?Parser $parser = null;
 
-	/** @var array<string, TreeNode> */
+	/** @var array<string, ?TreeNode> */
 	private static array $parsedAst = [];
 
 	public function __construct(
@@ -59,30 +60,39 @@ final class RegexGroupParser
 		/** @throws void */
 		self::$parser ??= Llk::load(new Read(__DIR__ . '/../../../resources/RegexGrammar.pp'));
 
-		try {
-			Strings::match('', $regex);
-		} catch (RegexpException) {
-			// pattern is invalid, so let the RegularExpressionPatternRule report it
-			return null;
-		}
-
-		$modifiers = $this->regexExpressionHelper->getPatternModifiers($regex) ?? '';
-		foreach (self::NOT_SUPPORTED_MODIFIERS as $notSupportedModifier) {
-			if (str_contains($modifiers, $notSupportedModifier)) {
+		if (array_key_exists($regex, self::$parsedAst)) {
+			$ast = self::$parsedAst[$regex];
+			if ($ast === null) {
 				return null;
 			}
-		}
 
-		if (str_contains($modifiers, 'x')) {
-			// in freespacing mode the # character starts a comment and runs until the end of the line
-			$regex = preg_replace('/(?<!\?)#.*/', '', $regex) ?? '';
-		}
+			$modifiers = $this->regexExpressionHelper->getPatternModifiers($regex) ?? '';
+		} else {
+			try {
+				Strings::match('', $regex);
+			} catch (RegexpException) {
+				// pattern is invalid, so let the RegularExpressionPatternRule report it
+				return self::$parsedAst[$regex] = null;
+			}
 
-		$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);
-		try {
-			$ast = self::$parsedAst[$rawRegex] ??= self::$parser->parse($rawRegex);
-		} catch (Exception) {
-			return null;
+			$modifiers = $this->regexExpressionHelper->getPatternModifiers($regex) ?? '';
+			foreach (self::NOT_SUPPORTED_MODIFIERS as $notSupportedModifier) {
+				if (str_contains($modifiers, $notSupportedModifier)) {
+					return self::$parsedAst[$regex] = null;
+				}
+			}
+
+			if (str_contains($modifiers, 'x')) {
+				// in freespacing mode the # character starts a comment and runs until the end of the line
+				$regex = preg_replace('/(?<!\?)#.*/', '', $regex) ?? '';
+			}
+
+			$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);
+			try {
+				$ast = self::$parsedAst[$regex] = self::$parser->parse($rawRegex);
+			} catch (Exception) {
+				return self::$parsedAst[$regex] = null;
+			}
 		}
 
 		$this->updateAlternationAstRemoveVerticalBarsAndAddEmptyToken($ast);


### PR DESCRIPTION
before this PR:
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php' --runs=5
Benchmark 1: php vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php
  Time (mean ± σ):     13.665 s ±  0.175 s    [User: 13.312 s, System: 0.344 s]
  Range (min … max):   13.511 s … 13.947 s    5 runs
```

after this PR:
```
➜  phpstan-src git:(cache-regx) ✗ hyperfine 'php vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php' --runs=5
Benchmark 1: php vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php
  Time (mean ± σ):     12.591 s ±  0.052 s    [User: 12.248 s, System: 0.334 s]
  Range (min … max):   12.503 s … 12.636 s    5 runs
```

---

after this PR the runtime of `NodeScopeResolverTest` is now dominated by `TypeTraverser` and `TypeCombinator`:

<img width="501" height="428" alt="grafik" src="https://github.com/user-attachments/assets/a1a3c56e-fbc7-4028-ab93-ec721fc75be2" />
