### PR TITLE
Unsetting optional offset might still give a list.

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -741,7 +741,21 @@ class ConstantArrayType implements Type
 					$k++;
 				}
 
-				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, TrinaryLogic::createNo());
+				$newIsList = TrinaryLogic::createNo();
+				if (!$this->isList->no() && in_array($i, $this->optionalKeys, true)) {
+					$preserveIsList = true;
+					foreach ($newKeyTypes as $k2 => $newKeyType2) {
+						if (!$newKeyType2 instanceof ConstantIntegerType || $newKeyType2->getValue() !== $k2) {
+							$preserveIsList = false;
+							break;
+						}
+					}
+					if ($preserveIsList) {
+						$newIsList = $this->isList;
+					}
+				}
+
+				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, $newIsList);
 			}
 
 			return $this;

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -742,7 +742,10 @@ class ConstantArrayType implements Type
 				}
 
 				$newIsList = TrinaryLogic::createNo();
-				if (!$this->isList->no()) {
+				// We're unsetting something that might not be on the array,
+				// so it might still be a list (with PHPStan definition)
+				// because the nextAutoIndexes will not change.
+				if (!$this->isList->no() && in_array($i, $this->optionalKeys, true)) {
 					$preserveIsList = true;
 					$isListOnlyIfKeysAreOptional = false;
 					foreach ($newKeyTypes as $k2 => $newKeyType2) {
@@ -765,7 +768,7 @@ class ConstantArrayType implements Type
 					}
 
 					if ($preserveIsList) {
-						$newIsList = $this->isList;
+						$newIsList = TrinaryLogic::createMaybe();
 					}
 				}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -821,6 +821,9 @@ class ConstantArrayType implements Type
 	/**
 	 * When we're unsetting something not on the array, it will be untouched,
 	 * So the nextAutoIndexes won't change, and the array might still be a list even with PHPStan definition.
+	 *
+	 * @param list<ConstantIntegerType|ConstantStringType> $newKeyTypes
+	 * @param int[] 									   $newOptionalKeys
 	 */
 	private static function isListAfterUnset(array $newKeyTypes, array $newOptionalKeys, TrinaryLogic $arrayIsList, bool $unsetOptionalKey): TrinaryLogic
 	{

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -741,7 +741,7 @@ class ConstantArrayType implements Type
 					$k++;
 				}
 
-				$newIsList = $this->isListAfterUnset(
+				$newIsList = self::isListAfterUnset(
 					$newKeyTypes,
 					$newOptionalKeys,
 					$this->isList,
@@ -758,6 +758,7 @@ class ConstantArrayType implements Type
 		if (count($constantScalars) > 0) {
 			$optionalKeys = $this->optionalKeys;
 
+			$arrayHasChanged = false;
 			foreach ($constantScalars as $constantScalar) {
 				$constantScalar = $constantScalar->toArrayKey();
 				if (!$constantScalar instanceof ConstantIntegerType && !$constantScalar instanceof ConstantStringType) {
@@ -769,6 +770,7 @@ class ConstantArrayType implements Type
 						continue;
 					}
 
+					$arrayHasChanged = true;
 					if (in_array($i, $optionalKeys, true)) {
 						continue 2;
 					}
@@ -777,7 +779,11 @@ class ConstantArrayType implements Type
 				}
 			}
 
-			$newIsList = $this->isListAfterUnset(
+			if (!$arrayHasChanged) {
+				return $this;
+			}
+
+			$newIsList = self::isListAfterUnset(
 				$this->keyTypes,
 				$optionalKeys,
 				$this->isList,
@@ -788,15 +794,21 @@ class ConstantArrayType implements Type
 		}
 
 		$optionalKeys = $this->optionalKeys;
+		$arrayHasChanged = false;
 		foreach ($this->keyTypes as $i => $keyType) {
 			if (!$offsetType->isSuperTypeOf($keyType)->yes()) {
 				continue;
 			}
+			$arrayHasChanged = true;
 			$optionalKeys[] = $i;
 		}
 		$optionalKeys = array_values(array_unique($optionalKeys));
 
-		$newIsList = $this->isListAfterUnset(
+		if (!$arrayHasChanged) {
+			return $this;
+		}
+
+		$newIsList = self::isListAfterUnset(
 			$this->keyTypes,
 			$optionalKeys,
 			$this->isList,
@@ -807,10 +819,10 @@ class ConstantArrayType implements Type
 	}
 
 	/**
-	 * If we're unsetting something that might not be on the array, it might still be a list (with PHPStan definition)
-	 * because the nextAutoIndexes will not change.
+	 * When we're unsetting something not on the array, it will be untouched,
+	 * So the nextAutoIndexes won't change, and the array might still be a list even with PHPStan definition.
 	 */
-	private function isListAfterUnset(array $newKeyTypes, array $newOptionalKeys, TrinaryLogic $arrayIsList, bool $unsetOptionalKey): TrinaryLogic
+	private static function isListAfterUnset(array $newKeyTypes, array $newOptionalKeys, TrinaryLogic $arrayIsList, bool $unsetOptionalKey): TrinaryLogic
 	{
 		if (!$unsetOptionalKey || $arrayIsList->no()) {
 			return TrinaryLogic::createNo();

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -741,36 +741,12 @@ class ConstantArrayType implements Type
 					$k++;
 				}
 
-				$newIsList = TrinaryLogic::createNo();
-				// We're unsetting something that might not be on the array,
-				// so it might still be a list (with PHPStan definition)
-				// because the nextAutoIndexes will not change.
-				if (!$this->isList->no() && in_array($i, $this->optionalKeys, true)) {
-					$preserveIsList = true;
-					$isListOnlyIfKeysAreOptional = false;
-					foreach ($newKeyTypes as $k2 => $newKeyType2) {
-						if (!$newKeyType2 instanceof ConstantIntegerType || $newKeyType2->getValue() !== $k2) {
-							// We found a non-optional key that implies that the array is never a list.
-							if (!in_array($k2, $newOptionalKeys, true)) {
-								$preserveIsList = false;
-								break;
-							}
-
-							// The array can still be a list if all the following keys are also optional.
-							$isListOnlyIfKeysAreOptional = true;
-							continue;
-						}
-
-						if ($isListOnlyIfKeysAreOptional && !in_array($k2, $newOptionalKeys, true)) {
-							$preserveIsList = false;
-							break;
-						}
-					}
-
-					if ($preserveIsList) {
-						$newIsList = TrinaryLogic::createMaybe();
-					}
-				}
+				$newIsList = $this->isListAfterUnset(
+					$newKeyTypes,
+					$newOptionalKeys,
+					$this->isList,
+					in_array($i, $this->optionalKeys, true),
+				);
 
 				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, $newIsList);
 			}
@@ -801,21 +777,64 @@ class ConstantArrayType implements Type
 				}
 			}
 
-			return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, $optionalKeys, TrinaryLogic::createNo());
+			$newIsList = $this->isListAfterUnset(
+				$this->keyTypes,
+				$optionalKeys,
+				$this->isList,
+				count($optionalKeys) === count($this->optionalKeys),
+			);
+
+			return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, $optionalKeys, $newIsList);
 		}
 
 		$optionalKeys = $this->optionalKeys;
-		$isList = $this->isList;
 		foreach ($this->keyTypes as $i => $keyType) {
 			if (!$offsetType->isSuperTypeOf($keyType)->yes()) {
 				continue;
 			}
 			$optionalKeys[] = $i;
-			$isList = TrinaryLogic::createNo();
 		}
 		$optionalKeys = array_values(array_unique($optionalKeys));
 
-		return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, $optionalKeys, $isList);
+		$newIsList = $this->isListAfterUnset(
+			$this->keyTypes,
+			$optionalKeys,
+			$this->isList,
+			count($optionalKeys) === count($this->optionalKeys),
+		);
+
+		return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, $optionalKeys, $newIsList);
+	}
+
+	/**
+	 * If we're unsetting something that might not be on the array, it might still be a list (with PHPStan definition)
+	 * because the nextAutoIndexes will not change.
+	 */
+	private function isListAfterUnset(array $newKeyTypes, array $newOptionalKeys, TrinaryLogic $arrayIsList, bool $unsetOptionalKey): TrinaryLogic
+	{
+		if (!$unsetOptionalKey || $arrayIsList->no()) {
+			return TrinaryLogic::createNo();
+		}
+
+		$isListOnlyIfKeysAreOptional = false;
+		foreach ($newKeyTypes as $k2 => $newKeyType2) {
+			if (!$newKeyType2 instanceof ConstantIntegerType || $newKeyType2->getValue() !== $k2) {
+				// We found a non-optional key that implies that the array is never a list.
+				if (!in_array($k2, $newOptionalKeys, true)) {
+					return TrinaryLogic::createNo();
+				}
+
+				// The array can still be a list if all the following keys are also optional.
+				$isListOnlyIfKeysAreOptional = true;
+				continue;
+			}
+
+			if ($isListOnlyIfKeysAreOptional && !in_array($k2, $newOptionalKeys, true)) {
+				return TrinaryLogic::createNo();
+			}
+		}
+
+		return TrinaryLogic::createMaybe();
 	}
 
 	public function chunkArray(Type $lengthType, TrinaryLogic $preserveKeys): Type

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -742,8 +742,31 @@ class ConstantArrayType implements Type
 				}
 
 				$newIsList = TrinaryLogic::createNo();
-				if (!$this->isList->no() && in_array($i, $this->optionalKeys, true)) {
-					$newIsList = TrinaryLogic::createMaybe();
+				if (!$this->isList->no()) {
+					$preserveIsList = true;
+					$isListOnlyIfKeysAreOptional = false;
+					foreach ($newKeyTypes as $k2 => $newKeyType2) {
+						if (!$newKeyType2 instanceof ConstantIntegerType || $newKeyType2->getValue() !== $k2) {
+							// We found a non-optional key that implies that the array is never a list.
+							if (!in_array($k2, $newOptionalKeys, true)) {
+								$preserveIsList = false;
+								break;
+							}
+
+							// The array can still be a list if all the following keys are also optional.
+							$isListOnlyIfKeysAreOptional = true;
+							continue;
+						}
+
+						if ($isListOnlyIfKeysAreOptional && !in_array($k2, $newOptionalKeys, true)) {
+							$preserveIsList = false;
+							break;
+						}
+					}
+
+					if ($preserveIsList) {
+						$newIsList = $this->isList;
+					}
 				}
 
 				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, $newIsList);

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -743,16 +743,7 @@ class ConstantArrayType implements Type
 
 				$newIsList = TrinaryLogic::createNo();
 				if (!$this->isList->no() && in_array($i, $this->optionalKeys, true)) {
-					$preserveIsList = true;
-					foreach ($newKeyTypes as $k2 => $newKeyType2) {
-						if (!$newKeyType2 instanceof ConstantIntegerType || $newKeyType2->getValue() !== $k2) {
-							$preserveIsList = false;
-							break;
-						}
-					}
-					if ($preserveIsList) {
-						$newIsList = $this->isList;
-					}
+					$newIsList = TrinaryLogic::createMaybe();
 				}
 
 				return new self($newKeyTypes, $newValueTypes, $this->nextAutoIndexes, $newOptionalKeys, $newIsList);

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -823,7 +823,7 @@ class ConstantArrayType implements Type
 	 * So the nextAutoIndexes won't change, and the array might still be a list even with PHPStan definition.
 	 *
 	 * @param list<ConstantIntegerType|ConstantStringType> $newKeyTypes
-	 * @param int[] 									   $newOptionalKeys
+	 * @param int[] $newOptionalKeys
 	 */
 	private static function isListAfterUnset(array $newKeyTypes, array $newOptionalKeys, TrinaryLogic $arrayIsList, bool $unsetOptionalKey): TrinaryLogic
 	{

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
@@ -19,7 +19,7 @@ function () {
 	assertType('true', array_is_list($a));
 	unset($a[2]);
 	assertType('array{1, 2}', $a);
-	assertType('false', array_is_list($a)); // Could be true
+	assertType('false', array_is_list($a));
 	$a[] = 4;
 	assertType('array{0: 1, 1: 2, 3: 4}', $a);
 	assertType('false', array_is_list($a));

--- a/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
+++ b/tests/PHPStan/Analyser/nsrt/array-is-list-unset.php
@@ -19,7 +19,7 @@ function () {
 	assertType('true', array_is_list($a));
 	unset($a[2]);
 	assertType('array{1, 2}', $a);
-	assertType('false', array_is_list($a));
+	assertType('false', array_is_list($a)); // Could be true
 	$a[] = 4;
 	assertType('array{0: 1, 1: 2, 3: 4}', $a);
 	assertType('false', array_is_list($a));

--- a/tests/PHPStan/Analyser/nsrt/bug-14177.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14177.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-namespace Bug14177;
+namespace Bug14177Nsrt;
 
 use function PHPStan\Testing\assertType;
 
@@ -91,9 +91,9 @@ class HelloWorld2
 	{
 		assertType('true', array_is_list($b));
 		unset($b[1]);
-		assertType('bool', array_is_list($b));
+		assertType('false', array_is_list($b)); // Could be true
 		$b[] = 'foo';
-		assertType('bool', array_is_list($b)); // Could be false
+		assertType('false', array_is_list($b));
 	}
 
 	/**
@@ -151,9 +151,9 @@ class HelloWorld2
 	{
 		assertType('bool', array_is_list($b));
 		unset($b[2]);
-		assertType('bool', array_is_list($b));
+		assertType('false', array_is_list($b)); // Could be true
 		$b[] = 'foo';
-		assertType('bool', array_is_list($b)); // Could be false
+		assertType('false', array_is_list($b));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/bug-14177.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14177.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14177;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testList(array $b): void
+	{
+		if (array_key_exists(3, $b)) {
+			assertType('list{0: string, 1: string, 2?: string, 3: string}', $b);
+		} else {
+			assertType('list{0: string, 1: string, 2?: string}', $b);
+		}
+		assertType('list{0: string, 1: string, 2?: string, 3?: string}', $b);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-14177.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14177.php
@@ -18,4 +18,102 @@ class HelloWorld
 		}
 		assertType('list{0: string, 1: string, 2?: string, 3?: string}', $b);
 	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset0(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[0]);
+		assertType('false', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset1(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[1]);
+		assertType('bool', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset2(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[2]);
+		assertType('bool', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset3(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[3]);
+		assertType('true', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	public function placeholderToEditor(string $html): void
+	{
+		$result = preg_replace_callback(
+			'~\[image\\sid="(\\d+)"(?:\\shref="([^"]*)")?(?:\\sclass="([^"]*)")?\]~',
+			function (array $matches): string {
+				$id = (int) $matches[1];
+
+				assertType('list{0: non-falsy-string, 1: numeric-string, 2?: string, 3?: string}', $matches);
+
+				$replacement = sprintf(
+					'<img src="%s"%s/>',
+					$id,
+					array_key_exists(3, $matches) ? sprintf(' class="%s"', $matches[3]) : '',
+				);
+
+				assertType('list{0: non-falsy-string, 1: numeric-string, 2?: string, 3?: string}', $matches);
+
+				return array_key_exists(2, $matches) && $matches[2] !== ''
+					? sprintf('<a href="%s">%s</a>', $matches[2], $replacement)
+					: $replacement;
+			},
+			$html,
+		);
+	}
+
+	public function placeholderToEditor2(string $html): void
+	{
+		$result = preg_replace_callback(
+			'~\[image\\sid="(\\d+)?"(?:\\shref="([^"]*)")?(?:\\sclass="([^"]*)")?\]~',
+			function (array $matches): string {
+				$id = (int) $matches[0];
+
+				assertType('list{0: non-falsy-string, 1?: \'\'|numeric-string, 2?: string, 3?: string}', $matches);
+
+				$replacement = sprintf(
+					'<img src="%s"%s/>',
+					$id,
+					array_key_exists(2, $matches) ? sprintf(' class="%s"', $matches[2]) : '',
+				);
+
+				assertType('list{0: non-falsy-string, 1?: \'\'|numeric-string, 2?: string, 3?: string}', $matches);
+
+				return array_key_exists(1, $matches) && $matches[1] !== ''
+					? sprintf('<a href="%s">%s</a>', $matches[1], $replacement)
+					: $replacement;
+			},
+			$html,
+		);
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-14177.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14177.php
@@ -91,7 +91,7 @@ class HelloWorld2
 	{
 		assertType('true', array_is_list($b));
 		unset($b[1]);
-		assertType('false', array_is_list($b)); // Could be true
+		assertType('false', array_is_list($b));
 		$b[] = 'foo';
 		assertType('false', array_is_list($b));
 	}
@@ -105,7 +105,7 @@ class HelloWorld2
 		unset($b[2]);
 		assertType('bool', array_is_list($b));
 		$b[] = 'foo';
-		assertType('bool', array_is_list($b)); // Could be false
+		assertType('bool', array_is_list($b));
 	}
 
 	/**
@@ -115,9 +115,9 @@ class HelloWorld2
 	{
 		assertType('true', array_is_list($b));
 		unset($b[3]);
-		assertType('bool', array_is_list($b)); // Could be true
+		assertType('bool', array_is_list($b));
 		$b[] = 'foo';
-		assertType('bool', array_is_list($b)); // Could be false
+		assertType('bool', array_is_list($b));
 	}
 
 	/**
@@ -165,7 +165,7 @@ class HelloWorld2
 		unset($b[3]);
 		assertType('bool', array_is_list($b));
 		$b[] = 'foo';
-		assertType('bool', array_is_list($b)); // Could be false
+		assertType('bool', array_is_list($b));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/bug-14177.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14177.php
@@ -19,54 +19,6 @@ class HelloWorld
 		assertType('list{0: string, 1: string, 2?: string, 3?: string}', $b);
 	}
 
-	/**
-	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
-	 */
-	public function testUnset0(array $b): void
-	{
-		assertType('true', array_is_list($b));
-		unset($b[0]);
-		assertType('false', array_is_list($b));
-		$b[] = 'foo';
-		assertType('false', array_is_list($b));
-	}
-
-	/**
-	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
-	 */
-	public function testUnset1(array $b): void
-	{
-		assertType('true', array_is_list($b));
-		unset($b[1]);
-		assertType('bool', array_is_list($b));
-		$b[] = 'foo';
-		assertType('false', array_is_list($b));
-	}
-
-	/**
-	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
-	 */
-	public function testUnset2(array $b): void
-	{
-		assertType('true', array_is_list($b));
-		unset($b[2]);
-		assertType('bool', array_is_list($b));
-		$b[] = 'foo';
-		assertType('false', array_is_list($b));
-	}
-
-	/**
-	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
-	 */
-	public function testUnset3(array $b): void
-	{
-		assertType('true', array_is_list($b));
-		unset($b[3]);
-		assertType('true', array_is_list($b));
-		$b[] = 'foo';
-		assertType('false', array_is_list($b));
-	}
-
 	public function placeholderToEditor(string $html): void
 	{
 		$result = preg_replace_callback(
@@ -115,5 +67,104 @@ class HelloWorld
 			},
 			$html,
 		);
+	}
+}
+
+class HelloWorld2
+{
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset0OnList(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[0]);
+		assertType('false', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset1OnList(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[1]);
+		assertType('bool', array_is_list($b));
+		$b[] = 'foo';
+		assertType('bool', array_is_list($b)); // Could be false
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset2OnList(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[2]);
+		assertType('bool', array_is_list($b));
+		$b[] = 'foo';
+		assertType('bool', array_is_list($b)); // Could be false
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnset3OnList(array $b): void
+	{
+		assertType('true', array_is_list($b));
+		unset($b[3]);
+		assertType('bool', array_is_list($b)); // Could be true
+		$b[] = 'foo';
+		assertType('bool', array_is_list($b)); // Could be false
+	}
+
+	/**
+	 * @param array{0: string, 1?: string, 2: string, 3?: string} $b
+	 */
+	public function testUnset0OnArray(array $b): void
+	{
+		assertType('bool', array_is_list($b));
+		unset($b[0]);
+		assertType('false', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	/**
+	 * @param array{0: string, 1?: string, 2: string, 3?: string} $b
+	 */
+	public function testUnset1OnArray(array $b): void
+	{
+		assertType('bool', array_is_list($b));
+		unset($b[1]);
+		assertType('false', array_is_list($b));
+		$b[] = 'foo';
+		assertType('false', array_is_list($b));
+	}
+
+	/**
+	 * @param array{0: string, 1?: string, 2: string, 3?: string} $b
+	 */
+	public function testUnset2OnArray(array $b): void
+	{
+		assertType('bool', array_is_list($b));
+		unset($b[2]);
+		assertType('bool', array_is_list($b));
+		$b[] = 'foo';
+		assertType('bool', array_is_list($b)); // Could be false
+	}
+
+	/**
+	 * @param array{0: string, 1?: string, 2: string, 3?: string} $b
+	 */
+	public function testUnset3OnArray(array $b): void
+	{
+		assertType('bool', array_is_list($b));
+		unset($b[3]);
+		assertType('bool', array_is_list($b));
+		$b[] = 'foo';
+		assertType('bool', array_is_list($b)); // Could be false
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-14177.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14177.php
@@ -151,7 +151,7 @@ class HelloWorld2
 	{
 		assertType('bool', array_is_list($b));
 		unset($b[2]);
-		assertType('false', array_is_list($b)); // Could be true
+		assertType('false', array_is_list($b));
 		$b[] = 'foo';
 		assertType('false', array_is_list($b));
 	}
@@ -166,5 +166,38 @@ class HelloWorld2
 		assertType('bool', array_is_list($b));
 		$b[] = 'foo';
 		assertType('bool', array_is_list($b)); // Could be false
+	}
+
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string} $a
+	 * @param list{0: string, 1?: string, 2?: string, 3?: string} $b
+	 * @param list{0: string, 1?: string, 2?: string, 3: string} $c
+	 * @param 1|2 $int
+	 */
+	public function testUnsetNonConstant(array $a, array $b, array $c, int $int): void
+	{
+		assertType('true', array_is_list($a));
+		assertType('true', array_is_list($b));
+		assertType('true', array_is_list($c));
+		unset($a[$int]);
+		unset($b[$int]);
+		unset($c[$int]);
+		assertType('false', array_is_list($a));
+		assertType('bool', array_is_list($b));
+		assertType('bool', array_is_list($c));
+	}
+
+	/**
+	 * @param list{0?: string, 1?: string, 2?: string, 3?: string} $a
+	 * @param list{0: string, 1?: string, 2?: string, 3?: string} $b
+	 */
+	public function testUnsetInt(array $a, array $b, array $c, int $int): void
+	{
+		assertType('true', array_is_list($a));
+		assertType('true', array_is_list($b));
+		unset($a[$int]);
+		unset($b[$int]);
+		assertType('bool', array_is_list($a));
+		assertType('false', array_is_list($b));
 	}
 }

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1145,4 +1145,10 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/pr-4375.php'], []);
 	}
 
+	public function testBug14177(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-14177.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-14177.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-14177.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14177;
+
+class HelloWorld
+{
+	public function placeholderToEditor(string $html): void
+	{
+		$result = preg_replace_callback(
+			'~\[image\\sid="(\\d+)"(?:\\shref="([^"]*)")?(?:\\sclass="([^"]*)")?]~',
+			function (array $matches): string {
+				$id = (int) $matches[1];
+
+				$replacement = sprintf(
+					'<img src="%s"%s/>',
+					$id,
+					array_key_exists(3, $matches) ? sprintf(' class="%s"', $matches[3]) : '',
+				);
+
+				return array_key_exists(2, $matches) && $matches[2] !== ''
+					? sprintf('<a href="%s">%s</a>', $matches[2], $replacement)
+					: $replacement;
+			},
+			$html,
+		);
+	}
+}


### PR DESCRIPTION
When doing `array_key_exists` on `list{0: string, 1: string, 2?: string, 3?: string}`,
the ArrayKeyExistsFunctionTypeSpecifyingExtension is specify `HasOffsetType` and in the else condition we're calling `tryRemove` on this `HasOffsetType`.

ConstantArrayType::tryRemove do
```
		if ($typeToRemove instanceof HasOffsetType) {
			return $this->unsetOffset($typeToRemove->getOffsetType());
		}
```
but the new array created is always with `$this->isList = Ternary::no`.

The issue is that the intersection with List gives Never ; see
https://phpstan.org/r/c8177c3c-a643-43dc-b62f-b207740d75f8

Technically, 
- removing an optional key could still be a list
- removing the last non optional key (which is not the easiest check since they might not be ordered) could still be a list

This is fully related to https://github.com/phpstan/phpstan/issues/11628
see https://phpstan.org/r/fb18be32-9fba-42ba-8815-b767734cac6a

This is kinda tricky as changing `$newIsList = TrinaryLogic::createMaybe()` to maybe or true will then creates an issue if I append an element later (cause PHPStan won't detect it's not a list anymore).

Also, some extra thought: when we're inside the `else` part of an array_key_exists call we're not really calling unset on the array. So maybe a simpler way to solve this, is to
- Ignore the issue with `unset`
- Solving the array_key_exists issue by
  - Adding an optional param to ConstantArrayType::unsetOffset like something `$newIsList` or preserve list
  - Changing the call inside ConstantArrayType::tryRemove to override the behavior of isList when trying to remove HasOffsetType and HasOffsetValueType.
  
Closes https://github.com/phpstan/phpstan/issues/14177