### PR TITLE
Remove --max-turns 50 from Claude PR reactions workflow

### DIFF
--- a/.github/workflows/claude-pr-reactions.yml
+++ b/.github/workflows/claude-pr-reactions.yml
@@ -47,4 +47,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.PHPSTAN_BOT_TOKEN }}
           trigger_phrase: "@phpstan-bot"
-          claude_args: "--model claude-opus-4-6 --max-turns 50"
+          claude_args: "--model claude-opus-4-6"


### PR DESCRIPTION
The CI failure was caused by the Claude agent exhausting its 50-turn
limit while iterating on test failures. Removing the cap lets the
agent use its default turn budget.

https://claude.ai/code/session_01QmkkMmUZa6d1AiKyhoJK8S