### PR TITLE
Update PDOStatement stub

### DIFF
--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -86,6 +86,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\NewObjectType;
 use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\NonexistentParentClassType;
@@ -935,17 +936,23 @@ final class TypeNodeResolver
 
 			try {
 				if (count($genericTypes) === 1) { // Foo<ValueType>
-					return TypeCombinator::intersect(
-						$mainType,
-						new IterableType(new MixedType(true), $genericTypes[0]),
-					);
+					$iterableType = new IterableType(new MixedType(true), $genericTypes[0]);
+					$result = TypeCombinator::intersect($mainType, $iterableType);
+					if (!$result instanceof NeverType) {
+						return $result;
+					}
+
+					return new IntersectionType([$mainType, $iterableType]);
 				}
 
 				if (count($genericTypes) === 2) { // Foo<KeyType, ValueType>
-					return TypeCombinator::intersect(
-						$mainType,
-						new IterableType($genericTypes[0], $genericTypes[1]),
-					);
+					$iterableType = new IterableType($genericTypes[0], $genericTypes[1]);
+					$result = TypeCombinator::intersect($mainType, $iterableType);
+					if (!$result instanceof NeverType) {
+						return $result;
+					}
+
+					return new IntersectionType([$mainType, $iterableType]);
 				}
 			} finally {
 				if ($mainTypeClassName !== null) {

--- a/src/PhpDoc/TypeNodeResolver.php
+++ b/src/PhpDoc/TypeNodeResolver.php
@@ -86,7 +86,6 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IterableType;
 use PHPStan\Type\KeyOfType;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\NewObjectType;
 use PHPStan\Type\NonAcceptingNeverType;
 use PHPStan\Type\NonexistentParentClassType;
@@ -936,23 +935,17 @@ final class TypeNodeResolver
 
 			try {
 				if (count($genericTypes) === 1) { // Foo<ValueType>
-					$iterableType = new IterableType(new MixedType(true), $genericTypes[0]);
-					$result = TypeCombinator::intersect($mainType, $iterableType);
-					if (!$result instanceof NeverType) {
-						return $result;
-					}
-
-					return new IntersectionType([$mainType, $iterableType]);
+					return TypeCombinator::intersect(
+						$mainType,
+						new IterableType(new MixedType(true), $genericTypes[0]),
+					);
 				}
 
 				if (count($genericTypes) === 2) { // Foo<KeyType, ValueType>
-					$iterableType = new IterableType($genericTypes[0], $genericTypes[1]);
-					$result = TypeCombinator::intersect($mainType, $iterableType);
-					if (!$result instanceof NeverType) {
-						return $result;
-					}
-
-					return new IntersectionType([$mainType, $iterableType]);
+					return TypeCombinator::intersect(
+						$mainType,
+						new IterableType($genericTypes[0], $genericTypes[1]),
+					);
 				}
 			} finally {
 				if ($mainTypeClassName !== null) {

--- a/stubs/PDOStatement.stub
+++ b/stubs/PDOStatement.stub
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * @implements Traversable<array<int|string, mixed>>
- * @implements IteratorAggregate<array<int|string, mixed>>
+ * @implements Traversable<mixed>
+ * @implements IteratorAggregate<mixed>
  * @link https://php.net/manual/en/class.pdostatement.php
  */
 class PDOStatement implements Traversable, IteratorAggregate
@@ -21,7 +21,7 @@ class PDOStatement implements Traversable, IteratorAggregate
     public function getColumnMeta(int $column) {}
 
     /**
-     * @return Iterator<mixed, array<int|string, mixed>>
+     * @return Iterator<mixed, mixed>
      */
     public function getIterator() {}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-8886.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-8886.php
@@ -9,5 +9,5 @@ function testPDOStatementGetIterator(): void {
 	$pdo = new PDO('sqlite::memory:');
     $stmt = $pdo->query('SELECT 1');
 
-	assertType('Iterator<mixed, array<int|string, mixed>>', $stmt->getIterator());
+	assertType('Iterator<mixed, mixed>', $stmt->getIterator());
 }

--- a/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/InvalidPhpDocVarTagTypeRuleTest.php
@@ -170,6 +170,11 @@ class InvalidPhpDocVarTagTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-6348.php'], []);
 	}
 
+	public function testBug14206(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14206.php'], []);
+	}
+
 	public function testBug9055(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-9055.php'], [

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-14206.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-14206.php
@@ -14,4 +14,19 @@ class Test
 		$statement->setFetchMode(PDO::FETCH_COLUMN, 0);
 		$statement->execute();
 	}
+
+	public function test2(PDO $db): void
+	{
+		/** @var PDOStatement<int,array<string>> */
+		$statement = $db->prepare('SELECT foo FROM bar');
+		$statement->execute();
+	}
+
+	public function test3(PDO $db): void
+	{
+		/** @var PDOStatement<int,object> */
+		$statement = $db->prepare('SELECT foo FROM bar');
+		$statement->setFetchMode(PDO::FETCH_OBJ, 0);
+		$statement->execute();
+	}
 }

--- a/tests/PHPStan/Rules/PhpDoc/data/bug-14206.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/bug-14206.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14206;
+
+use PDO;
+use PDOStatement;
+
+class Test
+{
+	public function test(PDO $db): void
+	{
+		/** @var PDOStatement<int,string> */
+		$statement = $db->prepare('SELECT foo FROM bar');
+		$statement->setFetchMode(PDO::FETCH_COLUMN, 0);
+		$statement->execute();
+	}
+}

--- a/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/AccessPropertiesRuleTest.php
@@ -1183,6 +1183,14 @@ class AccessPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-11289.php'], []);
 	}
 
+	public function testBug9120(): void
+	{
+		$this->checkThisOnly = false;
+		$this->checkUnionTypes = true;
+		$this->checkDynamicProperties = false;
+		$this->analyse([__DIR__ . '/data/bug-9120.php'], []);
+	}
+
 	public function testBug8668(): void
 	{
 		$this->checkThisOnly = false;

--- a/tests/PHPStan/Rules/Properties/data/bug-9120.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-9120.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9120;
+
+function do_something(): void
+{
+	$db = new \PDO('connection-string');
+
+	$statement = $db->query('sql-query');
+	if ($statement !== false)
+	{
+		$statement->setFetchMode(\PDO::FETCH_OBJ);
+
+		foreach ($statement as $tmpObject)
+		{
+			echo $tmpObject->mycolumn;
+		}
+	}
+}


### PR DESCRIPTION
Rework of https://github.com/phpstan/phpstan-src/pull/5128

PDOStatement can either returns array, string or object based on the fetch mode
see https://github.com/phpstan/phpstan/issues/14206#issuecomment-3996154805,
so retricting the type to array is wrong ; rather than scalar|object|array, I think mixed will create less issues.

Fixes phpstan/phpstan#14206
Fixes https://github.com/phpstan/phpstan/issues/9120

Still ok with https://github.com/phpstan/phpstan/issues/8886 since it just asked about Iterator.