### PR TITLE
Improve claude-easy-fixes workflow with detailed commit messages and PR descriptions

### DIFF
--- a/.github/workflows/claude-easy-fixes.yml
+++ b/.github/workflows/claude-easy-fixes.yml
@@ -199,6 +199,35 @@ jobs:
           6. Update CLAUDE.md with a few concise points about what new you learnt about the codebase
 
           Do not create a branch, push, or create a PR - this will be handled automatically.
+
+          ## Step 5: Write a summary
+
+          After completing the fix, write two files:
+
+          1. /tmp/commit-message.txt - A concise commit message (first line: short summary under 72 chars, then a blank line, then a few bullet points describing key changes). Example:
+             Fix array_key_exists narrowing for template types
+
+             - Added handling for TemplateType in TypeSpecifier when processing array_key_exists
+             - New regression test in tests/PHPStan/Analyser/nsrt/bug-12345.php
+             - The root cause was that TypeSpecifier did not unwrap template bounds before narrowing
+
+          2. /tmp/pr-description.md - A pull request description in this format:
+             ## Summary
+             Brief description of what the issue was about and what the fix does.
+
+             ## Changes
+             - Bullet points of specific code changes made
+             - Reference file paths where changes were made
+
+             ## Root cause
+             Explain why the bug happened and how the fix addresses it.
+
+             ## Test
+             Describe the regression test that was added.
+
+             Fixes phpstan/phpstan#{n}
+
+          These files are critical - they will be used for the commit message and PR description.
           """
 
           with open("/tmp/claude-prompt.txt", "w") as f:
@@ -220,6 +249,29 @@ jobs:
             --dangerously-skip-permissions \
             "$(cat /tmp/claude-prompt.txt)"
 
+      - name: "Read Claude's summary"
+        id: claude-summary
+        run: |
+          if [ -f /tmp/commit-message.txt ]; then
+            {
+              echo "commit_message<<COMMIT_MSG_EOF"
+              cat /tmp/commit-message.txt
+              echo "COMMIT_MSG_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "commit_message=Fix #${{ matrix.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ -f /tmp/pr-description.md ]; then
+            {
+              echo "pr_body<<PR_BODY_EOF"
+              cat /tmp/pr-description.md
+              echo "PR_BODY_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_body=Fixes phpstan/phpstan#${{ matrix.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "Create Pull Request"
         id: create-pr
         uses: peter-evans/create-pull-request@v6
@@ -228,6 +280,6 @@ jobs:
           branch-suffix: random
           delete-branch: true
           title: "Fix #${{ matrix.issue.number }}: ${{ matrix.issue.title }}"
-          body: "Fixes phpstan/phpstan#${{ matrix.issue.number }}"
+          body: ${{ steps.claude-summary.outputs.pr_body }}
           committer: "phpstan-bot <ondrej+phpstanbot@mirtes.cz>"
-          commit-message: "Fix #${{ matrix.issue.number }}"
+          commit-message: ${{ steps.claude-summary.outputs.commit_message }}


### PR DESCRIPTION
- Add Step 5 to Claude's prompt instructing it to write /tmp/commit-message.txt
  and /tmp/pr-description.md with structured summaries of its work
- Add "Read Claude's summary" step to capture the files as GitHub outputs
- Update create-pull-request action to use Claude's commit message and PR body
- Fall back to generic messages if Claude didn't write the summary files

https://claude.ai/code/session_01XNr9Fb7WHp6qfrhYXmXX3v