### PR TITLE
Fix escaped hash in regex extended modefixed escaped hash in regex extended mode

### DIFF
--- a/src/Type/Regex/RegexGroupParser.php
+++ b/src/Type/Regex/RegexGroupParser.php
@@ -85,7 +85,8 @@ final class RegexGroupParser
 
 			if (str_contains($modifiers, 'x')) {
 				// in freespacing mode the # character starts a comment and runs until the end of the line
-				$regex = preg_replace('/(?<!\?)#.*/', '', $regex) ?? '';
+				// but \# is an escaped literal hash, and (?#...) is an inline comment - neither starts a line comment
+				$regex = preg_replace('/(?<!\\\\)(?<!\(\?)#.*/', '', $regex) ?? '';
 			}
 
 			$rawRegex = $this->regexExpressionHelper->removeDelimitersAndModifiers($regex);

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -1073,3 +1073,18 @@ function bug12792(string $string): void {
 		assertType('array{string, non-empty-string}', $match); // could be array{'acd'|'ayd'|'bd', 'c'|'xb'|'y'}
 	}
 }
+
+function testExtendedSyntaxEscapedHash(string $string): void {
+	// \# in extended mode should be treated as literal hash, not comment
+	if (preg_match('/^ ([\#.]) $/x', $string, $matches)) {
+		assertType("array{non-falsy-string, '#'|'.'}", $matches);
+	}
+
+	// Real comment vs escaped hash
+	if (preg_match('/
+		(\d+)      # this is a comment
+		([\#ab]+)  # hash in character class (escaped)
+	/x', $string, $matches)) {
+		assertType('array{non-falsy-string, numeric-string, non-empty-string}', $matches);
+	}
+}


### PR DESCRIPTION
When using the `x` (extended) modifier, `\#` was incorrectly treated as the start of a comment. According to PCRE specification, `\#` is an escaped literal hash character and should not start a comment.

### Example

```php
preg_match('/^ ([\#.]) $/x', $s, $matches);
```

Before this fix, PHPStan would strip `\#.]) $/x` as a comment, breaking the pattern parsing.

### Changes

- `src/Type/Regex/RegexGroupParser.php`: Changed the comment-stripping regex from `/(?<!\?)#.*/` to `/(?<!\\)#.*/` to respect escaped hashes
- Added test case `testExtendedSyntaxEscapedHash` in `tests/PHPStan/Analyser/nsrt/preg_match_shapes.php`

### Note

This fix does not address `#` inside character classes like `[#.]` (which is also not a comment in PCRE). However, users can use the workaround `[\#.]` which now works correctly with this fix.
