### PR TITLE
Prevent unnecessary node-key calculation

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4725,7 +4725,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			} else {
 				$scope = $scope->removeTypeFromExpression($expr, $type);
 			}
-			$specifiedExpressions[$this->getNodeKey($expr)] = ExpressionTypeHolder::createYes($expr, $scope->getType($expr));
+			$specifiedExpressions[$typeSpecification['exprString']] = ExpressionTypeHolder::createYes($expr, $scope->getType($expr));
 		}
 
 		$conditions = [];


### PR DESCRIPTION
node-key calculation is used a lot, therefore sometimes shows up in blackfire profiles

<img width="1041" height="622" alt="grafik" src="https://github.com/user-attachments/assets/310a0282-8974-4804-ab49-536296ed293d" />
