### PR TITLE
NodeDependencies: cache normalized filenames

### DIFF
--- a/src/Dependency/NodeDependencies.php
+++ b/src/Dependency/NodeDependencies.php
@@ -9,6 +9,10 @@ use function array_values;
 
 final class NodeDependencies
 {
+	/**
+	 * @var array<string, string>
+	 */
+	private static array $normalizedFileNames = [];
 
 	/**
 	 * @param array<int, ClassReflection|FunctionReflection> $reflections
@@ -46,7 +50,7 @@ final class NodeDependencies
 				continue;
 			}
 
-			$dependencyFile = $this->fileHelper->normalizePath($dependencyFile);
+			$dependencyFile = self::$normalizedFileNames[$dependencyFile] ??= $this->fileHelper->normalizePath($dependencyFile);
 
 			if ($currentFile === $dependencyFile) {
 				continue;

--- a/src/Dependency/NodeDependencies.php
+++ b/src/Dependency/NodeDependencies.php
@@ -10,9 +10,6 @@ use function array_values;
 final class NodeDependencies
 {
 
-	/** @var array<string, string> */
-	private static array $normalizedFileNames = [];
-
 	/**
 	 * @param array<int, ClassReflection|FunctionReflection> $reflections
 	 */
@@ -49,7 +46,7 @@ final class NodeDependencies
 				continue;
 			}
 
-			$dependencyFile = self::$normalizedFileNames[$dependencyFile] ??= $this->fileHelper->normalizePath($dependencyFile);
+			$dependencyFile = $this->fileHelper->normalizePath($dependencyFile);
 
 			if ($currentFile === $dependencyFile) {
 				continue;

--- a/src/Dependency/NodeDependencies.php
+++ b/src/Dependency/NodeDependencies.php
@@ -9,9 +9,8 @@ use function array_values;
 
 final class NodeDependencies
 {
-	/**
-	 * @var array<string, string>
-	 */
+
+	/** @var array<string, string> */
 	private static array $normalizedFileNames = [];
 
 	/**

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -23,6 +23,7 @@ use const DIRECTORY_SEPARATOR;
 #[AutowiredService]
 final class FileHelper
 {
+
 	/** @var array<string, array<string, string>> */
 	private static array $normalizedFileNames = [];
 

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -25,7 +25,7 @@ final class FileHelper
 {
 
 	/** @var array<string, array<string, string>> */
-	private static array $normalizedFileNames = [];
+	private static array $normalizedPathsCache = [];
 
 	private string $workingDirectory;
 
@@ -63,7 +63,7 @@ final class FileHelper
 	/** @api */
 	public function normalizePath(string $originalPath, string $directorySeparator = DIRECTORY_SEPARATOR): string
 	{
-		$cached = self::$normalizedFileNames[$originalPath][$directorySeparator] ?? null;
+		$cached = self::$normalizedPathsCache[$originalPath][$directorySeparator] ?? null;
 		if ($cached !== null) {
 			return $cached;
 		}
@@ -110,7 +110,7 @@ final class FileHelper
 			}
 		}
 
-		return self::$normalizedFileNames[$originalPath][$directorySeparator] = ($scheme !== null ? $scheme . '://' : '') . $pathRoot . implode($directorySeparator, $normalizedPathParts);
+		return self::$normalizedPathsCache[$originalPath][$directorySeparator] = ($scheme !== null ? $scheme . '://' : '') . $pathRoot . implode($directorySeparator, $normalizedPathParts);
 	}
 
 }

--- a/src/File/FileHelper.php
+++ b/src/File/FileHelper.php
@@ -23,6 +23,8 @@ use const DIRECTORY_SEPARATOR;
 #[AutowiredService]
 final class FileHelper
 {
+	/** @var array<string, array<string, string>> */
+	private static array $normalizedFileNames = [];
 
 	private string $workingDirectory;
 
@@ -60,6 +62,11 @@ final class FileHelper
 	/** @api */
 	public function normalizePath(string $originalPath, string $directorySeparator = DIRECTORY_SEPARATOR): string
 	{
+		$cached = self::$normalizedFileNames[$originalPath][$directorySeparator] ?? null;
+		if ($cached !== null) {
+			return $cached;
+		}
+
 		$isLocalPath = false;
 		if ($originalPath !== '') {
 			if ($originalPath[0] === '/') {
@@ -102,7 +109,7 @@ final class FileHelper
 			}
 		}
 
-		return ($scheme !== null ? $scheme . '://' : '') . $pathRoot . implode($directorySeparator, $normalizedPathParts);
+		return self::$normalizedFileNames[$originalPath][$directorySeparator] = ($scheme !== null ? $scheme . '://' : '') . $pathRoot . implode($directorySeparator, $normalizedPathParts);
 	}
 
 }


### PR DESCRIPTION
in shopware, in which we have a lot of shared traits, the same paths are over and over again normalized.

<img width="434" height="761" alt="grafik" src="https://github.com/user-attachments/assets/9f63f0a2-5846-47af-b12e-68bda0701c0c" />

we can see `FileHelper::normalizePath` take ~41 seconds, from which 95% are called from `NodeDependencies::getFileDependencies`.

---

even running this PR on phpstan-src, I can see `FileHelper::normalizePath` dropping from 175.059 to 137.958