### PR TITLE
Run `make cs-fix` on PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,7 +77,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
-          php-version: "8.2"
+          php-version: "8.5"
 
       - name: "Validate Composer"
         run: "composer validate"

--- a/compiler/box/composer.json
+++ b/compiler/box/composer.json
@@ -1,7 +1,8 @@
 {
 	"require": {
 		"humbug/box": "^4.6",
-		"cweagans/composer-patches": "^1.7"
+		"cweagans/composer-patches": "^1.7",
+		"jetbrains/phpstorm-stubs": "dev-master as v2024.x-dev"
 	},
 	"config": {
 		"platform": {

--- a/compiler/box/composer.lock
+++ b/compiler/box/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb82d3fddd187abc2f321b38688fb441",
+    "content-hash": "8c72337081ddf7ca83d3b63b69ea241f",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1528,24 +1528,25 @@
         },
         {
             "name": "jetbrains/phpstorm-stubs",
-            "version": "v2024.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/JetBrains/phpstorm-stubs.git",
-                "reference": "0e82bdfe850c71857ee4ee3501ed82a9fc5d043c"
+                "url": "https://github.com/JetBrains/phpstorm-stubs",
+                "reference": "ef45e9e2a0a3c69c13ed59184d42f99a16240313"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/0e82bdfe850c71857ee4ee3501ed82a9fc5d043c",
-                "reference": "0e82bdfe850c71857ee4ee3501ed82a9fc5d043c",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/ef45e9e2a0a3c69c13ed59184d42f99a16240313",
+                "reference": "ef45e9e2a0a3c69c13ed59184d42f99a16240313",
                 "shasum": ""
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "v3.64.0",
-                "nikic/php-parser": "v5.3.1",
-                "phpdocumentor/reflection-docblock": "5.6.0",
-                "phpunit/phpunit": "11.4.3"
+                "friendsofphp/php-cs-fixer": "^v3.86",
+                "nikic/php-parser": "^v5.6",
+                "phpdocumentor/reflection-docblock": "^5.6",
+                "phpunit/phpunit": "^12.3"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -1568,10 +1569,7 @@
                 "stubs",
                 "type"
             ],
-            "support": {
-                "source": "https://github.com/JetBrains/phpstorm-stubs/tree/v2024.3"
-            },
-            "time": "2024-12-14T08:03:12+00:00"
+            "time": "2026-01-08T09:22:58+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -4199,9 +4197,18 @@
         }
     ],
     "packages-dev": [],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "jetbrains/phpstorm-stubs",
+            "version": "9999999-dev",
+            "alias": "v2024.x-dev",
+            "alias_normalized": "2024.9999999.9999999.9999999-dev"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "jetbrains/phpstorm-stubs": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -142,6 +142,7 @@ use function array_filter;
 use function array_key_exists;
 use function array_key_first;
 use function array_keys;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_pop;

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -207,6 +207,7 @@ use function array_filter;
 use function array_key_exists;
 use function array_key_last;
 use function array_keys;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_pop;

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -75,6 +75,7 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use function array_key_exists;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_reverse;

--- a/src/Fixable/PhpPrinter.php
+++ b/src/Fixable/PhpPrinter.php
@@ -5,6 +5,7 @@ namespace PHPStan\Fixable;
 use Override;
 use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
+use function array_last;
 use function count;
 use function rtrim;
 

--- a/src/Parser/LastConditionVisitor.php
+++ b/src/Parser/LastConditionVisitor.php
@@ -6,6 +6,7 @@ use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
+use function array_last;
 use function count;
 
 #[AutowiredService]

--- a/src/Parser/TryCatchTypeVisitor.php
+++ b/src/Parser/TryCatchTypeVisitor.php
@@ -6,6 +6,7 @@ use Override;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
+use function array_last;
 use function array_pop;
 use function array_reverse;
 use function count;

--- a/src/Parser/VariadicMethodsVisitor.php
+++ b/src/Parser/VariadicMethodsVisitor.php
@@ -10,6 +10,7 @@ use PhpParser\NodeVisitorAbstract;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ParametersAcceptor;
 use function array_key_exists;
+use function array_last;
 use function array_pop;
 use function in_array;
 use function sprintf;

--- a/src/Reflection/AttributeReflectionFactory.php
+++ b/src/Reflection/AttributeReflectionFactory.php
@@ -10,6 +10,7 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\ReflectionProvider\ReflectionProviderProvider;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
+use function array_last;
 use function count;
 use function is_int;
 

--- a/src/Reflection/GenericParametersAcceptorResolver.php
+++ b/src/Reflection/GenericParametersAcceptorResolver.php
@@ -13,6 +13,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function array_key_exists;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function count;

--- a/src/Reflection/ParametersAcceptorSelector.php
+++ b/src/Reflection/ParametersAcceptorSelector.php
@@ -46,6 +46,7 @@ use PHPStan\Type\UnionType;
 use function array_is_list;
 use function array_key_exists;
 use function array_key_last;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_slice;

--- a/src/Rules/FunctionCallParametersCheck.php
+++ b/src/Rules/FunctionCallParametersCheck.php
@@ -29,6 +29,7 @@ use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VerbosityLevel;
 use function array_fill;
 use function array_key_exists;
+use function array_last;
 use function count;
 use function implode;
 use function in_array;

--- a/src/Rules/Whitespace/FileWhitespaceRule.php
+++ b/src/Rules/Whitespace/FileWhitespaceRule.php
@@ -13,6 +13,7 @@ use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\FileNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use function array_last;
 use function count;
 
 /**

--- a/src/Type/FileTypeMapper.php
+++ b/src/Type/FileTypeMapper.php
@@ -27,6 +27,7 @@ use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Generic\TemplateTypeVarianceMap;
 use function array_key_exists;
 use function array_keys;
+use function array_last;
 use function array_map;
 use function array_merge;
 use function array_pop;


### PR DESCRIPTION
This is essentially revival of #4643 and #4689.

On current 2.1.x branch, `make cs` fails with below error only on PHP 8.5.
> Function array_last() should not be referenced via a fallback global name, but via a use statement.

This is because `SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly` sniff uses `function_exists` to decide if it checks the function calls.
On PHP 8.4 or lower, `array_last()` does not exist so the sniff doesn't check the usage of the function.

https://github.com/slevomat/coding-standard/blob/90b688162eba700bebca1f045ef5fe6f1936bc15/SlevomatCodingStandard/Sniffs/Namespaces/ReferenceUsedNamesOnlySniff.php#L207-L209

In this PR those errors are fixed with `make cs-fix`, and PHP_CodeSniffer are now run on CI with PHP 8.5.

With this fix, PHP-Scoper mistakenly prefixes `array_last` because it doesn't know the latest functions of PHP.
(Reported as humbug/php-scoper#1142)
As a workaround, `jetbrains/phpstorm-stubs` was added to `compiler/box/composer.json` so we can use `dev-master` version. The package is used by PHP-Scoper as the list of internal functions.