### PR TITLE
Fix spurious error nullCoalesce.offset

### DIFF
--- a/src/Analyser/ExprHandler/Helper/NonNullabilityHelper.php
+++ b/src/Analyser/ExprHandler/Helper/NonNullabilityHelper.php
@@ -42,7 +42,7 @@ final class NonNullabilityHelper
 				$originalNativeType = $originalScope->getNativeType($exprToSpecify);
 
 				return new EnsuredNonNullabilityResult($scope, [
-					new EnsuredNonNullabilityResultExpression($exprToSpecify, $originalExprType, $originalNativeType, $certainty),
+					new EnsuredNonNullabilityResultExpression($exprToSpecify, $originalExprType, $originalNativeType, $hasExpressionType),
 				]);
 			}
 			return new EnsuredNonNullabilityResult($scope, []);
@@ -55,16 +55,13 @@ final class NonNullabilityHelper
 		// To properly revert this, we must also save and restore the parent expression's type.
 		if ($exprToSpecify instanceof Expr\ArrayDimFetch && $exprToSpecify->dim !== null) {
 			$parentExpr = $exprToSpecify->var;
-			$parentCertainty = TrinaryLogic::createYes();
 			$hasParentExpressionType = $originalScope->hasExpressionType($parentExpr);
-			if (!$hasParentExpressionType->no()) {
-				$parentCertainty = $hasParentExpressionType;
-			}
+
 			$specifiedExpressions[] = new EnsuredNonNullabilityResultExpression(
 				$parentExpr,
 				$scope->getType($parentExpr),
 				$scope->getNativeType($parentExpr),
-				$parentCertainty,
+				$hasParentExpressionType,
 			);
 		}
 
@@ -104,6 +101,10 @@ final class NonNullabilityHelper
 	public function revertNonNullability(MutatingScope $scope, array $specifiedExpressions): MutatingScope
 	{
 		foreach ($specifiedExpressions as $specifiedExpressionResult) {
+			if ($specifiedExpressionResult->getCertainty()->no()) {
+				$scope = $scope->invalidateExpression($specifiedExpressionResult->getExpression());
+				continue;
+			}
 			$scope = $scope->specifyExpressionType(
 				$specifiedExpressionResult->getExpression(),
 				$specifiedExpressionResult->getOriginalType(),

--- a/src/Analyser/ExprHandler/Helper/NonNullabilityHelper.php
+++ b/src/Analyser/ExprHandler/Helper/NonNullabilityHelper.php
@@ -55,13 +55,11 @@ final class NonNullabilityHelper
 		// To properly revert this, we must also save and restore the parent expression's type.
 		if ($exprToSpecify instanceof Expr\ArrayDimFetch && $exprToSpecify->dim !== null) {
 			$parentExpr = $exprToSpecify->var;
-			$hasParentExpressionType = $originalScope->hasExpressionType($parentExpr);
-
 			$specifiedExpressions[] = new EnsuredNonNullabilityResultExpression(
 				$parentExpr,
 				$scope->getType($parentExpr),
 				$scope->getNativeType($parentExpr),
-				$hasParentExpressionType,
+				$originalScope->hasExpressionType($parentExpr),
 			);
 		}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -253,6 +253,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 			yield __DIR__ . '/data/dio-functions.php';
 		}
 
+		yield __DIR__ . '/../Rules/Variables/data/bug-13921.php';
 		yield __DIR__ . '/../Rules/Arrays/data/bug-14234.php';
 		yield __DIR__ . '/../Rules/Arrays/data/bug-11679.php';
 		yield __DIR__ . '/../Rules/Methods/data/bug-4801.php';

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -371,4 +371,17 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4004.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.0')]
+	public function testBug10305(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+
+		$this->analyse([__DIR__ . '/data/bug-10305.php'], [
+			[
+				'Result of || is always true.',
+				10,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Comparison/data/bug-10305.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-10305.php
@@ -1,0 +1,12 @@
+<?php // lint >= 8.0
+
+namespace Bug10305;
+
+class HelloWorld
+{
+	public null|string $prop;
+
+	public function isPropertySet(): bool {
+		return isset($this->prop) || null === $this->prop;
+	}
+}

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -362,4 +362,14 @@ class NullCoalesceRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug13921(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-13921.php'], [
+			[
+				'Offset 0 on non-empty-list<array<string|null>> on left side of ?? always exists and is not nullable.',
+				19,
+			],
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-13921.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-13921.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Bug13921;
+
+use SimpleXMLElement;
+use function PHPStan\Testing\assertType;
+
+/** @param list<array<?string>> $x */
+function foo(array $x): void {
+	var_dump($x[0]['bar'] ?? null);
+	assertType("list<array<string|null>>", $x);
+	var_dump($x[0] ?? null);
+}
+
+/** @param non-empty-list<array<?string>> $x */
+function nonEmptyFoo(array $x): void {
+	var_dump($x[0]['bar'] ?? null);
+	assertType("non-empty-list<array<string|null>>", $x);
+	var_dump($x[0] ?? null);
+}
+
+/** @param list<array<?string>> $x */
+function bar(array $x): void {
+	var_dump($x[0] ?? null);
+	assertType("list<array<string|null>>", $x);
+	var_dump($x[0]['bar'] ?? null);
+}
+
+/** @param list<array<?string>> $x */
+function baz(array $x): void {
+	var_dump($x[1] ?? null);
+	assertType("list<array<string|null>>", $x);
+	var_dump($x[0]['bar'] ?? null);
+}
+
+/** @param list<array<?string>> $x */
+function boo(array $x): void {
+	var_dump($x[0]['bar'] ?? null);
+	assertType("list<array<string|null>>", $x);
+	var_dump($x[1] ?? null);
+}
+
+function doBar(array $array)
+{
+	if (isset($array['foo'])) {
+		assertType("mixed~null", $array['foo']);
+		assertType("non-empty-array&hasOffsetValue('foo', mixed~null)", $array);
+	}
+}
+
+/** @param list<SimpleXMLElement> $x */
+function sooSimpleElement(array $x): void {
+	var_dump($x[0]['bar'] ?? null);
+	assertType("list<SimpleXMLElement>", $x);
+	var_dump($x[0] ?? null);
+}


### PR DESCRIPTION
before this PR we only remembered maybe/yes expr certainty when restoring expressions.
this lead to that previously not-existing expressions (no-certainy) where restored into a yes-certainty instead of the state before.

closes https://github.com/phpstan/phpstan/issues/13921
refs https://github.com/phpstan/phpstan/issues/10305#issuecomment-1885217867 (fixes a issue mentioned in comments but not the issue itself)