### PR TITLE
TrinaryLogic: detect logic errors

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -53,16 +53,28 @@ final class TrinaryLogic
 		return self::$registry[$value];
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->no()
+	 * @phpstan-assert-if-true =false $this->maybe()
+	 */
 	public function yes(): bool
 	{
 		return $this->value === self::YES;
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->no()
+	 * @phpstan-assert-if-true =false $this->yes()
+	 */
 	public function maybe(): bool
 	{
 		return $this->value === self::MAYBE;
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->maybe()
+	 * @phpstan-assert-if-true =false $this->yes()
+	 */
 	public function no(): bool
 	{
 		return $this->value === self::NO;

--- a/src/Type/AcceptsResult.php
+++ b/src/Type/AcceptsResult.php
@@ -26,16 +26,28 @@ final class AcceptsResult
 	{
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->no()
+	 * @phpstan-assert-if-true =false $this->maybe()
+	 */
 	public function yes(): bool
 	{
 		return $this->result->yes();
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->no()
+	 * @phpstan-assert-if-true =false $this->yes()
+	 */
 	public function maybe(): bool
 	{
 		return $this->result->maybe();
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->maybe()
+	 * @phpstan-assert-if-true =false $this->yes()
+	 */
 	public function no(): bool
 	{
 		return $this->result->no();

--- a/src/Type/IsSuperTypeOfResult.php
+++ b/src/Type/IsSuperTypeOfResult.php
@@ -26,16 +26,28 @@ final class IsSuperTypeOfResult
 	{
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->no()
+	 * @phpstan-assert-if-true =false $this->maybe()
+	 */
 	public function yes(): bool
 	{
 		return $this->result->yes();
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->no()
+	 * @phpstan-assert-if-true =false $this->yes()
+	 */
 	public function maybe(): bool
 	{
 		return $this->result->maybe();
 	}
 
+	/**
+	 * @phpstan-assert-if-true =false $this->maybe()
+	 * @phpstan-assert-if-true =false $this->yes()
+	 */
 	public function no(): bool
 	{
 		return $this->result->no();


### PR DESCRIPTION
allows detecting of dead code like

```
if ($flagState->yes()) {
	if ($flagState->no()) {
	}
}
```