### PR TITLE
Add "consts" to typos dictionary

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,6 +8,8 @@ ignore-hidden = false
 # Known typos
 NonRemoveableTypeTrait = "NonRemoveableTypeTrait"
 supportsLessOverridenParametersWithVariadic = "supportsLessOverridenParametersWithVariadic"
+# API property name
+consts = "consts"
 
 [default.extend-words]
 # override false-positives


### PR DESCRIPTION
The word "consts" is a valid API property name and should not be flagged as a typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)