### PR TITLE
cs: import `array_last` function

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -140,6 +140,7 @@ use function array_filter;
 use function array_key_exists;
 use function array_key_first;
 use function array_keys;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_pop;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -207,6 +207,7 @@ use function array_filter;
 use function array_key_exists;
 use function array_key_last;
 use function array_keys;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_pop;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -77,6 +77,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use function array_key_exists;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_reverse;

--- a/src/Fixable/PhpPrinter.php
+++ b/src/Fixable/PhpPrinter.php
@@ -5,6 +5,7 @@ namespace PHPStan\Fixable;
 use Override;
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
+use function array_last;
 use function count;
 use function rtrim;
 

--- a/src/Parser/LastConditionVisitor.php
+++ b/src/Parser/LastConditionVisitor.php
@@ -6,6 +6,7 @@ use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
+use function array_last;
 use function count;
 
 #[AutowiredService]

--- a/src/Parser/TryCatchTypeVisitor.php
+++ b/src/Parser/TryCatchTypeVisitor.php
@@ -6,6 +6,7 @@ use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
+use function array_last;
 use function array_pop;
 use function array_reverse;
 use function count;

--- a/src/Parser/VariadicMethodsVisitor.php
+++ b/src/Parser/VariadicMethodsVisitor.php
@@ -10,6 +10,7 @@ use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ParametersAcceptor;
 use function array_key_exists;
+use function array_last;
 use function array_pop;
 use function in_array;
 use function sprintf;

--- a/src/Reflection/AttributeReflectionFactory.php
+++ b/src/Reflection/AttributeReflectionFactory.php
@@ -10,6 +10,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ReflectionProvider\ReflectionProviderProvider;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
+use function array_last;
 use function count;
 use function is_int;
 

--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -13,6 +13,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function count;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -47,6 +47,7 @@ use PHPStan\Type\UnionType;
 use function array_is_list;
 use function array_key_exists;
 use function array_key_last;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_slice;

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -29,6 +29,7 @@ use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use function array_fill;
 use function array_key_exists;
+use function array_last;
 use function count;
 use function implode;
 use function in_array;

--- a/src/Rules/Whitespace/FileWhitespaceRule.php
+++ b/src/Rules/Whitespace/FileWhitespaceRule.php
@@ -13,6 +13,7 @@ use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\FileNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use function array_last;
 use function count;
 
 /**

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -27,6 +27,7 @@ use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
 use function array_key_exists;
 use function array_keys;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_pop;


### PR DESCRIPTION
I'm on PHP 8.5.1 and running `make cs` currently fails because of unimported `array_last` function.
<details>
<summary>Output of <code>make cs</code></summary>
<code><pre>
git clone https://github.com/phpstan/build-cs.git || true
fatal: destination path 'build-cs' already exists and is not an empty directory.
git -C build-cs fetch origin && git -C build-cs reset --hard origin/2.x
HEAD is now at b37678c Update dependency slevomat/coding-standard to v8.26.0
composer install --working-dir build-cs
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
3 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
XDEBUG_MODE=off php build-cs/vendor/bin/phpcs
............................................................   60 / 2178 (3%)
............................................................  120 / 2178 (6%)
..................E..............E.E........................  180 / 2178 (8%)
............................................................  240 / 2178 (11%)
............................................................  300 / 2178 (14%)
............................................................  360 / 2178 (17%)
............................................................  420 / 2178 (19%)
...............................E............................  480 / 2178 (22%)
............................................................  540 / 2178 (25%)
..............E.E..........E................................  600 / 2178 (28%)
..............................................E.............  660 / 2178 (30%)
............................................................  720 / 2178 (33%)
............................................................  780 / 2178 (36%)
............................................................  840 / 2178 (39%)
............................................................  900 / 2178 (41%)
............................................................  960 / 2178 (44%)
............................................................ 1020 / 2178 (47%)
...........................................................E 1080 / 2178 (50%)
............................................................ 1140 / 2178 (52%)
............................................................ 1200 / 2178 (55%)
...........................................E................ 1260 / 2178 (58%)
............................................................ 1320 / 2178 (61%)
............................................................ 1380 / 2178 (63%)
...E........................................................ 1440 / 2178 (66%)
......E..................................................... 1500 / 2178 (69%)
........................E................................... 1560 / 2178 (72%)
............................................................ 1620 / 2178 (74%)
............................................................ 1680 / 2178 (77%)
............................................................ 1740 / 2178 (80%)
............................................................ 1800 / 2178 (83%)
............................................................ 1860 / 2178 (85%)
............................................................ 1920 / 2178 (88%)
............................................................ 1980 / 2178 (91%)
............................................................ 2040 / 2178 (94%)
............................................................ 2100 / 2178 (96%)
............................................................ 2160 / 2178 (99%)
..................                                           2178 / 2178 (100%)



FILE: src/Parser/VariadicMethodsVisitor.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 4 ERRORS AFFECTING 4 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
  76 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
  84 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 103 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 104 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 4 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Parser/LastConditionVisitor.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 90 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Parser/TryCatchTypeVisitor.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 34 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Type/FileTypeMapper.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 10 ERRORS AFFECTING 10 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
 312 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 313 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 381 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 534 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 535 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 543 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 545 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 565 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 566 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 674 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 10 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Analyser/NodeScopeResolver.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
 1632 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
      |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 5586 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
      |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 5783 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
      |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Analyser/MutatingScope.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
 3658 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
      |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 3851 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
      |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Analyser/TypeSpecifier.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 1515 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
      |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Rules/FunctionCallParametersCheck.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
 591 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 592 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Rules/Whitespace/FileWhitespaceRule.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 3 LINES
----------------------------------------------------------------------------------------------------------------------------------------------
 59 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 65 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
 85 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Fixable/PhpPrinter.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 27 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Reflection/ParametersAcceptorSelector.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 498 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Reflection/GenericParametersAcceptorResolver.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 42 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
    |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------


FILE: src/Reflection/AttributeReflectionFactory.php
----------------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------------------------------------------------------------------------------
 110 | ERROR | [x] Function array_last() should not be referenced via a fallback global name, but via a use statement.
     |       |     (SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFallbackGlobalName)
----------------------------------------------------------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------------------------------------------------------------------------------

Time: 43.03 secs; Memory: 278.94MB
make: *** [cs] Error 1
</pre></code>
</details>