### PR TITLE
ExpressionTypeHolder: re-use objects more often

### DIFF
--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -34,23 +34,27 @@ final class ExpressionTypeHolder
 			return false;
 		}
 
-		return $this->type->equals($other->type);
+		return $this->type === $other->type || $this->type->equals($other->type);
 	}
 
 	public function and(self $other): self
 	{
 		if ($this->type === $other->type || $this->type->equals($other->type)) {
-			if ($this->certainty->equals($other->certainty)) {
+			$certainty = $this->certainty->and($other->certainty);
+			if ($certainty->yes()) {
 				return $this;
 			}
 
-			$type = $this->type;
-		} else {
-			$type = TypeCombinator::union($this->type, $other->type);
+			if ($this->certainty->maybe()) {
+				return $this;
+			}
+
+			return $other;
 		}
+
 		return new self(
 			$this->expr,
-			$type,
+			TypeCombinator::union($this->type, $other->type),
 			$this->certainty->and($other->certainty),
 		);
 	}

--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -40,8 +40,7 @@ final class ExpressionTypeHolder
 	public function and(self $other): self
 	{
 		if ($this->type === $other->type || $this->type->equals($other->type)) {
-			$certainty = $this->certainty->and($other->certainty);
-			if ($certainty->yes()) {
+			if ($this->certainty->and($other->certainty)->yes()) {
 				return $this;
 			}
 


### PR DESCRIPTION
`php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug`

before this PR:
```
Elapsed time: 28.18 seconds
Used memory: 443.66 MB
```
after this PR:
```
Elapsed time: 28.09 seconds
Used memory: 434.81 MB
```

=> saves 9 MB memory