### PR TITLE
Respect sys_get_temp_dir() from the parent process

### DIFF
--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -32,6 +32,8 @@ final class ProcessHelper
 
 		$processCommandArray = [
 			$phpCmd,
+			'-d',
+			'sys_temp_dir=' . escapeshellarg(sys_get_temp_dir()),
 		];
 
 		if ($input->getOption('memory-limit') === null) {

--- a/src/Process/ProcessHelper.php
+++ b/src/Process/ProcessHelper.php
@@ -11,6 +11,7 @@ use function ini_get;
 use function is_bool;
 use function php_ini_loaded_file;
 use function sprintf;
+use function sys_get_temp_dir;
 use const PHP_BINARY;
 
 final class ProcessHelper


### PR DESCRIPTION
Not sure how this should be tested on the CI, but I tested this locally and verified that it fixes https://github.com/phpstan/phpstan/issues/13929.

If I understand the code in `CommandHelper` correctly, `parameters.tmpDir` will override this if set. This is a bit annoying, but since there's no way (that I know of) to tell if an ini setting was set on CLI override or by php.ini, I suppose this is the most predictable behaviour.

It doesn't look too difficult to add a command line option to override the tmpDir from what I can see, although I'm not too clear how that would interact with the dependency injection, so I'm reluctant to mess with it for now.