### PR TITLE
TrinaryLogic: Prevent unnecessary work

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -100,14 +100,14 @@ final class TrinaryLogic
 		callable $callback,
 	): self
 	{
-		if ($this->no()) {
+		if ($this->value === self::NO) {
 			return $this;
 		}
 
 		$results = [];
 		foreach ($objects as $object) {
 			$result = $callback($object);
-			if ($result->no()) {
+			if ($result->value === self::NO) {
 				return $result;
 			}
 
@@ -140,14 +140,14 @@ final class TrinaryLogic
 		callable $callback,
 	): self
 	{
-		if ($this->yes()) {
+		if ($this->value === self::YES) {
 			return $this;
 		}
 
 		$results = [];
 		foreach ($objects as $object) {
 			$result = $callback($object);
-			if ($result->yes()) {
+			if ($result->value === self::YES) {
 				return $result;
 			}
 
@@ -221,7 +221,7 @@ final class TrinaryLogic
 		$results = [];
 		foreach ($objects as $object) {
 			$result = $callback($object);
-			if ($result->yes()) {
+			if ($result->value === self::YES) {
 				return $result;
 			}
 


### PR DESCRIPTION
prevent unnecessary method calls in a hot path

---

in `php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug`

`lazyMaxMin` calls `yes()` 1.1 million times

<img width="419" height="742" alt="grafik" src="https://github.com/user-attachments/assets/8dc4ee11-7154-4511-bfb0-3b9f42ccd4d5" />
