### PR TITLE
claude-ci-fix: use cross repo issue identifier

### DIFF
--- a/.github/workflows/claude-fix-issue.yml
+++ b/.github/workflows/claude-fix-issue.yml
@@ -87,7 +87,7 @@ jobs:
           prompt = f"""You are working on phpstan/phpstan-src, the source code of PHPStan - a PHP static analysis tool.
 
           Your task is to fix the following GitHub issue from the phpstan/phpstan repository:
-          Issue #{n}: {title}
+          Issue phpstan/phpstan#{n}: {title}
           URL: {url}
 
           Issue body:


### PR DESCRIPTION
will hopefully fix wrong issue urls in PR titles

<img width="335" height="765" alt="grafik" src="https://github.com/user-attachments/assets/7bb5cf98-e11d-42d1-845e-54833bb434c6" />

---

correct: `https://github.com/phpstan/phpstan/issues/11463`
wrong: `https://github.com/phpstan/phpstan-src/issues/11463`