### PR TITLE
Make sure invocations via blackfire use the same container

### DIFF
--- a/src/DependencyInjection/Configurator.php
+++ b/src/DependencyInjection/Configurator.php
@@ -94,6 +94,8 @@ final class Configurator extends \Nette\Bootstrap\Configurator
 		unset($staticParameters['env']['LINES']);
 		unset($staticParameters['env']['COLUMNS']);
 		unset($staticParameters['env']['SHELL_VERBOSITY']);
+		// make sure invocations via blackfire use the same container
+		unset($staticParameters['env']['BLACKFIRE_AGENT_SOCKET']);
 
 		$containerKey = [
 			$staticParameters,


### PR DESCRIPTION
analog https://github.com/phpstan/phpstan-src/pull/4924

refs https://github.com/phpstan/phpstan/issues/14072

blackfire adds a ENV var

<img width="1202" height="304" alt="grafik" src="https://github.com/user-attachments/assets/5d80ad21-7610-4dfe-bc5b-5596939d2b72" />

