### PR TITLE
Fix BcMath\Number increment/decrement

### DIFF
--- a/src/Rules/Operators/InvalidIncDecOperationRule.php
+++ b/src/Rules/Operators/InvalidIncDecOperationRule.php
@@ -132,6 +132,10 @@ final class InvalidIncDecOperationRule implements Rule
 			$deprecatedBool = true;
 		}
 
+		if ($this->phpVersion->supportsBcMathNumberOperatorOverloading()) {
+			$allowedTypes[] = new ObjectType('BcMath\Number');
+		}
+
 		$allowedTypes = new UnionType($allowedTypes);
 
 		$varType = $this->ruleLevelHelper->findTypeToCheck(

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -405,4 +405,12 @@ class Foo
 			assertType('bool', $a or $b);
 		}
 	}
+
+	public function bcIncDec(Number $a): void
+	{
+		assertType('BcMath\Number', ++$a);
+		assertType('BcMath\Number', $a++);
+		assertType('BcMath\Number', --$a);
+		assertType('BcMath\Number', $a--);
+	}
 }

--- a/tests/PHPStan/Rules/Operators/InvalidIncDecOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidIncDecOperationRuleTest.php
@@ -234,4 +234,10 @@ class InvalidIncDecOperationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/inc-non-numeric-string.php'], $errors);
 	}
 
+	#[RequiresPhp('>= 8.4')]
+	public function testBcMathNumber(): void
+	{
+		$this->analyse([__DIR__ . '/data/inc-dec-bcmath-number.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/inc-dec-bcmath-number.php
+++ b/tests/PHPStan/Rules/Operators/data/inc-dec-bcmath-number.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace IncDecBcMathNumber;
+
+use BcMath\Number;
+
+function testPreInc(Number $x): void {
+	++$x;
+}
+
+function testPostInc(Number $x): void {
+	$x++;
+}
+
+function testPreDec(Number $x): void {
+	--$x;
+}
+
+function testPostDec(Number $x): void {
+	$x--;
+}


### PR DESCRIPTION
Partial fix for https://github.com/phpstan/phpstan/issues/13965

This adds support for BcMath\Number increment/decrement operations on PHP >= 8.4.

```
php > $x = new BcMath\Number('3.14');
php > print $x;
3.14
php > $x++;
php > print $x;
4.14
```