### PR TITLE
Do not parse PR body to find issues to close

### DIFF
--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -27,18 +27,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PHPSTAN_BOT_TOKEN }}
         run: |
-          PR_BODY=$(gh pr view ${{ github.event.pull_request.number }} --repo "${{ github.repository }}" --json body --jq '.body')
+          URLS=(
+            $(gh pr view ${{ github.event.pull_request.number }} --repo "$GITHUB_REPOSITORY" --json closingIssuesReferences --jq '.closingIssuesReferences[].url')
+          )
 
-          # Parse "Closes/Fixes https://github.com/phpstan/phpstan/issues/123" patterns
-          URLS=$(echo "$PR_BODY" | grep -oiP '(?:closes?|fix(?:es)?)\s+https://github\.com/phpstan/phpstan/issues/[0-9]+' | grep -oP 'https://github\.com/phpstan/phpstan/issues/[0-9]+' || true)
-
-          if [ -z "$URLS" ]; then
-            echo "No linked issues found in PR body"
+          if (( ${#URLS[@]} == 0 )); then
+            echo "No issues are linked to this PR"
             exit 0
           fi
 
-          echo "$URLS" | while read -r url; do
-            NUMBER=$(echo "$url" | grep -oP '[0-9]+$')
+          for url in "${URLS[@]}"; do
+            NUMBER=${url##*/}
             echo "Closing phpstan/phpstan#${NUMBER}"
-            gh issue close "$NUMBER" --repo "phpstan/phpstan" --comment "Closed via merging ${{ github.event.pull_request.html_url }}"
+            gh issue close "$url" --comment "Closed via merging ${{ github.event.pull_request.html_url }}"
           done

--- a/.github/workflows/close-issues-on-merge.yml
+++ b/.github/workflows/close-issues-on-merge.yml
@@ -26,9 +26,12 @@ jobs:
       - name: "Find and close linked issues"
         env:
           GH_TOKEN: ${{ secrets.PHPSTAN_BOT_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          URLS=(
-            $(gh pr view ${{ github.event.pull_request.number }} --repo "$GITHUB_REPOSITORY" --json closingIssuesReferences --jq '.closingIssuesReferences[].url')
+          mapfile -t URLS < <(
+            gh pr view "$PR_NUMBER" --json closingIssuesReferences --jq '.closingIssuesReferences[].url'
           )
 
           if (( ${#URLS[@]} == 0 )); then
@@ -36,8 +39,8 @@ jobs:
             exit 0
           fi
 
-          for url in "${URLS[@]}"; do
-            NUMBER=${url##*/}
-            echo "Closing phpstan/phpstan#${NUMBER}"
-            gh issue close "$url" --comment "Closed via merging ${{ github.event.pull_request.html_url }}"
+          for issue_url in "${URLS[@]}"; do
+            issue_number=${issue_url##*/}
+            echo "Closing phpstan/phpstan#${issue_number}"
+            gh issue close "$issue_url" --comment "Closed via merging $PR_URL"
           done


### PR DESCRIPTION
Extracting linked issues from PR body is very hard as there are variety of syntaxes to link an issue. 
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

Especially some PRs use `phpstan/phpstan#<issue number>` format instead of the issue URL.

We should use `closingIssuesReferences` instead.