### PR TITLE
Prevent repetitive calls to getArgs()

### DIFF
--- a/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArgumentBasedFunctionReturnTypeExtension.php
@@ -50,11 +50,12 @@ final class ArgumentBasedFunctionReturnTypeExtension implements DynamicFunctionR
 		}
 		$argumentPosition = self::FUNCTION_NAMES[$functionReflection->getName()];
 
-		if (!isset($functionCall->getArgs()[$argumentPosition])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[$argumentPosition])) {
 			return null;
 		}
 
-		$argument = $functionCall->getArgs()[$argumentPosition];
+		$argument = $args[$argumentPosition];
 		$argumentType = $scope->getType($argument->value);
 		$argumentKeyType = $argumentType->getIterableKeyType();
 		$argumentValueType = $argumentType->getIterableValueType();

--- a/src/Type/Php/ArrayChangeKeyCaseFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayChangeKeyCaseFunctionReturnTypeExtension.php
@@ -42,15 +42,16 @@ final class ArrayChangeKeyCaseFunctionReturnTypeExtension implements DynamicFunc
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
-		if (!isset($functionCall->getArgs()[1])) {
+		$arrayType = $scope->getType($args[0]->value);
+		if (!isset($args[1])) {
 			$case = CASE_LOWER;
 		} else {
-			$caseType = $scope->getType($functionCall->getArgs()[1]->value);
+			$caseType = $scope->getType($args[1]->value);
 			$scalarValues = $caseType->getConstantScalarValues();
 			if (count($scalarValues) === 1) {
 				$case = (int) $scalarValues[0];

--- a/src/Type/Php/ArrayChunkFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayChunkFunctionReturnTypeExtension.php
@@ -30,22 +30,23 @@ final class ArrayChunkFunctionReturnTypeExtension implements DynamicFunctionRetu
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
 		if ($arrayType->isArray()->no()) {
 			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}
 
-		$lengthType = $scope->getType($functionCall->getArgs()[1]->value);
+		$lengthType = $scope->getType($args[1]->value);
 		$negativeOrZero = IntegerRangeType::fromInterval(null, 0);
 		if ($negativeOrZero->isSuperTypeOf($lengthType)->yes()) {
 			return $this->phpVersion->throwsValueErrorForInternalFunctions() ? new NeverType() : new NullType();
 		}
 
-		$preserveKeysType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : new ConstantBooleanType(false);
+		$preserveKeysType = isset($args[2]) ? $scope->getType($args[2]->value) : new ConstantBooleanType(false);
 
 		return $arrayType->chunkArray($lengthType, $preserveKeysType->isTrue());
 	}

--- a/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayColumnFunctionReturnTypeExtension.php
@@ -28,14 +28,15 @@ final class ArrayColumnFunctionReturnTypeExtension implements DynamicFunctionRet
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		$numArgs = count($functionCall->getArgs());
+		$args = $functionCall->getArgs();
+		$numArgs = count($args);
 		if ($numArgs < 2) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
-		$columnType = $scope->getType($functionCall->getArgs()[1]->value);
-		$indexType = $numArgs >= 3 ? $scope->getType($functionCall->getArgs()[2]->value) : new NullType();
+		$arrayType = $scope->getType($args[0]->value);
+		$columnType = $scope->getType($args[1]->value);
+		$indexType = $numArgs >= 3 ? $scope->getType($args[2]->value) : new NullType();
 
 		$constantArrayTypes = $arrayType->getConstantArrays();
 		if (count($constantArrayTypes) === 1) {

--- a/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCombineFunctionReturnTypeExtension.php
@@ -40,12 +40,13 @@ final class ArrayCombineFunctionReturnTypeExtension implements DynamicFunctionRe
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$firstArg = $functionCall->getArgs()[0]->value;
-		$secondArg = $functionCall->getArgs()[1]->value;
+		$firstArg = $args[0]->value;
+		$secondArg = $args[1]->value;
 
 		$keysParamType = $scope->getType($firstArg);
 		$valuesParamType = $scope->getType($secondArg);

--- a/src/Type/Php/ArrayCurrentDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayCurrentDynamicReturnTypeExtension.php
@@ -22,11 +22,12 @@ final class ArrayCurrentDynamicReturnTypeExtension implements DynamicFunctionRet
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		$iterableAtLeastOnce = $argType->isIterableAtLeastOnce();
 		if ($iterableAtLeastOnce->no()) {
 			return new ConstantBooleanType(false);

--- a/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillFunctionReturnTypeExtension.php
@@ -38,11 +38,12 @@ final class ArrayFillFunctionReturnTypeExtension implements DynamicFunctionRetur
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 3) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 3) {
 			return null;
 		}
 
-		$numberType = $scope->getType($functionCall->getArgs()[1]->value);
+		$numberType = $scope->getType($args[1]->value);
 		$isValidNumberType = IntegerRangeType::fromInterval(0, null)->isSuperTypeOf($numberType);
 
 		// check against negative-int, which is not allowed
@@ -53,8 +54,8 @@ final class ArrayFillFunctionReturnTypeExtension implements DynamicFunctionRetur
 			return new ConstantBooleanType(false);
 		}
 
-		$startIndexType = $scope->getType($functionCall->getArgs()[0]->value);
-		$valueType = $scope->getType($functionCall->getArgs()[2]->value);
+		$startIndexType = $scope->getType($args[0]->value);
+		$valueType = $scope->getType($args[2]->value);
 
 		if (
 			$startIndexType instanceof ConstantIntegerType

--- a/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFillKeysFunctionReturnTypeExtension.php
@@ -28,16 +28,17 @@ final class ArrayFillKeysFunctionReturnTypeExtension implements DynamicFunctionR
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$keysType = $scope->getType($functionCall->getArgs()[0]->value);
+		$keysType = $scope->getType($args[0]->value);
 		if ($keysType->isArray()->no()) {
 			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}
 
-		return $keysType->fillKeysArray($scope->getType($functionCall->getArgs()[1]->value));
+		return $keysType->fillKeysArray($scope->getType($args[1]->value));
 	}
 
 }

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeExtension.php
@@ -24,9 +24,10 @@ final class ArrayFilterFunctionReturnTypeExtension implements DynamicFunctionRet
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
-		$arrayArg = $functionCall->getArgs()[0]->value ?? null;
-		$callbackArg = $functionCall->getArgs()[1]->value ?? null;
-		$flagArg = $functionCall->getArgs()[2]->value ?? null;
+		$args = $functionCall->getArgs();
+		$arrayArg = $args[0]->value ?? null;
+		$callbackArg = $args[1]->value ?? null;
+		$flagArg = $args[2]->value ?? null;
 
 		return $this->arrayFilterFunctionReturnTypeHelper->getType($scope, $arrayArg, $callbackArg, $flagArg);
 	}

--- a/src/Type/Php/ArrayFindFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFindFunctionReturnTypeExtension.php
@@ -27,17 +27,18 @@ final class ArrayFindFunctionReturnTypeExtension implements DynamicFunctionRetur
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
 		if (count($arrayType->getArrays()) < 1) {
 			return null;
 		}
 
-		$arrayArg = $functionCall->getArgs()[0]->value ?? null;
-		$callbackArg = $functionCall->getArgs()[1]->value ?? null;
+		$arrayArg = $args[0]->value ?? null;
+		$callbackArg = $args[1]->value ?? null;
 
 		$resultTypes = $this->arrayFilterFunctionReturnTypeHelper->getType($scope, $arrayArg, $callbackArg, null);
 		$resultType = TypeCombinator::union(...array_map(static fn ($type) => $type->getIterableValueType(), $resultTypes->getArrays()));

--- a/src/Type/Php/ArrayFindKeyFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFindKeyFunctionReturnTypeExtension.php
@@ -23,11 +23,12 @@ final class ArrayFindKeyFunctionReturnTypeExtension implements DynamicFunctionRe
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
 		if (count($arrayType->getArrays()) < 1) {
 			return null;
 		}

--- a/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayFlipFunctionReturnTypeExtension.php
@@ -30,11 +30,12 @@ final class ArrayFlipFunctionReturnTypeExtension implements DynamicFunctionRetur
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) !== 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) !== 1) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
 		if ($arrayType->isArray()->no()) {
 			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}

--- a/src/Type/Php/ArrayKeyDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayKeyDynamicReturnTypeExtension.php
@@ -22,11 +22,12 @@ final class ArrayKeyDynamicReturnTypeExtension implements DynamicFunctionReturnT
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		$iterableAtLeastOnce = $argType->isIterableAtLeastOnce();
 		if ($iterableAtLeastOnce->no()) {
 			return new NullType();

--- a/src/Type/Php/ArrayKeyExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayKeyExistsFunctionTypeSpecifyingExtension.php
@@ -61,11 +61,12 @@ final class ArrayKeyExistsFunctionTypeSpecifyingExtension implements FunctionTyp
 		TypeSpecifierContext $context,
 	): SpecifiedTypes
 	{
-		if (count($node->getArgs()) < 2) {
+		$args = $node->getArgs();
+		if (count($args) < 2) {
 			return new SpecifiedTypes();
 		}
-		$key = $node->getArgs()[0]->value;
-		$array = $node->getArgs()[1]->value;
+		$key = $args[0]->value;
+		$array = $args[1]->value;
 		$keyType = $scope->getType($key)->toArrayKey();
 		$arrayType = $scope->getType($array);
 

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -38,13 +38,14 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		$numArgs = count($functionCall->getArgs());
+		$args = $functionCall->getArgs();
+		$numArgs = count($args);
 		if ($numArgs < 2) {
 			return null;
 		}
 
-		$singleArrayArgument = !isset($functionCall->getArgs()[2]);
-		$callback = $functionCall->getArgs()[0]->value;
+		$singleArrayArgument = !isset($args[2]);
+		$callback = $args[0]->value;
 		$callableType = $scope->getType($callback);
 		$callableIsNull = $callableType->isNull()->yes();
 
@@ -53,7 +54,7 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 				$callback,
 				array_map(
 					static fn (Node\Arg $arg) => new Node\Arg(new TypeExpr($scope->getType($arg->value)->getIterableValueType())),
-					array_slice($functionCall->getArgs(), 1),
+					array_slice($args, 1),
 				),
 			));
 		} elseif ($callableIsNull) {
@@ -61,7 +62,7 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 			$argTypes = [];
 			$areAllSameSize = true;
 			$expectedSize = null;
-			foreach (array_slice($functionCall->getArgs(), 1) as $index => $arg) {
+			foreach (array_slice($args, 1) as $index => $arg) {
 				$argTypes[$index] = $argType = $scope->getType($arg->value);
 				if (!$areAllSameSize || $numArgs === 2) {
 					continue;
@@ -85,9 +86,9 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 			}
 
 			if (!$areAllSameSize) {
-				$firstArr = $functionCall->getArgs()[1]->value;
+				$firstArr = $args[1]->value;
 				$identities = [];
-				foreach (array_slice($functionCall->getArgs(), 2) as $arg) {
+				foreach (array_slice($args, 2) as $arg) {
 					$identities[] = new Node\Expr\BinaryOp\Identical($firstArr, $arg->value);
 				}
 
@@ -117,7 +118,7 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 			$valueType = new MixedType();
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[1]->value);
+		$arrayType = $scope->getType($args[1]->value);
 
 		if ($singleArrayArgument) {
 			if ($callableIsNull) {

--- a/src/Type/Php/ArrayNextDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayNextDynamicReturnTypeExtension.php
@@ -23,11 +23,12 @@ final class ArrayNextDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		$iterableAtLeastOnce = $argType->isIterableAtLeastOnce();
 		if ($iterableAtLeastOnce->no()) {
 			return new ConstantBooleanType(false);

--- a/src/Type/Php/ArrayPadDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPadDynamicReturnTypeExtension.php
@@ -26,19 +26,20 @@ final class ArrayPadDynamicReturnTypeExtension implements DynamicFunctionReturnT
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[2])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[2])) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
-		$itemType = $scope->getType($functionCall->getArgs()[2]->value);
+		$arrayType = $scope->getType($args[0]->value);
+		$itemType = $scope->getType($args[2]->value);
 
 		$returnType = new ArrayType(
 			TypeCombinator::union($arrayType->getIterableKeyType(), new IntegerType()),
 			TypeCombinator::union($arrayType->getIterableValueType(), $itemType),
 		);
 
-		$lengthType = $scope->getType($functionCall->getArgs()[1]->value);
+		$lengthType = $scope->getType($args[1]->value);
 		if (
 			$arrayType->isIterableAtLeastOnce()->yes()
 			|| $lengthType->isSuperTypeOf(new ConstantIntegerType(0))->no()

--- a/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayPopFunctionReturnTypeExtension.php
@@ -22,11 +22,12 @@ final class ArrayPopFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		$iterableAtLeastOnce = $argType->isIterableAtLeastOnce();
 		if ($iterableAtLeastOnce->no()) {
 			return new NullType();

--- a/src/Type/Php/ArrayRandFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayRandFunctionReturnTypeExtension.php
@@ -28,12 +28,13 @@ final class ArrayRandFunctionReturnTypeExtension implements DynamicFunctionRetur
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		$argsCount = count($functionCall->getArgs());
+		$args = $functionCall->getArgs();
+		$argsCount = count($args);
 		if ($argsCount < 1) {
 			return null;
 		}
 
-		$firstArgType = $scope->getType($functionCall->getArgs()[0]->value);
+		$firstArgType = $scope->getType($args[0]->value);
 		$isInteger = $firstArgType->getIterableKeyType()->isInteger();
 		$isString = $firstArgType->getIterableKeyType()->isString();
 
@@ -49,7 +50,7 @@ final class ArrayRandFunctionReturnTypeExtension implements DynamicFunctionRetur
 			return $valueType;
 		}
 
-		$secondArgType = $scope->getType($functionCall->getArgs()[1]->value);
+		$secondArgType = $scope->getType($args[1]->value);
 
 		$one = new ConstantIntegerType(1);
 		if ($one->isSuperTypeOf($secondArgType)->yes()) {

--- a/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReduceFunctionReturnTypeExtension.php
@@ -25,28 +25,29 @@ final class ArrayReduceFunctionReturnTypeExtension implements DynamicFunctionRet
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[1])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[1])) {
 			return null;
 		}
 
-		$callbackType = $scope->getType($functionCall->getArgs()[1]->value);
+		$callbackType = $scope->getType($args[1]->value);
 		if ($callbackType->isCallable()->no()) {
 			return null;
 		}
 
 		$callbackReturnType = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$callbackType->getCallableParametersAcceptors($scope),
 		)->getReturnType();
 
-		if (isset($functionCall->getArgs()[2])) {
-			$initialType = $scope->getType($functionCall->getArgs()[2]->value);
+		if (isset($args[2])) {
+			$initialType = $scope->getType($args[2]->value);
 		} else {
 			$initialType = new NullType();
 		}
 
-		$arraysType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arraysType = $scope->getType($args[0]->value);
 		$constantArrays = $arraysType->getConstantArrays();
 		if (count($constantArrays) > 0) {
 			$onlyEmpty = TrinaryLogic::createYes();

--- a/src/Type/Php/ArrayReverseFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayReverseFunctionReturnTypeExtension.php
@@ -28,16 +28,17 @@ final class ArrayReverseFunctionReturnTypeExtension implements DynamicFunctionRe
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$type = $scope->getType($functionCall->getArgs()[0]->value);
+		$type = $scope->getType($args[0]->value);
 		if ($type->isArray()->no()) {
 			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}
 
-		$preserveKeysType = isset($functionCall->getArgs()[1]) ? $scope->getType($functionCall->getArgs()[1]->value) : new ConstantBooleanType(false);
+		$preserveKeysType = isset($args[1]) ? $scope->getType($args[1]->value) : new ConstantBooleanType(false);
 
 		return $type->reverseArray($preserveKeysType->isTrue());
 	}

--- a/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySearchFunctionDynamicReturnTypeExtension.php
@@ -29,12 +29,13 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		$argsCount = count($functionCall->getArgs());
+		$args = $functionCall->getArgs();
+		$argsCount = count($args);
 		if ($argsCount < 2) {
 			return null;
 		}
 
-		$haystackArgType = $scope->getType($functionCall->getArgs()[1]->value);
+		$haystackArgType = $scope->getType($args[1]->value);
 		if ($haystackArgType->isArray()->no()) {
 			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}
@@ -42,10 +43,10 @@ final class ArraySearchFunctionDynamicReturnTypeExtension implements DynamicFunc
 		if ($argsCount < 3) {
 			$strictArgType = new ConstantBooleanType(false);
 		} else {
-			$strictArgType = $scope->getType($functionCall->getArgs()[2]->value);
+			$strictArgType = $scope->getType($args[2]->value);
 		}
 
-		$needleArgType = $scope->getType($functionCall->getArgs()[0]->value);
+		$needleArgType = $scope->getType($args[0]->value);
 
 		return $haystackArgType->searchArray($needleArgType, $strictArgType->isTrue());
 	}

--- a/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayShiftFunctionReturnTypeExtension.php
@@ -22,11 +22,12 @@ final class ArrayShiftFunctionReturnTypeExtension implements DynamicFunctionRetu
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		$iterableAtLeastOnce = $argType->isIterableAtLeastOnce();
 		if ($iterableAtLeastOnce->no()) {
 			return new NullType();

--- a/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArraySumFunctionDynamicReturnTypeExtension.php
@@ -28,11 +28,12 @@ final class ArraySumFunctionDynamicReturnTypeExtension implements DynamicFunctio
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		$resultTypes = [];
 
 		if (count($argType->getConstantArrays()) > 0) {

--- a/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ArrayValuesFunctionDynamicReturnTypeExtension.php
@@ -29,11 +29,12 @@ final class ArrayValuesFunctionDynamicReturnTypeExtension implements DynamicFunc
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) !== 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) !== 1) {
 			return null;
 		}
 
-		$arrayType = $scope->getType($functionCall->getArgs()[0]->value);
+		$arrayType = $scope->getType($args[0]->value);
 		if ($arrayType->isArray()->no()) {
 			return $this->phpVersion->arrayFunctionsReturnNullWithNonArray() ? new NullType() : new NeverType();
 		}

--- a/src/Type/Php/AssertThrowTypeExtension.php
+++ b/src/Type/Php/AssertThrowTypeExtension.php
@@ -23,11 +23,12 @@ final class AssertThrowTypeExtension implements DynamicFunctionThrowTypeExtensio
 
 	public function getThrowTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $funcCall, Scope $scope): ?Type
 	{
-		if (count($funcCall->getArgs()) < 2) {
+		$args = $funcCall->getArgs();
+		if (count($args) < 2) {
 			return $functionReflection->getThrowType();
 		}
 
-		$customThrow = $scope->getType($funcCall->getArgs()[1]->value);
+		$customThrow = $scope->getType($args[1]->value);
 		if ((new ObjectType(Throwable::class))->isSuperTypeOf($customThrow)->yes()) {
 			return $customThrow;
 		}

--- a/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
+++ b/src/Type/Php/Base64DecodeDynamicFunctionReturnTypeExtension.php
@@ -29,11 +29,12 @@ final class Base64DecodeDynamicFunctionReturnTypeExtension implements DynamicFun
 		Scope $scope,
 	): Type
 	{
-		if (!isset($functionCall->getArgs()[1])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[1])) {
 			return new StringType();
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[1]->value);
+		$argType = $scope->getType($args[1]->value);
 
 		if ($argType instanceof MixedType) {
 			return new BenevolentUnionType([new StringType(), new ConstantBooleanType(false)]);

--- a/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
+++ b/src/Type/Php/BcMathStringOrNullReturnTypeExtension.php
@@ -47,7 +47,8 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 
 		$stringAndNumericStringType = new IntersectionType([new StringType(), new AccessoryNumericStringType()]);
 
-		if (isset($functionCall->getArgs()[1]) === false) {
+		$args = $functionCall->getArgs();
+		if (isset($args[1]) === false) {
 			if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
 				return new NeverType();
 			}
@@ -61,7 +62,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			$defaultReturnType = new UnionType([$stringAndNumericStringType, new NullType()]);
 		}
 
-		$secondArgument = $scope->getType($functionCall->getArgs()[1]->value);
+		$secondArgument = $scope->getType($args[1]->value);
 		$secondArgumentIsNumeric = ($secondArgument instanceof ConstantScalarType && is_numeric($secondArgument->getValue())) || $secondArgument->isInteger()->yes();
 
 		if ($secondArgument instanceof ConstantScalarType && ($this->isZero($secondArgument->getValue()) || !$secondArgumentIsNumeric)) {
@@ -72,7 +73,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return new NullType();
 		}
 
-		if (isset($functionCall->getArgs()[2]) === false) {
+		if (isset($args[2]) === false) {
 			if ($secondArgument instanceof ConstantScalarType || $secondArgumentIsNumeric) {
 				return $stringAndNumericStringType;
 			}
@@ -80,7 +81,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return $defaultReturnType;
 		}
 
-		$thirdArgument = $scope->getType($functionCall->getArgs()[2]->value);
+		$thirdArgument = $scope->getType($args[2]->value);
 		$thirdArgumentIsNumeric = false;
 		$thirdArgumentIsNegative = false;
 		if ($thirdArgument instanceof ConstantScalarType && is_numeric($thirdArgument->getValue())) {
@@ -127,7 +128,8 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			$defaultReturnType = new UnionType([$stringAndNumericStringType, new NullType()]);
 		}
 
-		if (isset($functionCall->getArgs()[0]) === false) {
+		$args = $functionCall->getArgs();
+		if (isset($args[0]) === false) {
 			if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
 				return new NeverType();
 			}
@@ -135,7 +137,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return $defaultReturnType;
 		}
 
-		$firstArgument = $scope->getType($functionCall->getArgs()[0]->value);
+		$firstArgument = $scope->getType($args[0]->value);
 
 		$firstArgumentIsPositive = $firstArgument instanceof ConstantScalarType && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() >= 0;
 		$firstArgumentIsNegative = $firstArgument instanceof ConstantScalarType && is_numeric($firstArgument->getValue()) && $firstArgument->getValue() < 0;
@@ -148,7 +150,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return new NullType();
 		}
 
-		if (isset($functionCall->getArgs()[1]) === false) {
+		if (isset($args[1]) === false) {
 			if ($firstArgumentIsPositive) {
 				return $stringAndNumericStringType;
 			}
@@ -156,7 +158,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return $defaultReturnType;
 		}
 
-		$secondArgument = $scope->getType($functionCall->getArgs()[1]->value);
+		$secondArgument = $scope->getType($args[1]->value);
 		$secondArgumentIsValid = $secondArgument instanceof ConstantScalarType && is_numeric($secondArgument->getValue()) && !$this->isZero($secondArgument->getValue());
 		$secondArgumentIsNonNumeric = $secondArgument instanceof ConstantScalarType && !is_numeric($secondArgument->getValue());
 		$secondArgumentIsNegative = $secondArgument instanceof ConstantScalarType && is_numeric($secondArgument->getValue()) && $secondArgument->getValue() < 0;
@@ -189,13 +191,14 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 	 */
 	private function getTypeForBcPowMod(FuncCall $functionCall, Scope $scope): Type
 	{
-		if ($this->phpVersion->throwsTypeErrorForInternalFunctions() && isset($functionCall->getArgs()[0]) === false) {
+		$args = $functionCall->getArgs();
+		if ($this->phpVersion->throwsTypeErrorForInternalFunctions() && isset($args[0]) === false) {
 			return new NeverType();
 		}
 
 		$stringAndNumericStringType = new IntersectionType([new StringType(), new AccessoryNumericStringType()]);
 
-		if (isset($functionCall->getArgs()[1]) === false) {
+		if (isset($args[1]) === false) {
 			if ($this->phpVersion->throwsTypeErrorForInternalFunctions()) {
 				return new NeverType();
 			}
@@ -203,7 +206,7 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return new UnionType([$stringAndNumericStringType, new ConstantBooleanType(false)]);
 		}
 
-		$exponent = $scope->getType($functionCall->getArgs()[1]->value);
+		$exponent = $scope->getType($args[1]->value);
 
 		// Expontent is non numeric
 		if ($this->phpVersion->throwsTypeErrorForInternalFunctions()
@@ -226,8 +229,8 @@ final class BcMathStringOrNullReturnTypeExtension implements DynamicFunctionRetu
 			return new ConstantBooleanType(false);
 		}
 
-		if (isset($functionCall->getArgs()[2])) {
-			$modulus = $scope->getType($functionCall->getArgs()[2]->value);
+		if (isset($args[2])) {
+			$modulus = $scope->getType($args[2]->value);
 			$modulusIsZero = $modulus instanceof ConstantScalarType && $this->isZero($modulus->getValue());
 			$modulusIsNonNumeric = $modulus instanceof ConstantScalarType && !is_numeric($modulus->getValue());
 

--- a/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ClassExistsFunctionTypeSpecifyingExtension.php
@@ -44,7 +44,8 @@ final class ClassExistsFunctionTypeSpecifyingExtension implements FunctionTypeSp
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		$argType = $scope->getType($node->getArgs()[0]->value);
+		$args = $node->getArgs();
+		$argType = $scope->getType($args[0]->value);
 		if ($argType instanceof ConstantStringType) {
 			return $this->typeSpecifier->create(
 				new FuncCall(new FullyQualified('class_exists'), [
@@ -62,7 +63,7 @@ final class ClassExistsFunctionTypeSpecifyingExtension implements FunctionTypeSp
 		}
 
 		return $this->typeSpecifier->create(
-			$node->getArgs()[0]->value,
+			$args[0]->value,
 			$narrowedType,
 			$context,
 			$scope,

--- a/src/Type/Php/DatePeriodConstructorReturnTypeExtension.php
+++ b/src/Type/Php/DatePeriodConstructorReturnTypeExtension.php
@@ -43,17 +43,18 @@ final class DatePeriodConstructorReturnTypeExtension implements DynamicStaticMet
 			return null;
 		}
 
-		if (!isset($methodCall->getArgs()[0])) {
+		$args = $methodCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$firstArgType = $scope->getType($methodCall->getArgs()[0]->value);
+		$firstArgType = $scope->getType($args[0]->value);
 		if ($firstArgType->isString()->yes()) {
 			$firstArgType = new ObjectType(DateTime::class);
 		}
 		$thirdArgType = null;
-		if (isset($methodCall->getArgs()[2])) {
-			$thirdArgType = $scope->getType($methodCall->getArgs()[2]->value);
+		if (isset($args[2])) {
+			$thirdArgType = $scope->getType($args[2]->value);
 		}
 
 		if (!$thirdArgType instanceof Type) {

--- a/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateTimeDynamicReturnTypeExtension.php
@@ -27,12 +27,13 @@ final class DateTimeDynamicReturnTypeExtension implements DynamicFunctionReturnT
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$formats = $scope->getType($functionCall->getArgs()[0]->value)->getConstantStrings();
-		$datetimes = $scope->getType($functionCall->getArgs()[1]->value)->getConstantStrings();
+		$formats = $scope->getType($args[0]->value)->getConstantStrings();
+		$datetimes = $scope->getType($args[1]->value)->getConstantStrings();
 
 		if (count($formats) === 0 || count($datetimes) === 0) {
 			return null;

--- a/src/Type/Php/DefineConstantTypeSpecifyingExtension.php
+++ b/src/Type/Php/DefineConstantTypeSpecifyingExtension.php
@@ -44,7 +44,8 @@ final class DefineConstantTypeSpecifyingExtension implements FunctionTypeSpecify
 		TypeSpecifierContext $context,
 	): SpecifiedTypes
 	{
-		$constantName = $scope->getType($node->getArgs()[0]->value);
+		$args = $node->getArgs();
+		$constantName = $scope->getType($args[0]->value);
 		if (
 			!$constantName instanceof ConstantStringType
 			|| $constantName->getValue() === ''
@@ -52,7 +53,7 @@ final class DefineConstantTypeSpecifyingExtension implements FunctionTypeSpecify
 			return new SpecifiedTypes([], []);
 		}
 
-		$valueType = $scope->getType($node->getArgs()[1]->value);
+		$valueType = $scope->getType($args[1]->value);
 		$finalType = $scope->getConstantExplicitTypeFromConfig(
 			$constantName->getValue(),
 			$valueType,

--- a/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterInputDynamicReturnTypeExtension.php
@@ -25,15 +25,16 @@ final class FilterInputDynamicReturnTypeExtension implements DynamicFunctionRetu
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
 		return $this->filterFunctionReturnTypeHelper->getInputType(
-			$scope->getType($functionCall->getArgs()[0]->value),
-			$scope->getType($functionCall->getArgs()[1]->value),
-			isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null,
-			isset($functionCall->getArgs()[3]) ? $scope->getType($functionCall->getArgs()[3]->value) : null,
+			$scope->getType($args[0]->value),
+			$scope->getType($args[1]->value),
+			isset($args[2]) ? $scope->getType($args[2]->value) : null,
+			isset($args[3]) ? $scope->getType($args[3]->value) : null,
 		);
 	}
 

--- a/src/Type/Php/FilterVarArrayDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarArrayDynamicReturnTypeExtension.php
@@ -42,12 +42,13 @@ final class FilterVarArrayDynamicReturnTypeExtension implements DynamicFunctionR
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
 		$functionName = strtolower($functionReflection->getName());
-		$inputArgType = $scope->getType($functionCall->getArgs()[0]->value);
+		$inputArgType = $scope->getType($args[0]->value);
 		$inputConstantArrayType = null;
 		if ($functionName === 'filter_var_array') {
 			if ($inputArgType->isArray()->no()) {
@@ -73,9 +74,9 @@ final class FilterVarArrayDynamicReturnTypeExtension implements DynamicFunctionR
 			$inputArgType = new ArrayType(new StringType(), new MixedType());
 		}
 
-		$filterArgType = $scope->getType($functionCall->getArgs()[1]->value);
+		$filterArgType = $scope->getType($args[1]->value);
 		$filterConstantArrayType = $filterArgType->getConstantArrays()[0] ?? null;
-		$addEmptyType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
+		$addEmptyType = isset($args[2]) ? $scope->getType($args[2]->value) : null;
 		$addEmpty = $addEmptyType === null || $addEmptyType->isTrue()->yes();
 
 		$valueTypesBuilder = ConstantArrayTypeBuilder::createEmpty();

--- a/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
+++ b/src/Type/Php/FilterVarDynamicReturnTypeExtension.php
@@ -26,13 +26,14 @@ final class FilterVarDynamicReturnTypeExtension implements DynamicFunctionReturn
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 1) {
 			return null;
 		}
 
-		$inputType = $scope->getType($functionCall->getArgs()[0]->value);
-		$filterType = isset($functionCall->getArgs()[1]) ? $scope->getType($functionCall->getArgs()[1]->value) : null;
-		$flagsType = isset($functionCall->getArgs()[2]) ? $scope->getType($functionCall->getArgs()[2]->value) : null;
+		$inputType = $scope->getType($args[0]->value);
+		$filterType = isset($args[1]) ? $scope->getType($args[1]->value) : null;
+		$flagsType = isset($args[2]) ? $scope->getType($args[2]->value) : null;
 
 		return $this->filterFunctionReturnTypeHelper->getType($inputType, $filterType, $flagsType);
 	}

--- a/src/Type/Php/HashFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/HashFunctionsReturnTypeExtension.php
@@ -99,7 +99,8 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
@@ -110,8 +111,8 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 		$functionData = self::SUPPORTED_FUNCTIONS[$lowerFunctionName];
 		if (is_bool($functionData['binary'])) {
 			$binaryType = new ConstantBooleanType($functionData['binary']);
-		} elseif (isset($functionCall->getArgs()[$functionData['binary']])) {
-			$binaryType = $scope->getType($functionCall->getArgs()[$functionData['binary']]->value);
+		} elseif (isset($args[$functionData['binary']])) {
+			$binaryType = $scope->getType($args[$functionData['binary']]->value);
 		} else {
 			$binaryType = new ConstantBooleanType(false);
 		}
@@ -125,7 +126,7 @@ final class HashFunctionsReturnTypeExtension implements DynamicFunctionReturnTyp
 		}
 		$stringReturnType = new IntersectionType($stringTypes);
 
-		$algorithmType = $scope->getType($functionCall->getArgs()[0]->value);
+		$algorithmType = $scope->getType($args[0]->value);
 		$constantAlgorithmTypes = $algorithmType->getConstantStrings();
 		if (count($constantAlgorithmTypes) === 0) {
 			if ($functionData['possiblyFalse'] || !$this->phpVersion->throwsValueErrorForInternalFunctions()) {

--- a/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/InArrayFunctionTypeSpecifyingExtension.php
@@ -41,19 +41,20 @@ final class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		$argsCount = count($node->getArgs());
+		$args = $node->getArgs();
+		$argsCount = count($args);
 		if ($argsCount < 2) {
 			return new SpecifiedTypes();
 		}
 
 		$isStrictComparison = false;
 		if ($argsCount >= 3) {
-			$strictNodeType = $scope->getType($node->getArgs()[2]->value);
+			$strictNodeType = $scope->getType($args[2]->value);
 			$isStrictComparison = $strictNodeType->isTrue()->yes();
 		}
 
-		$needleExpr = $node->getArgs()[0]->value;
-		$arrayExpr = $node->getArgs()[1]->value;
+		$needleExpr = $args[0]->value;
+		$arrayExpr = $args[1]->value;
 
 		$needleType = $scope->getType($needleExpr);
 		$arrayType = $scope->getType($arrayExpr);
@@ -101,7 +102,7 @@ final class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 				&& $arrayType->getIterableValueType()->isSuperTypeOf($needleType)->yes()
 			) {
 				return $this->typeSpecifier->create(
-					$node->getArgs()[1]->value,
+					$args[1]->value,
 					TypeCombinator::intersect($arrayType, new NonEmptyArrayType()),
 					$context,
 					$scope,
@@ -151,7 +152,7 @@ final class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 			}
 
 			$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
-				$node->getArgs()[1]->value,
+				$args[1]->value,
 				new ArrayType(new MixedType(), $arrayValueType),
 				TypeSpecifierContext::createTrue(),
 				$scope,
@@ -160,7 +161,7 @@ final class InArrayFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 
 		if ($context->true() && $arrayType->isArray()->yes()) {
 			$specifiedTypes = $specifiedTypes->unionWith($this->typeSpecifier->create(
-				$node->getArgs()[1]->value,
+				$args[1]->value,
 				TypeCombinator::intersect($arrayType, new NonEmptyArrayType()),
 				$context,
 				$scope,

--- a/src/Type/Php/IntdivThrowTypeExtension.php
+++ b/src/Type/Php/IntdivThrowTypeExtension.php
@@ -26,14 +26,15 @@ final class IntdivThrowTypeExtension implements DynamicFunctionThrowTypeExtensio
 
 	public function getThrowTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $funcCall, Scope $scope): ?Type
 	{
-		if (count($funcCall->getArgs()) < 2) {
+		$args = $funcCall->getArgs();
+		if (count($args) < 2) {
 			return $functionReflection->getThrowType();
 		}
 
-		$valueType = $scope->getType($funcCall->getArgs()[0]->value)->toInteger();
+		$valueType = $scope->getType($args[0]->value)->toInteger();
 		$containsMin = $valueType->isSuperTypeOf(new ConstantIntegerType(PHP_INT_MIN));
 
-		$divisorType = $scope->getType($funcCall->getArgs()[1]->value)->toInteger();
+		$divisorType = $scope->getType($args[1]->value)->toInteger();
 		if (!$containsMin->no()) {
 			$divisionByMinusOne = $divisorType->isSuperTypeOf(new ConstantIntegerType(-1));
 			if (!$divisionByMinusOne->no()) {

--- a/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsAFunctionTypeSpecifyingExtension.php
@@ -36,17 +36,18 @@ final class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifying
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		if (count($node->getArgs()) < 2) {
+		$args = $node->getArgs();
+		if (count($args) < 2) {
 			return new SpecifiedTypes();
 		}
-		$classType = $scope->getType($node->getArgs()[1]->value);
+		$classType = $scope->getType($args[1]->value);
 
 		if (!$classType instanceof ConstantStringType && !$context->true()) {
 			return new SpecifiedTypes([], []);
 		}
 
-		$objectOrClassType = $scope->getType($node->getArgs()[0]->value);
-		$allowStringType = isset($node->getArgs()[2]) ? $scope->getType($node->getArgs()[2]->value) : new ConstantBooleanType(false);
+		$objectOrClassType = $scope->getType($args[0]->value);
+		$allowStringType = isset($args[2]) ? $scope->getType($args[2]->value) : new ConstantBooleanType(false);
 		$allowString = !$allowStringType->equals(new ConstantBooleanType(false));
 
 		$resultType = $this->isAFunctionTypeSpecifyingHelper->determineType($objectOrClassType, $classType, $allowString, true);
@@ -57,7 +58,7 @@ final class IsAFunctionTypeSpecifyingExtension implements FunctionTypeSpecifying
 		}
 
 		return $this->typeSpecifier->create(
-			$node->getArgs()[0]->value,
+			$args[0]->value,
 			$resultType,
 			$context,
 			$scope,

--- a/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/IsSubclassOfFunctionTypeSpecifyingExtension.php
@@ -36,13 +36,14 @@ final class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeS
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		if (!$context->true() || count($node->getArgs()) < 2) {
+		$args = $node->getArgs();
+		if (!$context->true() || count($args) < 2) {
 			return new SpecifiedTypes();
 		}
 
-		$objectOrClassType = $scope->getType($node->getArgs()[0]->value);
-		$classType = $scope->getType($node->getArgs()[1]->value);
-		$allowStringType = isset($node->getArgs()[2]) ? $scope->getType($node->getArgs()[2]->value) : new ConstantBooleanType(true);
+		$objectOrClassType = $scope->getType($args[0]->value);
+		$classType = $scope->getType($args[1]->value);
+		$allowStringType = isset($args[2]) ? $scope->getType($args[2]->value) : new ConstantBooleanType(true);
 		$allowString = !$allowStringType->equals(new ConstantBooleanType(false));
 
 		// prevent false-positives in IsAFunctionTypeSpecifyingHelper
@@ -58,7 +59,7 @@ final class IsSubclassOfFunctionTypeSpecifyingExtension implements FunctionTypeS
 		}
 
 		return $this->typeSpecifier->create(
-			$node->getArgs()[0]->value,
+			$args[0]->value,
 			$resultType,
 			$context,
 			$scope,

--- a/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
+++ b/src/Type/Php/JsonThrowOnErrorDynamicReturnTypeExtension.php
@@ -56,9 +56,10 @@ final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctio
 	): Type
 	{
 		$argumentPosition = $this->argumentPositions[$functionReflection->getName()];
+		$args = $functionCall->getArgs();
 		$defaultReturnType = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
 
@@ -66,11 +67,11 @@ final class JsonThrowOnErrorDynamicReturnTypeExtension implements DynamicFunctio
 			$defaultReturnType = $this->narrowTypeForJsonDecode($functionCall, $scope, $defaultReturnType);
 		}
 
-		if (!isset($functionCall->getArgs()[$argumentPosition])) {
+		if (!isset($args[$argumentPosition])) {
 			return $defaultReturnType;
 		}
 
-		$optionsExpr = $functionCall->getArgs()[$argumentPosition]->value;
+		$optionsExpr = $args[$argumentPosition]->value;
 		if ($functionReflection->getName() === 'json_encode' && $this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'JSON_THROW_ON_ERROR')->yes()) {
 			return TypeCombinator::remove($defaultReturnType, new ConstantBooleanType(false));
 		}

--- a/src/Type/Php/JsonThrowTypeExtension.php
+++ b/src/Type/Php/JsonThrowTypeExtension.php
@@ -56,11 +56,12 @@ final class JsonThrowTypeExtension implements DynamicFunctionThrowTypeExtension
 			throw new ShouldNotHappenException();
 		}
 		$argumentPosition = self::ARGUMENTS_POSITIONS[$functionReflection->getName()];
-		if (!isset($functionCall->getArgs()[$argumentPosition])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[$argumentPosition])) {
 			return null;
 		}
 
-		$optionsExpr = $functionCall->getArgs()[$argumentPosition]->value;
+		$optionsExpr = $args[$argumentPosition]->value;
 		if (!$this->bitwiseFlagAnalyser->bitwiseOrContainsConstant($optionsExpr, $scope, 'JSON_THROW_ON_ERROR')->no()) {
 			return new ObjectType('JsonException');
 		}

--- a/src/Type/Php/LtrimFunctionReturnTypeExtension.php
+++ b/src/Type/Php/LtrimFunctionReturnTypeExtension.php
@@ -31,11 +31,12 @@ final class LtrimFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 1) {
 			return null;
 		}
 
-		$string = $scope->getType($functionCall->getArgs()[0]->value);
+		$string = $scope->getType($args[0]->value);
 
 		$accessory = [];
 		$defaultType = new StringType();
@@ -50,11 +51,11 @@ final class LtrimFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 			$defaultType = new IntersectionType($accessory);
 		}
 
-		if (count($functionCall->getArgs()) !== 2) {
+		if (count($args) !== 2) {
 			return $defaultType;
 		}
 
-		$trimChars = $scope->getType($functionCall->getArgs()[1]->value);
+		$trimChars = $scope->getType($args[1]->value);
 
 		$trimConstantStrings = $trimChars->getConstantStrings();
 		if (count($trimConstantStrings) > 0) {

--- a/src/Type/Php/MbConvertEncodingFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MbConvertEncodingFunctionReturnTypeExtension.php
@@ -42,15 +42,16 @@ final class MbConvertEncodingFunctionReturnTypeExtension implements DynamicFunct
 		Scope $scope,
 	): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 
 		$initialReturnType = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
 
@@ -60,10 +61,10 @@ final class MbConvertEncodingFunctionReturnTypeExtension implements DynamicFunct
 		}
 
 		if ($this->phpVersion->throwsValueErrorForInternalFunctions()) {
-			if (!isset($functionCall->getArgs()[2])) {
+			if (!isset($args[2])) {
 				return TypeCombinator::remove($result, new ConstantBooleanType(false));
 			}
-			$fromEncodingArgType = $scope->getType($functionCall->getArgs()[2]->value);
+			$fromEncodingArgType = $scope->getType($args[2]->value);
 
 			$returnFalseIfCannotDetectEncoding = false;
 			if (!$fromEncodingArgType->isArray()->no()) {

--- a/src/Type/Php/MbFunctionsReturnTypeExtension.php
+++ b/src/Type/Php/MbFunctionsReturnTypeExtension.php
@@ -49,18 +49,19 @@ final class MbFunctionsReturnTypeExtension implements DynamicFunctionReturnTypeE
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
+		$args = $functionCall->getArgs();
 		$returnType = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
 		$positionEncodingParam = $this->encodingPositionMap[$functionReflection->getName()];
 
-		if (count($functionCall->getArgs()) < $positionEncodingParam) {
+		if (count($args) < $positionEncodingParam) {
 			return TypeCombinator::remove($returnType, new BooleanType());
 		}
 
-		$strings = $scope->getType($functionCall->getArgs()[$positionEncodingParam - 1]->value)->getConstantStrings();
+		$strings = $scope->getType($args[$positionEncodingParam - 1]->value)->getConstantStrings();
 		$results = array_unique(array_map(fn (ConstantStringType $encoding): bool => $this->isSupportedEncoding($encoding->getValue()), $strings));
 
 		if ($returnType->equals(new UnionType([new StringType(), new BooleanType()]))) {

--- a/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
@@ -64,13 +64,13 @@ final class MbStrlenFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 		$encodings = [];
 
-		if (count($functionCall->getArgs()) === 1) {
+		if (count($args) === 1) {
 			// there is a chance to get an unsupported encoding 'pass' or 'none' here on PHP 7.3-7.4
 			$encodings = [mb_internal_encoding()];
-		} elseif (count($functionCall->getArgs()) === 2) { // custom encoding is specified
+		} elseif (count($args) === 2) { // custom encoding is specified
 			$encodings = array_map(
 				static fn (ConstantStringType $t) => $t->getValue(),
-				$scope->getType($functionCall->getArgs()[1]->value)->getConstantStrings(),
+				$scope->getType($args[1]->value)->getConstantStrings(),
 			);
 		}
 
@@ -138,7 +138,7 @@ final class MbStrlenFunctionReturnTypeExtension implements DynamicFunctionReturn
 			$range = TypeCombinator::remove(
 				ParametersAcceptorSelector::selectFromArgs(
 					$scope,
-					$functionCall->getArgs(),
+					$args,
 					$functionReflection->getVariants(),
 				)->getReturnType(),
 				new ConstantBooleanType(false),

--- a/src/Type/Php/MethodExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/MethodExistsTypeSpecifyingExtension.php
@@ -50,7 +50,8 @@ final class MethodExistsTypeSpecifyingExtension implements FunctionTypeSpecifyin
 		TypeSpecifierContext $context,
 	): SpecifiedTypes
 	{
-		$methodNameType = $scope->getType($node->getArgs()[1]->value);
+		$args = $node->getArgs();
+		$methodNameType = $scope->getType($args[1]->value);
 		if (!$methodNameType instanceof ConstantStringType) {
 			return $this->typeSpecifier->create(
 				new FuncCall(new FullyQualified('method_exists'), $node->getRawArgs()),
@@ -60,11 +61,11 @@ final class MethodExistsTypeSpecifyingExtension implements FunctionTypeSpecifyin
 			);
 		}
 
-		$objectType = $scope->getType($node->getArgs()[0]->value);
+		$objectType = $scope->getType($args[0]->value);
 		if ($objectType->isString()->yes()) {
 			if ($objectType->isClassString()->yes()) {
 				return $this->typeSpecifier->create(
-					$node->getArgs()[0]->value,
+					$args[0]->value,
 					new IntersectionType([
 						$objectType,
 						new HasMethodType($methodNameType->getValue()),
@@ -78,7 +79,7 @@ final class MethodExistsTypeSpecifyingExtension implements FunctionTypeSpecifyin
 		}
 
 		return $this->typeSpecifier->create(
-			$node->getArgs()[0]->value,
+			$args[0]->value,
 			new UnionType([
 				new IntersectionType([
 					new ObjectWithoutClassType(),

--- a/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
+++ b/src/Type/Php/MinMaxFunctionReturnTypeExtension.php
@@ -38,12 +38,13 @@ final class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (!isset($functionCall->getArgs()[0])) {
+		$args = $functionCall->getArgs();
+		if (!isset($args[0])) {
 			return null;
 		}
 
-		if (count($functionCall->getArgs()) === 1) {
-			$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		if (count($args) === 1) {
+			$argType = $scope->getType($args[0]->value);
 			if ($argType->isArray()->yes()) {
 				return $this->processArrayType(
 					$functionReflection->getName(),
@@ -57,8 +58,7 @@ final class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		// rewrite min($x, $y) as $x < $y ? $x : $y
 		// we don't handle arrays, which have different semantics
 		$functionName = $functionReflection->getName();
-		$args = $functionCall->getArgs();
-		if (count($functionCall->getArgs()) === 2) {
+		if (count($args) === 2) {
 			$argType0 = $scope->getType($args[0]->value);
 			$argType1 = $scope->getType($args[1]->value);
 
@@ -85,7 +85,7 @@ final class MinMaxFunctionReturnTypeExtension implements DynamicFunctionReturnTy
 		}
 
 		$argumentTypes = [];
-		foreach ($functionCall->getArgs() as $arg) {
+		foreach ($args as $arg) {
 			$argType = $scope->getType($arg->value);
 			if ($arg->unpack) {
 				$iterableValueType = $argType->getIterableValueType();

--- a/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php
@@ -59,15 +59,16 @@ final class ParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctio
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 1) {
 			return null;
 		}
 
 		$this->cacheReturnTypes();
 
-		$urlType = $scope->getType($functionCall->getArgs()[0]->value);
-		if (count($functionCall->getArgs()) > 1) {
-			$componentType = $scope->getType($functionCall->getArgs()[1]->value);
+		$urlType = $scope->getType($args[0]->value);
+		if (count($args) > 1) {
+			$componentType = $scope->getType($args[1]->value);
 
 			if (!$componentType->isConstantValue()->yes()) {
 				return $this->createAllComponentsReturnType($urlType->isLowercaseString()->yes());

--- a/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php
@@ -38,12 +38,13 @@ final class PathinfoFunctionDynamicReturnTypeExtension implements DynamicFunctio
 		Scope $scope,
 	): ?Type
 	{
-		$argsCount = count($functionCall->getArgs());
+		$args = $functionCall->getArgs();
+		$argsCount = count($args);
 		if ($argsCount === 0) {
 			return null;
 		}
 
-		$pathType = $scope->getType($functionCall->getArgs()[0]->value);
+		$pathType = $scope->getType($args[0]->value);
 
 		$builder = ConstantArrayTypeBuilder::createEmpty();
 		$builder->setOffsetValueType(new ConstantStringType('dirname'), new StringType(), !$pathType->isNonEmptyString()->yes());
@@ -56,7 +57,7 @@ final class PathinfoFunctionDynamicReturnTypeExtension implements DynamicFunctio
 			return $arrayType;
 		}
 
-		$flagsType = $scope->getType($functionCall->getArgs()[1]->value);
+		$flagsType = $scope->getType($args[1]->value);
 
 		$scalarValues = $flagsType->getConstantScalarValues();
 		if ($scalarValues !== []) {

--- a/src/Type/Php/PregFilterFunctionReturnTypeExtension.php
+++ b/src/Type/Php/PregFilterFunctionReturnTypeExtension.php
@@ -27,18 +27,19 @@ final class PregFilterFunctionReturnTypeExtension implements DynamicFunctionRetu
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
+		$args = $functionCall->getArgs();
 		$defaultReturn = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
 
-		$argsCount = count($functionCall->getArgs());
+		$argsCount = count($args);
 		if ($argsCount < 3) {
 			return $defaultReturn;
 		}
 
-		$subjectType = $scope->getType($functionCall->getArgs()[2]->value);
+		$subjectType = $scope->getType($args[2]->value);
 
 		if ($subjectType->isArray()->yes()) {
 			return new ArrayType(new IntegerType(), new StringType());

--- a/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
+++ b/src/Type/Php/PropertyExistsTypeSpecifyingExtension.php
@@ -55,7 +55,8 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 		TypeSpecifierContext $context,
 	): SpecifiedTypes
 	{
-		$propertyNameType = $scope->getType($node->getArgs()[1]->value);
+		$args = $node->getArgs();
+		$propertyNameType = $scope->getType($args[1]->value);
 		if (!$propertyNameType instanceof ConstantStringType) {
 			return $this->typeSpecifier->create(
 				new FuncCall(new FullyQualified('property_exists'), $node->getRawArgs()),
@@ -69,12 +70,12 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 			return new SpecifiedTypes([], []);
 		}
 
-		$objectType = $scope->getType($node->getArgs()[0]->value);
+		$objectType = $scope->getType($args[0]->value);
 		if ($objectType instanceof ConstantStringType) {
 			return new SpecifiedTypes([], []);
 		} elseif ($objectType->isObject()->yes()) {
 			$propertyNode = new PropertyFetch(
-				$node->getArgs()[0]->value,
+				$args[0]->value,
 				new Identifier($propertyNameType->getValue()),
 			);
 		} else {
@@ -89,7 +90,7 @@ final class PropertyExistsTypeSpecifyingExtension implements FunctionTypeSpecify
 		}
 
 		return $this->typeSpecifier->create(
-			$node->getArgs()[0]->value,
+			$args[0]->value,
 			new IntersectionType([
 				new ObjectWithoutClassType(),
 				new HasPropertyType($propertyNameType->getValue()),

--- a/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RandomIntFunctionReturnTypeExtension.php
@@ -29,16 +29,17 @@ final class RandomIntFunctionReturnTypeExtension implements DynamicFunctionRetur
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (in_array($functionReflection->getName(), ['rand', 'mt_rand'], true) && count($functionCall->getArgs()) === 0) {
+		$args = $functionCall->getArgs();
+		if (in_array($functionReflection->getName(), ['rand', 'mt_rand'], true) && count($args) === 0) {
 			return IntegerRangeType::fromInterval(0, null);
 		}
 
-		if (count($functionCall->getArgs()) < 2) {
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$minType = $scope->getType($functionCall->getArgs()[0]->value)->toInteger();
-		$maxType = $scope->getType($functionCall->getArgs()[1]->value)->toInteger();
+		$minType = $scope->getType($args[0]->value)->toInteger();
+		$maxType = $scope->getType($args[1]->value)->toInteger();
 
 		return $this->createRange($minType, $maxType);
 	}

--- a/src/Type/Php/RangeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/RangeFunctionReturnTypeExtension.php
@@ -42,13 +42,14 @@ final class RangeFunctionReturnTypeExtension implements DynamicFunctionReturnTyp
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 2) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 2) {
 			return null;
 		}
 
-		$startType = $scope->getType($functionCall->getArgs()[0]->value);
-		$endType = $scope->getType($functionCall->getArgs()[1]->value);
-		$stepType = count($functionCall->getArgs()) >= 3 ? $scope->getType($functionCall->getArgs()[2]->value) : new ConstantIntegerType(1);
+		$startType = $scope->getType($args[0]->value);
+		$endType = $scope->getType($args[1]->value);
+		$stepType = count($args) >= 3 ? $scope->getType($args[2]->value) : new ConstantIntegerType(1);
 
 		$constantReturnTypes = [];
 

--- a/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
@@ -76,9 +76,10 @@ final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctio
 	): Type
 	{
 		$subjectArgumentType = $this->getSubjectType($functionReflection, $functionCall, $scope);
+		$args = $functionCall->getArgs();
 		$defaultReturnType = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
 
@@ -94,8 +95,8 @@ final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctio
 		if (array_key_exists($functionReflection->getName(), self::FUNCTIONS_REPLACE_POSITION)) {
 			$replaceArgumentPosition = self::FUNCTIONS_REPLACE_POSITION[$functionReflection->getName()];
 
-			if (count($functionCall->getArgs()) > $replaceArgumentPosition) {
-				$replaceArgumentType = $scope->getType($functionCall->getArgs()[$replaceArgumentPosition]->value);
+			if (count($args) > $replaceArgumentPosition) {
+				$replaceArgumentType = $scope->getType($args[$replaceArgumentPosition]->value);
 				if ($replaceArgumentType->isArray()->yes()) {
 					$replaceArgumentType = $replaceArgumentType->getIterableValueType();
 				}
@@ -202,10 +203,11 @@ final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctio
 		}
 
 		$argumentPosition = self::FUNCTIONS_SUBJECT_POSITION[$functionReflection->getName()];
-		if (count($functionCall->getArgs()) <= $argumentPosition) {
+		$args = $functionCall->getArgs();
+		if (count($args) <= $argumentPosition) {
 			return null;
 		}
-		return $scope->getType($functionCall->getArgs()[$argumentPosition]->value);
+		return $scope->getType($args[$argumentPosition]->value);
 	}
 
 	private function canReturnNull(
@@ -214,9 +216,10 @@ final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctio
 		Scope $scope,
 	): bool
 	{
+		$args = $functionCall->getArgs();
 		if (
 			in_array($functionReflection->getName(), ['preg_replace', 'preg_replace_callback', 'preg_replace_callback_array'], true)
-			&& count($functionCall->getArgs()) > 0
+			&& count($args) > 0
 		) {
 			$subjectArgumentType = $this->getSubjectType($functionReflection, $functionCall, $scope);
 
@@ -230,7 +233,7 @@ final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctio
 
 		$possibleTypes = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
 

--- a/src/Type/Php/SetTypeFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/SetTypeFunctionTypeSpecifyingExtension.php
@@ -34,9 +34,10 @@ final class SetTypeFunctionTypeSpecifyingExtension implements FunctionTypeSpecif
 
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
-		$value = $node->getArgs()[0]->value;
+		$args = $node->getArgs();
+		$value = $args[0]->value;
 		$valueType = $scope->getType($value);
-		$castType = $scope->getType($node->getArgs()[1]->value);
+		$castType = $scope->getType($args[1]->value);
 
 		$constantStrings = $castType->getConstantStrings();
 		if (count($constantStrings) < 1) {

--- a/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrSplitFunctionReturnTypeExtension.php
@@ -51,12 +51,13 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
 	{
-		if (count($functionCall->getArgs()) < 1) {
+		$args = $functionCall->getArgs();
+		if (count($args) < 1) {
 			return null;
 		}
 
-		if (count($functionCall->getArgs()) >= 2) {
-			$splitLengthType = $scope->getType($functionCall->getArgs()[1]->value);
+		if (count($args) >= 2) {
+			$splitLengthType = $scope->getType($args[1]->value);
 		} else {
 			$splitLengthType = new ConstantIntegerType(1);
 		}
@@ -70,8 +71,8 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 
 		$encoding = null;
 		if ($functionReflection->getName() === 'mb_str_split') {
-			if (count($functionCall->getArgs()) >= 3) {
-				$strings = $scope->getType($functionCall->getArgs()[2]->value)->getConstantStrings();
+			if (count($args) >= 3) {
+				$strings = $scope->getType($args[2]->value)->getConstantStrings();
 				$values = array_unique(array_map(static fn (ConstantStringType $encoding): string => $encoding->getValue(), $strings));
 
 				if (count($values) === 1) {
@@ -85,7 +86,7 @@ final class StrSplitFunctionReturnTypeExtension implements DynamicFunctionReturn
 			}
 		}
 
-		$stringType = $scope->getType($functionCall->getArgs()[0]->value);
+		$stringType = $scope->getType($args[0]->value);
 		if (
 			isset($splitLength)
 			&& ($functionReflection->getName() === 'str_split' || $encoding !== null)

--- a/src/Type/Php/StrtotimeFunctionReturnTypeExtension.php
+++ b/src/Type/Php/StrtotimeFunctionReturnTypeExtension.php
@@ -33,15 +33,16 @@ final class StrtotimeFunctionReturnTypeExtension implements DynamicFunctionRetur
 
 	public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
 	{
+		$args = $functionCall->getArgs();
 		$defaultReturnType = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
-			$functionCall->getArgs(),
+			$args,
 			$functionReflection->getVariants(),
 		)->getReturnType();
-		if (count($functionCall->getArgs()) === 0) {
+		if (count($args) === 0) {
 			return $defaultReturnType;
 		}
-		$argType = $scope->getType($functionCall->getArgs()[0]->value);
+		$argType = $scope->getType($args[0]->value);
 		if ($argType instanceof MixedType) {
 			return TypeUtils::toBenevolentUnion($defaultReturnType);
 		}
@@ -57,7 +58,7 @@ final class StrtotimeFunctionReturnTypeExtension implements DynamicFunctionRetur
 		}
 
 		// 2nd param $baseTimestamp is too non-deterministic so simply return int
-		if (count($functionCall->getArgs()) > 1) {
+		if (count($args) > 1) {
 			return new IntegerType();
 		}
 

--- a/src/Type/Php/TrimFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TrimFunctionDynamicReturnTypeExtension.php
@@ -55,11 +55,11 @@ final class TrimFunctionDynamicReturnTypeExtension implements DynamicFunctionRet
 			$defaultType = new IntersectionType($accessory);
 		}
 
-		if (count($functionCall->getArgs()) !== 2) {
+		if (count($args) !== 2) {
 			return $defaultType;
 		}
 
-		$trimChars = $scope->getType($functionCall->getArgs()[1]->value);
+		$trimChars = $scope->getType($args[1]->value);
 
 		$trimConstantStrings = $trimChars->getConstantStrings();
 		if (count($trimConstantStrings) > 0) {


### PR DESCRIPTION
getArgs() currently takes 1% of cpu time

Its invoked a lot

<img width="403" height="335" alt="grafik" src="https://github.com/user-attachments/assets/df24b079-15c2-4176-ae73-176cc4351ab0" />
