### PR TITLE
Improve return type of `range()` function to always yield a `non-empty-list`

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1416,7 +1416,6 @@ class ConstantArrayType implements Type
 	{
 		$count = count($types);
 		$autoIndexes = range($count - count($this->optionalKeys), $count);
-		assert($autoIndexes !== []);
 
 		if ($this->isList->yes()) {
 			// Optimized version for lists: Assume that if a later key exists, then earlier keys also exist.

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -92,39 +92,25 @@ final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 								$startConstant = $endConstant;
 								$endConstant = $tmp;
 							}
-							return new IntersectionType([
-								new ArrayType(
-									IntegerRangeType::createAllGreaterThanOrEqualTo(0),
-									IntegerRangeType::fromInterval($startConstant->getValue(), $endConstant->getValue()),
+							return self::getNonEmptyListOfType(
+								IntegerRangeType::fromInterval(
+									$startConstant->getValue(),
+									$endConstant->getValue(),
 								),
-								new NonEmptyArrayType(),
-								new AccessoryArrayListType(),
-							]);
+							);
 						}
 
 						if ($stepType->isFloat()->yes()) {
-							return new IntersectionType([
-								new ArrayType(
-									IntegerRangeType::createAllGreaterThanOrEqualTo(0),
-									new FloatType(),
-								),
-								new NonEmptyArrayType(),
-								new AccessoryArrayListType(),
-							]);
+							return self::getNonEmptyListOfType(new FloatType());
 						}
 
-						return new IntersectionType([
-							new ArrayType(
-								IntegerRangeType::createAllGreaterThanOrEqualTo(0),
-								TypeCombinator::union(
-									$startConstant->generalize(GeneralizePrecision::moreSpecific()),
-									$endConstant->generalize(GeneralizePrecision::moreSpecific()),
-									$stepType->generalize(GeneralizePrecision::moreSpecific()),
-								),
+						return self::getNonEmptyListOfType(
+							TypeCombinator::union(
+								$startConstant->generalize(GeneralizePrecision::moreSpecific()),
+								$endConstant->generalize(GeneralizePrecision::moreSpecific()),
+								$stepType->generalize(GeneralizePrecision::moreSpecific()),
 							),
-							new NonEmptyArrayType(),
-							new AccessoryArrayListType(),
-						]);
+						);
 					}
 					$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
 					foreach ($rangeValues as $value) {
@@ -146,30 +132,45 @@ final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 
 		if ($isInteger && $isStepInteger) {
 			if ($argType instanceof IntegerRangeType) {
-				return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $argType), new NonEmptyArrayType(), new AccessoryArrayListType()]);
+				return self::getNonEmptyListOfType($argType);
 			}
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new IntegerType()), new NonEmptyArrayType(), new AccessoryArrayListType()]);
+			return self::getNonEmptyListOfType(new IntegerType());
 		}
 
 		if ($argType->isFloat()->yes()) {
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new FloatType()), new NonEmptyArrayType(), new AccessoryArrayListType()]);
+			return self::getNonEmptyListOfType(new FloatType());
 		}
 
 		$numberType = new UnionType([new IntegerType(), new FloatType()]);
 		$isNumber = $numberType->isSuperTypeOf($argType)->yes();
 		$isNumericString = $argType->isNumericString()->yes();
 		if ($isNumber || $isNumericString) {
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $numberType), new NonEmptyArrayType(), new AccessoryArrayListType()]);
+			return self::getNonEmptyListOfType($numberType);
 		}
 
 		if ($argType->isString()->yes()) {
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new StringType()), new NonEmptyArrayType(), new AccessoryArrayListType()]);
+			return self::getNonEmptyListOfType(new StringType());
 		}
 
-		return new IntersectionType([new ArrayType(
-			IntegerRangeType::createAllGreaterThanOrEqualTo(0),
-			new BenevolentUnionType([new IntegerType(), new FloatType(), new StringType()]),
-		), new AccessoryArrayListType()]);
+		return self::getNonEmptyListOfType(
+			new BenevolentUnionType([
+				new IntegerType(),
+				new FloatType(),
+				new StringType(),
+			]),
+		);
+	}
+
+	private static function getNonEmptyListOfType(Type $type): IntersectionType
+	{
+		return new IntersectionType([
+			new ArrayType(
+				IntegerRangeType::createAllGreaterThanOrEqualTo(0),
+				$type,
+			),
+			new NonEmptyArrayType(),
+			new AccessoryArrayListType(),
+		]);
 	}
 
 }

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -146,24 +146,24 @@ final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 
 		if ($isInteger && $isStepInteger) {
 			if ($argType instanceof IntegerRangeType) {
-				return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $argType), new AccessoryArrayListType()]);
+				return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $argType), new NonEmptyArrayType(), new AccessoryArrayListType()]);
 			}
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new IntegerType()), new AccessoryArrayListType()]);
+			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new IntegerType()), new NonEmptyArrayType(), new AccessoryArrayListType()]);
 		}
 
 		if ($argType->isFloat()->yes()) {
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new FloatType()), new AccessoryArrayListType()]);
+			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new FloatType()), new NonEmptyArrayType(), new AccessoryArrayListType()]);
 		}
 
 		$numberType = new UnionType([new IntegerType(), new FloatType()]);
 		$isNumber = $numberType->isSuperTypeOf($argType)->yes();
 		$isNumericString = $argType->isNumericString()->yes();
 		if ($isNumber || $isNumericString) {
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $numberType), new AccessoryArrayListType()]);
+			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), $numberType), new NonEmptyArrayType(), new AccessoryArrayListType()]);
 		}
 
 		if ($argType->isString()->yes()) {
-			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new StringType()), new AccessoryArrayListType()]);
+			return new IntersectionType([new ArrayType(IntegerRangeType::createAllGreaterThanOrEqualTo(0), new StringType()), new NonEmptyArrayType(), new AccessoryArrayListType()]);
 		}
 
 		return new IntersectionType([new ArrayType(

--- a/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/LegacyNodeScopeResolverTest.php
@@ -5594,19 +5594,19 @@ class LegacyNodeScopeResolverTest extends TypeInferenceTestCase
 				'range(2.1, 5)',
 			],
 			[
-				'list<int>',
+				'non-empty-list<int>',
 				'range(2, 5, $integer)',
 			],
 			[
-				'list<float|int>',
+				'non-empty-list<float|int>',
 				'range($float, 5, $integer)',
 			],
 			[
-				'list<(float|int|string)>',
+				'non-empty-list<(float|int|string)>',
 				'range($float, $mixed, $integer)',
 			],
 			[
-				'list<(float|int|string)>',
+				'non-empty-list<(float|int|string)>',
 				'range($integer, $mixed)',
 			],
 			[

--- a/tests/PHPStan/Analyser/nsrt/bug-11692.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11692.php
@@ -12,13 +12,12 @@ function doFoo(int $i, float $f, $floatOrInt): void {
 	assertType('non-empty-list<float>', range(1, 9999, .01));
 	assertType('non-empty-list<int<1, 9999>>', range(1, 9999, 3));
 
-	assertType('list<float|int>', range(1, 9999, $floatOrInt));
-	assertType('list<float|int>', range(1, 9999, $floatOrInt));
+	assertType('non-empty-list<float|int>', range(1, 9999, $floatOrInt));
 
-	assertType('list<int>', range(1, 3, $i));
-	assertType('list<float|int>', range(1, 3, $f));
+	assertType('non-empty-list<int>', range(1, 3, $i));
+	assertType('non-empty-list<float|int>', range(1, 3, $f));
 
-	assertType('list<int>', range(1, 9999, $i));
-	assertType('list<float|int>', range(1, 9999, $f));
+	assertType('non-empty-list<int>', range(1, 9999, $i));
+	assertType('non-empty-list<float|int>', range(1, 9999, $f));
 }
 

--- a/tests/PHPStan/Analyser/nsrt/bug-2378.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-2378.php
@@ -17,7 +17,7 @@ class Foo
 		assertType('array{\'a\', \'b\', \'c\', \'d\'}', range('a', 'd'));
 		assertType('array{\'a\', \'c\', \'e\', \'g\', \'i\'}', range('a', 'i', 2));
 
-		assertType('list<string>', range($s, $s));
+		assertType('non-empty-list<string>', range($s, $s));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/range-int-range.php
+++ b/tests/PHPStan/Analyser/nsrt/range-int-range.php
@@ -16,7 +16,7 @@ class Foo
 		int $b
 	): void
 	{
-		assertType('list<int<0, max>>', range($a, $b));
+		assertType('non-empty-list<int<0, max>>', range($a, $b));
 	}
 
 	/**
@@ -28,7 +28,7 @@ class Foo
 		int $b
 	): void
 	{
-		assertType('list<int<2, 20>>', range($a, $b));
+		assertType('non-empty-list<int<2, 20>>', range($a, $b));
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Foo
 		int $b
 	): void
 	{
-		assertType('list<int<5, 30>>', range($a, $b));
+		assertType('non-empty-list<int<5, 30>>', range($a, $b));
 	}
 
 	public function knownRange(

--- a/tests/PHPStan/Analyser/nsrt/range-numeric-string.php
+++ b/tests/PHPStan/Analyser/nsrt/range-numeric-string.php
@@ -16,7 +16,7 @@ class Foo
 		string $b
 	): void
 	{
-		assertType('list<float|int>', range($a, $b));
+		assertType('non-empty-list<float|int>', range($a, $b));
 	}
 
 }


### PR DESCRIPTION
## Description

By definition, the `range()` function will never return an empty array. This PR updates the `RangeFunctionReturnTypeExtension` to follow this definition for all cases.


> [!NOTE]
> PHP 8.3 changed how certain “special” or unusual `range()` calls are handled, but this does not affect the aforementioned definition.
> #### Example:
> ```php
> range(1, 5, -1); // increasing range with a negative step
> ```
> Up to PHP 8.2, the interpreter attempted to infer a sensible result (e.g. by normalizing the step). Starting with PHP 8.3, such calls either emit warnings or throw errors instead.


## Example
```php
range(1, $someInteger);
```
- Before:
  ```md
  list<int>
  ```
- Now:
  ```md
  non-empty-list<int>
  ```
  
## Implementation

Some return types previously did not use `NonEmptyArrayType`. This PR applies `NonEmptyArrayType` to all possible return types of `range()`, ensuring they differ only in their inner element type.

To avoid duplication, a small helper method `getNonEmptyListOfType($type)` was introduced and reused across the 9 different return statements.