### PR TITLE
Fix more PHP 7.4 errors

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/anonymous-function.php
+++ b/tests/PHPStan/Analyser/nsrt/anonymous-function.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace AnonymousFunction;
 

--- a/tests/PHPStan/Analyser/nsrt/callables.php
+++ b/tests/PHPStan/Analyser/nsrt/callables.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace Callables;
 

--- a/tests/PHPStan/Analyser/nsrt/explode.php
+++ b/tests/PHPStan/Analyser/nsrt/explode.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace ExplodeFunction;
 

--- a/tests/PHPStan/Analyser/nsrt/functions.php
+++ b/tests/PHPStan/Analyser/nsrt/functions.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 use function PHPStan\Testing\assertType;
 


### PR DESCRIPTION
after this PR 2 errors are left:

```
1) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "tests\PHPStan\Analyser\nsrt\range-function.php" ('D:\a\phpstan-src\phpstan-src\...on.php')
Failed assertions in D:\a\phpstan-src\phpstan-src\tests\PHPStan\Analyser\nsrt\range-function.php:

Line 17:
Expected: array{2, 3, 4, 5}
Actual:   array{2.0, 3.0, 4.0, 5.0}

D:\a\phpstan-src\phpstan-src\tests\PHPStan\Analyser\NodeScopeResolverTest.php:320
D:\a\phpstan-src\phpstan-src\tests\vendor\phpunit\phpunit\src\TextUI\Command.php:146
```

this seems to be a recent regression

----

```
2) PHPStan\Analyser\NodeScopeResolverTest::testFile with data set "tests\PHPStan\Analyser\nsrt\properties.php" ('D:\a\phpstan-src\phpstan-src\...es.php')
Failed assertions in D:\a\phpstan-src\phpstan-src\tests\PHPStan\Analyser\nsrt\properties.php:

Line 169:
Expected: DOMElement|null
Actual:   string
```

I wonder why this test does not fail starting with PHP 8.2+ - not sure whether its expected or not