### PR TITLE
Support call_user_func_array

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,7 +13,7 @@ parameters:
 			path: src/Analyser/AnalyserResultFinalizer.php
 
 		-
-			rawMessage: 'PHPDoc tag @var with type int|string is not subtype of type string.'
+			rawMessage: PHPDoc tag @var with type int|string is not subtype of type string.
 			identifier: varTag.type
 			count: 1
 			path: src/Analyser/ArgumentsNormalizer.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,6 +13,12 @@ parameters:
 			path: src/Analyser/AnalyserResultFinalizer.php
 
 		-
+			rawMessage: 'PHPDoc tag @var with type int|string is not subtype of type string.'
+			identifier: varTag.type
+			count: 1
+			path: src/Analyser/ArgumentsNormalizer.php
+
+		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
 			identifier: phpstanApi.instanceofType
 			count: 1

--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -22,7 +22,9 @@ use function array_key_exists;
 use function array_keys;
 use function array_values;
 use function count;
+use function key;
 use function ksort;
+use function is_string;
 use function max;
 use function sprintf;
 
@@ -120,16 +122,17 @@ final class ArgumentsNormalizer
 				}
 			}
 
-			if ($argsArrayArg === null) {
-				if ($arg->name === null && $i === 1) {
-					$argsArrayArg = $arg;
-					continue;
-				}
-				if ($arg->name !== null && $arg->name->toString() === 'args') {
-					$argsArrayArg = $arg;
-					continue;
-				}
+			if ($argsArrayArg !== null) {
+				continue;
 			}
+			if ($arg->name === null && $i === 1) {
+				$argsArrayArg = $arg;
+				continue;
+			}
+			if ($arg->name === null || $arg->name->toString() !== 'args') {
+				continue;
+			}
+			$argsArrayArg = $arg;
 		}
 
 		if ($callbackArg === null || $argsArrayArg === null) {
@@ -149,8 +152,11 @@ final class ArgumentsNormalizer
 		foreach ($argsArrayArg->value->items as $item) {
 			$key = null;
 			if ($item->key instanceof String_) {
-				/** @var int|string $offsetValue */
+				/** @var int|string $key */
 				$key = key([$item->key->value => null]);
+				if ($key === '') {
+					return null;
+				}
 			} elseif ($item->key !== null && !$item->key instanceof Int_) {
 				// Dynamic key, we cannot be sure.
 				return null;
@@ -161,7 +167,7 @@ final class ArgumentsNormalizer
 				$item->byRef,
 				$item->unpack,
 				$item->getAttributes(),
-				\is_string($key) ? new Identifier($key) : null,
+				is_string($key) ? new Identifier($key) : null,
 			);
 		}
 

--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -143,11 +143,6 @@ final class ArgumentsNormalizer
 			return null;
 		}
 
-		$calledOnType = $scope->getType($callbackArg->value);
-		if (!$calledOnType->isCallable()->yes()) {
-			return null;
-		}
-
 		$passThruArgs = [];
 		foreach ($argsArrayArg->value->items as $item) {
 			$key = null;
@@ -169,6 +164,11 @@ final class ArgumentsNormalizer
 				$item->getAttributes(),
 				is_string($key) ? new Identifier($key) : null,
 			);
+		}
+
+		$calledOnType = $scope->getType($callbackArg->value);
+		if (!$calledOnType->isCallable()->yes()) {
+			return null;
 		}
 
 		$callableParametersAcceptors = $calledOnType->getCallableParametersAcceptors($scope);

--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -3,10 +3,14 @@
 namespace PHPStan\Analyser;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Node\Expr\TypeExpr;
 use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
@@ -86,6 +90,98 @@ final class ArgumentsNormalizer
 			$callbackArg->value,
 			$passThruArgs,
 			$callUserFuncCall->getAttributes(),
+		), $acceptsNamedArguments];
+	}
+
+	/**
+	 * @return array{ParametersAcceptor, FuncCall, TrinaryLogic}|null
+	 */
+	public static function reorderCallUserFuncArrayArguments(
+		FuncCall $callUserFuncArrayCall,
+		Scope $scope,
+	): ?array
+	{
+		$args = $callUserFuncArrayCall->getArgs();
+		if (count($args) < 2) {
+			return null;
+		}
+
+		$callbackArg = null;
+		$argsArrayArg = null;
+		foreach ($args as $i => $arg) {
+			if ($callbackArg === null) {
+				if ($arg->name === null && $i === 0) {
+					$callbackArg = $arg;
+					continue;
+				}
+				if ($arg->name !== null && $arg->name->toString() === 'callback') {
+					$callbackArg = $arg;
+					continue;
+				}
+			}
+
+			if ($argsArrayArg === null) {
+				if ($arg->name === null && $i === 1) {
+					$argsArrayArg = $arg;
+					continue;
+				}
+				if ($arg->name !== null && $arg->name->toString() === 'args') {
+					$argsArrayArg = $arg;
+					continue;
+				}
+			}
+		}
+
+		if ($callbackArg === null || $argsArrayArg === null) {
+			return null;
+		}
+
+		if (!$argsArrayArg->value instanceof Array_) {
+			return null;
+		}
+
+		$calledOnType = $scope->getType($callbackArg->value);
+		if (!$calledOnType->isCallable()->yes()) {
+			return null;
+		}
+
+		$passThruArgs = [];
+		foreach ($argsArrayArg->value->items as $item) {
+			$key = null;
+			if ($item->key instanceof String_) {
+				/** @var int|string $offsetValue */
+				$key = key([$item->key->value => null]);
+			} elseif ($item->key !== null && !$item->key instanceof Int_) {
+				// Dynamic key, we cannot be sure.
+				return null;
+			}
+
+			$passThruArgs[] = new Arg(
+				$item->value,
+				$item->byRef,
+				$item->unpack,
+				$item->getAttributes(),
+				\is_string($key) ? new Identifier($key) : null,
+			);
+		}
+
+		$callableParametersAcceptors = $calledOnType->getCallableParametersAcceptors($scope);
+		$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+			$scope,
+			$passThruArgs,
+			$callableParametersAcceptors,
+			null,
+		);
+
+		$acceptsNamedArguments = TrinaryLogic::createYes();
+		foreach ($callableParametersAcceptors as $callableParametersAcceptor) {
+			$acceptsNamedArguments = $acceptsNamedArguments->and($callableParametersAcceptor->acceptsNamedArguments());
+		}
+
+		return [$parametersAcceptor, new FuncCall(
+			$callbackArg->value,
+			$passThruArgs,
+			$callUserFuncArrayCall->getAttributes(),
 		), $acceptsNamedArguments];
 	}
 

--- a/src/Analyser/ArgumentsNormalizer.php
+++ b/src/Analyser/ArgumentsNormalizer.php
@@ -22,9 +22,9 @@ use function array_key_exists;
 use function array_keys;
 use function array_values;
 use function count;
+use function is_string;
 use function key;
 use function ksort;
-use function is_string;
 use function max;
 use function sprintf;
 

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -770,6 +770,15 @@ final class FuncCallHandler implements ExprHandler
 			}
 		}
 
+		if ($functionReflection->getName() === 'call_user_func_array') {
+			$result = ArgumentsNormalizer::reorderCallUserFuncArrayArguments($expr, $scope);
+			if ($result !== null) {
+				[, $innerFuncCall] = $result;
+
+				return $scope->getType($innerFuncCall);
+			}
+		}
+
 		$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
 			$scope,
 			$expr->getArgs(),

--- a/src/Rules/Functions/CallUserFuncRule.php
+++ b/src/Rules/Functions/CallUserFuncRule.php
@@ -11,8 +11,8 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\FunctionCallParametersCheck;
 use PHPStan\Rules\Rule;
 use function count;
-use function ucfirst;
 use function sprintf;
+use function ucfirst;
 
 /**
  * @implements Rule<FuncCall>

--- a/src/Rules/Functions/CallUserFuncRule.php
+++ b/src/Rules/Functions/CallUserFuncRule.php
@@ -12,6 +12,7 @@ use PHPStan\Rules\FunctionCallParametersCheck;
 use PHPStan\Rules\Rule;
 use function count;
 use function ucfirst;
+use function sprintf;
 
 /**
  * @implements Rule<FuncCall>
@@ -47,20 +48,27 @@ final class CallUserFuncRule implements Rule
 		}
 
 		$functionReflection = $this->reflectionProvider->getFunction($node->name, $scope);
-		if ($functionReflection->getName() !== 'call_user_func') {
+
+		$functionName = $functionReflection->getName();
+		if ($functionName === 'call_user_func') {
+			$result = ArgumentsNormalizer::reorderCallUserFuncArguments(
+				$node,
+				$scope,
+			);
+		} elseif ($functionName === 'call_user_func_array') {
+			$result = ArgumentsNormalizer::reorderCallUserFuncArrayArguments(
+				$node,
+				$scope,
+			);
+		} else {
 			return [];
 		}
-
-		$result = ArgumentsNormalizer::reorderCallUserFuncArguments(
-			$node,
-			$scope,
-		);
 		if ($result === null) {
 			return [];
 		}
 		[$parametersAcceptor, $funcCall, $acceptsNamedArguments] = $result;
 
-		$callableDescription = 'callable passed to call_user_func()';
+		$callableDescription = sprintf('callable passed to %s()', $functionName);
 
 		return $this->check->check(
 			$parametersAcceptor,

--- a/tests/PHPStan/Analyser/nsrt/call-user-func-array-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/call-user-func-array-php8.php
@@ -1,0 +1,45 @@
+<?php // lint >= 8.0
+
+namespace CallUserFuncArrayPhp8;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @param T $t
+ * @return T
+ */
+function generic($t) {
+	return $t;
+}
+
+/**
+ * @template T
+ * @param T $t
+ * @return T
+ */
+function generic3($t = '', int $b = 100, string $c = '') {
+	return $t;
+}
+
+
+function fun3($a = '', $b = '', $c = ''): int {
+	return 1;
+}
+
+class Foo {
+	function doNamed() {
+		assertType('1', call_user_func_array('CallUserFuncPhp8\generic', ['t' => 1]));
+		assertType('array{1, 2, 3}', call_user_func_array('CallUserFuncPhp8\generic', ['t' => [1, 2, 3]]));
+
+		assertType('array{1, 2, 3}', call_user_func_array('CallUserFuncPhp8\generic3', ['t' => [1, 2, 3]]));
+		assertType('\'\'', call_user_func_array('CallUserFuncPhp8\generic3', ['b' => 150]));
+		assertType('\'\'', call_user_func_array('CallUserFuncPhp8\generic3', ['c' => 'lala']));
+		assertType('\'\'', call_user_func_array(args: ['c' => 'lala'], callback: 'CallUserFuncPhp8\generic3'));
+
+		assertType('int', call_user_func_array('CallUserFuncPhp8\fun3', ['a' => [1, 2, 3]]));
+		assertType('int', call_user_func_array('CallUserFuncPhp8\fun3', ['b' => [1, 2, 3]]));
+		assertType('int', call_user_func_array('CallUserFuncPhp8\fun3', ['c' => [1, 2, 3]]));
+		assertType('int', call_user_func_array('CallUserFuncPhp8\fun3', ['a' => [1, 2, 3], 'c' => 'c']));
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/call-user-func_array.php
+++ b/tests/PHPStan/Analyser/nsrt/call-user-func_array.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace CallUserFuncArray;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @template T
+ * @param T $t
+ * @return T
+ */
+function generic($t) {
+	return $t;
+}
+
+function fun(): int
+{
+	return 3;
+}
+
+function fun3($i, $x, $y): int
+{
+	return 3;
+}
+
+class c {
+	static function m(): string
+	{
+		return 'hello';
+	}
+}
+
+class Foo {
+	function proxy() {
+		$params = [
+			'CallUserFunc\generic',
+			[123, 456],
+		];
+
+		assertType('mixed', call_user_func_array(...$params));
+	}
+
+	/**
+	 * @param string[] $strings
+	 */
+	function doFunc($strings) {
+		assertType('true', call_user_func_array('CallUserFunc\generic', [true]));
+		assertType('\'hello\'', call_user_func_array('CallUserFunc\generic', ['hello']));
+		assertType('array<string>', call_user_func_array('CallUserFunc\generic', [$strings]));
+
+		assertType('int', call_user_func_array('CallUserFunc\fun', []));
+		assertType('int', call_user_func_array('CallUserFunc\fun3', [1 ,2 ,3]));
+		assertType('string', call_user_func_array(['CallUserFunc\c', 'm'], []));
+	}
+}

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -1128,7 +1128,7 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 				],
 			];
 		}
-		$this->analyse([__DIR__ . '/data/call-user-func-array.php'], $errors);
+		$this->analyse([__DIR__ . '/data/call-user-func-array-named-args.php'], $errors);
 	}
 
 	public function testFirstClassCallables(): void

--- a/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
@@ -74,6 +74,64 @@ class CallUserFuncRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testRuleCallUserFuncArray(): void
+	{
+		$this->analyse([__DIR__ . '/data/call-user-func-array.php'], [
+			[
+				'Callable passed to call_user_func_array() invoked with 0 parameters, 1 required.',
+				15,
+			],
+			[
+				'Parameter #1 $i of callable passed to call_user_func_array() expects int, string given.',
+				17,
+			],
+			[
+				'Parameter $i of callable passed to call_user_func_array() expects int, string given.',
+				18,
+			],
+			[
+				'Parameter $i of callable passed to call_user_func_array() expects int, string given.',
+				19,
+			],
+			[
+				'Unknown parameter $j in call to callable passed to call_user_func_array().',
+				22,
+			],
+			[
+				'Missing parameter $i (int) in call to callable passed to call_user_func_array().',
+				22,
+			],
+			[
+				'Callable passed to call_user_func_array() invoked with 0 parameters, 2-4 required.',
+				30,
+			],
+			[
+				'Callable passed to call_user_func_array() invoked with 1 parameter, 2-4 required.',
+				31,
+			],
+			[
+				'Callable passed to call_user_func_array() invoked with 0 parameters, at least 2 required.',
+				40,
+			],
+			[
+				'Callable passed to call_user_func_array() invoked with 1 parameter, at least 2 required.',
+				41,
+			],
+			[
+				'Result of callable passed to call_user_func_array() (void) is used.',
+				43,
+			],
+			[
+				'Parameter #1 $i of callable passed to call_user_func_array() expects int|null, string given.',
+				52,
+			],
+			[
+				'Parameter #1 $i of callable passed to call_user_func_array() expects int|null, string given.',
+				53,
+			],
+		]);
+	}
+
 	public function testBug7057(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-7057.php'], []);

--- a/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallUserFuncRuleTest.php
@@ -74,6 +74,7 @@ class CallUserFuncRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	public function testRuleCallUserFuncArray(): void
 	{
 		$this->analyse([__DIR__ . '/data/call-user-func-array.php'], [

--- a/tests/PHPStan/Rules/Functions/data/call-user-func-array-named-args.php
+++ b/tests/PHPStan/Rules/Functions/data/call-user-func-array-named-args.php
@@ -1,0 +1,3 @@
+<?php
+
+call_user_func_array('array_merge', ['foo' => ['bar' => 2]]);

--- a/tests/PHPStan/Rules/Functions/data/call-user-func-array.php
+++ b/tests/PHPStan/Rules/Functions/data/call-user-func-array.php
@@ -1,3 +1,58 @@
-<?php
+<?php // lint >= 8.0
 
-call_user_func_array('array_merge', ['foo' => ['bar' => 2]]);
+namespace CallUserFuncRuleArray;
+
+use function call_user_func_array;
+
+class Foo
+{
+
+	public function doFoo(): void
+	{
+		$f = function (int $i): void {
+
+		};
+		call_user_func_array($f, []);
+		call_user_func_array($f, [1]);
+		call_user_func_array($f, ['foo']);
+		call_user_func_array($f, ['i' => 'foo']);
+		call_user_func_array(args: ['i' => 'foo'], callback: $f);
+		call_user_func_array($f, ['i' => 1]);
+		call_user_func_array(args: ['i' => 1], callback: $f);
+		call_user_func_array($f, ['j' => 1]);
+	}
+
+	public function doBar(): void
+	{
+		$f = function (int $i, $j, $g = 2, $h = 3): void {
+		};
+
+		call_user_func_array($f, []);
+		call_user_func_array($f, [1]);
+		call_user_func_array($f, [2, 'foo']);
+	}
+
+	public function doVariadic(): void
+	{
+		$f = function ($i, $j, ...$params): void {
+		};
+
+		call_user_func_array($f, []);
+		call_user_func_array($f, [1]);
+		call_user_func_array($f, [2, 'foo']);
+		$result = call_user_func_array($f, [2, 'foo']);
+	}
+
+	public function doMore(): void
+	{
+		$f = function (?int $i = null, ?string $j = null): void {
+		};
+
+		call_user_func_array($f, []);
+		call_user_func_array($f, [1 => 'foo']); // Same as call_user_func_array($f, ['foo'])
+		call_user_func_array($f, ['1' => 'foo']); // Same as call_user_func_array($f, ['foo'])
+		call_user_func_array($f, [1 => 42]); // Same as call_user_func_array($f, [42])
+		call_user_func_array($f, ['1' => 42]); // Same as call_user_func_array($f, [42])
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/data/call-user-func-array.php
+++ b/tests/PHPStan/Rules/Functions/data/call-user-func-array.php
@@ -53,6 +53,8 @@ class Foo
 		call_user_func_array($f, ['1' => 'foo']); // Same as call_user_func_array($f, ['foo'])
 		call_user_func_array($f, [1 => 42]); // Same as call_user_func_array($f, [42])
 		call_user_func_array($f, ['1' => 42]); // Same as call_user_func_array($f, [42])
+
+		call_user_func_array($f, ['' => 42]); // Could be reported but should at least not crash PHPStan
 	}
 
 }


### PR DESCRIPTION
Extracted from https://github.com/phpstan/phpstan-src/pull/5282

This copy the existing behavior of `call_user_func` but for `call_user_func_array`.

Closes https://github.com/phpstan/phpstan/issues/5942
Closes https://github.com/phpstan/phpstan/issues/5934