### PR TITLE
TypeCombinator: prevent unnecessary work

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -814,14 +814,13 @@ final class TypeCombinator
 			foreach ($constantArrays as $constantArray) {
 				$valueTypes = $constantArray->getValueTypes();
 				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-					$keyTypeValue = $keyType->getValue();
-
-					$keyTypesForGeneralArray[$keyTypeValue] = $keyType;
 					$valueTypesForGeneralArray[] = $valueTypes[$i];
 
+					$keyTypeValue = $keyType->getValue();
 					if (array_key_exists($keyTypeValue, $constantKeyTypesNumbered)) {
 						continue;
 					}
+					$keyTypesForGeneralArray[$keyTypeValue] = $keyType;
 
 					$constantKeyTypesNumbered[$keyTypeValue] = $nextConstantKeyTypeIndex;
 					$nextConstantKeyTypeIndex *= 2;

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -820,7 +820,7 @@ final class TypeCombinator
 					if (array_key_exists($keyTypeValue, $constantKeyTypesNumbered)) {
 						continue;
 					}
-					$keyTypesForGeneralArray[$keyTypeValue] = $keyType;
+					$keyTypesForGeneralArray[] = $keyType;
 
 					$constantKeyTypesNumbered[$keyTypeValue] = $nextConstantKeyTypeIndex;
 					$nextConstantKeyTypeIndex *= 2;
@@ -832,7 +832,6 @@ final class TypeCombinator
 				}
 			}
 		}
-		$keyTypesForGeneralArray = array_values($keyTypesForGeneralArray);
 
 		if ($generalArrayOccurred && (!$overflowed || $filledArrays > 1)) {
 			$reducedArrayTypes = self::reduceArrays($arrayTypes, false);

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -814,10 +814,11 @@ final class TypeCombinator
 			foreach ($constantArrays as $constantArray) {
 				$valueTypes = $constantArray->getValueTypes();
 				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-					$keyTypesForGeneralArray[$keyType->getValue()] = $keyType;
+					$keyTypeValue = $keyType->getValue();
+
+					$keyTypesForGeneralArray[$keyTypeValue] = $keyType;
 					$valueTypesForGeneralArray[] = $valueTypes[$i];
 
-					$keyTypeValue = $keyType->getValue();
 					if (array_key_exists($keyTypeValue, $constantKeyTypesNumbered)) {
 						continue;
 					}

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -814,7 +814,7 @@ final class TypeCombinator
 			foreach ($constantArrays as $constantArray) {
 				$valueTypes = $constantArray->getValueTypes();
 				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-					$keyTypesForGeneralArray[] = $keyType;
+					$keyTypesForGeneralArray[$keyType->getValue()] = $keyType;
 					$valueTypesForGeneralArray[] = $valueTypes[$i];
 
 					$keyTypeValue = $keyType->getValue();
@@ -832,6 +832,7 @@ final class TypeCombinator
 				}
 			}
 		}
+		$keyTypesForGeneralArray = array_values($keyTypesForGeneralArray);
 
 		if ($generalArrayOccurred && (!$overflowed || $filledArrays > 1)) {
 			$reducedArrayTypes = self::reduceArrays($arrayTypes, false);


### PR DESCRIPTION
every constant array key needs only be contained once