### PR TITLE
Makefile: added phpbench target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tests/tmp
 /tests/.phpunit.result.cache
 /tests/PHPStan/Reflection/data/golden/
+/tests/bench/storage/baseline.xml
 tmp/.memory_limit
 e2e/bashunit
 /.phpbench

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tests/tmp
 /tests/.phpunit.result.cache
 /tests/PHPStan/Reflection/data/golden/
-/tests/bench/storage/baseline.xml
 tmp/.memory_limit
 e2e/bashunit
 /.phpbench
+tests/bench/storage/baseline.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /tests/tmp
 /tests/.phpunit.result.cache
 /tests/PHPStan/Reflection/data/golden/
+/tests/bench/storage/local-baseline.xml
 tmp/.memory_limit
 e2e/bashunit
 /.phpbench
-tests/bench/storage/baseline.xml

--- a/Makefile
+++ b/Makefile
@@ -195,10 +195,10 @@ phpbench:
 	@find tests/bench/storage/local-baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file does not exist or is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
 	composer require --dev phpbench/phpbench:^1.2.15
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=aggregate
-	composer remove --dev phpbench/phpbench --no-interaction
+	composer remove --dev phpbench/phpbench --no-interaction -q
 
 .PHONY: phpbench-baseline
 phpbench-baseline:
 	composer require --dev phpbench/phpbench:^1.2.15
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/local-baseline.xml
-	composer remove --dev phpbench/phpbench --no-interaction
+	composer remove --dev phpbench/phpbench --no-interaction -q

--- a/Makefile
+++ b/Makefile
@@ -192,13 +192,13 @@ infection:
 
 .PHONY: phpbench
 phpbench:
-	@find tests/bench/storage/baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
+	@find tests/bench/storage/local-baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file does not exist or is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
 	composer require --dev phpbench/phpbench:^1.2.15
-	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/baseline.xml --report=aggregate
+	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=aggregate
 	composer remove --dev phpbench/phpbench --no-interaction
 
 .PHONY: phpbench-baseline
 phpbench-baseline:
 	composer require --dev phpbench/phpbench:^1.2.15
-	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/baseline.xml
+	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/local-baseline.xml
 	composer remove --dev phpbench/phpbench --no-interaction

--- a/Makefile
+++ b/Makefile
@@ -195,10 +195,10 @@ phpbench:
 	@find tests/bench/storage/baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
 	composer require --dev phpbench/phpbench:^1.2.15
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/baseline.xml --report=aggregate
-	composer remove phpbench/phpbench --no-interaction
+	composer remove --dev phpbench/phpbench --no-interaction
 
 .PHONY: phpbench-baseline
 phpbench-baseline:
 	composer require --dev phpbench/phpbench:^1.2.15
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/baseline.xml
-	composer remove phpbench/phpbench --no-interaction
+	composer remove --dev phpbench/phpbench --no-interaction

--- a/Makefile
+++ b/Makefile
@@ -193,12 +193,12 @@ infection:
 .PHONY: phpbench
 phpbench:
 	@find tests/bench/storage/local-baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file does not exist or is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
-	composer require --dev phpbench/phpbench:^1.2.15
+	composer require --dev phpbench/phpbench:^1.2.15 -q
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=aggregate
 	composer remove --dev phpbench/phpbench --no-interaction -q
 
 .PHONY: phpbench-baseline
 phpbench-baseline:
-	composer require --dev phpbench/phpbench:^1.2.15
+	composer require --dev phpbench/phpbench:^1.2.15 -q
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/local-baseline.xml
 	composer remove --dev phpbench/phpbench --no-interaction -q

--- a/Makefile
+++ b/Makefile
@@ -189,3 +189,9 @@ infection:
 		--skip-initial-tests \
 		--ignore-msi-with-no-mutations \
 		--logger-text=php://stdout
+
+.PHONY: phpbench
+phpbench:
+	composer require --dev phpbench/phpbench:^1.2.15
+	XDEBUG_MODE=off tests/vendor/bin/phpbench run
+	composer remove phpbench/phpbench

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,13 @@ infection:
 
 .PHONY: phpbench
 phpbench:
+	@find tests/bench/storage/baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
 	composer require --dev phpbench/phpbench:^1.2.15
-	XDEBUG_MODE=off tests/vendor/bin/phpbench run
-	composer remove phpbench/phpbench
+	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/baseline.xml --report=aggregate
+	composer remove phpbench/phpbench --no-interaction
+
+.PHONY: phpbench-baseline
+phpbench-baseline:
+	composer require --dev phpbench/phpbench:^1.2.15
+	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/baseline.xml
+	composer remove phpbench/phpbench --no-interaction


### PR DESCRIPTION
allow running the benchmark locally.

this seems useful, as I recently got 'red' benchmark github action jobs, and want to verify/reproduce locally 

---

adds 2 new makefile targets

`make phpbench-baseline` (re)-generates the baseline
`make phpbench` verifies a recent enough baseline exists and runs the tests, compares them against the baseline

to achieve this we add the phpbench composer dependency at the start and later on remove it again.