### PR TITLE
Find all constant/method types per class at once

### DIFF
--- a/src/Reflection/BetterReflection/SourceLocator/CachingVisitor.php
+++ b/src/Reflection/BetterReflection/SourceLocator/CachingVisitor.php
@@ -20,13 +20,13 @@ final class CachingVisitor extends NodeVisitorAbstract
 
 	private string $contents;
 
-	/** @var array<string, array<FetchedNode<Node\Stmt\ClassLike>>> */
+	/** @var array<string, list<FetchedNode<Node\Stmt\ClassLike>>> */
 	private array $classNodes;
 
-	/** @var array<string, array<FetchedNode<Node\Stmt\Function_>>> */
+	/** @var array<string, list<FetchedNode<Node\Stmt\Function_>>> */
 	private array $functionNodes;
 
-	/** @var array<string, array<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>> */
+	/** @var array<string, list<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>> */
 	private array $constantNodes;
 
 	private ?Node\Stmt\Namespace_ $currentNamespaceNode = null;
@@ -124,7 +124,7 @@ final class CachingVisitor extends NodeVisitorAbstract
 	}
 
 	/**
-	 * @return array<string, array<FetchedNode<Node\Stmt\ClassLike>>>
+	 * @return array<string, list<FetchedNode<Node\Stmt\ClassLike>>>
 	 */
 	public function getClassNodes(): array
 	{
@@ -132,7 +132,7 @@ final class CachingVisitor extends NodeVisitorAbstract
 	}
 
 	/**
-	 * @return array<string, array<FetchedNode<Node\Stmt\Function_>>>
+	 * @return array<string, list<FetchedNode<Node\Stmt\Function_>>>
 	 */
 	public function getFunctionNodes(): array
 	{
@@ -140,7 +140,7 @@ final class CachingVisitor extends NodeVisitorAbstract
 	}
 
 	/**
-	 * @return array<string, array<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>>
+	 * @return array<string, list<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>>
 	 */
 	public function getConstantNodes(): array
 	{

--- a/src/Reflection/BetterReflection/SourceLocator/FetchedNodesResult.php
+++ b/src/Reflection/BetterReflection/SourceLocator/FetchedNodesResult.php
@@ -8,9 +8,9 @@ final class FetchedNodesResult
 {
 
 	/**
-	 * @param array<string, array<FetchedNode<Node\Stmt\ClassLike>>> $classNodes
-	 * @param array<string, array<FetchedNode<Node\Stmt\Function_>>> $functionNodes
-	 * @param array<string, array<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>> $constantNodes
+	 * @param array<string, list<FetchedNode<Node\Stmt\ClassLike>>> $classNodes
+	 * @param array<string, list<FetchedNode<Node\Stmt\Function_>>> $functionNodes
+	 * @param array<string, list<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>> $constantNodes
 	 */
 	public function __construct(
 		private array $classNodes,
@@ -21,7 +21,7 @@ final class FetchedNodesResult
 	}
 
 	/**
-	 * @return array<string, array<FetchedNode<Node\Stmt\ClassLike>>>
+	 * @return array<string, list<FetchedNode<Node\Stmt\ClassLike>>>
 	 */
 	public function getClassNodes(): array
 	{
@@ -29,7 +29,7 @@ final class FetchedNodesResult
 	}
 
 	/**
-	 * @return array<string, array<FetchedNode<Node\Stmt\Function_>>>
+	 * @return array<string, list<FetchedNode<Node\Stmt\Function_>>>
 	 */
 	public function getFunctionNodes(): array
 	{
@@ -37,7 +37,7 @@ final class FetchedNodesResult
 	}
 
 	/**
-	 * @return array<string, array<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>>
+	 * @return array<string, list<FetchedNode<Node\Stmt\Const_|Node\Expr\FuncCall>>>
 	 */
 	public function getConstantNodes(): array
 	{

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -44,14 +44,8 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 	/** @var array<lowercase-string, array<lowercase-string, array{ClassMethod, string}>> */
 	private array $methodNodes = [];
 
-	/** @var array<lowercase-string, array<lowercase-string, array{ClassMethod, string}>> */
-	private array $stubbedMethodNodes = [];
-
 	/** @var array<lowercase-string, array<lowercase-string, Type|null>> */
 	private array $constantTypes = [];
-
-	/** @var array<lowercase-string, array<lowercase-string, Type|null>> */
-	private array $stubbedConstantTypes = [];
 
 	private Php8StubsMap $map;
 
@@ -88,13 +82,10 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 	{
 		$lowerClassName = strtolower($className);
 		$lowerMethodName = strtolower($methodName);
-		if (isset($this->methodNodes[$lowerClassName][$lowerMethodName])) {
-			return $this->methodNodes[$lowerClassName][$lowerMethodName];
-		}
 
 		$this->findClassStubs($className);
-		if (isset($this->stubbedMethodNodes[$lowerClassName][$lowerMethodName])) {
-			return $this->methodNodes[$lowerClassName][$lowerMethodName] = $this->stubbedMethodNodes[$lowerClassName][$lowerMethodName];
+		if (isset($this->methodNodes[$lowerClassName][$lowerMethodName])) {
+			return $this->methodNodes[$lowerClassName][$lowerMethodName];
 		}
 
 		return null;
@@ -105,8 +96,8 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 		$lowerClassName = strtolower($className);
 
 		if (
-			array_key_exists($lowerClassName, $this->stubbedMethodNodes)
-			|| array_key_exists($lowerClassName, $this->stubbedConstantTypes)
+			isset($this->methodNodes[$lowerClassName])
+		 	|| isset($this->constantTypes[$lowerClassName])
 		) {
 			return;
 		}
@@ -123,8 +114,8 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
 		}
 
-		$this->stubbedMethodNodes[$lowerClassName] = [];
-		$this->stubbedConstantTypes[$lowerClassName] = [];
+		$this->methodNodes[$lowerClassName] = [];
+		$this->constantTypes[$lowerClassName] = [];
 
 		// find and remember all methods/constants within the stubFile
 		foreach ($class[0]->getNode()->stmts as $stmt) {
@@ -133,7 +124,7 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 					continue;
 				}
 
-				$this->stubbedMethodNodes[$lowerClassName][$stmt->name->toLowerString()] = [$stmt, $stubFile];
+				$this->methodNodes[$lowerClassName][$stmt->name->toLowerString()] = [$stmt, $stubFile];
 
 				continue;
 			}
@@ -151,7 +142,7 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 					continue;
 				}
 
-				$this->stubbedConstantTypes[$lowerClassName][$const->name->toLowerString()] = ParserNodeTypeToPHPStanType::resolve($stmt->type, null);
+				$this->constantTypes[$lowerClassName][$const->name->toLowerString()] = ParserNodeTypeToPHPStanType::resolve($stmt->type, null);
 			}
 		}
 	}
@@ -523,13 +514,10 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 	{
 		$lowerClassName = strtolower($className);
 		$lowerConstantName = strtolower($constantName);
-		if (isset($this->constantTypes[$lowerClassName][$lowerConstantName])) {
-			return $this->constantTypes[$lowerClassName][$lowerConstantName];
-		}
 
 		$this->findClassStubs($className);
-		if (isset($this->stubbedConstantTypes[$lowerClassName][$lowerConstantName])) {
-			return $this->constantTypes[$lowerClassName][$lowerConstantName] = $this->stubbedConstantTypes[$lowerClassName][$lowerConstantName];
+		if (isset($this->constantTypes[$lowerClassName][$lowerConstantName])) {
+			return $this->constantTypes[$lowerClassName][$lowerConstantName];
 		}
 
 		return null;

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -44,8 +44,11 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 	/** @var array<string, array<string, array{ClassMethod, string}>> */
 	private array $methodNodes = [];
 
-	/** @var array<string, array<string, Type|null>> */
+	/** @var array<lowercase-string, array<lowercase-string, Type|null>> */
 	private array $constantTypes = [];
+
+	/** @var array<lowercase-string, array<lowercase-string, Type|null>> */
+	private array $stubbedConstantTypes = [];
 
 	private Php8StubsMap $map;
 
@@ -485,38 +488,43 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 			return $this->constantTypes[$lowerClassName][$lowerConstantName];
 		}
 
-		$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
-		$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
-		$classes = $nodes->getClassNodes();
-		if (count($classes) !== 1) {
-			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-		}
-
-		$class = $classes[$lowerClassName];
-		if (count($class) !== 1) {
-			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-		}
-
-		foreach ($class[0]->getNode()->stmts as $stmt) {
-			if (!$stmt instanceof ClassConst) {
-				continue;
+		// read/parse each stubFile only once
+		if (!array_key_exists($lowerClassName, $this->stubbedConstantTypes)) {
+			$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
+			$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
+			$classes = $nodes->getClassNodes();
+			if (count($classes) !== 1) {
+				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
 			}
 
-			foreach ($stmt->consts as $const) {
-				if ($const->name->toString() !== $constantName) {
+			$class = $classes[$lowerClassName];
+			if (count($class) !== 1) {
+				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
+			}
+
+			// find and remember all constants within the stubFile
+			foreach ($class[0]->getNode()->stmts as $stmt) {
+				if (!$stmt instanceof ClassConst) {
 					continue;
 				}
 
-				if (!$this->isForCurrentVersion($stmt->attrGroups)) {
-					continue;
-				}
+				foreach ($stmt->consts as $const) {
+					if ($stmt->type === null) {
+						continue;
+					}
 
-				if ($stmt->type === null) {
-					return null;
-				}
+					if (!$this->isForCurrentVersion($stmt->attrGroups)) {
+						continue;
+					}
 
-				return $this->constantTypes[$lowerClassName][$lowerConstantName] = ParserNodeTypeToPHPStanType::resolve($stmt->type, null);
+					$this->stubbedConstantTypes[$lowerClassName][$const->name->toLowerString()] = ParserNodeTypeToPHPStanType::resolve($stmt->type, null);
+				}
 			}
+		}
+
+		// mark only the requested constant as being found
+		if (isset($this->stubbedConstantTypes[$lowerClassName][$lowerConstantName])) {
+			return $this->constantTypes[$lowerClassName][$lowerConstantName] = $this->stubbedConstantTypes[$lowerClassName][$lowerConstantName];
 		}
 
 		return null;

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -97,7 +97,7 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 
 		if (
 			isset($this->methodNodes[$lowerClassName])
-		 	|| isset($this->constantTypes[$lowerClassName])
+			|| isset($this->constantTypes[$lowerClassName])
 		) {
 			return;
 		}

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -41,8 +41,11 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 
 	private const DIRECTORY = __DIR__ . '/../../../vendor/phpstan/php-8-stubs';
 
-	/** @var array<string, array<string, array{ClassMethod, string}>> */
+	/** @var array<lowercase-string, array<lowercase-string, array{ClassMethod, string}>> */
 	private array $methodNodes = [];
+
+	/** @var array<lowercase-string, array<lowercase-string, array{ClassMethod, string}>> */
+	private array $stubbedMethodNodes = [];
 
 	/** @var array<lowercase-string, array<lowercase-string, Type|null>> */
 	private array $constantTypes = [];
@@ -89,29 +92,40 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 			return $this->methodNodes[$lowerClassName][$lowerMethodName];
 		}
 
-		$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
-		$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
-		$classes = $nodes->getClassNodes();
-		if (count($classes) !== 1) {
-			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-		}
-
-		$class = $classes[$lowerClassName];
-		if (count($class) !== 1) {
-			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-		}
-
-		foreach ($class[0]->getNode()->stmts as $stmt) {
-			if (!$stmt instanceof ClassMethod) {
-				continue;
+		if (!array_key_exists($lowerClassName, $this->stubbedConstantTypes)) {
+			$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
+			$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
+			$classes = $nodes->getClassNodes();
+			if (count($classes) !== 1) {
+				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
 			}
 
-			if ($stmt->name->toLowerString() === $lowerMethodName) {
+			$class = $classes[$lowerClassName];
+			if (count($class) !== 1) {
+				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
+			}
+
+			// find and remember all methods within the stubFile
+			foreach ($class[0]->getNode()->stmts as $stmt) {
+				if (!$stmt instanceof ClassMethod) {
+					continue;
+				}
+
+				if ($stmt->name->toLowerString() !== $lowerMethodName) {
+					continue;
+				}
+
 				if (!$this->isForCurrentVersion($stmt->attrGroups)) {
 					continue;
 				}
-				return $this->methodNodes[$lowerClassName][$lowerMethodName] = [$stmt, $stubFile];
+
+				$this->stubbedMethodNodes[$lowerClassName][$lowerMethodName] = [$stmt, $stubFile];
 			}
+		}
+
+		// mark only the requested method as being found
+		if (isset($this->stubbedMethodNodes[$lowerClassName][$lowerMethodName])) {
+			return $this->methodNodes[$lowerClassName][$lowerMethodName] = $this->stubbedMethodNodes[$lowerClassName][$lowerMethodName];
 		}
 
 		return null;

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -92,26 +92,55 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 			return $this->methodNodes[$lowerClassName][$lowerMethodName];
 		}
 
-		if (!array_key_exists($lowerClassName, $this->stubbedConstantTypes)) {
-			$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
-			$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
-			$classes = $nodes->getClassNodes();
-			if (count($classes) !== 1) {
-				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-			}
+		$this->findClassStubs($className);
+		if (isset($this->stubbedMethodNodes[$lowerClassName][$lowerMethodName])) {
+			return $this->methodNodes[$lowerClassName][$lowerMethodName] = $this->stubbedMethodNodes[$lowerClassName][$lowerMethodName];
+		}
 
-			$class = $classes[$lowerClassName];
-			if (count($class) !== 1) {
-				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-			}
+		return null;
+	}
 
-			// find and remember all methods within the stubFile
-			foreach ($class[0]->getNode()->stmts as $stmt) {
-				if (!$stmt instanceof ClassMethod) {
+	private function findClassStubs(string $className): void
+	{
+		$lowerClassName = strtolower($className);
+
+		if (
+			array_key_exists($lowerClassName, $this->stubbedMethodNodes)
+			|| array_key_exists($lowerClassName, $this->stubbedConstantTypes)
+		) {
+			return;
+		}
+
+		$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
+		$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
+		$classes = $nodes->getClassNodes();
+		if (count($classes) !== 1) {
+			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
+		}
+
+		$class = $classes[$lowerClassName];
+		if (count($class) !== 1) {
+			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
+		}
+
+		// find and remember all methods/constants within the stubFile
+		foreach ($class[0]->getNode()->stmts as $stmt) {
+			if ($stmt instanceof ClassMethod) {
+				if (!$this->isForCurrentVersion($stmt->attrGroups)) {
 					continue;
 				}
 
-				if ($stmt->name->toLowerString() !== $lowerMethodName) {
+				$this->stubbedMethodNodes[$lowerClassName][$stmt->name->toLowerString()] = [$stmt, $stubFile];
+
+				continue;
+			}
+
+			if (!$stmt instanceof ClassConst) {
+				continue;
+			}
+
+			foreach ($stmt->consts as $const) {
+				if ($stmt->type === null) {
 					continue;
 				}
 
@@ -119,16 +148,9 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 					continue;
 				}
 
-				$this->stubbedMethodNodes[$lowerClassName][$lowerMethodName] = [$stmt, $stubFile];
+				$this->stubbedConstantTypes[$lowerClassName][$const->name->toLowerString()] = ParserNodeTypeToPHPStanType::resolve($stmt->type, null);
 			}
 		}
-
-		// mark only the requested method as being found
-		if (isset($this->stubbedMethodNodes[$lowerClassName][$lowerMethodName])) {
-			return $this->methodNodes[$lowerClassName][$lowerMethodName] = $this->stubbedMethodNodes[$lowerClassName][$lowerMethodName];
-		}
-
-		return null;
 	}
 
 	/**
@@ -502,41 +524,7 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 			return $this->constantTypes[$lowerClassName][$lowerConstantName];
 		}
 
-		// read/parse each stubFile only once
-		if (!array_key_exists($lowerClassName, $this->stubbedConstantTypes)) {
-			$stubFile = self::DIRECTORY . '/' . $this->map->classes[$lowerClassName];
-			$nodes = $this->fileNodesFetcher->fetchNodes($stubFile);
-			$classes = $nodes->getClassNodes();
-			if (count($classes) !== 1) {
-				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-			}
-
-			$class = $classes[$lowerClassName];
-			if (count($class) !== 1) {
-				throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
-			}
-
-			// find and remember all constants within the stubFile
-			foreach ($class[0]->getNode()->stmts as $stmt) {
-				if (!$stmt instanceof ClassConst) {
-					continue;
-				}
-
-				foreach ($stmt->consts as $const) {
-					if ($stmt->type === null) {
-						continue;
-					}
-
-					if (!$this->isForCurrentVersion($stmt->attrGroups)) {
-						continue;
-					}
-
-					$this->stubbedConstantTypes[$lowerClassName][$const->name->toLowerString()] = ParserNodeTypeToPHPStanType::resolve($stmt->type, null);
-				}
-			}
-		}
-
-		// mark only the requested constant as being found
+		$this->findClassStubs($className);
 		if (isset($this->stubbedConstantTypes[$lowerClassName][$lowerConstantName])) {
 			return $this->constantTypes[$lowerClassName][$lowerConstantName] = $this->stubbedConstantTypes[$lowerClassName][$lowerConstantName];
 		}

--- a/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
+++ b/src/Reflection/SignatureMap/Php8SignatureMapProvider.php
@@ -123,6 +123,9 @@ final class Php8SignatureMapProvider implements SignatureMapProvider
 			throw new ShouldNotHappenException(sprintf('Class %s stub not found in %s.', $className, $stubFile));
 		}
 
+		$this->stubbedMethodNodes[$lowerClassName] = [];
+		$this->stubbedConstantTypes[$lowerClassName] = [];
+
 		// find and remember all methods/constants within the stubFile
 		foreach ($class[0]->getNode()->stmts as $stmt) {
 			if ($stmt instanceof ClassMethod) {


### PR DESCRIPTION
before this PR we read/ast-traversed every stub file only until we found the single symbol we were searching for.
after something was found, traversal stopped and we returned early.

this means we e.g. see the same file beeing read/php-parsed/ast-traversed from the filesystem multiple times, when e.g. multiple constants of the same class are unkown or a mix of constants and methods are unknown.

see a phpstan-doctrine example run:
```
phar:///Users/staabm/workspace/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/SignatureMap/../../../vendor/phpstan/php-8-stubs/stubs/ext/pdo/PDO.stub
phar:///Users/staabm/workspace/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/SignatureMap/../../../vendor/phpstan/php-8-stubs/stubs/ext/pdo/PDO.stub
phar:///Users/staabm/workspace/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/SignatureMap/../../../vendor/phpstan/php-8-stubs/stubs/ext/pdo/PDO.stub
phar:///Users/staabm/workspace/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/SignatureMap/../../../vendor/phpstan/php-8-stubs/stubs/ext/pdo/PDO.stub
phar:///Users/staabm/workspace/phpstan-doctrine/vendor/phpstan/phpstan/phpstan.phar/src/Reflection/SignatureMap/../../../vendor/phpstan/php-8-stubs/stubs/ext/pdo/PDO.stub
```

---

after this PR we remember all contained symbols within a stub file on the first read/parse/ast-traversal.
when later requested we can easily lookup whether a stub for a given method or constant exists, without the need to read/parse the stub file over and overr again.