### PR TITLE
Fix BcMath\Number unary plus/minus/bitwise-not

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -993,6 +993,10 @@ final class InitializerExprTypeResolver
 			return $this->getNeverType($leftType, $rightType);
 		}
 
+		if ((new ObjectType('BcMath\Number'))->isSuperTypeOf($leftType)->yes()) {
+			return new ErrorType();
+		}
+
 		$result = $this->getFiniteOrConstantScalarTypes($leftType, $rightType, static fn ($a, $b) => $a & $b);
 		if ($result instanceof Type) {
 			return $result;
@@ -1049,6 +1053,10 @@ final class InitializerExprTypeResolver
 	{
 		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
 			return $this->getNeverType($leftType, $rightType);
+		}
+
+		if ((new ObjectType('BcMath\Number'))->isSuperTypeOf($leftType)->yes()) {
+			return new ErrorType();
 		}
 
 		$result = $this->getFiniteOrConstantScalarTypes($leftType, $rightType, static fn ($a, $b) => $a | $b);
@@ -1157,6 +1165,10 @@ final class InitializerExprTypeResolver
 	{
 		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
 			return $this->getNeverType($leftType, $rightType);
+		}
+
+		if ((new ObjectType('BcMath\Number'))->isSuperTypeOf($leftType)->yes()) {
+			return new ErrorType();
 		}
 
 		$result = $this->getFiniteOrConstantScalarTypes($leftType, $rightType, static fn ($a, $b) => $a ^ $b);
@@ -1765,6 +1777,10 @@ final class InitializerExprTypeResolver
 			return $this->getNeverType($leftType, $rightType);
 		}
 
+		if ((new ObjectType('BcMath\Number'))->isSuperTypeOf($leftType)->yes()) {
+			return new ErrorType();
+		}
+
 		$leftTypes = $leftType->getConstantScalarTypes();
 		$rightTypes = $rightType->getConstantScalarTypes();
 		$leftTypesCount = count($leftTypes);
@@ -1827,6 +1843,10 @@ final class InitializerExprTypeResolver
 	{
 		if ($leftType instanceof NeverType || $rightType instanceof NeverType) {
 			return $this->getNeverType($leftType, $rightType);
+		}
+
+		if ((new ObjectType('BcMath\Number'))->isSuperTypeOf($leftType)->yes()) {
+			return new ErrorType();
 		}
 
 		$leftTypes = $leftType->getConstantScalarTypes();

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -762,6 +762,10 @@ class ObjectType implements TypeWithClassName, SubtractableType
 			]);
 		}
 
+		if ($this->isInstanceOf('BcMath\Number')->yes()) {
+			return new ObjectType('BcMath\Number');
+		}
+
 		return new ErrorType();
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bcmath-number.php
+++ b/tests/PHPStan/Analyser/nsrt/bcmath-number.php
@@ -380,9 +380,9 @@ class Foo
 	{
 		for ($b = 1; $b < count([]); $b++) {
 			assertType('*NEVER*', $a + $b);
-			assertType('*ERROR*', $a - $b); // Inconsistency: getPlusType handles never types right at the beginning, getMinusType doesn't.
-			assertType('*ERROR*', $a * $b);
-			assertType('*ERROR*', $a / $b);
+			assertType('*NEVER*', $a - $b);
+			assertType('*NEVER*', $a * $b);
+			assertType('*NEVER*', $a / $b);
 			assertType('*NEVER*', $a % $b);
 			assertType('non-empty-string&numeric-string', $a . $b);
 			assertType('*ERROR*', $a ** $b);
@@ -412,5 +412,12 @@ class Foo
 		assertType('BcMath\Number', $a++);
 		assertType('BcMath\Number', --$a);
 		assertType('BcMath\Number', $a--);
+	}
+
+	public function bcUnaryOp(Number $a): void
+	{
+		assertType('BcMath\Number', +$a);
+		assertType('BcMath\Number', -$a);
+		assertType('*ERROR*', ~$a);
 	}
 }

--- a/tests/PHPStan/Rules/Operators/InvalidUnaryOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidUnaryOperationRuleTest.php
@@ -169,4 +169,15 @@ class InvalidUnaryOperationRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.4')]
+	public function testBcMathNumber(): void
+	{
+		$this->analyse([__DIR__ . '/data/unary-bcmath-number.php'], [
+			[
+				'Unary operation "~" on BcMath\Number results in an error.',
+				16,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/unary-bcmath-number.php
+++ b/tests/PHPStan/Rules/Operators/data/unary-bcmath-number.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BcMathNumberUnaryOperators;
+
+use BcMath\Number;
+
+function testUnaryPlus(Number $x): void {
+	+$x;
+}
+
+function testUnaryMinus(Number $x): void {
+	-$x;
+}
+
+function testBitwiseNot(Number $x): void {
+	~$x;
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/13965

Returning `ObjectType('BcMath\Number')` from `toNumber()` fixed `+$x` and `-$x` but caused other tests to fail in these operations (https://github.com/phpstan/phpstan-src/blob/2.1.x/tests/PHPStan/Analyser/nsrt/bcmath-number.php)

* `$a & $b`
* `$a | $b`
* `$a ^ $b`
* `$a << $b`
* `$a >> $b`
 
This is fixed by checking for `BcMath\Number` early and returning `ErrorType` before calling `toNumber()` when handling those bitwise operations (`getBitwiseAndTypeFromTypes()` etc.)

I'm not sure if the `*ERROR*` -> `*NEVER*` changes in tests fix something or break something?