### PR TITLE
More precise types

### DIFF
--- a/src/Type/BenevolentUnionType.php
+++ b/src/Type/BenevolentUnionType.php
@@ -12,7 +12,7 @@ class BenevolentUnionType extends UnionType
 
 	/**
 	 * @api
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 */
 	public function __construct(array $types, bool $normalized = false)
 	{

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -95,7 +95,7 @@ class ConstantArrayType implements Type
 
 	/**
 	 * @api
-	 * @param array<int, ConstantIntegerType|ConstantStringType> $keyTypes
+	 * @param list<ConstantIntegerType|ConstantStringType> $keyTypes
 	 * @param array<int, Type> $valueTypes
 	 * @param non-empty-list<int> $nextAutoIndexes
 	 * @param int[] $optionalKeys
@@ -280,7 +280,7 @@ class ConstantArrayType implements Type
 	}
 
 	/**
-	 * @return array<int, ConstantIntegerType|ConstantStringType>
+	 * @return list<ConstantIntegerType|ConstantStringType>
 	 */
 	public function getKeyTypes(): array
 	{

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -40,7 +40,7 @@ final class ConstantArrayTypeBuilder
 	private bool $oversized = false;
 
 	/**
-	 * @param array<int, Type> $keyTypes
+	 * @param list<Type> $keyTypes
 	 * @param array<int, Type> $valueTypes
 	 * @param non-empty-list<int> $nextAutoIndexes
 	 * @param array<int> $optionalKeys
@@ -308,7 +308,7 @@ final class ConstantArrayTypeBuilder
 		}
 
 		if (!$this->degradeToGeneralArray) {
-			/** @var array<int, ConstantIntegerType|ConstantStringType> $keyTypes */
+			/** @var list<ConstantIntegerType|ConstantStringType> $keyTypes */
 			$keyTypes = $this->keyTypes;
 			return new ConstantArrayType($keyTypes, $this->valueTypes, $this->nextAutoIndexes, $this->optionalKeys, $this->isList);
 		}

--- a/src/Type/Generic/TemplateBenevolentUnionType.php
+++ b/src/Type/Generic/TemplateBenevolentUnionType.php
@@ -34,7 +34,7 @@ final class TemplateBenevolentUnionType extends BenevolentUnionType implements T
 		$this->default = $default;
 	}
 
-	/** @param Type[] $types */
+	/** @param list<Type> $types */
 	public function withTypes(array $types): self
 	{
 		return new self(

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -71,7 +71,7 @@ class IntersectionType implements CompoundType
 
 	/**
 	 * @api
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 */
 	public function __construct(private array $types)
 	{
@@ -85,7 +85,7 @@ class IntersectionType implements CompoundType
 	}
 
 	/**
-	 * @return Type[]
+	 * @return list<Type>
 	 */
 	public function getTypes(): array
 	{
@@ -93,7 +93,7 @@ class IntersectionType implements CompoundType
 	}
 
 	/**
-	 * @return Type[]
+	 * @return list<Type>
 	 */
 	private function getSortedTypes(): array
 	{

--- a/src/Type/OperatorTypeSpecifyingExtensionRegistry.php
+++ b/src/Type/OperatorTypeSpecifyingExtensionRegistry.php
@@ -32,7 +32,7 @@ final class OperatorTypeSpecifyingExtensionRegistry
 		$operatorSigil = $expr->getOperatorSigil();
 		$operatorTypeSpecifyingExtensions = $this->getOperatorTypeSpecifyingExtensions($operatorSigil, $leftType, $rightType);
 
-		/** @var Type[] $extensionTypes */
+		/** @var list<Type> $extensionTypes */
 		$extensionTypes = [];
 
 		foreach ($operatorTypeSpecifyingExtensions as $extension) {

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -180,7 +180,7 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 	}
 
 	/**
-	 * @return AccessoryType[]
+	 * @return list<AccessoryType>
 	 */
 	private function getAccessoryTypes(Type $arrayType, Type $valueType): array
 	{

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -150,7 +150,7 @@ final class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 	}
 
 	/**
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 */
 	private function processType(
 		string $functionName,

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -686,7 +686,7 @@ final class TypeCombinator
 
 	/**
 	 * @param Type[] $arrayTypes
-	 * @return Type[]
+	 * @return list<Type>
 	 */
 	private static function processArrayAccessoryTypes(array $arrayTypes): array
 	{

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -381,14 +381,14 @@ final class TypeCombinator
 
 			if ($tempTypes === []) {
 				if ($benevolentUnionObject instanceof TemplateBenevolentUnionType) {
-					return $benevolentUnionObject->withTypes($types);
+					return $benevolentUnionObject->withTypes(array_values($types));
 				}
 
-				return new BenevolentUnionType($types, true);
+				return new BenevolentUnionType(array_values($types), true);
 			}
 		}
 
-		return new UnionType($types, true);
+		return new UnionType(array_values($types), true);
 	}
 
 	/**
@@ -546,7 +546,7 @@ final class TypeCombinator
 	}
 
 	/**
-	 * @return array<Type>
+	 * @return list<Type>
 	 */
 	private static function getAccessoryCaseStringTypes(Type $type): array
 	{
@@ -1473,7 +1473,7 @@ final class TypeCombinator
 			return $types[0];
 		}
 
-		return new IntersectionType($types);
+		return new IntersectionType(array_values($types));
 	}
 
 	public static function removeFalsey(Type $type): Type

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -210,7 +210,7 @@ final class TypeUtils
 	}
 
 	/**
-	 * @return AccessoryType[]
+	 * @return list<AccessoryType>
 	 */
 	public static function getAccessoryTypes(Type $type): array
 	{

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -63,7 +63,7 @@ class UnionType implements CompoundType
 
 	/**
 	 * @api
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 */
 	public function __construct(private array $types, private bool $normalized = false)
 	{
@@ -90,7 +90,7 @@ class UnionType implements CompoundType
 	}
 
 	/**
-	 * @return Type[]
+	 * @return list<Type>
 	 */
 	public function getTypes(): array
 	{
@@ -126,7 +126,7 @@ class UnionType implements CompoundType
 	}
 
 	/**
-	 * @return Type[]
+	 * @return list<Type>
 	 */
 	protected function getSortedTypes(): array
 	{

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -16,8 +16,9 @@ final class UnionTypeHelper
 {
 
 	/**
-	 * @param Type[] $types
-	 * @return Type[]
+	 * @template T of Type
+	 * @param list<T>|array<T> $types
+	 * @return ($types is list<T> ? list<T> : array<T>)
 	 */
 	public static function sortTypes(array $types): array
 	{

--- a/src/Type/UnionTypeHelper.php
+++ b/src/Type/UnionTypeHelper.php
@@ -17,8 +17,8 @@ final class UnionTypeHelper
 
 	/**
 	 * @template T of Type
-	 * @param list<T>|array<T> $types
-	 * @return ($types is list<T> ? list<T> : array<T>)
+	 * @param list<T> $types
+	 * @return list<T>
 	 */
 	public static function sortTypes(array $types): array
 	{

--- a/tests/PHPStan/Type/TypeCombinatorTest.php
+++ b/tests/PHPStan/Type/TypeCombinatorTest.php
@@ -2805,7 +2805,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 	}
 
 	/**
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 * @param class-string<Type> $expectedTypeClass
 	 */
 	#[DataProvider('dataUnion')]
@@ -2861,7 +2861,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 	}
 
 	/**
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 * @param class-string<Type> $expectedTypeClass
 	 */
 	#[DataProvider('dataUnion')]
@@ -4760,7 +4760,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 	}
 
 	/**
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 * @param class-string<Type> $expectedTypeClass
 	 */
 	#[DataProvider('dataIntersect')]
@@ -4803,7 +4803,7 @@ class TypeCombinatorTest extends PHPStanTestCase
 	}
 
 	/**
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 * @param class-string<Type> $expectedTypeClass
 	 */
 	#[DataProvider('dataIntersect')]

--- a/tests/PHPStan/Type/UnionTypeTest.php
+++ b/tests/PHPStan/Type/UnionTypeTest.php
@@ -1411,7 +1411,7 @@ class UnionTypeTest extends PHPStanTestCase
 	}
 
 	/**
-	 * @param Type[] $types
+	 * @param list<Type> $types
 	 * @param list<string> $expectedDescriptions
 	 */
 	#[DataProvider('dataGetConstantArrays')]


### PR DESCRIPTION
first found of fixes to get TypeCombinator::union() / intersect() ready for no-named-arguments