### PR TITLE
WIP: Resolve types in processExpr

### DIFF
--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NullsafeShortCircuitingHelper;
@@ -29,6 +30,12 @@ use function array_merge;
 #[AutowiredService]
 final class ArrayDimFetchHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -75,7 +82,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 			$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$scope = $varResult->getScope();
 
-			return new ExpressionResult(
+			return $this->expressionResultFactory->create(
 				$scope,
 				hasYield: $varResult->hasYield(),
 				isAlwaysTerminating: $varResult->isAlwaysTerminating(),
@@ -104,7 +111,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 			)->getThrowPoints());
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $dimResult->hasYield() || $varResult->hasYield(),
 			isAlwaysTerminating: $dimResult->isAlwaysTerminating() || $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -110,7 +110,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 			$context->enterDeep(),
 		);
 
-		$varType = $scope->getType($expr->var);
+		$varType = $varResult->getType();
 		if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 			$throwPoints = array_merge($throwPoints, $offsetGetResult->getThrowPoints());
 		}

--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -85,6 +85,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 			return $this->expressionResultFactory->create(
 				$expr,
 				$scope,
+				typeCallback: static fn () => new NeverType(),
 				hasYield: $varResult->hasYield(),
 				isAlwaysTerminating: $varResult->isAlwaysTerminating(),
 				throwPoints: $varResult->getThrowPoints(),
@@ -100,21 +101,38 @@ final class ArrayDimFetchHandler implements ExprHandler
 		$impurePoints = array_merge($dimResult->getImpurePoints(), $varResult->getImpurePoints());
 		$scope = $varResult->getScope();
 
+		$offsetGetResult = $nodeScopeResolver->processExprNode(
+			$stmt,
+			new MethodCall($expr->var, new Identifier('offsetGet'), [new Arg($expr->dim)]),
+			$scope,
+			new ExpressionResultStorage(),
+			new NoopNodeCallback(),
+			$context->enterDeep(),
+		);
+
 		$varType = $scope->getType($expr->var);
 		if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
-			$throwPoints = array_merge($throwPoints, $nodeScopeResolver->processExprNode(
-				$stmt,
-				new MethodCall($expr->var, 'offsetGet'),
-				$scope,
-				$storage,
-				new NoopNodeCallback(),
-				$context,
-			)->getThrowPoints());
+			$throwPoints = array_merge($throwPoints, $offsetGetResult->getThrowPoints());
 		}
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $dimResult, $offsetGetResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				if ($varType instanceof NeverType) {
+					return $varType;
+				}
+
+				if (
+					!$varType->isArray()->yes()
+					&& (new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->yes()
+				) {
+					return $offsetGetResult->getTypeForScope($scope);
+				}
+
+				return $varType->getOffsetValueType($dimResult->getTypeForScope($scope));
+			},
 			hasYield: $dimResult->hasYield() || $varResult->hasYield(),
 			isAlwaysTerminating: $dimResult->isAlwaysTerminating() || $varResult->isAlwaysTerminating(),
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/ArrayDimFetchHandler.php
@@ -83,6 +83,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 			$scope = $varResult->getScope();
 
 			return $this->expressionResultFactory->create(
+				$expr,
 				$scope,
 				hasYield: $varResult->hasYield(),
 				isAlwaysTerminating: $varResult->isAlwaysTerminating(),
@@ -112,6 +113,7 @@ final class ArrayDimFetchHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $dimResult->hasYield() || $varResult->hasYield(),
 			isAlwaysTerminating: $dimResult->isAlwaysTerminating() || $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ArrayHandler.php
+++ b/src/Analyser/ExprHandler/ArrayHandler.php
@@ -72,6 +72,7 @@ final class ArrayHandler implements ExprHandler
 		$nodeScopeResolver->callNodeCallback($nodeCallback, new LiteralArrayNode($expr, $itemNodes), $scope, $storage);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/ArrayHandler.php
+++ b/src/Analyser/ExprHandler/ArrayHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -26,6 +27,7 @@ final class ArrayHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -69,7 +71,7 @@ final class ArrayHandler implements ExprHandler
 		}
 		$nodeScopeResolver->callNodeCallback($nodeCallback, new LiteralArrayNode($expr, $itemNodes), $scope, $storage);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/ArrayHandler.php
+++ b/src/Analyser/ExprHandler/ArrayHandler.php
@@ -12,12 +12,14 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\LiteralArrayItem;
 use PHPStan\Node\LiteralArrayNode;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\Type;
 use function array_merge;
+use function spl_object_id;
 
 /**
  * @implements ExprHandler<Array_>
@@ -50,11 +52,14 @@ final class ArrayHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
+		/** @var array<int, ExpressionResult> */
+		$itemResults = [];
 		foreach ($expr->items as $arrayItem) {
 			$itemNodes[] = new LiteralArrayItem($scope, $arrayItem);
 			$nodeScopeResolver->callNodeCallback($nodeCallback, $arrayItem, $scope, $storage);
 			if ($arrayItem->key !== null) {
 				$keyResult = $nodeScopeResolver->processExprNode($stmt, $arrayItem->key, $scope, $storage, $nodeCallback, $context->enterDeep());
+				$itemResults[spl_object_id($arrayItem->key)] = $keyResult;
 				$hasYield = $hasYield || $keyResult->hasYield();
 				$throwPoints = array_merge($throwPoints, $keyResult->getThrowPoints());
 				$impurePoints = array_merge($impurePoints, $keyResult->getImpurePoints());
@@ -63,6 +68,7 @@ final class ArrayHandler implements ExprHandler
 			}
 
 			$valueResult = $nodeScopeResolver->processExprNode($stmt, $arrayItem->value, $scope, $storage, $nodeCallback, $context->enterDeep());
+			$itemResults[spl_object_id($arrayItem->value)] = $valueResult;
 			$hasYield = $hasYield || $valueResult->hasYield();
 			$throwPoints = array_merge($throwPoints, $valueResult->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $valueResult->getImpurePoints());
@@ -74,6 +80,14 @@ final class ArrayHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: fn (Expr $expr, MutatingScope $scope) => $this->initializerExprTypeResolver->getArrayType($expr, static function (Expr $e) use ($itemResults, $scope, $nodeScopeResolver, $stmt): Type {
+				$id = spl_object_id($e);
+				if (isset($itemResults[$id])) {
+					return $itemResults[$id]->getTypeForScope($scope);
+				}
+
+				return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+			}),
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/ArrowFunctionHandler.php
+++ b/src/Analyser/ExprHandler/ArrowFunctionHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\ClosureTypeResolver;
@@ -23,6 +24,7 @@ final class ArrowFunctionHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private ClosureTypeResolver $closureTypeResolver,
 	)
 	{
@@ -37,7 +39,7 @@ final class ArrowFunctionHandler implements ExprHandler
 	{
 		$result = $nodeScopeResolver->processArrowFunctionNode($stmt, $expr, $scope, $storage, $nodeCallback, null);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$result->getScope(),
 			hasYield: $result->hasYield(),
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/ArrowFunctionHandler.php
+++ b/src/Analyser/ExprHandler/ArrowFunctionHandler.php
@@ -42,6 +42,7 @@ final class ArrowFunctionHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$result->getScope(),
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $result->getTypeForScope($scope),
 			hasYield: $result->hasYield(),
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/ArrowFunctionHandler.php
+++ b/src/Analyser/ExprHandler/ArrowFunctionHandler.php
@@ -40,6 +40,7 @@ final class ArrowFunctionHandler implements ExprHandler
 		$result = $nodeScopeResolver->processArrowFunctionNode($stmt, $expr, $scope, $storage, $nodeCallback, null);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$result->getScope(),
 			hasYield: $result->hasYield(),
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -147,7 +147,7 @@ final class AssignHandler implements ExprHandler
 					$scope = $scope->exitExpressionAssign($expr->expr);
 				}
 
-				return $this->expressionResultFactory->create($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+				return $this->expressionResultFactory->create($expr->expr, $scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
 			},
 			true,
 		);
@@ -162,6 +162,7 @@ final class AssignHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr->expr,
 			$scope,
 			hasYield: $result->hasYield(),
 			isAlwaysTerminating: $result->isAlwaysTerminating(),
@@ -708,7 +709,7 @@ final class AssignHandler implements ExprHandler
 					new GetOffsetValueTypeExpr($assignedExpr, $dimExpr),
 					$nodeCallback,
 					$context,
-					fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
+					fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($arrayItem->value, $scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
 					$enterExpressionAssign,
 				);
 				$scope = $result->getScope();
@@ -800,7 +801,7 @@ final class AssignHandler implements ExprHandler
 		}
 
 		// stored where processAssignVar is called
-		return $this->expressionResultFactory->create($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return $this->expressionResultFactory->create($assignedExpr, $scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
 	}
 
 	private function unwrapAssign(Expr $expr): Expr

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -147,7 +147,7 @@ final class AssignHandler implements ExprHandler
 					$scope = $scope->exitExpressionAssign($expr->expr);
 				}
 
-				return $this->expressionResultFactory->create($expr->expr, $scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+				return $this->expressionResultFactory->create($expr->expr, $scope, typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $result->getTypeForScope($scope), hasYield: $hasYield, isAlwaysTerminating: $isAlwaysTerminating, throwPoints: $throwPoints, impurePoints: $impurePoints);
 			},
 			true,
 		);
@@ -164,6 +164,7 @@ final class AssignHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr->expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $result->getTypeForScope($scope),
 			hasYield: $result->hasYield(),
 			isAlwaysTerminating: $result->isAlwaysTerminating(),
 			throwPoints: $result->getThrowPoints(),
@@ -195,10 +196,12 @@ final class AssignHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
+		$exprCallbackResult = null;
 		$isAssignOp = $assignedExpr instanceof Expr\AssignOp && !$enterExpressionAssign;
 		if ($var instanceof Variable) {
 			$nodeScopeResolver->storeBeforeScope($storage, $var, $scope);
 			$result = $processExprCallback($scope);
+			$exprCallbackResult = $result;
 			$hasYield = $result->hasYield();
 			$throwPoints = $result->getThrowPoints();
 			$impurePoints = $result->getImpurePoints();
@@ -385,6 +388,7 @@ final class AssignHandler implements ExprHandler
 
 			// 3. eval assigned expr
 			$result = $processExprCallback($scope);
+			$exprCallbackResult = $result;
 			$hasYield = $hasYield || $result->hasYield();
 			$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
@@ -511,6 +515,7 @@ final class AssignHandler implements ExprHandler
 
 			$scopeBeforeAssignEval = $scope;
 			$result = $processExprCallback($scope);
+			$exprCallbackResult = $result;
 			$hasYield = $hasYield || $result->hasYield();
 			$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
@@ -624,6 +629,7 @@ final class AssignHandler implements ExprHandler
 
 			$scopeBeforeAssignEval = $scope;
 			$result = $processExprCallback($scope);
+			$exprCallbackResult = $result;
 			$hasYield = $hasYield || $result->hasYield();
 			$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
@@ -670,6 +676,7 @@ final class AssignHandler implements ExprHandler
 		} elseif ($var instanceof List_) {
 			$nodeScopeResolver->storeBeforeScope($storage, $var, $scope);
 			$result = $processExprCallback($scope);
+			$exprCallbackResult = $result;
 			$hasYield = $result->hasYield();
 			$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
@@ -709,7 +716,7 @@ final class AssignHandler implements ExprHandler
 					new GetOffsetValueTypeExpr($assignedExpr, $dimExpr),
 					$nodeCallback,
 					$context,
-					fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($arrayItem->value, $scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
+					fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($arrayItem->value, $scope, typeCallback: static fn () => new MixedType(), hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
 					$enterExpressionAssign,
 				);
 				$scope = $result->getScope();
@@ -793,6 +800,7 @@ final class AssignHandler implements ExprHandler
 			$isAlwaysTerminating = $varResult->isAlwaysTerminating();
 			$scope = $varResult->getScope();
 			$result = $processExprCallback($scope);
+			$exprCallbackResult = $result;
 			$hasYield = $hasYield || $result->hasYield();
 			$throwPoints = array_merge($throwPoints, $result->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $result->getImpurePoints());
@@ -801,7 +809,7 @@ final class AssignHandler implements ExprHandler
 		}
 
 		// stored where processAssignVar is called
-		return $this->expressionResultFactory->create($assignedExpr, $scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return $this->expressionResultFactory->create($assignedExpr, $scope, typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $exprCallbackResult->getTypeForScope($scope), hasYield: $hasYield, isAlwaysTerminating: $isAlwaysTerminating, throwPoints: $throwPoints, impurePoints: $impurePoints);
 	}
 
 	private function unwrapAssign(Expr $expr): Expr

--- a/src/Analyser/ExprHandler/AssignHandler.php
+++ b/src/Analyser/ExprHandler/AssignHandler.php
@@ -21,6 +21,7 @@ use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ConditionalExpressionHolder;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExpressionTypeHolder;
 use PHPStan\Analyser\ExprHandler;
@@ -78,6 +79,7 @@ final class AssignHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private TypeSpecifier $typeSpecifier,
 		private PhpVersion $phpVersion,
 	)
@@ -105,7 +107,7 @@ final class AssignHandler implements ExprHandler
 			$expr->expr,
 			$nodeCallback,
 			$context,
-			static function (MutatingScope $scope) use ($stmt, $expr, $nodeCallback, $context, $storage, $nodeScopeResolver): ExpressionResult {
+			function (MutatingScope $scope) use ($stmt, $expr, $nodeCallback, $context, $storage, $nodeScopeResolver): ExpressionResult {
 				$impurePoints = [];
 				if ($expr instanceof AssignRef) {
 					$referencedExpr = $expr->expr;
@@ -145,7 +147,7 @@ final class AssignHandler implements ExprHandler
 					$scope = $scope->exitExpressionAssign($expr->expr);
 				}
 
-				return new ExpressionResult($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+				return $this->expressionResultFactory->create($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
 			},
 			true,
 		);
@@ -159,7 +161,7 @@ final class AssignHandler implements ExprHandler
 			}
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $result->hasYield(),
 			isAlwaysTerminating: $result->isAlwaysTerminating(),
@@ -706,7 +708,7 @@ final class AssignHandler implements ExprHandler
 					new GetOffsetValueTypeExpr($assignedExpr, $dimExpr),
 					$nodeCallback,
 					$context,
-					static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
+					fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
 					$enterExpressionAssign,
 				);
 				$scope = $result->getScope();
@@ -798,7 +800,7 @@ final class AssignHandler implements ExprHandler
 		}
 
 		// stored where processAssignVar is called
-		return new ExpressionResult($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return $this->expressionResultFactory->create($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
 	}
 
 	private function unwrapAssign(Expr $expr): Expr

--- a/src/Analyser/ExprHandler/AssignOpHandler.php
+++ b/src/Analyser/ExprHandler/AssignOpHandler.php
@@ -17,6 +17,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\InternalThrowPoint;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\ShouldNotHappenException;
@@ -71,10 +72,11 @@ final class AssignOpHandler implements ExprHandler
 					return $this->expressionResultFactory->create(
 						$expr,
 						$exprResult->getScope()->mergeWith($originalScope),
-						$exprResult->hasYield(),
-						$exprResult->isAlwaysTerminating(),
-						$exprResult->getThrowPoints(),
-						$exprResult->getImpurePoints(),
+						typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $exprResult->getTypeForScope($scope),
+						hasYield: $exprResult->hasYield(),
+						isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
+						throwPoints: $exprResult->getThrowPoints(),
+						impurePoints: $exprResult->getImpurePoints(),
 					);
 				}
 
@@ -97,6 +99,64 @@ final class AssignOpHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($assignResult, $nodeScopeResolver, $stmt): Type {
+				if ($expr instanceof Expr\AssignOp\Coalesce) {
+					// Coalesce assignop type is handled by BinaryOp\Coalesce
+					return $nodeScopeResolver->processExprNode($stmt, new BinaryOp\Coalesce($expr->var, $expr->expr, $expr->getAttributes()), $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+				}
+
+				$varType = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+				$exprType = $assignResult->getTypeForScope($scope);
+				$getType = static function (Expr $e) use ($expr, $varType, $exprType, $scope, $nodeScopeResolver, $stmt): Type {
+					if ($e === $expr->var) {
+						return $varType;
+					}
+					if ($e === $expr->expr) {
+						return $exprType;
+					}
+
+					return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+				};
+
+				if ($expr instanceof Expr\AssignOp\Concat) {
+					return $this->initializerExprTypeResolver->getConcatType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\BitwiseAnd) {
+					return $this->initializerExprTypeResolver->getBitwiseAndType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\BitwiseOr) {
+					return $this->initializerExprTypeResolver->getBitwiseOrType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\BitwiseXor) {
+					return $this->initializerExprTypeResolver->getBitwiseXorType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\Div) {
+					return $this->initializerExprTypeResolver->getDivType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\Mod) {
+					return $this->initializerExprTypeResolver->getModType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\Plus) {
+					return $this->initializerExprTypeResolver->getPlusType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\Minus) {
+					return $this->initializerExprTypeResolver->getMinusType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\Mul) {
+					return $this->initializerExprTypeResolver->getMulType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\Pow) {
+					return $this->initializerExprTypeResolver->getPowType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\ShiftLeft) {
+					return $this->initializerExprTypeResolver->getShiftLeftType($expr->var, $expr->expr, $getType);
+				}
+				if ($expr instanceof Expr\AssignOp\ShiftRight) {
+					return $this->initializerExprTypeResolver->getShiftRightType($expr->var, $expr->expr, $getType);
+				}
+
+				throw new ShouldNotHappenException(sprintf('Unhandled %s', get_class($expr)));
+			},
 			hasYield: $assignResult->hasYield(),
 			isAlwaysTerminating: $assignResult->isAlwaysTerminating(),
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/AssignOpHandler.php
+++ b/src/Analyser/ExprHandler/AssignOpHandler.php
@@ -89,7 +89,7 @@ final class AssignOpHandler implements ExprHandler
 		$throwPoints = $assignResult->getThrowPoints();
 		if (
 			($expr instanceof Expr\AssignOp\Div || $expr instanceof Expr\AssignOp\Mod) &&
-			!$scope->getType($expr->expr)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
+			!$assignResult->getType()->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
 		) {
 			$throwPoints[] = InternalThrowPoint::createExplicit($scope, new ObjectType(DivisionByZeroError::class), $expr, false);
 		}

--- a/src/Analyser/ExprHandler/AssignOpHandler.php
+++ b/src/Analyser/ExprHandler/AssignOpHandler.php
@@ -69,6 +69,7 @@ final class AssignOpHandler implements ExprHandler
 				if ($expr instanceof Expr\AssignOp\Coalesce) {
 					$nodeScopeResolver->storeBeforeScope($storage, $expr, $originalScope);
 					return $this->expressionResultFactory->create(
+						$expr,
 						$exprResult->getScope()->mergeWith($originalScope),
 						$exprResult->hasYield(),
 						$exprResult->isAlwaysTerminating(),
@@ -94,6 +95,7 @@ final class AssignOpHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $assignResult->hasYield(),
 			isAlwaysTerminating: $assignResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/AssignOpHandler.php
+++ b/src/Analyser/ExprHandler/AssignOpHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\InternalThrowPoint;
@@ -33,6 +34,7 @@ final class AssignOpHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private AssignHandler $assignHandler,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
@@ -55,7 +57,7 @@ final class AssignOpHandler implements ExprHandler
 			$expr,
 			$nodeCallback,
 			$context,
-			static function (MutatingScope $scope) use ($stmt, $expr, $nodeCallback, $context, $storage, $nodeScopeResolver): ExpressionResult {
+			function (MutatingScope $scope) use ($stmt, $expr, $nodeCallback, $context, $storage, $nodeScopeResolver): ExpressionResult {
 				$originalScope = $scope;
 				if ($expr instanceof Expr\AssignOp\Coalesce) {
 					$scope = $scope->filterByFalseyValue(
@@ -66,7 +68,7 @@ final class AssignOpHandler implements ExprHandler
 				$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 				if ($expr instanceof Expr\AssignOp\Coalesce) {
 					$nodeScopeResolver->storeBeforeScope($storage, $expr, $originalScope);
-					return new ExpressionResult(
+					return $this->expressionResultFactory->create(
 						$exprResult->getScope()->mergeWith($originalScope),
 						$exprResult->hasYield(),
 						$exprResult->isAlwaysTerminating(),
@@ -91,7 +93,7 @@ final class AssignOpHandler implements ExprHandler
 			$throwPoints[] = InternalThrowPoint::createExplicit($scope, new ObjectType(DivisionByZeroError::class), $expr, false);
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $assignResult->hasYield(),
 			isAlwaysTerminating: $assignResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BinaryOpHandler.php
+++ b/src/Analyser/ExprHandler/BinaryOpHandler.php
@@ -67,7 +67,7 @@ final class BinaryOpHandler implements ExprHandler
 		$throwPoints = array_merge($leftResult->getThrowPoints(), $rightResult->getThrowPoints());
 		if (
 			($expr instanceof BinaryOp\Div || $expr instanceof BinaryOp\Mod) &&
-			!$leftResult->getScope()->getType($expr->right)->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
+			!$rightResult->getType()->toNumber()->isSuperTypeOf(new ConstantIntegerType(0))->no()
 		) {
 			$throwPoints[] = InternalThrowPoint::createExplicit($leftResult->getScope(), new ObjectType(DivisionByZeroError::class), $expr, false);
 		}

--- a/src/Analyser/ExprHandler/BinaryOpHandler.php
+++ b/src/Analyser/ExprHandler/BinaryOpHandler.php
@@ -73,6 +73,7 @@ final class BinaryOpHandler implements ExprHandler
 		$scope = $rightResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating() || $rightResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BinaryOpHandler.php
+++ b/src/Analyser/ExprHandler/BinaryOpHandler.php
@@ -17,6 +17,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\InternalThrowPoint;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\Analyser\RicherScopeGetTypeHelper;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
@@ -75,6 +76,137 @@ final class BinaryOpHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($leftResult, $rightResult, $nodeScopeResolver, $stmt): Type {
+				$leftType = $leftResult->getTypeForScope($scope);
+				$rightType = $rightResult->getTypeForScope($scope);
+				$getType = static function (Expr $e) use ($expr, $leftResult, $rightResult, $scope, $nodeScopeResolver, $stmt): Type {
+					if ($e === $expr->left) {
+						return $leftResult->getTypeForScope($scope);
+					}
+					if ($e === $expr->right) {
+						return $rightResult->getTypeForScope($scope);
+					}
+
+					return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+				};
+
+				if ($expr instanceof BinaryOp\Smaller) {
+					return $leftType->isSmallerThan($rightType, $this->phpVersion)->toBooleanType();
+				}
+
+				if ($expr instanceof BinaryOp\SmallerOrEqual) {
+					return $leftType->isSmallerThanOrEqual($rightType, $this->phpVersion)->toBooleanType();
+				}
+
+				if ($expr instanceof BinaryOp\Greater) {
+					return $rightType->isSmallerThan($leftType, $this->phpVersion)->toBooleanType();
+				}
+
+				if ($expr instanceof BinaryOp\GreaterOrEqual) {
+					return $rightType->isSmallerThanOrEqual($leftType, $this->phpVersion)->toBooleanType();
+				}
+
+				if ($expr instanceof BinaryOp\Equal) {
+					if (
+						$expr->left instanceof Variable
+						&& is_string($expr->left->name)
+						&& $expr->right instanceof Variable
+						&& is_string($expr->right->name)
+						&& $expr->left->name === $expr->right->name
+					) {
+						return new ConstantBooleanType(true);
+					}
+
+					return $this->initializerExprTypeResolver->resolveEqualType($leftType, $rightType)->type;
+				}
+
+				if ($expr instanceof BinaryOp\NotEqual) {
+					$equalType = $this->initializerExprTypeResolver->resolveEqualType($leftType, $rightType)->type;
+					if ($equalType instanceof ConstantBooleanType) {
+						return new ConstantBooleanType(!$equalType->getValue());
+					}
+
+					return new BooleanType();
+				}
+
+				if ($expr instanceof BinaryOp\Identical) {
+					return $this->richerScopeGetTypeHelper->getIdenticalResultWithTypes($scope, $expr, $leftType, $rightType)->type;
+				}
+
+				if ($expr instanceof BinaryOp\NotIdentical) {
+					return $this->richerScopeGetTypeHelper->getNotIdenticalResultWithTypes($scope, $expr, $leftType, $rightType)->type;
+				}
+
+				if ($expr instanceof BinaryOp\LogicalXor) {
+					$leftBooleanType = $leftType->toBoolean();
+					$rightBooleanType = $rightType->toBoolean();
+
+					if (
+						$leftBooleanType instanceof ConstantBooleanType
+						&& $rightBooleanType instanceof ConstantBooleanType
+					) {
+						return new ConstantBooleanType(
+							$leftBooleanType->getValue() xor $rightBooleanType->getValue(),
+						);
+					}
+
+					return new BooleanType();
+				}
+
+				if ($expr instanceof BinaryOp\Spaceship) {
+					return $this->initializerExprTypeResolver->getSpaceshipType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Concat) {
+					return $this->initializerExprTypeResolver->getConcatType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\BitwiseAnd) {
+					return $this->initializerExprTypeResolver->getBitwiseAndType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\BitwiseOr) {
+					return $this->initializerExprTypeResolver->getBitwiseOrType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\BitwiseXor) {
+					return $this->initializerExprTypeResolver->getBitwiseXorType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Div) {
+					return $this->initializerExprTypeResolver->getDivType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Mod) {
+					return $this->initializerExprTypeResolver->getModType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Plus) {
+					return $this->initializerExprTypeResolver->getPlusType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Minus) {
+					return $this->initializerExprTypeResolver->getMinusType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Mul) {
+					return $this->initializerExprTypeResolver->getMulType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\Pow) {
+					return $this->initializerExprTypeResolver->getPowType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\ShiftLeft) {
+					return $this->initializerExprTypeResolver->getShiftLeftType($expr->left, $expr->right, $getType);
+				}
+
+				if ($expr instanceof BinaryOp\ShiftRight) {
+					return $this->initializerExprTypeResolver->getShiftRightType($expr->left, $expr->right, $getType);
+				}
+
+				throw new ShouldNotHappenException(sprintf('Unhandled %s', get_class($expr)));
+			},
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating() || $rightResult->isAlwaysTerminating(),
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/BinaryOpHandler.php
+++ b/src/Analyser/ExprHandler/BinaryOpHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\InternalThrowPoint;
@@ -39,6 +40,7 @@ final class BinaryOpHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 		private RicherScopeGetTypeHelper $richerScopeGetTypeHelper,
 		private PhpVersion $phpVersion,
@@ -70,7 +72,7 @@ final class BinaryOpHandler implements ExprHandler
 		}
 		$scope = $rightResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating() || $rightResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BitwiseNotHandler.php
+++ b/src/Analyser/ExprHandler/BitwiseNotHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\BitwiseNot;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -23,6 +24,7 @@ final class BitwiseNotHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -37,7 +39,7 @@ final class BitwiseNotHandler implements ExprHandler
 	{
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BitwiseNotHandler.php
+++ b/src/Analyser/ExprHandler/BitwiseNotHandler.php
@@ -40,6 +40,7 @@ final class BitwiseNotHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BitwiseNotHandler.php
+++ b/src/Analyser/ExprHandler/BitwiseNotHandler.php
@@ -12,6 +12,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\Type;
@@ -42,6 +43,13 @@ final class BitwiseNotHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$exprResult->getScope(),
+			typeCallback: fn (Expr $uninteresting, MutatingScope $scope) => $this->initializerExprTypeResolver->getBitwiseNotType($expr->expr, static function (Expr $e) use ($expr, $exprResult, $nodeScopeResolver, $stmt, $scope): Type {
+				if ($e === $expr->expr) {
+					return $exprResult->getTypeForScope($scope);
+				}
+
+				return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+			}),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -102,6 +102,7 @@ final class BooleanAndHandler implements ExprHandler
 		$nodeScopeResolver->callNodeCallbackWithExpression($nodeCallback, new BooleanAndNode($expr, $leftTruthyScope), $scope, $storage, $context);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$leftMergedWithRightScope,
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\BinaryOp\LogicalOr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -33,6 +34,7 @@ final class BooleanAndHandler implements ExprHandler
 	private const BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH = 4;
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NodeScopeResolver $nodeScopeResolver,
 	)
 	{
@@ -99,7 +101,7 @@ final class BooleanAndHandler implements ExprHandler
 
 		$nodeScopeResolver->callNodeCallbackWithExpression($nodeCallback, new BooleanAndNode($expr, $leftTruthyScope), $scope, $storage, $context);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$leftMergedWithRightScope,
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BooleanAndHandler.php
+++ b/src/Analyser/ExprHandler/BooleanAndHandler.php
@@ -92,7 +92,7 @@ final class BooleanAndHandler implements ExprHandler
 		$leftResult = $nodeScopeResolver->processExprNode($stmt, $expr->left, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$leftTruthyScope = $leftResult->getTruthyScope();
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $leftTruthyScope, $storage, $nodeCallback, $context);
-		$rightExprType = $rightResult->getScope()->getType($expr->right);
+		$rightExprType = $rightResult->getType();
 		if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 			$leftMergedWithRightScope = $leftResult->getFalseyScope();
 		} else {
@@ -104,6 +104,23 @@ final class BooleanAndHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$leftMergedWithRightScope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($leftResult, $rightResult): Type {
+				$leftBooleanType = $leftResult->getTypeForScope($scope)->toBoolean();
+				if ($leftBooleanType->isFalse()->yes()) {
+					return new ConstantBooleanType(false);
+				}
+
+				$rightBooleanType = $rightResult->getTypeForScope($scope)->toBoolean();
+				if ($rightBooleanType->isFalse()->yes()) {
+					return new ConstantBooleanType(false);
+				}
+
+				if ($leftBooleanType->isTrue()->yes() && $rightBooleanType->isTrue()->yes()) {
+					return new ConstantBooleanType(true);
+				}
+
+				return new BooleanType();
+			},
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating(),
 			throwPoints: array_merge($leftResult->getThrowPoints(), $rightResult->getThrowPoints()),

--- a/src/Analyser/ExprHandler/BooleanNotHandler.php
+++ b/src/Analyser/ExprHandler/BooleanNotHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\BooleanNot;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -23,6 +24,12 @@ use PHPStan\Type\Type;
 final class BooleanNotHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof BooleanNot;
@@ -33,7 +40,7 @@ final class BooleanNotHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$scope = $exprResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BooleanNotHandler.php
+++ b/src/Analyser/ExprHandler/BooleanNotHandler.php
@@ -43,6 +43,14 @@ final class BooleanNotHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($exprResult): Type {
+				$exprBooleanType = $exprResult->getTypeForScope($scope)->toBoolean();
+				if ($exprBooleanType instanceof ConstantBooleanType) {
+					return new ConstantBooleanType(!$exprBooleanType->getValue());
+				}
+
+				return new BooleanType();
+			},
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/BooleanNotHandler.php
+++ b/src/Analyser/ExprHandler/BooleanNotHandler.php
@@ -41,6 +41,7 @@ final class BooleanNotHandler implements ExprHandler
 		$scope = $exprResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BooleanOrHandler.php
+++ b/src/Analyser/ExprHandler/BooleanOrHandler.php
@@ -76,7 +76,7 @@ final class BooleanOrHandler implements ExprHandler
 		$leftResult = $nodeScopeResolver->processExprNode($stmt, $expr->left, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$leftFalseyScope = $leftResult->getFalseyScope();
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $leftFalseyScope, $storage, $nodeCallback, $context);
-		$rightExprType = $rightResult->getScope()->getType($expr->right);
+		$rightExprType = $rightResult->getType();
 		if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 			$leftMergedWithRightScope = $leftResult->getTruthyScope();
 		} else {
@@ -88,6 +88,23 @@ final class BooleanOrHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$leftMergedWithRightScope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($leftResult, $rightResult): Type {
+				$leftBooleanType = $leftResult->getTypeForScope($scope)->toBoolean();
+				if ($leftBooleanType->isTrue()->yes()) {
+					return new ConstantBooleanType(true);
+				}
+
+				$rightBooleanType = $rightResult->getTypeForScope($scope)->toBoolean();
+				if ($rightBooleanType->isTrue()->yes()) {
+					return new ConstantBooleanType(true);
+				}
+
+				if ($leftBooleanType->isFalse()->yes() && $rightBooleanType->isFalse()->yes()) {
+					return new ConstantBooleanType(false);
+				}
+
+				return new BooleanType();
+			},
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating(),
 			throwPoints: array_merge($leftResult->getThrowPoints(), $rightResult->getThrowPoints()),

--- a/src/Analyser/ExprHandler/BooleanOrHandler.php
+++ b/src/Analyser/ExprHandler/BooleanOrHandler.php
@@ -86,6 +86,7 @@ final class BooleanOrHandler implements ExprHandler
 		$nodeScopeResolver->callNodeCallbackWithExpression($nodeCallback, new BooleanOrNode($expr, $leftFalseyScope), $scope, $storage, $context);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$leftMergedWithRightScope,
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/BooleanOrHandler.php
+++ b/src/Analyser/ExprHandler/BooleanOrHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\BinaryOp\LogicalOr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -31,6 +32,7 @@ final class BooleanOrHandler implements ExprHandler
 	private const BOOLEAN_EXPRESSION_MAX_PROCESS_DEPTH = 4;
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NodeScopeResolver $nodeScopeResolver,
 	)
 	{
@@ -83,7 +85,7 @@ final class BooleanOrHandler implements ExprHandler
 
 		$nodeScopeResolver->callNodeCallbackWithExpression($nodeCallback, new BooleanOrNode($expr, $leftFalseyScope), $scope, $storage, $context);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$leftMergedWithRightScope,
 			hasYield: $leftResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $leftResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CastHandler.php
+++ b/src/Analyser/ExprHandler/CastHandler.php
@@ -12,6 +12,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\NullType;
@@ -44,6 +45,19 @@ final class CastHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $uninteresting, MutatingScope $scope) use ($expr, $exprResult, $nodeScopeResolver, $stmt): Type {
+				if ($expr instanceof Cast\Unset_) {
+					return new NullType();
+				}
+
+				return $this->initializerExprTypeResolver->getCastType($expr, static function (Expr $e) use ($expr, $exprResult, $nodeScopeResolver, $stmt, $scope): Type {
+					if ($e === $expr->expr) {
+						return $exprResult->getTypeForScope($scope);
+					}
+
+					return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+				});
+			},
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/CastHandler.php
+++ b/src/Analyser/ExprHandler/CastHandler.php
@@ -42,6 +42,7 @@ final class CastHandler implements ExprHandler
 		$scope = $exprResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CastHandler.php
+++ b/src/Analyser/ExprHandler/CastHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -24,6 +25,7 @@ final class CastHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -39,7 +41,7 @@ final class CastHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$scope = $exprResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CastStringHandler.php
+++ b/src/Analyser/ExprHandler/CastStringHandler.php
@@ -43,7 +43,7 @@ final class CastStringHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$impurePoints = $exprResult->getImpurePoints();
 
-		$exprType = $scope->getType($expr->expr);
+		$exprType = $exprResult->getType();
 		$toStringMethod = $scope->getMethodReflection($exprType, '__toString');
 		if ($toStringMethod !== null) {
 			if (!$toStringMethod->hasSideEffects()->no()) {

--- a/src/Analyser/ExprHandler/CastStringHandler.php
+++ b/src/Analyser/ExprHandler/CastStringHandler.php
@@ -59,6 +59,7 @@ final class CastStringHandler implements ExprHandler
 		$scope = $exprResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CastStringHandler.php
+++ b/src/Analyser/ExprHandler/CastStringHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Cast;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -25,6 +26,7 @@ final class CastStringHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -56,7 +58,7 @@ final class CastStringHandler implements ExprHandler
 
 		$scope = $exprResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CastStringHandler.php
+++ b/src/Analyser/ExprHandler/CastStringHandler.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\Type;
@@ -61,6 +62,13 @@ final class CastStringHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: fn (Expr $uninteresting, MutatingScope $scope) => $this->initializerExprTypeResolver->getCastType($expr, static function (Expr $e) use ($expr, $exprResult, $nodeScopeResolver, $stmt, $scope): Type {
+				if ($e === $expr->expr) {
+					return $exprResult->getTypeForScope($scope);
+				}
+
+				return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+			}),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/ClassConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ClassConstFetchHandler.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\MixedType;
@@ -59,6 +60,7 @@ final class ClassConstFetchHandler implements ExprHandler
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
 
+		$classResult = null;
 		if ($expr->class instanceof Expr) {
 			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$scope = $classResult->getScope();
@@ -84,6 +86,24 @@ final class ClassConstFetchHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($classResult, $nodeScopeResolver, $stmt): Type {
+				if (!$expr->name instanceof Identifier) {
+					return new MixedType();
+				}
+
+				return $this->initializerExprTypeResolver->getClassConstFetchTypeByReflection(
+					$expr->class,
+					$expr->name->name,
+					$scope->isInClass() ? $scope->getClassReflection() : null,
+					static function (Expr $e) use ($expr, $classResult, $scope, $nodeScopeResolver, $stmt): Type {
+						if ($classResult !== null && $e === $expr->class) {
+							return $classResult->getTypeForScope($scope);
+						}
+
+						return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+					},
+				);
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/ClassConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ClassConstFetchHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -26,6 +27,7 @@ final class ClassConstFetchHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -79,7 +81,7 @@ final class ClassConstFetchHandler implements ExprHandler
 			$isAlwaysTerminating = $isAlwaysTerminating || $nameResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/ClassConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ClassConstFetchHandler.php
@@ -82,6 +82,7 @@ final class ClassConstFetchHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/CloneHandler.php
+++ b/src/Analyser/ExprHandler/CloneHandler.php
@@ -44,6 +44,7 @@ final class CloneHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$exprResult->getScope(),
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => TypeTraverser::map(TypeCombinator::intersect($exprResult->getTypeForScope($scope), new ObjectWithoutClassType()), new CloneTypeTraverser()),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/CloneHandler.php
+++ b/src/Analyser/ExprHandler/CloneHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Clone_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -25,6 +26,12 @@ use PHPStan\Type\TypeTraverser;
 final class CloneHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof Clone_;
@@ -34,7 +41,7 @@ final class CloneHandler implements ExprHandler
 	{
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CloneHandler.php
+++ b/src/Analyser/ExprHandler/CloneHandler.php
@@ -42,6 +42,7 @@ final class CloneHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ClosureHandler.php
+++ b/src/Analyser/ExprHandler/ClosureHandler.php
@@ -43,6 +43,8 @@ final class ClosureHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			// TODO: replace with proper typeCallback that doesn't use $scope->getType()
+			typeCallback: fn (Expr $expr, MutatingScope $scope) => $this->closureTypeResolver->getClosureType($scope, $expr),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/ClosureHandler.php
+++ b/src/Analyser/ExprHandler/ClosureHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\ClosureTypeResolver;
@@ -23,6 +24,7 @@ final class ClosureHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private ClosureTypeResolver $closureTypeResolver,
 	)
 	{
@@ -38,7 +40,7 @@ final class ClosureHandler implements ExprHandler
 		$processClosureResult = $nodeScopeResolver->processClosureNode($stmt, $expr, $scope, $storage, $nodeCallback, $context, null);
 		$scope = $processClosureResult->applyByRefUseScope($processClosureResult->getScope());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/ClosureHandler.php
+++ b/src/Analyser/ExprHandler/ClosureHandler.php
@@ -41,6 +41,7 @@ final class ClosureHandler implements ExprHandler
 		$scope = $processClosureResult->applyByRefUseScope($processClosureResult->getScope());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\BinaryOp\Coalesce;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
@@ -26,6 +27,7 @@ final class CoalesceHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NonNullabilityHelper $nonNullabilityHelper,
 	)
 	{
@@ -82,7 +84,7 @@ final class CoalesceHandler implements ExprHandler
 			$scope = $scope->filterByTruthyValue(new Expr\Isset_([$expr->left]))->mergeWith($rightResult->getScope());
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $condResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $condResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -85,6 +85,7 @@ final class CoalesceHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $condResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $condResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -77,7 +77,7 @@ final class CoalesceHandler implements ExprHandler
 
 		$rightScope = $scope->filterByFalseyValue($expr);
 		$rightResult = $nodeScopeResolver->processExprNode($stmt, $expr->right, $rightScope, $storage, $nodeCallback, $context->enterDeep());
-		$rightExprType = $scope->getType($expr->right);
+		$rightExprType = $rightResult->getType();
 		if ($rightExprType instanceof NeverType && $rightExprType->isExplicit()) {
 			$scope = $scope->filterByTruthyValue(new Expr\Isset_([$expr->left]));
 		} else {

--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -87,6 +87,23 @@ final class CoalesceHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($condResult, $rightResult): Type {
+				$leftType = $condResult->getTypeForScope($scope);
+				$rightType = $rightResult->getTypeForScope($scope);
+
+				if ($leftType->isNull()->yes()) {
+					return $rightType;
+				}
+
+				if (!TypeCombinator::containsNull($leftType)) {
+					return $leftType;
+				}
+
+				return TypeCombinator::union(
+					TypeCombinator::removeNull($leftType),
+					$rightType,
+				);
+			},
 			hasYield: $condResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $condResult->isAlwaysTerminating(),
 			throwPoints: array_merge($condResult->getThrowPoints(), $rightResult->getThrowPoints()),

--- a/src/Analyser/ExprHandler/CoalesceHandler.php
+++ b/src/Analyser/ExprHandler/CoalesceHandler.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\Type;
@@ -87,22 +88,33 @@ final class CoalesceHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
-			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($condResult, $rightResult): Type {
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($expr, $condResult, $rightResult, $nodeScopeResolver, $stmt): Type {
+				$typeResolver = static fn (Expr $e): Type => $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+
+				$issetResult = $scope->issetCheckWithResolver($expr->left, static function (Type $type): ?bool {
+					$isNull = $type->isNull();
+					if ($isNull->maybe()) {
+						return null;
+					}
+
+					return !$isNull->yes();
+				}, $typeResolver);
+
 				$leftType = $condResult->getTypeForScope($scope);
 				$rightType = $rightResult->getTypeForScope($scope);
 
-				if ($leftType->isNull()->yes()) {
-					return $rightType;
+				if ($issetResult !== null && $issetResult !== false) {
+					return TypeCombinator::removeNull($leftType);
 				}
 
-				if (!TypeCombinator::containsNull($leftType)) {
-					return $leftType;
+				if ($issetResult === null) {
+					return TypeCombinator::union(
+						TypeCombinator::removeNull($leftType),
+						$rightType,
+					);
 				}
 
-				return TypeCombinator::union(
-					TypeCombinator::removeNull($leftType),
-					$rightType,
-				);
+				return $rightType;
 			},
 			hasYield: $condResult->hasYield() || $rightResult->hasYield(),
 			isAlwaysTerminating: $condResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ConstFetchHandler.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ConstantResolver;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -28,6 +29,7 @@ final class ConstFetchHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private ConstantResolver $constantResolver,
 	)
 	{
@@ -42,7 +44,7 @@ final class ConstFetchHandler implements ExprHandler
 	{
 		$nodeScopeResolver->callNodeCallback($nodeCallback, $expr->name, $scope, $storage);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/ConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ConstFetchHandler.php
@@ -46,6 +46,7 @@ final class ConstFetchHandler implements ExprHandler
 
 		$constName = (string) $expr->name;
 		$loweredConstName = strtolower($constName);
+		$names = null;
 		if ($loweredConstName === 'true') {
 			$constType = new ConstantBooleanType(true);
 		} elseif ($loweredConstName === 'false') {

--- a/src/Analyser/ExprHandler/ConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ConstFetchHandler.php
@@ -45,6 +45,7 @@ final class ConstFetchHandler implements ExprHandler
 		$nodeScopeResolver->callNodeCallback($nodeCallback, $expr->name, $scope, $storage);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/ConstFetchHandler.php
+++ b/src/Analyser/ExprHandler/ConstFetchHandler.php
@@ -44,9 +44,47 @@ final class ConstFetchHandler implements ExprHandler
 	{
 		$nodeScopeResolver->callNodeCallback($nodeCallback, $expr->name, $scope, $storage);
 
+		$constName = (string) $expr->name;
+		$loweredConstName = strtolower($constName);
+		if ($loweredConstName === 'true') {
+			$constType = new ConstantBooleanType(true);
+		} elseif ($loweredConstName === 'false') {
+			$constType = new ConstantBooleanType(false);
+		} elseif ($loweredConstName === 'null') {
+			$constType = new NullType();
+		} else {
+			$namespacedName = null;
+			if (!$expr->name->isFullyQualified() && $scope->getNamespace() !== null) {
+				$namespacedName = new FullyQualified([$scope->getNamespace(), $expr->name->toString()]);
+			}
+			$globalName = new FullyQualified($expr->name->toString());
+
+			$constType = $this->constantResolver->resolveConstant($expr->name, $scope) ?? new ErrorType();
+
+			$names = [$namespacedName, $globalName];
+		}
+
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($constType, $names) {
+				if ($names !== null) {
+					foreach ($names as $name) {
+						if ($name === null) {
+							continue;
+						}
+						$constFetch = new ConstFetch($name);
+						if ($scope->hasExpressionType($constFetch)->yes()) {
+							return $this->constantResolver->resolveConstantType(
+								$name->toString(),
+								$scope->expressionTypes[$scope->getNodeKey($constFetch)]->getType(),
+							);
+						}
+					}
+				}
+
+				return $constType;
+			},
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/EmptyHandler.php
+++ b/src/Analyser/ExprHandler/EmptyHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Empty_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
@@ -25,6 +26,7 @@ final class EmptyHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NonNullabilityHelper $nonNullabilityHelper,
 	)
 	{
@@ -69,7 +71,7 @@ final class EmptyHandler implements ExprHandler
 		$scope = $this->nonNullabilityHelper->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
 		$scope = $nodeScopeResolver->lookForUnsetAllowedUndefinedExpressions($scope, $expr->expr);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/EmptyHandler.php
+++ b/src/Analyser/ExprHandler/EmptyHandler.php
@@ -72,6 +72,7 @@ final class EmptyHandler implements ExprHandler
 		$scope = $nodeScopeResolver->lookForUnsetAllowedUndefinedExpressions($scope, $expr->expr);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/EmptyHandler.php
+++ b/src/Analyser/ExprHandler/EmptyHandler.php
@@ -13,6 +13,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -74,6 +75,31 @@ final class EmptyHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $expr, MutatingScope $scope) use ($nodeScopeResolver, $stmt): Type {
+				$typeResolver = static fn (Expr $e): Type => $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+
+				$result = $scope->issetCheckWithResolver($expr->expr, static function (Type $type): ?bool {
+					$isNull = $type->isNull();
+					$isFalsey = $type->toBoolean()->isFalse();
+					if ($isNull->maybe()) {
+						return null;
+					}
+					if ($isFalsey->maybe()) {
+						return null;
+					}
+
+					if ($isNull->yes()) {
+						return $isFalsey->no();
+					}
+
+					return !$isFalsey->yes();
+				}, $typeResolver);
+				if ($result === null) {
+					return new BooleanType();
+				}
+
+				return new ConstantBooleanType(!$result);
+			},
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/ErrorSuppressHandler.php
+++ b/src/Analyser/ExprHandler/ErrorSuppressHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\ErrorSuppress;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class ErrorSuppressHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof ErrorSuppress;
@@ -30,7 +37,7 @@ final class ErrorSuppressHandler implements ExprHandler
 	{
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ErrorSuppressHandler.php
+++ b/src/Analyser/ExprHandler/ErrorSuppressHandler.php
@@ -40,6 +40,7 @@ final class ErrorSuppressHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$exprResult->getScope(),
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $exprResult->getTypeForScope($scope),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/ErrorSuppressHandler.php
+++ b/src/Analyser/ExprHandler/ErrorSuppressHandler.php
@@ -38,6 +38,7 @@ final class ErrorSuppressHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/EvalHandler.php
+++ b/src/Analyser/ExprHandler/EvalHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Eval_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -25,6 +26,12 @@ use function array_merge;
 final class EvalHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof Eval_;
@@ -40,7 +47,7 @@ final class EvalHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$scope = $exprResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/EvalHandler.php
+++ b/src/Analyser/ExprHandler/EvalHandler.php
@@ -50,6 +50,7 @@ final class EvalHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createImplicit($scope, $expr)]),

--- a/src/Analyser/ExprHandler/EvalHandler.php
+++ b/src/Analyser/ExprHandler/EvalHandler.php
@@ -48,6 +48,7 @@ final class EvalHandler implements ExprHandler
 		$scope = $exprResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ExitHandler.php
+++ b/src/Analyser/ExprHandler/ExitHandler.php
@@ -55,6 +55,7 @@ final class ExitHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: true,

--- a/src/Analyser/ExprHandler/ExitHandler.php
+++ b/src/Analyser/ExprHandler/ExitHandler.php
@@ -57,6 +57,7 @@ final class ExitHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new NonAcceptingNeverType(),
 			hasYield: $hasYield,
 			isAlwaysTerminating: true,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/ExitHandler.php
+++ b/src/Analyser/ExprHandler/ExitHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Exit_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -23,6 +24,12 @@ use function array_merge;
 #[AutowiredService]
 final class ExitHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -47,7 +54,7 @@ final class ExitHandler implements ExprHandler
 			$scope = $exprResult->getScope();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: true,

--- a/src/Analyser/ExprHandler/FirstClassCallableFuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FirstClassCallableFuncCallHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -15,7 +16,6 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprContext;
 use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
@@ -27,6 +27,7 @@ final class FirstClassCallableFuncCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -47,8 +48,36 @@ final class FirstClassCallableFuncCallHandler implements ExprHandler
 		ExpressionContext $context,
 	): ExpressionResult
 	{
-		// handled in NodeScopeResolver before ExprHandlers are called
-		throw new ShouldNotHappenException();
+		$nameResult = null;
+		if ($expr->name instanceof Expr) {
+			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			$scope = $nameResult->getScope();
+		}
+
+		return $this->expressionResultFactory->create(
+			$expr,
+			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($nameResult): Type {
+				if ($nameResult !== null) {
+					$callableType = $nameResult->getTypeForScope($scope);
+					if (!$callableType->isCallable()->yes()) {
+						return new ObjectType(Closure::class);
+					}
+
+					return $this->initializerExprTypeResolver->createFirstClassCallable(
+						null,
+						$callableType->getCallableParametersAcceptors($scope),
+						$scope->nativeTypesPromoted,
+					);
+				}
+
+				return $this->initializerExprTypeResolver->getFirstClassCallableType($expr, InitializerExprContext::fromScope($scope), $scope->nativeTypesPromoted);
+			},
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: $nameResult !== null ? $nameResult->getThrowPoints() : [],
+			impurePoints: $nameResult !== null ? $nameResult->getImpurePoints() : [],
+		);
 	}
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type

--- a/src/Analyser/ExprHandler/FirstClassCallableMethodCallHandler.php
+++ b/src/Analyser/ExprHandler/FirstClassCallableMethodCallHandler.php
@@ -9,15 +9,16 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use function array_merge;
 
 /**
  * @implements ExprHandler<MethodCall>
@@ -27,6 +28,7 @@ final class FirstClassCallableMethodCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -47,8 +49,43 @@ final class FirstClassCallableMethodCallHandler implements ExprHandler
 		ExpressionContext $context,
 	): ExpressionResult
 	{
-		// handled in NodeScopeResolver before ExprHandlers are called
-		throw new ShouldNotHappenException();
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+		$scope = $varResult->getScope();
+		$throwPoints = $varResult->getThrowPoints();
+		$impurePoints = $varResult->getImpurePoints();
+
+		if (!$expr->name instanceof Identifier) {
+			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			$scope = $nameResult->getScope();
+			$throwPoints = array_merge($throwPoints, $nameResult->getThrowPoints());
+			$impurePoints = array_merge($impurePoints, $nameResult->getImpurePoints());
+		}
+
+		return $this->expressionResultFactory->create(
+			$expr,
+			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($varResult): Type {
+				if (!$expr->name instanceof Identifier) {
+					return new ObjectType(Closure::class);
+				}
+
+				$varType = $varResult->getTypeForScope($scope);
+				$method = $scope->getMethodReflection($varType, $expr->name->toString());
+				if ($method === null) {
+					return new ObjectType(Closure::class);
+				}
+
+				return $this->initializerExprTypeResolver->createFirstClassCallable(
+					$method,
+					$method->getVariants(),
+					$scope->nativeTypesPromoted,
+				);
+			},
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: $throwPoints,
+			impurePoints: $impurePoints,
+		);
 	}
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type

--- a/src/Analyser/ExprHandler/FirstClassCallableNewHandler.php
+++ b/src/Analyser/ExprHandler/FirstClassCallableNewHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -15,7 +16,6 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprContext;
 use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Type;
 
 /**
@@ -26,6 +26,7 @@ final class FirstClassCallableNewHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -46,8 +47,24 @@ final class FirstClassCallableNewHandler implements ExprHandler
 		ExpressionContext $context,
 	): ExpressionResult
 	{
-		// handled in NodeScopeResolver before ExprHandlers are called
-		throw new ShouldNotHappenException();
+		$throwPoints = [];
+		$impurePoints = [];
+		if ($expr->class instanceof Expr) {
+			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			$scope = $classResult->getScope();
+			$throwPoints = $classResult->getThrowPoints();
+			$impurePoints = $classResult->getImpurePoints();
+		}
+
+		return $this->expressionResultFactory->create(
+			$expr,
+			$scope,
+			typeCallback: fn (Expr $expr, MutatingScope $scope) => $this->initializerExprTypeResolver->getFirstClassCallableType($expr, InitializerExprContext::fromScope($scope), $scope->nativeTypesPromoted),
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: $throwPoints,
+			impurePoints: $impurePoints,
+		);
 	}
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type

--- a/src/Analyser/ExprHandler/FirstClassCallableStaticCallHandler.php
+++ b/src/Analyser/ExprHandler/FirstClassCallableStaticCallHandler.php
@@ -4,9 +4,11 @@ namespace PHPStan\Analyser\ExprHandler;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -14,8 +16,8 @@ use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprContext;
 use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Type;
+use function array_merge;
 
 /**
  * @implements ExprHandler<StaticCall>
@@ -25,6 +27,7 @@ final class FirstClassCallableStaticCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -45,8 +48,30 @@ final class FirstClassCallableStaticCallHandler implements ExprHandler
 		ExpressionContext $context,
 	): ExpressionResult
 	{
-		// handled in NodeScopeResolver before ExprHandlers are called
-		throw new ShouldNotHappenException();
+		$throwPoints = [];
+		$impurePoints = [];
+		if ($expr->class instanceof Expr) {
+			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			$scope = $classResult->getScope();
+			$throwPoints = $classResult->getThrowPoints();
+			$impurePoints = $classResult->getImpurePoints();
+		}
+		if (!$expr->name instanceof Identifier) {
+			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			$scope = $nameResult->getScope();
+			$throwPoints = array_merge($throwPoints, $nameResult->getThrowPoints());
+			$impurePoints = array_merge($impurePoints, $nameResult->getImpurePoints());
+		}
+
+		return $this->expressionResultFactory->create(
+			$expr,
+			$scope,
+			typeCallback: fn (Expr $expr, MutatingScope $scope) => $this->initializerExprTypeResolver->getFirstClassCallableType($expr, InitializerExprContext::fromScope($scope), $scope->nativeTypesPromoted),
+			hasYield: false,
+			isAlwaysTerminating: false,
+			throwPoints: $throwPoints,
+			impurePoints: $impurePoints,
+		);
 	}
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -88,6 +88,8 @@ final class FuncCallHandler implements ExprHandler
 		private bool $implicitThrows,
 		#[AutowiredParameter]
 		private bool $rememberPossiblyImpureFunctionValues,
+		#[AutowiredParameter]
+		private array $earlyTerminatingFunctionCalls,
 	)
 	{
 	}
@@ -164,6 +166,9 @@ final class FuncCallHandler implements ExprHandler
 			$normalizedExpr = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $expr) ?? $expr;
 			$returnType = $parametersAcceptor->getReturnType();
 			$isAlwaysTerminating = $isAlwaysTerminating || $returnType instanceof NeverType && $returnType->isExplicit();
+		}
+		if (!$isAlwaysTerminating && $expr->name instanceof Name && in_array((string) $expr->name, $this->earlyTerminatingFunctionCalls, true)) {
+			$isAlwaysTerminating = true;
 		}
 
 		if (

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\VoidToNullTypeTransformer;
@@ -79,6 +80,7 @@ final class FuncCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private ReflectionProvider $reflectionProvider,
 		private DynamicThrowTypeExtensionProvider $dynamicThrowTypeExtensionProvider,
 		private DynamicReturnTypeExtensionRegistryProvider $dynamicReturnTypeExtensionRegistryProvider,
@@ -470,7 +472,7 @@ final class FuncCallHandler implements ExprHandler
 			$scope = $scope->afterOpenSslCall($functionReflection->getName());
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -104,8 +104,10 @@ final class FuncCallHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
+		$nameResult = null;
 		if ($expr->name instanceof Expr) {
-			$nameType = $scope->getType($expr->name);
+			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, $context->enterDeep());
+			$nameType = $nameResult->getType();
 			if (!$nameType->isCallable()->no()) {
 				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
 					$scope,
@@ -115,7 +117,6 @@ final class FuncCallHandler implements ExprHandler
 				);
 			}
 
-			$nameResult = $nodeScopeResolver->processExprNode($stmt, $expr->name, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$scope = $nameResult->getScope();
 			$throwPoints = $nameResult->getThrowPoints();
 			$impurePoints = $nameResult->getImpurePoints();
@@ -475,6 +476,105 @@ final class FuncCallHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($nameResult, $nodeScopeResolver, $stmt): Type {
+				if ($expr->name instanceof Expr) {
+					$calledOnType = $nameResult->getTypeForScope($scope);
+					if ($calledOnType->isCallable()->no()) {
+						return new ErrorType();
+					}
+
+					$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+						$scope,
+						$expr->getArgs(),
+						$calledOnType->getCallableParametersAcceptors($scope),
+						null,
+					);
+
+					$functionName = null;
+					if ($expr->name instanceof String_) {
+						/** @var non-empty-string $name */
+						$name = $expr->name->value;
+						$functionName = new Name($name);
+					} elseif (
+						$expr->name instanceof FuncCall
+						&& $expr->name->name instanceof Name
+						&& $expr->name->isFirstClassCallable()
+					) {
+						$functionName = $expr->name->name;
+					}
+
+					$normalizedNode = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $expr);
+					if ($normalizedNode !== null && $functionName !== null && $this->reflectionProvider->hasFunction($functionName, $scope)) {
+						$functionReflection = $this->reflectionProvider->getFunction($functionName, $scope);
+						$resolvedType = $this->getDynamicFunctionReturnType($scope, $normalizedNode, $functionReflection);
+						if ($resolvedType !== null) {
+							return $resolvedType;
+						}
+					}
+
+					return $parametersAcceptor->getReturnType();
+				}
+
+				if (!$this->reflectionProvider->hasFunction($expr->name, $scope)) {
+					return new ErrorType();
+				}
+
+				$functionReflection = $this->reflectionProvider->getFunction($expr->name, $scope);
+				if ($scope->nativeTypesPromoted) {
+					return ParametersAcceptorSelector::combineAcceptors($functionReflection->getVariants())->getNativeReturnType();
+				}
+
+				if ($functionReflection->getName() === 'call_user_func') {
+					$result = ArgumentsNormalizer::reorderCallUserFuncArguments($expr, $scope);
+					if ($result !== null) {
+						[, $innerFuncCall] = $result;
+
+						return $nodeScopeResolver->processExprNode($stmt, $innerFuncCall, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+					}
+				}
+
+				$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+					$scope,
+					$expr->getArgs(),
+					$functionReflection->getVariants(),
+					$functionReflection->getNamedArgumentsVariants(),
+				);
+				$normalizedNode = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $expr);
+				if ($normalizedNode !== null) {
+					if ($functionReflection->getName() === 'clone' && count($normalizedNode->getArgs()) > 0) {
+						$cloneResult = $nodeScopeResolver->processExprNode($stmt, new Expr\Clone_($normalizedNode->getArgs()[0]->value), $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+						$cloneType = $cloneResult->getTypeForScope($scope);
+						if (count($normalizedNode->getArgs()) === 2) {
+							$propertiesResult = $nodeScopeResolver->processExprNode($stmt, $normalizedNode->getArgs()[1]->value, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+							$propertiesType = $propertiesResult->getTypeForScope($scope);
+							if ($propertiesType->isConstantArray()->yes()) {
+								$constantArrays = $propertiesType->getConstantArrays();
+								if (count($constantArrays) === 1) {
+									$accessories = [];
+									foreach ($constantArrays[0]->getKeyTypes() as $keyType) {
+										$constantKeyTypes = $keyType->getConstantScalarValues();
+										if (count($constantKeyTypes) !== 1) {
+											return $cloneType;
+										}
+										$accessories[] = new HasPropertyType((string) $constantKeyTypes[0]);
+									}
+									if (count($accessories) > 0 && count($accessories) <= 16) {
+										return TypeCombinator::intersect($cloneType, ...$accessories);
+									}
+								}
+							}
+						}
+
+						return $cloneType;
+					}
+					$resolvedType = $this->getDynamicFunctionReturnType($scope, $normalizedNode, $functionReflection);
+					if ($resolvedType !== null) {
+						return $resolvedType;
+					}
+				}
+
+				return VoidToNullTypeTransformer::transform($parametersAcceptor->getReturnType(), $expr);
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -822,6 +822,10 @@ final class FuncCallHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		if ($expr->name instanceof Name && in_array((string) $expr->name, $this->earlyTerminatingFunctionCalls, true)) {
+			return new NeverType(true);
+		}
+
 		if ($expr->name instanceof Expr) {
 			$calledOnType = $scope->getType($expr->name);
 			if ($calledOnType->isCallable()->no()) {

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -473,6 +473,7 @@ final class FuncCallHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/IncludeHandler.php
+++ b/src/Analyser/ExprHandler/IncludeHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -26,6 +27,12 @@ use function in_array;
 final class IncludeHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof Include_;
@@ -42,7 +49,7 @@ final class IncludeHandler implements ExprHandler
 		$identifier = in_array($expr->type, [Include_::TYPE_INCLUDE, Include_::TYPE_INCLUDE_ONCE], true) ? 'include' : 'require';
 		$scope = $exprResult->getScope()->afterExtractCall();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/IncludeHandler.php
+++ b/src/Analyser/ExprHandler/IncludeHandler.php
@@ -52,6 +52,7 @@ final class IncludeHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createImplicit($scope, $expr)]),

--- a/src/Analyser/ExprHandler/IncludeHandler.php
+++ b/src/Analyser/ExprHandler/IncludeHandler.php
@@ -50,6 +50,7 @@ final class IncludeHandler implements ExprHandler
 		$scope = $exprResult->getScope()->afterExtractCall();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/InstanceofHandler.php
+++ b/src/Analyser/ExprHandler/InstanceofHandler.php
@@ -63,6 +63,7 @@ final class InstanceofHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/InstanceofHandler.php
+++ b/src/Analyser/ExprHandler/InstanceofHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -33,6 +34,12 @@ use function strtolower;
 final class InstanceofHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof Instanceof_;
@@ -55,7 +62,7 @@ final class InstanceofHandler implements ExprHandler
 			$isAlwaysTerminating = $isAlwaysTerminating || $classResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/InstanceofHandler.php
+++ b/src/Analyser/ExprHandler/InstanceofHandler.php
@@ -53,7 +53,19 @@ final class InstanceofHandler implements ExprHandler
 		$impurePoints = $exprResult->getImpurePoints();
 		$isAlwaysTerminating = $exprResult->isAlwaysTerminating();
 		$scope = $exprResult->getScope();
-		if (!$expr->class instanceof Name) {
+		$classTypeFromName = null;
+		$classResult = null;
+		if ($expr->class instanceof Name) {
+			$unresolvedClassName = $expr->class->toString();
+			if (
+				strtolower($unresolvedClassName) === 'static'
+				&& $scope->isInClass()
+			) {
+				$classTypeFromName = new StaticType($scope->getClassReflection());
+			} else {
+				$classTypeFromName = new ObjectType($scope->resolveName($expr->class));
+			}
+		} else {
 			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$scope = $classResult->getScope();
 			$hasYield = $hasYield || $classResult->hasYield();
@@ -65,6 +77,41 @@ final class InstanceofHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($exprResult, $classResult, $classTypeFromName): Type {
+				$expressionType = $exprResult->getTypeForScope($scope);
+				if (
+					$scope->isInTrait()
+					&& TypeUtils::findThisType($expressionType) !== null
+				) {
+					return new BooleanType();
+				}
+				if ($expressionType instanceof NeverType) {
+					return new ConstantBooleanType(false);
+				}
+
+				$uncertainty = false;
+				if ($classTypeFromName !== null) {
+					$classType = $classTypeFromName;
+				} else {
+					$classType = $classResult->getTypeForScope($scope);
+					$traverser = new InstanceOfClassTypeTraverser();
+					$classType = TypeTraverser::map($classType, $traverser);
+					$uncertainty = $traverser->getUncertainty();
+				}
+
+				if ($classType->isSuperTypeOf(new MixedType())->yes()) {
+					return new BooleanType();
+				}
+
+				$isSuperType = $classType->isSuperTypeOf($expressionType);
+				if ($isSuperType->no()) {
+					return new ConstantBooleanType(false);
+				} elseif ($isSuperType->yes() && !$uncertainty) {
+					return new ConstantBooleanType(true);
+				}
+
+				return new BooleanType();
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/InterpolatedStringHandler.php
+++ b/src/Analyser/ExprHandler/InterpolatedStringHandler.php
@@ -44,11 +44,14 @@ final class InterpolatedStringHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
-		foreach ($expr->parts as $part) {
-			if (!$part instanceof Expr) {
+		$partResults = [];
+		foreach ($expr->parts as $i => $part) {
+			if (!($part instanceof Expr)) {
 				continue;
 			}
+
 			$partResult = $nodeScopeResolver->processExprNode($stmt, $part, $scope, $storage, $nodeCallback, $context->enterDeep());
+			$partResults[$i] = $partResult;
 			$hasYield = $hasYield || $partResult->hasYield();
 			$throwPoints = array_merge($throwPoints, $partResult->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $partResult->getImpurePoints());
@@ -59,6 +62,24 @@ final class InterpolatedStringHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $uninteresting, MutatingScope $scope) use ($expr, $partResults): Type {
+				$resultType = null;
+				foreach ($expr->parts as $i => $part) {
+					if ($part instanceof InterpolatedStringPart) {
+						$partType = new ConstantStringType($part->value);
+					} else {
+						$partType = $partResults[$i]->getTypeForScope($scope)->toString();
+					}
+					if ($resultType === null) {
+						$resultType = $partType;
+						continue;
+					}
+
+					$resultType = $this->initializerExprTypeResolver->resolveConcatType($resultType, $partType);
+				}
+
+				return $resultType ?? new ConstantStringType('');
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/InterpolatedStringHandler.php
+++ b/src/Analyser/ExprHandler/InterpolatedStringHandler.php
@@ -57,6 +57,7 @@ final class InterpolatedStringHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/InterpolatedStringHandler.php
+++ b/src/Analyser/ExprHandler/InterpolatedStringHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -26,6 +27,7 @@ final class InterpolatedStringHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -54,7 +56,7 @@ final class InterpolatedStringHandler implements ExprHandler
 			$scope = $partResult->getScope();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/IssetHandler.php
+++ b/src/Analyser/ExprHandler/IssetHandler.php
@@ -118,6 +118,7 @@ final class IssetHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/IssetHandler.php
+++ b/src/Analyser/ExprHandler/IssetHandler.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
@@ -32,6 +33,7 @@ final class IssetHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NonNullabilityHelper $nonNullabilityHelper,
 	)
 	{
@@ -115,7 +117,7 @@ final class IssetHandler implements ExprHandler
 			$scope = $this->nonNullabilityHelper->revertNonNullability($scope, $nonNullabilityResult->getSpecifiedExpressions());
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/IssetHandler.php
+++ b/src/Analyser/ExprHandler/IssetHandler.php
@@ -96,7 +96,7 @@ final class IssetHandler implements ExprHandler
 				continue;
 			}
 
-			$varType = $scope->getType($var->var);
+			$varType = $nodeScopeResolver->processExprNode($stmt, $var->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), $context->enterDeep())->getType();
 			if ($varType->isArray()->yes() || (new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 				continue;
 			}
@@ -120,6 +120,36 @@ final class IssetHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $expr, MutatingScope $scope) use ($nodeScopeResolver, $stmt): Type {
+				$typeResolver = static fn (Expr $e): Type => $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+
+				$issetResult = true;
+				foreach ($expr->vars as $var) {
+					$result = $scope->issetCheckWithResolver($var, static function (Type $type): ?bool {
+						$isNull = $type->isNull();
+						if ($isNull->maybe()) {
+							return null;
+						}
+
+						return !$isNull->yes();
+					}, $typeResolver);
+					if ($result !== null) {
+						if (!$result) {
+							return new ConstantBooleanType($result);
+						}
+
+						continue;
+					}
+
+					$issetResult = $result;
+				}
+
+				if ($issetResult === null) {
+					return new BooleanType();
+				}
+
+				return new ConstantBooleanType($issetResult);
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/MatchHandler.php
+++ b/src/Analyser/ExprHandler/MatchHandler.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\InternalThrowPoint;
@@ -51,6 +52,7 @@ final class MatchHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 	)
@@ -472,7 +474,7 @@ final class MatchHandler implements ExprHandler
 			$expr->cond = $expr->cond->getExpr();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/MatchHandler.php
+++ b/src/Analyser/ExprHandler/MatchHandler.php
@@ -475,6 +475,7 @@ final class MatchHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/MatchHandler.php
+++ b/src/Analyser/ExprHandler/MatchHandler.php
@@ -201,6 +201,8 @@ final class MatchHandler implements ExprHandler
 		$arms = $expr->arms;
 		$armCondsToSkip = [];
 		$armBodyScopes = [];
+		/** @var ExpressionResult[] */
+		$armBodyResults = [];
 		if ($condType->isEnum()->yes()) {
 			// enum match analysis would work even without this if branch
 			// but would be much slower
@@ -336,6 +338,7 @@ final class MatchHandler implements ExprHandler
 						$nodeCallback,
 						ExpressionContext::createTopLevel(),
 					);
+					$armBodyResults[] = $armResult;
 					$armScope = $armResult->getScope();
 					$armBodyScopes[] = $armScope;
 					$hasYield = $hasYield || $armResult->hasYield();
@@ -370,6 +373,7 @@ final class MatchHandler implements ExprHandler
 				$matchArmBody = new MatchExpressionArmBody($matchScope, $arm->body);
 				$armNodes[$i] = new MatchExpressionArm($matchArmBody, [], $arm->getStartLine());
 				$armResult = $nodeScopeResolver->processExprNode($stmt, $arm->body, $matchScope, $storage, $nodeCallback, ExpressionContext::createTopLevel());
+				$armBodyResults[] = $armResult;
 				$matchScope = $armResult->getScope();
 				$hasYield = $hasYield || $armResult->hasYield();
 				$throwPoints = array_merge($throwPoints, $armResult->getThrowPoints());
@@ -424,6 +428,7 @@ final class MatchHandler implements ExprHandler
 				$nodeCallback,
 				ExpressionContext::createTopLevel(),
 			);
+			$armBodyResults[] = $armResult;
 			$armScope = $armResult->getScope();
 			$armBodyScopes[] = $armScope;
 			$hasYield = $hasYield || $armResult->hasYield();
@@ -477,6 +482,14 @@ final class MatchHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($armBodyResults): Type {
+				$types = [];
+				foreach ($armBodyResults as $armBodyResult) {
+					$types[] = $armBodyResult->getTypeForScope($scope);
+				}
+
+				return TypeCombinator::union(...$types);
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/MatchHandler.php
+++ b/src/Analyser/ExprHandler/MatchHandler.php
@@ -186,9 +186,9 @@ final class MatchHandler implements ExprHandler
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
 		$deepContext = $context->enterDeep();
-		$condType = $scope->getType($expr->cond);
-		$condNativeType = $scope->getNativeType($expr->cond);
 		$condResult = $nodeScopeResolver->processExprNode($stmt, $expr->cond, $scope, $storage, $nodeCallback, $deepContext);
+		$condType = $condResult->getType();
+		$condNativeType = $condResult->getNativeType();
 		$scope = $condResult->getScope();
 		$hasYield = $condResult->hasYield();
 		$throwPoints = $condResult->getThrowPoints();

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -100,7 +100,7 @@ final class MethodCallHandler implements ExprHandler
 		}
 		$parametersAcceptor = null;
 		$methodReflection = null;
-		$calledOnType = $scope->getType($expr->var);
+		$calledOnType = $varResult->getType();
 		if ($expr->name instanceof Identifier) {
 			$methodName = $expr->name->name;
 			$methodReflection = $scope->getMethodReflection($calledOnType, $methodName);

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -196,6 +196,35 @@ final class MethodCallHandler implements ExprHandler
 		$result = $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($varResult): Type {
+				if ($expr->name instanceof Identifier) {
+					$varType = $varResult->getTypeForScope($scope);
+
+					if ($scope->nativeTypesPromoted) {
+						$methodReflection = $scope->getMethodReflection(
+							$varType,
+							$expr->name->name,
+						);
+						if ($methodReflection === null) {
+							return new ErrorType();
+						}
+
+						return ParametersAcceptorSelector::combineAcceptors($methodReflection->getVariants())->getNativeReturnType();
+					}
+
+					$returnType = $this->methodCallReturnTypeHelper->methodCallReturnType(
+						$scope,
+						$varType,
+						$expr->name->name,
+						$expr,
+					);
+
+					return $returnType ?? new ErrorType();
+				}
+
+				// TODO: handle dynamic method names
+				return new MixedType();
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -194,6 +194,7 @@ final class MethodCallHandler implements ExprHandler
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
 
 		$result = $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
@@ -222,6 +223,7 @@ final class MethodCallHandler implements ExprHandler
 			if ($calledMethodScope !== null) {
 				$scope = $scope->mergeInitializedProperties($calledMethodScope);
 				return $this->expressionResultFactory->create(
+					$expr,
 					$scope,
 					hasYield: $result->hasYield(),
 					isAlwaysTerminating: $result->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -287,6 +287,7 @@ final class MethodCallHandler implements ExprHandler
 				return $this->expressionResultFactory->create(
 					$expr,
 					$scope,
+					typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $result->getTypeForScope($scope),
 					hasYield: $result->hasYield(),
 					isAlwaysTerminating: $result->isAlwaysTerminating(),
 					throwPoints: $result->getThrowPoints(),

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\MethodCallReturnTypeHelper;
@@ -57,6 +58,7 @@ final class MethodCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private DynamicThrowTypeExtensionProvider $dynamicThrowTypeExtensionProvider,
 		private MethodCallReturnTypeHelper $methodCallReturnTypeHelper,
 		#[AutowiredParameter(ref: '%exceptions.implicitThrows%')]
@@ -191,7 +193,7 @@ final class MethodCallHandler implements ExprHandler
 		$impurePoints = array_merge($impurePoints, $argsResult->getImpurePoints());
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
 
-		$result = new ExpressionResult(
+		$result = $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
@@ -219,7 +221,7 @@ final class MethodCallHandler implements ExprHandler
 			$calledMethodScope = $nodeScopeResolver->processCalledMethod($methodReflection);
 			if ($calledMethodScope !== null) {
 				$scope = $scope->mergeInitializedProperties($calledMethodScope);
-				return new ExpressionResult(
+				return $this->expressionResultFactory->create(
 					$scope,
 					hasYield: $result->hasYield(),
 					isAlwaysTerminating: $result->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -349,6 +349,26 @@ final class MethodCallHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		if ($expr->name instanceof Identifier && array_key_exists($expr->name->toLowerString(), $this->earlyTerminatingMethodNames)) {
+			$calledOnType = $scope->getType($expr->var);
+			foreach ($calledOnType->getObjectClassNames() as $referencedClass) {
+				if (!$this->reflectionProvider->hasClass($referencedClass)) {
+					continue;
+				}
+
+				$classReflection = $this->reflectionProvider->getClass($referencedClass);
+				foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
+					if (!isset($this->earlyTerminatingMethodCalls[$className])) {
+						continue;
+					}
+
+					if (in_array($expr->name->name, $this->earlyTerminatingMethodCalls[$className], true)) {
+						return new NeverType(true);
+					}
+				}
+			}
+		}
+
 		if ($expr->name instanceof Identifier) {
 			if ($scope->nativeTypesPromoted) {
 				$methodReflection = $scope->getMethodReflection(

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -26,6 +26,7 @@ use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\Node\Expr\PossiblyImpureCallExpr;
 use PHPStan\Node\InvalidateExprNode;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\ExtendedParametersAcceptor;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
@@ -65,9 +66,22 @@ final class MethodCallHandler implements ExprHandler
 		private bool $implicitThrows,
 		#[AutowiredParameter]
 		private bool $rememberPossiblyImpureFunctionValues,
+		#[AutowiredParameter]
+		private array $earlyTerminatingMethodCalls,
+		private ReflectionProvider $reflectionProvider,
 	)
 	{
+		$earlyTerminatingMethodNames = [];
+		foreach ($this->earlyTerminatingMethodCalls as $methodNames) {
+			foreach ($methodNames as $methodName) {
+				$earlyTerminatingMethodNames[strtolower($methodName)] = true;
+			}
+		}
+		$this->earlyTerminatingMethodNames = $earlyTerminatingMethodNames;
 	}
+
+	/** @var array<string, true> */
+	private array $earlyTerminatingMethodNames;
 
 	public function supports(Expr $expr): bool
 	{
@@ -143,6 +157,25 @@ final class MethodCallHandler implements ExprHandler
 			$normalizedExpr = ArgumentsNormalizer::reorderMethodArguments($parametersAcceptor, $expr) ?? $expr;
 			$returnType = $parametersAcceptor->getReturnType();
 			$isAlwaysTerminating = $returnType instanceof NeverType && $returnType->isExplicit();
+		}
+		if (!$isAlwaysTerminating && $expr->name instanceof Identifier && array_key_exists($expr->name->toLowerString(), $this->earlyTerminatingMethodNames)) {
+			foreach ($calledOnType->getObjectClassNames() as $referencedClass) {
+				if (!$this->reflectionProvider->hasClass($referencedClass)) {
+					continue;
+				}
+
+				$classReflection = $this->reflectionProvider->getClass($referencedClass);
+				foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
+					if (!isset($this->earlyTerminatingMethodCalls[$className])) {
+						continue;
+					}
+
+					if (in_array($expr->name->name, $this->earlyTerminatingMethodCalls[$className], true)) {
+						$isAlwaysTerminating = true;
+						break 2;
+					}
+				}
+			}
 		}
 
 		$argsResult = $nodeScopeResolver->processArgs(

--- a/src/Analyser/ExprHandler/NewHandler.php
+++ b/src/Analyser/ExprHandler/NewHandler.php
@@ -88,6 +88,7 @@ final class NewHandler implements ExprHandler
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
 		$normalizedExpr = $expr;
+		$classResult = null;
 		if ($expr->class instanceof Name) {
 			$className = $scope->resolveName($expr->class);
 
@@ -207,6 +208,17 @@ final class NewHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($classResult): Type {
+				if ($expr->class instanceof Name) {
+					return $this->exactInstantiation($scope, $expr, $expr->class);
+				}
+				if ($expr->class instanceof Node\Stmt\Class_) {
+					$anonymousClassReflection = $this->reflectionProvider->getAnonymousClassReflection($expr->class, $scope);
+					return new ObjectType($anonymousClassReflection->getName());
+				}
+
+				return $classResult->getTypeForScope($scope)->getObjectTypeOrClassStringObjectType();
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/NewHandler.php
+++ b/src/Analyser/ExprHandler/NewHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -63,6 +64,7 @@ final class NewHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private ReflectionProvider $reflectionProvider,
 		private DynamicThrowTypeExtensionProvider $dynamicThrowTypeExtensionProvider,
 		private DynamicReturnTypeExtensionRegistryProvider $dynamicReturnTypeExtensionRegistryProvider,
@@ -202,7 +204,7 @@ final class NewHandler implements ExprHandler
 		$impurePoints = array_merge($impurePoints, $argsResult->getImpurePoints());
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/NewHandler.php
+++ b/src/Analyser/ExprHandler/NewHandler.php
@@ -205,6 +205,7 @@ final class NewHandler implements ExprHandler
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
+++ b/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
@@ -81,6 +81,7 @@ final class NullsafeMethodCallHandler implements ExprHandler
 		$scope = $this->nonNullabilityHelper->revertNonNullability($exprResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
+++ b/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
@@ -17,6 +17,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Type\NullType;
@@ -62,6 +63,8 @@ final class NullsafeMethodCallHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+
 		$nonNullabilityResult = $this->nonNullabilityHelper->ensureShallowNonNullability($scope, $scope, $expr->var);
 		$attributes = array_merge($expr->getAttributes(), ['virtualNullsafeMethodCall' => true]);
 		unset($attributes[ExprPrinter::ATTRIBUTE_CACHE_KEY]);
@@ -83,6 +86,20 @@ final class NullsafeMethodCallHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $exprResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				if ($varType->isNull()->yes()) {
+					return new NullType();
+				}
+				if (!TypeCombinator::containsNull($varType)) {
+					return $exprResult->getTypeForScope($scope);
+				}
+
+				return TypeCombinator::union(
+					$exprResult->getTypeForScope($scope),
+					new NullType(),
+				);
+			},
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: false,
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
+++ b/src/Analyser/ExprHandler/NullsafeMethodCallHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
@@ -31,6 +32,7 @@ final class NullsafeMethodCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NonNullabilityHelper $nonNullabilityHelper,
 	)
 	{
@@ -78,7 +80,7 @@ final class NullsafeMethodCallHandler implements ExprHandler
 		);
 		$scope = $this->nonNullabilityHelper->revertNonNullability($exprResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
@@ -73,6 +73,7 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 		$scope = $this->nonNullabilityHelper->revertNonNullability($exprResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
@@ -17,6 +17,7 @@ use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Node\Printer\ExprPrinter;
 use PHPStan\Type\NullType;
@@ -62,6 +63,8 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+
 		$nonNullabilityResult = $this->nonNullabilityHelper->ensureShallowNonNullability($scope, $scope, $expr->var);
 		$attributes = array_merge($expr->getAttributes(), ['virtualNullsafePropertyFetch' => true]);
 		unset($attributes[ExprPrinter::ATTRIBUTE_CACHE_KEY]);
@@ -75,6 +78,20 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $exprResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				if ($varType->isNull()->yes()) {
+					return new NullType();
+				}
+				if (!TypeCombinator::containsNull($varType)) {
+					return $exprResult->getTypeForScope($scope);
+				}
+
+				return TypeCombinator::union(
+					$exprResult->getTypeForScope($scope),
+					new NullType(),
+				);
+			},
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: false,
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/NullsafePropertyFetchHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NonNullabilityHelper;
@@ -31,6 +32,7 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NonNullabilityHelper $nonNullabilityHelper,
 	)
 	{
@@ -70,7 +72,7 @@ final class NullsafePropertyFetchHandler implements ExprHandler
 		), $nonNullabilityResult->getScope(), $storage, $nodeCallback, $context);
 		$scope = $this->nonNullabilityHelper->revertNonNullability($exprResult->getScope(), $nonNullabilityResult->getSpecifiedExpressions());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/PipeHandler.php
+++ b/src/Analyser/ExprHandler/PipeHandler.php
@@ -90,6 +90,7 @@ final class PipeHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$callResult->getScope(),
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $callResult->getTypeForScope($scope),
 			hasYield: $callResult->hasYield(),
 			isAlwaysTerminating: $callResult->isAlwaysTerminating(),
 			throwPoints: $callResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/PipeHandler.php
+++ b/src/Analyser/ExprHandler/PipeHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -27,6 +28,12 @@ use function array_merge;
 #[AutowiredService]
 final class PipeHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -80,7 +87,7 @@ final class PipeHandler implements ExprHandler
 
 		$callResult = $nodeScopeResolver->processExprNode($stmt, $callExpr, $scope, $storage, $nodeCallback, $context);
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$callResult->getScope(),
 			hasYield: $callResult->hasYield(),
 			isAlwaysTerminating: $callResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PipeHandler.php
+++ b/src/Analyser/ExprHandler/PipeHandler.php
@@ -88,6 +88,7 @@ final class PipeHandler implements ExprHandler
 		$callResult = $nodeScopeResolver->processExprNode($stmt, $callExpr, $scope, $storage, $nodeCallback, $context);
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$callResult->getScope(),
 			hasYield: $callResult->hasYield(),
 			isAlwaysTerminating: $callResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PostDecHandler.php
+++ b/src/Analyser/ExprHandler/PostDecHandler.php
@@ -50,6 +50,7 @@ final class PostDecHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $varResult->getTypeForScope($scope),
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),
 			throwPoints: $varResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/PostDecHandler.php
+++ b/src/Analyser/ExprHandler/PostDecHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\PreDec;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 #[AutowiredService]
 final class PostDecHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -40,7 +47,7 @@ final class PostDecHandler implements ExprHandler
 			$nodeCallback,
 		)->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PostDecHandler.php
+++ b/src/Analyser/ExprHandler/PostDecHandler.php
@@ -48,6 +48,7 @@ final class PostDecHandler implements ExprHandler
 		)->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PostIncHandler.php
+++ b/src/Analyser/ExprHandler/PostIncHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\PreInc;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 #[AutowiredService]
 final class PostIncHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -40,7 +47,7 @@ final class PostIncHandler implements ExprHandler
 			$nodeCallback,
 		)->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PostIncHandler.php
+++ b/src/Analyser/ExprHandler/PostIncHandler.php
@@ -48,6 +48,7 @@ final class PostIncHandler implements ExprHandler
 		)->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PostIncHandler.php
+++ b/src/Analyser/ExprHandler/PostIncHandler.php
@@ -50,6 +50,7 @@ final class PostIncHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $varResult->getTypeForScope($scope),
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),
 			throwPoints: $varResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/PreDecHandler.php
+++ b/src/Analyser/ExprHandler/PreDecHandler.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\BenevolentUnionType;
@@ -101,6 +102,8 @@ final class PreDecHandler implements ExprHandler
 	{
 		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 
+		$minusResult = $nodeScopeResolver->processExprNode($stmt, new Minus($expr->var, new Int_(1)), $varResult->getScope(), new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+
 		$scope = $nodeScopeResolver->processVirtualAssign(
 			$varResult->getScope(),
 			$storage,
@@ -113,6 +116,54 @@ final class PreDecHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $minusResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				$varScalars = $varType->getConstantScalarValues();
+
+				if (count($varScalars) > 0) {
+					$newTypes = [];
+					foreach ($varScalars as $varValue) {
+						if ($varValue === '') {
+							$varValue = -1;
+						} elseif (is_string($varValue) && !is_numeric($varValue)) {
+							try {
+								$varValue = str_decrement($varValue);
+							} catch (ValueError) {
+								return new NeverType();
+							}
+						} elseif (is_numeric($varValue)) {
+							--$varValue;
+						}
+
+						$newTypes[] = $scope->getTypeFromValue($varValue);
+					}
+					return TypeCombinator::union(...$newTypes);
+				}
+
+				if ($varType->isString()->yes()) {
+					if ($varType->isLiteralString()->yes()) {
+						return new IntersectionType([
+							new StringType(),
+							new AccessoryLiteralStringType(),
+						]);
+					}
+
+					if ($varType->isNumericString()->yes()) {
+						return new BenevolentUnionType([
+							new IntegerType(),
+							new FloatType(),
+						]);
+					}
+
+					return new BenevolentUnionType([
+						new StringType(),
+						new IntegerType(),
+						new FloatType(),
+					]);
+				}
+
+				return $minusResult->getTypeForScope($scope);
+			},
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),
 			throwPoints: $varResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/PreDecHandler.php
+++ b/src/Analyser/ExprHandler/PreDecHandler.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -35,6 +36,12 @@ use function str_decrement;
 #[AutowiredService]
 final class PreDecHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -103,7 +110,7 @@ final class PreDecHandler implements ExprHandler
 			$nodeCallback,
 		)->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PreDecHandler.php
+++ b/src/Analyser/ExprHandler/PreDecHandler.php
@@ -111,6 +111,7 @@ final class PreDecHandler implements ExprHandler
 		)->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PreIncHandler.php
+++ b/src/Analyser/ExprHandler/PreIncHandler.php
@@ -14,6 +14,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Type\Accessory\AccessoryLiteralStringType;
 use PHPStan\Type\BenevolentUnionType;
@@ -102,6 +103,8 @@ final class PreIncHandler implements ExprHandler
 	{
 		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->var, $scope, $storage, $nodeCallback, $context->enterDeep());
 
+		$plusResult = $nodeScopeResolver->processExprNode($stmt, new Plus($expr->var, new Int_(1)), $varResult->getScope(), new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+
 		$scope = $nodeScopeResolver->processVirtualAssign(
 			$varResult->getScope(),
 			$storage,
@@ -114,6 +117,54 @@ final class PreIncHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $plusResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				$varScalars = $varType->getConstantScalarValues();
+
+				if (count($varScalars) > 0) {
+					$newTypes = [];
+					foreach ($varScalars as $varValue) {
+						if ($varValue === '') {
+							$varValue = '1';
+						} elseif (is_string($varValue) && !is_numeric($varValue)) {
+							try {
+								$varValue = str_increment($varValue);
+							} catch (ValueError) {
+								return new NeverType();
+							}
+						} elseif (!is_bool($varValue)) {
+							++$varValue;
+						}
+
+						$newTypes[] = $scope->getTypeFromValue($varValue);
+					}
+					return TypeCombinator::union(...$newTypes);
+				}
+
+				if ($varType->isString()->yes()) {
+					if ($varType->isLiteralString()->yes()) {
+						return new IntersectionType([
+							new StringType(),
+							new AccessoryLiteralStringType(),
+						]);
+					}
+
+					if ($varType->isNumericString()->yes()) {
+						return new BenevolentUnionType([
+							new IntegerType(),
+							new FloatType(),
+						]);
+					}
+
+					return new BenevolentUnionType([
+						new StringType(),
+						new IntegerType(),
+						new FloatType(),
+					]);
+				}
+
+				return $plusResult->getTypeForScope($scope);
+			},
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),
 			throwPoints: $varResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/PreIncHandler.php
+++ b/src/Analyser/ExprHandler/PreIncHandler.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -36,6 +37,12 @@ use function str_increment;
 #[AutowiredService]
 final class PreIncHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -104,7 +111,7 @@ final class PreIncHandler implements ExprHandler
 			$nodeCallback,
 		)->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PreIncHandler.php
+++ b/src/Analyser/ExprHandler/PreIncHandler.php
@@ -112,6 +112,7 @@ final class PreIncHandler implements ExprHandler
 		)->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $varResult->hasYield(),
 			isAlwaysTerminating: $varResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PrintHandler.php
+++ b/src/Analyser/ExprHandler/PrintHandler.php
@@ -47,6 +47,7 @@ final class PrintHandler implements ExprHandler
 		$scope = $exprResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PrintHandler.php
+++ b/src/Analyser/ExprHandler/PrintHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Print_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -24,6 +25,12 @@ use function array_merge;
 final class PrintHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof Print_;
@@ -39,7 +46,7 @@ final class PrintHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$scope = $exprResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/PrintHandler.php
+++ b/src/Analyser/ExprHandler/PrintHandler.php
@@ -49,6 +49,7 @@ final class PrintHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new ConstantIntegerType(1),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/PropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/PropertyFetchHandler.php
@@ -82,6 +82,31 @@ final class PropertyFetchHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($varResult): Type {
+				if ($expr->name instanceof Identifier) {
+					$holderType = $varResult->getTypeForScope($scope);
+
+					if ($scope->nativeTypesPromoted) {
+						$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNodeWithTypes($expr, $scope, $holderType, null);
+						if ($propertyReflection === null) {
+							return new ErrorType();
+						}
+
+						if (!$propertyReflection->hasNativeType()) {
+							return new MixedType();
+						}
+
+						return $propertyReflection->getNativeType();
+					}
+
+					$returnType = $this->propertyFetchType($scope, $holderType, $expr->name->name, $expr);
+
+					return $returnType ?? new ErrorType();
+				}
+
+				// TODO: handle dynamic property names
+				return new MixedType();
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/PropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/PropertyFetchHandler.php
@@ -80,6 +80,7 @@ final class PropertyFetchHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/PropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/PropertyFetchHandler.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NullsafeShortCircuitingHelper;
@@ -34,6 +35,7 @@ final class PropertyFetchHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private PhpVersion $phpVersion,
 		private PropertyReflectionFinder $propertyReflectionFinder,
 	)
@@ -77,7 +79,7 @@ final class PropertyFetchHandler implements ExprHandler
 			}
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/ScalarHandler.php
+++ b/src/Analyser/ExprHandler/ScalarHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -25,6 +26,7 @@ final class ScalarHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -37,7 +39,7 @@ final class ScalarHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/ScalarHandler.php
+++ b/src/Analyser/ExprHandler/ScalarHandler.php
@@ -42,6 +42,7 @@ final class ScalarHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: fn (Expr $expr, MutatingScope $scope) => $this->initializerExprTypeResolver->getType($expr, InitializerExprContext::fromScope($scope)),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/ScalarHandler.php
+++ b/src/Analyser/ExprHandler/ScalarHandler.php
@@ -40,6 +40,7 @@ final class ScalarHandler implements ExprHandler
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -31,6 +31,7 @@ use PHPStan\Node\Expr\PossiblyImpureCallExpr;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
@@ -64,9 +65,22 @@ final class StaticCallHandler implements ExprHandler
 		private bool $implicitThrows,
 		#[AutowiredParameter]
 		private bool $rememberPossiblyImpureFunctionValues,
+		#[AutowiredParameter]
+		private array $earlyTerminatingMethodCalls,
+		private ReflectionProvider $reflectionProvider,
 	)
 	{
+		$earlyTerminatingMethodNames = [];
+		foreach ($this->earlyTerminatingMethodCalls as $methodNames) {
+			foreach ($methodNames as $methodName) {
+				$earlyTerminatingMethodNames[strtolower($methodName)] = true;
+			}
+		}
+		$this->earlyTerminatingMethodNames = $earlyTerminatingMethodNames;
 	}
+
+	/** @var array<string, true> */
+	private array $earlyTerminatingMethodNames;
 
 	public function supports(Expr $expr): bool
 	{
@@ -201,6 +215,28 @@ final class StaticCallHandler implements ExprHandler
 			$normalizedExpr = ArgumentsNormalizer::reorderStaticCallArguments($parametersAcceptor, $expr) ?? $expr;
 			$returnType = $parametersAcceptor->getReturnType();
 			$isAlwaysTerminating = $returnType instanceof NeverType && $returnType->isExplicit();
+		}
+		if (!$isAlwaysTerminating && $expr->name instanceof Identifier && array_key_exists($expr->name->toLowerString(), $this->earlyTerminatingMethodNames)) {
+			$staticCalledOnType = $expr->class instanceof Name ? $scope->resolveTypeByName($expr->class) : ($classResult !== null ? $classResult->getType() : null);
+			if ($staticCalledOnType !== null) {
+				foreach ($staticCalledOnType->getObjectClassNames() as $referencedClass) {
+					if (!$this->reflectionProvider->hasClass($referencedClass)) {
+						continue;
+					}
+
+					$classReflection = $this->reflectionProvider->getClass($referencedClass);
+					foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
+						if (!isset($this->earlyTerminatingMethodCalls[$className])) {
+							continue;
+						}
+
+						if (in_array($expr->name->name, $this->earlyTerminatingMethodCalls[$className], true)) {
+							$isAlwaysTerminating = true;
+							break 2;
+						}
+					}
+				}
+			}
 		}
 		$argsResult = $nodeScopeResolver->processArgs($stmt, $methodReflection, null, $parametersAcceptor, $normalizedExpr, $scope, $storage, $nodeCallback, $context, $closureBindScope);
 		$scope = $argsResult->getScope();

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -382,6 +382,26 @@ final class StaticCallHandler implements ExprHandler
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type
 	{
+		if ($expr->name instanceof Identifier && array_key_exists($expr->name->toLowerString(), $this->earlyTerminatingMethodNames)) {
+			$staticCalledOnType = $expr->class instanceof Name ? $scope->resolveTypeByName($expr->class) : $scope->getType($expr->class);
+			foreach ($staticCalledOnType->getObjectClassNames() as $referencedClass) {
+				if (!$this->reflectionProvider->hasClass($referencedClass)) {
+					continue;
+				}
+
+				$classReflection = $this->reflectionProvider->getClass($referencedClass);
+				foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
+					if (!isset($this->earlyTerminatingMethodCalls[$className])) {
+						continue;
+					}
+
+					if (in_array($expr->name->name, $this->earlyTerminatingMethodCalls[$className], true)) {
+						return new NeverType(true);
+					}
+				}
+			}
+		}
+
 		if ($expr->name instanceof Identifier) {
 			if ($scope->nativeTypesPromoted) {
 				if ($expr->class instanceof Name) {

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -79,6 +79,7 @@ final class StaticCallHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
+		$classResult = null;
 		if ($expr->class instanceof Expr) {
 			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$hasYield = $classResult->hasYield();
@@ -262,6 +263,45 @@ final class StaticCallHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($classResult): Type {
+				if ($expr->name instanceof Identifier) {
+					if ($expr->class instanceof Name) {
+						$staticMethodCalledOnType = $this->resolveTypeByNameWithLateStaticBinding($scope, $expr->class, $expr->name);
+					} elseif ($classResult !== null) {
+						if ($scope->nativeTypesPromoted) {
+							$staticMethodCalledOnType = $classResult->getTypeForScope($scope);
+						} else {
+							$staticMethodCalledOnType = TypeCombinator::removeNull($classResult->getTypeForScope($scope))->getObjectTypeOrClassStringObjectType();
+						}
+					} else {
+						return new ErrorType();
+					}
+
+					if ($scope->nativeTypesPromoted) {
+						$methodReflection = $scope->getMethodReflection(
+							$staticMethodCalledOnType,
+							$expr->name->name,
+						);
+						if ($methodReflection === null) {
+							return new ErrorType();
+						}
+
+						return ParametersAcceptorSelector::combineAcceptors($methodReflection->getVariants())->getNativeReturnType();
+					}
+
+					$callType = $this->methodCallReturnTypeHelper->methodCallReturnType(
+						$scope,
+						$staticMethodCalledOnType,
+						$expr->name->toString(),
+						$expr,
+					);
+
+					return $callType ?? new ErrorType();
+				}
+
+				// TODO: handle dynamic method names
+				return new MixedType();
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -260,6 +260,7 @@ final class StaticCallHandler implements ExprHandler
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ArgumentsNormalizer;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\MethodCallReturnTypeHelper;
@@ -56,6 +57,7 @@ final class StaticCallHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private DynamicThrowTypeExtensionProvider $dynamicThrowTypeExtensionProvider,
 		private MethodCallReturnTypeHelper $methodCallReturnTypeHelper,
 		#[AutowiredParameter(ref: '%exceptions.implicitThrows%')]
@@ -257,7 +259,7 @@ final class StaticCallHandler implements ExprHandler
 		$impurePoints = array_merge($impurePoints, $argsResult->getImpurePoints());
 		$isAlwaysTerminating = $isAlwaysTerminating || $argsResult->isAlwaysTerminating();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
@@ -79,6 +79,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\VarLikeIdentifier;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ExprHandler\Helper\NullsafeShortCircuitingHelper;
@@ -35,6 +36,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private PropertyReflectionFinder $propertyReflectionFinder,
 	)
 	{
@@ -76,7 +78,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 			$scope = $nameResult->getScope();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
+++ b/src/Analyser/ExprHandler/StaticPropertyFetchHandler.php
@@ -61,6 +61,7 @@ final class StaticPropertyFetchHandler implements ExprHandler
 			),
 		];
 		$isAlwaysTerminating = false;
+		$classResult = null;
 		if ($expr->class instanceof Expr) {
 			$classResult = $nodeScopeResolver->processExprNode($stmt, $expr->class, $scope, $storage, $nodeCallback, $context->enterDeep());
 			$hasYield = $classResult->hasYield();
@@ -81,6 +82,34 @@ final class StaticPropertyFetchHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($classResult): Type {
+				if ($expr->name instanceof VarLikeIdentifier) {
+					if ($expr->class instanceof Name) {
+						$holderType = $scope->resolveTypeByName($expr->class);
+					} else {
+						$holderType = TypeCombinator::removeNull($classResult->getTypeForScope($scope))->getObjectTypeOrClassStringObjectType();
+					}
+
+					if ($scope->nativeTypesPromoted) {
+						$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNodeWithTypes($expr, $scope, $holderType, null);
+						if ($propertyReflection === null) {
+							return new ErrorType();
+						}
+						if (!$propertyReflection->hasNativeType()) {
+							return new MixedType();
+						}
+
+						return $propertyReflection->getNativeType();
+					}
+
+					$fetchType = $this->propertyFetchType($scope, $holderType, $expr->name->toString(), $expr);
+
+					return $fetchType ?? new ErrorType();
+				}
+
+				// TODO: handle dynamic property names
+				return new MixedType();
+			},
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/TernaryHandler.php
+++ b/src/Analyser/ExprHandler/TernaryHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -26,6 +27,7 @@ final class TernaryHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private NodeScopeResolver $nodeScopeResolver,
 	)
 	{
@@ -117,7 +119,7 @@ final class TernaryHandler implements ExprHandler
 			}
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$finalScope,
 			hasYield: $ternaryCondResult->hasYield(),
 			isAlwaysTerminating: $ternaryCondResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/TernaryHandler.php
+++ b/src/Analyser/ExprHandler/TernaryHandler.php
@@ -80,19 +80,17 @@ final class TernaryHandler implements ExprHandler
 		$impurePoints = $ternaryCondResult->getImpurePoints();
 		$ifTrueScope = $ternaryCondResult->getTruthyScope();
 		$ifFalseScope = $ternaryCondResult->getFalseyScope();
-		$ifTrueType = null;
-
 		if ($expr->if === null) {
 			$elseResult = $nodeScopeResolver->processExprNode($stmt, $expr->else, $ifFalseScope, $storage, $nodeCallback, $context);
 			$throwPoints = array_merge($throwPoints, $elseResult->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $elseResult->getImpurePoints());
 			$ifFalseScope = $elseResult->getScope();
+			$ifResult = null;
 		} else {
 			$ifResult = $nodeScopeResolver->processExprNode($stmt, $expr->if, $ifTrueScope, $storage, $nodeCallback, $context);
 			$throwPoints = array_merge($throwPoints, $ifResult->getThrowPoints());
 			$impurePoints = array_merge($impurePoints, $ifResult->getImpurePoints());
 			$ifTrueScope = $ifResult->getScope();
-			$ifTrueType = $ifTrueScope->getType($expr->if);
 
 			$elseResult = $nodeScopeResolver->processExprNode($stmt, $expr->else, $ifFalseScope, $storage, $nodeCallback, $context);
 			$throwPoints = array_merge($throwPoints, $elseResult->getThrowPoints());
@@ -100,28 +98,55 @@ final class TernaryHandler implements ExprHandler
 			$ifFalseScope = $elseResult->getScope();
 		}
 
-		$condType = $scope->getType($expr->cond);
-		if ($condType->isTrue()->yes()) {
+		$ifTrueType = $ifResult !== null ? $ifResult->getType() : null;
+		$ifFalseType = $elseResult->getType();
+
+		if ($ternaryCondResult->getType()->toBoolean()->isTrue()->yes()) {
 			$finalScope = $ifTrueScope;
-		} elseif ($condType->isFalse()->yes()) {
+		} elseif ($ternaryCondResult->getType()->toBoolean()->isFalse()->yes()) {
 			$finalScope = $ifFalseScope;
 		} else {
 			if ($ifTrueType instanceof NeverType && $ifTrueType->isExplicit()) {
 				$finalScope = $ifFalseScope;
+			} elseif ($ifFalseType instanceof NeverType && $ifFalseType->isExplicit()) {
+				$finalScope = $ifTrueScope;
 			} else {
-				$ifFalseType = $ifFalseScope->getType($expr->else);
-
-				if ($ifFalseType instanceof NeverType && $ifFalseType->isExplicit()) {
-					$finalScope = $ifTrueScope;
-				} else {
-					$finalScope = $ifTrueScope->mergeWith($ifFalseScope);
-				}
+				$finalScope = $ifTrueScope->mergeWith($ifFalseScope);
 			}
 		}
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$finalScope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($expr, $ternaryCondResult, $ifResult, $elseResult): Type {
+				$booleanCondType = $ternaryCondResult->getTypeForScope($scope)->toBoolean();
+
+				if ($expr->if === null) {
+					if ($booleanCondType->isTrue()->yes()) {
+						return $ternaryCondResult->getTypeForScope($scope);
+					}
+					if ($booleanCondType->isFalse()->yes()) {
+						return $elseResult->getTypeForScope($scope);
+					}
+
+					return TypeCombinator::union(
+						TypeCombinator::removeFalsey($ternaryCondResult->getTypeForScope($scope)),
+						$elseResult->getTypeForScope($scope),
+					);
+				}
+
+				if ($booleanCondType->isTrue()->yes()) {
+					return $ifResult->getTypeForScope($scope);
+				}
+				if ($booleanCondType->isFalse()->yes()) {
+					return $elseResult->getTypeForScope($scope);
+				}
+
+				return TypeCombinator::union(
+					$ifResult->getTypeForScope($scope),
+					$elseResult->getTypeForScope($scope),
+				);
+			},
 			hasYield: $ternaryCondResult->hasYield(),
 			isAlwaysTerminating: $ternaryCondResult->isAlwaysTerminating(),
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/TernaryHandler.php
+++ b/src/Analyser/ExprHandler/TernaryHandler.php
@@ -120,6 +120,7 @@ final class TernaryHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$finalScope,
 			hasYield: $ternaryCondResult->hasYield(),
 			isAlwaysTerminating: $ternaryCondResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ThrowHandler.php
+++ b/src/Analyser/ExprHandler/ThrowHandler.php
@@ -46,7 +46,7 @@ final class ThrowHandler implements ExprHandler
 			typeCallback: static fn () => new NonAcceptingNeverType(),
 			hasYield: false,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
-			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createExplicit($scope, $scope->getType($expr->expr), $expr, false)]),
+			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createExplicit($scope, $exprResult->getType(), $expr, false)]),
 			impurePoints: $exprResult->getImpurePoints(),
 		);
 	}

--- a/src/Analyser/ExprHandler/ThrowHandler.php
+++ b/src/Analyser/ExprHandler/ThrowHandler.php
@@ -41,6 +41,7 @@ final class ThrowHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ThrowHandler.php
+++ b/src/Analyser/ExprHandler/ThrowHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\Throw_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\InternalThrowPoint;
@@ -24,6 +25,12 @@ use function array_merge;
 final class ThrowHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof Throw_;
@@ -33,7 +40,7 @@ final class ThrowHandler implements ExprHandler
 	{
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/ThrowHandler.php
+++ b/src/Analyser/ExprHandler/ThrowHandler.php
@@ -43,6 +43,7 @@ final class ThrowHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new NonAcceptingNeverType(),
 			hasYield: false,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createExplicit($scope, $scope->getType($expr->expr), $expr, false)]),

--- a/src/Analyser/ExprHandler/UnaryMinusHandler.php
+++ b/src/Analyser/ExprHandler/UnaryMinusHandler.php
@@ -40,6 +40,7 @@ final class UnaryMinusHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/UnaryMinusHandler.php
+++ b/src/Analyser/ExprHandler/UnaryMinusHandler.php
@@ -12,6 +12,7 @@ use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Analyser\NoopNodeCallback;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Type\Type;
@@ -42,6 +43,13 @@ final class UnaryMinusHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$exprResult->getScope(),
+			typeCallback: fn (Expr $uninteresting, MutatingScope $scope) => $this->initializerExprTypeResolver->getUnaryMinusType($expr->expr, static function (Expr $e) use ($expr, $exprResult, $nodeScopeResolver, $stmt, $scope): Type {
+				if ($e === $expr->expr) {
+					return $exprResult->getTypeForScope($scope);
+				}
+
+				return $nodeScopeResolver->processExprNode($stmt, $e, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getTypeForScope($scope);
+			}),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/UnaryMinusHandler.php
+++ b/src/Analyser/ExprHandler/UnaryMinusHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\UnaryMinus;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -23,6 +24,7 @@ final class UnaryMinusHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private InitializerExprTypeResolver $initializerExprTypeResolver,
 	)
 	{
@@ -37,7 +39,7 @@ final class UnaryMinusHandler implements ExprHandler
 	{
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/UnaryPlusHandler.php
+++ b/src/Analyser/ExprHandler/UnaryPlusHandler.php
@@ -38,6 +38,7 @@ final class UnaryPlusHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/UnaryPlusHandler.php
+++ b/src/Analyser/ExprHandler/UnaryPlusHandler.php
@@ -40,6 +40,7 @@ final class UnaryPlusHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$exprResult->getScope(),
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $exprResult->getTypeForScope($scope)->toNumber(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: $exprResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/UnaryPlusHandler.php
+++ b/src/Analyser/ExprHandler/UnaryPlusHandler.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\UnaryPlus;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class UnaryPlusHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof UnaryPlus;
@@ -30,7 +37,7 @@ final class UnaryPlusHandler implements ExprHandler
 	{
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$exprResult->getScope(),
 			hasYield: $exprResult->hasYield(),
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/VariableHandler.php
+++ b/src/Analyser/ExprHandler/VariableHandler.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -30,6 +31,12 @@ use function is_string;
 #[AutowiredService]
 final class VariableHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -86,7 +93,7 @@ final class VariableHandler implements ExprHandler
 			$isAlwaysTerminating = $nameResult->isAlwaysTerminating();
 			$scope = $nameResult->getScope();
 		}
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			$hasYield,
 			$isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/VariableHandler.php
+++ b/src/Analyser/ExprHandler/VariableHandler.php
@@ -81,6 +81,7 @@ final class VariableHandler implements ExprHandler
 		$throwPoints = [];
 		$impurePoints = [];
 		$isAlwaysTerminating = false;
+		$nameResult = null;
 		if (is_string($expr->name)) {
 			if (in_array($expr->name, Scope::SUPERGLOBAL_VARIABLES, true)) {
 				$impurePoints[] = new ImpurePoint($scope, $expr, 'superglobal', 'access to superglobal variable', true);
@@ -96,12 +97,25 @@ final class VariableHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
-			$hasYield,
-			$isAlwaysTerminating,
-			$throwPoints,
-			$impurePoints,
-			static fn (): MutatingScope => $scope->filterByTruthyValue($expr),
-			static fn (): MutatingScope => $scope->filterByFalseyValue($expr),
+			typeCallback: static function (Expr $expr, MutatingScope $scope): Type {
+				if (is_string($expr->name)) {
+					if ($scope->hasVariableType($expr->name)->no()) {
+						return new ErrorType();
+					}
+
+					return $scope->getVariableType($expr->name);
+				}
+
+				// TODO: handle dynamic variable names with constant strings
+				// needs a different approach for filterByTruthyValue
+				return new MixedType();
+			},
+			hasYield: $hasYield,
+			isAlwaysTerminating: $isAlwaysTerminating,
+			throwPoints: $throwPoints,
+			impurePoints: $impurePoints,
+			truthyScopeCallback: static fn (): MutatingScope => $scope->filterByTruthyValue($expr),
+			falseyScopeCallback: static fn (): MutatingScope => $scope->filterByFalseyValue($expr),
 		);
 	}
 

--- a/src/Analyser/ExprHandler/VariableHandler.php
+++ b/src/Analyser/ExprHandler/VariableHandler.php
@@ -94,6 +94,7 @@ final class VariableHandler implements ExprHandler
 			$scope = $nameResult->getScope();
 		}
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			$hasYield,
 			$isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/AlwaysRememberedExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/AlwaysRememberedExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -20,6 +21,12 @@ use PHPStan\Type\Type;
 #[AutowiredService]
 final class AlwaysRememberedExprHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -40,7 +47,7 @@ final class AlwaysRememberedExprHandler implements ExprHandler
 		$innerResult = $nodeScopeResolver->processExprNode($stmt, $innerExpr, $scope, $storage, $nodeCallback, $context);
 		$scope = $innerResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $innerResult->hasYield(),
 			isAlwaysTerminating: $innerResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/Virtual/AlwaysRememberedExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/AlwaysRememberedExprHandler.php
@@ -50,6 +50,7 @@ final class AlwaysRememberedExprHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $scope->nativeTypesPromoted ? $expr->getNativeExprType() : $expr->getExprType(),
 			hasYield: $innerResult->hasYield(),
 			isAlwaysTerminating: $innerResult->isAlwaysTerminating(),
 			throwPoints: $innerResult->getThrowPoints(),

--- a/src/Analyser/ExprHandler/Virtual/AlwaysRememberedExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/AlwaysRememberedExprHandler.php
@@ -48,6 +48,7 @@ final class AlwaysRememberedExprHandler implements ExprHandler
 		$scope = $innerResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $innerResult->hasYield(),
 			isAlwaysTerminating: $innerResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/Virtual/ExistingArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/ExistingArrayDimFetchHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class ExistingArrayDimFetchHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof ExistingArrayDimFetch;
@@ -31,7 +38,7 @@ final class ExistingArrayDimFetchHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/ExistingArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/ExistingArrayDimFetchHandler.php
@@ -39,6 +39,7 @@ final class ExistingArrayDimFetchHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/ExistingArrayDimFetchHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/ExistingArrayDimFetchHandler.php
@@ -35,12 +35,13 @@ final class ExistingArrayDimFetchHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->getVar(), $scope, $storage, $nodeCallback, $context->enterDeep());
+		$dimResult = $nodeScopeResolver->processExprNode($stmt, $expr->getDim(), $varResult->getScope(), $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $varResult->getTypeForScope($scope)->getOffsetValueType($dimResult->getTypeForScope($scope)),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/FunctionCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/FunctionCallableNodeHandler.php
@@ -50,6 +50,7 @@ final class FunctionCallableNodeHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/FunctionCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/FunctionCallableNodeHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 #[AutowiredService]
 final class FunctionCallableNodeHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -42,7 +49,7 @@ final class FunctionCallableNodeHandler implements ExprHandler
 			$isAlwaysTerminating = $nameResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/FunctionCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/FunctionCallableNodeHandler.php
@@ -52,6 +52,7 @@ final class FunctionCallableNodeHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/Virtual/GetIterableKeyTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetIterableKeyTypeExprHandler.php
@@ -39,6 +39,7 @@ final class GetIterableKeyTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/GetIterableKeyTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetIterableKeyTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class GetIterableKeyTypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof GetIterableKeyTypeExpr;
@@ -31,7 +38,7 @@ final class GetIterableKeyTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/GetIterableKeyTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetIterableKeyTypeExprHandler.php
@@ -35,12 +35,12 @@ final class GetIterableKeyTypeExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$innerResult = $nodeScopeResolver->processExprNode($stmt, $expr->getExpr(), $scope, $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $scope->getIterableKeyType($innerResult->getTypeForScope($scope)),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/GetIterableValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetIterableValueTypeExprHandler.php
@@ -39,6 +39,7 @@ final class GetIterableValueTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/GetIterableValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetIterableValueTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class GetIterableValueTypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof GetIterableValueTypeExpr;
@@ -31,7 +38,7 @@ final class GetIterableValueTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/GetIterableValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetIterableValueTypeExprHandler.php
@@ -35,12 +35,12 @@ final class GetIterableValueTypeExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$innerResult = $nodeScopeResolver->processExprNode($stmt, $expr->getExpr(), $scope, $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $scope->getIterableValueType($innerResult->getTypeForScope($scope)),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/GetOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetOffsetValueTypeExprHandler.php
@@ -39,6 +39,7 @@ final class GetOffsetValueTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/GetOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetOffsetValueTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class GetOffsetValueTypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof GetOffsetValueTypeExpr;
@@ -31,7 +38,7 @@ final class GetOffsetValueTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/GetOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/GetOffsetValueTypeExprHandler.php
@@ -35,12 +35,13 @@ final class GetOffsetValueTypeExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->getVar(), $scope, $storage, $nodeCallback, $context->enterDeep());
+		$dimResult = $nodeScopeResolver->processExprNode($stmt, $expr->getDim(), $varResult->getScope(), $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $varResult->getTypeForScope($scope)->getOffsetValueType($dimResult->getTypeForScope($scope)),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/InstantiationCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/InstantiationCallableNodeHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 #[AutowiredService]
 final class InstantiationCallableNodeHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -42,7 +49,7 @@ final class InstantiationCallableNodeHandler implements ExprHandler
 			$isAlwaysTerminating = $classResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/InstantiationCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/InstantiationCallableNodeHandler.php
@@ -50,6 +50,7 @@ final class InstantiationCallableNodeHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/InstantiationCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/InstantiationCallableNodeHandler.php
@@ -52,6 +52,7 @@ final class InstantiationCallableNodeHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/Virtual/MethodCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/MethodCallableNodeHandler.php
@@ -53,6 +53,7 @@ final class MethodCallableNodeHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/MethodCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/MethodCallableNodeHandler.php
@@ -55,6 +55,7 @@ final class MethodCallableNodeHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/Virtual/MethodCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/MethodCallableNodeHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -22,6 +23,12 @@ use function array_merge;
 #[AutowiredService]
 final class MethodCallableNodeHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -45,7 +52,7 @@ final class MethodCallableNodeHandler implements ExprHandler
 			$isAlwaysTerminating = $nameResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/NativeTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/NativeTypeExprHandler.php
@@ -39,6 +39,7 @@ final class NativeTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/NativeTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/NativeTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class NativeTypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof NativeTypeExpr;
@@ -31,7 +38,7 @@ final class NativeTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/NativeTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/NativeTypeExprHandler.php
@@ -41,6 +41,7 @@ final class NativeTypeExprHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $scope->nativeTypesPromoted ? $expr->getNativeType() : $expr->getPhpDocType(),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/OriginalPropertyTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/OriginalPropertyTypeExprHandler.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser\ExprHandler\Virtual;
 
 use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
@@ -38,12 +39,34 @@ final class OriginalPropertyTypeExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$propertyFetch = $expr->getPropertyFetch();
+		if ($propertyFetch instanceof Expr\PropertyFetch) {
+			$holderResult = $nodeScopeResolver->processExprNode($stmt, $propertyFetch->var, $scope, $storage, $nodeCallback, $context->enterDeep());
+		} else {
+			$holderResult = $propertyFetch->class instanceof Expr
+				? $nodeScopeResolver->processExprNode($stmt, $propertyFetch->class, $scope, $storage, $nodeCallback, $context->enterDeep())
+				: null;
+		}
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: function (Expr $expr, MutatingScope $scope) use ($propertyFetch, $holderResult): Type {
+				if ($holderResult !== null) {
+					$holderType = $holderResult->getTypeForScope($scope);
+				} elseif ($propertyFetch instanceof Expr\StaticPropertyFetch && $propertyFetch->class instanceof Name) {
+					$holderType = $scope->resolveTypeByName($propertyFetch->class);
+				} else {
+					return new ErrorType();
+				}
+
+				$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNodeWithTypes($propertyFetch, $scope, $holderType, null);
+				if ($propertyReflection === null) {
+					return new ErrorType();
+				}
+
+				return $propertyReflection->getReadableType();
+			},
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/OriginalPropertyTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/OriginalPropertyTypeExprHandler.php
@@ -42,6 +42,7 @@ final class OriginalPropertyTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/OriginalPropertyTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/OriginalPropertyTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -24,6 +25,7 @@ final class OriginalPropertyTypeExprHandler implements ExprHandler
 {
 
 	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
 		private PropertyReflectionFinder $propertyReflectionFinder,
 	)
 	{
@@ -39,7 +41,7 @@ final class OriginalPropertyTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/SetExistingOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/SetExistingOffsetValueTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -23,6 +24,12 @@ use PHPStan\Type\UnionType;
 final class SetExistingOffsetValueTypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof SetExistingOffsetValueTypeExpr;
@@ -33,7 +40,7 @@ final class SetExistingOffsetValueTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/SetExistingOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/SetExistingOffsetValueTypeExprHandler.php
@@ -37,12 +37,31 @@ final class SetExistingOffsetValueTypeExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->getVar(), $scope, $storage, $nodeCallback, $context->enterDeep());
+		$dimResult = $nodeScopeResolver->processExprNode($stmt, $expr->getDim(), $varResult->getScope(), $storage, $nodeCallback, $context->enterDeep());
+		$valueResult = $nodeScopeResolver->processExprNode($stmt, $expr->getValue(), $dimResult->getScope(), $storage, $nodeCallback, $context->enterDeep());
+
+		$propertyFetchResult = $expr->getVar() instanceof OriginalPropertyTypeExpr
+			? $nodeScopeResolver->processExprNode($stmt, $expr->getVar()->getPropertyFetch(), $scope, $storage, $nodeCallback, $context->enterDeep())
+			: null;
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $dimResult, $valueResult, $propertyFetchResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				if ($propertyFetchResult !== null) {
+					$currentPropertyType = $propertyFetchResult->getTypeForScope($scope);
+					if ($varType instanceof UnionType) {
+						$varType = $varType->filterTypes(static fn (Type $innerType) => !$innerType->isSuperTypeOf($currentPropertyType)->no());
+					}
+				}
+
+				return $varType->setExistingOffsetValueType(
+					$dimResult->getTypeForScope($scope),
+					$valueResult->getTypeForScope($scope),
+				);
+			},
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/SetExistingOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/SetExistingOffsetValueTypeExprHandler.php
@@ -41,6 +41,7 @@ final class SetExistingOffsetValueTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/SetOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/SetOffsetValueTypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -23,6 +24,12 @@ use PHPStan\Type\UnionType;
 final class SetOffsetValueTypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof SetOffsetValueTypeExpr;
@@ -33,7 +40,7 @@ final class SetOffsetValueTypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/SetOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/SetOffsetValueTypeExprHandler.php
@@ -37,12 +37,31 @@ final class SetOffsetValueTypeExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->getVar(), $scope, $storage, $nodeCallback, $context->enterDeep());
+		$dimResult = $expr->getDim() !== null ? $nodeScopeResolver->processExprNode($stmt, $expr->getDim(), $varResult->getScope(), $storage, $nodeCallback, $context->enterDeep()) : null;
+		$valueResult = $nodeScopeResolver->processExprNode($stmt, $expr->getValue(), ($dimResult ?? $varResult)->getScope(), $storage, $nodeCallback, $context->enterDeep());
+
+		$propertyFetchResult = $expr->getVar() instanceof OriginalPropertyTypeExpr
+			? $nodeScopeResolver->processExprNode($stmt, $expr->getVar()->getPropertyFetch(), $scope, $storage, $nodeCallback, $context->enterDeep())
+			: null;
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($varResult, $dimResult, $valueResult, $propertyFetchResult): Type {
+				$varType = $varResult->getTypeForScope($scope);
+				if ($propertyFetchResult !== null) {
+					$currentPropertyType = $propertyFetchResult->getTypeForScope($scope);
+					if ($varType instanceof UnionType) {
+						$varType = $varType->filterTypes(static fn (Type $innerType) => !$innerType->isSuperTypeOf($currentPropertyType)->no());
+					}
+				}
+
+				return $varType->setOffsetValueType(
+					$dimResult !== null ? $dimResult->getTypeForScope($scope) : null,
+					$valueResult->getTypeForScope($scope),
+				);
+			},
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/SetOffsetValueTypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/SetOffsetValueTypeExprHandler.php
@@ -41,6 +41,7 @@ final class SetOffsetValueTypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/StaticMethodCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/StaticMethodCallableNodeHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -22,6 +23,12 @@ use function array_merge;
 #[AutowiredService]
 final class StaticMethodCallableNodeHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -51,7 +58,7 @@ final class StaticMethodCallableNodeHandler implements ExprHandler
 			$isAlwaysTerminating = $isAlwaysTerminating || $nameResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/StaticMethodCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/StaticMethodCallableNodeHandler.php
@@ -61,6 +61,7 @@ final class StaticMethodCallableNodeHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExprHandler/Virtual/StaticMethodCallableNodeHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/StaticMethodCallableNodeHandler.php
@@ -59,6 +59,7 @@ final class StaticMethodCallableNodeHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: $hasYield,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/Virtual/TypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/TypeExprHandler.php
@@ -41,6 +41,7 @@ final class TypeExprHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => $expr->getExprType(),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/TypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/TypeExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class TypeExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof TypeExpr;
@@ -31,7 +38,7 @@ final class TypeExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/TypeExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/TypeExprHandler.php
@@ -39,6 +39,7 @@ final class TypeExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/UnsetOffsetExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/UnsetOffsetExprHandler.php
@@ -35,12 +35,13 @@ final class UnsetOffsetExprHandler implements ExprHandler
 
 	public function processExpr(NodeScopeResolver $nodeScopeResolver, Stmt $stmt, Expr $expr, MutatingScope $scope, ExpressionResultStorage $storage, callable $nodeCallback, ExpressionContext $context): ExpressionResult
 	{
-		// because this is a virtual node handler, the caller will only be interested in the type
-		// we don't need to process the inner expr
+		$varResult = $nodeScopeResolver->processExprNode($stmt, $expr->getVar(), $scope, $storage, $nodeCallback, $context->enterDeep());
+		$dimResult = $nodeScopeResolver->processExprNode($stmt, $expr->getDim(), $varResult->getScope(), $storage, $nodeCallback, $context->enterDeep());
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn (Expr $uninteresting, MutatingScope $scope) => $varResult->getTypeForScope($scope)->unsetOffset($dimResult->getTypeForScope($scope)),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],

--- a/src/Analyser/ExprHandler/Virtual/UnsetOffsetExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/UnsetOffsetExprHandler.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\MutatingScope;
@@ -21,6 +22,12 @@ use PHPStan\Type\Type;
 final class UnsetOffsetExprHandler implements ExprHandler
 {
 
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
+
 	public function supports(Expr $expr): bool
 	{
 		return $expr instanceof UnsetOffsetExpr;
@@ -31,7 +38,7 @@ final class UnsetOffsetExprHandler implements ExprHandler
 		// because this is a virtual node handler, the caller will only be interested in the type
 		// we don't need to process the inner expr
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/Virtual/UnsetOffsetExprHandler.php
+++ b/src/Analyser/ExprHandler/Virtual/UnsetOffsetExprHandler.php
@@ -39,6 +39,7 @@ final class UnsetOffsetExprHandler implements ExprHandler
 		// we don't need to process the inner expr
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,

--- a/src/Analyser/ExprHandler/YieldFromHandler.php
+++ b/src/Analyser/ExprHandler/YieldFromHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\YieldFrom;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -26,6 +27,12 @@ use function array_merge;
 #[AutowiredService]
 final class YieldFromHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -48,7 +55,7 @@ final class YieldFromHandler implements ExprHandler
 		$exprResult = $nodeScopeResolver->processExprNode($stmt, $expr->expr, $scope, $storage, $nodeCallback, $context->enterDeep());
 		$scope = $exprResult->getScope();
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: true,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/YieldFromHandler.php
+++ b/src/Analyser/ExprHandler/YieldFromHandler.php
@@ -58,6 +58,14 @@ final class YieldFromHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope) use ($exprResult): Type {
+				$generatorReturnType = $exprResult->getTypeForScope($scope)->getTemplateType(Generator::class, 'TReturn');
+				if ($generatorReturnType instanceof ErrorType) {
+					return new MixedType();
+				}
+
+				return $generatorReturnType;
+			},
 			hasYield: true,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
 			throwPoints: array_merge($exprResult->getThrowPoints(), [InternalThrowPoint::createImplicit($scope, $expr)]),

--- a/src/Analyser/ExprHandler/YieldFromHandler.php
+++ b/src/Analyser/ExprHandler/YieldFromHandler.php
@@ -56,6 +56,7 @@ final class YieldFromHandler implements ExprHandler
 		$scope = $exprResult->getScope();
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: true,
 			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),

--- a/src/Analyser/ExprHandler/YieldHandler.php
+++ b/src/Analyser/ExprHandler/YieldHandler.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Expr\Yield_;
 use PhpParser\Node\Stmt;
 use PHPStan\Analyser\ExpressionContext;
 use PHPStan\Analyser\ExpressionResult;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\ExpressionResultStorage;
 use PHPStan\Analyser\ExprHandler;
 use PHPStan\Analyser\ImpurePoint;
@@ -26,6 +27,12 @@ use function array_merge;
 #[AutowiredService]
 final class YieldHandler implements ExprHandler
 {
+
+	public function __construct(
+		private ExpressionResultFactory $expressionResultFactory,
+	)
+	{
+	}
 
 	public function supports(Expr $expr): bool
 	{
@@ -78,7 +85,7 @@ final class YieldHandler implements ExprHandler
 			$isAlwaysTerminating = $isAlwaysTerminating || $valueResult->isAlwaysTerminating();
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: true,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/YieldHandler.php
+++ b/src/Analyser/ExprHandler/YieldHandler.php
@@ -86,6 +86,7 @@ final class YieldHandler implements ExprHandler
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: true,
 			isAlwaysTerminating: $isAlwaysTerminating,

--- a/src/Analyser/ExprHandler/YieldHandler.php
+++ b/src/Analyser/ExprHandler/YieldHandler.php
@@ -88,6 +88,20 @@ final class YieldHandler implements ExprHandler
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static function (Expr $uninteresting, MutatingScope $scope): Type {
+				$functionReflection = $scope->getFunction();
+				if ($functionReflection === null) {
+					return new MixedType();
+				}
+
+				$returnType = $functionReflection->getReturnType();
+				$generatorSendType = $returnType->getTemplateType(Generator::class, 'TSend');
+				if ($generatorSendType instanceof ErrorType) {
+					return new MixedType();
+				}
+
+				return $generatorSendType;
+			},
 			hasYield: true,
 			isAlwaysTerminating: $isAlwaysTerminating,
 			throwPoints: $throwPoints,

--- a/src/Analyser/ExpressionResult.php
+++ b/src/Analyser/ExpressionResult.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Analyser;
 
+use PHPStan\DependencyInjection\GenerateFactory;
+
+#[GenerateFactory(interface: ExpressionResultFactory::class)]
 final class ExpressionResult
 {
 

--- a/src/Analyser/ExpressionResult.php
+++ b/src/Analyser/ExpressionResult.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser;
 
+use PhpParser\Node\Expr;
 use PHPStan\DependencyInjection\GenerateFactory;
 
 #[GenerateFactory(interface: ExpressionResultFactory::class)]
@@ -25,6 +26,7 @@ final class ExpressionResult
 	 * @param (callable(): MutatingScope)|null $falseyScopeCallback
 	 */
 	public function __construct(
+		private Expr $expr,
 		private MutatingScope $scope,
 		private bool $hasYield,
 		private bool $isAlwaysTerminating,

--- a/src/Analyser/ExpressionResult.php
+++ b/src/Analyser/ExpressionResult.php
@@ -3,11 +3,22 @@
 namespace PHPStan\Analyser;
 
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Match_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
 use PHPStan\DependencyInjection\GenerateFactory;
+use PHPStan\DependencyInjection\Type\ExpressionTypeResolverExtensionRegistryProvider;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
 
 #[GenerateFactory(interface: ExpressionResultFactory::class)]
 final class ExpressionResult
 {
+
+	/** @var callable(Expr, MutatingScope): Type */
+	private $typeCallback;
 
 	/** @var (callable(): MutatingScope)|null */
 	private $truthyScopeCallback;
@@ -19,25 +30,51 @@ final class ExpressionResult
 
 	private ?MutatingScope $falseyScope = null;
 
+	private ?Type $cachedType = null;
+
+	private ?Type $cachedNativeType = null;
+
+	private ?Type $cachedKeepVoidType = null;
+
 	/**
 	 * @param InternalThrowPoint[] $throwPoints
 	 * @param ImpurePoint[] $impurePoints
+	 * @param callable(MutatingScope): Type $typeCallback
 	 * @param (callable(): MutatingScope)|null $truthyScopeCallback
 	 * @param (callable(): MutatingScope)|null $falseyScopeCallback
 	 */
 	public function __construct(
+		private ExpressionTypeResolverExtensionRegistryProvider $expressionTypeResolverExtensionRegistryProvider,
 		private Expr $expr,
 		private MutatingScope $scope,
 		private bool $hasYield,
 		private bool $isAlwaysTerminating,
 		private array $throwPoints,
 		private array $impurePoints,
+		callable $typeCallback,
 		?callable $truthyScopeCallback = null,
 		?callable $falseyScopeCallback = null,
 	)
 	{
+		$this->typeCallback = $typeCallback;
 		$this->truthyScopeCallback = $truthyScopeCallback;
 		$this->falseyScopeCallback = $falseyScopeCallback;
+	}
+
+	private function withExpr(Expr $expr): self
+	{
+		return new self(
+			$this->expressionTypeResolverExtensionRegistryProvider,
+			$expr,
+			$this->scope,
+			$this->hasYield,
+			$this->isAlwaysTerminating,
+			$this->throwPoints,
+			$this->impurePoints,
+			$this->typeCallback,
+			$this->truthyScopeCallback,
+			$this->falseyScopeCallback,
+		);
 	}
 
 	public function getScope(): MutatingScope
@@ -99,6 +136,99 @@ final class ExpressionResult
 	public function isAlwaysTerminating(): bool
 	{
 		return $this->isAlwaysTerminating;
+	}
+
+	/**
+	 * `ExpressionResult::getType()` is a replacement for `MutatingScope::getType(Expr)`
+	 * for use inside `ExprHandler::processExpr()` implementations.
+	 */
+	public function getType(): Type
+	{
+		if ($this->cachedType !== null) {
+			return $this->cachedType;
+		}
+
+		return $this->cachedType = TypeUtils::resolveLateResolvableTypes($this->getTypeByScope($this->scope));
+	}
+
+	/**
+	 * `ExpressionResult::getTypeForScope(Scope)` is used
+	 * instead of `$scope->getType(Expr)` inside typeCallback ExpressionResultFactory argument.
+	 */
+	public function getTypeForScope(MutatingScope $scope): Type
+	{
+		if ($scope->nativeTypesPromoted) {
+			return $this->getNativeType();
+		}
+
+		return $this->getType();
+	}
+
+	/**
+	 * `ExpressionResult::getNativeType()` is a replacement for `MutatingScope::getNativeType(Expr)`
+	 * for use inside `ExprHandler::processExpr()` implementations.
+	 */
+	public function getNativeType(): Type
+	{
+		if ($this->cachedNativeType !== null) {
+			return $this->cachedNativeType;
+		}
+
+		return $this->cachedNativeType = TypeUtils::resolveLateResolvableTypes($this->getTypeByScope($this->scope->doNotTreatPhpDocTypesAsCertain()));
+	}
+
+	public function getKeepVoidType(): Type
+	{
+		if ($this->cachedKeepVoidType !== null) {
+			return $this->cachedKeepVoidType;
+		}
+
+		if (
+			!$this->expr instanceof Match_
+			&& (
+				(
+					!$this->expr instanceof FuncCall
+					&& !$this->expr instanceof MethodCall
+					&& !$this->expr instanceof Expr\NullsafeMethodCall
+					&& !$this->expr instanceof Expr\StaticCall
+				) || $this->expr->isFirstClassCallable()
+			)
+		) {
+			return $this->getType();
+		}
+
+		$originalType = $this->getType();
+		if (!TypeCombinator::containsNull($originalType)) {
+			return $this->cachedKeepVoidType = $originalType;
+		}
+
+		$clonedExpr = clone $this->expr;
+		$clonedExpr->setAttribute(MutatingScope::KEEP_VOID_ATTRIBUTE_NAME, true);
+
+		return $this->cachedKeepVoidType = $this->withExpr($clonedExpr)->getType();
+	}
+
+	private function getTypeByScope(MutatingScope $scope): Type
+	{
+		foreach ($this->expressionTypeResolverExtensionRegistryProvider->getRegistry()->getExtensions() as $extension) {
+			$type = $extension->getType($this->expr, $scope);
+			if ($type !== null) {
+				return $type;
+			}
+		}
+
+		if (
+			!$this->expr instanceof Variable
+			&& !$this->expr instanceof Expr\Closure
+			&& !$this->expr instanceof Expr\ArrowFunction
+			&& $scope->hasExpressionType($this->expr)->yes()
+		) {
+			$exprString = $scope->getNodeKey($this->expr);
+			return $scope->expressionTypes[$exprString]->getType();
+		}
+
+		$typeCallback = $this->typeCallback;
+		return $typeCallback($this->expr, $scope);
 	}
 
 }

--- a/src/Analyser/ExpressionResultFactory.php
+++ b/src/Analyser/ExpressionResultFactory.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+interface ExpressionResultFactory
+{
+
+	/**
+	 * @param InternalThrowPoint[] $throwPoints
+	 * @param ImpurePoint[] $impurePoints
+	 * @param (callable(): MutatingScope)|null $truthyScopeCallback
+	 * @param (callable(): MutatingScope)|null $falseyScopeCallback
+	 */
+	public function create(
+		MutatingScope $scope,
+		bool $hasYield,
+		bool $isAlwaysTerminating,
+		array $throwPoints,
+		array $impurePoints,
+		?callable $truthyScopeCallback = null,
+		?callable $falseyScopeCallback = null,
+	): ExpressionResult;
+
+}

--- a/src/Analyser/ExpressionResultFactory.php
+++ b/src/Analyser/ExpressionResultFactory.php
@@ -2,6 +2,8 @@
 
 namespace PHPStan\Analyser;
 
+use PhpParser\Node\Expr;
+
 interface ExpressionResultFactory
 {
 
@@ -12,6 +14,7 @@ interface ExpressionResultFactory
 	 * @param (callable(): MutatingScope)|null $falseyScopeCallback
 	 */
 	public function create(
+		Expr $expr,
 		MutatingScope $scope,
 		bool $hasYield,
 		bool $isAlwaysTerminating,

--- a/src/Analyser/ExpressionResultFactory.php
+++ b/src/Analyser/ExpressionResultFactory.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser;
 
 use PhpParser\Node\Expr;
+use PHPStan\Type\Type;
 
 interface ExpressionResultFactory
 {
@@ -10,6 +11,7 @@ interface ExpressionResultFactory
 	/**
 	 * @param InternalThrowPoint[] $throwPoints
 	 * @param ImpurePoint[] $impurePoints
+	 * @param callable(Expr, MutatingScope): Type $typeCallback
 	 * @param (callable(): MutatingScope)|null $truthyScopeCallback
 	 * @param (callable(): MutatingScope)|null $falseyScopeCallback
 	 */
@@ -20,6 +22,7 @@ interface ExpressionResultFactory
 		bool $isAlwaysTerminating,
 		array $throwPoints,
 		array $impurePoints,
+		callable $typeCallback,
 		?callable $truthyScopeCallback = null,
 		?callable $falseyScopeCallback = null,
 	): ExpressionResult;

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -994,6 +994,15 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 	public function issetCheck(Expr $expr, callable $typeCallback, ?bool $result = null): ?bool
 	{
 		// mirrored in PHPStan\Rules\IssetCheck
+		return $this->issetCheckWithResolver($expr, $typeCallback, fn (Expr $expr): Type => $this->getType($expr), $result);
+	}
+
+	/**
+	 * @param callable(Type): ?bool $typeCallback
+	 * @param callable(Expr): Type $typeResolver
+	 */
+	public function issetCheckWithResolver(Expr $expr, callable $typeCallback, callable $typeResolver, ?bool $result = null): ?bool
+	{
 		if ($expr instanceof Node\Expr\Variable && is_string($expr->name)) {
 			$hasVariable = $this->hasVariableType($expr->name);
 			if ($hasVariable->maybe()) {
@@ -1014,41 +1023,46 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 			return $result;
 		} elseif ($expr instanceof Node\Expr\ArrayDimFetch && $expr->dim !== null) {
-			$type = $this->getType($expr->var);
+			$type = $typeResolver($expr->var);
 			if (!$type->isOffsetAccessible()->yes()) {
-				return $result ?? $this->issetCheckUndefined($expr->var);
+				return $result ?? $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 			}
 
-			$dimType = $this->getType($expr->dim);
+			$dimType = $typeResolver($expr->dim);
 			$hasOffsetValue = $type->hasOffsetValueType($dimType);
 			if ($hasOffsetValue->no()) {
 				return false;
 			}
 
-			// If offset cannot be null, store this error message and see if one of the earlier offsets is.
-			// E.g. $array['a']['b']['c'] ?? null; is a valid coalesce if a OR b or C might be null.
 			if ($hasOffsetValue->yes()) {
 				$result = $typeCallback($type->getOffsetValueType($dimType));
 
 				if ($result !== null) {
-					return $this->issetCheck($expr->var, $typeCallback, $result);
+					return $this->issetCheckWithResolver($expr->var, $typeCallback, $typeResolver, $result);
 				}
 			}
 
-			// Has offset, it is nullable
 			return null;
 
 		} elseif ($expr instanceof Node\Expr\PropertyFetch || $expr instanceof Node\Expr\StaticPropertyFetch) {
 
-			$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNode($expr, $this);
+			if ($expr instanceof Node\Expr\PropertyFetch) {
+				$holderType = $typeResolver($expr->var);
+			} elseif ($expr->class instanceof Name) {
+				$holderType = $this->resolveTypeByName($expr->class);
+			} else {
+				$holderType = $typeResolver($expr->class);
+			}
+
+			$propertyReflection = $this->propertyReflectionFinder->findPropertyReflectionFromNodeWithTypes($expr, $this, $holderType, null);
 
 			if ($propertyReflection === null) {
 				if ($expr instanceof Node\Expr\PropertyFetch) {
-					return $this->issetCheckUndefined($expr->var);
+					return $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 				}
 
 				if ($expr->class instanceof Expr) {
-					return $this->issetCheckUndefined($expr->class);
+					return $this->issetCheckUndefinedWithResolver($expr->class, $typeResolver);
 				}
 
 				return null;
@@ -1056,11 +1070,11 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 			if (!$propertyReflection->isNative()) {
 				if ($expr instanceof Node\Expr\PropertyFetch) {
-					return $this->issetCheckUndefined($expr->var);
+					return $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 				}
 
 				if ($expr->class instanceof Expr) {
-					return $this->issetCheckUndefined($expr->class);
+					return $this->issetCheckUndefinedWithResolver($expr->class, $typeResolver);
 				}
 
 				return null;
@@ -1069,11 +1083,11 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			if ($propertyReflection->hasNativeType() && !$propertyReflection->isVirtual()->yes()) {
 				if (!$this->hasExpressionType($expr)->yes()) {
 					if ($expr instanceof Node\Expr\PropertyFetch) {
-						return $this->issetCheckUndefined($expr->var);
+						return $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 					}
 
 					if ($expr->class instanceof Expr) {
-						return $this->issetCheckUndefined($expr->class);
+						return $this->issetCheckUndefinedWithResolver($expr->class, $typeResolver);
 					}
 
 					return null;
@@ -1087,11 +1101,11 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			$result = $typeCallback($propertyReflection->getWritableType());
 			if ($result !== null) {
 				if ($expr instanceof Node\Expr\PropertyFetch) {
-					return $this->issetCheck($expr->var, $typeCallback, $result);
+					return $this->issetCheckWithResolver($expr->var, $typeCallback, $typeResolver, $result);
 				}
 
 				if ($expr->class instanceof Expr) {
-					return $this->issetCheck($expr->class, $typeCallback, $result);
+					return $this->issetCheckWithResolver($expr->class, $typeCallback, $typeResolver, $result);
 				}
 			}
 
@@ -1102,10 +1116,13 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 			return $result;
 		}
 
-		return $typeCallback($this->getType($expr));
+		return $typeCallback($typeResolver($expr));
 	}
 
-	private function issetCheckUndefined(Expr $expr): ?bool
+	/**
+	 * @param callable(Expr): Type $typeResolver
+	 */
+	private function issetCheckUndefinedWithResolver(Expr $expr, callable $typeResolver): ?bool
 	{
 		if ($expr instanceof Node\Expr\Variable && is_string($expr->name)) {
 			$hasVariable = $this->hasVariableType($expr->name);
@@ -1117,30 +1134,35 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		}
 
 		if ($expr instanceof Node\Expr\ArrayDimFetch && $expr->dim !== null) {
-			$type = $this->getType($expr->var);
+			$type = $typeResolver($expr->var);
 			if (!$type->isOffsetAccessible()->yes()) {
-				return $this->issetCheckUndefined($expr->var);
+				return $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 			}
 
-			$dimType = $this->getType($expr->dim);
+			$dimType = $typeResolver($expr->dim);
 			$hasOffsetValue = $type->hasOffsetValueType($dimType);
 
 			if (!$hasOffsetValue->no()) {
-				return $this->issetCheckUndefined($expr->var);
+				return $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 			}
 
 			return false;
 		}
 
 		if ($expr instanceof Expr\PropertyFetch) {
-			return $this->issetCheckUndefined($expr->var);
+			return $this->issetCheckUndefinedWithResolver($expr->var, $typeResolver);
 		}
 
 		if ($expr instanceof Expr\StaticPropertyFetch && $expr->class instanceof Expr) {
-			return $this->issetCheckUndefined($expr->class);
+			return $this->issetCheckUndefinedWithResolver($expr->class, $typeResolver);
 		}
 
 		return null;
+	}
+
+	private function issetCheckUndefined(Expr $expr): ?bool
+	{
+		return $this->issetCheckUndefinedWithResolver($expr, fn (Expr $expr): Type => $this->getType($expr));
 	}
 
 	/** @api */

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -1176,7 +1176,7 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		return $this->getType($clonedNode);
 	}
 
-	public function doNotTreatPhpDocTypesAsCertain(): Scope
+	public function doNotTreatPhpDocTypesAsCertain(): self
 	{
 		return $this->promoteNativeTypes();
 	}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -222,6 +222,7 @@ class NodeScopeResolver
 		private readonly ParameterClosureTypeExtensionProvider $parameterClosureTypeExtensionProvider,
 		private readonly ScopeFactory $scopeFactory,
 		private readonly DeepNodeCloner $deepNodeCloner,
+		private readonly ExpressionResultFactory $expressionResultFactory,
 		#[AutowiredParameter]
 		private readonly bool $polluteScopeWithLoopInitialAssignments,
 		#[AutowiredParameter]
@@ -2509,10 +2510,10 @@ class NodeScopeResolver
 
 		if ($expr instanceof List_) {
 			// only in assign and foreach, processed elsewhere
-			return new ExpressionResult($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []);
+			return $this->expressionResultFactory->create($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []);
 		}
 
-		return new ExpressionResult(
+		return $this->expressionResultFactory->create(
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,
@@ -2886,7 +2887,7 @@ class NodeScopeResolver
 		$this->callNodeCallback($nodeCallback, new InArrowFunctionNode($arrowFunctionType, $expr), $arrowFunctionScope, $storage);
 		$exprResult = $this->processExprNode($stmt, $expr->expr, $arrowFunctionScope, $storage, $nodeCallback, ExpressionContext::createTopLevel());
 
-		return new ExpressionResult($scope, false, $exprResult->isAlwaysTerminating(), $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
+		return $this->expressionResultFactory->create($scope, false, $exprResult->isAlwaysTerminating(), $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
 	}
 
 	/**
@@ -3528,7 +3529,7 @@ class NodeScopeResolver
 		}
 
 		// not storing this, it's scope after processing all args
-		return new ExpressionResult($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return $this->expressionResultFactory->create($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
 	}
 
 	/**
@@ -3665,7 +3666,7 @@ class NodeScopeResolver
 			$assignedExpr,
 			new VirtualAssignNodeCallback($nodeCallback),
 			ExpressionContext::createDeep(),
-			static fn (MutatingScope $scope): ExpressionResult => new ExpressionResult($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
+			fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
 			false,
 		);
 	}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -781,7 +781,7 @@ class NodeScopeResolver
 							&& $scope->getFunction() instanceof PhpMethodFromParserNodeReflection
 							&& $scope->getFunction()->getDeclaringClass()->hasConstructor()
 							&& $scope->getFunction()->getDeclaringClass()->getConstructor()->getName() === $scope->getFunction()->getName()
-							&& TypeUtils::findThisType($scope->getType($node->getPropertyFetch()->var)) !== null
+							&& TypeUtils::findThisType($this->processExprNode(new Node\Stmt\Expression($node->getPropertyFetch()->var), $node->getPropertyFetch()->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getType()) !== null
 						) {
 							return;
 						}
@@ -912,7 +912,6 @@ class NodeScopeResolver
 			if ($stmt->expr instanceof Expr\Throw_) {
 				$scope = $stmtScope;
 			}
-			$earlyTerminationExpr = $this->findEarlyTerminatingExpr($stmt->expr, $scope);
 			$hasAssign = false;
 			$currentScope = $scope;
 			$result = $this->processExprNode($stmt, $stmt->expr, $scope, $storage, static function (Node $node, Scope $scope) use ($nodeCallback, $currentScope, &$hasAssign): void {
@@ -925,6 +924,7 @@ class NodeScopeResolver
 				}
 				$nodeCallback($node, $scope);
 			}, ExpressionContext::createTopLevel());
+			$earlyTerminationExpr = $this->findEarlyTerminatingExpr($stmt->expr, $result);
 			$throwPoints = array_filter($result->getThrowPoints(), static fn ($throwPoint) => $throwPoint->isExplicit());
 			if (
 				count($result->getImpurePoints()) === 0
@@ -1095,9 +1095,9 @@ class NodeScopeResolver
 				$this->callNodeCallback($nodeCallback, $stmt->type, $scope, $storage);
 			}
 		} elseif ($stmt instanceof If_) {
-			$conditionType = ($this->treatPhpDocTypesAsCertain ? $scope->getType($stmt->cond) : $scope->getNativeType($stmt->cond))->toBoolean();
-			$ifAlwaysTrue = $conditionType->isTrue()->yes();
 			$condResult = $this->processExprNode($stmt, $stmt->cond, $scope, $storage, $nodeCallback, ExpressionContext::createDeep());
+			$conditionType = ($this->treatPhpDocTypesAsCertain ? $condResult->getType() : $condResult->getNativeType())->toBoolean();
+			$ifAlwaysTrue = $conditionType->isTrue()->yes();
 			$exitPoints = [];
 			$throwPoints = $overridingThrowPoints ?? $condResult->getThrowPoints();
 			$impurePoints = $condResult->getImpurePoints();
@@ -1131,8 +1131,8 @@ class NodeScopeResolver
 			$condScope = $scope;
 			foreach ($stmt->elseifs as $elseif) {
 				$this->callNodeCallback($nodeCallback, $elseif, $scope, $storage);
-				$elseIfConditionType = ($this->treatPhpDocTypesAsCertain ? $condScope->getType($elseif->cond) : $scope->getNativeType($elseif->cond))->toBoolean();
 				$condResult = $this->processExprNode($stmt, $elseif->cond, $condScope, $storage, $nodeCallback, ExpressionContext::createDeep());
+				$elseIfConditionType = ($this->treatPhpDocTypesAsCertain ? $condResult->getType() : $condResult->getNativeType())->toBoolean();
 				$throwPoints = array_merge($throwPoints, $condResult->getThrowPoints());
 				$impurePoints = array_merge($impurePoints, $condResult->getImpurePoints());
 				$condScope = $condResult->getScope();
@@ -1298,7 +1298,7 @@ class NodeScopeResolver
 				$finalScope = $breakExitPoint->getScope()->mergeWith($finalScope);
 			}
 
-			$exprType = $scope->getType($stmt->expr);
+			$exprType = $condResult->getType();
 			$hasExpr = $scope->hasExpressionType($stmt->expr);
 			if (
 				count($breakExitPoints) === 0
@@ -1336,7 +1336,7 @@ class NodeScopeResolver
 
 						return new ArrayType($type->getKeyType(), $arrayDimFetchLoopType);
 					});
-					$newExprNativeType = TypeTraverser::map($scope->getNativeType($stmt->expr), static function (Type $type, callable $traverse) use ($arrayDimFetchLoopNativeType): Type {
+					$newExprNativeType = TypeTraverser::map($condResult->getNativeType(), static function (Type $type, callable $traverse) use ($arrayDimFetchLoopNativeType): Type {
 						if ($type instanceof UnionType || $type instanceof IntersectionType) {
 							return $traverse($type);
 						}
@@ -1387,7 +1387,7 @@ class NodeScopeResolver
 				$throwPoints = array_merge($throwPoints, $finalScopeResult->getThrowPoints());
 				$impurePoints = array_merge($impurePoints, $finalScopeResult->getImpurePoints());
 			}
-			if (!(new ObjectType(Traversable::class))->isSuperTypeOf($scope->getType($stmt->expr))->no()) {
+			if (!(new ObjectType(Traversable::class))->isSuperTypeOf($condResult->getType())->no()) {
 				$throwPoints[] = InternalThrowPoint::createImplicit($scope, $stmt->expr);
 			}
 			if ($context->isTopLevel() && $stmt->byRef) {
@@ -1406,7 +1406,7 @@ class NodeScopeResolver
 			$originalStorage = $storage;
 			$storage = $originalStorage->duplicate();
 			$condResult = $this->processExprNode($stmt, $stmt->cond, $scope, $storage, new NoopNodeCallback(), ExpressionContext::createDeep());
-			$beforeCondBooleanType = ($this->treatPhpDocTypesAsCertain ? $scope->getType($stmt->cond) : $scope->getNativeType($stmt->cond))->toBoolean();
+			$beforeCondBooleanType = ($this->treatPhpDocTypesAsCertain ? $condResult->getType() : $condResult->getNativeType())->toBoolean();
 			$condScope = $condResult->getFalseyScope();
 			if (!$context->isTopLevel() && $beforeCondBooleanType->isFalse()->yes()) {
 				if (!$this->polluteScopeWithLoopInitialAssignments) {
@@ -2051,7 +2051,7 @@ class NodeScopeResolver
 				$throwPoints = array_merge($throwPoints, $exprResult->getThrowPoints());
 				$impurePoints = array_merge($impurePoints, $exprResult->getImpurePoints());
 				if ($var instanceof ArrayDimFetch && $var->dim !== null) {
-					$varType = $scope->getType($var->var);
+					$varType = $this->processExprNode($stmt, $var->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getType();
 					if (!$varType->isArray()->yes() && !(new ObjectType(ArrayAccess::class))->isSuperTypeOf($varType)->no()) {
 						$throwPoints = array_merge($throwPoints, $this->processExprNode(
 							$stmt,
@@ -2197,8 +2197,8 @@ class NodeScopeResolver
 				}
 				$scope = $scope->assignExpression(
 					new Expr\ClassConstFetch(new Name\FullyQualified($scope->getClassReflection()->getName()), $const->name),
-					$scope->getType($const->value),
-					$scope->getNativeType($const->value),
+					$constResult->getType(),
+					$constResult->getNativeType(),
 				);
 			}
 		} elseif ($stmt instanceof Node\Stmt\EnumCase) {
@@ -2417,50 +2417,10 @@ class NodeScopeResolver
 		return $scope;
 	}
 
-	private function findEarlyTerminatingExpr(Expr $expr, Scope $scope): ?Expr
+	// TODO: move $earlyTerminatingMethodCalls/$earlyTerminatingFunctionCalls config into MethodCallHandler/FuncCallHandler
+	private function findEarlyTerminatingExpr(Expr $expr, ExpressionResult $result): ?Expr
 	{
-		if (($expr instanceof MethodCall || $expr instanceof Expr\StaticCall) && $expr->name instanceof Node\Identifier) {
-			if (array_key_exists($expr->name->toLowerString(), $this->earlyTerminatingMethodNames)) {
-				if ($expr instanceof MethodCall) {
-					$methodCalledOnType = $scope->getType($expr->var);
-				} else {
-					if ($expr->class instanceof Name) {
-						$methodCalledOnType = $scope->resolveTypeByName($expr->class);
-					} else {
-						$methodCalledOnType = $scope->getType($expr->class);
-					}
-				}
-
-				foreach ($methodCalledOnType->getObjectClassNames() as $referencedClass) {
-					if (!$this->reflectionProvider->hasClass($referencedClass)) {
-						continue;
-					}
-
-					$classReflection = $this->reflectionProvider->getClass($referencedClass);
-					foreach (array_merge([$referencedClass], $classReflection->getParentClassesNames(), $classReflection->getNativeReflection()->getInterfaceNames()) as $className) {
-						if (!isset($this->earlyTerminatingMethodCalls[$className])) {
-							continue;
-						}
-
-						if (in_array((string) $expr->name, $this->earlyTerminatingMethodCalls[$className], true)) {
-							return $expr;
-						}
-					}
-				}
-			}
-		}
-
-		if ($expr instanceof FuncCall && $expr->name instanceof Name) {
-			if (in_array((string) $expr->name, $this->earlyTerminatingFunctionCalls, true)) {
-				return $expr;
-			}
-		}
-
-		if ($expr instanceof Expr\Exit_ || $expr instanceof Expr\Throw_) {
-			return $expr;
-		}
-
-		$exprType = $scope->getType($expr);
+		$exprType = $result->getType();
 		if ($exprType instanceof NeverType && $exprType->isExplicit()) {
 			return $expr;
 		}
@@ -2689,7 +2649,8 @@ class NodeScopeResolver
 					$inAssignRightSideVariableName === $use->var->name
 					&& $inAssignRightSideExpr !== null
 				) {
-					$inAssignRightSideType = $scope->getType($inAssignRightSideExpr);
+					$inAssignRightSideResult = $this->processExprNode(new Node\Stmt\Expression($inAssignRightSideExpr), $inAssignRightSideExpr, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep());
+					$inAssignRightSideType = $inAssignRightSideResult->getType();
 					if ($inAssignRightSideType instanceof ClosureType) {
 						$variableType = $inAssignRightSideType;
 					} else {
@@ -2700,7 +2661,7 @@ class NodeScopeResolver
 							$variableType = TypeCombinator::union($scope->getVariableType($inAssignRightSideVariableName), $inAssignRightSideType);
 						}
 					}
-					$inAssignRightSideNativeType = $scope->getNativeType($inAssignRightSideExpr);
+					$inAssignRightSideNativeType = $inAssignRightSideResult->getNativeType();
 					if ($inAssignRightSideNativeType instanceof ClosureType) {
 						$variableNativeType = $inAssignRightSideNativeType;
 					} else {

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -781,7 +781,7 @@ class NodeScopeResolver
 							&& $scope->getFunction() instanceof PhpMethodFromParserNodeReflection
 							&& $scope->getFunction()->getDeclaringClass()->hasConstructor()
 							&& $scope->getFunction()->getDeclaringClass()->getConstructor()->getName() === $scope->getFunction()->getName()
-							&& TypeUtils::findThisType($this->processExprNode(new Node\Stmt\Expression($node->getPropertyFetch()->var), $node->getPropertyFetch()->var, $scope, new ExpressionResultStorage(), new NoopNodeCallback(), ExpressionContext::createDeep())->getType()) !== null
+							&& TypeUtils::findThisType($scope->getType($node->getPropertyFetch()->var)) !== null
 						) {
 							return;
 						}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2510,12 +2510,21 @@ class NodeScopeResolver
 
 		if ($expr instanceof List_) {
 			// only in assign and foreach, processed elsewhere
-			return $this->expressionResultFactory->create($expr, $scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []);
+			return $this->expressionResultFactory->create(
+				$expr,
+				$scope,
+				typeCallback: static fn () => new MixedType(),
+				hasYield: false,
+				isAlwaysTerminating: false,
+				throwPoints: [],
+				impurePoints: [],
+			);
 		}
 
 		return $this->expressionResultFactory->create(
 			$expr,
 			$scope,
+			typeCallback: static fn () => new MixedType(),
 			hasYield: false,
 			isAlwaysTerminating: false,
 			throwPoints: [],
@@ -2888,7 +2897,15 @@ class NodeScopeResolver
 		$this->callNodeCallback($nodeCallback, new InArrowFunctionNode($arrowFunctionType, $expr), $arrowFunctionScope, $storage);
 		$exprResult = $this->processExprNode($stmt, $expr->expr, $arrowFunctionScope, $storage, $nodeCallback, ExpressionContext::createTopLevel());
 
-		return $this->expressionResultFactory->create($expr, $scope, false, $exprResult->isAlwaysTerminating(), $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
+		return $this->expressionResultFactory->create(
+			$expr,
+			$scope,
+			typeCallback: static fn (Expr $unassigned, MutatingScope $scope) => $scope->getType($expr), // todo
+			hasYield: false,
+			isAlwaysTerminating: $exprResult->isAlwaysTerminating(),
+			throwPoints: $exprResult->getThrowPoints(),
+			impurePoints: $exprResult->getImpurePoints(),
+		);
 	}
 
 	/**
@@ -3530,7 +3547,15 @@ class NodeScopeResolver
 		}
 
 		// not storing this, it's scope after processing all args
-		return $this->expressionResultFactory->create($callLike, $scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return $this->expressionResultFactory->create(
+			$callLike,
+			$scope,
+			typeCallback: static fn () => new MixedType(),
+			hasYield: $hasYield,
+			isAlwaysTerminating: $isAlwaysTerminating,
+			throwPoints: $throwPoints,
+			impurePoints: $impurePoints,
+		);
 	}
 
 	/**
@@ -3667,7 +3692,15 @@ class NodeScopeResolver
 			$assignedExpr,
 			new VirtualAssignNodeCallback($nodeCallback),
 			ExpressionContext::createDeep(),
-			fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($assignedExpr, $scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
+			fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create(
+				$assignedExpr,
+				$scope,
+				typeCallback: static fn () => new MixedType(),
+				hasYield: false,
+				isAlwaysTerminating: false,
+				throwPoints: [],
+				impurePoints: [],
+			),
 			false,
 		);
 	}

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2417,7 +2417,6 @@ class NodeScopeResolver
 		return $scope;
 	}
 
-	// TODO: move $earlyTerminatingMethodCalls/$earlyTerminatingFunctionCalls config into MethodCallHandler/FuncCallHandler
 	private function findEarlyTerminatingExpr(Expr $expr, ExpressionResult $result): ?Expr
 	{
 		$exprType = $result->getType();

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -2510,10 +2510,11 @@ class NodeScopeResolver
 
 		if ($expr instanceof List_) {
 			// only in assign and foreach, processed elsewhere
-			return $this->expressionResultFactory->create($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []);
+			return $this->expressionResultFactory->create($expr, $scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []);
 		}
 
 		return $this->expressionResultFactory->create(
+			$expr,
 			$scope,
 			hasYield: false,
 			isAlwaysTerminating: false,
@@ -2887,7 +2888,7 @@ class NodeScopeResolver
 		$this->callNodeCallback($nodeCallback, new InArrowFunctionNode($arrowFunctionType, $expr), $arrowFunctionScope, $storage);
 		$exprResult = $this->processExprNode($stmt, $expr->expr, $arrowFunctionScope, $storage, $nodeCallback, ExpressionContext::createTopLevel());
 
-		return $this->expressionResultFactory->create($scope, false, $exprResult->isAlwaysTerminating(), $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
+		return $this->expressionResultFactory->create($expr, $scope, false, $exprResult->isAlwaysTerminating(), $exprResult->getThrowPoints(), $exprResult->getImpurePoints());
 	}
 
 	/**
@@ -3529,7 +3530,7 @@ class NodeScopeResolver
 		}
 
 		// not storing this, it's scope after processing all args
-		return $this->expressionResultFactory->create($scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
+		return $this->expressionResultFactory->create($callLike, $scope, $hasYield, $isAlwaysTerminating, $throwPoints, $impurePoints);
 	}
 
 	/**
@@ -3666,7 +3667,7 @@ class NodeScopeResolver
 			$assignedExpr,
 			new VirtualAssignNodeCallback($nodeCallback),
 			ExpressionContext::createDeep(),
-			fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
+			fn (MutatingScope $scope): ExpressionResult => $this->expressionResultFactory->create($assignedExpr, $scope, hasYield: false, isAlwaysTerminating: false, throwPoints: [], impurePoints: []),
 			false,
 		);
 	}

--- a/src/Analyser/RicherScopeGetTypeHelper.php
+++ b/src/Analyser/RicherScopeGetTypeHelper.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Rules\Properties\PropertyReflectionFinder;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Type;
 use PHPStan\Type\TypeResult;
 use function is_string;
 
@@ -29,6 +30,14 @@ final class RicherScopeGetTypeHelper
 	 */
 	public function getIdenticalResult(Scope $scope, Identical $expr): TypeResult
 	{
+		return $this->getIdenticalResultWithTypes($scope, $expr, $scope->getType($expr->left), $scope->getType($expr->right));
+	}
+
+	/**
+	 * @return TypeResult<BooleanType>
+	 */
+	public function getIdenticalResultWithTypes(Scope $scope, Identical $expr, Type $leftType, Type $rightType): TypeResult
+	{
 		if (
 			$expr->left instanceof Variable
 			&& is_string($expr->left->name)
@@ -38,9 +47,6 @@ final class RicherScopeGetTypeHelper
 		) {
 			return new TypeResult(new ConstantBooleanType(true), []);
 		}
-
-		$leftType = $scope->getType($expr->left);
-		$rightType = $scope->getType($expr->right);
 
 		if (
 			(
@@ -80,7 +86,15 @@ final class RicherScopeGetTypeHelper
 	 */
 	public function getNotIdenticalResult(Scope $scope, Node\Expr\BinaryOp\NotIdentical $expr): TypeResult
 	{
-		$identicalResult = $this->getIdenticalResult($scope, new Identical($expr->left, $expr->right));
+		return $this->getNotIdenticalResultWithTypes($scope, $expr, $scope->getType($expr->left), $scope->getType($expr->right));
+	}
+
+	/**
+	 * @return TypeResult<BooleanType>
+	 */
+	public function getNotIdenticalResultWithTypes(Scope $scope, Node\Expr\BinaryOp\NotIdentical $expr, Type $leftType, Type $rightType): TypeResult
+	{
+		$identicalResult = $this->getIdenticalResultWithTypes($scope, new Identical($expr->left, $expr->right), $leftType, $rightType);
 		$identicalType = $identicalResult->type;
 		if ($identicalType instanceof ConstantBooleanType) {
 			return new TypeResult(new ConstantBooleanType(!$identicalType->getValue()), $identicalResult->reasons);

--- a/src/Rules/Properties/PropertyReflectionFinder.php
+++ b/src/Rules/Properties/PropertyReflectionFinder.php
@@ -90,14 +90,39 @@ final class PropertyReflectionFinder
 	{
 		if ($propertyFetch instanceof Node\Expr\PropertyFetch) {
 			$propertyHolderType = $scope->getType($propertyFetch->var);
+			$nameType = $propertyFetch->name instanceof Expr ? $scope->getType($propertyFetch->name) : null;
+
+			return $this->findPropertyReflectionFromNodeWithTypes($propertyFetch, $scope, $propertyHolderType, $nameType);
+		}
+
+		if ($propertyFetch->class instanceof Node\Name) {
+			$propertyHolderType = $scope->resolveTypeByName($propertyFetch->class);
+		} else {
+			$propertyHolderType = $scope->getType($propertyFetch->class);
+		}
+
+		$nameType = $propertyFetch->name instanceof Expr ? $scope->getType($propertyFetch->name) : null;
+
+		return $this->findPropertyReflectionFromNodeWithTypes($propertyFetch, $scope, $propertyHolderType, $nameType);
+	}
+
+	/**
+	 * @param Node\Expr\PropertyFetch|Node\Expr\StaticPropertyFetch $propertyFetch
+	 */
+	public function findPropertyReflectionFromNodeWithTypes($propertyFetch, Scope $scope, Type $holderType, ?Type $nameType): ?FoundPropertyReflection
+	{
+		if ($propertyFetch instanceof Node\Expr\PropertyFetch) {
 			if ($propertyFetch->name instanceof Node\Identifier) {
-				return $this->findInstancePropertyReflection($propertyHolderType, $propertyFetch->name->name, $scope);
+				return $this->findInstancePropertyReflection($holderType, $propertyFetch->name->name, $scope);
 			}
 
-			$nameType = $scope->getType($propertyFetch->name);
+			if ($nameType === null) {
+				return null;
+			}
+
 			$nameTypeConstantStrings = $nameType->getConstantStrings();
 			if (count($nameTypeConstantStrings) === 1) {
-				return $this->findInstancePropertyReflection($propertyHolderType, $nameTypeConstantStrings[0]->getValue(), $scope);
+				return $this->findInstancePropertyReflection($holderType, $nameTypeConstantStrings[0]->getValue(), $scope);
 			}
 
 			return null;
@@ -107,13 +132,7 @@ final class PropertyReflectionFinder
 			return null;
 		}
 
-		if ($propertyFetch->class instanceof Node\Name) {
-			$propertyHolderType = $scope->resolveTypeByName($propertyFetch->class);
-		} else {
-			$propertyHolderType = $scope->getType($propertyFetch->class);
-		}
-
-		return $this->findStaticPropertyReflection($propertyHolderType, $propertyFetch->name->name, $scope);
+		return $this->findStaticPropertyReflection($holderType, $propertyFetch->name->name, $scope);
 	}
 
 	private function findInstancePropertyReflection(Type $propertyHolderType, string $propertyName, Scope $scope): ?FoundPropertyReflection

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\AnalyserResultFinalizer;
 use PHPStan\Analyser\Error;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\Fiber\FiberNodeScopeResolver;
 use PHPStan\Analyser\FileAnalyser;
 use PHPStan\Analyser\IgnoreErrorExtensionProvider;
@@ -109,6 +110,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 			self::getContainer()->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			self::getContainer()->getByType(DeepNodeCloner::class),
+			self::getContainer()->getByType(ExpressionResultFactory::class),
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),
 			self::getContainer()->getParameter('polluteScopeWithBlock'),

--- a/src/Testing/TypeInferenceTestCase.php
+++ b/src/Testing/TypeInferenceTestCase.php
@@ -6,6 +6,7 @@ use LogicException;
 use PhpParser\Node;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\Fiber\FiberNodeScopeResolver;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Analyser\NodeScopeResolver;
@@ -84,6 +85,7 @@ abstract class TypeInferenceTestCase extends PHPStanTestCase
 			$container->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			self::getContainer()->getByType(DeepNodeCloner::class),
+			self::getContainer()->getByType(ExpressionResultFactory::class),
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
 			$container->getParameter('polluteScopeWithBlock'),

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -825,6 +825,7 @@ class AnalyserTest extends PHPStanTestCase
 			$container->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$container->getByType(DeepNodeCloner::class),
+			$container->getByType(ExpressionResultFactory::class),
 			false,
 			true,
 			true,

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Analyser\Fiber;
 
 use PhpParser\Node;
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\Type\ParameterClosureThisExtensionProvider;
@@ -129,6 +130,7 @@ class FiberNodeScopeResolverRuleTest extends RuleTestCase
 			self::getContainer()->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			self::getContainer()->getByType(DeepNodeCloner::class),
+			self::getContainer()->getByType(ExpressionResultFactory::class),
 			$this->shouldPolluteScopeWithLoopInitialAssignments(),
 			$this->shouldPolluteScopeWithAlwaysIterableForeach(),
 			self::getContainer()->getParameter('polluteScopeWithBlock'),

--- a/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/Fiber/FiberNodeScopeResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Analyser\Fiber;
 
+use PHPStan\Analyser\ExpressionResultFactory;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\DependencyInjection\Type\ParameterClosureThisExtensionProvider;
 use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
@@ -62,6 +63,7 @@ class FiberNodeScopeResolverTest extends TypeInferenceTestCase
 			$container->getByType(ParameterClosureTypeExtensionProvider::class),
 			self::createScopeFactory($reflectionProvider, $typeSpecifier),
 			$container->getByType(DeepNodeCloner::class),
+			self::getContainer()->getByType(ExpressionResultFactory::class),
 			$container->getParameter('polluteScopeWithLoopInitialAssignments'),
 			$container->getParameter('polluteScopeWithAlwaysIterableForeach'),
 			$container->getParameter('polluteScopeWithBlock'),


### PR DESCRIPTION
Hi, this is step ~7 out of 12 I have planned. The endgoal is to get rid of 17 % of performance penalty and repeated calls to MutatingScope::resolveType. Of course the performance improvement might not pan out (the new version might also have bottlenecks we'll not see until the very end), but I still like how the new code looks like so I think the rewrite is worth it.

Right now PHPStan traverses AST during analysis multiple times:

* In NodeScopeResolver to go through the AST and update Scope with assignments etc.
* In MutatingScope::resolveType to go through the AST of en entire expression to figure out its type
* In TypeSpecifier to narrow types in Scope based on expressions like `instanceof`

There are many problems this causes. One of the most understandable examples is that MutatingScope actually also has to call NodeScopeResolver (and TypeSpecifier for that matter) when resolving type of BooleanAnd and others: https://github.com/phpstan/phpstan-src/blob/f1e88529a680470d23bbce177b8a57a1b429421b/src/Analyser/MutatingScope.php#L1069 - so there's definitely multiple invocations of the same code.

The ongoing refactoring aims to change that. I already introduced `ExprHandler` which consolidates code handling from NodeScopeResolver and MutatingScope into a single class for the same expression type. `processExpr` is what originally happened in NodeScopeResolver and `resolveType` is what happened in MutatingScope. But this didn't fundamentally change the code logic and performance.

My idea is to introduce `getType` into `ExpressionResult` - which means that after `NodeScopeResolver::processExprNode` finishes, we don't have just the updated Scope, we also have the Type of the expression. This should reduce the need to call `NodeScopeResolver` when resolving a type, because we already have the right scope to based our type resolution on!

Right now the refactoring **duplicates and transforms the logic from `resolveType`** to be suitably run in `processExpr`, specifically in `typeCallback` constructor parameter of ExpressionResult. This means that calling `$scope->getType($expr)` inside typeCallback is forbidden. Instead, the code should ask `$exprResult->getType()` from previously called `processExprNode`.

In cases where the `$expr` passed into `getType` is synthetic (virtual - is created with `new` in the code, doesn't come from the parsed AST), we need to call `processExprNode` and grab its type from ExpressionResult after.

Thanks to Fibers on PHP 8.1+, the code in `resolveType` is basically dead, `MutatingScope::getType()` should never be called. That's why **I can live with the current duplication**, in PHPStan 3.0 we'll be able to **delete a lot of code**. Currently it means that any changes to type resolution have to be edited twice - in `resolveType` and in `typeCallback`. If we fail to have equivalent logic, tests on PHP 7.4-8.0 or on PHP 8.1+ will fail.

This is starting to get some really nice benefits. Previously, NullsafeShortCircuitingHelper had to be called recursively for every eligible expression, to see if there's `?->` somewhere in the chain that would influence the final result. With the new way, this code only has to happen once, in NullsafePropertyFetchHandler + NullsafeMethodCallHandler.

I imagine this will have other benefits, like no longer needing to unwrap assigns in TypeSpecifier https://github.com/phpstan/phpstan-src/blob/c14518f41ee154d2e6a73a47a6b617404a65d203/src/Analyser/TypeSpecifier.php#L1994-L2001, or bugs regarding to assignments in the middle of expressions (Fibers helped in some cases but not everywhere). One example for all: https://phpstan.org/r/51fc6cea-be4d-47f5-a4b8-e13416fd3f62

In the next steps, I also will move the code from TypeSpecifier to respective ExprHandlers, in a new `specifyTypes` method. And then I will copy and adjust the code in processExpr so that `ExpressionResult` can inform about narrowed types in some form as well. And in PHPStan 3.0. we'll be able to delete all the `specifyTypes` methods as well.

I encourage you to wrap your head around this. I look forward to your feedback!