### PR TITLE
Split claude react-on-comment into two jobs to avoid expensive setup

### DIFF
--- a/.github/workflows/claude-react-on-comment.yml
+++ b/.github/workflows/claude-react-on-comment.yml
@@ -19,8 +19,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-trigger:
+    name: "Check trigger phrase"
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      triggered: ${{ steps.check.outputs.triggered }}
+    steps:
+      - name: "Check for trigger phrase"
+        id: check
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || '' }}
+        run: |
+          if echo "$COMMENT_BODY" | grep -qF "@phpstan-bot"; then
+            echo "triggered=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "triggered=false" >> "$GITHUB_OUTPUT"
+          fi
+
   react:
     name: "React on comment"
+    needs: check-trigger
+    if: needs.check-trigger.outputs.triggered == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
 


### PR DESCRIPTION
Add a lightweight check-trigger job on ubuntu-latest that checks if the
comment contains the @phpstan-bot trigger phrase. The expensive react job
(setup-php, composer install on blacksmith runner) only runs when the
trigger phrase is actually present.

https://claude.ai/code/session_01T86RqyQoZyKWyG4MUnf7FC