### PR TITLE
Filter less expression types

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3956,7 +3956,9 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 			$expr = $expressionTypeHolder->getExpr();
 
-			return $expr instanceof Variable || $expr instanceof VirtualNode;
+			return $expr instanceof Variable
+				|| $expr instanceof FuncCall
+				|| $expr instanceof VirtualNode;
 		};
 
 		$mergedExpressionTypes = array_filter($mergedExpressionTypes, $filter);

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -15,12 +15,19 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 
 	private bool $treatPhpDocTypesAsCertain = true;
 
+	private bool $polluteScopeWithAlwaysIterableForeach = true;
+
 	protected function getRule(): Rule
 	{
 		return new NumberComparisonOperatorsConstantConditionRule(
 			$this->treatPhpDocTypesAsCertain,
 			true,
 		);
+	}
+
+	protected function shouldPolluteScopeWithAlwaysIterableForeach(): bool
+	{
+		return $this->polluteScopeWithAlwaysIterableForeach;
 	}
 
 	public function testBug8277(): void
@@ -267,6 +274,12 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-3387.php'], []);
+	}
+
+	public function testBug13984(): void
+	{
+		$this->polluteScopeWithAlwaysIterableForeach = false;
+		$this->analyse([__DIR__ . '/data/bug-13984.php'], []);
 	}
 
 	public function testBug13874(): void

--- a/tests/PHPStan/Rules/Comparison/data/bug-13984.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13984.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Bug13984;
+
+$list = [
+	'a',
+	'b',
+	'c',
+];
+
+/** @param list<string> $list */
+function acceptList(array $list): bool {
+	if (count($list) < 1) {
+		return false;
+	}
+
+	$compare = ['a', 'b', 'c'];
+
+	foreach($list as $key => $item) {
+		foreach ($compare as $k => $v) {
+			if ($item === $v && $v !== 'a') {
+				unset($list[$key]);
+			}
+		}
+	}
+
+	if (count($list) > 0) {
+		return true;
+	}
+
+	return false;
+}
+
+assert(acceptList($list) === true);


### PR DESCRIPTION
I dunno if this is the famous "hard-to-reproduce bug" you tried to fix @ondrejmirtes
<img width="552" height="389" alt="image" src="https://github.com/user-attachments/assets/3d8a07d0-a634-4107-adbd-2af9adfa3d88" />
since you touched related code https://github.com/phpstan/phpstan-src/commit/f65449b77a1ace469329753cd9ced8e7c632aac0

as markus reported the initial commit introducing the issue as https://github.com/phpstan/phpstan-src/pull/4719
(cf https://github.com/phpstan/phpstan/issues/13984#issuecomment-3778304386)

I looked at every expr class and seems like not filtering FuncCall is solving the issue.

Seems like it 
Fixes https://github.com/phpstan/phpstan/issues/13984