### PR TITLE
Support StaticMethodParameterClosureTypeExtension for New_ expressions

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -4816,6 +4816,17 @@ class NodeScopeResolver
 						return $staticMethodParameterClosureTypeExtension->getTypeFromStaticMethodCall($calleeReflection, $callLike, $parameter, $scope);
 					}
 				}
+			} elseif ($callLike instanceof New_ && $callLike->class instanceof Name) {
+				$staticCall = new StaticCall(
+					$callLike->class,
+					new Identifier('__construct'),
+					$callLike->getArgs(),
+				);
+				foreach ($this->parameterClosureTypeExtensionProvider->getStaticMethodParameterClosureTypeExtensions() as $staticMethodParameterClosureTypeExtension) {
+					if ($staticMethodParameterClosureTypeExtension->isStaticMethodSupported($calleeReflection, $parameter)) {
+						return $staticMethodParameterClosureTypeExtension->getTypeFromStaticMethodCall($calleeReflection, $staticCall, $parameter, $scope);
+					}
+				}
 			} elseif ($callLike instanceof MethodCall) {
 				foreach ($this->parameterClosureTypeExtensionProvider->getMethodParameterClosureTypeExtensions() as $methodParameterClosureTypeExtension) {
 					if ($methodParameterClosureTypeExtension->isMethodSupported($calleeReflection, $parameter)) {

--- a/tests/PHPStan/Analyser/data/parameter-closure-type-extension-arrow-function.php
+++ b/tests/PHPStan/Analyser/data/parameter-closure-type-extension-arrow-function.php
@@ -107,7 +107,15 @@ class StaticMethodParameterClosureTypeExtension implements \PHPStan\Type\StaticM
 
 	public function isStaticMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
 	{
-		return $methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'staticMethodWithCallable';
+		if ($methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'staticMethodWithCallable') {
+			return true;
+		}
+
+		if ($methodReflection->getDeclaringClass()->getName() === Bar::class && $methodReflection->getName() === '__construct') {
+			return true;
+		}
+
+		return false;
 	}
 
 	public function getTypeFromStaticMethodCall(
@@ -116,6 +124,32 @@ class StaticMethodParameterClosureTypeExtension implements \PHPStan\Type\StaticM
 		ParameterReflection $parameter,
 		Scope $scope
 	): ?Type {
+		if ($methodReflection->getDeclaringClass()->getName() === Bar::class && $methodReflection->getName() === '__construct') {
+			$args = $methodCall->getArgs();
+
+			if (count($args) < 2) {
+				return null;
+			}
+
+			$integer = $scope->getType($args[0]->value)->getConstantScalarValues()[0];
+
+			if ($integer === 1) {
+				return new CallableType(
+					[
+						new NativeParameterReflection('test', false, new IntegerType(), PassedByReference::createNo(), false, null),
+					],
+					new MixedType()
+				);
+			}
+
+			return new CallableType(
+				[
+					new NativeParameterReflection('test', false, new StringType(), PassedByReference::createNo(), false, null),
+				],
+				new MixedType()
+			);
+		}
+
 		return new CallableType(
 			[
 				new NativeParameterReflection('test', false, new FloatType(), PassedByReference::createNo(), false, null),
@@ -173,6 +207,20 @@ class Generic
 	}
 }
 
+class Bar
+{
+
+	/**
+	 * @param int $foo
+	 * @param callable(mixed) $callback
+	 */
+	public function __construct(int $foo, callable $callback)
+	{
+
+	}
+
+}
+
 /**
  * @param int $foo
  * @param callable(Generic<array-key>) $callback
@@ -192,6 +240,10 @@ function test(Foo $foo): void
 	(new Foo)->methodWithCallable(2, fn (Generic $i) => assertType('string', $i->getValue()));
 
 	Foo::staticMethodWithCallable(fn ($i) => assertType('float', $i));
+
+	new Bar(1, fn ($i) => assertType('int', $i));
+
+	new Bar(2, fn ($i) => assertType('string', $i));
 }
 
 functionWithCallable(1, fn ($i) => assertType('int', $i->getValue()));

--- a/tests/PHPStan/Analyser/data/parameter-closure-type-extension.php
+++ b/tests/PHPStan/Analyser/data/parameter-closure-type-extension.php
@@ -117,7 +117,15 @@ class StaticMethodParameterClosureTypeExtension implements \PHPStan\Type\StaticM
 
 	public function isStaticMethodSupported(MethodReflection $methodReflection, ParameterReflection $parameter): bool
 	{
-		return $methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'staticMethodWithClosure';
+		if ($methodReflection->getDeclaringClass()->getName() === Foo::class && $methodReflection->getName() === 'staticMethodWithClosure') {
+			return true;
+		}
+
+		if ($methodReflection->getDeclaringClass()->getName() === Bar::class && $methodReflection->getName() === '__construct') {
+			return true;
+		}
+
+		return false;
 	}
 
 	public function getTypeFromStaticMethodCall(
@@ -126,6 +134,32 @@ class StaticMethodParameterClosureTypeExtension implements \PHPStan\Type\StaticM
 		ParameterReflection $parameter,
 		Scope $scope
 	): ?Type {
+		if ($methodReflection->getDeclaringClass()->getName() === Bar::class && $methodReflection->getName() === '__construct') {
+			$args = $methodCall->getArgs();
+
+			if (count($args) < 2) {
+				return null;
+			}
+
+			$integer = $scope->getType($args[0]->value)->getConstantScalarValues()[0];
+
+			if ($integer === 1) {
+				return new ClosureType(
+					[
+						new NativeParameterReflection('test', false, new IntegerType(), PassedByReference::createNo(), false, null),
+					],
+					new VoidType()
+				);
+			}
+
+			return new ClosureType(
+				[
+					new NativeParameterReflection('test', false, new StringType(), PassedByReference::createNo(), false, null),
+				],
+				new VoidType()
+			);
+		}
+
 		return new ClosureType(
 			[
 				new NativeParameterReflection('test', false, new FloatType(), PassedByReference::createNo(), false, null),
@@ -185,6 +219,20 @@ class Generic
 	}
 }
 
+class Bar
+{
+
+	/**
+	 * @param int $foo
+	 * @param Closure(mixed): void $callback
+	 */
+	public function __construct(int $foo, Closure $callback)
+	{
+
+	}
+
+}
+
 /**
  * @param int $foo
  * @param Closure(Generic<array-key>): void $callback
@@ -208,6 +256,14 @@ function test(Foo $foo): void
 
 	Foo::staticMethodWithClosure(function ($i) {
 		assertType('float', $i);
+	});
+
+	new Bar(1, function ($i) {
+		assertType('int', $i);
+	});
+
+	new Bar(2, function ($i) {
+		assertType('string', $i);
 	});
 }
 


### PR DESCRIPTION
See https://github.com/phpstan/phpstan/discussions/14014#discussioncomment-15590392

Decided to add support to the current extensions to make it easier to merge this instead of proposing the change to:
- https://github.com/phpstan/phpstan-src/pull/4290

/cc @ondrejmirtes @calebdw 