### PR TITLE
Use sha256 which is cpu optimized in PHP 8.4+

### DIFF
--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -38,13 +38,13 @@ use function count;
 use function explode;
 use function get_loaded_extensions;
 use function getenv;
+use function hash_file;
 use function implode;
 use function is_array;
 use function is_dir;
 use function is_file;
 use function ksort;
 use function microtime;
-use function sha1_file;
 use function sort;
 use function sprintf;
 use function str_starts_with;
@@ -1055,7 +1055,7 @@ return [
 			return $this->fileHashes[$path];
 		}
 
-		$hash = sha1_file($path);
+		$hash = hash_file('sha256', $path);
 		if ($hash === false) {
 			throw new CouldNotReadFileException($path);
 		}

--- a/src/Analyser/RuleErrorTransformer.php
+++ b/src/Analyser/RuleErrorTransformer.php
@@ -27,7 +27,7 @@ use PHPStan\ShouldNotHappenException;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use function get_class;
-use function sha1;
+use function hash;
 use function str_contains;
 use function str_repeat;
 
@@ -114,7 +114,7 @@ final class RuleErrorTransformer
 			$oldCode = FileReader::read($fixingFile);
 
 			$this->parser->parse($oldCode);
-			$hash = sha1($oldCode);
+			$hash = hash('sha256', $oldCode);
 			$oldTokens = $this->parser->getTokens();
 
 			$indentTraverser = new NodeTraverser();

--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -17,13 +17,13 @@ use function array_keys;
 use function closedir;
 use function dirname;
 use function error_get_last;
+use function hash;
 use function is_dir;
 use function is_file;
 use function opendir;
 use function readdir;
 use function rename;
 use function rmdir;
-use function sha1;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
@@ -107,7 +107,7 @@ final class FileCacheStorage implements CacheStorage
 	 */
 	private function getFilePaths(string $key): array
 	{
-		$keyHash = sha1($key);
+		$keyHash = hash('sha256', $key);
 		$firstDirectory = sprintf('%s/%s', $this->directory, substr($keyHash, 0, 2));
 		$secondDirectory = sprintf('%s/%s', $firstDirectory, substr($keyHash, 2, 2));
 		$filePath = sprintf('%s/%s.php', $secondDirectory, $keyHash);

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -17,10 +17,10 @@ use PHPStan\ShouldNotHappenException;
 use Symfony\Component\Console\Input\InputInterface;
 use function array_merge;
 use function count;
+use function hash_file;
 use function is_file;
 use function memory_get_peak_usage;
 use function microtime;
-use function sha1_file;
 use function sprintf;
 
 /**
@@ -151,7 +151,7 @@ final class AnalyseApplication
 						continue;
 					}
 
-					$newHash = sha1_file($file);
+					$newHash = hash_file('sha256', $file);
 					if ($newHash === $hash) {
 						continue;
 					}

--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -15,6 +15,7 @@ use function array_keys;
 use function count;
 use function error_reporting;
 use function explode;
+use function hash_file;
 use function implode;
 use function in_array;
 use function is_dir;
@@ -22,7 +23,6 @@ use function is_file;
 use function ksort;
 use function restore_error_handler;
 use function set_error_handler;
-use function sha1_file;
 use function sprintf;
 use function str_ends_with;
 use function substr;
@@ -94,7 +94,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 				array_keys($this->dynamicParameters),
 				$this->configs,
 				PHP_VERSION_ID - PHP_RELEASE_VERSION,
-				is_file($attributesPhp) ? sha1_file($attributesPhp) : 'attributes-missing',
+				is_file($attributesPhp) ? hash_file('sha256', $attributesPhp) : 'attributes-missing',
 				NeonAdapter::CACHE_KEY, $this->getAllConfigFilesHashes(),
 			],
 		);
@@ -224,7 +224,7 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 	{
 		$hashes = [];
 		foreach ($this->allConfigFiles as $file) {
-			$hash = sha1_file($file);
+			$hash = hash_file('sha256', $file);
 
 			if ($hash === false) {
 				throw new CouldNotReadFileException($file);

--- a/src/File/FileMonitor.php
+++ b/src/File/FileMonitor.php
@@ -10,9 +10,9 @@ use function array_key_exists;
 use function array_keys;
 use function array_merge;
 use function array_unique;
+use function hash_file;
 use function is_dir;
 use function is_file;
-use function sha1_file;
 
 #[AutowiredService]
 final class FileMonitor
@@ -107,7 +107,7 @@ final class FileMonitor
 
 	private function getFileHash(string $filePath): string
 	{
-		$hash = sha1_file($filePath);
+		$hash = hash_file('sha256', $filePath);
 
 		if ($hash === false) {
 			throw new CouldNotReadFileException($filePath);

--- a/src/Fixable/Patcher.php
+++ b/src/Fixable/Patcher.php
@@ -15,8 +15,8 @@ use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use function array_map;
 use function count;
+use function hash;
 use function implode;
-use function sha1;
 use function str_starts_with;
 use function substr;
 use const PHP_VERSION_ID;
@@ -42,7 +42,7 @@ final class Patcher
 	public function applyDiffs(string $fileName, array $diffs): string
 	{
 		$fileContents = FileReader::read($fileName);
-		$fileHash = sha1($fileContents);
+		$fileHash = hash('sha256', $fileContents);
 		$diffHunks = [];
 		foreach ($diffs as $diff) {
 			if ($diff->originalHash !== $fileHash) {

--- a/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/SourceLocator/OptimizedDirectorySourceLocatorFactory.php
@@ -10,12 +10,12 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstantNameHelper;
 use function array_key_exists;
 use function count;
+use function hash_file;
 use function in_array;
 use function ltrim;
 use function php_strip_whitespace;
 use function preg_match_all;
 use function preg_replace;
-use function sha1_file;
 use function sprintf;
 use function strtolower;
 
@@ -44,7 +44,7 @@ final class OptimizedDirectorySourceLocatorFactory
 		$files = $this->fileFinder->findFiles([$directory])->getFiles();
 		$fileHashes = [];
 		foreach ($files as $file) {
-			$hash = sha1_file($file);
+			$hash = hash_file('sha256', $file);
 			if ($hash === false) {
 				continue;
 			}
@@ -108,7 +108,7 @@ final class OptimizedDirectorySourceLocatorFactory
 	{
 		$fileHashes = [];
 		foreach ($files as $file) {
-			$hash = sha1_file($file);
+			$hash = hash_file('sha256', $file);
 			if ($hash === false) {
 				continue;
 			}

--- a/src/Testing/PHPStanTestCase.php
+++ b/src/Testing/PHPStanTestCase.php
@@ -37,9 +37,9 @@ use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use function array_merge;
 use function count;
+use function hash;
 use function implode;
 use function rtrim;
-use function sha1;
 use function sprintf;
 use function sys_get_temp_dir;
 use const DIRECTORY_SEPARATOR;
@@ -59,7 +59,7 @@ abstract class PHPStanTestCase extends TestCase
 		foreach (static::getAdditionalConfigFiles() as $configFile) {
 			$additionalConfigFiles[] = $configFile;
 		}
-		$cacheKey = sha1(implode("\n", $additionalConfigFiles));
+		$cacheKey = hash('sha256', implode("\n", $additionalConfigFiles));
 
 		if (!isset(self::$containers[$cacheKey])) {
 			$tmpDir = sys_get_temp_dir() . '/phpstan-tests';

--- a/src/Testing/TestCaseSourceLocatorFactory.php
+++ b/src/Testing/TestCaseSourceLocatorFactory.php
@@ -21,9 +21,9 @@ use PHPStan\Reflection\BetterReflection\SourceLocator\PhpVersionBlacklistSourceL
 use PHPStan\Reflection\BetterReflection\SourceLocator\SkipPolyfillSourceLocator;
 use ReflectionClass;
 use function dirname;
+use function hash;
 use function is_file;
 use function serialize;
-use function sha1;
 use const PHP_VERSION_ID;
 
 final class TestCaseSourceLocatorFactory
@@ -55,7 +55,7 @@ final class TestCaseSourceLocatorFactory
 	{
 		$classLoaders = ClassLoader::getRegisteredLoaders();
 		$classLoaderReflection = new ReflectionClass(ClassLoader::class);
-		$cacheKey = sha1(serialize([
+		$cacheKey = hash('sha256', serialize([
 			$this->phpVersion->getVersionId(),
 			$this->fileExtensions,
 			$this->excludePaths,


### PR DESCRIPTION
starting with PHP 8.4+ sha256 can be 2-5x faster than sha1, see https://github.com/php/php-src/pull/15152

---

see https://speakerdeck.com/edorian/upcoming-changes-in-php-8-dot-4-property-hooks-improved-performance-and-so-much-more?slide=71

<img width="1050" height="783" alt="grafik" src="https://github.com/user-attachments/assets/4f03c19c-57fa-41ab-b3a6-c28c3b8db90f" />
