### PR TITLE
Drop MutatingScope->rememberConstructorScope()

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -373,28 +373,6 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		return $expressionTypes;
 	}
 
-	public function rememberConstructorScope(): self
-	{
-		return $this->scopeFactory->create(
-			$this->context,
-			$this->isDeclareStrictTypes(),
-			null,
-			$this->getNamespace(),
-			$this->rememberConstructorExpressions($this->expressionTypes),
-			$this->rememberConstructorExpressions($this->nativeExpressionTypes),
-			$this->conditionalExpressions,
-			$this->inClosureBindScopeClasses,
-			$this->anonymousFunctionReflection,
-			$this->inFirstLevelStatement,
-			[],
-			[],
-			$this->inFunctionCallsStack,
-			$this->afterExtractCall,
-			$this->parentScope,
-			$this->nativeTypesPromoted,
-		);
-	}
-
 	private function isReadonlyPropertyFetch(PropertyFetch $expr, bool $allowOnlyOnThis): bool
 	{
 		if (!$this->phpVersion->supportsReadOnlyProperties()) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -871,7 +871,7 @@ class NodeScopeResolver
 					}
 
 					if (count($scopesToMerge) > 0) {
-						$scope = $scopesToMerge[0]->mergeWith(...array_slice($scopesToMerge, 1))->rememberConstructorScope();
+						$scope = $scopesToMerge[0]->mergeWith(...array_slice($scopesToMerge, 1));
 					}
 
 				}

--- a/tests/PHPStan/Analyser/nsrt/remember-readonly-constructor-narrowed.php
+++ b/tests/PHPStan/Analyser/nsrt/remember-readonly-constructor-narrowed.php
@@ -143,3 +143,28 @@ class DeepPropertyFetching {
 		assertType('int', $this->prop->writable);
 	}
 }
+
+class HelloWorldReadonlyPropertyInClosureScope {
+	private readonly int $i;
+
+	public function __construct()
+	{
+		if (rand(0,1)) {
+			$this->i = 4;
+		} else {
+			$this->i = 10;
+		}
+	}
+
+	public function doFoo() {
+		assertType('4|10', $this->i);
+
+		(function() {
+			assertType('4|10', $this->i);
+		})();
+
+		$func = function() {
+			assertType('4|10', $this->i);
+		};
+	}
+}


### PR DESCRIPTION
the scope when processing methods already contains remembered expressions.
this means we don't need to re-remember expressions and can drop this unnecessary logic.

refs https://github.com/phpstan/phpstan-src/pull/3930