### PR TITLE
NodeScopeResolver: Skip const args processing

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -37,6 +37,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Break_;
@@ -5563,7 +5564,13 @@ class NodeScopeResolver
 		}
 
 		$args = $callLike->getArgs();
-		$hasAttributeGroups = isset($stmt->attrGroups) && count($stmt->attrGroups) > 0;
+		$hasAttributeGroups =
+			(
+				$stmt instanceof Node\Stmt\ClassLike
+				|| $stmt instanceof FunctionLike
+				|| $stmt instanceof Node\Stmt\ClassConst
+			)
+			&& count($stmt->attrGroups) > 0;
 
 		$parameters = null;
 		if ($parametersAcceptor !== null) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5564,8 +5564,7 @@ class NodeScopeResolver
 		}
 
 		$args = $callLike->getArgs();
-		$hasAttributeGroups =
-			(
+		$hasAttributeGroups = (
 				$stmt instanceof Node\Stmt\ClassLike
 				|| $stmt instanceof FunctionLike
 				|| $stmt instanceof Node\Stmt\ClassConst

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5571,7 +5571,7 @@ class NodeScopeResolver
 				|| $stmt instanceof Node\Stmt\Property
 				|| $stmt instanceof Node\Stmt\EnumCase
 			)
-			&& count($stmt->attrGroups) > 0;
+			&& count($stmt->attrGroups) > 0; // @phpstan-ignore property.notFound
 
 		$parameters = null;
 		if ($parametersAcceptor !== null) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5563,6 +5563,7 @@ class NodeScopeResolver
 		}
 
 		$args = $callLike->getArgs();
+		$hasAttributeGroups = count($stmt->attrGroups) > 0;
 
 		$parameters = null;
 		if ($parametersAcceptor !== null) {
@@ -5574,6 +5575,22 @@ class NodeScopeResolver
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
 		foreach ($args as $i => $arg) {
+			if (!$hasAttributeGroups) {
+				if ($arg->value instanceof ConstFetch) {
+					$loweredConstName = strtolower($arg->value->name->toString());
+					if (in_array($loweredConstName, ['true', 'false', 'null'], true)) {
+						continue;
+					}
+				}
+
+				if (
+					$arg->value instanceof Node\Scalar\Int_
+					|| $arg->value instanceof Node\Scalar\Float_
+				) {
+					continue;
+				}
+			}
+
 			$assignByReference = false;
 			$parameter = null;
 			$parameterType = null;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5594,6 +5594,7 @@ class NodeScopeResolver
 				if (
 					$arg->value instanceof Node\Scalar\Int_
 					|| $arg->value instanceof Node\Scalar\Float_
+					|| ($arg->value instanceof Expr\UnaryMinus && $arg->value->expr instanceof Node\Scalar)
 				) {
 					continue;
 				}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5595,6 +5595,7 @@ class NodeScopeResolver
 					$arg->value instanceof Node\Scalar\Int_
 					|| $arg->value instanceof Node\Scalar\Float_
 					|| ($arg->value instanceof Expr\UnaryMinus && $arg->value->expr instanceof Node\Scalar)
+					// don't skip strings and arrays as these might be callable references
 				) {
 					continue;
 				}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5565,13 +5565,14 @@ class NodeScopeResolver
 
 		$args = $callLike->getArgs();
 		$hasAttributeGroups = (
+			($stmt instanceof FunctionLike && count($stmt->getAttrGroups()) > 0)
+			|| ((
 				$stmt instanceof Node\Stmt\ClassLike
-				|| $stmt instanceof FunctionLike
 				|| $stmt instanceof Node\Stmt\ClassConst
 				|| $stmt instanceof Node\Stmt\Property
 				|| $stmt instanceof Node\Stmt\EnumCase
 			)
-			&& count($stmt->attrGroups) > 0; // @phpstan-ignore property.notFound
+			&& count($stmt->attrGroups) > 0));
 
 		$parameters = null;
 		if ($parametersAcceptor !== null) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5563,7 +5563,7 @@ class NodeScopeResolver
 		}
 
 		$args = $callLike->getArgs();
-		$hasAttributeGroups = count($stmt->attrGroups) > 0;
+		$hasAttributeGroups = isset($stmt->attrGroups) && count($stmt->attrGroups) > 0;
 
 		$parameters = null;
 		if ($parametersAcceptor !== null) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5568,6 +5568,8 @@ class NodeScopeResolver
 				$stmt instanceof Node\Stmt\ClassLike
 				|| $stmt instanceof FunctionLike
 				|| $stmt instanceof Node\Stmt\ClassConst
+				|| $stmt instanceof Node\Stmt\Property
+				|| $stmt instanceof Node\Stmt\EnumCase
 			)
 			&& count($stmt->attrGroups) > 0;
 


### PR DESCRIPTION
const args cannot impact the call-site, therefore skip them - except when they are referenced via attributes