### PR TITLE
NodeScopeResolver: Prevent repetitive union of static types

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -250,6 +250,7 @@ class NodeScopeResolver
 	private array $calledMethodResults = [];
 
 	private readonly Type $nonIntKeyOffsetValueType;
+
 	private readonly Type $intKeyOffsetValueType;
 
 	/**
@@ -307,7 +308,7 @@ class NodeScopeResolver
 		);
 		$this->intKeyOffsetValueType = TypeCombinator::union(
 			$this->nonIntKeyOffsetValueType,
-			new StringType()
+			new StringType(),
 		);
 	}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -300,16 +300,6 @@ class NodeScopeResolver
 			}
 		}
 		$this->earlyTerminatingMethodNames = $earlyTerminatingMethodNames;
-
-		$this->nonIntKeyOffsetValueType = TypeCombinator::union(
-			new ArrayType(new MixedType(), new MixedType()),
-			new ObjectType(ArrayAccess::class),
-			new NullType(),
-		);
-		$this->intKeyOffsetValueType = TypeCombinator::union(
-			$this->nonIntKeyOffsetValueType,
-			new StringType(),
-		);
 	}
 
 	/**
@@ -6620,6 +6610,16 @@ class NodeScopeResolver
 				!$offsetValueType instanceof MixedType
 				&& !$offsetValueType->isConstantArray()->yes()
 			) {
+				$this->nonIntKeyOffsetValueType ??= TypeCombinator::union(
+					new ArrayType(new MixedType(), new MixedType()),
+					new ObjectType(ArrayAccess::class),
+					new NullType(),
+				);
+				$this->intKeyOffsetValueType ??= TypeCombinator::union(
+					$this->nonIntKeyOffsetValueType,
+					new StringType(),
+				);
+
 				if ($offsetType !== null && $offsetType->isInteger()->yes()) {
 					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->intKeyOffsetValueType);
 				} else {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -249,9 +249,9 @@ class NodeScopeResolver
 	/** @var array<string, MutatingScope|null> */
 	private array $calledMethodResults = [];
 
-	private readonly Type $nonIntKeyOffsetValueType;
+	private Type $nonIntKeyOffsetValueType;
 
-	private readonly Type $intKeyOffsetValueType;
+	private Type $intKeyOffsetValueType;
 
 	/**
 	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -249,9 +249,9 @@ class NodeScopeResolver
 	/** @var array<string, MutatingScope|null> */
 	private array $calledMethodResults = [];
 
-	private Type $nonIntKeyOffsetValueType;
+	private ?Type $nonIntKeyOffsetValueType = null;
 
-	private Type $intKeyOffsetValueType;
+	private ?Type $intKeyOffsetValueType = null;
 
 	/**
 	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])
@@ -6615,12 +6615,13 @@ class NodeScopeResolver
 					new ObjectType(ArrayAccess::class),
 					new NullType(),
 				);
-				$this->intKeyOffsetValueType ??= TypeCombinator::union(
-					$this->nonIntKeyOffsetValueType,
-					new StringType(),
-				);
 
 				if ($offsetType !== null && $offsetType->isInteger()->yes()) {
+					$this->intKeyOffsetValueType ??= TypeCombinator::union(
+						$this->nonIntKeyOffsetValueType,
+						new StringType(),
+					);
+
 					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->intKeyOffsetValueType);
 				} else {
 					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->nonIntKeyOffsetValueType);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -249,6 +249,9 @@ class NodeScopeResolver
 	/** @var array<string, MutatingScope|null> */
 	private array $calledMethodResults = [];
 
+	private readonly Type $nonIntKeyOffsetValueType;
+	private readonly Type $intKeyOffsetValueType;
+
 	/**
 	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])
 	 * @param array<int, string> $earlyTerminatingFunctionCalls
@@ -296,6 +299,16 @@ class NodeScopeResolver
 			}
 		}
 		$this->earlyTerminatingMethodNames = $earlyTerminatingMethodNames;
+
+		$this->nonIntKeyOffsetValueType = TypeCombinator::union(
+			new ArrayType(new MixedType(), new MixedType()),
+			new ObjectType(ArrayAccess::class),
+			new NullType(),
+		);
+		$this->intKeyOffsetValueType = TypeCombinator::union(
+			$this->nonIntKeyOffsetValueType,
+			new StringType()
+		);
 	}
 
 	/**
@@ -6606,15 +6619,11 @@ class NodeScopeResolver
 				!$offsetValueType instanceof MixedType
 				&& !$offsetValueType->isConstantArray()->yes()
 			) {
-				$types = [
-					new ArrayType(new MixedType(), new MixedType()),
-					new ObjectType(ArrayAccess::class),
-					new NullType(),
-				];
 				if ($offsetType !== null && $offsetType->isInteger()->yes()) {
-					$types[] = new StringType();
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->intKeyOffsetValueType);
+				} else {
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->nonIntKeyOffsetValueType);
 				}
-				$offsetValueType = TypeCombinator::intersect($offsetValueType, TypeCombinator::union(...$types));
 			}
 
 			$arrayDimFetch = $dimFetchStack[$i] ?? null;


### PR DESCRIPTION
before PR

<img width="430" height="690" alt="grafik" src="https://github.com/user-attachments/assets/5cecd266-7ba1-4549-ac3a-c723f66dd14a" />

----

after PR - `union` no longer appears as one of the callees

<img width="420" height="333" alt="grafik" src="https://github.com/user-attachments/assets/0cdaa75a-9a6b-4998-8d77-bbb1ceba68eb" />
