### PR TITLE
Call operator type specifying extensions for bitwise and arithmetic operators

### DIFF
--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -986,6 +986,12 @@ final class InitializerExprTypeResolver
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
 
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\BitwiseAnd($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
+		}
+
 		return $this->getBitwiseAndTypeFromTypes($leftType, $rightType);
 	}
 
@@ -1044,6 +1050,12 @@ final class InitializerExprTypeResolver
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
 
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\BitwiseOr($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
+		}
+
 		return $this->getBitwiseOrTypeFromTypes($leftType, $rightType);
 	}
 
@@ -1091,6 +1103,12 @@ final class InitializerExprTypeResolver
 	{
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
+
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\BitwiseXor($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
+		}
 
 		return $this->getBitwiseXorTypeFromTypes($leftType, $rightType);
 	}
@@ -2034,6 +2052,12 @@ final class InitializerExprTypeResolver
 	 */
 	private function resolveCommonMath(Expr\BinaryOp $expr, Type $leftType, Type $rightType): Type
 	{
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions($expr, $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
+		}
+
 		$types = TypeCombinator::union($leftType, $rightType);
 		$leftNumberType = $leftType->toNumber();
 		$rightNumberType = $rightType->toNumber();
@@ -2071,12 +2095,6 @@ final class InitializerExprTypeResolver
 
 				return $union->toNumber();
 			}
-		}
-
-		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
-			->callOperatorTypeSpecifyingExtensions($expr, $leftType, $rightType);
-		if ($specifiedTypes !== null) {
-			return $specifiedTypes;
 		}
 
 		if (

--- a/src/Reflection/InitializerExprTypeResolver.php
+++ b/src/Reflection/InitializerExprTypeResolver.php
@@ -1774,6 +1774,12 @@ final class InitializerExprTypeResolver
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
 
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\ShiftLeft($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
+		}
+
 		return $this->getShiftLeftTypeFromTypes($left, $right, $leftType, $rightType);
 	}
 
@@ -1837,6 +1843,12 @@ final class InitializerExprTypeResolver
 	{
 		$leftType = $getTypeCallback($left);
 		$rightType = $getTypeCallback($right);
+
+		$specifiedTypes = $this->operatorTypeSpecifyingExtensionRegistryProvider->getRegistry()
+			->callOperatorTypeSpecifyingExtensions(new BinaryOp\ShiftRight($left, $right), $leftType, $rightType);
+		if ($specifiedTypes !== null) {
+			return $specifiedTypes;
+		}
 
 		return $this->getShiftRightTypeFromTypes($left, $right, $leftType, $rightType);
 	}

--- a/tests/PHPStan/Analyser/OperatorTypeSpecifyingExtensionTypeInferenceTest.php
+++ b/tests/PHPStan/Analyser/OperatorTypeSpecifyingExtensionTypeInferenceTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class OperatorTypeSpecifyingExtensionTypeInferenceTest extends TypeInferenceTestCase
+{
+
+	public static function dataAsserts(): iterable
+	{
+		yield from self::gatherAssertTypes(__DIR__ . '/data/operator-type-specifying-extension.php');
+	}
+
+	/**
+	 * @param mixed ...$args
+	 */
+	#[DataProvider('dataAsserts')]
+	public function testAsserts(
+		string $assertType,
+		string $file,
+		...$args,
+	): void
+	{
+		$this->assertFileAsserts($assertType, $file, ...$args);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/operator-type-specifying-extension.neon',
+		];
+	}
+
+}

--- a/tests/PHPStan/Analyser/data/operator-type-specifying-extension.php
+++ b/tests/PHPStan/Analyser/data/operator-type-specifying-extension.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace OperatorExtensionTest;
+
+use PHPStan\Fixture\TestBitwiseOperand;
+use PHPStan\Fixture\TestDecimal;
+use function PHPStan\Testing\assertType;
+
+// =============================================================================
+// Bitwise operator extension tests
+// =============================================================================
+
+function testBitwiseAnd(TestBitwiseOperand $a, TestBitwiseOperand $b): void
+{
+	assertType('PHPStan\Fixture\TestBitwiseOperand', $a & $b);
+}
+
+function testBitwiseOr(TestBitwiseOperand $a, TestBitwiseOperand $b): void
+{
+	assertType('PHPStan\Fixture\TestBitwiseOperand', $a | $b);
+}
+
+function testBitwiseXor(TestBitwiseOperand $a, TestBitwiseOperand $b): void
+{
+	assertType('PHPStan\Fixture\TestBitwiseOperand', $a ^ $b);
+}
+
+// =============================================================================
+// Arithmetic operator extension tests (via TestDecimal)
+// =============================================================================
+
+function testArithmeticAdd(TestDecimal $a, TestDecimal $b): void
+{
+	assertType('PHPStan\Fixture\TestDecimal', $a + $b);
+}
+
+function testArithmeticSub(TestDecimal $a, TestDecimal $b): void
+{
+	assertType('PHPStan\Fixture\TestDecimal', $a - $b);
+}
+
+function testArithmeticMul(TestDecimal $a, TestDecimal $b): void
+{
+	assertType('PHPStan\Fixture\TestDecimal', $a * $b);
+}
+
+function testArithmeticDiv(TestDecimal $a, TestDecimal $b): void
+{
+	assertType('PHPStan\Fixture\TestDecimal', $a / $b);
+}
+
+function testArithmeticPow(TestDecimal $a, TestDecimal $b): void
+{
+	assertType('PHPStan\Fixture\TestDecimal', $a ** $b);
+}

--- a/tests/PHPStan/Analyser/data/operator-type-specifying-extension.php
+++ b/tests/PHPStan/Analyser/data/operator-type-specifying-extension.php
@@ -25,6 +25,16 @@ function testBitwiseXor(TestBitwiseOperand $a, TestBitwiseOperand $b): void
 	assertType('PHPStan\Fixture\TestBitwiseOperand', $a ^ $b);
 }
 
+function testShiftLeft(TestBitwiseOperand $a, TestBitwiseOperand $b): void
+{
+	assertType('PHPStan\Fixture\TestBitwiseOperand', $a << $b);
+}
+
+function testShiftRight(TestBitwiseOperand $a, TestBitwiseOperand $b): void
+{
+	assertType('PHPStan\Fixture\TestBitwiseOperand', $a >> $b);
+}
+
 // =============================================================================
 // Arithmetic operator extension tests (via TestDecimal)
 // =============================================================================

--- a/tests/PHPStan/Analyser/operator-type-specifying-extension.neon
+++ b/tests/PHPStan/Analyser/operator-type-specifying-extension.neon
@@ -1,0 +1,9 @@
+services:
+	-
+		class: PHPStan\Type\TestBitwiseOperatorTypeSpecifyingExtension
+		tags:
+			- phpstan.broker.operatorTypeSpecifyingExtension
+	-
+		class: PHPStan\Type\TestDecimalOperatorTypeSpecifyingExtension
+		tags:
+			- phpstan.broker.operatorTypeSpecifyingExtension

--- a/tests/PHPStan/Fixture/TestBitwiseOperand.php
+++ b/tests/PHPStan/Fixture/TestBitwiseOperand.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Fixture;
+
+/**
+ * Test fixture for verifying bitwise operator type specifying extensions.
+ */
+final class TestBitwiseOperand
+{
+
+}

--- a/tests/PHPStan/Type/TestBitwiseOperatorTypeSpecifyingExtension.php
+++ b/tests/PHPStan/Type/TestBitwiseOperatorTypeSpecifyingExtension.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type;
+
+use PHPStan\Fixture\TestBitwiseOperand;
+use function in_array;
+
+/**
+ * Test extension for verifying that bitwise operators call type specifying extensions.
+ */
+final class TestBitwiseOperatorTypeSpecifyingExtension implements OperatorTypeSpecifyingExtension
+{
+
+	public function isOperatorSupported(string $operatorSigil, Type $leftSide, Type $rightSide): bool
+	{
+		$testType = new ObjectType(TestBitwiseOperand::class);
+
+		return in_array($operatorSigil, ['&', '|', '^'], true)
+			&& $testType->isSuperTypeOf($leftSide)->yes()
+			&& $testType->isSuperTypeOf($rightSide)->yes();
+	}
+
+	public function specifyType(string $operatorSigil, Type $leftSide, Type $rightSide): Type
+	{
+		return new ObjectType(TestBitwiseOperand::class);
+	}
+
+}

--- a/tests/PHPStan/Type/TestBitwiseOperatorTypeSpecifyingExtension.php
+++ b/tests/PHPStan/Type/TestBitwiseOperatorTypeSpecifyingExtension.php
@@ -15,7 +15,7 @@ final class TestBitwiseOperatorTypeSpecifyingExtension implements OperatorTypeSp
 	{
 		$testType = new ObjectType(TestBitwiseOperand::class);
 
-		return in_array($operatorSigil, ['&', '|', '^'], true)
+		return in_array($operatorSigil, ['&', '|', '^', '<<', '>>'], true)
 			&& $testType->isSuperTypeOf($leftSide)->yes()
 			&& $testType->isSuperTypeOf($rightSide)->yes();
 	}


### PR DESCRIPTION
## Summary

This PR ensures `OperatorTypeSpecifyingExtension` implementations are called consistently for all supported binary operators:

- Add extension calls to `getBitwiseAndType`, `getBitwiseOrType`, `getBitwiseXorType`
- Move extension call to the top of `resolveCommonMath` (before integer range optimization)
- Remove the duplicate extension call that was later in `resolveCommonMath`

This is prerequisite work for phpstan/phpstan#14288 (GMP operator type inference), split out per review feedback on #5223.

## Testing approach

Per @ondrejmirtes' feedback:
> "Please introduce the changes to InitializerExprTypeResolver in a separate PR - this will force you to create synthetic extensions just for test purposes... Without this, if we once removed the GMP extensions then this feature would become untested."

This PR creates **synthetic test extensions** independent of any specific type (like GMP):

1. **`TestBitwiseOperand`** - A dummy fixture class
2. **`TestBitwiseOperatorTypeSpecifyingExtension`** - Returns `TestBitwiseOperand` for `&`, `|`, `^` operators
3. Uses existing **`TestDecimal`** + **`TestDecimalOperatorTypeSpecifyingExtension`** for arithmetic operators

The test verifies the resolver correctly invokes extensions for both bitwise and arithmetic operators. This ensures the resolver infrastructure remains tested even if specific extensions (like a future GMP extension) are removed.

## Test plan

- [x] Added `OperatorTypeSpecifyingExtensionTypeInferenceTest` with 8 assertions
- [x] All existing tests pass (11634 tests, 78899 assertions)

Generated with [Claude Code](https://claude.com/claude-code)