### PR TITLE
Fix 'restricted open_basedir' e2e test

### DIFF
--- a/src/Internal/AgentDetector.php
+++ b/src/Internal/AgentDetector.php
@@ -52,7 +52,7 @@ final class AgentDetector
 			return true;
 		}
 
-		if (file_exists('/opt/.devin')) {
+		if (@file_exists('/opt/.devin')) {
 			return true;
 		}
 


### PR DESCRIPTION
since https://github.com/phpstan/phpstan-src/commit/c288e7e35c25b53e904e0e6e3ed66a8e4c6494a4 e2e tests started failling:

```
e2e/restricted-php-ini
...
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
 0/4 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0%
 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


In AgentDetector.php line 44:
                                                                               
  file_exists(): open_basedir restriction in effect. File(/opt/.devin) is not  
   within the allowed path(s): (/home/runner/work/phpstan-src/phpstan-src:/tm  
  p)                                                                           
                                                                               

analyse [-c|--configuration CONFIGURATION] [-l|--level LEVEL] [--no-progress] [--debug] [-a|--autoload-file AUTOLOAD-FILE] [--error-format ERROR-FORMAT] [-b|--generate-baseline [GENERATE-BASELINE]] [--allow-empty-baseline] [--memory-limit MEMORY-LIMIT] [--xdebug] [--tmp-file TMP-FILE] [--instead-of INSTEAD-OF] [--fix] [--watch] [--pro] [--fail-without-result-cache] [--] [<paths>...]
```

the test in question was added with https://github.com/phpstan/phpstan/pull/7518
which was fixed with https://github.com/phpstan/phpstan-src/pull/1466 - this PR inspired me for the fix here.
