### PR TITLE
Prevent unnecessary work in IntersectionType

### DIFF
--- a/src/Type/AcceptsResult.php
+++ b/src/Type/AcceptsResult.php
@@ -152,4 +152,25 @@ final class AcceptsResult
 		return new self(TrinaryLogic::maxMin(...$results), array_values(array_unique($reasons)));
 	}
 
+	/**
+	 * @template T
+	 * @param T[] $objects
+	 * @param callable(T): self $callback
+	 */
+	public static function lazyMaxMin(
+		array $objects,
+		callable $callback,
+	): self
+	{
+		$results = [];
+		foreach ($objects as $object) {
+			$isAcceptedBy = $callback($object);
+			if ($isAcceptedBy->result->yes()) {
+				return $isAcceptedBy;
+			}
+			$results[] = $isAcceptedBy;
+		}
+		return self::maxMin(...$results);
+	}
+
 }

--- a/src/Type/AcceptsResult.php
+++ b/src/Type/AcceptsResult.php
@@ -163,14 +163,26 @@ final class AcceptsResult
 	): self
 	{
 		$results = [];
+		$reasons = [];
+		$hasNo = false;
 		foreach ($objects as $object) {
 			$isAcceptedBy = $callback($object);
 			if ($isAcceptedBy->result->yes()) {
 				return $isAcceptedBy;
+			} elseif ($isAcceptedBy->result->no()) {
+				$hasNo = true;
 			}
 			$results[] = $isAcceptedBy;
+
+			foreach ($isAcceptedBy->reasons as $reason) {
+				$reasons[] = $reason;
+			}
 		}
-		return self::maxMin(...$results);
+
+		return new self(
+			$hasNo ? TrinaryLogic::createNo() : TrinaryLogic::createMaybe(),
+			array_values(array_unique($reasons)),
+		);
 	}
 
 }

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -266,7 +266,16 @@ class IntersectionType implements CompoundType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		$result = IsSuperTypeOfResult::maxMin(...array_map(static fn (Type $innerType) => $otherType->isSuperTypeOf($innerType), $this->types));
+		$results = [];
+		foreach ($this->types as $innerType) {
+			$isSuperTypeOf = $otherType->isSuperTypeOf($innerType);
+			if ($isSuperTypeOf->yes()) {
+				return IsSuperTypeOfResult::createYes();
+			}
+			$results[] = $isSuperTypeOf;
+		}
+		$result = IsSuperTypeOfResult::maxMin(...$results);
+
 		if (
 			!$result->no()
 			&& $this->isOversizedArray()->yes()
@@ -280,7 +289,16 @@ class IntersectionType implements CompoundType
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult
 	{
-		$result = AcceptsResult::maxMin(...array_map(static fn (Type $innerType) => $acceptingType->accepts($innerType, $strictTypes), $this->types));
+		$results = [];
+		foreach ($this->types as $innerType) {
+			$isAcceptedBy = $acceptingType->isAcceptedBy($innerType, $strictTypes);
+
+			if ($isAcceptedBy->yes()) {
+				return AcceptsResult::createYes();
+			}
+		}
+		$result = AcceptsResult::maxMin(...$results);
+
 		if ($this->isOversizedArray()->yes()) {
 			if (!$result->no()) {
 				return AcceptsResult::createYes();

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -266,15 +266,10 @@ class IntersectionType implements CompoundType
 			return $otherType->isSuperTypeOf($this);
 		}
 
-		$results = [];
-		foreach ($this->types as $innerType) {
-			$isSuperTypeOf = $otherType->isSuperTypeOf($innerType);
-			if ($isSuperTypeOf->yes()) {
-				return IsSuperTypeOfResult::createYes();
-			}
-			$results[] = $isSuperTypeOf;
-		}
-		$result = IsSuperTypeOfResult::maxMin(...$results);
+		$result = IsSuperTypeOfResult::lazyMaxMin(
+			$this->types,
+			static fn (Type $innerType) => $otherType->isSuperTypeOf($innerType),
+		);
 
 		if (
 			!$result->no()
@@ -289,15 +284,10 @@ class IntersectionType implements CompoundType
 
 	public function isAcceptedBy(Type $acceptingType, bool $strictTypes): AcceptsResult
 	{
-		$results = [];
-		foreach ($this->types as $innerType) {
-			$isAcceptedBy = $acceptingType->accepts($innerType, $strictTypes);
-			if ($isAcceptedBy->yes()) {
-				return AcceptsResult::createYes();
-			}
-			$results[] = $isAcceptedBy;
-		}
-		$result = AcceptsResult::maxMin(...$results);
+		$result = AcceptsResult::lazyMaxMin(
+			$this->types,
+			static fn (Type $innerType) => $acceptingType->accepts($innerType, $strictTypes),
+		);
 
 		if ($this->isOversizedArray()->yes()) {
 			if (!$result->no()) {

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -291,11 +291,11 @@ class IntersectionType implements CompoundType
 	{
 		$results = [];
 		foreach ($this->types as $innerType) {
-			$isAcceptedBy = $acceptingType->isAcceptedBy($innerType, $strictTypes);
-
+			$isAcceptedBy = $acceptingType->accepts($innerType, $strictTypes);
 			if ($isAcceptedBy->yes()) {
 				return AcceptsResult::createYes();
 			}
+			$results[] = $isAcceptedBy;
 		}
 		$result = AcceptsResult::maxMin(...$results);
 

--- a/src/Type/IsSuperTypeOfResult.php
+++ b/src/Type/IsSuperTypeOfResult.php
@@ -196,14 +196,26 @@ final class IsSuperTypeOfResult
 	): self
 	{
 		$results = [];
+		$reasons = [];
+		$hasNo = false;
 		foreach ($objects as $object) {
 			$isSuperTypeOf = $callback($object);
 			if ($isSuperTypeOf->result->yes()) {
 				return $isSuperTypeOf;
+			} elseif ($isSuperTypeOf->result->no()) {
+				$hasNo = true;
 			}
 			$results[] = $isSuperTypeOf;
+
+			foreach ($isSuperTypeOf->reasons as $reason) {
+				$reasons[] = $reason;
+			}
 		}
-		return self::maxMin(...$results);
+
+		return new self(
+			$hasNo ? TrinaryLogic::createNo() : TrinaryLogic::createMaybe(),
+			array_values(array_unique($reasons)),
+		);
 	}
 
 	public function negate(): self

--- a/src/Type/IsSuperTypeOfResult.php
+++ b/src/Type/IsSuperTypeOfResult.php
@@ -185,6 +185,27 @@ final class IsSuperTypeOfResult
 		return new self(TrinaryLogic::maxMin(...$results), array_values(array_unique($reasons)));
 	}
 
+	/**
+	 * @template T
+	 * @param T[] $objects
+	 * @param callable(T): self $callback
+	 */
+	public static function lazyMaxMin(
+		array $objects,
+		callable $callback,
+	): self
+	{
+		$results = [];
+		foreach ($objects as $object) {
+			$isSuperTypeOf = $callback($object);
+			if ($isSuperTypeOf->result->yes()) {
+				return $isSuperTypeOf;
+			}
+			$results[] = $isSuperTypeOf;
+		}
+		return self::maxMin(...$results);
+	}
+
 	public function negate(): self
 	{
 		return new self($this->result->negate(), $this->reasons);


### PR DESCRIPTION
return early when possible.

before this PR we built the whole result, merging part results and interpreting the combined overall result in the end.
we can save unnecessary work exiting early in case one of the part results are YES (similar how its done in `TrinaryLogic::maxMin`).

---

Wordpress repro

2.1.x
```
➜  wordpress-develop git:(trunk) hyperfine 'php ../../bin/phpstan analyse --debug src/wp-includes/html-api/class-wp-html-processor.php -v'
Benchmark 1: php ../../bin/phpstan analyse --debug src/wp-includes/html-api/class-wp-html-processor.php -v
  Time (mean ± σ):      8.962 s ±  0.061 s    [User: 8.224 s, System: 0.366 s]
  Range (min … max):    8.880 s …  9.060 s    10 runs
```

this PR
```
➜  wordpress-develop git:(trunk) hyperfine 'php ../../bin/phpstan analyse --debug src/wp-includes/html-api/class-wp-html-processor.php -v'
Benchmark 1: php ../../bin/phpstan analyse --debug src/wp-includes/html-api/class-wp-html-processor.php -v
  Time (mean ± σ):      8.647 s ±  0.112 s    [User: 7.864 s, System: 0.368 s]
  Range (min … max):    8.548 s …  8.932 s    10 runs
```

----

I think similar things can be done for union