### PR TITLE
Fix false positive nullsafe.neverNull on left side of ??

### DIFF
--- a/src/Rules/IssetCheck.php
+++ b/src/Rules/IssetCheck.php
@@ -252,6 +252,16 @@ final class IssetCheck
 		}
 
 		if ($expr instanceof Expr\NullsafePropertyFetch) {
+			// For ?? the nullsafe operator is needed when the object can be null,
+			// because ?? does not catch TypeError from property access on null.
+			// isset()/empty() handle null objects natively so ?-> is truly redundant there.
+			if ($identifier === 'nullCoalesce') {
+				$varType = $this->treatPhpDocTypesAsCertain ? $scope->getScopeType($expr->var) : $scope->getScopeNativeType($expr->var);
+				if (!$varType->isNull()->no()) {
+					return null;
+				}
+			}
+
 			if ($expr->name instanceof Node\Identifier) {
 				return RuleErrorBuilder::message(sprintf('Using nullsafe property access "?->%s" %s is unnecessary. Use -> instead.', $expr->name->name, $operatorDescription))
 					->identifier('nullsafe.neverNull')

--- a/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/NullCoalesceRuleTest.php
@@ -254,20 +254,8 @@ class NullCoalesceRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/../Properties/data/bug-7109.php'], [
 			[
-				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
-				17,
-			],
-			[
-				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
-				28,
-			],
-			[
 				'Expression on left side of ?? is not nullable.',
 				40,
-			],
-			[
-				'Using nullsafe property access "?->aaa" on left side of ?? is unnecessary. Use -> instead.',
-				66,
 			],
 			[
 				'Expression on left side of ?? is not nullable.',
@@ -368,6 +356,17 @@ class NullCoalesceRuleTest extends RuleTestCase
 			[
 				'Offset 0 on non-empty-list<array<string|null>> on left side of ?? always exists and is not nullable.',
 				19,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0')]
+	public function testNullsafeCoalesceNullableObject(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-nullsafe-coalesce-nullable-object.php'], [
+			[
+				'Expression on left side of ?? is not nullable.',
+				59,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Variables/data/bug-nullsafe-coalesce-nullable-object.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-nullsafe-coalesce-nullable-object.php
@@ -1,0 +1,61 @@
+<?php // lint >= 8.0
+
+namespace BugNullsafeCoalesceNullableObject;
+
+class Detail
+{
+	public string $label;
+
+	public function __construct(string $label)
+	{
+		$this->label = $label;
+	}
+}
+
+class Node
+{
+	private ?Detail $detail;
+
+	public function __construct(?Detail $detail)
+	{
+		$this->detail = $detail;
+	}
+
+	public function getDetail(): ?Detail
+	{
+		return $this->detail;
+	}
+}
+
+class Root
+{
+	private ?Node $node;
+
+	public function __construct(?Node $node)
+	{
+		$this->node = $node;
+	}
+
+	public function getNode(): ?Node
+	{
+		return $this->node;
+	}
+}
+
+class Foo
+{
+	public function chainedNullable(Root $root): void
+	{
+		$a = $root->getNode()?->getDetail()?->label ?? '';
+	}
+
+	public function singleNullable(Node $node): void
+	{
+		$a = $node->getDetail()?->label ?? '';
+	}
+
+	public function allNonNullable(Detail $detail): void
+	{
+		$a = $detail?->label ?? '';
+	}
+}


### PR DESCRIPTION
## Problem

`IssetCheck` unconditionally reports `?->` property access as unnecessary (`nullsafe.neverNull`) when it appears on the left side of `??`, `isset()`, or `empty()`.

This is correct for `isset()`/`empty()` — PHP handles null objects natively in those constructs without throwing. But for `??`, it is a **false positive**: the null coalescing operator does **not** catch `TypeError` from property access on a null object.

```php
class Foo {
    public function getBar(): ?Bar { /* ... */ }
}

// PHPStan reports: Using nullsafe property access "?->baz" on left side of ?? is unnecessary.
// But removing ?-> would cause TypeError at runtime when getBar() returns null:
$foo->getBar()?->baz ?? 'default';
//              ^^^
//  Without ?->: null->baz throws TypeError (not caught by ??)
//  With ?->:    null?->baz evaluates to null, ?? returns 'default'
```

## Root cause

In `IssetCheck::check()`, the `NullsafePropertyFetch` block (line 254) fires unconditionally regardless of context. It doesn't distinguish between `??` (where `?->` prevents `TypeError`) and `isset()`/`empty()` (where PHP already handles null objects).

## Fix

When the identifier is `nullCoalesce`, check whether the object being accessed (`$expr->var`) has a nullable type. If it does, the nullsafe operator is genuinely needed and no error should be reported.

`isset()` and `empty()` behavior is unchanged — `?->` remains correctly flagged as unnecessary there since PHP handles null objects natively in those constructs.

## Test changes

- Removed 3 false positive expectations from `NullCoalesceRuleTest::testBug7109()` (lines 17, 28, 66 of the test data file)
- Added new regression test `testNullsafeCoalesceNullableObject()` covering:
  - Chained nullable method calls with `?->` on left of `??` (no error expected)
  - Single nullable return with `?->` (no error expected)
  - Non-nullable object with `?->` (correctly reports "Expression not nullable")