### PR TITLE
Faster Ternary analysis

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1119,14 +1119,20 @@ final class TypeSpecifier
 			return $this->specifyTypesInCondition($scope, $expr->expr, $context)->setRootExpr($expr);
 		} elseif (
 			$expr instanceof Expr\Ternary
-			&& !$context->null()
 			&& !$expr->cond instanceof Expr\Ternary
+			&& !$context->null()
 		) {
-			$ifExpr = $expr->if ?? $expr->cond;
-			$conditionExpr = new BooleanOr(
-				new BooleanAnd($expr->cond, $ifExpr),
-				new BooleanAnd(new Expr\BooleanNot($expr->cond), $expr->else),
-			);
+			if ($expr->if !== null) {
+				$conditionExpr = new BooleanOr(
+					new BooleanAnd($expr->cond, $expr->if),
+					new BooleanAnd(new Expr\BooleanNot($expr->cond), $expr->else),
+				);
+			} else {
+				$conditionExpr = new BooleanOr(
+					$expr->cond,
+					new BooleanAnd(new Expr\BooleanNot($expr->cond), $expr->else),
+				);
+			}
 
 			return $this->specifyTypesInCondition($scope, $conditionExpr, $context)->setRootExpr($expr);
 


### PR DESCRIPTION
before this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100'
Benchmark 1: vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100
  Time (mean ± σ):      1.739 s ±  0.006 s    [User: 1.571 s, System: 0.165 s]
  Range (min … max):    1.734 s …  1.754 s    10 runs
 
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100'
Benchmark 1: vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100
  Time (mean ± σ):      1.735 s ±  0.009 s    [User: 1.567 s, System: 0.165 s]
  Range (min … max):    1.730 s …  1.759 s    10 runs
```

with this PR
```
➜  phpstan-src git:(fast-tern) ✗ hyperfine 'vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100'
Benchmark 1: vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100
  Time (mean ± σ):      1.668 s ±  0.009 s    [User: 1.502 s, System: 0.163 s]
  Range (min … max):    1.661 s …  1.689 s    10 runs
 
➜  phpstan-src git:(fast-tern) ✗ hyperfine 'vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100'
Benchmark 1: vendor/bin/phpunit tests/PHPStan/Analyser/AnalyserIntegrationTest.php --filter testBug14100
  Time (mean ± σ):      1.663 s ±  0.004 s    [User: 1.498 s, System: 0.162 s]
  Range (min … max):    1.659 s …  1.670 s    10 runs
```
