### PR TITLE
AcceptsResult: cache Yes/No/Maybe

### DIFF
--- a/src/Type/AcceptsResult.php
+++ b/src/Type/AcceptsResult.php
@@ -28,6 +28,12 @@ use function array_values;
 final class AcceptsResult
 {
 
+	private static self $YES;
+
+	private static self $MAYBE;
+
+	private static self $NO;
+
 	/**
 	 * @api
 	 * @param list<string> $reasons Human-readable explanations of why acceptance failed
@@ -68,23 +74,29 @@ final class AcceptsResult
 
 	public static function createYes(): self
 	{
-		return new self(TrinaryLogic::createYes(), []);
+		return self::$YES ??= new self(TrinaryLogic::createYes(), []);
 	}
 
 	/** @param list<string> $reasons */
 	public static function createNo(array $reasons = []): self
 	{
+		if ($reasons === []) {
+			return self::$NO ??= new self(TrinaryLogic::createNo(), $reasons);
+		}
 		return new self(TrinaryLogic::createNo(), $reasons);
 	}
 
 	public static function createMaybe(): self
 	{
-		return new self(TrinaryLogic::createMaybe(), []);
+		return self::$MAYBE ??= new self(TrinaryLogic::createMaybe(), []);
 	}
 
 	public static function createFromBoolean(bool $value): self
 	{
-		return new self(TrinaryLogic::createFromBoolean($value), []);
+		if ($value === true) {
+			return self::createYes();
+		}
+		return self::createNo();
 	}
 
 	public function and(self $other): self
@@ -162,7 +174,6 @@ final class AcceptsResult
 		callable $callback,
 	): self
 	{
-		$results = [];
 		$reasons = [];
 		$hasNo = false;
 		foreach ($objects as $object) {
@@ -172,7 +183,6 @@ final class AcceptsResult
 			} elseif ($isAcceptedBy->result->no()) {
 				$hasNo = true;
 			}
-			$results[] = $isAcceptedBy;
 
 			foreach ($isAcceptedBy->reasons as $reason) {
 				$reasons[] = $reason;

--- a/src/Type/IsSuperTypeOfResult.php
+++ b/src/Type/IsSuperTypeOfResult.php
@@ -195,7 +195,6 @@ final class IsSuperTypeOfResult
 		callable $callback,
 	): self
 	{
-		$results = [];
 		$reasons = [];
 		$hasNo = false;
 		foreach ($objects as $object) {
@@ -205,7 +204,6 @@ final class IsSuperTypeOfResult
 			} elseif ($isSuperTypeOf->result->no()) {
 				$hasNo = true;
 			}
-			$results[] = $isSuperTypeOf;
 
 			foreach ($isSuperTypeOf->reasons as $reason) {
 				$reasons[] = $reason;


### PR DESCRIPTION
I found some useless variable in lazyMaxMin, and then I found that you cached Yes/no/maybe in SuperTypeOf but not AcceptResult @staabm. I think we can do the same.