### PR TITLE
Fix workflow_dispatch issue number being converted to float

### DIFF
--- a/.github/workflows/claude-fix-issue.yml
+++ b/.github/workflows/claude-fix-issue.yml
@@ -6,13 +6,13 @@ on:
       issue-number:
         description: "Issue number from phpstan/phpstan repository"
         required: true
-        type: number
+        type: string
   workflow_call:
     inputs:
       issue-number:
         description: "Issue number from phpstan/phpstan repository"
         required: true
-        type: number
+        type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
Change input type from `number` to `string` for the issue-number input
in both workflow_dispatch and workflow_call triggers. GitHub Actions
treats number inputs as floats, converting "14100" to "14100.0".

https://claude.ai/code/session_013WeBacui19hKNg8a8fKEmD