### PR TITLE
MutatingScope: prevent unnecessary scope re-creation after openssl* calls

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -573,10 +573,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 	public function afterOpenSslCall(string $openSslFunctionName): self
 	{
-		$expressionTypes = $this->expressionTypes;
-		$nativeExpressionTypes = $this->nativeExpressionTypes;
-
-		if (in_array($openSslFunctionName, [
+		if (!in_array($openSslFunctionName, [
 			'openssl_cipher_iv_length',
 			'openssl_cms_decrypt',
 			'openssl_cms_encrypt',
@@ -631,9 +628,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			'openssl_x509_read',
 			'openssl_x509_verify',
 		], true)) {
-			unset($expressionTypes['\openssl_error_string()']);
-			unset($nativeExpressionTypes['\openssl_error_string()']);
+			return $this;
 		}
+
+		$expressionTypes = $this->expressionTypes;
+		$nativeExpressionTypes = $this->nativeExpressionTypes;
+		unset($expressionTypes['\openssl_error_string()']);
+		unset($nativeExpressionTypes['\openssl_error_string()']);
 
 		return $this->scopeFactory->create(
 			$this->context,

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -514,6 +514,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 	public function afterClearstatcacheCall(): self
 	{
+		$changed = false;
+
 		$expressionTypes = $this->expressionTypes;
 		$nativeExpressionTypes = $this->nativeExpressionTypes;
 		foreach (array_keys($expressionTypes) as $exprString) {
@@ -547,8 +549,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 				unset($expressionTypes[$exprString]);
 				unset($nativeExpressionTypes[$exprString]);
+				$changed = true;
 				continue 2;
 			}
+		}
+
+		if (!$changed) {
+			return $this;
 		}
 
 		return $this->scopeFactory->create(
@@ -573,7 +580,19 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 	public function afterOpenSslCall(string $openSslFunctionName): self
 	{
-		if (!in_array($openSslFunctionName, [
+		$expressionTypes = $this->expressionTypes;
+		$nativeExpressionTypes = $this->nativeExpressionTypes;
+
+		$errorStringFunction = '\openssl_error_string()';
+		if (
+			!array_key_exists($errorStringFunction, $expressionTypes)
+			&& !array_key_exists($errorStringFunction, $nativeExpressionTypes)
+		) {
+			return $this;
+		}
+
+		$changed = false;
+		if (in_array($openSslFunctionName, [
 			'openssl_cipher_iv_length',
 			'openssl_cms_decrypt',
 			'openssl_cms_encrypt',
@@ -628,13 +647,14 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			'openssl_x509_read',
 			'openssl_x509_verify',
 		], true)) {
-			return $this;
+			unset($expressionTypes[$errorStringFunction]);
+			unset($nativeExpressionTypes[$errorStringFunction]);
+			$changed = true;
 		}
 
-		$expressionTypes = $this->expressionTypes;
-		$nativeExpressionTypes = $this->nativeExpressionTypes;
-		unset($expressionTypes['\openssl_error_string()']);
-		unset($nativeExpressionTypes['\openssl_error_string()']);
+		if (!$changed) {
+			return $this;
+		}
 
 		return $this->scopeFactory->create(
 			$this->context,


### PR DESCRIPTION
minimize scope re-creating to maximize re-use of resolved expressions (so prevent repetative resolving of the same expressions).

scope re-creation is one of the top 5 calls as is type resolving.

<img width="466" height="300" alt="grafik" src="https://github.com/user-attachments/assets/ef5449b2-57cc-4d31-9ca5-bb84ddbc9024" />
