### PR TITLE
Regression test for #14041

### DIFF
--- a/tests/PHPStan/Rules/Arrays/DuplicateKeysInLiteralArraysRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/DuplicateKeysInLiteralArraysRuleTest.php
@@ -110,4 +110,9 @@ class DuplicateKeysInLiteralArraysRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13022.php'], []);
 	}
 
+	public function testBug14041(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14041.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Arrays/data/bug-14041.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-14041.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14041;
+
+use Pdo\Mysql;
+
+$connection_options['pdo'] = [
+	\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+	Mysql::ATTR_USE_BUFFERED_QUERY => TRUE,
+	Mysql::ATTR_FOUND_ROWS => TRUE,
+	\PDO::ATTR_EMULATE_PREPARES => TRUE,
+	Mysql::ATTR_MULTI_STATEMENTS => FALSE,
+	\PDO::ATTR_STRINGIFY_FETCHES => TRUE,
+];


### PR DESCRIPTION
Regression coverage for https://github.com/phpstan/phpstan/issues/14041

If `pdo_mysql` is not installed, this fails today, but should pass on Tuesday when the JetBrains stubs are updated.
