### PR TITLE
Faster ExpressionTypeHolder->equals()

### DIFF
--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -26,6 +26,10 @@ final class ExpressionTypeHolder
 
 	public function equals(self $other): bool
 	{
+		if ($this === $other) {
+			return true;
+		}
+
 		if (!$this->certainty->equals($other->certainty)) {
 			return false;
 		}


### PR DESCRIPTION
since we have this [`return $this` shortcut in `and`](https://github.com/phpstan/phpstan-src/pull/4777/files#diff-2767b4b5b27bcfe03991183ee9839ced3a7b8c65a86899cf03e7b56605d6ad65R44), we can utilize it in the `equals` case