### PR TITLE
Fix #14124: Reassigning to `array<string, list<T>>` out parameter does not see the `list<T>` property during assignment

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6627,7 +6627,7 @@ class NodeScopeResolver
 			}
 
 			if ($var instanceof Variable && is_string($var->name)) {
-				$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, new TypeExpr($valueToWrite)), $scope, $storage);
+				$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, $assignedPropertyExpr), $scope, $storage);
 				$scope = $scope->assignVariable($var->name, $valueToWrite, $nativeValueToWrite, TrinaryLogic::createYes());
 			} else {
 				if ($var instanceof PropertyFetch || $var instanceof StaticPropertyFetch) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6314,7 +6314,7 @@ class NodeScopeResolver
 				}
 			} else {
 				if ($var instanceof Variable) {
-					$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, new TypeExpr($valueToWrite)), $scopeBeforeAssignEval, $storage);
+					$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, $assignedPropertyExpr), $scopeBeforeAssignEval, $storage);
 				} elseif ($var instanceof PropertyFetch || $var instanceof StaticPropertyFetch) {
 					$this->callNodeCallback($nodeCallback, new PropertyAssignNode($var, $assignedPropertyExpr, $isAssignOp), $scopeBeforeAssignEval, $storage);
 					if ($var instanceof PropertyFetch && $var->name instanceof Node\Identifier && !$isAssignOp) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6627,7 +6627,7 @@ class NodeScopeResolver
 			}
 
 			if ($var instanceof Variable && is_string($var->name)) {
-				$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, $assignedPropertyExpr), $scope, $storage);
+				$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, new TypeExpr($valueToWrite)), $scope, $storage);
 				$scope = $scope->assignVariable($var->name, $valueToWrite, $nativeValueToWrite, TrinaryLogic::createYes());
 			} else {
 				if ($var instanceof PropertyFetch || $var instanceof StaticPropertyFetch) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6297,7 +6297,7 @@ class NodeScopeResolver
 
 			if ($varType->isArray()->yes() || !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->yes()) {
 				if ($var instanceof Variable && is_string($var->name)) {
-					$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, $assignedPropertyExpr), $scopeBeforeAssignEval, $storage);
+					$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, new TypeExpr($valueToWrite)), $scopeBeforeAssignEval, $storage);
 					$scope = $scope->assignVariable($var->name, $valueToWrite, $nativeValueToWrite, TrinaryLogic::createYes());
 				} else {
 					if ($var instanceof PropertyFetch || $var instanceof StaticPropertyFetch) {
@@ -6314,7 +6314,7 @@ class NodeScopeResolver
 				}
 			} else {
 				if ($var instanceof Variable) {
-					$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, $assignedPropertyExpr), $scopeBeforeAssignEval, $storage);
+					$this->callNodeCallback($nodeCallback, new VariableAssignNode($var, new TypeExpr($valueToWrite)), $scopeBeforeAssignEval, $storage);
 				} elseif ($var instanceof PropertyFetch || $var instanceof StaticPropertyFetch) {
 					$this->callNodeCallback($nodeCallback, new PropertyAssignNode($var, $assignedPropertyExpr, $isAssignOp), $scopeBeforeAssignEval, $storage);
 					if ($var instanceof PropertyFetch && $var->name instanceof Node\Identifier && !$isAssignOp) {

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -253,6 +253,8 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield __DIR__ . '/../Rules/Arrays/data/narrow-superglobal.php';
 		yield __DIR__ . '/../Rules/Methods/data/bug-12927.php';
 		yield __DIR__ . '/../Rules/Properties/data/bug-14012.php';
+		yield __DIR__ . '/../Rules/Variables/data/bug-14124.php';
+		yield __DIR__ . '/../Rules/Variables/data/bug-14124b.php';
 	}
 
 	/**

--- a/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
@@ -81,4 +81,9 @@ class ParameterOutAssignedTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12754.php'], []);
 	}
 
+	public function testBug14124(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14124.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/ParameterOutAssignedTypeRuleTest.php
@@ -86,4 +86,9 @@ class ParameterOutAssignedTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14124.php'], []);
 	}
 
+	public function testBug14124b(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14124b.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-14124.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-14124.php
@@ -2,6 +2,8 @@
 
 namespace Bug14124;
 
+use function PHPStan\Testing\assertType;
+
 /**
  * @param array<string, list<string>> $convert
  * @param-out array<string, list<string>> $convert
@@ -13,6 +15,7 @@ function example3a(array &$convert): void
 			$val = strtoupper($val);
 		}
 	}
+	assertType('array<string, list<string>>', $convert);
 }
 
 /**
@@ -26,4 +29,5 @@ function example3b(array &$convert): void
 			$convert[$outerKey][$key] = strtoupper($val);
 		}
 	}
+	assertType('array<string, list<string>>', $convert);
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-14124.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-14124.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Bug14124;
+
+/**
+ * @param array<string, list<string>> $convert
+ * @param-out array<string, list<string>> $convert
+ */
+function example3a(array &$convert): void
+{
+	foreach ($convert as &$inner) {
+		foreach ($inner as &$val) {
+			$val = strtoupper($val);
+		}
+	}
+}
+
+/**
+ * @param array<string, list<string>> $convert
+ * @param-out array<string, list<string>> $convert
+ */
+function example3b(array &$convert): void
+{
+	foreach ($convert as $outerKey => $inner) {
+		foreach ($inner as $key => $val) {
+			$convert[$outerKey][$key] = strtoupper($val);
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Variables/data/bug-14124b.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-14124b.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Bug14124b;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param array<string, list<list<string>>> $convert
+ * @param-out array<string, list<list<string>>> $convert
+ */
+function example3a(array &$convert): void
+{
+	foreach ($convert as &$inner) {
+		foreach ($inner as &$val) {
+			foreach ($val as &$val2) {
+				$val2 = strtoupper($val2);
+			}
+		}
+	}
+	assertType('array<string, list<list<string>>>', $convert);
+}
+
+/**
+ * @param array<string, list<list<string>>> $convert
+ * @param-out array<string, list<list<string>>> $convert
+ */
+function example3b(array &$convert): void
+{
+	foreach ($convert as $outerKey => $inner) {
+		foreach ($inner as $key => $val) {
+			foreach ($val as $key2 => $val2) {
+				$convert[$outerKey][$key][$key2] = strtoupper($val);
+			}
+		}
+	}
+	assertType('array<string, list<list<string>>>', $convert);
+}


### PR DESCRIPTION
inspired by https://github.com/phpstan/phpstan-src/pull/4999

Fixes phpstan/phpstan#14124