### PR TITLE
Prevent unnecessary work in TypeSpecifier->createForExpr()

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1835,8 +1835,10 @@ final class TypeSpecifier
 			!$context->null()
 			&& $expr instanceof Expr\BinaryOp\Coalesce
 		) {
-			$rightIsSuperType = $type->isSuperTypeOf($scope->getType($expr->right));
-			if (($context->true() && $rightIsSuperType->no()) || ($context->false() && $rightIsSuperType->yes())) {
+			if (
+				($context->true() && $type->isSuperTypeOf($scope->getType($expr->right))->no())
+				|| ($context->false() && $type->isSuperTypeOf($scope->getType($expr->right))->yes())
+			) {
 				$expr = $expr->left;
 			}
 		}
@@ -1909,14 +1911,18 @@ final class TypeSpecifier
 
 		$sureTypes = [];
 		$sureNotTypes = [];
-		$exprString = $this->exprPrinter->printExpr($expr);
-		$originalExprString = $this->exprPrinter->printExpr($originalExpr);
 		if ($context->false()) {
+			$exprString = $this->exprPrinter->printExpr($expr);
+			$originalExprString = $this->exprPrinter->printExpr($originalExpr);
+
 			$sureNotTypes[$exprString] = [$expr, $type];
 			if ($exprString !== $originalExprString) {
 				$sureNotTypes[$originalExprString] = [$originalExpr, $type];
 			}
 		} elseif ($context->true()) {
+			$exprString = $this->exprPrinter->printExpr($expr);
+			$originalExprString = $this->exprPrinter->printExpr($originalExpr);
+
 			$sureTypes[$exprString] = [$expr, $type];
 			if ($exprString !== $originalExprString) {
 				$sureTypes[$originalExprString] = [$originalExpr, $type];

--- a/src/Reflection/ResolvedMethodReflection.php
+++ b/src/Reflection/ResolvedMethodReflection.php
@@ -24,6 +24,8 @@ final class ResolvedMethodReflection implements ExtendedMethodReflection
 
 	private Type|false|null $selfOutType = false;
 
+	private ?TrinaryLogic $hasSideEffects = null;
+
 	public function __construct(
 		private ExtendedMethodReflection $reflection,
 		private TemplateTypeMap $resolvedTemplateTypeMap,
@@ -167,7 +169,7 @@ final class ResolvedMethodReflection implements ExtendedMethodReflection
 
 	public function hasSideEffects(): TrinaryLogic
 	{
-		return $this->reflection->hasSideEffects();
+		return $this->hasSideEffects ??= $this->reflection->hasSideEffects();
 	}
 
 	public function isPure(): TrinaryLogic


### PR DESCRIPTION
saves ~1 second on `php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug`