### PR TITLE
TypeCombinator: Remove unnecessary md5 encoding

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -35,7 +35,6 @@ use function array_values;
 use function count;
 use function get_class;
 use function is_int;
-use function md5;
 use function sprintf;
 use function usort;
 use const PHP_INT_MAX;
@@ -197,7 +196,7 @@ final class TypeCombinator
 		for ($i = 0; $i < $typesCount; $i++) {
 			if ($types[$i]->isConstantScalarValue()->yes()) {
 				$type = $types[$i];
-				$scalarTypes[get_class($type)][md5($type->describe(VerbosityLevel::cache()))] = $type;
+				$scalarTypes[get_class($type)][$type->describe(VerbosityLevel::cache())] = $type;
 				unset($types[$i]);
 				continue;
 			}


### PR DESCRIPTION
lets reduce the work beeing done to a minimum in our most hot path