### PR TITLE
Fix fatal error when `path` has array value in ignoreErrors

### DIFF
--- a/src/DependencyInjection/ValidateIgnoredErrorsExtension.php
+++ b/src/DependencyInjection/ValidateIgnoredErrorsExtension.php
@@ -38,10 +38,12 @@ use PHPStan\Type\TypeAliasResolver;
 use function array_keys;
 use function array_map;
 use function count;
+use function gettype;
 use function implode;
 use function is_array;
 use function is_dir;
 use function is_file;
+use function is_string;
 use function sprintf;
 use const PHP_VERSION_ID;
 
@@ -167,8 +169,16 @@ final class ValidateIgnoredErrorsExtension extends CompilerExtension
 					}
 
 					if (isset($ignoreError['path'])) {
+						if (!is_string($ignoreError['path'])) {
+							$errors[] = sprintf("Key 'path' of ignoreErrors expects a string, %s given. Did you mean 'paths'?", gettype($ignoreError['path']));
+							continue;
+						}
 						$ignorePaths = [$ignoreError['path']];
 					} elseif (isset($ignoreError['paths'])) {
+						if (!is_array($ignoreError['paths'])) {
+							$errors[] = sprintf("Key 'paths' of ignoreErrors expects an array, %s given. Did you mean 'path'?", gettype($ignoreError['paths']));
+							continue;
+						}
 						$ignorePaths = $ignoreError['paths'];
 					} else {
 						continue;

--- a/tests/PHPStan/DependencyInjection/InvalidIgnoredErrorExceptionTest.php
+++ b/tests/PHPStan/DependencyInjection/InvalidIgnoredErrorExceptionTest.php
@@ -55,6 +55,14 @@ class InvalidIgnoredErrorExceptionTest extends PHPStanTestCase
 			__DIR__ . '/invalidIgnoreErrors/count-without-path.neon',
 			'An ignoreErrors entry with count field must also contain path field.',
 		];
+		yield [
+			__DIR__ . '/invalidIgnoreErrors/path-with-array-value.neon',
+			"Key 'path' of ignoreErrors expects a string, array given. Did you mean 'paths'?",
+		];
+		yield [
+			__DIR__ . '/invalidIgnoreErrors/paths-with-string-value.neon',
+			"Key 'paths' of ignoreErrors expects an array, string given. Did you mean 'path'?",
+		];
 	}
 
 	#[DataProvider('dataValidateIgnoreErrors')]

--- a/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/path-with-array-value.neon
+++ b/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/path-with-array-value.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			identifier: some.identifier
+			path:
+				- tests/some-file.php

--- a/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/paths-with-string-value.neon
+++ b/tests/PHPStan/DependencyInjection/invalidIgnoreErrors/paths-with-string-value.neon
@@ -1,0 +1,5 @@
+parameters:
+	ignoreErrors:
+		-
+			identifier: some.identifier
+			paths: tests/some-file.php


### PR DESCRIPTION
Closes phpstan/phpstan#14231