### PR TITLE
Prevent `TypeCombinator::intersect()` calls in `MutatingScope-> specifyExpressionType()`

### DIFF
--- a/src/Analyser/Ignore/IgnoredErrorHelper.php
+++ b/src/Analyser/Ignore/IgnoredErrorHelper.php
@@ -106,13 +106,18 @@ final class IgnoredErrorHelper
 				continue;
 			}
 
+			$reportUnmatched = (bool) ($uniquedExpandedIgnoreErrors[$key]['reportUnmatched'] ?? $this->reportUnmatchedIgnoredErrors);
+			if (!$reportUnmatched) {
+				$reportUnmatched = $ignoreError['reportUnmatched'] ?? $this->reportUnmatchedIgnoredErrors;
+			}
+
 			$uniquedExpandedIgnoreErrors[$key] = [
 				'message' => $ignoreError['message'] ?? null,
 				'rawMessage' => $ignoreError['rawMessage'] ?? null,
 				'path' => $ignoreError['path'],
 				'identifier' => $ignoreError['identifier'] ?? null,
 				'count' => ($uniquedExpandedIgnoreErrors[$key]['count'] ?? 1) + ($ignoreError['count'] ?? 1),
-				'reportUnmatched' => ($uniquedExpandedIgnoreErrors[$key]['reportUnmatched'] ?? $this->reportUnmatchedIgnoredErrors) || ($ignoreError['reportUnmatched'] ?? $this->reportUnmatchedIgnoredErrors),
+				'reportUnmatched' => $reportUnmatched,
 			];
 		}
 

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1857,7 +1857,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			return $offsetAccessibleType;
 		}
 
-		if (!$offsetAccessibleType->isArray()->yes() && (new ObjectType(ArrayAccess::class))->isSuperTypeOf($offsetAccessibleType)->yes()) {
+		if (
+			!$offsetAccessibleType->isArray()->yes()
+			&& (new ObjectType(ArrayAccess::class))->isSuperTypeOf($offsetAccessibleType)->yes()
+		) {
 			return $this->getType(
 				new MethodCall(
 					$arrayDimFetch->var,
@@ -3368,11 +3371,15 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			$dimType = $scope->getType($expr->dim)->toArrayKey();
 			if ($dimType->isInteger()->yes() || $dimType->isString()->yes()) {
 				$exprVarType = $scope->getType($expr->var);
-				if (!$exprVarType instanceof MixedType && !$exprVarType->isArray()->no()) {
-					if ($dimType->isInteger()->yes()) {
-						$varType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::intOffsetAccessibleType());
-					} else {
-						$varType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::generalOffsetAccessibleType());
+				$isArray = $exprVarType->isArray();
+				if (!$exprVarType instanceof MixedType && !$isArray->no()) {
+					$varType = $exprVarType;
+					if (!$isArray->yes()) {
+						if ($dimType->isInteger()->yes()) {
+							$varType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::intOffsetAccessibleType());
+						} else {
+							$varType = TypeCombinator::intersect($exprVarType, StaticTypeFactory::generalOffsetAccessibleType());
+						}
 					}
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {

--- a/tests/PHPStan/Analyser/nsrt/bug-11518-types-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11518-types-php7.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.0
+<?php // lint < 8.0
 
 namespace Bug11518Types;
 
@@ -12,7 +12,7 @@ function blah(array $a): array
 {
 	if (!array_key_exists('thing', $a)) {
 		$a['thing'] = 'bla';
-		assertType('non-empty-array&hasOffsetValue(\'thing\', \'bla\')', $a);
+		assertType('non-empty-array<mixed>&hasOffsetValue(\'thing\', \'bla\')', $a);
 	} else {
 		assertType('non-empty-array&hasOffset(\'thing\')', $a);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-11518-types-php7.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11518-types-php7.php
@@ -1,6 +1,6 @@
 <?php // lint < 8.0
 
-namespace Bug11518Types;
+namespace Bug11518TypesPhp7;
 
 use function PHPStan\Testing\assertType;
 

--- a/tests/PHPStan/Analyser/nsrt/bug-11518-types.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11518-types.php
@@ -12,7 +12,7 @@ function blah(array $a): array
 {
 	if (!array_key_exists('thing', $a)) {
 		$a['thing'] = 'bla';
-		assertType('non-empty-array&hasOffsetValue(\'thing\', \'bla\')', $a);
+		assertType('non-empty-array<mixed>&hasOffsetValue(\'thing\', \'bla\')', $a);
 	} else {
 		assertType('non-empty-array&hasOffset(\'thing\')', $a);
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-2911.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-2911.php
@@ -134,6 +134,6 @@ final class ArrayItemRemoval2
 	function foo(array $array): void {
 		$array['bar'] = 'string';
 
-		assertType("non-empty-array&hasOffsetValue('bar', 'string')", $array);
+		assertType("non-empty-array<mixed>&hasOffsetValue('bar', 'string')", $array);
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/composer-array-bug.php
+++ b/tests/PHPStan/Analyser/nsrt/composer-array-bug.php
@@ -47,17 +47,17 @@ class Foo
 				}
 			}
 
-			assertType("non-empty-array&hasOffsetValue('authors', mixed)", $this->config);
+			assertType("non-empty-array<mixed>&hasOffsetValue('authors', mixed)", $this->config);
 			assertType("mixed", $this->config['authors']);
 
 			if (empty($this->config['authors'])) {
 				unset($this->config['authors']);
 				assertType("array<mixed~'authors', mixed>", $this->config);
 			} else {
-				assertType("non-empty-array&hasOffsetValue('authors', mixed~(0|0.0|''|'0'|array{}|false|null))", $this->config);
+				assertType("non-empty-array<mixed>&hasOffsetValue('authors', mixed~(0|0.0|''|'0'|array{}|false|null))", $this->config);
 			}
 
-			assertType("array", $this->config);
+			assertType("array<mixed>", $this->config);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/superglobals.php
+++ b/tests/PHPStan/Analyser/nsrt/superglobals.php
@@ -31,14 +31,14 @@ class Superglobals
 	public function canBePartlyOverwritten(): void
 	{
 		$GLOBALS['foo'] = 'foo';
-		assertType("non-empty-array&hasOffsetValue('foo', 'foo')", $GLOBALS);
+		assertType("non-empty-array<mixed>&hasOffsetValue('foo', 'foo')", $GLOBALS);
 		assertNativeType("non-empty-array<mixed>&hasOffsetValue('foo', 'foo')", $GLOBALS);
 	}
 
 	public function canBeNarrowed(): void
 	{
 		if (isset($GLOBALS['foo'])) {
-			assertType("non-empty-array&hasOffsetValue('foo', mixed~null)", $GLOBALS);
+			assertType("non-empty-array<mixed>&hasOffsetValue('foo', mixed~null)", $GLOBALS);
 			assertNativeType("non-empty-array<mixed>&hasOffset('foo')", $GLOBALS); // https://github.com/phpstan/phpstan/issues/8395
 		} else {
 			assertType('array<mixed>', $GLOBALS);

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1318,7 +1318,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-2911.php'], [
 			[
-				'Parameter #1 $array of function Bug2911\bar expects array{bar: string}, non-empty-array given.',
+				'Parameter #1 $array of function Bug2911\bar expects array{bar: string}, non-empty-array<mixed> given.',
 				23,
 			],
 		]);

--- a/tests/PHPStan/Rules/Functions/data/bug-7156.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-7156.php
@@ -32,7 +32,7 @@ function foobar2(mixed $data): void
 		throw new \RuntimeException();
 	}
 
-	assertType("non-empty-array&hasOffsetValue('value', string)", $data);
+	assertType("non-empty-array<mixed, mixed>&hasOffsetValue('value', string)", $data);
 
 	foo($data);
 }


### PR DESCRIPTION
running `phpstan analyse --debug src/` on Wordpress:

before this PR:
`TypeCombinator::intersect` invoked 37100x
after this PR:
`TypeCombinator::intersect` invoked 1146x

saves 3-5 seconds which translates to a 2-3% perf improvement

----

`TypeCombinator::intersect` is the most expensive part of `MutatingScope-> specifyExpressionType()` in WP:

<img width="437" height="652" alt="grafik" src="https://github.com/user-attachments/assets/2ad33e6a-92ea-4bfe-9188-8329bd97f049" />

----

requires https://github.com/phpstan/phpstan-src/pull/5047/files