### PR TITLE
UnionType: inline array_map() call

### DIFF
--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -1234,7 +1234,12 @@ class UnionType implements CompoundType
 	 */
 	protected function unionTypes(callable $getType): Type
 	{
-		return TypeCombinator::union(...array_map($getType, $this->types));
+		$newTypes = [];
+		foreach($this->types as $type) {
+			$newTypes[] = $getType($type);
+		}
+
+		return TypeCombinator::union(...$newTypes);
 	}
 
 	/**


### PR DESCRIPTION
the method is called often enough that this change leads to a 0,5% memory decrease 

before this PR
```
Used memory: 396.59 MB
```

after this PR
```
Used memory: 394.59 MB
```