### PR TITLE
Make ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT configurable

### DIFF
--- a/conf/config.neon
+++ b/conf/config.neon
@@ -111,6 +111,7 @@ parameters:
 	reportMagicProperties: false
 	ignoreErrors: []
 	internalErrorsCountLimit: 50
+	constantArrayTypeBuilderArrayCountLimit: 256
 	cache:
 		nodesByStringCountMax: 256
 		resolvedPhpDocBlockCacheCountMax: 2048

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -134,6 +134,7 @@ parametersSchema:
 		)
 	)
 	internalErrorsCountLimit: int()
+	constantArrayTypeBuilderArrayCountLimit: int()
 	cache: structure([
 		nodesByStringCountMax: int(),
 		resolvedPhpDocBlockCacheCountMax: int(),

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1151,7 +1151,7 @@ final class TypeSpecifier
 
 			if (
 				$sizeType instanceof ConstantIntegerType
-				&& $sizeType->getValue() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
+				&& $sizeType->getValue() < ConstantArrayTypeBuilder::getArrayCountLimit()
 				&& $isList->yes()
 				&& $arrayType->getKeyType()->isSuperTypeOf(IntegerRangeType::fromInterval(0, $sizeType->getValue() - 1))->yes()
 			) {
@@ -1168,7 +1168,7 @@ final class TypeSpecifier
 			if (
 				$sizeType instanceof IntegerRangeType
 				&& $sizeType->getMin() !== null
-				&& $sizeType->getMin() < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT
+				&& $sizeType->getMin() < ConstantArrayTypeBuilder::getArrayCountLimit()
 				&& $isList->yes()
 				&& $arrayType->getKeyType()->isSuperTypeOf(IntegerRangeType::fromInterval(0, ($sizeType->getMax() ?? $sizeType->getMin()) - 1))->yes()
 			) {
@@ -1179,7 +1179,7 @@ final class TypeSpecifier
 					$builderData[] = [$offsetType, $arrayType->getOffsetValueType($offsetType), false];
 				}
 				if ($sizeType->getMax() !== null) {
-					if ($sizeType->getMax() - $sizeType->getMin() > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+					if ($sizeType->getMax() - $sizeType->getMin() > ConstantArrayTypeBuilder::getArrayCountLimit()) {
 						$resultTypes[] = $arrayType;
 						continue;
 					}
@@ -1201,7 +1201,7 @@ final class TypeSpecifier
 					continue;
 				}
 
-				if (count($builderData) > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+				if (count($builderData) > ConstantArrayTypeBuilder::getArrayCountLimit()) {
 					$resultTypes[] = $arrayType;
 					continue;
 				}

--- a/src/DependencyInjection/ConstantArrayTypeLimitAccessor.php
+++ b/src/DependencyInjection/ConstantArrayTypeLimitAccessor.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\DependencyInjection;
+
+final class ConstantArrayTypeLimitAccessor
+{
+
+	private static int $limit = 256;
+
+	public static function getLimit(): int
+	{
+		return self::$limit;
+	}
+
+	public static function setLimit(int $limit): void
+	{
+		self::$limit = $limit;
+	}
+
+}

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -199,6 +199,7 @@ final class ContainerFactory
 		$container->getService('typeSpecifier');
 
 		BleedingEdgeToggle::setBleedingEdge($container->getParameter('featureToggles')['bleedingEdge']);
+		ConstantArrayTypeLimitAccessor::setLimit($container->getParameter('constantArrayTypeBuilderArrayCountLimit'));
 	}
 
 	public function getCurrentWorkingDirectory(): string

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -1046,7 +1046,7 @@ final class TypeNodeResolver
 	private function resolveArrayShapeNode(ArrayShapeNode $typeNode, NameScope $nameScope): Type
 	{
 		$builder = ConstantArrayTypeBuilder::createEmpty();
-		if (count($typeNode->items) > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+		if (count($typeNode->items) > ConstantArrayTypeBuilder::getArrayCountLimit()) {
 			$builder->degradeToGeneralArray(true);
 		}
 

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -631,7 +631,7 @@ final class InitializerExprTypeResolver
 	 */
 	public function getArrayType(Expr\Array_ $expr, callable $getTypeCallback): Type
 	{
-		if (count($expr->items) > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+		if (count($expr->items) > ConstantArrayTypeBuilder::getArrayCountLimit()) {
 			return $this->oversizedArrayBuilder->build($expr, $getTypeCallback);
 		}
 
@@ -1464,7 +1464,7 @@ final class InitializerExprTypeResolver
 		$leftCount = count($leftConstantArrays);
 		$rightCount = count($rightConstantArrays);
 		if ($leftCount > 0 && $rightCount > 0
-			&& ($leftCount + $rightCount < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT)) {
+			&& ($leftCount + $rightCount < ConstantArrayTypeBuilder::getArrayCountLimit())) {
 			$resultTypes = [];
 			foreach ($rightConstantArrays as $rightConstantArray) {
 				foreach ($leftConstantArrays as $leftConstantArray) {

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type\Constant;
 
+use PHPStan\DependencyInjection\ConstantArrayTypeLimitAccessor;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -30,8 +31,16 @@ use function min;
 final class ConstantArrayTypeBuilder
 {
 
+	/**
+	 * @deprecated Use getArrayCountLimit() instead
+	 */
 	public const ARRAY_COUNT_LIMIT = 256;
 	private const CLOSURES_COUNT_LIMIT = 16;
+
+	public static function getArrayCountLimit(): int
+	{
+		return ConstantArrayTypeLimitAccessor::getLimit();
+	}
 
 	private bool $degradeToGeneralArray = false;
 
@@ -70,7 +79,7 @@ final class ConstantArrayTypeBuilder
 			$startArrayType->isList(),
 		);
 
-		if (count($startArrayType->getKeyTypes()) > self::ARRAY_COUNT_LIMIT) {
+		if (count($startArrayType->getKeyTypes()) > self::getArrayCountLimit()) {
 			$builder->degradeToGeneralArray(true);
 		}
 
@@ -147,7 +156,7 @@ final class ConstantArrayTypeBuilder
 					$this->optionalKeys[] = count($this->keyTypes) - 1;
 				}
 
-				if (count($this->keyTypes) > self::ARRAY_COUNT_LIMIT) {
+				if (count($this->keyTypes) > self::getArrayCountLimit()) {
 					$this->degradeToGeneralArray = true;
 					$this->oversized = true;
 				}
@@ -220,7 +229,7 @@ final class ConstantArrayTypeBuilder
 					$this->optionalKeys[] = count($this->keyTypes) - 1;
 				}
 
-				if (count($this->keyTypes) > self::ARRAY_COUNT_LIMIT) {
+				if (count($this->keyTypes) > self::getArrayCountLimit()) {
 					$this->degradeToGeneralArray = true;
 					$this->oversized = true;
 				}
@@ -244,7 +253,7 @@ final class ConstantArrayTypeBuilder
 					}
 				}
 			}
-			if (count($scalarTypes) > 0 && count($scalarTypes) < self::ARRAY_COUNT_LIMIT) {
+			if (count($scalarTypes) > 0 && count($scalarTypes) < self::getArrayCountLimit()) {
 				$match = true;
 				$valueTypes = $this->valueTypes;
 				foreach ($scalarTypes as $scalarType) {

--- a/src/Type/ConstantTypeHelper.php
+++ b/src/Type/ConstantTypeHelper.php
@@ -42,7 +42,7 @@ final class ConstantTypeHelper
 			return new ConstantStringType($value);
 		} elseif (is_array($value)) {
 			$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-			if (count($value) > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+			if (count($value) > ConstantArrayTypeBuilder::getArrayCountLimit()) {
 				$arrayBuilder->degradeToGeneralArray(true);
 			}
 			foreach ($value as $k => $v) {

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -128,7 +128,7 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 			if (count($constantArrays) > 0) {
 				$arrayTypes = [];
 				$totalCount = TypeCombinator::countConstantArrayValueTypes($constantArrays) * TypeCombinator::countConstantArrayValueTypes([$valueType]);
-				if ($totalCount < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+				if ($totalCount < ConstantArrayTypeBuilder::getArrayCountLimit()) {
 					foreach ($constantArrays as $constantArray) {
 						$returnedArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
 						$valueTypes = $constantArray->getValueTypes();

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -904,7 +904,7 @@ final class TypeCombinator
 	{
 		$constantArrayValuesCount = self::countConstantArrayValueTypes($types);
 
-		if ($constantArrayValuesCount <= ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+		if ($constantArrayValuesCount <= ConstantArrayTypeBuilder::getArrayCountLimit()) {
 			return $types;
 		}
 
@@ -991,7 +991,7 @@ final class TypeCombinator
 			$keyType = self::union(...$keyTypes);
 			$valueType = self::union(...$valueTypes);
 
-			if ($valueType instanceof UnionType && count($valueType->getTypes()) > ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
+			if ($valueType instanceof UnionType && count($valueType->getTypes()) > ConstantArrayTypeBuilder::getArrayCountLimit()) {
 				$valueType = $valueType->generalize(GeneralizePrecision::lessSpecific());
 			}
 


### PR DESCRIPTION
🤖 Generated by [Claude Code](https://claude.ai/code)

Fixes https://github.com/phpstan/phpstan/issues/8636 (which has happened on our project too)

## Summary

- Add new configuration parameter `constantArrayTypeBuilderArrayCountLimit` that allows users to customize the array count limit
- Default value remains 256 (current behavior)
- Follow the existing `BleedingEdgeToggle` pattern with a static accessor class
- Keep the original constant for backward compatibility (marked as deprecated)

### Usage

Users can configure the limit in their `phpstan.neon`:

```neon
parameters:
    constantArrayTypeBuilderArrayCountLimit: 512
```

## Test plan

- [x] **Unit tests pass**: `vendor/bin/phpunit tests/PHPStan/Type/Constant/ConstantArrayTypeBuilderTest.php` (7 tests, 41 assertions)
- [x] **Syntax validation**: All modified files pass `php -l` syntax check
- [x] **Manual verification** with test script demonstrating the feature:

```php
<?php
use PHPStan\DependencyInjection\ConstantArrayTypeLimitAccessor;
use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
use PHPStan\Type\Constant\ConstantStringType;

// Build array with 300 elements
$builder = ConstantArrayTypeBuilder::createEmpty();
for ($i = 0; $i < 300; $i++) {
    $builder->setOffsetValueType(new ConstantStringType("key_$i"), new ConstantStringType("value_$i"));
}

// With default limit (256): array is degraded
$type = $builder->getArray();
// Result: PHPStan\Type\IntersectionType (degraded)

// With increased limit (512): array is tracked precisely
ConstantArrayTypeLimitAccessor::setLimit(512);
$builder2 = ConstantArrayTypeBuilder::createEmpty();
for ($i = 0; $i < 300; $i++) {
    $builder2->setOffsetValueType(new ConstantStringType("key_$i"), new ConstantStringType("value_$i"));
}
$type2 = $builder2->getArray();
// Result: PHPStan\Type\Constant\ConstantArrayType with 300 keys (precise)
```

**Test results:**
| Array Size | Limit | Result |
|------------|-------|--------|
| 200 | 256 | ✓ Precise (`ConstantArrayType`) |
| 300 | 256 | ✗ Degraded (`IntersectionType`) |
| 300 | 512 | ✓ Precise (`ConstantArrayType`) |
| 600 | 512 | ✗ Degraded (`IntersectionType`) |