### PR TITLE
Support `chop()` function as an alias of `rtrim()`

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1506,7 +1506,7 @@ final class TypeSpecifier
 			&& $exprNode instanceof FuncCall
 			&& $exprNode->name instanceof Name
 			&& in_array(strtolower((string) $exprNode->name), [
-				'trim', 'ltrim', 'rtrim',
+				'trim', 'ltrim', 'rtrim', 'chop',
 				'mb_trim', 'mb_ltrim', 'mb_rtrim',
 			], true)
 			&& isset($exprNode->getArgs()[0])

--- a/src/Type/Php/TrimFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/TrimFunctionDynamicReturnTypeExtension.php
@@ -27,7 +27,7 @@ final class TrimFunctionDynamicReturnTypeExtension implements DynamicFunctionRet
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
-		return in_array($functionReflection->getName(), ['trim', 'rtrim'], true);
+		return in_array($functionReflection->getName(), ['trim', 'rtrim', 'chop'], true);
 	}
 
 	public function getTypeFromFunctionCall(

--- a/tests/PHPStan/Analyser/nsrt/bug-12973.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12973.php
@@ -77,3 +77,20 @@ function rtrimTypes(string $value): void
 	}
 	assertType('string', $value);
 }
+
+function chopTypes(string $value): void
+{
+	if (chop($value) === '') {
+		assertType('string', $value);
+	} else {
+		assertType('non-empty-string', $value);
+	}
+	assertType('string', $value);
+
+	if (chop($value) !== '') {
+		assertType('non-empty-string', $value);
+	} else {
+		assertType('string', $value);
+	}
+	assertType('string', $value);
+}

--- a/tests/PHPStan/Analyser/nsrt/lowercase-string-trim.php
+++ b/tests/PHPStan/Analyser/nsrt/lowercase-string-trim.php
@@ -15,15 +15,19 @@ class Foo
 		assertType('lowercase-string', trim($lowercase));
 		assertType('lowercase-string', ltrim($lowercase));
 		assertType('lowercase-string', rtrim($lowercase));
+		assertType('lowercase-string', chop($lowercase));
 		assertType('lowercase-string', trim($lowercase, $string));
 		assertType('lowercase-string', ltrim($lowercase, $string));
 		assertType('lowercase-string', rtrim($lowercase, $string));
+		assertType('lowercase-string', chop($lowercase));
 		assertType('string', trim($string));
 		assertType('string', ltrim($string));
 		assertType('string', rtrim($string));
+		assertType('string', chop($string));
 		assertType('string', trim($string, $lowercase));
 		assertType('string', ltrim($string, $lowercase));
 		assertType('string', rtrim($string, $lowercase));
+		assertType('string', chop($string, $lowercase));
 	}
 
 }

--- a/tests/PHPStan/Analyser/nsrt/uppercase-string-trim.php
+++ b/tests/PHPStan/Analyser/nsrt/uppercase-string-trim.php
@@ -15,15 +15,19 @@ class Foo
 		assertType('uppercase-string', trim($uppercase));
 		assertType('uppercase-string', ltrim($uppercase));
 		assertType('uppercase-string', rtrim($uppercase));
+		assertType('uppercase-string', chop($uppercase));
 		assertType('uppercase-string', trim($uppercase, $string));
 		assertType('uppercase-string', ltrim($uppercase, $string));
 		assertType('uppercase-string', rtrim($uppercase, $string));
+		assertType('uppercase-string', chop($uppercase, $string));
 		assertType('string', trim($string));
 		assertType('string', ltrim($string));
 		assertType('string', rtrim($string));
+		assertType('string', chop($string));
 		assertType('string', trim($string, $uppercase));
 		assertType('string', ltrim($string, $uppercase));
 		assertType('string', rtrim($string, $uppercase));
+		assertType('string', chop($string, $uppercase));
 	}
 
 }


### PR DESCRIPTION
It's now a minor alias, but can occasionally be found in legacy code.

See <https://www.php.net/chop>.