### PR TITLE
Prevent crash when analysing curl_setopt

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -333,6 +333,8 @@ jobs:
             extensions: "soap"
           - script: "bin/phpstan analyse -l 8 -a tests/e2e/data/soap.php -c tests/e2e/data/empty.neon tests/e2e/data/soap.php"
             extensions: ""
+          - script: "bin/phpstan analyse -l 8 -c tests/e2e/data/empty.neon tests/e2e/data/curl_setopt.php"
+            extensions: ":curl"
           - script: "bin/phpstan analyse -l 8 tests/e2e/anon-class/Granularity.php"
             extensions: ""
           - script: "bin/phpstan analyse -l 8 e2e/phpstan-phpunit-190/test.php -c e2e/phpstan-phpunit-190/test.neon"

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -1224,7 +1224,7 @@ final class ParametersAcceptorSelector
 			}
 		}
 
-		if (defined('CURLOPT_SHARE') && CURLOPT_SHARE === $curlOpt) {
+		if (defined('CURLOPT_SHARE') && $curlOpt === CURLOPT_SHARE) {
 			$phpversion = PhpVersionStaticAccessor::getInstance();
 
 			if ($phpversion->supportsCurlShareHandle()) {

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -1224,7 +1224,7 @@ final class ParametersAcceptorSelector
 			}
 		}
 
-		if ($curlOpt === CURLOPT_SHARE) {
+		if (defined('CURLOPT_SHARE') && CURLOPT_SHARE === $curlOpt) {
 			$phpversion = PhpVersionStaticAccessor::getInstance();
 
 			if ($phpversion->supportsCurlShareHandle()) {

--- a/tests/e2e/data/curl_setopt.php
+++ b/tests/e2e/data/curl_setopt.php
@@ -1,0 +1,3 @@
+<?php
+$ch = curl_init('');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
The crash happened when analysing curl_setopt without having the curl extension loaded. It crashed due to Undefined constant "CURLOPT_SHARE".