### PR TITLE
Fix Claude PR reactions workflow: don't cancel in-progress runs, use sticky comment

### DIFF
--- a/.github/workflows/claude-pr-reactions.yml
+++ b/.github/workflows/claude-pr-reactions.yml
@@ -48,4 +48,3 @@ jobs:
           github_token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           trigger_phrase: "@phpstan-bot"
           claude_args: "--model claude-opus-4-6 --max-turns 50"
-          use_sticky_comment: true

--- a/.github/workflows/claude-pr-reactions.yml
+++ b/.github/workflows/claude-pr-reactions.yml
@@ -48,3 +48,5 @@ jobs:
           github_token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           trigger_phrase: "@phpstan-bot"
           claude_args: "--model claude-opus-4-6 --max-turns 50"
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/claude-pr-reactions.yml
+++ b/.github/workflows/claude-pr-reactions.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: claude-pr-reactions-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   react:
@@ -48,3 +48,4 @@ jobs:
           github_token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           trigger_phrase: "@phpstan-bot"
           claude_args: "--model claude-opus-4-6 --max-turns 50"
+          use_sticky_comment: true


### PR DESCRIPTION
- cancel-in-progress: false — prevents a new comment from killing an
  in-progress Claude run on the same PR
- use_sticky_comment: true — reuses a single comment instead of creating
  a new one each time, reducing noise

https://claude.ai/code/session_01BR4nrqzgpFAMjFJBkmrryy