### PR TITLE
Implement rule for `unserialize`

### DIFF
--- a/conf/bleedingEdge.neon
+++ b/conf/bleedingEdge.neon
@@ -7,6 +7,7 @@ parameters:
 		stricterFunctionMap: true
 		reportPreciseLineForUnusedFunctionParameter: true
 		checkPrintfParameterTypes: true
+		checkUnserializeFunction: true
 		internalTag: true
 		newStaticInAbstractClassStaticMethod: true
 		checkExtensionsForComparisonOperators: true

--- a/conf/config.level5.neon
+++ b/conf/config.level5.neon
@@ -10,6 +10,8 @@ conditionalTags:
 		phpstan.rules.rule: %featureToggles.checkParameterCastableToNumberFunctions%
 	PHPStan\Rules\Functions\PrintfParameterTypeRule:
 		phpstan.rules.rule: %featureToggles.checkPrintfParameterTypes%
+	PHPStan\Rules\Functions\UnserializeRule:
+		phpstan.rules.rule: %featureToggles.checkUnserializeFunction%
 
 autowiredAttributeServices:
 	# registers rules with #[RegisteredRule] attribute
@@ -22,3 +24,7 @@ services:
 		class: PHPStan\Rules\Functions\PrintfParameterTypeRule
 		arguments:
 			checkStrictPrintfPlaceholderTypes: %checkStrictPrintfPlaceholderTypes%
+	-
+		class: PHPStan\Rules\Functions\UnserializeRule
+		arguments:
+			checkInsecureUnserialize: %checkInsecureUnserialize%

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -34,6 +34,7 @@ parameters:
 		stricterFunctionMap: false
 		reportPreciseLineForUnusedFunctionParameter: false
 		checkPrintfParameterTypes: false
+		checkUnserializeFunction: false
 		internalTag: false
 		newStaticInAbstractClassStaticMethod: false
 		checkExtensionsForComparisonOperators: false

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -86,6 +86,7 @@ parameters:
 	reportPossiblyNonexistentConstantArrayOffset: false
 	checkMissingOverrideMethodAttribute: false
 	checkMissingOverridePropertyAttribute: null
+	checkInsecureUnserialize: false
 	mixinExcludeClasses: []
 	scanFiles: []
 	scanDirectories: []

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -36,6 +36,7 @@ parametersSchema:
 		stricterFunctionMap: bool()
 		reportPreciseLineForUnusedFunctionParameter: bool()
 		checkPrintfParameterTypes: bool()
+		checkUnserializeFunction: bool()
 		internalTag: bool()
 		newStaticInAbstractClassStaticMethod: bool()
 		checkExtensionsForComparisonOperators: bool()

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -94,6 +94,7 @@ parametersSchema:
 	reportPossiblyNonexistentConstantArrayOffset: bool()
 	checkMissingOverrideMethodAttribute: bool()
 	checkMissingOverridePropertyAttribute: schema(bool(), nullable())
+	checkInsecureUnserialize: bool()
 	parallel: structure([
 		jobSize: int(),
 		processTimeout: float(),

--- a/src/Php/PhpVersion.php
+++ b/src/Php/PhpVersion.php
@@ -96,6 +96,11 @@ final class PhpVersion
 		return $this->versionId >= 70400;
 	}
 
+	public function supportsUnserializeMaxDepthOption(): bool
+	{
+		return $this->versionId >= 70400;
+	}
+
 	public function supportsNoncapturingCatches(): bool
 	{
 		return $this->versionId >= 80000;

--- a/src/Rules/Functions/UnserializeRule.php
+++ b/src/Rules/Functions/UnserializeRule.php
@@ -6,8 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\Scope;
-use PHPStan\DependencyInjection\AutowiredParameter;
-use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Reflection\ReflectionProvider;
@@ -20,14 +18,12 @@ use function sprintf;
 /**
  * @implements Rule<Node\Expr\FuncCall>
  */
-#[RegisteredRule(level: 5)]
 final class UnserializeRule implements Rule
 {
 
 	public function __construct(
 		private readonly PhpVersion $phpVersion,
 		private readonly ReflectionProvider $reflectionProvider,
-		#[AutowiredParameter]
 		private readonly bool $checkInsecureUnserialize,
 	)
 	{

--- a/src/Rules/Functions/UnserializeRule.php
+++ b/src/Rules/Functions/UnserializeRule.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\ArgumentsNormalizer;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\VerbosityLevel;
+use function count;
+use function sprintf;
+
+/**
+ * @implements Rule<Node\Expr\FuncCall>
+ */
+#[RegisteredRule(level: 5)]
+final class UnserializeRule implements Rule
+{
+
+	public function __construct(
+		private readonly PhpVersion $phpVersion,
+		private readonly ReflectionProvider $reflectionProvider,
+		#[AutowiredParameter]
+		private readonly bool $checkInsecureUnserialize,
+	)
+	{
+	}
+
+	public function getNodeType(): string
+	{
+		return FuncCall::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!($node->name instanceof Node\Name)) {
+			return [];
+		}
+
+		if (!$this->reflectionProvider->hasFunction($node->name, $scope)) {
+			return [];
+		}
+
+		$functionReflection = $this->reflectionProvider->getFunction($node->name, $scope);
+		if ($functionReflection->getName() !== 'unserialize') {
+			return [];
+		}
+
+		$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$node->getArgs(),
+			$functionReflection->getVariants(),
+			$functionReflection->getNamedArgumentsVariants(),
+		);
+
+		$normalizedFuncCall = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $node);
+		if ($normalizedFuncCall === null) {
+			return [];
+		}
+
+		$args = $normalizedFuncCall->getArgs();
+		if (count($args) !== 2) {
+			if ($this->checkInsecureUnserialize) {
+				return [
+					RuleErrorBuilder::message(
+						'Calling unserialize() without parameter $2 options and "allowed_classes" set to false or a list of allowed class names is insecure.',
+					)->identifier('unserialize.options.missing')->build(),
+				];
+			}
+			return [];
+		}
+
+		$type = $scope->getType($args[1]->value);
+		$constantArrays = $type->getConstantArrays();
+		if ($constantArrays === []) {
+			return [];
+		}
+
+		$allowedClassesChecked = false;
+		$errors = [];
+		foreach ($constantArrays[0]->getValueTypes() as $i => $valueType) {
+			$key = $constantArrays[0]->getKeyTypes()[$i]->getValue();
+			switch ($key) {
+				case 'allowed_classes':
+					$allowedClassesChecked = true;
+					if ($valueType->isBoolean()->yes()) {
+						if ($this->checkInsecureUnserialize && $valueType->isTrue()->yes()) {
+							$errors[] = RuleErrorBuilder::message(
+								'Parameter #2 $options to function unserialize must either be false or a list of allowed class names.',
+							)->identifier('unserialize.allowedClasses.insecure')->build();
+						}
+						continue 2;
+					}
+					$optionConstantArrays = $valueType->getConstantArrays();
+					if ($valueType->isBoolean()->no() && $optionConstantArrays !== []) {
+						foreach ($optionConstantArrays[0]->getValueTypes() as $j => $itemType) {
+							$constantStrings = $itemType->getConstantStrings();
+							if ($constantStrings !== []) {
+								continue;
+							}
+							$errors[] = RuleErrorBuilder::message(sprintf(
+								'Parameter #2 $options to function unserialize contains an invalid value for "allowed_classes" item #%d.',
+								$j + 1,
+							))->identifier('unserialize.allowedClasses.invalidType')->build();
+						}
+					} else {
+						$errors[] = RuleErrorBuilder::message(sprintf(
+							'Parameter #2 $options to function unserialize contains an invalid value %s for "allowed_classes".',
+							$valueType->describe(VerbosityLevel::value()),
+						))->identifier('unserialize.allowedClasses.invalidType')->build();
+					}
+					break;
+				case 'max_depth':
+					if (!$this->phpVersion->supportsUnserializeMaxDepthOption()) {
+						$errors[] = RuleErrorBuilder::message(
+							'Parameter #2 $options to function unserialize contains an option "max_depth" which is not supported by this PHP version.',
+						)->identifier('unserialize.maxDepth.unsupported')->build();
+					} elseif ($valueType->isInteger()->no()) {
+						$errors[] = RuleErrorBuilder::message(sprintf(
+							'Parameter #2 $options to function unserialize contains an invalid value %s for "max_depth".',
+							$valueType->describe(VerbosityLevel::value()),
+						))->identifier('unserialize.maxDepth.invalidType')->build();
+					}
+					break;
+				default:
+					$errors[] = RuleErrorBuilder::message(sprintf(
+						'Parameter #2 $options to function unserialize contains unsupported option "%s".',
+						$key,
+					))->identifier('unserialize.unsupported')->build();
+			}
+		}
+		if ($this->checkInsecureUnserialize && !$allowedClassesChecked) {
+			$errors[] = RuleErrorBuilder::message(
+				'Parameter #2 $options to function unserialize must be present with "allowed_classes" set to false or a list of allowed class names.',
+			)->identifier('unserialize.allowedClasses.missing')->build();
+		}
+
+		return $errors;
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/UnserializeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/UnserializeRuleTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<UnserializeRule>
+ */
+class UnserializeRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new UnserializeRule(new PhpVersion(PHP_VERSION_ID), self::createReflectionProvider(), true);
+	}
+
+	public function testFile(): void
+	{
+		$expectedErrors = [
+			[
+				'Parameter #2 $options to function unserialize contains an invalid value for "allowed_classes" item #1.',
+				5,
+			],
+			[
+				'Parameter #2 $options to function unserialize contains an invalid value null for "allowed_classes".',
+				7,
+			],
+			[
+				'Parameter #2 $options to function unserialize contains an invalid value null for "max_depth".',
+				9,
+			],
+			[
+				'Parameter #2 $options to function unserialize must be present with "allowed_classes" set to false or a list of allowed class names.',
+				9,
+			],
+			[
+				'Parameter #2 $options to function unserialize contains unsupported option "foo".',
+				11,
+			],
+			[
+				'Parameter #2 $options to function unserialize must be present with "allowed_classes" set to false or a list of allowed class names.',
+				11,
+			],
+			[
+				'Parameter #2 $options to function unserialize must either be false or a list of allowed class names.',
+				13,
+			],
+			[
+				'Calling unserialize() without parameter $2 options and "allowed_classes" set to false or a list of allowed class names is insecure.',
+				15,
+			],
+		];
+
+		$this->analyse([__DIR__ . '/data/unserialize.php'], $expectedErrors);
+	}
+
+	#[RequiresPhp('< 7.4')]
+	public function testMaxDepth(): void
+	{
+		$expectedErrors = [
+			[
+				'Parameter #2 $options to function unserialize contains an option "max_depth" which is not supported by this PHP version.',
+				5,
+			],
+		];
+
+		$this->analyse([__DIR__ . '/data/unserialize_max_depth.php'], $expectedErrors);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/unserialize.php
+++ b/tests/PHPStan/Rules/Functions/data/unserialize.php
@@ -1,0 +1,15 @@
+<?php
+
+$payload = 'b:0;';
+
+unserialize($payload, ['allowed_classes' => [null]]);
+
+unserialize($payload, ['allowed_classes' => null]);
+
+unserialize($payload, ['max_depth' => null]);
+
+unserialize($payload, ['foo' => null]);
+
+unserialize($payload, ['allowed_classes' => true]);
+
+unserialize($payload);

--- a/tests/PHPStan/Rules/Functions/data/unserialize_max_depth.php
+++ b/tests/PHPStan/Rules/Functions/data/unserialize_max_depth.php
@@ -1,0 +1,5 @@
+<?php
+
+$payload = 'b:0;';
+
+unserialize($payload, ['allowed_classes' => false, 'max_depth' => 3]);


### PR DESCRIPTION
This PR implements a new rule for [`unserialize`](https://www.php.net/manual/en/function.unserialize.php). Following behaviors will trigger an error:

* Parameter $2 options is NOT set (only with parameter `checkInsecureUnserialize: true`)
* Parameter $2 options has an invalid array key (neither `allowed_classes` nor `max_depth`)
* Parameter $2 options has invalid type for `allowed_classes`
* Parameter $2 options has `'allowed_classes' => true` (only with parameter `checkInsecureUnserialize: true`)
* Parameter $2 options has invalid array item for `allowed_classes`
* Parameter $2 options has `max_depth` key on PHP < 7.4
* Parameter $2 options has invalid type for `max_depth`
* Parameter $2 options is set, but does not have `allowed_classes` configured (only with parameter `checkInsecureUnserialize: true`)