### PR TITLE
Error: Don't persist redundant filePath value

### DIFF
--- a/src/Analyser/Error.php
+++ b/src/Analyser/Error.php
@@ -45,6 +45,10 @@ final class Error implements JsonSerializable
 		if ($this->identifier !== null && !self::validateIdentifier($this->identifier)) {
 			throw new ShouldNotHappenException(sprintf('Invalid identifier: %s', $this->identifier));
 		}
+
+		if ($file === $filePath) {
+			$this->filePath = null;
+		}
 	}
 
 	public function getMessage(): string

--- a/src/Analyser/Error.php
+++ b/src/Analyser/Error.php
@@ -46,9 +46,11 @@ final class Error implements JsonSerializable
 			throw new ShouldNotHappenException(sprintf('Invalid identifier: %s', $this->identifier));
 		}
 
-		if ($file === $filePath) {
-			$this->filePath = null;
+		if ($file !== $filePath) {
+			return;
 		}
+
+		$this->filePath = null;
 	}
 
 	public function getMessage(): string


### PR DESCRIPTION
Most errors in the `resultCache.php` contain the same `path` and `filePath`, see e.g.

```
...
\PHPStan\Analyser\Error::__set_state(array(
       'message' => 'Doing instanceof PHPStan\\Type\\FloatType is error-prone and deprecated. Use Type::isFloat() instead.',
       'file' => '/Users/m.staab/dvl/phpstan-src/src/Type/Generic/TemplateTypeFactory.php',
       'line' => 82,
       'canBeIgnored' => true,
       'filePath' => '/Users/m.staab/dvl/phpstan-src/src/Type/Generic/TemplateTypeFactory.php',
       'traitFilePath' => NULL,
       'tip' => 'Learn more: <fg=cyan>https://phpstan.org/blog/why-is-instanceof-type-wrong-and-getting-deprecated</>',
       'nodeLine' => 82,
       'nodeType' => 'PhpParser\\Node\\Expr\\Instanceof_',
       'identifier' => 'phpstanApi.instanceofType',
       'metadata' => 
      array (
      ),
       'fixedErrorDiff' => NULL,
    )),
...
```

since we already have a fallback logic like

```
	public function getFilePath(): string
	{
		if ($this->filePath === null) {
			return $this->file;
		}

		return $this->filePath;
	}
```

we can just assign `null` to `filePath` and save 1% of result-cache size