### PR TITLE
Fix isset() falsey branch not narrowing array type for dim fetches

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -87,7 +87,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 4
+			count: 5
 			path: src/Analyser/TypeSpecifier.php
 
 		-

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -929,19 +929,20 @@ final class TypeSpecifier
 						$dimType = $scope->getType($issetExpr->dim);
 
 						if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
-							$types = $varType instanceof UnionType ? $varType->getTypes() : [$varType];
+							$constantArrays = $varType->getConstantArrays();
 							$typesToRemove = [];
-							foreach ($types as $innerType) {
-								$hasOffset = $innerType->hasOffsetValueType($dimType);
-								if (!$hasOffset->yes() || !$innerType->getOffsetValueType($dimType)->isNull()->no()) {
+							foreach ($constantArrays as $constantArray) {
+								$hasOffset = $constantArray->hasOffsetValueType($dimType);
+								if (!$hasOffset->yes() || !$constantArray->getOffsetValueType($dimType)->isNull()->no()) {
 									continue;
 								}
 
-								$typesToRemove[] = $innerType;
+								$typesToRemove[] = $constantArray;
 							}
 
 							if ($typesToRemove !== []) {
 								$typeToRemove = TypeCombinator::union(...$typesToRemove);
+
 								$result = $this->create(
 									$issetExpr->var,
 									$typeToRemove,

--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -920,6 +920,52 @@ final class TypeSpecifier
 					return $exprType;
 				}
 
+				if (
+					$issetExpr instanceof ArrayDimFetch
+					&& $issetExpr->dim !== null
+				) {
+					$varType = $scope->getType($issetExpr->var);
+					if (!$varType instanceof MixedType) {
+						$dimType = $scope->getType($issetExpr->dim);
+
+						if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
+							$types = $varType instanceof UnionType ? $varType->getTypes() : [$varType];
+							$typesToRemove = [];
+							foreach ($types as $innerType) {
+								$hasOffset = $innerType->hasOffsetValueType($dimType);
+								if (!$hasOffset->yes() || !$innerType->getOffsetValueType($dimType)->isNull()->no()) {
+									continue;
+								}
+
+								$typesToRemove[] = $innerType;
+							}
+
+							if ($typesToRemove !== []) {
+								$typeToRemove = TypeCombinator::union(...$typesToRemove);
+								$result = $this->create(
+									$issetExpr->var,
+									$typeToRemove,
+									TypeSpecifierContext::createFalse(),
+									$scope,
+								)->setRootExpr($expr);
+
+								if ($scope->hasExpressionType($issetExpr->var)->maybe()) {
+									$result = $result->unionWith(
+										$this->create(
+											new IssetExpr($issetExpr->var),
+											new NullType(),
+											TypeSpecifierContext::createTruthy(),
+											$scope,
+										)->setRootExpr($expr),
+									);
+								}
+
+								return $result;
+							}
+						}
+					}
+				}
+
 				return new SpecifiedTypes();
 			}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-10544.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10544.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10544;
+
+use function PHPStan\Testing\assertType;
+
+class Boo {
+	/**
+	 * @param array{check1:bool,boo:string}|array{check2:bool,foo:string} $param
+	 */
+	public function foo(array $param): string {
+		if (isset($param['check1'])) {
+			assertType('array{check1: bool, boo: string}', $param);
+			return $param['boo'];
+		}
+		assertType('array{check2: bool, foo: string}', $param);
+		return $param['foo'];
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12401.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12401.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12401;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array{a: string, b: string}|array{c: string} $data
+ */
+function test(array $data): void {
+	if (isset($data['a'])) {
+		assertType('array{a: string, b: string}', $data);
+	} else {
+		assertType('array{c: string}', $data);
+	}
+
+	if (isset($data['a'])) {
+		assertType('array{a: string, b: string}', $data);
+	} elseif (isset($data['c'])) {
+		assertType('array{c: string}', $data);
+	} else {
+		assertType('*NEVER*', $data);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-5128.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-5128.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace Bug5128;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array{a: string}|array{b: string} $array
+ */
+function a(array $array): string {
+	if (isset($array['a'])) {
+		assertType('array{a: string}', $array);
+		return $array['a'];
+	}
+
+	assertType('array{b: string}', $array);
+	return $array['b'];
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-8724.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-8724.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8724;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @phpstan-type NumberFilterStructure array{
+ *      type: 'equals'|'notEqual'|'lessThan'|'lessThanOrEqual'|'greaterThan'|'greaterThanOrEqual'|'inRange'|'blank'|'notBlank',
+ * }
+ * @phpstan-type CombinedNumberFilterStructure array{
+ *      operator: 'AND'|'OR'
+ * }
+ */
+class HelloWorld
+{
+	/** @param NumberFilterStructure|CombinedNumberFilterStructure $filter */
+	public function test(array $filter): void
+	{
+		if (isset($filter['operator'])) {
+			assertType("array{operator: 'AND'|'OR'}", $filter);
+			return;
+		}
+
+		assertType("array{type: 'blank'|'equals'|'greaterThan'|'greaterThanOrEqual'|'inRange'|'lessThan'|'lessThanOrEqual'|'notBlank'|'notEqual'}", $filter);
+		echo $filter['type'];
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-9908.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9908.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9908;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function test(): void
+	{
+		$a = [];
+		if (rand() % 2) {
+			$a = ['bar' => 'string'];
+		}
+
+		if (isset($a['bar'])) {
+			$a['bar'] = 1;
+		}
+
+		assertType("array{}|array{bar: 1}", $a);
+	}
+
+	/**
+	 * @param array{bar?: int} $foo
+	 */
+	public function sayHello(array $foo): void
+	{
+		echo 'Hello' . print_r($foo, true);
+	}
+
+	public function test2(): void
+	{
+		$a = [];
+		if (rand() % 2) {
+			$a = ['bar' => 'string'];
+		}
+
+		if (isset($a['bar'])) {
+			$a['bar'] = 1;
+		}
+
+		$this->sayHello($a);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-9908.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9908.php
@@ -41,4 +41,17 @@ class HelloWorld
 
 		$this->sayHello($a);
 	}
+
+	/**
+	 * @param array{a: string, b: string}|array{a: string|null, c: string}|array{a?: string, d: string} $a
+	 */
+	public function moreTests($a): void
+	{
+		if (isset($a['a'])) {
+			assertType("array{a: string, b: string}|array{a: string, c: string}|array{a: string, d: string}", $a);
+		} else {
+			// Could be "array{a: null, c: string}|array{d: string}"
+			assertType("array{a: string|null, c: string}|array{a?: string, d: string}", $a);
+		}
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/tagged-unions.php
+++ b/tests/PHPStan/Analyser/nsrt/tagged-unions.php
@@ -55,7 +55,7 @@ class Foo
 		if (isset($foo['C'])) {
 			assertType("array{A: string, C: 1}", $foo);
 		} else {
-			assertType("array{A: int, B: 1}|array{A: string, C: 1}", $foo); // could be array{A: int, B: 1}
+			assertType("array{A: int, B: 1}", $foo);
 		}
 
 		assertType('array{A: int, B: 1}|array{A: string, C: 1}', $foo);


### PR DESCRIPTION
## Summary
When using `isset($a['key'])` on a union type array, the falsey branch did not narrow the array variable's type. This caused the original union members to leak through after the if-block, even though they were handled by the truthy branch.

For example:
```php
$a = [];
if (rand() % 2) {
    $a = ['bar' => 'string'];
}
// $a: array{}|array{bar: 'string'}

if (isset($a['bar'])) {
    $a['bar'] = 1;
}
// Expected: array{}|array{bar: 1}
// Actual:   array{}|array{bar: 'string'}|array{bar: 1}
```

The `array{bar: 'string'}` type leaked through because the falsey branch of `isset` for `ArrayDimFetch` expressions returned empty `SpecifiedTypes()`, leaving the array variable's type unchanged. When merged with the truthy branch result, the old type persisted.

## Changes
- `src/Analyser/TypeSpecifier.php`: In the falsey `isset` handler for non-variable expressions, added narrowing logic for `ArrayDimFetch` with constant string/integer dims. The logic iterates over union members of the array variable and removes those where the offset is definitely present (`hasOffsetValueType().yes()`) and the value is definitely non-null (`getOffsetValueType().isNull().no()`). When the array variable has uncertain existence (`maybe` certainty), an `IssetExpr` specification is included to preserve the `maybe` certainty.
- `tests/PHPStan/Analyser/nsrt/bug-9908.php`: New regression test reproducing the original issue.
- `tests/PHPStan/Analyser/nsrt/tagged-unions.php`: Updated test expectation at line 58 to reflect the improved narrowing precision — `!isset($foo['C'])` now correctly excludes the `array{A: string, C: 1}` member that definitely has key `C` with a non-null value.
- `phpstan-baseline.neon`: Updated `instanceof ConstantStringType` count for `TypeSpecifier.php` (4→5).

## Root cause
The `TypeSpecifier::specifyTypesInCondition` method's falsey `isset` handler had a code path for non-variable `ArrayDimFetch` expressions (line ~923) that returned empty `SpecifiedTypes()` when the offset value was not nullable and the isset check result was uncertain. This meant the array variable received no type narrowing in the falsey branch, causing its original type (including members where isset would be true) to persist and leak through during scope merging after the if-block.

The fix carefully avoids two pitfalls:
1. Using `HasOffsetType` removal directly (via `TypeCombinator::remove`) would be too aggressive for optional keys, where `tryRemove` unsets the offset entirely.
2. Any type narrowing through `SpecifiedTypes` sets variable certainty to `yes`, which would be wrong when the variable might not be defined. The fix uses `IssetExpr` to restore `maybe` certainty when needed.

## Test
The regression test `tests/PHPStan/Analyser/nsrt/bug-9908.php` includes:
- `test()`: Asserts that after `isset($a['bar'])` + `$a['bar'] = 1`, the type is `array{}|array{bar: 1}` (not including the original `array{bar: 'string'}`)
- `test2()`: Verifies the same code passes when used as an argument to a method expecting `array{bar?: int}`

Fixes phpstan/phpstan#9908

Closes phpstan/phpstan#10544
Closes phpstan/phpstan#8724
Closes phpstan/phpstan#5128
Closes phpstan/phpstan#12401