### PR TITLE
MutatingScope: Faster createConditionalExpressions

### DIFF
--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -24,6 +24,15 @@ final class ExpressionTypeHolder
 		return new self($expr, $type, TrinaryLogic::createMaybe());
 	}
 
+	public function equalTypes(self $other): bool
+	{
+		if ($this === $other) {
+			return true;
+		}
+
+		return $this->type === $other->type || $this->type->equals($other->type);
+	}
+
 	public function equals(self $other): bool
 	{
 		if ($this === $other) {

--- a/src/Analyser/ExpressionTypeHolder.php
+++ b/src/Analyser/ExpressionTypeHolder.php
@@ -10,7 +10,11 @@ use PHPStan\Type\TypeCombinator;
 final class ExpressionTypeHolder
 {
 
-	public function __construct(private Expr $expr, private Type $type, private TrinaryLogic $certainty)
+	public function __construct(
+		private readonly Expr $expr,
+		private readonly Type $type,
+		private readonly TrinaryLogic $certainty,
+	)
 	{
 	}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -4014,7 +4014,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 				continue;
 			}
 
-			if (!$mergedExpressionTypes[$exprString]->getType()->equals($holder->getType())) {
+			if (!$mergedExpressionTypes[$exprString]->equalTypes($holder)) {
 				continue;
 			}
 
@@ -4023,13 +4023,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 		$typeGuards = [];
 		foreach ($newVariableTypes as $exprString => $holder) {
-			if (!$holder->getCertainty()->yes()) {
-				continue;
-			}
 			if (!array_key_exists($exprString, $mergedExpressionTypes)) {
 				continue;
 			}
-			if ($mergedExpressionTypes[$exprString]->getType()->equals($holder->getType())) {
+			if (!$holder->getCertainty()->yes()) {
+				continue;
+			}
+			if ($mergedExpressionTypes[$exprString]->equalTypes($holder)) {
 				continue;
 			}
 
@@ -4194,7 +4194,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		foreach ($finallyVariableTypeHolders as $exprString => $variableTypeHolder) {
 			if (
 				isset($originalVariableTypeHolders[$exprString])
-				&& !$originalVariableTypeHolders[$exprString]->getType()->equals($variableTypeHolder->getType())
+				&& !$originalVariableTypeHolders[$exprString]->equalTypes($variableTypeHolder)
 			) {
 				$ourVariableTypeHolders[$exprString] = $variableTypeHolder;
 				continue;
@@ -4766,7 +4766,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 				return false;
 			}
 
-			if (!$variableTypeHolder->getType()->equals($otherVariableTypeHolders[$variableExprString]->getType())) {
+			if (!$variableTypeHolder->equalTypes($otherVariableTypeHolders[$variableExprString])) {
 				return false;
 			}
 		}


### PR DESCRIPTION
this PR optimizes one of the top 3 methods regarding cost:

<img width="507" height="367" alt="grafik" src="https://github.com/user-attachments/assets/0ba788bb-8998-460a-b85a-366261d57c29" />


---

blackfire diff of `php bin/phpstan analyze src/Rules src/Analyser --debug -v`

<img width="441" height="535" alt="grafik" src="https://github.com/user-attachments/assets/ff90c08d-8f75-4f78-8b01-bdddd3fe2e54" />
