### PR TITLE
TypeCombinator: Remove never types early

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -151,10 +151,23 @@ final class TypeCombinator
 		$alreadyNormalized = [];
 		$alreadyNormalizedCounter = 0;
 
+		$containsNonNever = false;
+
 		$benevolentTypes = [];
 		$benevolentUnionObject = null;
 		// transform A | (B | C) to A | B | C
 		for ($i = 0; $i < $typesCount; $i++) {
+			// transform A | never to A
+			if ($types[$i] instanceof NeverType) {
+				if ($containsNonNever) {
+					array_splice($types, $i--, 1);
+					$typesCount--;
+					continue;
+				}
+			} else {
+				$containsNonNever = true;
+			}
+
 			if ($types[$i] instanceof BenevolentUnionType) {
 				if ($types[$i] instanceof TemplateBenevolentUnionType && $benevolentUnionObject === null) {
 					$benevolentUnionObject = $types[$i];


### PR DESCRIPTION
when possible eliminate NeverType early which saves us checking them later on in a quadratic loop

after this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug' -i --runs=3 --warmup=1
Benchmark 1: php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug
  Time (mean ± σ):     35.353 s ±  0.226 s    [User: 34.775 s, System: 0.566 s]
  Range (min … max):   35.093 s … 35.503 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 
```

before this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug' -i --runs=3 --warmup=1
Benchmark 1: php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug
  Time (mean ± σ):     36.018 s ±  0.169 s    [User: 35.434 s, System: 0.571 s]
  Range (min … max):   35.823 s … 36.117 s    3 runs
 
  Warning: Ignoring non-zero exit code.
 ```