### PR TITLE
Less expression printing

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4484,14 +4484,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 	private function shouldInvalidateExpression(string $exprStringToInvalidate, Expr $exprToInvalidate, Expr $expr, bool $requireMoreCharacters = false): bool
 	{
-		$exprString = $this->getNodeKey($expr);
-		if ($requireMoreCharacters && $exprStringToInvalidate === $exprString) {
+		if ($requireMoreCharacters && $exprStringToInvalidate === $this->getNodeKey($expr)) {
 			return false;
 		}
 
 		// Variables will not contain traversable expressions. skip the NodeFinder overhead
 		if ($expr instanceof Variable && is_string($expr->name) && !$requireMoreCharacters) {
-			return $exprStringToInvalidate === $exprString;
+			return $exprStringToInvalidate === $this->getNodeKey($expr);
 		}
 
 		$nodeFinder = new NodeFinder();


### PR DESCRIPTION
with the recent changes from https://github.com/phpstan/phpstan-src/commit/21d86f0675008ebea2ba52fdee6013a6180a228d we started printing all expressions.

since expression printing shows up in most profiles, we should only print when we really need the string