### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: "Downgrade PHPUnit"
         if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
-        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 --update-with-dependencies --ignore-platform-reqs"
+        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 doctrine/instantiator:^1.0 --update-with-dependencies --ignore-platform-reqs"
 
       - uses: "ramsey/composer-install@v3"
 

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -42,7 +42,7 @@ jobs:
 
       # only sebastian/diff ^4 supports PHP 7.4 so we need that in the PHAR
       - name: "Downgrade PHPUnit"
-        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 --update-with-dependencies --ignore-platform-reqs"
+        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 doctrine/instantiator:^1.0 --update-with-dependencies --ignore-platform-reqs"
 
       - name: "Install compiler dependencies"
         uses: "ramsey/composer-install@v3"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Downgrade PHPUnit"
         if: matrix.php-version == '7.4' || matrix.php-version == '8.0' || matrix.php-version == '8.1'
         shell: bash
-        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 --update-with-dependencies --ignore-platform-reqs"
+        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 doctrine/instantiator:^1.0 --update-with-dependencies --ignore-platform-reqs"
 
       - uses: "ramsey/composer-install@v3"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,13 +245,13 @@ jobs:
 
       - name: "Downgrade PHPUnit"
         shell: bash
-        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 --update-with-dependencies --ignore-platform-reqs"
+        run: "composer require --dev phpunit/phpunit:^9.6 sebastian/diff:^4.0 doctrine/instantiator:^1.0 --update-with-dependencies --ignore-platform-reqs"
 
       - uses: "ramsey/composer-install@v3"
 
       - name: "Downgrade PHPUnit with Paratest"
         shell: bash
-        run: "composer require --dev phpunit/phpunit:^9.6 brianium/paratest:^6.5 symfony/console:^5.4 symfony/process:^5.4 --update-with-dependencies --ignore-platform-reqs --working-dir=tests"
+        run: "composer require --dev phpunit/phpunit:^9.6 brianium/paratest:^6.5 symfony/console:^5.4 symfony/process:^5.4 doctrine/instantiator:^1.0 --update-with-dependencies --ignore-platform-reqs --working-dir=tests"
 
       - uses: ./.github/actions/downgrade-code
         with:


### PR DESCRIPTION
by a recent release of dotrince/instantiator 2.1.x it seems we now need to explicitly declare `doctrine/instantiator:^1.0` for the PHPUnit downgrade.

I don't know exactly why that is, but it seems with this PR we are at least back to the state we had yesterday and no longer have additional errors we just saw in https://github.com/phpstan/phpstan-src/pull/4724 like
```
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - doctrine/instantiator is locked to version 2.1.0 and an update of this package was not requested.
    - doctrine/instantiator 2.1.0 requires php ^8.4 -> your php version (8.2.99; overridden via config.platform, actual: 7.4.33) does not satisfy that requirement.
  Problem 2
    - phpunit/phpunit is locked to version 9.6.31 and an update of this package was not requested.
    - doctrine/instantiator 2.1.0 requires php ^8.4 -> your php version (8.2.99; overridden via config.platform, actual: 7.4.33) does not satisfy that requirement.
    - phpunit/phpunit 9.6.31 requires doctrine/instantiator ^1.5.0 || ^2 -> satisfiable by doctrine/instantiator[2.1.0].

Error: Your lock file does not contain a compatible set of packages. Please run composer update.
```