### PR TITLE
NodeScopeResolver: faster produceArrayDimFetchAssignValueToWrite()

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6604,7 +6604,7 @@ class NodeScopeResolver
 			$offsetValueType = array_pop($offsetValueTypeStack);
 			if (
 				!$offsetValueType instanceof MixedType
-				&& !$offsetValueType->isConstantArray()->yes()
+				&& !$offsetValueType->isArray()->yes()
 			) {
 				$types = [
 					new ArrayType(new MixedType(), new MixedType()),

--- a/tests/PHPStan/Analyser/nsrt/bug-13270b-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13270b-php8.php
@@ -19,7 +19,7 @@ class Test
 			if (!array_key_exists('priceWithVat', $data['price'])) {
 				$data['price']['priceWithVat'] = null;
 			}
-			assertType("non-empty-array&hasOffsetValue('priceWithVat', mixed)", $data['price']);
+			assertType("non-empty-array&hasOffset('priceWithVat')", $data['price']);
 			if (!array_key_exists('priceWithoutVat', $data['price'])) {
 				$data['price']['priceWithoutVat'] = null;
 			}

--- a/tests/PHPStan/Analyser/nsrt/superglobals.php
+++ b/tests/PHPStan/Analyser/nsrt/superglobals.php
@@ -32,7 +32,7 @@ class Superglobals
 	{
 		$GLOBALS['foo'] = 'foo';
 		assertType("non-empty-array&hasOffsetValue('foo', 'foo')", $GLOBALS);
-		assertNativeType("non-empty-array&hasOffsetValue('foo', 'foo')", $GLOBALS);
+		assertNativeType("non-empty-array<mixed>&hasOffsetValue('foo', 'foo')", $GLOBALS);
 	}
 
 	public function canBeNarrowed(): void


### PR DESCRIPTION
~50% faster

before PR

<img width="422" height="642" alt="grafik" src="https://github.com/user-attachments/assets/3d48722d-5898-41cf-992e-c4d2d86f98b2" />

----

after PR

<img width="424" height="348" alt="grafik" src="https://github.com/user-attachments/assets/986d4dc4-d926-48a0-8e2b-9d7f3c92a031" />
