### PR TITLE
Defer by-ref closure scope modifications after all args are processed

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3493,7 +3493,7 @@ class NodeScopeResolver
 			}
 		} elseif ($expr instanceof Expr\Closure) {
 			$processClosureResult = $this->processClosureNode($stmt, $expr, $scope, $storage, $nodeCallback, $context, null);
-			$scope = $processClosureResult->getScope();
+			$scope = $processClosureResult->applyByRefUseScope($processClosureResult->getScope());
 
 			return new ExpressionResult(
 				$scope,
@@ -5142,7 +5142,7 @@ class NodeScopeResolver
 			array_merge($publicStatementResult->getImpurePoints(), $closureImpurePoints),
 		), $closureScope, $storage);
 
-		return new ProcessClosureResult($scope->processClosureScope($closureResultScope, null, $byRefUses), $statementResult->getThrowPoints(), $statementResult->getImpurePoints(), $invalidateExpressions, $isAlwaysTerminating);
+		return new ProcessClosureResult($scope, $statementResult->getThrowPoints(), $statementResult->getImpurePoints(), $invalidateExpressions, $isAlwaysTerminating, $closureResultScope, $byRefUses);
 	}
 
 	/**
@@ -5551,6 +5551,8 @@ class NodeScopeResolver
 		$isAlwaysTerminating = false;
 		/** @var list<array{InvalidateExprNode[], string[]}> $deferredInvalidateExpressions */
 		$deferredInvalidateExpressions = [];
+		/** @var ProcessClosureResult[] $deferredByRefClosureResults */
+		$deferredByRefClosureResults = [];
 		foreach ($args as $i => $arg) {
 			$assignByReference = false;
 			$parameter = null;
@@ -5662,6 +5664,7 @@ class NodeScopeResolver
 				}
 
 				$scope = $closureResult->getScope();
+				$deferredByRefClosureResults[] = $closureResult;
 				$invalidateExpressions = $closureResult->getInvalidateExpressions();
 				if ($restoreThisScope !== null) {
 					$nodeFinder = new NodeFinder();
@@ -5751,6 +5754,10 @@ class NodeScopeResolver
 
 		foreach ($deferredInvalidateExpressions as [$invalidateExpressions, $uses]) {
 			$scope = $this->processImmediatelyCalledCallable($scope, $invalidateExpressions, $uses);
+		}
+
+		foreach ($deferredByRefClosureResults as $deferredClosureResult) {
+			$scope = $deferredClosureResult->applyByRefUseScope($scope);
 		}
 
 		if ($parameters !== null) {

--- a/src/Analyser/ProcessClosureResult.php
+++ b/src/Analyser/ProcessClosureResult.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser;
 
+use PhpParser\Node\ClosureUse;
 use PHPStan\Node\InvalidateExprNode;
 
 final class ProcessClosureResult
@@ -11,6 +12,7 @@ final class ProcessClosureResult
 	 * @param InternalThrowPoint[] $throwPoints
 	 * @param ImpurePoint[] $impurePoints
 	 * @param InvalidateExprNode[] $invalidateExpressions
+	 * @param ClosureUse[] $byRefUses
 	 */
 	public function __construct(
 		private MutatingScope $scope,
@@ -18,6 +20,8 @@ final class ProcessClosureResult
 		private array $impurePoints,
 		private array $invalidateExpressions,
 		private bool $isAlwaysTerminating,
+		private ?MutatingScope $byRefClosureResultScope = null,
+		private array $byRefUses = [],
 	)
 	{
 	}
@@ -25,6 +29,15 @@ final class ProcessClosureResult
 	public function getScope(): MutatingScope
 	{
 		return $this->scope;
+	}
+
+	public function applyByRefUseScope(MutatingScope $scope): MutatingScope
+	{
+		if ($this->byRefClosureResultScope === null) {
+			return $scope;
+		}
+
+		return $scope->processClosureScope($this->byRefClosureResultScope, null, $this->byRefUses);
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Methods/data/discussion-14038.php
+++ b/tests/PHPStan/Rules/Methods/data/discussion-14038.php
@@ -30,3 +30,21 @@ class HelloWorld
 		);
 	}
 }
+
+class ByRefTest
+{
+	private function foo(callable $c, string $s): void
+	{
+	}
+
+	public function testByRef(): void
+	{
+		$x = 'hello';
+		$this->foo(
+			function() use (&$x): void {
+				$x = 42;
+			},
+			$x,
+		);
+	}
+}


### PR DESCRIPTION
processClosureNode returned a scope with by-ref captured variable modifications already applied. In processArgs, this polluted the scope used for evaluating subsequent arguments - but closures are not called during argument evaluation, so by-ref changes cannot have taken effect yet.

The fix separates the by-ref data (closureResultScope, byRefUses) from the returned scope in ProcessClosureResult and lets callers decide when to apply it. The standalone closure call site applies immediately, while processArgs defers it until after all arguments are processed - same pattern as the existing deferral of processImmediatelyCalledCallable.