### PR TITLE
Print more precise elapsed time

### DIFF
--- a/src/Command/InceptionResult.php
+++ b/src/Command/InceptionResult.php
@@ -104,7 +104,7 @@ final class InceptionResult
 	{
 		if ($this->getErrorOutput()->isVerbose()) {
 			$elapsedTime = round(microtime(true) - $analysisStartTime, 2);
-			if ($elapsedTime < 10) {
+			if ($elapsedTime < 60) {
 				$elapsedTimeString = sprintf('%.2f seconds', $elapsedTime);
 			} else {
 				$elapsedTimeString = $this->formatDuration((int) $elapsedTime);


### PR DESCRIPTION
running `time php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug` takes 37 seconds.
for perf tunning its useful to see more precise timings than a value cut to full seconds