### PR TITLE
Add regression test

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -1504,6 +1504,12 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testBug11598(): void
+	{
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11598.php');
+		$this->assertNoErrors($errors);
+	}
+
 	public function testBug11640(): void
 	{
 		$errors = $this->runAnalyse(__DIR__ . '/data/bug-11640.php');

--- a/tests/PHPStan/Analyser/data/bug-11598.php
+++ b/tests/PHPStan/Analyser/data/bug-11598.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Bug11598;
+
+use function unserialize;
+
+function(): void {
+	[ // @phpstan-ignore offsetAccess.nonArray
+		'bar' => $foo,
+	] = '';
+
+	// @phpstan-ignore offsetAccess.nonArray
+	[
+		'bar' => $foo,
+	] = '';
+};


### PR DESCRIPTION
phpstan/phpstan#11598 was already resolved probably somewhere in 2.0.0.
This PR adds a regression test for the issue.

Closes phpstan/phpstan#11598