### PR TITLE
Propose stricter types por SplFileInfo

### DIFF
--- a/resources/functionMap_bleedingEdge.php
+++ b/resources/functionMap_bleedingEdge.php
@@ -3,6 +3,12 @@
 return [
 	'new' => [
 		'php_uname' => ['string', 'mode='=>'"a"|"s"|"n"|"r"|"v"|"m"'],
+		'SplFileInfo::__construct' => ['void', 'filename'=>'non-empty-string'],
+		'SplFileInfo::__toString' => ['non-empty-string'],
+		'SplFileInfo::getBasename' => ['non-empty-string', 'suffix='=>'string'],
+		'SplFileInfo::getFilename' => ['non-empty-string'],
+		'SplFileInfo::getPathname' => ['non-empty-string'],
+		'SplFileInfo::getRealPath' => ['non-empty-string|false'],
 	],
 	'old' => [
 		'php_uname' => ['string', 'mode='=>'string'],


### PR DESCRIPTION
Those methods can return an empty string, but only if the instance is created with an empty string.

I propose these changes in bleeding edge, as it would break the compatibility in the constructor.