### PR TITLE
TemplateTypeHelper: prevent unnecessary work

### DIFF
--- a/src/Type/Generic/TemplateTypeHelper.php
+++ b/src/Type/Generic/TemplateTypeHelper.php
@@ -24,6 +24,10 @@ final class TemplateTypeHelper
 		bool $keepErrorTypes = false,
 	): Type
 	{
+		if (!$type->hasTemplateOrLateResolvableType()) {
+			return $type;
+		}
+
 		$references = $type->getReferencedTemplateTypes($positionVariance);
 
 		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($standins, $references, $callSiteVariances, $keepErrorTypes): Type {


### PR DESCRIPTION
most time consuming user of `TypeTraverser::map()` is `TemplateTypeHelper::resolveTemplateTypes`:

<img width="446" height="739" alt="grafik" src="https://github.com/user-attachments/assets/3876483e-fde4-4af7-983c-c29cb63beed2" />

while `TypeTraverser::map()` is the most time consuming method-call in shopware (and also in phpstan-src reference benchmark):

<img width="437" height="860" alt="grafik" src="https://github.com/user-attachments/assets/d00c5b82-f4c3-43da-8dea-26e32051da89" />

after this PR `TypeTraverser::map()` no longer is in the top 8 of slow calls, while beeing in top 2 before.

---

before this PR:
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug' -i --runs=3 --warmup=1
Benchmark 1: php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug
  Time (mean ± σ):     26.391 s ±  0.413 s    [User: 25.598 s, System: 0.780 s]
  Range (min … max):   25.959 s … 26.783 s    3 runs
 
  Warning: Ignoring non-zero exit code.
```

after this PR:
```
➜  phpstan-src git:(early-ret) ✗ hyperfine 'php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug' -i --runs=3 --warmup=1
Benchmark 1: php bin/phpstan analyse src/Analyser/ src/Rules/ -v --debug
  Time (mean ± σ):     25.841 s ±  0.046 s    [User: 25.103 s, System: 0.729 s]
  Range (min … max):   25.788 s … 25.872 s    3 runs
 
  Warning: Ignoring non-zero exit code.
```