### PR TITLE
phpstan-bot: react only on 'open' pull requests

### DIFF
--- a/.github/workflows/claude-react-on-review.yml
+++ b/.github/workflows/claude-react-on-review.yml
@@ -10,6 +10,7 @@ jobs:
     if: >
       github.event.pull_request.user.login == 'phpstan-bot'
       && github.event.review.user.login != 'phpstan-bot'
+      && github.event.pull_request.state == 'open'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2

--- a/.github/workflows/claude-react-on-review.yml
+++ b/.github/workflows/claude-react-on-review.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.pull_request.user.login == 'phpstan-bot'
-      && github.event.review.user.login != 'phpstan-bot'
       && github.event.pull_request.state == 'open'
+      && github.event.review.user.login != 'phpstan-bot'
+      && github.event.review.state != 'approved'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2


### PR DESCRIPTION
we don't want the bot analyze comments on already closed PRs (and waste tokens/gh-actions resources) or 'approval' reviews

---

taken from https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request

<img width="548" height="146" alt="grafik" src="https://github.com/user-attachments/assets/15554017-4be8-45ca-b0be-d4d3bd4a67d8" />

<img width="890" height="672" alt="grafik" src="https://github.com/user-attachments/assets/0686db16-2c03-4030-abda-e449a5940893" />


