### PR TITLE
Consider ArrayAccess side effects for dead catch analysis

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2094,7 +2094,7 @@ class NodeScopeResolver
 					if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 						$throwPoints = array_merge($throwPoints, $this->processExprNode(
 							$stmt,
-							new MethodCall($this->deepNodeCloner->cloneNode($var->var), 'offsetUnset'),
+							new MethodCall($var->var, 'offsetUnset'),
 							$scope,
 							$storage,
 							new NoopNodeCallback(),
@@ -3629,11 +3629,11 @@ class NodeScopeResolver
 			if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 				$throwPoints = array_merge($throwPoints, $this->processExprNode(
 					$stmt,
-					new MethodCall($this->deepNodeCloner->cloneNode($expr->var), 'offsetGet'),
+					new MethodCall($expr->var, 'offsetGet'),
 					$scope,
 					$storage,
 					new NoopNodeCallback(),
-					ExpressionContext::createDeep(),
+					$context,
 				)->getThrowPoints());
 			}
 		} elseif ($expr instanceof Array_) {
@@ -3945,11 +3945,11 @@ class NodeScopeResolver
 
 				$throwPoints = array_merge($throwPoints, $this->processExprNode(
 					$stmt,
-					new MethodCall($this->deepNodeCloner->cloneNode($var->var), 'offsetExists'),
+					new MethodCall($var->var, 'offsetExists'),
 					$scope,
 					$storage,
 					new NoopNodeCallback(),
-					ExpressionContext::createDeep(),
+					$context,
 				)->getThrowPoints());
 			}
 			foreach (array_reverse($expr->vars) as $var) {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2090,6 +2090,18 @@ class NodeScopeResolver
 				$throwPoints = array_merge($throwPoints, $exprResult->getThrowPoints());
 				$impurePoints = array_merge($impurePoints, $exprResult->getImpurePoints());
 				if ($var instanceof ArrayDimFetch && $var->dim !== null) {
+					$varType = $scope->getType($var->var);
+					if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
+						$throwPoints = array_merge($throwPoints, $this->processExprNode(
+							$stmt,
+							new MethodCall($this->deepNodeCloner->cloneNode($var->var), 'offsetUnset'),
+							$scope,
+							$storage,
+							new NoopNodeCallback(),
+							ExpressionContext::createDeep(),
+						)->getThrowPoints());
+					}
+
 					$clonedVar = $this->deepNodeCloner->cloneNode($var->var);
 					$traverser = new NodeTraverser();
 					$traverser->addVisitor(new class () extends NodeVisitorAbstract {
@@ -3612,6 +3624,18 @@ class NodeScopeResolver
 			$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
 			$isAlwaysTerminating = $isAlwaysTerminating || $result->isAlwaysTerminating();
 			$scope = $result->getScope();
+
+			$varType = $scope->getType($expr->var);
+			if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
+				$throwPoints = array_merge($throwPoints, $this->processExprNode(
+					$stmt,
+					new MethodCall($this->deepNodeCloner->cloneNode($expr->var), 'offsetGet'),
+					$scope,
+					$storage,
+					new NoopNodeCallback(),
+					ExpressionContext::createDeep(),
+				)->getThrowPoints());
+			}
 		} elseif ($expr instanceof Array_) {
 			$itemNodes = [];
 			$hasYield = false;
@@ -3909,6 +3933,24 @@ class NodeScopeResolver
 				$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
 				$isAlwaysTerminating = $isAlwaysTerminating || $result->isAlwaysTerminating();
 				$nonNullabilityResults[] = $nonNullabilityResult;
+
+				if (!($var instanceof ArrayDimFetch)) {
+					continue;
+				}
+
+				$varType = $scope->getType($var->var);
+				if ($varType->isArray()->yes() || (new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
+					continue;
+				}
+
+				$throwPoints = array_merge($throwPoints, $this->processExprNode(
+					$stmt,
+					new MethodCall($this->deepNodeCloner->cloneNode($var->var), 'offsetExists'),
+					$scope,
+					$storage,
+					new NoopNodeCallback(),
+					ExpressionContext::createDeep(),
+				)->getThrowPoints());
 			}
 			foreach (array_reverse($expr->vars) as $var) {
 				$scope = $this->lookForUnsetAllowedUndefinedExpressions($scope, $var);

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -6414,10 +6414,11 @@ class NodeScopeResolver
 				$scope = $scope->assignExpression($expr, $type, $nativeType);
 			}
 
-			if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
+			$setVarType = $scope->getType($originalVar->var);
+			if (!$setVarType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($setVarType)->no()) {
 				$throwPoints = array_merge($throwPoints, $this->processExprNode(
 					$stmt,
-					new MethodCall($var, 'offsetSet'),
+					new MethodCall($originalVar->var, 'offsetSet'),
 					$scope,
 					$storage,
 					new NoopNodeCallback(),

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -174,6 +174,7 @@ use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantTypeHelper;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\Generic\TemplateTypeHelper;
@@ -6415,7 +6416,11 @@ class NodeScopeResolver
 			}
 
 			$setVarType = $scope->getType($originalVar->var);
-			if (!$setVarType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($setVarType)->no()) {
+			if (
+				!$setVarType instanceof ErrorType
+				&& !$setVarType->isArray()->yes()
+				&& !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($setVarType)->no()
+			) {
 				$throwPoints = array_merge($throwPoints, $this->processExprNode(
 					$stmt,
 					new MethodCall($originalVar->var, 'offsetSet'),

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -633,6 +633,22 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - Exception is never thrown in the try block.',
 				142,
 			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				183,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				189,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				197,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				203,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -614,6 +614,11 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-9267.php'], []);
 	}
 
+	public function testBug11427(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-11427.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.4')]
 	public function testPropertyHooks(): void
 	{

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -616,7 +616,24 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 
 	public function testBug11427(): void
 	{
-		$this->analyse([__DIR__ . '/data/bug-11427.php'], []);
+		$this->analyse([__DIR__ . '/data/bug-11427.php'], [
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				124,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				130,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				136,
+			],
+			[
+				'Dead catch - Exception is never thrown in the try block.',
+				142,
+			],
+		]);
 	}
 
 	#[RequiresPhp('>= 8.4')]

--- a/tests/PHPStan/Rules/Exceptions/data/bug-11427.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-11427.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Bug11427;
+
+/** @implements \ArrayAccess<int, int> */
+class C implements \ArrayAccess {
+	#[\ReturnTypeWillChange]
+	public function offsetExists($offset) {
+		throw new \Exception("exists");
+	}
+
+	#[\ReturnTypeWillChange]
+	public function offsetGet($offset) {
+		throw new \Exception("get");
+	}
+
+	#[\ReturnTypeWillChange]
+	public function offsetSet($offset, $value) {
+		throw new \Exception("set");
+	}
+
+	#[\ReturnTypeWillChange]
+	public function offsetUnset($offset) {
+		throw new \Exception("unset");
+	}
+}
+
+function test(C $c): void {
+	try {
+		$x = isset($c[1]);
+	} catch (\Exception $e) {
+		// offsetExists can throw
+	}
+
+	try {
+		$x = $c[1];
+	} catch (\Exception $e) {
+		// offsetGet can throw
+	}
+
+	try {
+		$c[1] = 1;
+	} catch (\Exception $e) {
+		// offsetSet can throw
+	}
+
+	try {
+		unset($c[1]);
+	} catch (\Exception $e) {
+		// offsetUnset can throw
+	}
+}
+
+/**
+ * Union type where isArray() returns maybe and isSuperTypeOf(ArrayAccess) returns maybe.
+ * This ensures the conditions in NodeScopeResolver are tested with types
+ * that distinguish !->yes() from ->no() and !->no() from ->yes().
+ *
+ * @param array<int, int>|C $c
+ */
+function testArrayOrArrayAccess($c): void {
+	try {
+		$x = isset($c[1]);
+	} catch (\Exception $e) {
+		// offsetExists can throw when $c is C
+	}
+
+	try {
+		$x = $c[1];
+	} catch (\Exception $e) {
+		// offsetGet can throw when $c is C
+	}
+
+	try {
+		$c[1] = 1;
+	} catch (\Exception $e) {
+		// offsetSet can throw when $c is C
+	}
+
+	try {
+		unset($c[1]);
+	} catch (\Exception $e) {
+		// offsetUnset can throw when $c is C
+	}
+}

--- a/tests/PHPStan/Rules/Exceptions/data/bug-11427.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-11427.php
@@ -143,3 +143,64 @@ function test2(D $c): void {
 		// offsetUnset cannot throw
 	}
 }
+
+/**
+ * @param array<C> $arrayOfC
+ */
+function test3(array $arrayOfC): void
+{
+	try {
+		$x = isset($arrayOfC[0][1]);
+	} catch (\Exception $e) {
+		// offsetExists can throw
+	}
+
+	try {
+		$x = $arrayOfC[0][1];
+	} catch (\Exception $e) {
+		// offsetGet can throw
+	}
+
+	try {
+		$arrayOfC[0][1] = 1;
+	} catch (\Exception $e) {
+		// offsetSet can throw
+	}
+
+	try {
+		unset($arrayOfC[0][1]);
+	} catch (\Exception $e) {
+		// offsetUnset can throw
+	}
+}
+
+/**
+ * @param array<C> $arrayOfC
+ */
+function test4(array $arrayOfC): void {
+	try {
+		$x = isset($arrayOfC[0]);
+	} catch (\Exception $e) {
+		// offsetExists cannot throw
+	}
+
+	try {
+		$x = $arrayOfC[0];
+	} catch (\Exception $e) {
+		// offsetGet cannot throw
+	}
+
+	/** @var C<int, int> $newC */
+	$newC = new C();
+	try {
+		$arrayOfC[0] = $newC;
+	} catch (\Exception $e) {
+		// offsetSet cannot throw
+	}
+
+	try {
+		unset($arrayOfC[0]);
+	} catch (\Exception $e) {
+		// offsetUnset cannot throw
+	}
+}

--- a/tests/PHPStan/Rules/Exceptions/data/bug-11427.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-11427.php
@@ -83,3 +83,63 @@ function testArrayOrArrayAccess($c): void {
 		// offsetUnset can throw when $c is C
 	}
 }
+
+class D implements \ArrayAccess {
+	/**
+	 * @throws void
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetExists($offset) {
+		throw new \Exception("exists");
+	}
+
+	/**
+	 * @throws void
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetGet($offset) {
+		throw new \Exception("get");
+	}
+
+	/**
+	 * @throws void
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetSet($offset, $value) {
+		throw new \Exception("set");
+	}
+
+	/**
+	 * @throws void
+	 */
+	#[\ReturnTypeWillChange]
+	public function offsetUnset($offset) {
+		throw new \Exception("unset");
+	}
+}
+
+function test2(D $c): void {
+	try {
+		$x = isset($c[1]);
+	} catch (\Exception $e) {
+		// offsetExists cannot throw
+	}
+
+	try {
+		$x = $c[1];
+	} catch (\Exception $e) {
+		// offsetGet cannot throw
+	}
+
+	try {
+		$c[1] = 1;
+	} catch (\Exception $e) {
+		// offsetSet cannot throw
+	}
+
+	try {
+		unset($c[1]);
+	} catch (\Exception $e) {
+		// offsetUnset cannot throw
+	}
+}


### PR DESCRIPTION
- Synthesize offsetGet throw points in ArrayDimFetch handler for ArrayAccess objects
- Synthesize offsetUnset throw points in Unset_ handler for ArrayAccess objects
- Synthesize offsetExists throw points in Isset_ handler for ArrayAccess objects
- offsetSet was already handled; this brings the other three operations to parity
- New regression test in tests/PHPStan/Rules/Exceptions/data/bug-11427.php

From https://github.com/phpstan/phpstan-src/pull/4910

Closes https://github.com/phpstan/phpstan/issues/11427