### PR TITLE
NodeScopeResolver: Prevent repetitive union of static types

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3351,21 +3351,21 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 				$exprVarType = $scope->getType($expr->var);
 				if (!$exprVarType instanceof MixedType && !$exprVarType->isArray()->no()) {
 					if ($dimType->isInteger()->yes()) {
-						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::intOffsetValueType());
+						$varType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::intOffsetAccessibleType());
 					} else {
-						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::generalOffsetValueType());
+						$varType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::generalOffsetAccessibleType());
 					}
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
-						$offsetValueType = TypeCombinator::intersect(
-							$offsetValueType,
+						$varType = TypeCombinator::intersect(
+							$varType,
 							new HasOffsetValueType($dimType, $type),
 						);
 					}
 
 					$scope = $scope->specifyExpressionType(
 						$expr->var,
-						$offsetValueType,
+						$varType,
 						$scope->getNativeType($expr->var),
 						$certainty,
 					);

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -125,6 +125,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
+use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
@@ -3349,21 +3350,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			if ($dimType->isInteger()->yes() || $dimType->isString()->yes()) {
 				$exprVarType = $scope->getType($expr->var);
 				if (!$exprVarType instanceof MixedType && !$exprVarType->isArray()->no()) {
-					$this->nonIntKeyOffsetValueType ??= TypeCombinator::union(
-						new ArrayType(new MixedType(), new MixedType()),
-						new ObjectType(ArrayAccess::class),
-						new NullType(),
-					);
-
 					if ($dimType->isInteger()->yes()) {
-						$this->intKeyOffsetValueType ??= TypeCombinator::union(
-							$this->nonIntKeyOffsetValueType,
-							new StringType(),
-						);
-
-						$offsetValueType = TypeCombinator::intersect($exprVarType, $this->intKeyOffsetValueType);
+						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::getIntArrayKeyValueType());
 					} else {
-						$offsetValueType = TypeCombinator::intersect($exprVarType, $this->nonIntKeyOffsetValueType);
+						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::getNonIntArrayKeyValueType());
 					}
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3351,9 +3351,9 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 				$exprVarType = $scope->getType($expr->var);
 				if (!$exprVarType instanceof MixedType && !$exprVarType->isArray()->no()) {
 					if ($dimType->isInteger()->yes()) {
-						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::getIntArrayKeyValueType());
+						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::intOffsetValueType());
 					} else {
-						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::getNonIntArrayKeyValueType());
+						$offsetValueType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::generalOffsetValueType());
 					}
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3349,15 +3349,22 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			if ($dimType->isInteger()->yes() || $dimType->isString()->yes()) {
 				$exprVarType = $scope->getType($expr->var);
 				if (!$exprVarType instanceof MixedType && !$exprVarType->isArray()->no()) {
-					$types = [
+					$this->nonIntKeyOffsetValueType ??= TypeCombinator::union(
 						new ArrayType(new MixedType(), new MixedType()),
 						new ObjectType(ArrayAccess::class),
 						new NullType(),
-					];
+					);
+
 					if ($dimType->isInteger()->yes()) {
-						$types[] = new StringType();
+						$this->intKeyOffsetValueType ??= TypeCombinator::union(
+							$this->nonIntKeyOffsetValueType,
+							new StringType(),
+						);
+
+						$offsetValueType = TypeCombinator::intersect($exprVarType, $this->intKeyOffsetValueType);
+					} else {
+						$offsetValueType = TypeCombinator::intersect($exprVarType, $this->nonIntKeyOffsetValueType);
 					}
-					$offsetValueType = TypeCombinator::intersect($exprVarType, TypeCombinator::union(...$types));
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
 						$offsetValueType = TypeCombinator::intersect(

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6607,9 +6607,9 @@ class NodeScopeResolver
 				&& !$offsetValueType->isArray()->yes()
 			) {
 				if ($offsetType !== null && $offsetType->isInteger()->yes()) {
-					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::intOffsetValueType());
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::intOffsetAccessibleType());
 				} else {
-					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::generalOffsetValueType());
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::generalOffsetAccessibleType());
 				}
 			}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6607,9 +6607,9 @@ class NodeScopeResolver
 				&& !$offsetValueType->isArray()->yes()
 			) {
 				if ($offsetType !== null && $offsetType->isInteger()->yes()) {
-					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::getIntArrayKeyValueType());
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::intOffsetValueType());
 				} else {
-					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::getNonIntArrayKeyValueType());
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::generalOffsetValueType());
 				}
 			}
 

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -249,10 +249,6 @@ class NodeScopeResolver
 	/** @var array<string, MutatingScope|null> */
 	private array $calledMethodResults = [];
 
-	private ?Type $nonIntKeyOffsetValueType = null;
-
-	private ?Type $intKeyOffsetValueType = null;
-
 	/**
 	 * @param string[][] $earlyTerminatingMethodCalls className(string) => methods(string[])
 	 * @param array<int, string> $earlyTerminatingFunctionCalls
@@ -6610,21 +6606,10 @@ class NodeScopeResolver
 				!$offsetValueType instanceof MixedType
 				&& !$offsetValueType->isArray()->yes()
 			) {
-				$this->nonIntKeyOffsetValueType ??= TypeCombinator::union(
-					new ArrayType(new MixedType(), new MixedType()),
-					new ObjectType(ArrayAccess::class),
-					new NullType(),
-				);
-
 				if ($offsetType !== null && $offsetType->isInteger()->yes()) {
-					$this->intKeyOffsetValueType ??= TypeCombinator::union(
-						$this->nonIntKeyOffsetValueType,
-						new StringType(),
-					);
-
-					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->intKeyOffsetValueType);
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::getIntArrayKeyValueType());
 				} else {
-					$offsetValueType = TypeCombinator::intersect($offsetValueType, $this->nonIntKeyOffsetValueType);
+					$offsetValueType = TypeCombinator::intersect($offsetValueType, StaticTypeFactory::getNonIntArrayKeyValueType());
 				}
 			}
 

--- a/src/Type/StaticTypeFactory.php
+++ b/src/Type/StaticTypeFactory.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type;
 
+use ArrayAccess;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantFloatType;
@@ -16,7 +17,7 @@ final class StaticTypeFactory
 		static $falsey;
 
 		if ($falsey === null) {
-			$falsey = new UnionType([
+			$falsey = TypeCombinator::union(
 				new NullType(),
 				new ConstantBooleanType(false),
 				new ConstantIntegerType(0),
@@ -24,7 +25,7 @@ final class StaticTypeFactory
 				new ConstantStringType(''),
 				new ConstantStringType('0'),
 				new ConstantArrayType([], []),
-			]);
+			);
 		}
 
 		return $falsey;
@@ -39,6 +40,35 @@ final class StaticTypeFactory
 		}
 
 		return $truthy;
+	}
+
+	public static function getNonIntArrayKeyValueType(): Type
+	{
+		static $nonIntArrayKeyType;
+
+		if ($nonIntArrayKeyType === null) {
+			$nonIntArrayKeyType = TypeCombinator::union(
+				new ArrayType(new MixedType(), new MixedType()),
+				new ObjectType(ArrayAccess::class),
+				new NullType(),
+			);
+		}
+
+		return $nonIntArrayKeyType;
+	}
+
+	public static function getIntArrayKeyValueType(): Type
+	{
+		static $intArrayKeyType;
+
+		if ($intArrayKeyType === null) {
+			$intArrayKeyType = TypeCombinator::union(
+				self::getNonIntArrayKeyValueType(),
+				new StringType(),
+			);
+		}
+
+		return $intArrayKeyType;
 	}
 
 }

--- a/src/Type/StaticTypeFactory.php
+++ b/src/Type/StaticTypeFactory.php
@@ -44,31 +44,31 @@ final class StaticTypeFactory
 
 	public static function generalOffsetValueType(): Type
 	{
-		static $nonIntArrayKeyType;
+		static $generalOffsetValueType;
 
-		if ($nonIntArrayKeyType === null) {
-			$nonIntArrayKeyType = TypeCombinator::union(
+		if ($generalOffsetValueType === null) {
+			$generalOffsetValueType = TypeCombinator::union(
 				new ArrayType(new MixedType(), new MixedType()),
 				new ObjectType(ArrayAccess::class),
 				new NullType(),
 			);
 		}
 
-		return $nonIntArrayKeyType;
+		return $generalOffsetValueType;
 	}
 
 	public static function intOffsetValueType(): Type
 	{
-		static $intArrayKeyType;
+		static $intOffsetValueType;
 
-		if ($intArrayKeyType === null) {
-			$intArrayKeyType = TypeCombinator::union(
+		if ($intOffsetValueType === null) {
+			$intOffsetValueType = TypeCombinator::union(
 				self::generalOffsetValueType(),
 				new StringType(),
 			);
 		}
 
-		return $intArrayKeyType;
+		return $intOffsetValueType;
 	}
 
 }

--- a/src/Type/StaticTypeFactory.php
+++ b/src/Type/StaticTypeFactory.php
@@ -42,33 +42,33 @@ final class StaticTypeFactory
 		return $truthy;
 	}
 
-	public static function generalOffsetValueType(): Type
+	public static function generalOffsetAccessibleType(): Type
 	{
-		static $generalOffsetValueType;
+		static $generalOffsetAccessible;
 
-		if ($generalOffsetValueType === null) {
-			$generalOffsetValueType = TypeCombinator::union(
+		if ($generalOffsetAccessible === null) {
+			$generalOffsetAccessible = TypeCombinator::union(
 				new ArrayType(new MixedType(), new MixedType()),
 				new ObjectType(ArrayAccess::class),
 				new NullType(),
 			);
 		}
 
-		return $generalOffsetValueType;
+		return $generalOffsetAccessible;
 	}
 
-	public static function intOffsetValueType(): Type
+	public static function intOffsetAccessibleType(): Type
 	{
-		static $intOffsetValueType;
+		static $intOffsetAccessible;
 
-		if ($intOffsetValueType === null) {
-			$intOffsetValueType = TypeCombinator::union(
-				self::generalOffsetValueType(),
+		if ($intOffsetAccessible === null) {
+			$intOffsetAccessible = TypeCombinator::union(
+				self::generalOffsetAccessibleType(),
 				new StringType(),
 			);
 		}
 
-		return $intOffsetValueType;
+		return $intOffsetAccessible;
 	}
 
 }

--- a/src/Type/StaticTypeFactory.php
+++ b/src/Type/StaticTypeFactory.php
@@ -42,7 +42,7 @@ final class StaticTypeFactory
 		return $truthy;
 	}
 
-	public static function getNonIntArrayKeyValueType(): Type
+	public static function generalOffsetValueType(): Type
 	{
 		static $nonIntArrayKeyType;
 
@@ -57,13 +57,13 @@ final class StaticTypeFactory
 		return $nonIntArrayKeyType;
 	}
 
-	public static function getIntArrayKeyValueType(): Type
+	public static function intOffsetValueType(): Type
 	{
 		static $intArrayKeyType;
 
 		if ($intArrayKeyType === null) {
 			$intArrayKeyType = TypeCombinator::union(
-				self::getNonIntArrayKeyValueType(),
+				self::generalOffsetValueType(),
 				new StringType(),
 			);
 		}


### PR DESCRIPTION
re-use types introduced in https://github.com/phpstan/phpstan-src/pull/4841

removes a few `TypeCombinator::union` calls

<img width="445" height="176" alt="grafik" src="https://github.com/user-attachments/assets/6455a149-3ae4-472f-9f4e-8d9298e11337" />

---

since `TypeCombinator::union` is the slowest path we have right now, this is a great thing to have.

<img width="460" height="248" alt="grafik" src="https://github.com/user-attachments/assets/b46512c2-b1be-44f8-afb0-6056aa25a6a6" />
