### PR TITLE
NodeDependencies: prevent unnecessary FileHelper::normalizePath() calls

### DIFF
--- a/src/Dependency/NodeDependencies.php
+++ b/src/Dependency/NodeDependencies.php
@@ -42,6 +42,10 @@ final class NodeDependencies
 			if ($dependencyFile === null) {
 				continue;
 			}
+			if ($currentFile === $dependencyFile) {
+				continue;
+			}
+
 			$dependencyFile = $this->fileHelper->normalizePath($dependencyFile);
 
 			if ($currentFile === $dependencyFile) {


### PR DESCRIPTION
in shopware this is invoked a lot, and I can see on my machine that the path oftentimes already matches even before normalization

<img width="440" height="862" alt="grafik" src="https://github.com/user-attachments/assets/1f0d6048-0166-4811-920d-672ced27cce2" />

----

its in the top 5 used calls when running `php vendor/bin/phpstan analyze tests/integration/Core/System --debug`

<img width="477" height="405" alt="grafik" src="https://github.com/user-attachments/assets/4af7c0de-95e0-44bc-a840-efda2e485933" />
