### PR TITLE
Cover dynamic static calls in tests

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
@@ -121,6 +121,11 @@ class CallToStaticMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10819.php'], $errors);
 	}
 
+	public function testDynamicStaticCall(): void
+	{
+		$this->analyse([__DIR__ . '/data/dynamic-static-call.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.5')]
 	public function testPipeOperator(): void
 	{

--- a/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
+++ b/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
@@ -29,8 +29,8 @@ class Bar {
 
 class Baz {
 	function doBaz(Foo $foo, FinalFoo $finalFoo, Bar $bar):void {
-		$foo::doFoo();
-		$finalFoo::doFoo();
-		$bar::finalFoo();
+		$foo::doFoo(); // no error, subclass could override static method with impure impl
+		$finalFoo::doFoo(); // could error, because final class
+		$bar::finalFoo(); // could error, because final method
 	}
 }

--- a/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
+++ b/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DynamicStaticCall;
+
+class SomeClass {}
+
+class Foo {
+	/** @phpstan-pure */
+	static public function doFoo():int
+	{
+		return 42;
+	}
+}
+
+final class FinalFoo {
+	/** @phpstan-pure */
+	static public function doFoo():int
+	{
+		return 42;
+	}
+}
+
+class Bar {
+	/** @phpstan-pure */
+	final static public function finalFoo():int
+	{
+		return 42;
+	}
+}
+
+
+class Baz {
+	function doBaz(Foo $foo, FinalFoo $finalFoo, Bar $bar):void {
+		$foo::doFoo();
+		$finalFoo::doFoo();
+		$bar::finalFoo();
+	}
+}

--- a/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
+++ b/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
@@ -2,8 +2,6 @@
 
 namespace DynamicStaticCall;
 
-class SomeClass {}
-
 class Foo {
 	/** @phpstan-pure */
 	static public function doFoo():int

--- a/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
+++ b/tests/PHPStan/Rules/Methods/data/dynamic-static-call.php
@@ -30,7 +30,7 @@ class Bar {
 class Baz {
 	function doBaz(Foo $foo, FinalFoo $finalFoo, Bar $bar):void {
 		$foo::doFoo(); // no error, subclass could override static method with impure impl
-		$finalFoo::doFoo(); // could error, because final class
-		$bar::finalFoo(); // could error, because final method
+		$finalFoo::doFoo(); // could be "Call to static method .. on a separate line has no effect", because final class
+		$bar::finalFoo(); // could be "Call to static method .. on a separate line has no effect", because final method
 	}
 }


### PR DESCRIPTION
lets add coverage for this scenario with more basic classes which do not depend on phpversion (like DateTimeImmutable via phpstorm stubs)