### PR TITLE
Simplify PHPBench make-target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,12 +193,8 @@ infection:
 .PHONY: phpbench
 phpbench:
 	@find tests/bench/storage/local-baseline.xml -mtime -60m | grep . || (echo "PHPBench baseline file does not exist or is too old. Regenerate it using 'make phpbench-baseline'." && exit 1)
-	composer require --dev phpbench/phpbench:^1.2.15 -q
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --file=tests/bench/storage/local-baseline.xml --report=aggregate
-	composer remove --dev phpbench/phpbench --no-interaction -q
 
 .PHONY: phpbench-baseline
 phpbench-baseline:
-	composer require --dev phpbench/phpbench:^1.2.15 -q
 	XDEBUG_MODE=off tests/vendor/bin/phpbench run --dump-file=tests/bench/storage/local-baseline.xml
-	composer remove --dev phpbench/phpbench --no-interaction -q


### PR DESCRIPTION
no need to install it.. we have it in `tests/composer.json`