### PR TITLE
Don't store scalar values in resolvedTypes

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1369,16 +1369,6 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		}
 
 		if ($node instanceof ConstFetch) {
-			$constName = (string) $node->name;
-			$loweredConstName = strtolower($constName);
-			if ($loweredConstName === 'true') {
-				return new ConstantBooleanType(true);
-			} elseif ($loweredConstName === 'false') {
-				return new ConstantBooleanType(false);
-			} elseif ($loweredConstName === 'null') {
-				return new NullType();
-			}
-
 			$namespacedName = null;
 			if (!$node->name->isFullyQualified() && $this->getNamespace() !== null) {
 				$namespacedName = new FullyQualified([$this->getNamespace(), $node->name->toString()]);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -813,6 +813,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
 		} elseif ($node instanceof Node\Scalar\Float_) {
 			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
+		} elseif ($node instanceof Expr\UnaryMinus && $node->expr instanceof Node\Scalar) {
+			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
 		} elseif ($node instanceof ConstFetch) {
 			$loweredConstName = strtolower($node->name->toString());
 			if (in_array($loweredConstName, ['true', 'false', 'null'], true)) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -807,6 +807,19 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 	/** @api */
 	public function getType(Expr $node): Type
 	{
+		if ($node instanceof Node\Scalar\Int_) {
+			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
+		} elseif ($node instanceof String_) {
+			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
+		} elseif ($node instanceof Node\Scalar\Float_) {
+			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
+		} elseif ($node instanceof ConstFetch) {
+			$loweredConstName = strtolower($node->name->toString());
+			if (in_array($loweredConstName, ['true', 'false', 'null'], true)) {
+				return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
+			}
+		}
+
 		if ($node instanceof GetIterableKeyTypeExpr) {
 			return $this->getIterableKeyType($this->getType($node->getExpr()));
 		}
@@ -1245,11 +1258,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			});
 		}
 
-		if ($node instanceof Node\Scalar\Int_) {
-			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
-		} elseif ($node instanceof String_) {
-			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
-		} elseif ($node instanceof Node\Scalar\InterpolatedString) {
+		if ($node instanceof Node\Scalar\InterpolatedString) {
 			$resultType = null;
 			foreach ($node->parts as $part) {
 				if ($part instanceof InterpolatedStringPart) {
@@ -1266,8 +1275,6 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			}
 
 			return $resultType ?? new ConstantStringType('');
-		} elseif ($node instanceof Node\Scalar\Float_) {
-			return $this->initializerExprTypeResolver->getType($node, InitializerExprContext::fromScope($this));
 		} elseif ($node instanceof Expr\CallLike && $node->isFirstClassCallable()) {
 			return $this->getFirstClassCallableType($node);
 		} elseif ($node instanceof Expr\Closure || $node instanceof Expr\ArrowFunction) {


### PR DESCRIPTION
before this PR we stored types about constant values in scope

<img width="537" height="184" alt="grafik" src="https://github.com/user-attachments/assets/1af0f94d-81c9-4ae8-ae9f-6162132ae526" />

similar to https://github.com/phpstan/phpstan-src/pull/4663 I think this is not useful.

---

this was especially questionable for constant arrays:

<img width="593" height="265" alt="grafik" src="https://github.com/user-attachments/assets/bb520855-a11c-4593-9f50-3a75f5cca854" />
