### PR TITLE
FileCacheStorage: Don't use sprintf() on maybe huge strings

### DIFF
--- a/src/Cache/FileCacheStorage.php
+++ b/src/Cache/FileCacheStorage.php
@@ -82,11 +82,7 @@ final class FileCacheStorage implements CacheStorage
 		}
 		FileWriter::write(
 			$tmpPath,
-			sprintf(
-				"<?php declare(strict_types = 1);\n\n%s\nreturn %s;",
-				sprintf('// %s', $key),
-				$exported,
-			),
+			"<?php declare(strict_types = 1);\n\n" . '// ' . $key . "\nreturn " . $exported . ';',
 		);
 
 		$renameSuccess = @rename($tmpPath, $path);


### PR DESCRIPTION
this seems to be the most expensive use of `sprintf` - memory wise

<img width="427" height="712" alt="grafik" src="https://github.com/user-attachments/assets/ddcc2094-c4d0-4694-85b9-889701499d86" />
