### PR TITLE
Fix stub @param types not applied inside method bodies (regression since 2.1.38)

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -137,6 +137,7 @@ use PHPStan\Parser\ReversePipeTransformerVisitor;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\PhpDoc\Tag\VarTag;
 use PHPStan\Reflection\Assertions;
 use PHPStan\Reflection\Callables\CallableParametersAcceptor;
@@ -267,6 +268,7 @@ class NodeScopeResolver
 		#[AutowiredParameter(ref: '@defaultAnalysisParser')]
 		private readonly Parser $parser,
 		private readonly FileTypeMapper $fileTypeMapper,
+		private readonly StubPhpDocProvider $stubPhpDocProvider,
 		private readonly PhpVersion $phpVersion,
 		private readonly PhpDocInheritanceResolver $phpDocInheritanceResolver,
 		private readonly FileHelper $fileHelper,
@@ -7446,12 +7448,20 @@ class NodeScopeResolver
 				return $param->var->name;
 			}, $node->getParams());
 			$currentResolvedPhpDoc = null;
-			if ($docComment !== null) {
+			if ($class !== null) {
+				$currentResolvedPhpDoc = $this->stubPhpDocProvider->findMethodPhpDoc(
+					$class,
+					$class,
+					$functionName,
+					$positionalParameterNames,
+				);
+			}
+			if ($currentResolvedPhpDoc === null && $docComment !== null) {
 				$currentResolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
 					$file,
 					$class,
 					$trait,
-					$node->name->name,
+					$functionName,
 					$docComment,
 				);
 			}

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -27,6 +27,7 @@ use PHPStan\Fixable\Patcher;
 use PHPStan\Node\DeepNodeCloner;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
+use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\ClassReflectionFactory;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Rules\DirectRegistry as DirectRuleRegistry;
@@ -102,6 +103,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			self::getContainer()->getByType(ParameterOutTypeExtensionProvider::class),
 			$this->getParser(),
 			self::getContainer()->getByType(FileTypeMapper::class),
+			self::getContainer()->getByType(StubPhpDocProvider::class),
 			self::getContainer()->getByType(PhpVersion::class),
 			self::getContainer()->getByType(PhpDocInheritanceResolver::class),
 			self::getContainer()->getByType(FileHelper::class),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -21,6 +21,7 @@ use PHPStan\Node\DeepNodeCloner;
 use PHPStan\Node\InClassNode;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
+use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\ClassReflectionFactory;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -77,6 +78,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$container->getByType(ParameterOutTypeExtensionProvider::class),
 			self::getParser(),
 			$container->getByType(FileTypeMapper::class),
+			$container->getByType(StubPhpDocProvider::class),
 			$container->getByType(PhpVersion::class),
 			$container->getByType(PhpDocInheritanceResolver::class),
 			$container->getByType(FileHelper::class),

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -22,6 +22,7 @@ use PHPStan\Node\Printer\Printer;
 use PHPStan\Parser\RichParser;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
+use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\ClassReflectionFactory;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Rules\AlwaysFailRule;
@@ -818,6 +819,7 @@ class AnalyserTest extends PHPStanTestCase
 			$container->getByType(ParameterOutTypeExtensionProvider::class),
 			$this->getParser(),
 			$fileTypeMapper,
+			$container->getByType(StubPhpDocProvider::class),
 			$container->getByType(PhpVersion::class),
 			$phpDocInheritanceResolver,
 			$fileHelper,

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
@@ -13,6 +13,7 @@ use PHPStan\File\FileHelper;
 use PHPStan\Node\DeepNodeCloner;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
+use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\ClassReflectionFactory;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Rules\IdentifierRuleError;
@@ -122,6 +123,7 @@ class FiberNodeScopeResolverRuleTest extends RuleTestCase
 			self::getContainer()->getByType(ParameterOutTypeExtensionProvider::class),
 			$this->getParser(),
 			self::getContainer()->getByType(FileTypeMapper::class),
+			self::getContainer()->getByType(StubPhpDocProvider::class),
 			self::getContainer()->getByType(PhpVersion::class),
 			self::getContainer()->getByType(PhpDocInheritanceResolver::class),
 			self::getContainer()->getByType(FileHelper::class),

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
@@ -11,6 +11,7 @@ use PHPStan\File\FileHelper;
 use PHPStan\Node\DeepNodeCloner;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
+use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\ClassReflectionFactory;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
@@ -55,6 +56,7 @@ class FiberNodeScopeResolverTest extends TypeInferenceTestCase
 			$container->getByType(ParameterOutTypeExtensionProvider::class),
 			self::getParser(),
 			$container->getByType(FileTypeMapper::class),
+			$container->getByType(StubPhpDocProvider::class),
 			$container->getByType(PhpVersion::class),
 			$container->getByType(PhpDocInheritanceResolver::class),
 			$container->getByType(FileHelper::class),

--- a/tests/PHPStan/Analyser/StubMethodBodyTypesTest.php
+++ b/tests/PHPStan/Analyser/StubMethodBodyTypesTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class StubMethodBodyTypesTest extends TypeInferenceTestCase
+{
+
+	public static function dataFileAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/stub-method-body-types.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataFileAsserts')]
+	public function testFileAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/data/stub-method-body-types.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/stub-method-body-types.neon
+++ b/tests/PHPStan/Analyser/data/stub-method-body-types.neon
@@ -1,0 +1,3 @@
+parameters:
+	stubFiles:
+		- stub-method-body-types.stub

--- a/tests/PHPStan/Analyser/data/stub-method-body-types.php
+++ b/tests/PHPStan/Analyser/data/stub-method-body-types.php
@@ -1,0 +1,27 @@
+<?php
+
+use function PHPStan\Testing\assertType;
+
+class StubMethodBodyTypesClass
+{
+	/**
+	 * Source declares @param string — stub overrides to @param callable-string
+	 * @param string $callback
+	 * @return string
+	 */
+	public function process($callback): string
+	{
+		// Stub should override the source file's @param type inside the method body
+		assertType('callable-string', $callback);
+		return $callback;
+	}
+}
+
+class StubMethodBodyTypesExternalCaller
+{
+	public function test(StubMethodBodyTypesClass $obj): void
+	{
+		// Stub should also work for external callers (already worked before regression)
+		assertType('non-empty-string', $obj->process('strlen'));
+	}
+}

--- a/tests/PHPStan/Analyser/data/stub-method-body-types.stub
+++ b/tests/PHPStan/Analyser/data/stub-method-body-types.stub
@@ -1,0 +1,10 @@
+<?php
+
+class StubMethodBodyTypesClass
+{
+	/**
+	 * @param callable-string $callback
+	 * @return non-empty-string
+	 */
+	public function process($callback): string {}
+}


### PR DESCRIPTION
## Summary

- Fixes `NodeScopeResolver::getPhpDocs()` to consult `StubPhpDocProvider` before falling back to `FileTypeMapper` when resolving parameter types inside method bodies
- Adds `StubPhpDocProvider` as a constructor parameter to `NodeScopeResolver`
- Updates all direct `NodeScopeResolver` constructor call sites in test infrastructure to include the new parameter

## Problem

Since 2.1.38 (PR #4829 — "Rework phpDoc inheritance to resolve through reflection instead of re-walking the hierarchy"), stub `@param` type overrides were silently ignored inside method bodies. External callers of a stubbed method still saw the correct stub types, but the method's own body would use the source file's `@param` type instead.

**Root cause**: The removed `PhpDocBlock::docBlockToResolvedDocBlock()` helper previously called `StubPhpDocProvider::findMethodPhpDoc()` first and fell back to `FileTypeMapper` only if no stub was found. The rewritten path in `getPhpDocs()` only consulted `FileTypeMapper`, never checking stubs.

Fixes https://github.com/phpstan/phpstan/issues/14118

## Test plan

- [ ] New `StubMethodBodyTypesTest` verifies stub `@param callable-string` overrides source `@param string` inside the method body
- [ ] New test also confirms external callers still see stub `@return non-empty-string`
- [ ] Full analyser + rules test suites pass (7752 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)