### PR TITLE
IntersectionType cannot be void

### DIFF
--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -807,6 +807,7 @@ class IntersectionType implements CompoundType
 	public function isVoid(): TrinaryLogic
 	{
 		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isVoid());
+		return TrinaryLogic::createNo();
 	}
 
 	public function isScalar(): TrinaryLogic

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -806,7 +806,6 @@ class IntersectionType implements CompoundType
 
 	public function isVoid(): TrinaryLogic
 	{
-		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->isVoid());
 		return TrinaryLogic::createNo();
 	}
 


### PR DESCRIPTION
before this PR we checked IntersectionTypes of up to 38 inner-elements whether these are void.

by definition a IntersectionType cannot be void