### PR TITLE
Don't invalidate container cache on user-interactions in the shell

### DIFF
--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -87,20 +87,28 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 		$staticParameters = $this->staticParameters;
 		ksort($staticParameters['env']);
 		unset($staticParameters['env']['_']);
+		// make sure variables which can get defined by the shell
+		// after user-interactions with the UI will not invalidate the container cache
 		unset($staticParameters['env']['SHLVL']);
+		unset($staticParameters['env']['OLDPWD']);
+		unset($staticParameters['env']['LINES']);
+		unset($staticParameters['env']['COLUMNS']);
+		unset($staticParameters['env']['SHELL_VERBOSITY']);
+
+		$containerKey = [
+			$staticParameters,
+			array_keys($this->dynamicParameters),
+			$this->configs,
+			PHP_VERSION_ID - PHP_RELEASE_VERSION,
+			is_file($attributesPhp) ? hash_file('sha256', $attributesPhp) : 'attributes-missing',
+			NeonAdapter::CACHE_KEY,
+			$this->getAllConfigFilesHashes(),
+			var_export(TurboExtensionEnabler::isLoaded(), true),
+		];
 
 		$className = $loader->load(
 			[$this, 'generateContainer'],
-			[
-				$staticParameters,
-				array_keys($this->dynamicParameters),
-				$this->configs,
-				PHP_VERSION_ID - PHP_RELEASE_VERSION,
-				is_file($attributesPhp) ? hash_file('sha256', $attributesPhp) : 'attributes-missing',
-				NeonAdapter::CACHE_KEY,
-				$this->getAllConfigFilesHashes(),
-				var_export(TurboExtensionEnabler::isLoaded(), true),
-			],
+			$containerKey,
 		);
 
 		if ($this->journalContainer) {


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/14072#issuecomment-3901284202

---

ENV variables used for building the container key sometimes change, based on user interactions in the shell.

<img width="1141" height="253" alt="Image" src="https://github.com/user-attachments/assets/2bcc533d-a137-4d35-9c25-99ae0f5639d0" />

it happens after you `cd` between folders and run PHPStan again.

see https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html

> OLDPWD
> The previous working directory as set by the cd builtin.

---

I see another case: the container invalidates as soon as you re-size the shell window, because a ENV var exists which defines the LINES and COLUMNS in the window

<img width="863" height="224" alt="Image" src="https://github.com/user-attachments/assets/d72bb79a-5596-458f-ab3d-9b0021a0b3fc" />

---

while I think this is just a workaround for a more general problem - I see no way atm to find out which ENV vars are relevant for us and which are not