### PR TITLE
[PHPStan 2.1.35] Add failing test where original Node not processed under VirtualNode on NodeScopeResolver::processNodes()

### DIFF
--- a/tests/PHPStan/Analyser/VirtualNodeOriginalNodeCallbackTest.php
+++ b/tests/PHPStan/Analyser/VirtualNodeOriginalNodeCallbackTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Node\StaticMethodCallableNode;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class VirtualNodeOriginalNodeCallbackTest extends TypeInferenceTestCase
+{
+	public function testOriginalNodeOfVirtualNodeIsPassedToCallback(): void
+	{
+		$sawVirtualNode = false;
+		$sawOriginalNode = false;
+
+		self::processFile(
+			__DIR__ . '/data/virtual-node-original-node.php',
+			static function (Node $node, Scope $scope) use (&$sawVirtualNode, &$sawOriginalNode): void {
+				if ($node instanceof StaticMethodCallableNode) {
+					$sawVirtualNode = true;
+					return;
+				}
+
+				if ($node instanceof StaticCall) {
+					$sawOriginalNode = true;
+				}
+			},
+		);
+
+		self::assertTrue($sawVirtualNode, 'Expected callback to receive StaticMethodCallableNode.');
+		self::assertTrue($sawOriginalNode, 'Expected callback to receive original PhpParser\\Node\\Expr\\StaticCall.');
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/virtual-node-original-node.php
+++ b/tests/PHPStan/Analyser/data/virtual-node-original-node.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace VirtualNodeOriginalNodeCallback;
+
+final class Foo
+{
+	public static function doFoo(): void
+	{
+	}
+
+	public function doFoo(): void
+	{
+		$cb = self::doFoo(...);
+		$cb();
+	}
+}


### PR DESCRIPTION
@ondrejmirtes this is failing test case where since PHPStan 2.1.35, it seems original node under `VirtualNode` no longer processed on `NodeScopeResolver::processNodes()`, 

see issue:

- https://github.com/phpstan/phpstan/issues/13992

Related PRs:

see comparison of **Before** vs **After** Bump to PHPStan 2.1.35

- 2.1.34 (working) : https://github.com/rectorphp/rector-downgrade-php/pull/359
- 2.1.35 (not working): https://github.com/rectorphp/rector-downgrade-php/pull/360

/cc @calebdw @TomasVotruba


Test can be run with:

```
➜  phpstan-src git:(add-failing-tset) vendor/bin/phpunit tests/PHPStan/Analyser/VirtualNodeOriginalNodeCallbackTest.php                       
PHPUnit 11.5.46 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.16
Configuration: /Users/samsonasik/www/phpstan-src/phpunit.xml
Random Seed:   1768974045

F                                                                   1 / 1 (100%)

Time: 00:00.355, Memory: 50.00 MB

There was 1 failure:

1) PHPStan\Analyser\VirtualNodeOriginalNodeCallbackTest::testOriginalNodeOfVirtualNodeIsPassedToCallback
Expected callback to receive original PhpParser\Node\Expr\StaticCall.
Failed asserting that false is true.

/Users/samsonasik/www/phpstan-src/tests/PHPStan/Analyser/VirtualNodeOriginalNodeCallbackTest.php:32
```