### PR TITLE
feat: add AnalysisResult::withFileSpecificErrors() to public API

### DIFF
--- a/src/Command/AnalysisResult.php
+++ b/src/Command/AnalysisResult.php
@@ -148,4 +148,25 @@ final class AnalysisResult
 		return $this->changedProjectExtensionFilesOutsideOfAnalysedPaths;
 	}
 
+	/**
+	 * @api
+	 * @param list<Error> $fileSpecificErrors
+	 */
+	public function withFileSpecificErrors(array $fileSpecificErrors): self
+	{
+		return new self(
+			$fileSpecificErrors,
+			$this->notFileSpecificErrors,
+			$this->internalErrors,
+			$this->warnings,
+			$this->collectedData,
+			$this->defaultLevelUsed,
+			$this->projectConfigFile,
+			$this->savedResultCache,
+			$this->peakMemoryUsageBytes,
+			$this->isResultCacheUsed,
+			$this->changedProjectExtensionFilesOutsideOfAnalysedPaths,
+		);
+	}
+
 }


### PR DESCRIPTION
Custom ErrorFormatter implementations that need to filter or modify file-specific errors currently have to call the `AnalysisResult` constructor directly, which is not part of the public API.

This adds an `@api` `withFileSpecificErrors()` method that returns a copy of the result with different file-specific errors, allowing extensions to create modified results without relying on internal constructor.

See example usecase: https://github.com/shipmonk-rnd/dead-code-detector/pull/292