### PR TITLE
ConstantStringType: Prevent creation of unnecessary constant-object types

### DIFF
--- a/src/Type/Constant/ConstantStringType.php
+++ b/src/Type/Constant/ConstantStringType.php
@@ -311,6 +311,11 @@ class ConstantStringType extends StringType implements ConstantScalarType
 
 		/** @var int|string $offsetValue */
 		$offsetValue = key([$this->value => null]);
+
+		if ($offsetValue === $this->value) {
+			return $this;
+		}
+
 		return $this->arrayKeyType = is_int($offsetValue) ? new ConstantIntegerType($offsetValue) : new ConstantStringType($offsetValue);
 	}
 


### PR DESCRIPTION
before this PR most constant-string key types contained the same constant type again, which represents the php auto converted array-key variant.

I don't think we should hold 2 objects per constant string type which is used as array key.

<img width="575" height="462" alt="grafik" src="https://github.com/user-attachments/assets/617b02fc-a6c2-4ef4-a75c-b4d6dcd0b3a5" />
