### PR TITLE
Fix PHP7.4 build

### DIFF
--- a/build/baseline-7.4.neon
+++ b/build/baseline-7.4.neon
@@ -77,3 +77,8 @@ parameters:
 			message: "#^Class PHPStan\\\\Reflection\\\\BetterReflection\\\\SourceLocator\\\\CachingVisitor has an uninitialized property \\$constantNodes\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
 			path: ../src/Reflection/BetterReflection/SourceLocator/CachingVisitor.php
+
+		-
+			message: '#^Parameter \#1 \$array \(non-empty-list<PHPStan\\Type\\Type>\) of array_values is already a list, call has no effect\.$#'
+			count: 1
+			path: ../src/Type/TypeCombinator.php


### PR DESCRIPTION
PHP7.4 does not support named arguments, therefore is triggering 

> Parameter... of array_values is already a list, call has no effect

which does not happen on PHP8+