### PR TITLE
Fix ignore comment handling for multiple traits in a single file

### DIFF
--- a/src/Analyser/FileAnalyser.php
+++ b/src/Analyser/FileAnalyser.php
@@ -118,7 +118,9 @@ final class FileAnalyser
 					}
 					if ($node instanceof InTraitNode) {
 						$traitNode = $node->getOriginalNode();
-						$linesToIgnore[$scope->getFileDescription()] = $this->getLinesToIgnoreFromTokens([$traitNode]);
+						$fileDescription = $scope->getFileDescription();
+						$linesToIgnore[$fileDescription] ??= [];
+						$linesToIgnore[$fileDescription] += $this->getLinesToIgnoreFromTokens([$traitNode]);
 
 						$traitFileName = $node->getTraitReflection()->getFileName();
 						if ($traitFileName !== null) {

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1631,6 +1631,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug13945Two(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13945-2.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return list<Error>

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1625,6 +1625,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug13945(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-13945.php');
+		$this->assertNoErrors($errors);
+	}
+
 	/**
 	 * @param string[]|null $allAnalysedFiles
 	 * @return list<Error>

--- a/tests/PHPStan/Analyser/data/bug-13945-2.php
+++ b/tests/PHPStan/Analyser/data/bug-13945-2.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13945;
+
+trait Foo {
+	public function baz(): void {
+		$this->myProperty = "a"; // @phpstan-ignore property.notFound
+	}
+}
+
+trait Baz {
+}
+
+class HelloWorld
+{
+	use Baz;
+	use Foo;
+}

--- a/tests/PHPStan/Analyser/data/bug-13945-2.php
+++ b/tests/PHPStan/Analyser/data/bug-13945-2.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Bug13945;
+namespace Bug13945Two;
 
 trait Foo {
 	public function baz(): void {

--- a/tests/PHPStan/Analyser/data/bug-13945.php
+++ b/tests/PHPStan/Analyser/data/bug-13945.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13945;
+
+trait Foo {
+	public function baz(): void {
+		$this->myProperty = "a"; // @phpstan-ignore property.notFound
+	}
+}
+
+trait Baz {
+}
+
+class HelloWorld
+{
+	use Foo;
+	use Baz;
+}


### PR DESCRIPTION
`$linesToIgnore` data was not correctly gathered when:

- more than one traits are defined in a same file
- those traits are used in a same class

Closes phpstan/phpstan#13945