### PR TITLE
Fix seemingly same type reports as invalid/incompatible.

### DIFF
--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -93,15 +93,15 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
-				return new CallableType(
+				return $this->transformCommonType(new CallableType(
 					$acceptedType->getParameters(),
-					$traverse($this->transformCommonType($acceptedType->getReturnType())),
+					$traverse($acceptedType->getReturnType()),
 					$acceptedType->isVariadic(),
 					$acceptedType->getTemplateTypeMap(),
 					$acceptedType->getResolvedTemplateTypeMap(),
 					$acceptedType->getTemplateTags(),
 					$acceptedType->isPure(),
-				);
+				));
 			}
 
 			if ($acceptedType instanceof ClosureType) {
@@ -109,9 +109,9 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
-				return new ClosureType(
+				return $this->transformCommonType(new ClosureType(
 					$acceptedType->getParameters(),
-					$traverse($this->transformCommonType($acceptedType->getReturnType())),
+					$traverse($acceptedType->getReturnType()),
 					$acceptedType->isVariadic(),
 					$acceptedType->getTemplateTypeMap(),
 					$acceptedType->getResolvedTemplateTypeMap(),
@@ -123,7 +123,7 @@ final class RuleLevelHelper
 					$acceptedType->getUsedVariables(),
 					$acceptedType->acceptsNamedArguments(),
 					$acceptedType->mustUseReturnValue(),
-				);
+				));
 			}
 
 			if (

--- a/src/Rules/RuleLevelHelper.php
+++ b/src/Rules/RuleLevelHelper.php
@@ -93,7 +93,7 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
-				return $this->transformCommonType(new CallableType(
+				return new CallableType(
 					$acceptedType->getParameters(),
 					$traverse($acceptedType->getReturnType()),
 					$acceptedType->isVariadic(),
@@ -101,7 +101,7 @@ final class RuleLevelHelper
 					$acceptedType->getResolvedTemplateTypeMap(),
 					$acceptedType->getTemplateTags(),
 					$acceptedType->isPure(),
-				));
+				);
 			}
 
 			if ($acceptedType instanceof ClosureType) {
@@ -109,7 +109,7 @@ final class RuleLevelHelper
 					return $acceptedType;
 				}
 
-				return $this->transformCommonType(new ClosureType(
+				return new ClosureType(
 					$acceptedType->getParameters(),
 					$traverse($acceptedType->getReturnType()),
 					$acceptedType->isVariadic(),
@@ -123,7 +123,7 @@ final class RuleLevelHelper
 					$acceptedType->getUsedVariables(),
 					$acceptedType->acceptsNamedArguments(),
 					$acceptedType->mustUseReturnValue(),
-				));
+				);
 			}
 
 			if (
@@ -142,10 +142,10 @@ final class RuleLevelHelper
 				}
 			}
 
-			return $traverse($this->transformCommonType($acceptedType));
+			return $traverse($acceptedType);
 		});
 
-		return [$acceptedType, $checkForUnion];
+		return [$this->transformCommonType($acceptedType), $checkForUnion];
 	}
 
 	/** @api */

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -177,15 +177,6 @@ final class TemplateTypeVariance
 
 		if ($this->invariant()) {
 			$result = $a->equals($b);
-			if (
-				!$result
-				&& $a instanceof TemplateType
-				&& $b instanceof TemplateType
-				&& $a->getScope()->equals($b->getScope())
-				&& $a->getName() === $b->getName()
-			) {
-				$result = true;
-			}
 			$reasons = [];
 			if (!$result) {
 				if (

--- a/src/Type/Generic/TemplateTypeVariance.php
+++ b/src/Type/Generic/TemplateTypeVariance.php
@@ -177,6 +177,15 @@ final class TemplateTypeVariance
 
 		if ($this->invariant()) {
 			$result = $a->equals($b);
+			if (
+				!$result
+				&& $a instanceof TemplateType
+				&& $b instanceof TemplateType
+				&& $a->getScope()->equals($b->getScope())
+				&& $a->getName() === $b->getName()
+			) {
+				$result = true;
+			}
 			$reasons = [];
 			if (!$result) {
 				if (

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\Attributes\RequiresPhp;
 class InstantiationRuleTest extends RuleTestCase
 {
 
+	private bool $checkExplicitMixed = false;
+
 	protected function getRule(): Rule
 	{
 		$reflectionProvider = self::createReflectionProvider();
@@ -27,7 +29,7 @@ class InstantiationRuleTest extends RuleTestCase
 		return new InstantiationRule(
 			$container,
 			$reflectionProvider,
-			new FunctionCallParametersCheck(new RuleLevelHelper($reflectionProvider, true, false, true, false, false, false, true), new NullsafeCheck(), new UnresolvableTypeHelper(), new PropertyReflectionFinder(), $reflectionProvider, true, true, true, true),
+			new FunctionCallParametersCheck(new RuleLevelHelper($reflectionProvider, true, false, true, $this->checkExplicitMixed, false, false, true), new NullsafeCheck(), new UnresolvableTypeHelper(), new PropertyReflectionFinder(), $reflectionProvider, true, true, true, true),
 			new ClassNameCheck(
 				new ClassCaseSensitivityCheck($reflectionProvider, true),
 				new ClassForbiddenNameCheck($container),
@@ -568,6 +570,13 @@ class InstantiationRuleTest extends RuleTestCase
 	public function testBug14097(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-14097.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0')]
+	public function testBug13440(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-13440.php'], []);
 	}
 
 	public function testNewStaticWithConsistentConstructor(): void

--- a/tests/PHPStan/Rules/Classes/data/bug-13440.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-13440.php
@@ -1,0 +1,37 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug13440;
+
+use Closure;
+
+/** @template T */
+interface Foo {}
+
+/**
+ * @template TVal
+ * @template TReturn
+ */
+class Box
+{
+    /**
+     * @param TVal $val
+     * @param Closure(Foo<TVal>): TReturn $cb
+     */
+    public function __construct(
+        private mixed $val,
+        private Closure $cb,
+    ) {
+    }
+
+    /**
+     * @template TNewReturn
+     * @param Closure(Foo<TVal>): TNewReturn $cb
+     * @return self<TVal, TNewReturn>
+     */
+    public function test(Closure $cb): self
+    {
+        return new self($this->val, $cb);
+    }
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-13440.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-13440.php
@@ -35,3 +35,30 @@ class Box
         return new self($this->val, $cb);
     }
 }
+
+/**
+ * @template TVal
+ * @template TReturn
+ */
+class Box2
+{
+	/**
+	 * @param TVal $val
+	 * @param callable(Foo<TVal>): TReturn $cb
+	 */
+	public function __construct(
+		private mixed $val,
+		private $cb,
+	) {
+	}
+
+	/**
+	 * @template TNewReturn
+	 * @param callable(Foo<TVal>): TNewReturn $cb
+	 * @return self<TVal, TNewReturn>
+	 */
+	public function test($cb): self
+	{
+		return new self($this->val, $cb);
+	}
+}

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -1025,6 +1025,7 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12250.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	public function testBug12688(): void
 	{
 		$this->checkExplicitMixed = true;

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -1025,6 +1025,13 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-12250.php'], []);
 	}
 
+	public function testBug12688(): void
+	{
+		$this->checkExplicitMixed = true;
+		$this->checkImplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-12688.php'], []);
+	}
+
 	public function testBug4525(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-4525.php'], []);

--- a/tests/PHPStan/Rules/Properties/data/bug-12688.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12688.php
@@ -1,0 +1,54 @@
+<?php // lint >= 8.1
+
+namespace Bug12688;
+
+/**
+ * @template T = mixed
+ */
+interface I {}
+
+/**
+ * @implements I<mixed>
+ */
+enum E implements I
+{
+	case E;
+}
+
+/**
+ * @template T
+ */
+final class TemplateWithoutDefaultWorks
+{
+	/**
+	 * @var I<T>
+	 */
+	public readonly I $i;
+
+	/**
+	 * @param I<T> $i
+	 */
+	public function __construct(I $i = E::E)
+	{
+		$this->i = $i;
+	}
+}
+
+/**
+ * @template T = mixed
+ */
+final class TemplateWithDefaultDoesNotWork
+{
+	/**
+	 * @var I<T>
+	 */
+	public readonly I $i;
+
+	/**
+	 * @param I<T> $i
+	 */
+	public function __construct(I $i = E::E)
+	{
+		$this->i = $i;
+	}
+}


### PR DESCRIPTION
Rework of https://github.com/phpstan/phpstan-src/pull/5073

Closes https://github.com/phpstan/phpstan/issues/13440
Closes https://github.com/phpstan/phpstan/issues/12688

The issue was that one closure was changed into Closure(template-strict-mixed), while the other stayed Closure(template-mixed) and therefor they were not equal.

Instead of just transforming common in return type, we should transform them in parameter and return types.
Best way to do it it's to transform common type on the closure. (Cf commit 2)

And then when I thought again about it, I think there is some loss on calling transformCommonType inside the `TypeTraverser::map` call since we might call in multiple times when traversing the types. The first one will transform the mixed to strict mixed, but other call will be useless.
So it's seems better to just call it once on the whole accepted type at the end.