### PR TITLE
ConstantArrayType: prevent unnecessary work

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -563,13 +563,12 @@ class ConstantArrayType implements Type
 			if (
 				$has->yes()
 				&& !$phpVersion->supportsCallableInstanceMethods()
+				&& $classOrObject->isString()->yes()
 			) {
-				if ($classOrObject->isString()->yes()) {
-					$methodReflection = $type->getMethod($methodName->getValue(), new OutOfClassScope());
+				$methodReflection = $type->getMethod($methodName->getValue(), new OutOfClassScope());
 
-					if (!$methodReflection->isStatic()) {
-						continue;
-					}
+				if (!$methodReflection->isStatic()) {
+					continue;
 				}
 			}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -572,7 +572,7 @@ class ConstantArrayType implements Type
 						continue;
 					}
 				} elseif ($isString->maybe()) {
-					continue;
+					$has = $has->and(TrinaryLogic::createMaybe());
 				}
 			}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -563,12 +563,16 @@ class ConstantArrayType implements Type
 			if (
 				$has->yes()
 				&& !$phpVersion->supportsCallableInstanceMethods()
-				&& $classOrObject->isString()->yes()
 			) {
-				$methodReflection = $type->getMethod($methodName->getValue(), new OutOfClassScope());
+				$isString = $classOrObject->isString();
+				if ($isString->yes()) {
+					$methodReflection = $type->getMethod($methodName->getValue(), new OutOfClassScope());
 
-				if (!$methodReflection->isStatic()) {
-					continue;
+					if (!$methodReflection->isStatic()) {
+						continue;
+					}
+				} elseif ($isString->maybe()) {
+					$has = $has->and(TrinaryLogic::createMaybe());
 				}
 			}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -564,9 +564,12 @@ class ConstantArrayType implements Type
 				$has->yes()
 				&& !$phpVersion->supportsCallableInstanceMethods()
 			) {
-				$methodReflection = $type->getMethod($methodName->getValue(), new OutOfClassScope());
-				if ($classOrObject->isString()->yes() && !$methodReflection->isStatic()) {
-					continue;
+				if ($classOrObject->isString()->yes()) {
+					$methodReflection = $type->getMethod($methodName->getValue(), new OutOfClassScope());
+
+					if (!$methodReflection->isStatic()) {
+						continue;
+					}
 				}
 			}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -572,7 +572,7 @@ class ConstantArrayType implements Type
 						continue;
 					}
 				} elseif ($isString->maybe()) {
-					$has = $has->and(TrinaryLogic::createMaybe());
+					continue;
 				}
 			}
 

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -358,7 +358,7 @@ class CallCallablesRuleTest extends RuleTestCase
 		$errors = [];
 		if (PHP_VERSION_ID >= 80000) {
 			$errors[] = [
-				"Trying to invoke array{'MaybeNotCallable\\\Bar'|\$this(MaybeNotCallable\Bar), 'doFoo'} but it's not a callable.",
+				"Trying to invoke array{'MaybeNotCallable\\\Bar'|\$this(MaybeNotCallable\Bar), 'doFoo'} but it might not be a callable.",
 				15,
 			];
 		}

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -353,4 +353,17 @@ class CallCallablesRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testMaybeNotCallable(): void
+	{
+		$errors = [];
+		if (PHP_VERSION_ID >= 80000) {
+			$errors[] = [
+				"Trying to invoke array{'MaybeNotCallable\\\Bar'|\$this(MaybeNotCallable\Bar), 'doFoo'} but it might not be a callable.",
+				15,
+			];
+		}
+
+		$this->analyse([__DIR__ . '/data/maybe-not-callable.php'], $errors);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallCallablesRuleTest.php
@@ -358,7 +358,7 @@ class CallCallablesRuleTest extends RuleTestCase
 		$errors = [];
 		if (PHP_VERSION_ID >= 80000) {
 			$errors[] = [
-				"Trying to invoke array{'MaybeNotCallable\\\Bar'|\$this(MaybeNotCallable\Bar), 'doFoo'} but it might not be a callable.",
+				"Trying to invoke array{'MaybeNotCallable\\\Bar'|\$this(MaybeNotCallable\Bar), 'doFoo'} but it's not a callable.",
 				15,
 			];
 		}

--- a/tests/PHPStan/Rules/Functions/data/maybe-not-callable.php
+++ b/tests/PHPStan/Rules/Functions/data/maybe-not-callable.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MaybeNotCallable;
+
+class Bar
+{
+	private function doFoo()
+	{
+		echo 'yes';
+	}
+
+	public function doBar()
+	{
+		$cb = [rand(0,1) ? 'MaybeNotCallable\Bar' : $this, 'doFoo'];
+		$cb();
+	}
+}


### PR DESCRIPTION
`getMethod` sees a lot of calls. prevent if possible.

<img width="447" height="328" alt="grafik" src="https://github.com/user-attachments/assets/b330d63d-2b8f-47c5-8653-95ac69d66534" />

---

fixes https://phpstan.org/r/fd3b7f2e-db94-494d-b4cf-b722818a758f
which misses a error for php8+
see https://3v4l.org/ItoqW#veol