### PR TITLE
Implement array_all type specifying for arrow functions

### DIFF
--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -18,7 +18,6 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use function array_find;
-use function assert;
 use function count;
 use function is_string;
 use function strtolower;
@@ -38,7 +37,7 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
 	{
 		$args = $node->getArgs();
-		if (!$context->true() || count($args) < 2) {
+		if (!$context->truthy() || count($args) < 2) {
 			return new SpecifiedTypes();
 		}
 
@@ -49,14 +48,13 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		} elseif (
 			$callable instanceof Expr\Closure &&
 			count($callable->stmts) === 1 &&
-			$callable->stmts[0] instanceof Stmt\Return_
+			$callable->stmts[0] instanceof Stmt\Return_ &&
+			isset($callable->stmts[0]->expr)
 		) {
 			$callableExpr = $callable->stmts[0]->expr;
 		} else {
 			return new SpecifiedTypes();
 		}
-
-		assert(isset($callableExpr));
 
 		$callableParams = $callable->params;
 		$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callableExpr, $context)->getSureTypes();

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -4,12 +4,14 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\ShouldNotHappenException;
@@ -38,12 +40,39 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		}
 
 		$array = $args[0]->value;
+		$arrayArgType = $scope->getType($array);
+		$arrayTypes = $arrayArgType->getArrays();
+
+		if(count($arrayTypes) === 0) {
+			return new SpecifiedTypes();
+		}
+
 		$callable = $args[1]->value;
 
 
-		if ($callable instanceof Expr\ArrowFunction && $callable->expr instanceof Expr\FuncCall) {
+		// if ($callable instanceof Expr\ArrowFunction && $callable->expr instanceof Expr\FuncCall) {
+		if ($callable instanceof Expr\ArrowFunction) {
 
 			$callableParms = $callable->params;
+
+			// foreach($arrayTypes as $arrayType) {
+			// 	$keyType = $arrayType->getKeyType();
+			// 	$itemType = $arrayType->getItemType();
+			//
+			// 	$variables = [];
+			//
+			// 	if (count($callableParms) < 1) {
+			// 		continue;
+			// 	}
+			//
+			// 	if ($callableParms[0] ?? null instanceof Expr\Variable) {
+			// 		$variables[$callableParms[0]->name] = $itemType;
+			// 	}
+			//
+			// 	if ($callableParms[1] ?? null instanceof Expr\Variable) {
+			// 		$variables[$callableParms[1]->name] = $keyType;
+			// 	}
+			// }
 			$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
 
 			if(count($callableParms) >= 1 && $callableParms[0] instanceof Expr\Variable) {
@@ -86,6 +115,18 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 
 		return new SpecifiedTypes();
 	}
+
+	// /**
+	//  * @param array<string, TypeExpr> $paramTypes
+	//  */
+	// private function replaceVariable(Expr $expr, array $paramTypes) : Expr {
+	// 	if ($expr instanceof Variable)  {
+	// 		$variableName = $expr->name;
+	// 		if (isset($paramTypes[$variableName])) {
+	// 			return $paramTypes[$variableName];
+	// 		}
+	// 	} elseif ($expr instanceof )
+	// }
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
 	{

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -55,6 +55,8 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 			return new SpecifiedTypes();
 		}
 
+		assert(isset($callableExpr));
+
 		$callableParams = $callable->params;
 		$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callableExpr, $context)->getSureTypes();
 

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -18,6 +18,7 @@ use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use function array_find;
+use function assert;
 use function count;
 use function is_string;
 use function strtolower;

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -5,7 +5,6 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Param;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
@@ -19,6 +18,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use function array_find;
 use function count;
+use function is_string;
 use function strtolower;
 
 #[AutowiredService]

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
@@ -41,44 +42,45 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		}
 
 		$array = $args[0]->value;
-		$arrayArgType = $scope->getType($array);
-		$arrayTypes = $arrayArgType->getArrays();
-
-		if (count($arrayTypes) === 0) {
+		$callable = $args[1]->value;
+		if ($callable instanceof Expr\ArrowFunction) {
+			$callableExpr = $callable->expr;
+		} elseif (
+			$callable instanceof Expr\Closure &&
+			count($callable->stmts) === 1 &&
+			$callable->stmts[0] instanceof Stmt\Return_
+		) {
+			$callableExpr = $callable->stmts[0]->expr;
+		} else {
 			return new SpecifiedTypes();
 		}
 
-		$callable = $args[1]->value;
+		$callableParams = $callable->params;
+		$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callableExpr, $context)->getSureTypes();
 
-		if ($callable instanceof Expr\ArrowFunction) {
+		if (
+			isset($callableParams[0]) &&
+			$callableParams[0]->var instanceof Variable &&
+			is_string($callableParams[0]->var->name)
+		) {
+			$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[0]->var->name);
+		}
 
-			$callableParams = $callable->params;
-			$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
+		if (
+			isset($callableParams[1]) &&
+			$callableParams[1]->var instanceof Variable &&
+			is_string($callableParams[1]->var->name)
+		) {
+			$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[1]->var->name);
+		}
 
-			if (
-				isset($callableParams[0]) &&
-				$callableParams[0]->var instanceof Variable &&
-				is_string($callableParams[0]->var->name)
-			) {
-				$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[0]->var->name);
-			}
-
-			if (
-				isset($callableParams[1]) &&
-				$callableParams[1]->var instanceof Variable &&
-				is_string($callableParams[1]->var->name)
-			) {
-				$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[1]->var->name);
-			}
-
-			if (isset($keyType) || isset($valueType)) {
-				return $this->typeSpecifier->create(
-					$array,
-					new ArrayType($keyType ?? new MixedType(), $valueType ?? new MixedType()),
-					$context,
-					$scope,
-				);
-			}
+		if (isset($keyType) || isset($valueType)) {
+			return $this->typeSpecifier->create(
+				$array,
+				new ArrayType($keyType ?? new MixedType(), $valueType ?? new MixedType()),
+				$context,
+				$scope,
+			);
 		}
 
 		return new SpecifiedTypes();

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -2,8 +2,10 @@
 
 namespace PHPStan\Type\Php;
 
+use PhpParser\Node\Param;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
@@ -53,12 +55,20 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 			$callableParms = $callable->params;
 			$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
 
-			if (isset($callableParms[0]) && $callableParms[0] instanceof Expr\Variable) {
-				$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[0]->name);
+			if (
+				isset($callableParms[0]) &&
+				$callableParms[0] instanceof Param &&
+				$callableParms[0]->var instanceof Variable
+			) {
+				$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[0]->var->name);
 			}
 
-			if (isset($callableParms[1]) && $callableParms[1] instanceof Expr\Variable) {
-				$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[1]->name);
+			if (
+				isset($callableParms[1]) &&
+				$callableParms[1] instanceof Param &&
+				$callableParms[1]->var instanceof Variable
+			) {
+				$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[1]->var->name);
 			}
 
 			if (isset($keyType) || isset($valueType)) {

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -4,20 +4,19 @@ namespace PHPStan\Type\Php;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
 use PHPStan\Analyser\TypeSpecifierAwareExtension;
 use PHPStan\Analyser\TypeSpecifierContext;
 use PHPStan\DependencyInjection\AutowiredService;
-use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\FunctionTypeSpecifyingExtension;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+use function array_find;
+use function count;
 use function strtolower;
 
 #[AutowiredService]
@@ -43,72 +42,31 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		$arrayArgType = $scope->getType($array);
 		$arrayTypes = $arrayArgType->getArrays();
 
-		if(count($arrayTypes) === 0) {
+		if (count($arrayTypes) === 0) {
 			return new SpecifiedTypes();
 		}
 
 		$callable = $args[1]->value;
 
-
-		// if ($callable instanceof Expr\ArrowFunction && $callable->expr instanceof Expr\FuncCall) {
 		if ($callable instanceof Expr\ArrowFunction) {
 
 			$callableParms = $callable->params;
-
-			// foreach($arrayTypes as $arrayType) {
-			// 	$keyType = $arrayType->getKeyType();
-			// 	$itemType = $arrayType->getItemType();
-			//
-			// 	$variables = [];
-			//
-			// 	if (count($callableParms) < 1) {
-			// 		continue;
-			// 	}
-			//
-			// 	if ($callableParms[0] ?? null instanceof Expr\Variable) {
-			// 		$variables[$callableParms[0]->name] = $itemType;
-			// 	}
-			//
-			// 	if ($callableParms[1] ?? null instanceof Expr\Variable) {
-			// 		$variables[$callableParms[1]->name] = $keyType;
-			// 	}
-			// }
 			$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
 
-			if(count($callableParms) >= 1 && $callableParms[0] instanceof Expr\Variable) {
-
-				$callableParmValueName = $callableParms[0]->name;
-				$specifiedTypeOfValue = array_find(
-					$specifiedTypesInFuncCall,
-					fn($specifiedType) => $specifiedType[0] instanceof Expr\Variable && $specifiedType[0]->name === $callableParmValueName
-				);
-
-				if(isset($specifiedTypeOfValue)) {
-					$valueType = $specifiedTypeOfValue[1];
-				}
-
+			if (isset($callableParms[0]) && $callableParms[0] instanceof Expr\Variable) {
+				$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[0]->name);
 			}
 
-			if(count($callableParms) >= 2 && $callableParms[1] instanceof Expr\Variable) {
-
-				$callableParmKeyName = $callableParms[1]->name;
-				$specifiedTypeOfKey = array_find(
-					$specifiedTypesInFuncCall,
-					fn($specifiedType) => $specifiedType[0] instanceof Expr\Variable && $specifiedType[0]->name === $callableParmKeyName
-				);
-
-				if(isset($specifiedTypeOfKey)) {
-					$keyType = $specifiedTypeOfKey[1];
-				}
-
+			if (isset($callableParms[1]) && $callableParms[1] instanceof Expr\Variable) {
+				$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[1]->name);
 			}
 
-			if(isset($keyType) || isset($valueType)) {
+			if (isset($keyType) || isset($valueType)) {
 				return $this->typeSpecifier->create(
 					$array,
 					new ArrayType($keyType ?? new MixedType(), $valueType ?? new MixedType()),
 					$context,
-					$scope
+					$scope,
 				);
 			}
 		}
@@ -116,17 +74,22 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 		return new SpecifiedTypes();
 	}
 
-	// /**
-	//  * @param array<string, TypeExpr> $paramTypes
-	//  */
-	// private function replaceVariable(Expr $expr, array $paramTypes) : Expr {
-	// 	if ($expr instanceof Variable)  {
-	// 		$variableName = $expr->name;
-	// 		if (isset($paramTypes[$variableName])) {
-	// 			return $paramTypes[$variableName];
-	// 		}
-	// 	} elseif ($expr instanceof )
-	// }
+	/**
+	 * @param array<string, list{Expr, Type}> $specifiedTypes
+	 */
+	private function fetchTypeByVariable(array $specifiedTypes, string $variableName): ?Type
+	{
+		$specifiedTypeOfKey = array_find(
+			$specifiedTypes,
+			static fn ($specifiedType) => $specifiedType[0] instanceof Expr\Variable && $specifiedType[0]->name === $variableName,
+		);
+
+		if (isset($specifiedTypeOfKey)) {
+			return $specifiedTypeOfKey[1];
+		}
+
+		return null;
+	}
 
 	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
 	{

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+use PHPStan\Type\MixedType;
+use function strtolower;
+
+#[AutowiredService]
+final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private TypeSpecifier $typeSpecifier;
+
+	public function isFunctionSupported(FunctionReflection $functionReflection, FuncCall $node, TypeSpecifierContext $context): bool
+	{
+		return strtolower($functionReflection->getName()) === 'array_all'
+			&& !$context->null();
+	}
+
+	public function specifyTypes(FunctionReflection $functionReflection, FuncCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+	{
+		$args = $node->getArgs();
+		if (!$context->true() || count($args) < 2) {
+			return new SpecifiedTypes();
+		}
+
+		$array = $args[0]->value;
+		$callable = $args[1]->value;
+		if ($callable instanceof Expr\ArrowFunction && $callable->expr instanceof Expr\FuncCall) {
+			$specifiedTypesInCallable = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
+			$callableParm = $callable->params[0];
+			if (!$callableParm instanceof Expr\Variable || !key_exists("$" . $callableParm->name, $specifiedTypesInCallable)) {
+				return new SpecifiedTypes();
+			}
+			$ItemType = $specifiedTypesInCallable["$" . $callableParm->name][1];
+			return $this->typeSpecifier->create(
+				$array,
+				new ArrayType(new MixedType(), $ItemType),
+				$context,
+				$scope
+			);
+		}
+
+		return new SpecifiedTypes();
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -39,19 +39,49 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 
 		$array = $args[0]->value;
 		$callable = $args[1]->value;
+
+
 		if ($callable instanceof Expr\ArrowFunction && $callable->expr instanceof Expr\FuncCall) {
-			$specifiedTypesInCallable = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
-			$callableParm = $callable->params[0];
-			if (!$callableParm instanceof Expr\Variable || !key_exists("$" . $callableParm->name, $specifiedTypesInCallable)) {
-				return new SpecifiedTypes();
+
+			$callableParms = $callable->params;
+			$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
+
+			if(count($callableParms) >= 1 && $callableParms[0] instanceof Expr\Variable) {
+
+				$callableParmValueName = $callableParms[0]->name;
+				$specifiedTypeOfValue = array_find(
+					$specifiedTypesInFuncCall,
+					fn($specifiedType) => $specifiedType[0] instanceof Expr\Variable && $specifiedType[0]->name === $callableParmValueName
+				);
+
+				if(isset($specifiedTypeOfValue)) {
+					$valueType = $specifiedTypeOfValue[1];
+				}
+
 			}
-			$ItemType = $specifiedTypesInCallable["$" . $callableParm->name][1];
-			return $this->typeSpecifier->create(
-				$array,
-				new ArrayType(new MixedType(), $ItemType),
-				$context,
-				$scope
-			);
+
+			if(count($callableParms) >= 2 && $callableParms[1] instanceof Expr\Variable) {
+
+				$callableParmKeyName = $callableParms[1]->name;
+				$specifiedTypeOfKey = array_find(
+					$specifiedTypesInFuncCall,
+					fn($specifiedType) => $specifiedType[0] instanceof Expr\Variable && $specifiedType[0]->name === $callableParmKeyName
+				);
+
+				if(isset($specifiedTypeOfKey)) {
+					$keyType = $specifiedTypeOfKey[1];
+				}
+
+			}
+
+			if(isset($keyType) || isset($valueType)) {
+				return $this->typeSpecifier->create(
+					$array,
+					new ArrayType($keyType ?? new MixedType(), $valueType ?? new MixedType()),
+					$context,
+					$scope
+				);
+			}
 		}
 
 		return new SpecifiedTypes();

--- a/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
+++ b/src/Type/Php/ArrayAllFunctionTypeSpecifyingExtension.php
@@ -2,10 +2,10 @@
 
 namespace PHPStan\Type\Php;
 
-use PhpParser\Node\Param;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Param;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
 use PHPStan\Analyser\TypeSpecifier;
@@ -52,23 +52,23 @@ final class ArrayAllFunctionTypeSpecifyingExtension implements FunctionTypeSpeci
 
 		if ($callable instanceof Expr\ArrowFunction) {
 
-			$callableParms = $callable->params;
+			$callableParams = $callable->params;
 			$specifiedTypesInFuncCall = $this->typeSpecifier->specifyTypesInCondition($scope, $callable->expr, $context)->getSureTypes();
 
 			if (
-				isset($callableParms[0]) &&
-				$callableParms[0] instanceof Param &&
-				$callableParms[0]->var instanceof Variable
+				isset($callableParams[0]) &&
+				$callableParams[0]->var instanceof Variable &&
+				is_string($callableParams[0]->var->name)
 			) {
-				$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[0]->var->name);
+				$valueType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[0]->var->name);
 			}
 
 			if (
-				isset($callableParms[1]) &&
-				$callableParms[1] instanceof Param &&
-				$callableParms[1]->var instanceof Variable
+				isset($callableParams[1]) &&
+				$callableParams[1]->var instanceof Variable &&
+				is_string($callableParams[1]->var->name)
 			) {
-				$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParms[1]->var->name);
+				$keyType = $this->fetchTypeByVariable($specifiedTypesInFuncCall, $callableParams[1]->var->name);
 			}
 
 			if (isset($keyType) || isset($valueType)) {

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -26,6 +26,7 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\IntegerType;
@@ -1319,6 +1320,46 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'(int) $float' => 'int',
 				],
 				[],
+			],
+			[
+				new FuncCall(
+					new Name("array_all"),
+					[
+						new Arg(new Variable("array")),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
+									'expr' => new FuncCall(new Name("is_int"), [new Arg(new Variable("value"))]),
+									'params' => [new Variable("value")],
+								],
+								[]
+							)
+						)
+					]
+				),
+				[
+					'$array' => 'array<int>'
+				],
+				[]
+			],
+			[
+				new FuncCall(
+					new Name("array_all"),
+					[
+						new Arg(new Variable("array")),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
+									'expr' => new FuncCall(new Name("is_int"), [new Arg(new Expr\ConstFetch(new Name("1")))]),
+									'params' => [new Variable("value")],
+								],
+								[]
+							)
+						)
+					]
+				),
+				[],
+				[]
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Analyser;
 
-use Bug4820\Param;
 use Override;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser;
 
+use Bug4820\Param;
 use Override;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -1318,139 +1319,6 @@ class TypeSpecifierTest extends PHPStanTestCase
 					'$float' => 'float',
 					'(int) $float' => 'int',
 				],
-				[],
-			],
-			[
-				new FuncCall(
-					new Name('array_all'),
-					[
-						new Arg(new Variable('array')),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new FuncCall(new Name('is_int'), [new Arg(new Variable('value'))]),
-									'params' => [new Variable('value')],
-								],
-								[],
-							),
-						),
-					],
-				),
-				[
-					'$array' => 'array<int>',
-				],
-				[],
-			],
-			[
-				new FuncCall(
-					new Name('array_all'),
-					[
-						new Arg(new Variable('array')),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new FuncCall(new Name('is_string'), [new Arg(new Variable('key'))]),
-									'params' => [new Variable('value'), new Variable('key')],
-								],
-								[],
-							),
-						),
-					],
-				),
-				[
-					'$array' => 'array<string, mixed>',
-				],
-				[],
-			],
-			[
-				new FuncCall(
-					new Name('array_all'),
-					[
-						new Arg(new Variable('array')),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new Expr\BinaryOp\BooleanAnd(
-										new FuncCall(new Name('is_int'), [new Arg(new Variable('value'))]),
-										new FuncCall(new Name('is_string'), [new Arg(new Variable('key'))]),
-									),
-									'params' => [new Variable('value'), new Variable('key')],
-								],
-								[],
-							),
-						),
-					],
-				),
-				[
-					'$array' => 'array<string, int>',
-				],
-				[],
-			],
-			[
-				new FuncCall(
-					new Name('array_all'),
-					[
-						new Arg(new Variable('array')),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new Expr\BinaryOp\BooleanAnd(
-										new FuncCall(new Name('is_string'), [new Arg(new Variable('value'))]),
-										new FuncCall(new Name('is_numeric'), [new Arg(new Variable('value'))]),
-									),
-									'params' => [new Variable('value'), new Variable('key')],
-								],
-								[],
-							),
-						),
-					],
-				),
-				[
-					'$array' => 'array<numeric-string>',
-				],
-				[],
-			],
-			[
-				new FuncCall(
-					new Name('array_all'),
-					[
-						new Arg(new Variable('array')),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new Expr\BinaryOp\BooleanOr(
-										new FuncCall(new Name('is_float'), [new Arg(new Variable('value'))]),
-										new FuncCall(new Name('is_bool'), [new Arg(new Variable('value'))]),
-									),
-									'params' => [new Variable('value'), new Variable('key')],
-								],
-								[],
-							),
-						),
-					],
-				),
-				[
-					'$array' => 'array<bool|float>',
-				],
-				[],
-			],
-			[
-				new FuncCall(
-					new Name('array_all'),
-					[
-						new Arg(new Variable('array')),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new FuncCall(new Name('is_int'), [new Arg(new Expr\ConstFetch(new Name('1')))]),
-									'params' => [new Variable('value')],
-								],
-								[],
-							),
-						),
-					],
-				),
-				[],
 				[],
 			],
 		];

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\Node\VarLikeIdentifier;
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Node\Expr\AlwaysRememberedExpr;
@@ -1339,6 +1340,27 @@ class TypeSpecifierTest extends PHPStanTestCase
 				),
 				[
 					'$array' => 'array<int>'
+				],
+				[]
+			],
+			[
+				new FuncCall(
+					new Name("array_all"),
+					[
+						new Arg(new Variable("array")),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
+									'expr' => new FuncCall(new Name("is_string"), [new Arg(new Variable("key"))]),
+									'params' => [new Variable("value"), new Variable("key")],
+								],
+								[]
+							)
+						)
+					]
+				),
+				[
+					'$array' => 'array<string, mixed>'
 				],
 				[]
 			],

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -1372,6 +1372,78 @@ class TypeSpecifierTest extends PHPStanTestCase
 						new Arg(
 							new Expr\ArrowFunction(
 								[
+									'expr' => new Expr\BinaryOp\BooleanAnd(
+										new FuncCall(new Name("is_int"), [new Arg(new Variable("value"))]),
+										new FuncCall(new Name("is_string"), [new Arg(new Variable("key"))]),
+									),
+									'params' => [new Variable("value"), new Variable("key")],
+								],
+								[]
+							)
+						)
+					]
+				),
+				[
+					'$array' => 'array<string, int>'
+				],
+				[]
+			],
+			[
+				new FuncCall(
+					new Name("array_all"),
+					[
+						new Arg(new Variable("array")),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
+									'expr' => new Expr\BinaryOp\BooleanAnd(
+										new FuncCall(new Name("is_string"), [new Arg(new Variable("value"))]),
+										new FuncCall(new Name("is_numeric"), [new Arg(new Variable("value"))]),
+									),
+									'params' => [new Variable("value"), new Variable("key")],
+								],
+								[]
+							)
+						)
+					]
+				),
+				[
+					'$array' => 'array<numeric-string>'
+				],
+				[]
+			],
+			[
+				new FuncCall(
+					new Name("array_all"),
+					[
+						new Arg(new Variable("array")),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
+									'expr' => new Expr\BinaryOp\BooleanOr(
+										new FuncCall(new Name("is_float"), [new Arg(new Variable("value"))]),
+										new FuncCall(new Name("is_bool"), [new Arg(new Variable("value"))]),
+									),
+									'params' => [new Variable("value"), new Variable("key")],
+								],
+								[]
+							)
+						)
+					]
+				),
+				[
+					'$array' => 'array<bool|float>'
+				],
+				[]
+			],
+			[
+				new FuncCall(
+					new Name("array_all"),
+					[
+						new Arg(new Variable("array")),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
 									'expr' => new FuncCall(new Name("is_int"), [new Arg(new Expr\ConstFetch(new Name("1")))]),
 									'params' => [new Variable("value")],
 								],

--- a/tests/PHPStan/Analyser/TypeSpecifierTest.php
+++ b/tests/PHPStan/Analyser/TypeSpecifierTest.php
@@ -17,7 +17,6 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
-use PhpParser\Node\VariadicPlaceholder;
 use PhpParser\Node\VarLikeIdentifier;
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Node\Expr\AlwaysRememberedExpr;
@@ -27,7 +26,6 @@ use PHPStan\TrinaryLogic;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\IntegerType;
@@ -1324,136 +1322,136 @@ class TypeSpecifierTest extends PHPStanTestCase
 			],
 			[
 				new FuncCall(
-					new Name("array_all"),
+					new Name('array_all'),
 					[
-						new Arg(new Variable("array")),
+						new Arg(new Variable('array')),
 						new Arg(
 							new Expr\ArrowFunction(
 								[
-									'expr' => new FuncCall(new Name("is_int"), [new Arg(new Variable("value"))]),
-									'params' => [new Variable("value")],
+									'expr' => new FuncCall(new Name('is_int'), [new Arg(new Variable('value'))]),
+									'params' => [new Variable('value')],
 								],
-								[]
-							)
-						)
-					]
+								[],
+							),
+						),
+					],
 				),
 				[
-					'$array' => 'array<int>'
+					'$array' => 'array<int>',
 				],
-				[]
+				[],
 			],
 			[
 				new FuncCall(
-					new Name("array_all"),
+					new Name('array_all'),
 					[
-						new Arg(new Variable("array")),
+						new Arg(new Variable('array')),
 						new Arg(
 							new Expr\ArrowFunction(
 								[
-									'expr' => new FuncCall(new Name("is_string"), [new Arg(new Variable("key"))]),
-									'params' => [new Variable("value"), new Variable("key")],
+									'expr' => new FuncCall(new Name('is_string'), [new Arg(new Variable('key'))]),
+									'params' => [new Variable('value'), new Variable('key')],
 								],
-								[]
-							)
-						)
-					]
+								[],
+							),
+						),
+					],
 				),
 				[
-					'$array' => 'array<string, mixed>'
+					'$array' => 'array<string, mixed>',
 				],
-				[]
+				[],
 			],
 			[
 				new FuncCall(
-					new Name("array_all"),
+					new Name('array_all'),
 					[
-						new Arg(new Variable("array")),
-						new Arg(
-							new Expr\ArrowFunction(
-								[
-									'expr' => new Expr\BinaryOp\BooleanAnd(
-										new FuncCall(new Name("is_int"), [new Arg(new Variable("value"))]),
-										new FuncCall(new Name("is_string"), [new Arg(new Variable("key"))]),
-									),
-									'params' => [new Variable("value"), new Variable("key")],
-								],
-								[]
-							)
-						)
-					]
-				),
-				[
-					'$array' => 'array<string, int>'
-				],
-				[]
-			],
-			[
-				new FuncCall(
-					new Name("array_all"),
-					[
-						new Arg(new Variable("array")),
+						new Arg(new Variable('array')),
 						new Arg(
 							new Expr\ArrowFunction(
 								[
 									'expr' => new Expr\BinaryOp\BooleanAnd(
-										new FuncCall(new Name("is_string"), [new Arg(new Variable("value"))]),
-										new FuncCall(new Name("is_numeric"), [new Arg(new Variable("value"))]),
+										new FuncCall(new Name('is_int'), [new Arg(new Variable('value'))]),
+										new FuncCall(new Name('is_string'), [new Arg(new Variable('key'))]),
 									),
-									'params' => [new Variable("value"), new Variable("key")],
+									'params' => [new Variable('value'), new Variable('key')],
 								],
-								[]
-							)
-						)
-					]
+								[],
+							),
+						),
+					],
 				),
 				[
-					'$array' => 'array<numeric-string>'
+					'$array' => 'array<string, int>',
 				],
-				[]
+				[],
 			],
 			[
 				new FuncCall(
-					new Name("array_all"),
+					new Name('array_all'),
 					[
-						new Arg(new Variable("array")),
+						new Arg(new Variable('array')),
+						new Arg(
+							new Expr\ArrowFunction(
+								[
+									'expr' => new Expr\BinaryOp\BooleanAnd(
+										new FuncCall(new Name('is_string'), [new Arg(new Variable('value'))]),
+										new FuncCall(new Name('is_numeric'), [new Arg(new Variable('value'))]),
+									),
+									'params' => [new Variable('value'), new Variable('key')],
+								],
+								[],
+							),
+						),
+					],
+				),
+				[
+					'$array' => 'array<numeric-string>',
+				],
+				[],
+			],
+			[
+				new FuncCall(
+					new Name('array_all'),
+					[
+						new Arg(new Variable('array')),
 						new Arg(
 							new Expr\ArrowFunction(
 								[
 									'expr' => new Expr\BinaryOp\BooleanOr(
-										new FuncCall(new Name("is_float"), [new Arg(new Variable("value"))]),
-										new FuncCall(new Name("is_bool"), [new Arg(new Variable("value"))]),
+										new FuncCall(new Name('is_float'), [new Arg(new Variable('value'))]),
+										new FuncCall(new Name('is_bool'), [new Arg(new Variable('value'))]),
 									),
-									'params' => [new Variable("value"), new Variable("key")],
+									'params' => [new Variable('value'), new Variable('key')],
 								],
-								[]
-							)
-						)
-					]
+								[],
+							),
+						),
+					],
 				),
 				[
-					'$array' => 'array<bool|float>'
+					'$array' => 'array<bool|float>',
 				],
-				[]
+				[],
 			],
 			[
 				new FuncCall(
-					new Name("array_all"),
+					new Name('array_all'),
 					[
-						new Arg(new Variable("array")),
+						new Arg(new Variable('array')),
 						new Arg(
 							new Expr\ArrowFunction(
 								[
-									'expr' => new FuncCall(new Name("is_int"), [new Arg(new Expr\ConstFetch(new Name("1")))]),
-									'params' => [new Variable("value")],
+									'expr' => new FuncCall(new Name('is_int'), [new Arg(new Expr\ConstFetch(new Name('1')))]),
+									'params' => [new Variable('value')],
 								],
-								[]
-							)
-						)
-					]
+								[],
+							),
+						),
+					],
 				),
 				[],
-				[]
+				[],
 			],
 		];
 	}

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -1,0 +1,61 @@
+<?php // lint >= 8.4
+
+namespace ArrayAll;
+
+use function PHPStan\Testing\assertType;
+
+class Foo {
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test1($array) {
+		if (array_all($array, fn ($value) => is_int($value))) {
+			assertType("array<int>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test2($array) {
+		if (array_all($array, fn ($value, $key) => is_string($key))) {
+			assertType("array<string, mixed>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test3($array) {
+		if (array_all($array, fn ($value, $key) => is_string($key) && is_int($value))) {
+			assertType("array<string, int>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test4($array) {
+		if (array_all($array, fn ($value) => is_string($value) && is_numeric($value))) {
+			assertType("array<numeric-string>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test5($array) {
+		if (array_all($array, fn ($value) => is_bool($value) || is_float($value))) {
+			assertType("array<bool|float>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test6($array) {
+		if (array_all($array, fn ($value) => is_float(1))) {
+			assertType("array<mixed>", $array);
+		}
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -2,6 +2,9 @@
 
 namespace ArrayAll;
 
+use DateTime;
+use DateTimeImmutable;
+
 use function PHPStan\Testing\assertType;
 
 class Foo {
@@ -56,6 +59,24 @@ class Foo {
 	public function test6($array) {
 		if (array_all($array, fn ($value) => is_float(1))) {
 			assertType("array<mixed>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test7($array) {
+		if (array_all($array, fn ($value) => $value instanceof DateTime)) {
+			assertType("array<DateTime>", $array);
+		}
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test8($array) {
+		if (array_all($array, fn ($value) => $value instanceof DateTime || $value instanceof DateTimeImmutable)) {
+			assertType("array<DateTime|DateTimeImmutable>", $array);
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -176,4 +176,16 @@ class Foo {
 		}
 		assertType("array<mixed>", $array);
 	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test15($array) {
+		if (array_all($array, fn ($value) => is_int($value)) === true) {
+			assertType("array<int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -165,4 +165,15 @@ class Foo {
 		assertType("array<mixed>", $array);
 	}
 
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test14($array) {
+		if (array_all($array, function ($value, $key) {return;})) {
+			assertType("array<mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
 }

--- a/tests/PHPStan/Analyser/nsrt/array-all.php
+++ b/tests/PHPStan/Analyser/nsrt/array-all.php
@@ -8,13 +8,17 @@ use DateTimeImmutable;
 use function PHPStan\Testing\assertType;
 
 class Foo {
+
 	/**
 	 * @param array<mixed> $array
 	 */
 	public function test1($array) {
 		if (array_all($array, fn ($value) => is_int($value))) {
 			assertType("array<int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -23,7 +27,10 @@ class Foo {
 	public function test2($array) {
 		if (array_all($array, fn ($value, $key) => is_string($key))) {
 			assertType("array<string, mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array", $array);
 	}
 
 	/**
@@ -32,7 +39,10 @@ class Foo {
 	public function test3($array) {
 		if (array_all($array, fn ($value, $key) => is_string($key) && is_int($value))) {
 			assertType("array<string, int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -41,7 +51,10 @@ class Foo {
 	public function test4($array) {
 		if (array_all($array, fn ($value) => is_string($value) && is_numeric($value))) {
 			assertType("array<numeric-string>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -50,7 +63,10 @@ class Foo {
 	public function test5($array) {
 		if (array_all($array, fn ($value) => is_bool($value) || is_float($value))) {
 			assertType("array<bool|float>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -59,7 +75,10 @@ class Foo {
 	public function test6($array) {
 		if (array_all($array, fn ($value) => is_float(1))) {
 			assertType("array<mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -68,7 +87,10 @@ class Foo {
 	public function test7($array) {
 		if (array_all($array, fn ($value) => $value instanceof DateTime)) {
 			assertType("array<DateTime>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
 
 	/**
@@ -77,6 +99,70 @@ class Foo {
 	public function test8($array) {
 		if (array_all($array, fn ($value) => $value instanceof DateTime || $value instanceof DateTimeImmutable)) {
 			assertType("array<DateTime|DateTimeImmutable>", $array);
+		} else {
+			assertType("array<mixed>", $array);
 		}
+		assertType("array<mixed>", $array);
 	}
+
+	/**
+	 * @param list<mixed> $array
+	 */
+	public function test9($array) {
+		if (array_all($array, fn ($value, $key) => is_int($key))) {
+			assertType("list<mixed>", $array);
+		} else {
+			assertType("list<mixed>", $array);
+		}
+		assertType("list<mixed>", $array);
+	}
+
+	/**
+	 * @param non-empty-array<mixed> $array
+	 */
+	public function test10($array) {
+		if (array_all($array, fn ($value, $key) => is_int($key))) {
+			assertType("non-empty-array<int, mixed>", $array);
+		} else {
+			assertType("non-empty-array<mixed>", $array);
+		}
+		assertType("non-empty-array", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test11($array) {
+		if (array_all($array, function ($value) {return is_int($value);})) {
+			assertType("array<int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test12($array) {
+		if (array_all($array, function ($value) {$value = 1; return is_int($value);})) {
+			assertType("array<mixed>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
+	/**
+	 * @param array<mixed> $array
+	 */
+	public function test13($array) {
+		if (array_all($array, function ($value, $key) {return is_int($value) && is_string($key);})) {
+			assertType("array<string, int>", $array);
+		} else {
+			assertType("array<mixed>", $array);
+		}
+		assertType("array<mixed>", $array);
+	}
+
 }


### PR DESCRIPTION
This PR partially resolves https://github.com/phpstan/phpstan/issues/12939 by specifying array element types when array_all returns true.

To keep this initial PR focused, it currently supports only ArrowFunction (e.g., `array_all($arr, fn($v, $k) => is_int($v) && is_string($k))`). It correctly recognizes union and intersection types when the arrow function uses `||` (or) and `&&` (and).

The following features are left as future scope:

Standard Closures: (e.g., `function($v) { ... }`)

String and First-class callables: (e.g., `'is_int'` or `is_int(...)`). Note that these currently throw an ArgumentCountError in PHP anyway, as `array_all()` passes both value and key, but functions like is_int expect exactly one argument (see: https://3v4l.org/2DQ9a#veol).

Custom assertions: Support for `@phpstan-assert-if-true` and similar annotations is not included in this PR, as mapping variables to types in those contexts is currently difficult and requires further work.