### PR TITLE
Simplify TypeCombinator->processArrayTypes()

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -1109,12 +1109,12 @@ final class TypeCombinator
 
 	public static function intersect(Type ...$types): Type
 	{
-		$types = array_values($types);
-
 		$typesCount = count($types);
 		if ($typesCount === 0) {
 			return new NeverType();
 		}
+
+		$types = array_values($types);
 		if ($typesCount === 1) {
 			return $types[0];
 		}

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -839,17 +839,15 @@ final class TypeCombinator
 				return [self::intersect($reducedArrayTypes[0], ...$accessoryTypes)];
 			}
 
-			$useTemplateArray = true;
 			$templateArrayType = null;
 			foreach ($arrayTypes as $arrayType) {
 				if (!$arrayType instanceof TemplateArrayType) {
-					$useTemplateArray = false;
+					$templateArrayType = null;
 					break;
 				}
 
 				if ($templateArrayType !== null) {
-					$useTemplateArray = false;
-					break;
+					continue;
 				}
 
 				$templateArrayType = $arrayType;
@@ -860,7 +858,7 @@ final class TypeCombinator
 				self::union(...self::optimizeConstantArrays($valueTypesForGeneralArray)),
 			);
 
-			if ($useTemplateArray && $templateArrayType !== null) {
+			if ($templateArrayType !== null) {
 				$arrayType = new TemplateArrayType(
 					$templateArrayType->getScope(),
 					$templateArrayType->getStrategy(),

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -838,15 +838,21 @@ final class TypeCombinator
 			if (count($reducedArrayTypes) === 1) {
 				return [self::intersect($reducedArrayTypes[0], ...$accessoryTypes)];
 			}
-			$scopes = [];
+
 			$useTemplateArray = true;
+			$templateArrayType = null;
 			foreach ($arrayTypes as $arrayType) {
 				if (!$arrayType instanceof TemplateArrayType) {
 					$useTemplateArray = false;
 					break;
 				}
 
-				$scopes[$arrayType->getScope()->describe()] = $arrayType;
+				if ($templateArrayType !== null) {
+					$useTemplateArray = false;
+					break;
+				}
+
+				$templateArrayType = $arrayType;
 			}
 
 			$arrayType = new ArrayType(
@@ -854,15 +860,14 @@ final class TypeCombinator
 				self::union(...self::optimizeConstantArrays($valueTypesForGeneralArray)),
 			);
 
-			if ($useTemplateArray && count($scopes) === 1) {
-				$templateArray = array_values($scopes)[0];
+			if ($useTemplateArray && $templateArrayType !== null) {
 				$arrayType = new TemplateArrayType(
-					$templateArray->getScope(),
-					$templateArray->getStrategy(),
-					$templateArray->getVariance(),
-					$templateArray->getName(),
+					$templateArrayType->getScope(),
+					$templateArrayType->getStrategy(),
+					$templateArrayType->getVariance(),
+					$templateArrayType->getName(),
 					$arrayType,
-					$templateArray->getDefault(),
+					$templateArrayType->getDefault(),
 				);
 			}
 


### PR DESCRIPTION
removes some unnecessary work from the hot path