### PR TITLE
Simplify NodeScopeResolver->processImmediatelyCalledCallable()

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5166,18 +5166,8 @@ class NodeScopeResolver
 
 		$finder = new NodeFinder();
 		foreach ($invalidatedExpressions as $invalidateExpression) {
-			$found = false;
-			foreach ($uses as $use) {
-				$result = $finder->findFirst([$invalidateExpression->getExpr()], static fn ($node) => $node instanceof Variable && $node->name === $use);
-				if ($result === null) {
-					continue;
-				}
-
-				$found = true;
-				break;
-			}
-
-			if (!$found) {
+			$result = $finder->findFirst([$invalidateExpression->getExpr()], static fn ($node) => $node instanceof Variable && in_array($node->name, $uses, true));
+			if ($result === null) {
 				continue;
 			}
 


### PR DESCRIPTION
traverse each expression only once, intstead of once per use