### PR TITLE
Prevent repetative method calls on ParametersAcceptor

### DIFF
--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -55,7 +55,7 @@ final class GenericParametersAcceptorResolver
 			$namedArgTypes[$i] = $argType;
 		}
 
-		foreach ($parametersAcceptor->getParameters() as $param) {
+		foreach ($parameters as $param) {
 			if (isset($namedArgTypes[$param->getName()])) {
 				$argType = $namedArgTypes[$param->getName()];
 			} elseif ($param->getDefaultValue() !== null) {
@@ -104,10 +104,10 @@ final class GenericParametersAcceptorResolver
 					TrinaryLogic::createMaybe(),
 					null,
 					[],
-				), $parametersAcceptor->getParameters()),
+				), $parameters),
 				$parametersAcceptor->isVariadic(),
-				$parametersAcceptor->getReturnType(),
-				$parametersAcceptor->getReturnType(),
+				$returnType,
+				$returnType,
 				new MixedType(),
 				TemplateTypeVarianceMap::createEmpty(),
 			);


### PR DESCRIPTION
as can be seen in 

<img width="1588" height="1182" alt="grafik" src="https://github.com/user-attachments/assets/dac0d1f0-1b4c-473b-8765-1bb42d64d2e1" />

`getParameters()` and `getReturnType` is called 3x more than others