### PR TITLE
Fix named argument parameter matching in getFunctionCallStackWithParameters

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -5542,14 +5542,26 @@ class NodeScopeResolver
 			$parameterType = null;
 			$parameterNativeType = null;
 			if ($parameters !== null) {
-				if (isset($parameters[$i])) {
-					$assignByReference = $parameters[$i]->passedByReference()->createsNewVariable();
-					$parameterType = $parameters[$i]->getType();
-
-					if ($parameters[$i] instanceof ExtendedParameterReflection) {
-						$parameterNativeType = $parameters[$i]->getNativeType();
+				$matchedParameter = null;
+				if ($arg->name !== null) {
+					foreach ($parameters as $p) {
+						if ($p->getName() === $arg->name->toString()) {
+							$matchedParameter = $p;
+							break;
+						}
 					}
-					$parameter = $parameters[$i];
+				} elseif (isset($parameters[$i])) {
+					$matchedParameter = $parameters[$i];
+				}
+
+				if ($matchedParameter !== null) {
+					$assignByReference = $matchedParameter->passedByReference()->createsNewVariable();
+					$parameterType = $matchedParameter->getType();
+
+					if ($matchedParameter instanceof ExtendedParameterReflection) {
+						$parameterNativeType = $matchedParameter->getNativeType();
+					}
+					$parameter = $matchedParameter;
 				} elseif (count($parameters) > 0 && $parametersAcceptor->isVariadic()) {
 					$lastParameter = array_last($parameters);
 					$assignByReference = $lastParameter->passedByReference()->createsNewVariable();

--- a/tests/PHPStan/Rules/ScopeFunctionCallStackRuleTest.php
+++ b/tests/PHPStan/Rules/ScopeFunctionCallStackRuleTest.php
@@ -32,6 +32,14 @@ class ScopeFunctionCallStackRuleTest extends RuleTestCase
 				"var_dump\nprint_r\nsleep",
 				13,
 			],
+			[
+				'ScopeFunctionCallStack\NamedArgumentTest::testMethod',
+				31,
+			],
+			[
+				'ScopeFunctionCallStack\NamedArgumentTest::testMethod',
+				42,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/ScopeFunctionCallStackWithParametersRuleTest.php
+++ b/tests/PHPStan/Rules/ScopeFunctionCallStackWithParametersRuleTest.php
@@ -32,6 +32,16 @@ class ScopeFunctionCallStackWithParametersRuleTest extends RuleTestCase
 				"var_dump (\$value)\nprint_r (\$value)\nsleep (\$seconds)",
 				13,
 			],
+			[
+				// Named argument test - should report $notImmediate, not $immediate
+				'ScopeFunctionCallStack\NamedArgumentTest::testMethod ($notImmediate)',
+				31,
+			],
+			[
+				// Named argument with missing required param - should still match by name
+				'ScopeFunctionCallStack\NamedArgumentTest::testMethod ($notImmediate)',
+				42,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/data/scope-function-call-stack.php
+++ b/tests/PHPStan/Rules/data/scope-function-call-stack.php
@@ -12,3 +12,35 @@ function (): void
 
 	var_dump(print_r(fn () => sleep(throw new \Exception())));
 };
+
+class NamedArgumentTest
+{
+	/**
+	 * @param-immediately-invoked-callable $immediate
+	 */
+	public function testMethod(callable $immediate, ?callable $notImmediate = null): void
+	{
+		$immediate();
+	}
+
+	public function test(): void
+	{
+		// When using named argument for $notImmediate, the parameter should be reported as "notImmediate", not "immediate"
+		$this->testMethod(
+			notImmediate: function () {
+				throw new \Exception(); // should report: NamedArgumentTest::testMethod ($notImmediate)
+			},
+			immediate: function () {},
+		);
+	}
+
+	public function testMissingRequiredArg(): void
+	{
+		// Named argument with missing required param - should still match parameter by name
+		$this->testMethod(
+			notImmediate: function () {
+				throw new \Exception(); // reports $notImmediate
+			},
+		);
+	}
+}


### PR DESCRIPTION

When processing function calls with named arguments, the parameter was incorrectly matched using positional index instead of argument name. This caused Scope::getFunctionCallStackWithParameters() to return the wrong parameter when:

1. Arguments were passed out of order using named syntax
2. A named argument was passed for an optional parameter while a required parameter was missing

The fix matches parameters by name for named arguments before falling back to positional matching.