### PR TITLE
ParametersAcceptorSelector: early return type traversal

### DIFF
--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -567,12 +567,11 @@ final class ParametersAcceptorSelector
 	{
 		$has = false;
 		TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$has): Type {
-			if ($has || $type instanceof TemplateType || $type instanceof LateResolvableType) {
+			if ($type instanceof TemplateType || $type instanceof LateResolvableType) {
 				$has = true;
-				return $type;
 			}
 
-			return $traverse($type);
+			return $has ? $type : $traverse($type);
 		});
 
 		return $has;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -567,7 +567,7 @@ final class ParametersAcceptorSelector
 	{
 		$has = false;
 		TypeTraverser::map($type, static function (Type $type, callable $traverse) use (&$has): Type {
-			if ($type instanceof TemplateType || $type instanceof LateResolvableType) {
+			if ($has || $type instanceof TemplateType || $type instanceof LateResolvableType) {
 				$has = true;
 				return $type;
 			}


### PR DESCRIPTION
no need to deep traverse maybe complex type structures. stop traversal on first find.

type traversal is one of the slowest parts atm:

<img width="677" height="325" alt="grafik" src="https://github.com/user-attachments/assets/f9b22c00-888f-4623-b8a8-2e1ebfdc67b2" />
