### PR TITLE
Stop ignoring offsetAccess.invalidOffset

### DIFF
--- a/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/VersionCompareFunctionDynamicReturnTypeExtension.php
@@ -120,7 +120,7 @@ final class VersionCompareFunctionDynamicReturnTypeExtension implements DynamicF
 						}
 
 						$value = version_compare($version1String->getValue(), $version2String->getValue(), $operatorValue);
-						$types[$value] = new ConstantBooleanType($value); // @phpstan-ignore offsetAccess.invalidOffset
+						$types[(int) $value] = new ConstantBooleanType($value);
 					}
 				} else {
 					$value = version_compare($version1String->getValue(), $version2String->getValue());


### PR DESCRIPTION
In this case we're just using true/false as key, so they can be converted to int safely.