### PR TITLE
Fix invokable objects incorrectly labeled as instances of `Closure`

### DIFF
--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\Accessory;
 
+use Closure;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ClassMemberAccessAnswerer;
@@ -17,6 +18,7 @@ use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IsSuperTypeOfResult;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonGenericTypeTrait;
@@ -83,7 +85,11 @@ class HasMethodType implements AccessoryType, CompoundType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		if ($this->isCallable()->yes() && $otherType->isCallable()->yes()) {
+		if (
+			$this->isCallable()->yes()
+			&& $otherType->isCallable()->yes()
+			&& !(new ObjectType(Closure::class))->isSuperTypeOf($otherType)->yes()
+		) {
 			return IsSuperTypeOfResult::createYes();
 		}
 

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -569,4 +569,17 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 		]);
 	}
 
+	public static function dataBug13975(): iterable
+	{
+		yield [__DIR__ . '/data/bug-13975-a.php'];
+		yield [__DIR__ . '/data/bug-13975-b.php'];
+	}
+
+	#[DataProvider('dataBug13975')]
+	public function testBug13975(string $file): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([$file], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-13975-a.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-13975-a.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Bug13975a;
+
+function foo(): callable
+{
+	return new class () {
+		public function __invoke(): void
+		{
+		}
+	};
+}
+
+$foo = foo();
+
+if (\is_object($foo) && method_exists($foo, '__invoke') && !$foo instanceof \Closure) {
+	echo 'true';
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-13975-b.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-13975-b.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Bug13975b;
+
+class X {}
+
+function foo(): callable
+{
+	return new class () {
+		public function __invoke(): void
+		{
+		}
+	};
+}
+
+$foo = foo();
+
+$class = \Closure::class;
+if (rand(0, 1)) {
+	$class = X::class;
+}
+
+if (\is_object($foo) && method_exists($foo, '__invoke') && !$foo instanceof $class) {
+	echo 'true';
+}


### PR DESCRIPTION
Closes https://github.com/phpstan/phpstan/issues/13975