### PR TITLE
Faster TrinaryLogic::maxMin()

### DIFF
--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -265,17 +265,17 @@ final class TrinaryLogic
 		callable $callback,
 	): self
 	{
-		$results = [];
+		$min = self::YES;
 		foreach ($objects as $object) {
 			$result = $callback($object);
 			if ($result->value === self::YES) {
 				return $result;
 			}
 
-			$results[] = $result;
+			$min &= $result->value;
 		}
 
-		return self::maxMin(...$results);
+		return self::$registry[$min] ??= new self($min);
 	}
 
 	public function negate(): self

--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -240,11 +240,15 @@ final class TrinaryLogic
 	 */
 	public static function maxMin(self ...$operands): self
 	{
-		if ($operands === []) {
-			throw new ShouldNotHappenException();
+		$max = self::NO;
+		$min = self::YES;
+		foreach ($operands as $operand) {
+			$max |= $operand->value;
+			$min &= $operand->value;
 		}
-		$operandValues = array_column($operands, 'value');
-		return self::create(max($operandValues) > self::MAYBE ? self::YES : min($operandValues));
+		$maxMin = $max === self::YES ? self::YES : $min;
+
+		return self::$registry[$maxMin] ??= new self($maxMin);
 	}
 
 	/**

--- a/src/TrinaryLogic.php
+++ b/src/TrinaryLogic.php
@@ -240,6 +240,10 @@ final class TrinaryLogic
 	 */
 	public static function maxMin(self ...$operands): self
 	{
+		if ($operands === []) {
+			throw new ShouldNotHappenException();
+		}
+
 		$max = self::NO;
 		$min = self::YES;
 		foreach ($operands as $operand) {


### PR DESCRIPTION
analog https://github.com/phpstan/phpstan-src/pull/4833

Benchmark:
```php
<?php

require 'src/TrinaryLogic.php';

$t = \PHPStan\TrinaryLogic::createYes();
for ($i = 10_000_000; $i--;) {
	\PHPStan\TrinaryLogic::maxMin(\PHPStan\TrinaryLogic::createYes(), \PHPStan\TrinaryLogic::createYes(), \PHPStan\TrinaryLogic::createYes(), \PHPStan\TrinaryLogic::createNo());
}
```

before
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php trinary.php'
Benchmark 1: php trinary.php
  Time (mean ± σ):      1.714 s ±  0.010 s    [User: 1.694 s, System: 0.016 s]
  Range (min … max):    1.702 s …  1.733 s    10 runs
```

after
```
➜  phpstan-src git:(trin) ✗ hyperfine 'php trinary.php'
Benchmark 1: php trinary.php
  Time (mean ± σ):      1.492 s ±  0.031 s    [User: 1.474 s, System: 0.014 s]
  Range (min … max):    1.464 s …  1.575 s    10 runs
```

---

relevant because of slow path in Wordpress

<img width="445" height="663" alt="grafik" src="https://github.com/user-attachments/assets/a966dee8-b3a7-4a7e-8ccc-2d0e9a89d8f1" />
