### PR TITLE
Prevent Scalar expressions to be specified

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -24,6 +24,7 @@ use PhpParser\Node\InterpolatedStringPart;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\PropertyHook;
+use PhpParser\Node\Scalar;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
@@ -4265,6 +4266,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 	public function specifyExpressionType(Expr $expr, Type $type, Type $nativeType, TrinaryLogic $certainty): self
 	{
+		if ($expr instanceof Scalar) {
+			return $this;
+		}
+
 		if ($expr instanceof ConstFetch) {
 			$loweredConstName = strtolower($expr->name->toString());
 			if (in_array($loweredConstName, ['true', 'false', 'null'], true)) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3947,6 +3947,9 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		} else {
 			$cond = $expr->cond;
 		}
+		if ($cond instanceof Scalar) {
+			return $this;
+		}
 
 		$type = $this->getType($cond);
 		$nativeType = $this->getNativeType($cond);

--- a/tests/PHPStan/Rules/Debug/DebugScopeRuleTest.php
+++ b/tests/PHPStan/Rules/Debug/DebugScopeRuleTest.php
@@ -58,9 +58,7 @@ class DebugScopeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/pr-4663.php'], [
 			[
 				implode("\n", [
-					'__phpstanRemembered(1) (Maybe): 1',
 					"\$result (Yes): 'no matches!'",
-					'native __phpstanRemembered(1) (Maybe): 1',
 					"native \$result (Yes): 'no matches!'",
 				]),
 				11,

--- a/tests/PHPStan/Rules/Debug/DebugScopeRuleTest.php
+++ b/tests/PHPStan/Rules/Debug/DebugScopeRuleTest.php
@@ -53,4 +53,19 @@ class DebugScopeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testPr4663(): void
+	{
+		$this->analyse([__DIR__ . '/data/pr-4663.php'], [
+			[
+				implode("\n", [
+					'__phpstanRemembered(1) (Maybe): 1',
+					"\$result (Yes): 'no matches!'",
+					'native __phpstanRemembered(1) (Maybe): 1',
+					"native \$result (Yes): 'no matches!'",
+				]),
+				11,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Debug/data/pr-4663.php
+++ b/tests/PHPStan/Rules/Debug/data/pr-4663.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1); // lint >= 8.1
+
+namespace PR4663;
+
+use function PHPStan\debugScope;
+
+function (): void {
+	$result = match(1){
+		default => 'no matches!'
+	};
+	debugScope();
+};


### PR DESCRIPTION
before this change a call to `match(1)` would specify a expression `$scope->expressionTypes[1]` (integer key). 
we expect this array to be keyed with `string` types though:

https://github.com/phpstan/phpstan-src/blob/21a16027a4b285a06a7e6efe5b3718195b34231b/src/Analyser/MutatingScope.php#L200

In addition literal const scalar values do not make sense to be specified in scope.. it does not provide more information

[found in snippet:](https://phpstan.org/r/2695177e-2bce-4206-9efa-1d3288ad340c)

```php
<?php declare(strict_types = 1); // lint >= 8.1

namespace Bug10418;

use function PHPStan\debugScope;

function (): void {
	$text = '123';
	$result = match(1){
		preg_match('/(\d+)/', $text, $match) => 'matched number: ' . $match[1],
		preg_match('/(\w+)/', $text, $match) => 'matched word: ' . json_encode($match),
		default => 'no matches!'
	};
	debugScope();
};

```