### PR TITLE
Switch agent output from JSON to TOON for ~19% token reduction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"nette/utils": "^3.2.5",
 		"nikic/php-parser": "^5.7.0",
 		"ondram/ci-detector": "^4.0",
+		"shipfastlabs/agent-detector": "^1.0",
 		"ondrejmirtes/better-reflection": "6.65.0.9",
 		"ondrejmirtes/composer-attribute-collector": "^1.1.1",
 		"ondrejmirtes/php-merge": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		"nette/utils": "^3.2.5",
 		"nikic/php-parser": "^5.7.0",
 		"ondram/ci-detector": "^4.0",
+		"helgesverre/toon": "^1.0",
 		"shipfastlabs/agent-detector": "^1.0",
 		"ondrejmirtes/better-reflection": "6.65.0.9",
 		"ondrejmirtes/composer-attribute-collector": "^1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "497c2b3e1f40e830554ddfc28db64bf3",
+    "content-hash": "b5e59905b1e998eeaab3c3ab52d1c959",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -3360,6 +3360,74 @@
                 }
             ],
             "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "shipfastlabs/agent-detector",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shipfastlabs/agent-detector.git",
+                "reference": "4c77d504ea709c570ca0e740c2334add991de244"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shipfastlabs/agent-detector/zipball/4c77d504ea709c570ca0e740c2334add991de244",
+                "reference": "4c77d504ea709c570ca0e740c2334add991de244",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.24.0",
+                "peckphp/peck": "^0.1.3",
+                "pestphp/pest": "^3.8.5|^4.1.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0|^4.0.2",
+                "phpstan/phpstan": "^2.1.26",
+                "rector/rector": "^2.1.7",
+                "symfony/var-dumper": "^7.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pushpak Chahjed",
+                    "email": "pushpak1300@gmail.com"
+                }
+            ],
+            "description": "Detect if code is running in an AI agent or automated development environment",
+            "keywords": [
+                "Agent",
+                "ai",
+                "automation",
+                "claude",
+                "cursor",
+                "detection",
+                "devin",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/shipfastlabs/agent-detector/issues",
+                "source": "https://github.com/shipfastlabs/agent-detector/tree/v1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/pushpak1300",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-12T10:04:52+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5e59905b1e998eeaab3c3ab52d1c959",
+    "content-hash": "6d8bd877d4224b1f6901c6d37d8c47d6",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -527,6 +527,71 @@
                 "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
             },
             "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
+            "name": "helgesverre/toon",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/HelgeSverre/toon-php.git",
+                "reference": "1d6703a0bbe69663099f36db8c76b4930355667a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/HelgeSverre/toon-php/zipball/1d6703a0bbe69663099f36db8c76b4930355667a",
+                "reference": "1d6703a0bbe69663099f36db8c76b4930355667a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.10",
+                "phpbench/phpbench": "^1.4",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "HelgeSverre\\Toon\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Helge Sverre",
+                    "email": "helge.sverre@gmail.com"
+                }
+            ],
+            "description": "Token-Oriented Object Notation - A compact data format for reducing token consumption when sending structured data to LLMs",
+            "keywords": [
+                "ai",
+                "anthropic",
+                "claude",
+                "compression",
+                "cost-reduction",
+                "format",
+                "gpt",
+                "laravel",
+                "llm",
+                "openai",
+                "optimization",
+                "prompt",
+                "serialization",
+                "token"
+            ],
+            "support": {
+                "issues": "https://github.com/HelgeSverre/toon-php/issues",
+                "source": "https://github.com/HelgeSverre/toon-php/tree/v1.4.0"
+            },
+            "time": "2025-11-06T11:37:12+00:00"
         },
         {
             "name": "hoa/compiler",

--- a/conf/services.neon
+++ b/conf/services.neon
@@ -197,6 +197,9 @@ services:
 		arguments:
 			pretty: true
 
+	errorFormatter.toon:
+		class: PHPStan\Command\ErrorFormatter\ToonErrorFormatter
+
 	stubFileTypeMapper:
 		class: PHPStan\Type\FileTypeMapper
 		arguments:

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -242,7 +242,7 @@ final class AnalyseCommand extends Command
 			/** @var AgentDetectedErrorFormatter $agentFormatter */
 			$agentFormatter = $container->getByType(AgentDetectedErrorFormatter::class);
 			if ($agentFormatter->isAgentDetected()) {
-				$errorFormat = 'json';
+				$errorFormat = 'toon';
 			}
 		}
 

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command;
 use OndraM\CiDetector\CiDetector;
 use Override;
 use PHPStan\Analyser\InternalError;
+use PHPStan\Command\ErrorFormatter\AgentDetectedErrorFormatter;
 use PHPStan\Command\ErrorFormatter\BaselineNeonErrorFormatter;
 use PHPStan\Command\ErrorFormatter\BaselinePhpErrorFormatter;
 use PHPStan\Command\ErrorFormatter\ErrorFormatter;
@@ -235,11 +236,20 @@ final class AnalyseCommand extends Command
 			$errorFormat = $inceptionResult->getContainer()->getParameter('errorFormat');
 		}
 
+		$container = $inceptionResult->getContainer();
+
+		if ($errorFormat === null) {
+			/** @var AgentDetectedErrorFormatter $agentFormatter */
+			$agentFormatter = $container->getByType(AgentDetectedErrorFormatter::class);
+			if ($agentFormatter->isAgentDetected()) {
+				$errorFormat = 'json';
+			}
+		}
+
 		if ($errorFormat === null) {
 			$errorFormat = 'table';
 		}
 
-		$container = $inceptionResult->getContainer();
 		$errorFormatterServiceName = sprintf('errorFormatter.%s', $errorFormat);
 		if (!$container->hasService($errorFormatterServiceName)) {
 			$errorOutput->writeLineFormatted(sprintf(

--- a/src/Command/ErrorFormatter/AgentDetectedErrorFormatter.php
+++ b/src/Command/ErrorFormatter/AgentDetectedErrorFormatter.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use AgentDetector\AgentDetector;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+
+/**
+ * @api
+ */
+#[AutowiredService(as: AgentDetectedErrorFormatter::class)]
+final class AgentDetectedErrorFormatter implements ErrorFormatter
+{
+
+	public function __construct(
+		#[AutowiredParameter(ref: '@errorFormatter.json')]
+		private JsonErrorFormatter $jsonErrorFormatter,
+	)
+	{
+	}
+
+	public function isAgentDetected(): bool
+	{
+		return AgentDetector::detect()->isAgent;
+	}
+
+	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+	{
+		return $this->jsonErrorFormatter->formatErrors($analysisResult, $output);
+	}
+
+}

--- a/src/Command/ErrorFormatter/AgentDetectedErrorFormatter.php
+++ b/src/Command/ErrorFormatter/AgentDetectedErrorFormatter.php
@@ -16,8 +16,8 @@ final class AgentDetectedErrorFormatter implements ErrorFormatter
 {
 
 	public function __construct(
-		#[AutowiredParameter(ref: '@errorFormatter.json')]
-		private JsonErrorFormatter $jsonErrorFormatter,
+		#[AutowiredParameter(ref: '@errorFormatter.toon')]
+		private ToonErrorFormatter $toonErrorFormatter,
 	)
 	{
 	}
@@ -29,7 +29,7 @@ final class AgentDetectedErrorFormatter implements ErrorFormatter
 
 	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
 	{
-		return $this->jsonErrorFormatter->formatErrors($analysisResult, $output);
+		return $this->toonErrorFormatter->formatErrors($analysisResult, $output);
 	}
 
 }

--- a/src/Command/ErrorFormatter/ToonErrorFormatter.php
+++ b/src/Command/ErrorFormatter/ToonErrorFormatter.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use HelgeSverre\Toon\Toon;
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use function count;
+
+final class ToonErrorFormatter implements ErrorFormatter
+{
+
+	public function formatErrors(AnalysisResult $analysisResult, Output $output): int
+	{
+		$errorsArray = [
+			'totals' => [
+				'errors' => count($analysisResult->getNotFileSpecificErrors()),
+				'file_errors' => count($analysisResult->getFileSpecificErrors()),
+			],
+			'files' => [],
+			'errors' => [],
+		];
+
+		$tipFormatter = new OutputFormatter(false);
+
+		foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+			$file = $fileSpecificError->getFile();
+			if (!isset($errorsArray['files'][$file])) {
+				$errorsArray['files'][$file] = [
+					'errors' => 0,
+					'messages' => [],
+				];
+			}
+			$errorsArray['files'][$file]['errors']++;
+
+			$message = [
+				'message' => $fileSpecificError->getMessage(),
+				'line' => $fileSpecificError->getLine(),
+				'ignorable' => $fileSpecificError->canBeIgnored(),
+			];
+
+			if ($fileSpecificError->getTip() !== null) {
+				$message['tip'] = $tipFormatter->format($fileSpecificError->getTip());
+			}
+
+			if ($fileSpecificError->getIdentifier() !== null) {
+				$message['identifier'] = $fileSpecificError->getIdentifier();
+			}
+
+			$errorsArray['files'][$file]['messages'][] = $message;
+		}
+
+		foreach ($analysisResult->getNotFileSpecificErrors() as $notFileSpecificError) {
+			$errorsArray['errors'][] = $notFileSpecificError;
+		}
+
+		$toon = Toon::encode($errorsArray);
+
+		$output->writeRaw($toon);
+
+		return $analysisResult->hasErrors() ? 1 : 0;
+	}
+
+}

--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Command;
 
+use AgentDetector\AgentDetector;
 use OndraM\CiDetector\CiDetector;
 use Override;
 use Symfony\Component\Console\Helper\Helper;
@@ -29,6 +30,8 @@ final class ErrorsConsoleStyle extends SymfonyStyle
 
 	private ?bool $isCiDetected = null;
 
+	private ?bool $isAgentDetected = null;
+
 	public function __construct(InputInterface $input, OutputInterface $output)
 	{
 		parent::__construct($input, $output);
@@ -43,6 +46,11 @@ final class ErrorsConsoleStyle extends SymfonyStyle
 		}
 
 		return $this->isCiDetected;
+	}
+
+	private function isAgentDetected(): bool
+	{
+		return $this->isAgentDetected ??= AgentDetector::detect()->isAgent;
 	}
 
 	/**
@@ -95,9 +103,10 @@ final class ErrorsConsoleStyle extends SymfonyStyle
 		}
 
 		$ci = $this->isCiDetected();
-		$this->progressBar->setOverwrite(!$ci);
+		$agent = $this->isAgentDetected();
+		$this->progressBar->setOverwrite(!$ci && !$agent);
 
-		if ($ci) {
+		if ($ci || $agent) {
 			$this->progressBar->minSecondsBetweenRedraws(15);
 			$this->progressBar->maxSecondsBetweenRedraws(30);
 		} elseif (DIRECTORY_SEPARATOR === '\\') {

--- a/tests/PHPStan/Command/ErrorFormatter/AgentDetectedErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/AgentDetectedErrorFormatterTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command\ErrorFormatter;
+
+use Override;
+use PHPStan\Testing\ErrorFormatterTestCase;
+use function putenv;
+
+class AgentDetectedErrorFormatterTest extends ErrorFormatterTestCase
+{
+
+	#[Override]
+	protected function setUp(): void
+	{
+		putenv('AI_AGENT');
+		putenv('CURSOR_TRACE_ID');
+		putenv('CURSOR_AGENT');
+		putenv('GEMINI_CLI');
+		putenv('CODEX_SANDBOX');
+		putenv('AUGMENT_AGENT');
+		putenv('OPENCODE_CLIENT');
+		putenv('OPENCODE');
+		putenv('CLAUDECODE');
+		putenv('CLAUDE_CODE');
+		putenv('REPL_ID');
+	}
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		putenv('AI_AGENT');
+	}
+
+	public function testIsAgentDetectedReturnsFalse(): void
+	{
+		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$this->assertFalse($formatter->isAgentDetected());
+	}
+
+	public function testIsAgentDetectedReturnsTrueWithAiAgent(): void
+	{
+		putenv('AI_AGENT=test');
+		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$this->assertTrue($formatter->isAgentDetected());
+	}
+
+	public function testIsAgentDetectedReturnsTrueWithClaudeCode(): void
+	{
+		putenv('CLAUDE_CODE=1');
+		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$this->assertTrue($formatter->isAgentDetected());
+	}
+
+	public function testFormatErrorsProducesValidJson(): void
+	{
+		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+
+		$exitCode = $formatter->formatErrors(
+			$this->getAnalysisResult(1, 0),
+			$this->getOutput(),
+		);
+
+		$this->assertSame(1, $exitCode);
+		$this->assertJsonStringEqualsJsonString(
+			'{"totals":{"errors":0,"file_errors":1},"files":{"/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with \\"spaces\\" and unicode 😃.php":{"errors":1,"messages":[{"message":"Foo","line":4,"ignorable":true}]}},"errors":[]}',
+			$this->getOutputContent(),
+		);
+	}
+
+	public function testFormatErrorsNoErrors(): void
+	{
+		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+
+		$exitCode = $formatter->formatErrors(
+			$this->getAnalysisResult(0, 0),
+			$this->getOutput(),
+		);
+
+		$this->assertSame(0, $exitCode);
+		$this->assertJsonStringEqualsJsonString(
+			'{"totals":{"errors":0,"file_errors":0},"files":{},"errors":[]}',
+			$this->getOutputContent(),
+		);
+	}
+
+}

--- a/tests/PHPStan/Command/ErrorFormatter/AgentDetectedErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/AgentDetectedErrorFormatterTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Command\ErrorFormatter;
 
+use HelgeSverre\Toon\Toon;
 use Override;
 use PHPStan\Testing\ErrorFormatterTestCase;
 use function putenv;
@@ -33,27 +34,27 @@ class AgentDetectedErrorFormatterTest extends ErrorFormatterTestCase
 
 	public function testIsAgentDetectedReturnsFalse(): void
 	{
-		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$formatter = new AgentDetectedErrorFormatter(new ToonErrorFormatter());
 		$this->assertFalse($formatter->isAgentDetected());
 	}
 
 	public function testIsAgentDetectedReturnsTrueWithAiAgent(): void
 	{
 		putenv('AI_AGENT=test');
-		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$formatter = new AgentDetectedErrorFormatter(new ToonErrorFormatter());
 		$this->assertTrue($formatter->isAgentDetected());
 	}
 
 	public function testIsAgentDetectedReturnsTrueWithClaudeCode(): void
 	{
 		putenv('CLAUDE_CODE=1');
-		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$formatter = new AgentDetectedErrorFormatter(new ToonErrorFormatter());
 		$this->assertTrue($formatter->isAgentDetected());
 	}
 
-	public function testFormatErrorsProducesValidJson(): void
+	public function testFormatErrorsProducesToonOutput(): void
 	{
-		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$formatter = new AgentDetectedErrorFormatter(new ToonErrorFormatter());
 
 		$exitCode = $formatter->formatErrors(
 			$this->getAnalysisResult(1, 0),
@@ -61,15 +62,33 @@ class AgentDetectedErrorFormatterTest extends ErrorFormatterTestCase
 		);
 
 		$this->assertSame(1, $exitCode);
-		$this->assertJsonStringEqualsJsonString(
-			'{"totals":{"errors":0,"file_errors":1},"files":{"/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with \\"spaces\\" and unicode 😃.php":{"errors":1,"messages":[{"message":"Foo","line":4,"ignorable":true}]}},"errors":[]}',
-			$this->getOutputContent(),
-		);
+
+		$expectedData = [
+			'totals' => [
+				'errors' => 0,
+				'file_errors' => 1,
+			],
+			'files' => [
+				'/data/folder/with space/and unicode 😃/project/folder with unicode 😃/file name with "spaces" and unicode 😃.php' => [
+					'errors' => 1,
+					'messages' => [
+						[
+							'message' => 'Foo',
+							'line' => 4,
+							'ignorable' => true,
+						],
+					],
+				],
+			],
+			'errors' => [],
+		];
+
+		$this->assertSame(Toon::encode($expectedData), $this->getOutputContent());
 	}
 
 	public function testFormatErrorsNoErrors(): void
 	{
-		$formatter = new AgentDetectedErrorFormatter(new JsonErrorFormatter(false));
+		$formatter = new AgentDetectedErrorFormatter(new ToonErrorFormatter());
 
 		$exitCode = $formatter->formatErrors(
 			$this->getAnalysisResult(0, 0),
@@ -77,10 +96,17 @@ class AgentDetectedErrorFormatterTest extends ErrorFormatterTestCase
 		);
 
 		$this->assertSame(0, $exitCode);
-		$this->assertJsonStringEqualsJsonString(
-			'{"totals":{"errors":0,"file_errors":0},"files":{},"errors":[]}',
-			$this->getOutputContent(),
-		);
+
+		$expectedData = [
+			'totals' => [
+				'errors' => 0,
+				'file_errors' => 0,
+			],
+			'files' => [],
+			'errors' => [],
+		];
+
+		$this->assertSame(Toon::encode($expectedData), $this->getOutputContent());
 	}
 
 }


### PR DESCRIPTION
This pull request switches the AI agent output format from JSON to [TOON](https://github.com/HelgeSverre/toon-php) (Token-Oriented Object Notation) — a compact, machine-parseable format optimized for LLM contexts.

Follows up on #4938.

**Why:**

TOON saves ~15% tokens compared to JSON while keeping the same data structure fully machine-parseable. It achieves this by declaring field names once as a header (`messages[9]{message,line,ignorable,identifier}:`) and encoding each error as a single comma-separated line — no repeated keys, braces, or brackets per entry.

**Token comparison (9 real errors, measured with `o200k_base` tokenizer):**

| Format | Characters | Tokens | vs JSON |
|--------|-----------|--------|---------|
| table | 2,667 | 379 | -4% |
| json | 1,705 | 394 | baseline |
| **toon** | **1,377** | **334** | **-15%** |

**How detection works:**

1. When Claude Code runs PHPStan, it sets the `CLAUDECODE` / `CLAUDE_CODE` environment variable
2. When Cursor runs PHPStan, it sets `CURSOR_TRACE_ID` / `CURSOR_AGENT`
3. Other agents set their own env vars (`GEMINI_CLI`, `CODEX_SANDBOX`, `AI_AGENT`, `AUGMENT_AGENT`, `OPENCODE`, `REPL_ID`, etc.)
4. PHPStan detects these via `shipfastlabs/agent-detector` and automatically switches to TOON format + suppresses progress bar animations — no flags needed

**What changed:**

1. Added `helgesverre/toon` dependency for TOON encoding
2. Created `ToonErrorFormatter` — builds the same error data structure as `JsonErrorFormatter` but encodes as TOON
3. Agent detection now switches to `toon` format instead of `json`
4. TOON format is also available directly via `--error-format=toon`

**Output:**

```
totals:
  errors: 0
  file_errors: 1
files:
  "/path/to/file.php":
    errors: 1
    messages[1]{message,line,ignorable,identifier}:
      "Error message",10,true,error.id
errors[0]:
```

Explicit `--error-format=table` or config `errorFormat: table` always takes priority over agent detection.

related https://github.com/laravel/pint/pull/415