### PR TITLE
TableErrorFormatter: Limit number of errors

### DIFF
--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -12,6 +12,7 @@ use PHPStan\File\RelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use function array_map;
+use function array_slice;
 use function count;
 use function explode;
 use function getenv;
@@ -159,12 +160,15 @@ final class TableErrorFormatter implements ErrorFormatter
 				];
 			}
 
-			$style->table(['Line', $this->relativePathHelper->getRelativePath($file)], $rows);
 			$printedErrors += count($rows);
-
 			if ($errorsBudget > 0 && $printedErrors > $errorsBudget) {
+				$rows = array_slice($rows, 0, $errorsBudget - ($printedErrors - count($rows)));
+
+				$style->table(['Line', $this->relativePathHelper->getRelativePath($file)], $rows);
 				break;
 			}
+
+			$style->table(['Line', $this->relativePathHelper->getRelativePath($file)], $rows);
 		}
 
 		if (count($analysisResult->getNotFileSpecificErrors()) > 0) {

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command\ErrorFormatter;
 use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalyseCommand;
 use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\CommandHelper;
 use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\AutowiredService;
@@ -44,7 +45,7 @@ final class TableErrorFormatter implements ErrorFormatter
 		#[AutowiredParameter]
 		private ?string $editorUrlTitle,
 		#[AutowiredParameter]
-		private ?int $level,
+		private string $usedLevel,
 	)
 	{
 	}
@@ -189,7 +190,7 @@ final class TableErrorFormatter implements ErrorFormatter
 
 			$note = [];
 			$note[] = sprintf('Result is limited to the first %d errors', $errorsBudget);
-			if ($this->level > 0) {
+			if ($this->usedLevel !== CommandHelper::DEFAULT_LEVEL) {
 				$note[] = '- Consider lowering the PHPStan level';
 			}
 			$note[] = sprintf('- Pass %s=1 environment variable to show all errors', self::FORCE_SHOW_ALL_ERRORS);

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -29,7 +29,7 @@ use function str_replace;
 final class TableErrorFormatter implements ErrorFormatter
 {
 
-	private const MAX_ERRORS_TO_SHOW = 1000;
+	private const DEFAULT_MAX_ERRORS_TO_SHOW = 1000;
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,
@@ -90,7 +90,7 @@ final class TableErrorFormatter implements ErrorFormatter
 
 		$errorsBudget = getenv('PHPSTAN_ERRORS_LIMIT');
 		if ($errorsBudget === false) {
-			$errorsBudget = self::MAX_ERRORS_TO_SHOW;
+			$errorsBudget = self::DEFAULT_MAX_ERRORS_TO_SHOW;
 		}
 		$errorsBudget = (int) $errorsBudget;
 

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -30,6 +30,7 @@ final class TableErrorFormatter implements ErrorFormatter
 {
 
 	private const ERRORS_LIMIT = 1000;
+	private const string FORCE_SHOW_ALL_ERRORS = 'PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS';
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,
@@ -90,11 +91,11 @@ final class TableErrorFormatter implements ErrorFormatter
 			$fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
 		}
 
-		$forceShowAll = getenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS');
+		$forceShowAll = getenv(self::FORCE_SHOW_ALL_ERRORS);
 		if (in_array($forceShowAll, [false, '0'], true)) {
 			$errorsBudget = self::ERRORS_LIMIT;
 		} else {
-			$errorsBudget = 0;
+			$errorsBudget = null;
 		}
 
 		$printedErrors = 0;
@@ -164,7 +165,7 @@ final class TableErrorFormatter implements ErrorFormatter
 			}
 
 			$printedErrors += count($rows);
-			if ($errorsBudget > 0 && $printedErrors > $errorsBudget) {
+			if ($errorsBudget !== null && $printedErrors > $errorsBudget) {
 				$rows = array_slice($rows, 0, $errorsBudget - ($printedErrors - count($rows)));
 
 				$style->table(['Line', $this->relativePathHelper->getRelativePath($file)], $rows);
@@ -183,7 +184,7 @@ final class TableErrorFormatter implements ErrorFormatter
 			$style->table(['', 'Warning'], array_map(static fn (string $warning): array => ['', OutputFormatter::escape($warning)], $analysisResult->getWarnings()));
 		}
 
-		if ($errorsBudget > 0 && $printedErrors > $errorsBudget) {
+		if ($errorsBudget !== null && $printedErrors > $errorsBudget) {
 			$style->error(sprintf('Found %s+ errors', self::ERRORS_LIMIT));
 
 			$note = [];
@@ -191,7 +192,7 @@ final class TableErrorFormatter implements ErrorFormatter
 			if ($this->level > 0) {
 				$note[] = '- Consider lowering the PHPStan level';
 			}
-			$note[] = '- Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors';
+			$note[] = sprintf('- Pass %s=1 environment variable to show all errors', self::FORCE_SHOW_ALL_ERRORS);
 			$note[] = '- Consider using PHPStan Pro for more comfortable error browsing';
 			$note[] = '  Learn more: https://phpstan.com';
 			$style->note(implode("\n", $note));

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -191,9 +191,9 @@ final class TableErrorFormatter implements ErrorFormatter
 			if ($this->level > 0) {
 				$note[] = '- Consider lowering the PHPStan level';
 			}
-			$note[] = '- Consider using PHPStan Pro for more comfortable error browsing';
 			$note[] = '- Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors';
-			$note[] = '- Learn more: https://phpstan.com';
+			$note[] = '- Consider using PHPStan Pro for more comfortable error browsing';
+			$note[] = '  Learn more: https://phpstan.com';
 			$style->note(implode("\n", $note));
 		} else {
 			$finalMessage = sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount());

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -46,8 +46,19 @@ final class TableErrorFormatter implements ErrorFormatter
 		private ?string $editorUrlTitle,
 		#[AutowiredParameter]
 		private string $usedLevel,
+		private ?int $errorsBudget = null,
 	)
 	{
+		if ($this->errorsBudget !== null) {
+			return;
+		}
+
+		$forceShowAll = getenv(self::FORCE_SHOW_ALL_ERRORS);
+		if (!in_array($forceShowAll, [false, '0'], true)) {
+			return;
+		}
+
+		$this->errorsBudget = self::ERRORS_LIMIT;
 	}
 
 	/** @api */
@@ -92,13 +103,7 @@ final class TableErrorFormatter implements ErrorFormatter
 			$fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
 		}
 
-		$forceShowAll = getenv(self::FORCE_SHOW_ALL_ERRORS);
-		if (in_array($forceShowAll, [false, '0'], true)) {
-			$errorsBudget = self::ERRORS_LIMIT;
-		} else {
-			$errorsBudget = null;
-		}
-
+		$errorsBudget = $this->errorsBudget;
 		$printedErrors = 0;
 		foreach ($fileErrors as $file => $errors) {
 			$rows = [];
@@ -186,7 +191,7 @@ final class TableErrorFormatter implements ErrorFormatter
 		}
 
 		if ($errorsBudget !== null && $printedErrors > $errorsBudget) {
-			$style->error(sprintf('Found %s+ errors', self::ERRORS_LIMIT));
+			$style->error(sprintf('Found %s+ errors', $errorsBudget));
 
 			$note = [];
 			$note[] = sprintf('Result is limited to the first %d errors', $errorsBudget);

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -30,7 +30,7 @@ use function str_replace;
 final class TableErrorFormatter implements ErrorFormatter
 {
 
-	private const ERRORS_LIMIT = 1000;
+	public const ERRORS_LIMIT = 1000;
 	private const FORCE_SHOW_ALL_ERRORS = 'PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS';
 
 	public function __construct(

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -91,7 +91,7 @@ final class TableErrorFormatter implements ErrorFormatter
 		}
 
 		$forceShowAll = getenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS');
-		if (\in_array($forceShowAll, [false, '0'], true)) {
+		if (in_array($forceShowAll, [false, '0'], true)) {
 			$errorsBudget = self::ERRORS_LIMIT;
 		} else {
 			$errorsBudget = 0;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -29,7 +29,7 @@ use function str_replace;
 final class TableErrorFormatter implements ErrorFormatter
 {
 
-	private const DEFAULT_MAX_ERRORS_TO_SHOW = 1000;
+	private const DEFAULT_ERRORS_LIMIT = 1000;
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,
@@ -90,7 +90,7 @@ final class TableErrorFormatter implements ErrorFormatter
 
 		$errorsBudget = getenv('PHPSTAN_ERRORS_LIMIT');
 		if ($errorsBudget === false) {
-			$errorsBudget = self::DEFAULT_MAX_ERRORS_TO_SHOW;
+			$errorsBudget = self::DEFAULT_ERRORS_LIMIT;
 		}
 		$errorsBudget = (int) $errorsBudget;
 

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -91,7 +91,7 @@ final class TableErrorFormatter implements ErrorFormatter
 		}
 
 		$forceShowAll = getenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS');
-		if ($forceShowAll === false || $forceShowAll === '0') {
+		if (\in_array($forceShowAll, [false, '0'], true)) {
 			$errorsBudget = self::ERRORS_LIMIT;
 		} else {
 			$errorsBudget = 0;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -43,7 +43,7 @@ final class TableErrorFormatter implements ErrorFormatter
 		#[AutowiredParameter]
 		private ?string $editorUrlTitle,
 		#[AutowiredParameter]
-		private int $level,
+		private ?int $level,
 	)
 	{
 	}

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -15,6 +15,7 @@ use function array_map;
 use function count;
 use function explode;
 use function getenv;
+use function implode;
 use function in_array;
 use function is_string;
 use function ltrim;
@@ -26,6 +27,8 @@ use function str_replace;
 #[AutowiredService(name: 'errorFormatter.table')]
 final class TableErrorFormatter implements ErrorFormatter
 {
+
+	private const MAX_ERRORS_TO_SHOW = 1000;
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,
@@ -84,6 +87,13 @@ final class TableErrorFormatter implements ErrorFormatter
 			$fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
 		}
 
+		$errorsBudget = getenv('PHPSTAN_ERRORS_LIMIT');
+		if ($errorsBudget === false) {
+			$errorsBudget = self::MAX_ERRORS_TO_SHOW;
+		}
+		$errorsBudget = (int) $errorsBudget;
+
+		$printedErrors = 0;
 		foreach ($fileErrors as $file => $errors) {
 			$rows = [];
 			foreach ($errors as $error) {
@@ -150,6 +160,11 @@ final class TableErrorFormatter implements ErrorFormatter
 			}
 
 			$style->table(['Line', $this->relativePathHelper->getRelativePath($file)], $rows);
+			$printedErrors += count($rows);
+
+			if ($errorsBudget > 0 && $printedErrors > $errorsBudget) {
+				break;
+			}
 		}
 
 		if (count($analysisResult->getNotFileSpecificErrors()) > 0) {
@@ -170,6 +185,15 @@ final class TableErrorFormatter implements ErrorFormatter
 			$style->error($finalMessage);
 		} else {
 			$style->warning($finalMessage);
+		}
+
+		if ($errorsBudget > 0 && $printedErrors > $errorsBudget) {
+			$note = [];
+			$note[] = sprintf('Result is limited to the first %d errors', $errorsBudget);
+			$note[] = '- Consider lowering the PHPStan level';
+			$note[] = '- Consider using PHPStan Pro for more comfortable error browsing';
+			$note[] = '- Pass PHPSTAN_ERRORS_LIMIT=0 environment variable to show all errors';
+			$style->note(implode("\n", $note));
 		}
 
 		return $analysisResult->getTotalErrorsCount() > 0 ? 1 : 0;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -29,7 +29,7 @@ use function str_replace;
 final class TableErrorFormatter implements ErrorFormatter
 {
 
-	private const DEFAULT_ERRORS_LIMIT = 1000;
+	private const ERRORS_LIMIT = 1000;
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,
@@ -42,6 +42,8 @@ final class TableErrorFormatter implements ErrorFormatter
 		private ?string $editorUrl,
 		#[AutowiredParameter]
 		private ?string $editorUrlTitle,
+		#[AutowiredParameter]
+		private int $level,
 	)
 	{
 	}
@@ -88,11 +90,11 @@ final class TableErrorFormatter implements ErrorFormatter
 			$fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
 		}
 
-		$errorsBudget = getenv('PHPSTAN_ERRORS_LIMIT');
-		if ($errorsBudget === false) {
-			$errorsBudget = self::DEFAULT_ERRORS_LIMIT;
+		if (getenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS') === '1') {
+			$errorsBudget = self::ERRORS_LIMIT;
+		} else {
+			$errorsBudget = 0;
 		}
-		$errorsBudget = (int) $errorsBudget;
 
 		$printedErrors = 0;
 		foreach ($fileErrors as $file => $errors) {
@@ -180,24 +182,29 @@ final class TableErrorFormatter implements ErrorFormatter
 			$style->table(['', 'Warning'], array_map(static fn (string $warning): array => ['', OutputFormatter::escape($warning)], $analysisResult->getWarnings()));
 		}
 
-		$finalMessage = sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount());
-		if ($warningsCount > 0) {
-			$finalMessage .= sprintf($warningsCount === 1 ? ' and %d warning' : ' and %d warnings', $warningsCount);
-		}
-
-		if ($analysisResult->getTotalErrorsCount() > 0) {
-			$style->error($finalMessage);
-		} else {
-			$style->warning($finalMessage);
-		}
-
 		if ($errorsBudget > 0 && $printedErrors > $errorsBudget) {
+			$style->error(sprintf('Found %s+ errors', self::ERRORS_LIMIT));
+
 			$note = [];
 			$note[] = sprintf('Result is limited to the first %d errors', $errorsBudget);
-			$note[] = '- Consider lowering the PHPStan level';
+			if ($this->level > 0) {
+				$note[] = '- Consider lowering the PHPStan level';
+			}
 			$note[] = '- Consider using PHPStan Pro for more comfortable error browsing';
-			$note[] = '- Pass PHPSTAN_ERRORS_LIMIT=0 environment variable to show all errors';
+			$note[] = '- Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors';
+			$note[] = '- Learn more: https://phpstan.com';
 			$style->note(implode("\n", $note));
+		} else {
+			$finalMessage = sprintf($analysisResult->getTotalErrorsCount() === 1 ? 'Found %d error' : 'Found %d errors', $analysisResult->getTotalErrorsCount());
+			if ($warningsCount > 0) {
+				$finalMessage .= sprintf($warningsCount === 1 ? ' and %d warning' : ' and %d warnings', $warningsCount);
+			}
+
+			if ($analysisResult->getTotalErrorsCount() > 0) {
+				$style->error($finalMessage);
+			} else {
+				$style->warning($finalMessage);
+			}
 		}
 
 		return $analysisResult->getTotalErrorsCount() > 0 ? 1 : 0;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -90,7 +90,8 @@ final class TableErrorFormatter implements ErrorFormatter
 			$fileErrors[$fileSpecificError->getFile()][] = $fileSpecificError;
 		}
 
-		if (getenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS') === '1') {
+		$forceShowAll = getenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS');
+		if ($forceShowAll === false || $forceShowAll === '0') {
 			$errorsBudget = self::ERRORS_LIMIT;
 		} else {
 			$errorsBudget = 0;

--- a/src/Command/ErrorFormatter/TableErrorFormatter.php
+++ b/src/Command/ErrorFormatter/TableErrorFormatter.php
@@ -31,7 +31,7 @@ final class TableErrorFormatter implements ErrorFormatter
 {
 
 	private const ERRORS_LIMIT = 1000;
-	private const string FORCE_SHOW_ALL_ERRORS = 'PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS';
+	private const FORCE_SHOW_ALL_ERRORS = 'PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS';
 
 	public function __construct(
 		private RelativePathHelper $relativePathHelper,

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -30,7 +30,7 @@ use function substr;
 final class NeonAdapter implements Adapter
 {
 
-	public const CACHE_KEY = 'v32-limited-errors';
+	public const CACHE_KEY = 'v31-expand-relative-paths';
 
 	private const PREVENT_MERGING_SUFFIX = '!';
 

--- a/src/DependencyInjection/NeonAdapter.php
+++ b/src/DependencyInjection/NeonAdapter.php
@@ -30,7 +30,7 @@ use function substr;
 final class NeonAdapter implements Adapter
 {
 
-	public const CACHE_KEY = 'v31-expand-relative-paths';
+	public const CACHE_KEY = 'v32-limited-errors';
 
 	private const PREVENT_MERGING_SUFFIX = '!';
 

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -76,6 +76,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 			false,
 			null,
 			null,
+			0,
 		);
 		$analysisResult = $analyserApplication->analyse(
 			[$path],

--- a/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
+++ b/tests/PHPStan/Command/AnalyseApplicationIntegrationTest.php
@@ -76,7 +76,7 @@ class AnalyseApplicationIntegrationTest extends PHPStanTestCase
 			false,
 			null,
 			null,
-			0,
+			CommandHelper::DEFAULT_LEVEL,
 		);
 		$analysisResult = $analyserApplication->analyse(
 			[$path],

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Command\ErrorFormatter;
 use Override;
 use PHPStan\Analyser\Error;
 use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\CommandHelper;
 use PHPStan\File\FuzzyRelativePathHelper;
 use PHPStan\File\NullRelativePathHelper;
 use PHPStan\File\SimpleRelativePathHelper;
@@ -441,7 +442,7 @@ TABLE,
 			false,
 			null,
 			null,
-			0,
+			CommandHelper::DEFAULT_LEVEL,
 		);
 		$error = new Error('Test', 'Foo.php', 12, filePath: self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput(true));
@@ -463,7 +464,7 @@ TABLE,
 			false,
 			$editorUrl,
 			$editorUrlTitle,
-			0,
+			CommandHelper::DEFAULT_LEVEL,
 		);
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -449,8 +449,9 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 		$formatter = $this->createErrorFormatter(
 			null,
-			usedLevel: $usedLevel,
-			errorsBudget: $errorsBudget,
+			null,
+			$usedLevel,
+			$errorsBudget,
 		);
 		$errors = [];
 		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 12, filePath: 'Foo.php', traitFilePath: 'Bar.php');

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -466,6 +466,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			}
 			putenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1');
 			$errorsBudget = null;
+		} else {
+			putenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS');
 		}
 
 		$formatter = $this->createErrorFormatter(

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -299,6 +299,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 	{
 		yield [
 			'errorsBudget' => null,
+			'usedLevel' => CommandHelper::DEFAULT_LEVEL,
+			'showAllErrors' => false,
 			'expected' => ' ------ -------------------------------
   Line   Foo.php (in context of trait)
  ------ -------------------------------
@@ -315,6 +317,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		];
 		yield [
 			'errorsBudget' => 1,
+			'usedLevel' => CommandHelper::DEFAULT_LEVEL,
+			'showAllErrors' => false,
 			'expected' => ' ------ -------------------------------
   Line   Foo.php (in context of trait)
  ------ -------------------------------
@@ -325,8 +329,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  [ERROR] Found 1+ errors
 
  ! [NOTE] Result is limited to the first 1 errors
- !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
- !        environment variable to show all errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors
  !        - Consider using PHPStan Pro for more comfortable error browsing
  !          Learn more: https://phpstan.com
 
@@ -336,6 +339,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		yield [
 			'errorsBudget' => 3,
 			'usedLevel' => '8',
+			'showAllErrors' => false,
 			'expected' => ' ------ -------------------------------
   Line   Foo.php (in context of trait)
  ------ -------------------------------
@@ -349,8 +353,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
  ! [NOTE] Result is limited to the first 3 errors
  !        - Consider lowering the PHPStan level
- !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
- !        environment variable to show all errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors
  !        - Consider using PHPStan Pro for more comfortable error browsing
  !          Learn more: https://phpstan.com
 
@@ -359,6 +362,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 			yield [
 				'errorsBudget' => 3,
+				'usedLevel' => CommandHelper::DEFAULT_LEVEL,
+				'showAllErrors' => false,
 				'expected' => ' ------ -------------------------------
   Line   Foo.php (in context of trait)
  ------ -------------------------------
@@ -371,8 +376,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  [ERROR] Found 3+ errors
 
  ! [NOTE] Result is limited to the first 3 errors
- !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
- !        environment variable to show all errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors
  !        - Consider using PHPStan Pro for more comfortable error browsing
  !          Learn more: https://phpstan.com
 
@@ -381,6 +385,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 			yield [
 				'errorsBudget' => 4,
+				'usedLevel' => CommandHelper::DEFAULT_LEVEL,
+				'showAllErrors' => false,
 				'expected' => ' ------ -------------------------------
   Line   Foo.php (in context of trait)
  ------ -------------------------------
@@ -397,6 +403,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			];
 			yield [
 				'errorsBudget' => 5,
+				'usedLevel' => CommandHelper::DEFAULT_LEVEL,
+				'showAllErrors' => false,
 				'expected' => ' ------ -------------------------------
   Line   Foo.php (in context of trait)
  ------ -------------------------------
@@ -413,6 +421,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			];
 
 			yield [
+				'errorsBudget' => null,
 				'usedLevel' => '8',
 				'showAllErrors' => true,
 				'expected' => ' ------ -------------------------------
@@ -433,10 +442,10 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
 	#[DataProvider('dataErrorLimit')]
 	public function testErrorLimit(
+		?int $errorsBudget,
+		string $usedLevel,
+		bool $showAllErrors,
 		string $expected,
-		?int $errorsBudget = null,
-		string $usedLevel = CommandHelper::DEFAULT_LEVEL,
-		bool $showAllErrors = false,
 	): void
 	{
 		if ($showAllErrors) {

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -423,20 +423,25 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			yield [
 				'errorsBudget' => null,
 				'usedLevel' => '8',
-				'showAllErrors' => true,
-				'expected' => ' ------ -------------------------------
-  Line   Foo.php (in context of trait)
- ------ -------------------------------
-  12     Test
-  13     Test
-  14     Test
-  15     Test
- ------ -------------------------------
+				'showAllErrors' => false,
+				'expected' => '
 
-
- [ERROR] Found 4 errors
+ [ERROR] Found 1000+ errors
 
 ',
+				'generateErrorsCount' => TableErrorFormatter::ERRORS_LIMIT + 5,
+			];
+
+			yield [
+				'errorsBudget' => null,
+				'usedLevel' => '8',
+				'showAllErrors' => true,
+				'expected' => '
+
+ [ERROR] Found 1005 errors
+
+',
+				'generateErrorsCount' => TableErrorFormatter::ERRORS_LIMIT + 5,
 			];
 	}
 
@@ -446,6 +451,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		string $usedLevel,
 		bool $showAllErrors,
 		string $expected,
+		int $generateErrorsCount = 4,
 	): void
 	{
 		putenv('COLUMNS=200');
@@ -464,10 +470,11 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 			$errorsBudget,
 		);
 		$errors = [];
-		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 12, filePath: 'Foo.php', traitFilePath: 'Bar.php');
-		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 13, filePath: 'Foo.php', traitFilePath: 'Bar.php');
-		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 14, filePath: 'Foo.php', traitFilePath: 'Bar.php');
-		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 15, filePath: 'Foo.php', traitFilePath: 'Bar.php');
+		$line = 12;
+		for ($i = 0; $i < $generateErrorsCount; $i++) {
+			$errors[] = new Error('Test', 'Foo.php (in context of trait)', $line, filePath: 'Foo.php', traitFilePath: 'Bar.php');
+			$line++;
+		}
 		$formatter->formatErrors(new AnalysisResult($errors, [], [], [], [], false, null, true, 0, false, []), $this->getOutput());
 
 		$this->assertStringContainsString($expected, $this->getOutputContent());

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -448,6 +448,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		string $expected,
 	): void
 	{
+		putenv('COLUMNS=200');
 		if ($showAllErrors) {
 			if ($errorsBudget !== null) {
 				$this->fail('showAllErrors cannot be true when errorsBudget is set');

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -456,6 +456,9 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		int $generateErrorsCount = 4,
 	): void
 	{
+		// windows has minor formatting differences (line breaks)
+		$this->skipIfNotOnUnix();
+
 		putenv('COLUMNS=80');
 		if ($showAllErrors) {
 			if ($errorsBudget !== null) {

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -441,6 +441,7 @@ TABLE,
 			false,
 			null,
 			null,
+			0
 		);
 		$error = new Error('Test', 'Foo.php', 12, filePath: self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput(true));
@@ -462,6 +463,7 @@ TABLE,
 			false,
 			$editorUrl,
 			$editorUrlTitle,
+			0
 		);
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -454,7 +454,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		int $generateErrorsCount = 4,
 	): void
 	{
-		putenv('COLUMNS=200');
+		putenv('COLUMNS=120');
 		if ($showAllErrors) {
 			if ($errorsBudget !== null) {
 				$this->fail('showAllErrors cannot be true when errorsBudget is set');

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -441,7 +441,7 @@ TABLE,
 			false,
 			null,
 			null,
-			0
+			0,
 		);
 		$error = new Error('Test', 'Foo.php', 12, filePath: self::DIRECTORY_PATH . '/rel/Foo.php');
 		$formatter->formatErrors(new AnalysisResult([$error], [], [], [], [], false, null, true, 0, false, []), $this->getOutput(true));
@@ -463,7 +463,7 @@ TABLE,
 			false,
 			$editorUrl,
 			$editorUrlTitle,
-			0
+			0,
 		);
 	}
 

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -329,7 +329,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  [ERROR] Found 1+ errors
 
  ! [NOTE] Result is limited to the first 1 errors
- !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+ !        environment variable to show all errors
  !        - Consider using PHPStan Pro for more comfortable error browsing
  !          Learn more: https://phpstan.com
 
@@ -353,7 +354,8 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 
  ! [NOTE] Result is limited to the first 3 errors
  !        - Consider lowering the PHPStan level
- !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+ !        environment variable to show all errors
  !        - Consider using PHPStan Pro for more comfortable error browsing
  !          Learn more: https://phpstan.com
 
@@ -376,10 +378,10 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
  [ERROR] Found 3+ errors
 
  ! [NOTE] Result is limited to the first 3 errors
- !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1 environment variable to show all errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+ !        environment variable to show all errors
  !        - Consider using PHPStan Pro for more comfortable error browsing
  !          Learn more: https://phpstan.com
-
 ',
 			];
 
@@ -454,7 +456,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		int $generateErrorsCount = 4,
 	): void
 	{
-		putenv('COLUMNS=120');
+		putenv('COLUMNS=80');
 		if ($showAllErrors) {
 			if ($errorsBudget !== null) {
 				$this->fail('showAllErrors cannot be true when errorsBudget is set');

--- a/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
+++ b/tests/PHPStan/Command/ErrorFormatter/TableErrorFormatterTest.php
@@ -35,6 +35,7 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		putenv('COLUMNS');
 		putenv('TERM_PROGRAM');
 		putenv('TERMINAL_EMULATOR' . ($this->terminalEmulator !== false ? '=' . $this->terminalEmulator : ''));
+		putenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS');
 	}
 
 	public static function dataFormatterOutputProvider(): iterable
@@ -294,6 +295,173 @@ class TableErrorFormatterTest extends ErrorFormatterTestCase
 		$this->assertSame($expected, $this->getOutputContent(false, $verbose), sprintf('%s: output do not match', $message));
 	}
 
+	public static function dataErrorLimit(): iterable
+	{
+		yield [
+			'errorsBudget' => null,
+			'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+  13     Test
+  14     Test
+  15     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 4 errors
+
+',
+		];
+		yield [
+			'errorsBudget' => 1,
+			'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 1+ errors
+
+ ! [NOTE] Result is limited to the first 1 errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+ !        environment variable to show all errors
+ !        - Consider using PHPStan Pro for more comfortable error browsing
+ !          Learn more: https://phpstan.com
+
+',
+		];
+
+		yield [
+			'errorsBudget' => 3,
+			'usedLevel' => '8',
+			'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+  13     Test
+  14     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 3+ errors
+
+ ! [NOTE] Result is limited to the first 3 errors
+ !        - Consider lowering the PHPStan level
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+ !        environment variable to show all errors
+ !        - Consider using PHPStan Pro for more comfortable error browsing
+ !          Learn more: https://phpstan.com
+
+',
+		];
+
+			yield [
+				'errorsBudget' => 3,
+				'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+  13     Test
+  14     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 3+ errors
+
+ ! [NOTE] Result is limited to the first 3 errors
+ !        - Pass PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1
+ !        environment variable to show all errors
+ !        - Consider using PHPStan Pro for more comfortable error browsing
+ !          Learn more: https://phpstan.com
+
+',
+			];
+
+			yield [
+				'errorsBudget' => 4,
+				'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+  13     Test
+  14     Test
+  15     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 4 errors
+
+',
+			];
+			yield [
+				'errorsBudget' => 5,
+				'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+  13     Test
+  14     Test
+  15     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 4 errors
+
+',
+			];
+
+			yield [
+				'usedLevel' => '8',
+				'showAllErrors' => true,
+				'expected' => ' ------ -------------------------------
+  Line   Foo.php (in context of trait)
+ ------ -------------------------------
+  12     Test
+  13     Test
+  14     Test
+  15     Test
+ ------ -------------------------------
+
+
+ [ERROR] Found 4 errors
+
+',
+			];
+	}
+
+	#[DataProvider('dataErrorLimit')]
+	public function testErrorLimit(
+		string $expected,
+		?int $errorsBudget = null,
+		string $usedLevel = CommandHelper::DEFAULT_LEVEL,
+		bool $showAllErrors = false,
+	): void
+	{
+		if ($showAllErrors) {
+			if ($errorsBudget !== null) {
+				$this->fail('showAllErrors cannot be true when errorsBudget is set');
+			}
+			putenv('PHPSTAN_TABLE_ERROR_FORMATTER_FORCE_SHOW_ALL_ERRORS=1');
+			$errorsBudget = null;
+		}
+
+		$formatter = $this->createErrorFormatter(
+			null,
+			usedLevel: $usedLevel,
+			errorsBudget: $errorsBudget,
+		);
+		$errors = [];
+		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 12, filePath: 'Foo.php', traitFilePath: 'Bar.php');
+		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 13, filePath: 'Foo.php', traitFilePath: 'Bar.php');
+		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 14, filePath: 'Foo.php', traitFilePath: 'Bar.php');
+		$errors[] = new Error('Test', 'Foo.php (in context of trait)', 15, filePath: 'Foo.php', traitFilePath: 'Bar.php');
+		$formatter->formatErrors(new AnalysisResult($errors, [], [], [], [], false, null, true, 0, false, []), $this->getOutput());
+
+		$this->assertStringContainsString($expected, $this->getOutputContent());
+	}
+
 	public function testEditorUrlWithTrait(): void
 	{
 		$formatter = $this->createErrorFormatter('editor://%file%/%line%');
@@ -450,7 +618,12 @@ TABLE,
 		$this->assertStringContainsString('at rel/Foo.php:12', $this->getOutputContent(true));
 	}
 
-	private function createErrorFormatter(?string $editorUrl, ?string $editorUrlTitle = null): TableErrorFormatter
+	private function createErrorFormatter(
+		?string $editorUrl,
+		?string $editorUrlTitle = null,
+		string $usedLevel = CommandHelper::DEFAULT_LEVEL,
+		?int $errorsBudget = null,
+	): TableErrorFormatter
 	{
 		$relativePathHelper = new FuzzyRelativePathHelper(new NullRelativePathHelper(), self::DIRECTORY_PATH, [], '/');
 
@@ -464,7 +637,8 @@ TABLE,
 			false,
 			$editorUrl,
 			$editorUrlTitle,
-			CommandHelper::DEFAULT_LEVEL,
+			$usedLevel,
+			$errorsBudget,
 		);
 	}
 


### PR DESCRIPTION
closes https://github.com/phpstan/phpstan/issues/14232

"mago benchmark" running PHPStan with warmed cache on macbook m4 pro with PHP 8.3.34
before this PR: 20-21 seconds
after this PR: 3-4 seconds

----

running on wordpress with warmed result cache

note the difference in "Elapsed time"


## before the PR

<img width="862" height="301" alt="grafik" src="https://github.com/user-attachments/assets/ac5ca6cb-6591-439a-a700-8536fbb6d099" />


<img width="731" height="340" alt="grafik" src="https://github.com/user-attachments/assets/a8d4947d-9da1-47d8-9ba4-26428eb43709" />



## after the PR

`../../bin/phpstan -v` 

<img width="889" height="374" alt="grafik" src="https://github.com/user-attachments/assets/a7c5ff78-f727-4bb5-ae17-aec5ce0ffe68" />




----

`PHPSTAN_ERRORS_LIMIT=0 ../../bin/phpstan -v ` 

<img width="966" height="507" alt="grafik" src="https://github.com/user-attachments/assets/ac7da10d-3f08-4028-82e5-7244a1974c47" />

----

`PHPSTAN_ERRORS_LIMIT=50 ../../bin/phpstan -v `

<img width="1003" height="462" alt="grafik" src="https://github.com/user-attachments/assets/dc339ca5-fcd8-435c-a894-35e710d37171" />

