### PR TITLE
POC force list in ConstantArrayTypeBuilder

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -1060,13 +1060,15 @@ final class TypeNodeResolver
 			$builder->setOffsetValueType($offsetType, $this->resolve($itemNode->valueType, $nameScope), $itemNode->optional);
 		}
 
-		$arrayType = $builder->getArray();
-
-		$accessories = [];
-		if (in_array($typeNode->kind, [
+		$isList = in_array($typeNode->kind, [
 			ArrayShapeNode::KIND_LIST,
 			ArrayShapeNode::KIND_NON_EMPTY_LIST,
-		], true)) {
+		], true);
+
+		$arrayType = $isList ? $builder->getList() : $builder->getArray();
+
+		$accessories = [];
+		if ($isList) {
 			$accessories[] = new AccessoryArrayListType();
 		}
 

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -1065,7 +1065,7 @@ final class TypeNodeResolver
 			ArrayShapeNode::KIND_NON_EMPTY_LIST,
 		], true);
 
-		$arrayType = $isList ? $builder->getList() : $builder->getArray();
+		$arrayType = $builder->getArray($isList);
 
 		$accessories = [];
 		if ($isList) {

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -61,6 +61,7 @@ use function assert;
 use function count;
 use function implode;
 use function in_array;
+use function is_int;
 use function is_string;
 use function min;
 use function pow;
@@ -1812,23 +1813,21 @@ class ConstantArrayType implements Type
 			}
 
 			$keyValue = $keyType->getValue();
-			$changed = false;
 			foreach ($optionalKeys as $j => $key) {
 				if (
 					$i === $key
 					|| (
 						$isList
-						&& \is_int($keyValue)
-						&& \is_int($this->keyTypes[$key]->getValue())
+						&& is_int($keyValue)
+						&& is_int($this->keyTypes[$key]->getValue())
 						&& $this->keyTypes[$key]->getValue() < $keyValue
 					)
 				) {
 					unset($optionalKeys[$j]);
-					$changed = true;
 				}
 			}
 
-			if ($changed) {
+			if (count($this->optionalKeys) !== count($optionalKeys)) {
 				return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, array_values($optionalKeys), $this->isList);
 			}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1805,16 +1805,31 @@ class ConstantArrayType implements Type
 	{
 		$offsetType = $offsetType->toArrayKey();
 		$optionalKeys = $this->optionalKeys;
+		$isList = $this->isList->yes();
 		foreach ($this->keyTypes as $i => $keyType) {
 			if (!$keyType->equals($offsetType)) {
 				continue;
 			}
 
+			$keyValue = $keyType->getValue();
+			$changed = false;
 			foreach ($optionalKeys as $j => $key) {
-				if ($i === $key) {
+				if (
+					$i === $key
+					|| (
+						$isList
+						&& \is_int($keyValue)
+						&& \is_int($this->keyTypes[$key]->getValue())
+						&& $this->keyTypes[$key]->getValue() < $keyValue
+					)
+				) {
 					unset($optionalKeys[$j]);
-					return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, array_values($optionalKeys), $this->isList);
+					$changed = true;
 				}
+			}
+
+			if ($changed) {
+				return new self($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, array_values($optionalKeys), $this->isList);
 			}
 
 			break;

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -11,6 +11,7 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\CallableType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -373,6 +374,17 @@ final class ConstantArrayTypeBuilder
 		}
 
 		return new IntersectionType([$array, ...$types]);
+	}
+
+	public function getList(): Type
+	{
+		if ($this->isList->no()) {
+			return new NeverType();
+		}
+
+		$this->isList = TrinaryLogic::createYes();
+
+		return $this->getArray();
 	}
 
 	public function isList(): bool

--- a/src/Type/Constant/ConstantArrayTypeBuilder.php
+++ b/src/Type/Constant/ConstantArrayTypeBuilder.php
@@ -325,8 +325,16 @@ final class ConstantArrayTypeBuilder
 		$this->disableArrayDegradation = true;
 	}
 
-	public function getArray(): Type
+	public function getArray(bool $forceList = false): Type
 	{
+		if ($forceList) {
+			if ($this->isList->no()) {
+				return new NeverType();
+			}
+
+			$this->isList = TrinaryLogic::createYes();
+		}
+
 		$keyTypesCount = count($this->keyTypes);
 		if ($keyTypesCount === 0) {
 			return new ConstantArrayType([], []);
@@ -374,17 +382,6 @@ final class ConstantArrayTypeBuilder
 		}
 
 		return new IntersectionType([$array, ...$types]);
-	}
-
-	public function getList(): Type
-	{
-		if ($this->isList->no()) {
-			return new NeverType();
-		}
-
-		$this->isList = TrinaryLogic::createYes();
-
-		return $this->getArray();
 	}
 
 	public function isList(): bool

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -503,7 +503,17 @@ class IssetRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 
-		$this->analyse([__DIR__ . '/data/isset-constant-array.php'], []);
+		$this->analyse([__DIR__ . '/data/isset-constant-array.php'], [
+			[
+				'Offset 2 on list{0: string, 1: string, 2: string, 3: string, 4?: string} in isset() always exists and is not nullable.',
+				13,
+			],
+			[
+				'Offset 3 on array{string, string, string, string, string} in isset() always exists and is not nullable.',
+				17,
+			],
+
+		]);
 	}
 
 	public function testBug10640(): void

--- a/tests/PHPStan/Rules/Variables/IssetRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/IssetRuleTest.php
@@ -499,6 +499,13 @@ class IssetRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testIssetConstantArray(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+
+		$this->analyse([__DIR__ . '/data/isset-constant-array.php'], []);
+	}
+
 	public function testBug10640(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Variables/data/isset-constant-array.php
+++ b/tests/PHPStan/Rules/Variables/data/isset-constant-array.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace IssetConstantArray;
+
+class HelloWorld
+{
+	/**
+	 * @param list{0: string, 1: string, 2?: string, 3?: string, 4?: string} $list
+	 */
+	public function sayHello(array $list): bool
+	{
+		if (isset($list[3])) {
+			return isset($list[2]); // offset 3 implies offset 2;
+		}
+
+		if (isset($list[4])) {
+			return isset($list[3]); // offset 4 implies offset 3;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
I feel like there is some inconsistency about how constant list are handled.
In someplace we're generating a ConstantArray(isList = maybe) and we're adding the AccessoryArrayListType and in some other place we're generating a ConstantArray(isList = true) without the accessory.

The second one is better, since the logic is well handled in the constantArray while the first one can gives weird behavior because we're not handling similar logic in the UnionType (like the fact that a constant array with optional keys and being a list implying some conditions).

The ConstantArrayTypeBuilder, when building the array is often loosing the certainty of the list when adding optional keys (as soon as the second one is added), so I feel like we should have a way to re-force it.

This could be used here too https://github.com/phpstan/phpstan-src/blob/93e6978b46e8c5be3a75210b6bfecc7d56d4f2eb/src/Type/Php/RegexArrayShapeMatcher.php#L298-L304 and certainly at some others place.

But first I'd like your opinion on the idea + how the ConstantArrayBuilder API should change:
- A new method ?
- A new param to getArray ?

But looking at the tests I have an issue:
`list{0?: string, 1?: string, 2?: string, 3?: string}` is `ConstantArray(isList = true)&AccessoryIsList` which is simplified to `ConstantArray(isList = true)` by TypeCombinator::intersect (because the accessory is superTypeOf ConstantArray), so it's displayed `array{0?: string, 1?: string, 2?: string, 3?: string}`.

I tried:
- modifying ConstantArray(isList = true)::describe but at least ~400 tests are failing because it changes lot of error message (with array like `array{1, 2, 3}` becoming `list{1, 2, 3}`).

- modifying TypeCombinator::intersect to keep AccessoryArrayListType, less tests are failing, but it's still hard to avoid changing existing error messages ; I didn't find a way yet.

I dunno if it inspired you @ondrejmirtes @staabm or if I just abandon this for now