### PR TITLE
feat: add option to report ignores without comments

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -296,6 +296,12 @@ jobs:
           - script: |
               cd e2e/nested-trait-use
               ../../bin/phpstan analyze
+          - script: |
+              cd e2e/report-ignores-without-comments
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan --error-format=raw")
+              echo "$OUTPUT"
+              ../bashunit -a contains 'test.php:4:Ignore with identifier variable.undefined has no comment' "$OUTPUT"
+              ../bashunit -a not_contains 'test.php:7' "$OUTPUT"
 
     steps:
       - name: "Checkout"

--- a/conf/config.neon
+++ b/conf/config.neon
@@ -118,6 +118,7 @@ parameters:
 		resolvedPhpDocBlockCacheCountMax: 2048
 		nameScopeMapMemoryCacheCountMax: 2048
 	reportUnmatchedIgnoredErrors: true
+	reportIgnoresWithoutComments: false
 	typeAliases: []
 	universalObjectCratesClasses:
 		- stdClass

--- a/conf/parametersSchema.neon
+++ b/conf/parametersSchema.neon
@@ -143,6 +143,7 @@ parametersSchema:
 		nameScopeMapMemoryCacheCountMax: int()
 	])
 	reportUnmatchedIgnoredErrors: bool()
+	reportIgnoresWithoutComments: bool()
 	typeAliases: arrayOf(string())
 	universalObjectCratesClasses: listOf(string())
 	stubFiles: listOf(string())

--- a/e2e/report-ignores-without-comments/phpstan.neon
+++ b/e2e/report-ignores-without-comments/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 5
+    paths:
+        - test.php
+    reportIgnoresWithoutComments: true

--- a/e2e/report-ignores-without-comments/test.php
+++ b/e2e/report-ignores-without-comments/test.php
@@ -1,0 +1,7 @@
+<?php
+
+// @phpstan-ignore variable.undefined
+echo $undefined;
+
+// @phpstan-ignore variable.undefined (this one has a comment so no error)
+echo $anotherUndefined;

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -205,7 +205,7 @@ final class AnalyserResultFinalizer
 
 					foreach ($identifiers as $identifier) {
 						$errors[] = (new Error(
-							sprintf('No error with identifier %s is reported on line %d.', $identifier, $line),
+							sprintf('No error with identifier %s is reported on line %d.', $identifier['name'], $line),
 							$file,
 							$line,
 							false,

--- a/src/Analyser/FileAnalyser.php
+++ b/src/Analyser/FileAnalyser.php
@@ -60,6 +60,8 @@ final class FileAnalyser
 		private IgnoreErrorExtensionProvider $ignoreErrorExtensionProvider,
 		private RuleErrorTransformer $ruleErrorTransformer,
 		private LocalIgnoresProcessor $localIgnoresProcessor,
+		#[AutowiredParameter]
+		private bool $reportIgnoresWithoutComments,
 	)
 	{
 	}
@@ -128,6 +130,32 @@ final class FileAnalyser
 				$unmatchedLineIgnores = $nodeCallback->getUnmatchedLineIgnores();
 				$temporaryFileErrors = $nodeCallback->getTemporaryFileErrors();
 				$processedFiles = $nodeCallback->getProcessedFiles();
+
+				if ($this->reportIgnoresWithoutComments) {
+					foreach ($linesToIgnore as $ignoredFile => $lines) {
+						foreach ($lines as $line => $identifiers) {
+							if ($identifiers === null) {
+								continue;
+							}
+
+							foreach ($identifiers as $identifier) {
+								if ($identifier['comment'] !== null) {
+									continue;
+								}
+
+								$fileErrors[] = (new Error(
+									sprintf('Ignore with identifier %s has no comment.', $identifier['name']),
+									$ignoredFile,
+									$line,
+									false,
+									$ignoredFile,
+									null,
+									'Explain why this ignore is necessary in parentheses after the identifier.',
+								))->withIdentifier('ignore.noComment');
+							}
+						}
+					}
+				}
 
 				$localIgnoresProcessorResult = $this->localIgnoresProcessor->process(
 					$temporaryFileErrors,

--- a/src/Analyser/FileAnalyserCallback.php
+++ b/src/Analyser/FileAnalyserCallback.php
@@ -21,6 +21,7 @@ use function sprintf;
 
 /**
  * @phpstan-import-type CollectorData from CollectedData
+ * @phpstan-import-type Identifier from FileAnalyserResult
  * @phpstan-import-type LinesToIgnore from FileAnalyserResult
  */
 final class FileAnalyserCallback
@@ -231,7 +232,7 @@ final class FileAnalyserCallback
 
 	/**
 	 * @param Node[] $nodes
-	 * @return array<int, non-empty-list<string>|null>
+	 * @return array<int, non-empty-list<Identifier>|null>
 	 */
 	private function getLinesToIgnoreFromTokens(array $nodes): array
 	{
@@ -239,7 +240,7 @@ final class FileAnalyserCallback
 			return [];
 		}
 
-		/** @var array<int, non-empty-list<string>|null> */
+		/** @var array<int, non-empty-list<Identifier>|null> */
 		return $nodes[0]->getAttribute('linesToIgnore', []);
 	}
 

--- a/src/Analyser/FileAnalyserResult.php
+++ b/src/Analyser/FileAnalyserResult.php
@@ -6,7 +6,8 @@ use PHPStan\Collectors\CollectedData;
 use PHPStan\Dependency\RootExportedNode;
 
 /**
- * @phpstan-type LinesToIgnore = array<string, array<int, non-empty-list<string>|null>>
+ * @phpstan-type Identifier = array{name: string, comment: string|null}
+ * @phpstan-type LinesToIgnore = array<string, array<int, non-empty-list<Identifier>|null>>
  * @phpstan-import-type CollectorData from CollectedData
  */
 final class FileAnalyserResult

--- a/src/Analyser/LocalIgnoresProcessor.php
+++ b/src/Analyser/LocalIgnoresProcessor.php
@@ -49,7 +49,7 @@ final class LocalIgnoresProcessor
 				}
 
 				foreach ($identifiers as $i => $ignoredIdentifier) {
-					if ($ignoredIdentifier !== $tmpFileError->getIdentifier()) {
+					if ($ignoredIdentifier['name'] !== $tmpFileError->getIdentifier()) {
 						continue;
 					}
 
@@ -68,7 +68,7 @@ final class LocalIgnoresProcessor
 						$unmatchedIgnoredIdentifiers = $unmatchedLineIgnores[$tmpFileError->getFile()][$line];
 						if (is_array($unmatchedIgnoredIdentifiers)) {
 							foreach ($unmatchedIgnoredIdentifiers as $j => $unmatchedIgnoredIdentifier) {
-								if ($ignoredIdentifier !== $unmatchedIgnoredIdentifier) {
+								if ($ignoredIdentifier['name'] !== $unmatchedIgnoredIdentifier['name']) {
 									continue;
 								}
 

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -313,7 +313,7 @@ final class FixerWorkerCommand extends Command
 					if ($error->getIdentifier() === null) {
 						continue;
 					}
-					if (!in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched', 'ignore.unmatchedLine', 'ignore.unmatchedIdentifier'], true)) {
+					if (!in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched', 'ignore.unmatchedLine', 'ignore.unmatchedIdentifier', 'ignore.noComment'], true)) {
 						continue;
 					}
 					$ignoreFileErrors[] = $error;

--- a/src/Parser/RichParser.php
+++ b/src/Parser/RichParser.php
@@ -7,12 +7,14 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Token;
+use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Analyser\Ignore\IgnoreLexer;
 use PHPStan\Analyser\Ignore\IgnoreParseException;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\File\FileReader;
 use PHPStan\ShouldNotHappenException;
 use function array_filter;
+use function array_key_last;
 use function array_map;
 use function count;
 use function implode;
@@ -30,6 +32,9 @@ use const T_COMMENT;
 use const T_DOC_COMMENT;
 use const T_WHITESPACE;
 
+/**
+ * @phpstan-import-type Identifier from FileAnalyserResult
+ */
 final class RichParser implements Parser
 {
 
@@ -120,7 +125,7 @@ final class RichParser implements Parser
 
 	/**
 	 * @param Token[] $tokens
-	 * @return array{lines: array<int, non-empty-list<string>|null>, errors: array<int, non-empty-list<string>>}
+	 * @return array{lines: array<int, non-empty-list<Identifier>|null>, errors: array<int, non-empty-list<string>>}
 	 */
 	private function getLinesToIgnore(array $tokens): array
 	{
@@ -277,33 +282,29 @@ final class RichParser implements Parser
 	}
 
 	/**
-	 * @return non-empty-list<string>
+	 * @return non-empty-list<Identifier>
 	 * @throws IgnoreParseException
 	 */
 	private function parseIdentifiers(string $text, int $ignorePos): array
 	{
 		$text = substr($text, $ignorePos + strlen('@phpstan-ignore'));
-		$originalTokens = $this->ignoreLexer->tokenize($text);
-		$tokens = [];
-
-		foreach ($originalTokens as $originalToken) {
-			if ($originalToken[IgnoreLexer::TYPE_OFFSET] === IgnoreLexer::TOKEN_WHITESPACE) {
-				continue;
-			}
-			$tokens[] = $originalToken;
-		}
+		$tokens = $this->ignoreLexer->tokenize($text);
 
 		$c = count($tokens);
 
 		$identifiers = [];
+		$comment = null;
 		$openParenthesisCount = 0;
 		$expected = [IgnoreLexer::TOKEN_IDENTIFIER];
+		$lastTokenTypeLabel = '@phpstan-ignore';
 
 		for ($i = 0; $i < $c; $i++) {
-			$lastTokenTypeLabel = isset($tokenType) ? $this->ignoreLexer->getLabel($tokenType) : '@phpstan-ignore';
+			if (isset($tokenType) && $tokenType !== IgnoreLexer::TOKEN_WHITESPACE) {
+				$lastTokenTypeLabel = $this->ignoreLexer->getLabel($tokenType);
+			}
 			[IgnoreLexer::VALUE_OFFSET => $content, IgnoreLexer::TYPE_OFFSET => $tokenType, IgnoreLexer::LINE_OFFSET => $tokenLine] = $tokens[$i];
 
-			if ($expected !== null && !in_array($tokenType, $expected, true)) {
+			if ($expected !== null && !in_array($tokenType, [...$expected, IgnoreLexer::TOKEN_WHITESPACE], true)) {
 				$tokenTypeLabel = $this->ignoreLexer->getLabel($tokenType);
 				$otherTokenContent = $tokenType === IgnoreLexer::TOKEN_OTHER ? sprintf(" '%s'", $content) : '';
 				$expectedLabels = implode(' or ', array_map(fn ($token) => $this->ignoreLexer->getLabel($token), $expected));
@@ -312,6 +313,9 @@ final class RichParser implements Parser
 			}
 
 			if ($tokenType === IgnoreLexer::TOKEN_OPEN_PARENTHESIS) {
+				if ($openParenthesisCount > 0) {
+					$comment .= $content;
+				}
 				$openParenthesisCount++;
 				$expected = null;
 				continue;
@@ -320,17 +324,25 @@ final class RichParser implements Parser
 			if ($tokenType === IgnoreLexer::TOKEN_CLOSE_PARENTHESIS) {
 				$openParenthesisCount--;
 				if ($openParenthesisCount === 0) {
+					$key = array_key_last($identifiers);
+					if ($key !== null) {
+						$identifiers[$key]['comment'] = $comment;
+						$comment = null;
+					}
 					$expected = [IgnoreLexer::TOKEN_COMMA, IgnoreLexer::TOKEN_END];
+				} else {
+					$comment .= $content;
 				}
 				continue;
 			}
 
 			if ($openParenthesisCount > 0) {
+				$comment .= $content;
 				continue; // waiting for comment end
 			}
 
 			if ($tokenType === IgnoreLexer::TOKEN_IDENTIFIER) {
-				$identifiers[] = $content;
+				$identifiers[] = ['name' => $content, 'comment' => null];
 				$expected = [IgnoreLexer::TOKEN_COMMA, IgnoreLexer::TOKEN_END, IgnoreLexer::TOKEN_OPEN_PARENTHESIS];
 				continue;
 			}
@@ -349,6 +361,7 @@ final class RichParser implements Parser
 			throw new IgnoreParseException('Missing identifier', 1);
 		}
 
+		/** @phpstan-ignore return.type (return type is correct, not sure why it's being changed from array shape to key-value shape) */
 		return $identifiers;
 	}
 

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -140,6 +140,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 				new IgnoreErrorExtensionProvider(self::getContainer()),
 				self::getContainer()->getByType(RuleErrorTransformer::class),
 				new LocalIgnoresProcessor(),
+				false,
 			);
 			$this->analyser = new Analyser(
 				$fileAnalyser,

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -850,6 +850,7 @@ class AnalyserTest extends PHPStanTestCase
 			new IgnoreErrorExtensionProvider(new NetteContainer(new Container([]))),
 			$container->getByType(RuleErrorTransformer::class),
 			new LocalIgnoresProcessor(),
+			false,
 		);
 
 		return new Analyser(

--- a/tests/PHPStan/Parser/RichParserTest.php
+++ b/tests/PHPStan/Parser/RichParserTest.php
@@ -2,10 +2,14 @@
 
 namespace PHPStan\Parser;
 
+use PHPStan\Analyser\FileAnalyserResult;
 use PHPStan\Testing\PHPStanTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use const PHP_EOL;
 
+/**
+ * @phpstan-import-type Identifier from FileAnalyserResult
+ */
 class RichParserTest extends PHPStanTestCase
 {
 
@@ -50,7 +54,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore test',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -58,7 +62,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref',
 			[
-				2 => ['return.ref'],
+				2 => [['name' => 'return.ref', 'comment' => null]],
 			],
 		];
 
@@ -66,7 +70,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref, return.non',
 			[
-				2 => ['return.ref', 'return.non'],
+				2 => [['name' => 'return.ref', 'comment' => null], ['name' => 'return.non', 'comment' => null]],
 			],
 		];
 
@@ -74,7 +78,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref, return.non (foo)',
 			[
-				2 => ['return.ref', 'return.non'],
+				2 => [['name' => 'return.ref', 'comment' => null], ['name' => 'return.non', 'comment' => 'foo']],
 			],
 		];
 
@@ -82,7 +86,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore return.ref, return.non (foo, because...)',
 			[
-				2 => ['return.ref', 'return.non'],
+				2 => [['name' => 'return.ref', 'comment' => null], ['name' => 'return.non', 'comment' => 'foo, because...']],
 			],
 		];
 
@@ -90,7 +94,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'/* @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -98,7 +102,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'/** @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -106,7 +110,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'  /** @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -114,7 +118,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test();  /** @phpstan-ignore test */test();',
 			[
-				2 => ['test'],
+				2 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -123,7 +127,7 @@ class RichParserTest extends PHPStanTestCase
 			'// @phpstan-ignore test' . PHP_EOL .
 			'test();',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -132,7 +136,7 @@ class RichParserTest extends PHPStanTestCase
 			'// @phpstan-ignore test' . PHP_EOL .
 			'test(); // @phpstan-ignore test',
 			[
-				3 => ['test', 'test'],
+				3 => [['name' => 'test', 'comment' => null], ['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -141,7 +145,7 @@ class RichParserTest extends PHPStanTestCase
 			'   // @phpstan-ignore test' . PHP_EOL .
 			'test();',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -153,7 +157,7 @@ class RichParserTest extends PHPStanTestCase
 			' */' . PHP_EOL .
 			'test();',
 			[
-				6 => ['test'],
+				6 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -163,7 +167,7 @@ class RichParserTest extends PHPStanTestCase
 			'/** @phpstan-ignore test */' . PHP_EOL .
 			'test();',
 			[
-				4 => ['test'],
+				4 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -174,7 +178,7 @@ class RichParserTest extends PHPStanTestCase
 			' * @phpstan-ignore test' . PHP_EOL .
 			' */ test();',
 			[
-				5 => ['test'],
+				5 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -185,7 +189,7 @@ class RichParserTest extends PHPStanTestCase
 			' * @phpstan-ignore test' . PHP_EOL .
 			' */',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -194,7 +198,7 @@ class RichParserTest extends PHPStanTestCase
 			PHP_EOL .
 			'/** @phpstan-ignore test */' . PHP_EOL,
 			[
-				4 => ['test'],
+				4 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -204,7 +208,7 @@ class RichParserTest extends PHPStanTestCase
 			'/** @phpstan-ignore test */' . PHP_EOL .
 			'doFoo();' . PHP_EOL,
 			[
-				4 => ['test'],
+				4 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -213,7 +217,7 @@ class RichParserTest extends PHPStanTestCase
 			PHP_EOL .
 			'/** @phpstan-ignore test */',
 			[
-				3 => ['test'],
+				3 => [['name' => 'test', 'comment' => null]],
 			],
 		];
 
@@ -221,7 +225,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (comment), identifier2 (comment2)' . PHP_EOL,
 			[
-				2 => ['identifier', 'identifier2'],
+				2 => [['name' => 'identifier', 'comment' => 'comment'], ['name' => 'identifier2', 'comment' => 'comment2']],
 			],
 		];
 
@@ -229,7 +233,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			"test(); // @phpstan-ignore  identifier (comment1),\tidentifier2 ,  identifier3 (comment3) " . PHP_EOL,
 			[
-				2 => ['identifier', 'identifier2', 'identifier3'],
+				2 => [['name' => 'identifier', 'comment' => 'comment1'], ['name' => 'identifier2', 'comment' => null], ['name' => 'identifier3', 'comment' => 'comment3']],
 			],
 		];
 
@@ -237,7 +241,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (comment with inner (parenthesis))' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'comment with inner (parenthesis)']],
 			],
 		];
 
@@ -245,7 +249,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier ((((multi!))))' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => '(((multi!)))']],
 			],
 		];
 
@@ -253,7 +257,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (var_export() is used intentionally)' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'var_export() is used intentionally']],
 			],
 		];
 
@@ -261,7 +265,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (FileSystem::write() does not support LOCK_EX)' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'FileSystem::write() does not support LOCK_EX']],
 			],
 		];
 
@@ -269,7 +273,7 @@ class RichParserTest extends PHPStanTestCase
 			'<?php' . PHP_EOL .
 			'test(); // @phpstan-ignore identifier (type ensured in self::createClient())' . PHP_EOL,
 			[
-				2 => ['identifier'],
+				2 => [['name' => 'identifier', 'comment' => 'type ensured in self::createClient()']],
 			],
 		];
 
@@ -287,7 +291,7 @@ class RichParserTest extends PHPStanTestCase
 			'  }' . PHP_EOL .
 			'}',
 			[
-				10 => ['variable.undefined'],
+				10 => [['name' => 'variable.undefined', 'comment' => null]],
 			],
 		];
 
@@ -308,13 +312,13 @@ class RichParserTest extends PHPStanTestCase
 			'  }' . PHP_EOL .
 			'}',
 			[
-				13 => ['variable.undefined'],
+				13 => [['name' => 'variable.undefined', 'comment' => null]],
 			],
 		];
 	}
 
 	/**
-	 * @param array<int, list<string>|null> $expectedLines
+	 * @param array<int, list<Identifier>|null> $expectedLines
 	 */
 	#[DataProvider('dataLinesToIgnore')]
 	public function testLinesToIgnore(string $code, array $expectedLines): void


### PR DESCRIPTION
Hello!

Supersedes #3976 

Closes https://github.com/phpstan/phpstan/issues/11340

This PR adds the following option (false by default)
- `reportIgnoresWithoutComments`: reports `@phpstan-ignore` usages without comments


Thanks!