### PR TITLE
Fix PHP 7.4 build

### DIFF
--- a/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
@@ -146,7 +146,7 @@ final class MbStrlenFunctionReturnTypeExtension implements DynamicFunctionReturn
 		}
 
 		if (!$this->phpVersion->throwsOnInvalidMbStringEncoding() && in_array(self::UNSUPPORTED_ENCODING, $encodings, true)) {
-			return new UnionType([$range, new ConstantBooleanType(false)]);
+			return TypeCombinator::union($range, new ConstantBooleanType(false));
 		}
 		return $range;
 	}


### PR DESCRIPTION
```
There was 1 error:

1) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "tests/PHPStan/Analyser/data/mb-strlen-php73.php" ('/home/runner/work/phpstan-src...73.php')
PHPStan\ShouldNotHappenException: Cannot create PHPStan\Type\UnionType with: 1|3|5|6, false

/home/runner/work/phpstan-src/phpstan-src/src/Type/UnionType.php:78
/home/runner/work/phpstan-src/phpstan-src/src/Type/UnionType.php:95
/home/runner/work/phpstan-src/phpstan-src/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php:140
/home/runner/work/phpstan-src/phpstan-src/src/Analyser/MutatingScope.php:2568 
/home/runner/work/phpstan-src/phpstan-src/src/Analyser/MutatingScope.php:2552
/home/runner/work/phpstan-src/phpstan-src/src/Analyser/MutatingScope.php:924
/home/runner/work/phpstan-src/phpstan-src/src/Testing/TypeInferenceTestCase.php:272
```