### PR TITLE
Pass CLI `--error-format` option into the DIC container parameter

### DIFF
--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -161,6 +161,7 @@ final class AnalyseCommand extends Command
 
 		$tmpFile = $input->getOption('tmp-file');
 		$insteadOfFile = $input->getOption('instead-of');
+		$errorFormat = $input->getOption('error-format');
 
 		if (
 			!is_array($paths)
@@ -170,6 +171,7 @@ final class AnalyseCommand extends Command
 			|| (!is_string($level) && $level !== null)
 			|| (!is_string($tmpFile) && $tmpFile !== null)
 			|| (!is_string($insteadOfFile) && $insteadOfFile !== null)
+			|| (!is_string($errorFormat) && $errorFormat !== null)
 			|| (!is_bool($allowXdebug))
 		) {
 			throw new ShouldNotHappenException();
@@ -191,6 +193,7 @@ final class AnalyseCommand extends Command
 				$tmpFile,
 				$insteadOfFile,
 				true,
+				$errorFormat,
 			);
 		} catch (InceptionNotSuccessfulException $e) {
 			return 1;
@@ -226,21 +229,12 @@ final class AnalyseCommand extends Command
 		}
 
 		$errorOutput = $inceptionResult->getErrorOutput();
-		$errorFormat = $input->getOption('error-format');
+		$container = $inceptionResult->getContainer();
 
-		if (!is_string($errorFormat) && $errorFormat !== null) {
-			throw new ShouldNotHappenException();
-		}
-
-		if ($errorFormat === null) {
-			$errorFormat = $inceptionResult->getContainer()->getParameter('errorFormat');
-		}
-
+		$errorFormat = $container->getParameter('errorFormat');
 		if ($errorFormat === null) {
 			$errorFormat = 'table';
 		}
-
-		$container = $inceptionResult->getContainer();
 		$errorFormatterServiceName = sprintf('errorFormatter.%s', $errorFormat);
 		if (!$container->hasService($errorFormatterServiceName)) {
 			$errorOutput->writeLineFormatted(sprintf(

--- a/src/Command/CommandHelper.php
+++ b/src/Command/CommandHelper.php
@@ -95,6 +95,7 @@ final class CommandHelper
 		?string $singleReflectionFile,
 		?string $singleReflectionInsteadOfFile,
 		bool $cleanupContainerCache,
+		?string $errorFormat = null,
 	): InceptionResult
 	{
 		$stdOutput = new SymfonyOutput($output, new SymfonyStyle(new ErrorsConsoleStyle($input, $output)));
@@ -386,7 +387,7 @@ final class CommandHelper
 		}
 
 		try {
-			$container = $containerFactory->create($tmpDir, $additionalConfigFiles, $paths, $composerAutoloaderProjectPaths, $analysedPathsFromConfig, $level ?? self::DEFAULT_LEVEL, $generateBaselineFile, $autoloadFile, $singleReflectionFile, $singleReflectionInsteadOfFile);
+			$container = $containerFactory->create($tmpDir, $additionalConfigFiles, $paths, $composerAutoloaderProjectPaths, $analysedPathsFromConfig, $level ?? self::DEFAULT_LEVEL, $generateBaselineFile, $autoloadFile, $singleReflectionFile, $singleReflectionInsteadOfFile, $errorFormat);
 		} catch (InvalidConfigurationException | AssertionException $e) {
 			$errorOutput->writeLineFormatted('<error>Invalid configuration:</error>');
 			$errorOutput->writeLineFormatted($e->getMessage());

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -109,6 +109,7 @@ final class ContainerFactory
 		?string $cliAutoloadFile = null,
 		?string $singleReflectionFile = null,
 		?string $singleReflectionInsteadOfFile = null,
+		?string $errorFormat = null,
 	): Container
 	{
 		[$allConfigFiles, $projectConfig] = $this->detectDuplicateIncludedFiles(
@@ -146,12 +147,16 @@ final class ContainerFactory
 			'cliAutoloadFile' => $cliAutoloadFile,
 			'env' => getenv(),
 		]);
-		$configurator->addDynamicParameters([
+		$dynamicParameters = [
 			'singleReflectionFile' => $singleReflectionFile,
 			'singleReflectionInsteadOfFile' => $singleReflectionInsteadOfFile,
 			'analysedPaths' => $analysedPaths,
 			'analysedPathsFromConfig' => $analysedPathsFromConfig,
-		]);
+		];
+		if ($errorFormat !== null) {
+			$dynamicParameters['errorFormat'] = $errorFormat;
+		}
+		$configurator->addDynamicParameters($dynamicParameters);
 		$configurator->addConfig($this->configDirectory . '/config.neon');
 		foreach ($additionalConfigFiles as $additionalConfigFile) {
 			$configurator->addConfig($additionalConfigFile);

--- a/tests/PHPStan/Command/CommandHelperTest.php
+++ b/tests/PHPStan/Command/CommandHelperTest.php
@@ -319,4 +319,47 @@ class CommandHelperTest extends TestCase
 		}
 	}
 
+	public function testErrorFormatFromCli(): void
+	{
+		$result = CommandHelper::begin(
+			new StringInput(''),
+			new NullOutput(),
+			[__DIR__],
+			null,
+			null,
+			[],
+			null,
+			null,
+			'0',
+			false,
+			false,
+			null,
+			null,
+			false,
+			'json',
+		);
+		$this->assertSame('json', $result->getContainer()->getParameter('errorFormat'));
+	}
+
+	public function testErrorFormatDefault(): void
+	{
+		$result = CommandHelper::begin(
+			new StringInput(''),
+			new NullOutput(),
+			[__DIR__],
+			null,
+			null,
+			[],
+			null,
+			null,
+			'0',
+			false,
+			false,
+			null,
+			null,
+			false,
+		);
+		$this->assertNull($result->getContainer()->getParameter('errorFormat'));
+	}
+
 }


### PR DESCRIPTION
The errorFormat DIC parameter was not updated when the `--error-format` CLI option was used - it always held the config file value (default null). This meant reading the parameter from the container would not reflect the actually-used value.