### PR TITLE
Faster IntersectionType->getFiniteTypes()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1426,6 +1426,12 @@ parameters:
 			path: src/Type/IntersectionType.php
 
 		-
+			rawMessage: 'Doing instanceof PHPStan\Type\Enum\EnumCaseObjectType is error-prone and deprecated. Use Type::getEnumCases() instead.'
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Type/IntersectionType.php
+
+		-
 			rawMessage: Doing instanceof PHPStan\Type\IntersectionType is error-prone and deprecated.
 			identifier: phpstanApi.instanceofType
 			count: 3

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -54,6 +54,7 @@ use function implode;
 use function in_array;
 use function is_int;
 use function ksort;
+use function md5;
 use function sprintf;
 use function strcasecmp;
 use function strlen;
@@ -1345,6 +1346,10 @@ class IntersectionType implements CompoundType
 		foreach ($this->types as $type) {
 			$oneType = [];
 			foreach ($type->getFiniteTypes() as $finiteType) {
+				if ($finiteType instanceof EnumCaseObjectType) {
+					$oneType[$finiteType->getClassName().'::'.$finiteType->getEnumCaseName()] = $finiteType;
+					continue;
+				}
 				$oneType[$finiteType->describe(VerbosityLevel::typeOnly())] = $finiteType;
 			}
 			$compare[] = $oneType;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -54,7 +54,6 @@ use function implode;
 use function in_array;
 use function is_int;
 use function ksort;
-use function md5;
 use function sprintf;
 use function strcasecmp;
 use function strlen;
@@ -1347,7 +1346,7 @@ class IntersectionType implements CompoundType
 			$oneType = [];
 			foreach ($type->getFiniteTypes() as $finiteType) {
 				if ($finiteType instanceof EnumCaseObjectType) {
-					$oneType[$finiteType->getClassName().'::'.$finiteType->getEnumCaseName()] = $finiteType;
+					$oneType[$finiteType->getClassName() . '::' . $finiteType->getEnumCaseName()] = $finiteType;
 					continue;
 				}
 				$oneType[$finiteType->describe(VerbosityLevel::typeOnly())] = $finiteType;


### PR DESCRIPTION
make large enum analysis faster

---

requires https://github.com/phpstan/phpstan-src/pull/4744

---

the repro from https://github.com/phpstan/phpstan/issues/11968

before this PR: 32.32 seconds
after this PR: 8.57 seconds