### PR TITLE
Faster IsSuperTypeOfResult creation

### DIFF
--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -110,8 +110,10 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isArray()->and($otherType->isList()), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isArray()->and($otherType->isList())->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/AccessoryLiteralStringType.php
+++ b/src/Type/Accessory/AccessoryLiteralStringType.php
@@ -106,8 +106,10 @@ class AccessoryLiteralStringType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isLiteralString(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isLiteralString()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/AccessoryLowercaseStringType.php
+++ b/src/Type/Accessory/AccessoryLowercaseStringType.php
@@ -103,8 +103,10 @@ class AccessoryLowercaseStringType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isLowercaseString(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isLowercaseString()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/AccessoryNonEmptyStringType.php
+++ b/src/Type/Accessory/AccessoryNonEmptyStringType.php
@@ -108,8 +108,10 @@ class AccessoryNonEmptyStringType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isNonEmptyString(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isNonEmptyString()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/AccessoryNonFalsyStringType.php
+++ b/src/Type/Accessory/AccessoryNonFalsyStringType.php
@@ -110,8 +110,10 @@ class AccessoryNonFalsyStringType implements CompoundType, AccessoryType
 			return IsSuperTypeOfResult::createYes();
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isNonFalsyString(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isNonFalsyString()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/AccessoryNumericStringType.php
+++ b/src/Type/Accessory/AccessoryNumericStringType.php
@@ -103,8 +103,10 @@ class AccessoryNumericStringType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isNumericString(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isNumericString()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/AccessoryUppercaseStringType.php
+++ b/src/Type/Accessory/AccessoryUppercaseStringType.php
@@ -103,8 +103,10 @@ class AccessoryUppercaseStringType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isUppercaseString(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isUppercaseString()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/HasMethodType.php
+++ b/src/Type/Accessory/HasMethodType.php
@@ -100,12 +100,12 @@ class HasMethodType implements AccessoryType, CompoundType
 		}
 
 		if ($otherType instanceof self) {
-			$limit = IsSuperTypeOfResult::createYes();
+			$limit = TrinaryLogic::createYes();
 		} else {
-			$limit = IsSuperTypeOfResult::createMaybe();
+			$limit = TrinaryLogic::createMaybe();
 		}
 
-		return $limit->and(new IsSuperTypeOfResult($otherType->hasMethod($this->methodName), []));
+		return new IsSuperTypeOfResult($limit->and($otherType->hasMethod($this->methodName)), []);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -101,10 +101,10 @@ class HasOffsetType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		$result = new IsSuperTypeOfResult($otherType->isOffsetAccessible()->and($otherType->hasOffsetValueType($this->offsetType)), []);
-
-		return $result
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isOffsetAccessible()->and($otherType->hasOffsetValueType($this->offsetType))->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -116,11 +116,15 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		$result = new IsSuperTypeOfResult($otherType->isOffsetAccessible()->and($otherType->hasOffsetValueType($this->offsetType)), []);
+		$result = new IsSuperTypeOfResult(
+			$otherType->isOffsetAccessible()
+				->and($otherType->hasOffsetValueType($this->offsetType))
+				->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 
 		return $result
-			->and($otherType->getOffsetValueType($this->offsetType)->isSuperTypeOf($this->valueType))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+			->and($otherType->getOffsetValueType($this->offsetType)->isSuperTypeOf($this->valueType));
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/HasPropertyType.php
+++ b/src/Type/Accessory/HasPropertyType.php
@@ -92,15 +92,15 @@ class HasPropertyType implements AccessoryType, CompoundType
 		}
 
 		if ($otherType instanceof self) {
-			$limit = IsSuperTypeOfResult::createYes();
+			$limit = TrinaryLogic::createYes();
 		} else {
-			$limit = IsSuperTypeOfResult::createMaybe();
+			$limit = TrinaryLogic::createMaybe();
 		}
 
-		return $limit->and(new IsSuperTypeOfResult(
-			$otherType->hasInstanceProperty($this->propertyName)->or($otherType->hasStaticProperty($this->propertyName)),
+		return new IsSuperTypeOfResult(
+			$limit->and($otherType->hasInstanceProperty($this->propertyName)->or($otherType->hasStaticProperty($this->propertyName))),
 			[],
-		));
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -110,8 +110,10 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isArray()->and($otherType->isIterableAtLeastOnce()), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isArray()->and($otherType->isIterableAtLeastOnce())->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -98,8 +98,10 @@ class OversizedArrayType implements CompoundType, AccessoryType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isArray()->and($otherType->isOversizedArray()), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isArray()->and($otherType->isOversizedArray())->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[],
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -206,7 +206,7 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 
 		return new IsSuperTypeOfResult(
 			$otherType->isCallable()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
-			[]
+			[],
 		);
 	}
 

--- a/src/Type/CallableType.php
+++ b/src/Type/CallableType.php
@@ -204,8 +204,10 @@ class CallableType implements CompoundType, CallableParametersAcceptor
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		return (new IsSuperTypeOfResult($otherType->isCallable(), []))
-			->and($otherType instanceof self ? IsSuperTypeOfResult::createYes() : IsSuperTypeOfResult::createMaybe());
+		return new IsSuperTypeOfResult(
+			$otherType->isCallable()->and($otherType instanceof self ? TrinaryLogic::createYes() : TrinaryLogic::createMaybe()),
+			[]
+		);
 	}
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult


### PR DESCRIPTION
instead of creating `IsSuperTypeOfResult` without reasons and merge them later on, just merge the `Trinary` object and create the `IsSuperTypeOfResult` based on that. Effectively we create the same result with less intermediate objects involved.

triggered by Wordpress profiles, in which `IsSuperTypeOfResult->and()` is showing up

<img width="413" height="684" alt="grafik" src="https://github.com/user-attachments/assets/4012d1fe-4b55-458a-a1ac-79f44592adac" />

improvement is only a few seconds though
