### PR TITLE
Fix test lint-comment

### DIFF
--- a/.claude/skills/regression-test/SKILL.md
+++ b/.claude/skills/regression-test/SKILL.md
@@ -49,7 +49,9 @@ Use when the bug is about **wrong inferred type, missing type narrowing, or inco
 Example (`tests/PHPStan/Analyser/nsrt/bug-12875.php`):
 
 ```php
-<?php declare(strict_types = 1); // lint >= 8.0
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug12875;
 

--- a/.github/workflows/tests-levels-matrix.php
+++ b/.github/workflows/tests-levels-matrix.php
@@ -2,9 +2,15 @@
 
 shell_exec('php vendor/bin/phpunit --group levels --list-tests-xml test-list.xml');
 
+libxml_use_internal_errors(true);
 $simpleXml = simplexml_load_file('test-list.xml');
 if ($simpleXml === false) {
-	throw new RuntimeException('Error loading test-list.xml');
+	$errors = [];
+	foreach (libxml_get_errors() as $error) {
+		$errors[] = $error->message;
+	}
+
+	throw new RuntimeException('Error loading test-list.xml: ' . implode(', ', $errors));
 }
 
 $testFilters = [];

--- a/.github/workflows/tests-levels-matrix.php
+++ b/.github/workflows/tests-levels-matrix.php
@@ -1,6 +1,9 @@
 <?php declare(strict_types = 1);
 
-shell_exec('php vendor/bin/phpunit --group levels --list-tests-xml test-list.xml');
+exec('php vendor/bin/phpunit --group levels --list-tests-xml test-list.xml', $output, $return);
+if ($return !== 0) {
+	throw new RuntimeException(implode("\n", $output));
+}
 
 libxml_use_internal_errors(true);
 $simpleXml = simplexml_load_file('test-list.xml');

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -474,7 +474,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			if (preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m) === 1) {
 				return version_compare(PHP_VERSION, $m[2], $m[1]) === false;
 			} elseif (str_contains($firstLine, 'lint')) {
-				throw new LogicException(sprintf('// lint comment must immediately follow the php starting tag in %s', $file));
+				throw new LogicException(sprintf("'// lint' comment must immediately follow the php starting tag in %s on line 1", $file));
 			}
 		}
 

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Testing;
 
+use LogicException;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
@@ -432,8 +433,12 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 		$files = [];
 		foreach ($finder->files()->name('*.php')->in($directory) as $fileInfo) {
 			$path = $fileInfo->getPathname();
-			if (self::isFileLintSkipped($path)) {
-				continue;
+			try {
+				if (self::isFileLintSkipped($path)) {
+					continue;
+				}
+			} catch (LogicException $e) {
+				self::fail($e->getMessage());
 			}
 			$files[] = $path;
 		}
@@ -467,6 +472,8 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 
 			if (preg_match('~<?php\\s*\\/\\/\s*lint\s*([^\d\s]+)\s*([^\s]+)\s*~i', $firstLine, $m) === 1) {
 				return version_compare(PHP_VERSION, $m[2], $m[1]) === false;
+			} elseif (str_contains($firstLine, 'lint')) {
+				throw new LogicException(sprintf('// lint comment must immediately follow the php starting tag in %s', $file));
 			}
 		}
 

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -45,6 +45,7 @@ use function is_dir;
 use function is_string;
 use function preg_match;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function stripos;
 use function strtolower;

--- a/tests/PHPStan/Analyser/nsrt/bug-11472.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11472.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 declare(strict_types = 1);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11472.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11472.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.0
+<?php // lint >= 8.1
 
 declare(strict_types = 1);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11472.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11472.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.1
+<?php
 
 declare(strict_types = 1);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11472.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11472.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1); // lint >= 8.1
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
 
 namespace Bug11472;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12866.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12866.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1); // lint >= 8.0
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug12866;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12875.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12875.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1); // lint >= 8.0
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
 
 namespace Bug12875a;
 


### PR DESCRIPTION
fix existing tests and claude instructions.

added a exception when the first line contains the `lint`-substring but at the wrong position