### PR TITLE
Fix false positive match.alwaysTrue with consecutive match(true) expressions

### DIFF
--- a/src/Analyser/ExprHandler/MatchHandler.php
+++ b/src/Analyser/ExprHandler/MatchHandler.php
@@ -454,11 +454,18 @@ final class MatchHandler implements ExprHandler
 		}
 
 		if ($isExhaustive) {
+			$preMatchConditionalExpressions = $scope->getConditionalExpressions();
 			$armBodyFinalScope = null;
 			foreach ($armBodyScopes as $armBodyScope) {
 				$armBodyFinalScope = $armBodyScope->mergeWith($armBodyFinalScope);
 			}
-			$scope = $armBodyFinalScope ?? $scope;
+			if ($armBodyFinalScope !== null) {
+				// Prevent conditional expressions created during arm scope merging
+				// from leaking into the post-match scope. These encode relationships
+				// between arm-narrowed types (e.g. "if equals(A) is false, then
+				// equals(B) is true") that should not affect subsequent code.
+				$scope = $armBodyFinalScope->replaceConditionalExpressions($preMatchConditionalExpressions);
+			}
 		} else {
 			$armBodyFinalScope = null;
 			foreach ($armBodyScopes as $armBodyScope) {

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3320,6 +3320,39 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		);
 	}
 
+	/**
+	 * @return array<string, ConditionalExpressionHolder[]>
+	 */
+	public function getConditionalExpressions(): array
+	{
+		return $this->conditionalExpressions;
+	}
+
+	/**
+	 * @param array<string, ConditionalExpressionHolder[]> $conditionalExpressions
+	 */
+	public function replaceConditionalExpressions(array $conditionalExpressions): self
+	{
+		return $this->scopeFactory->create(
+			$this->context,
+			$this->isDeclareStrictTypes(),
+			$this->getFunction(),
+			$this->getNamespace(),
+			$this->expressionTypes,
+			$this->nativeExpressionTypes,
+			$conditionalExpressions,
+			$this->inClosureBindScopeClasses,
+			$this->anonymousFunctionReflection,
+			$this->inFirstLevelStatement,
+			$this->currentlyAssignedExpressions,
+			$this->currentlyAllowedUndefinedExpressions,
+			$this->inFunctionCallsStack,
+			$this->afterExtractCall,
+			$this->parentScope,
+			$this->nativeTypesPromoted,
+		);
+	}
+
 	public function exitFirstLevelStatements(): self
 	{
 		if (!$this->inFirstLevelStatement) {

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -460,6 +460,12 @@ class MatchExpressionRuleTest extends RuleTestCase
 	}
 
 	#[RequiresPhp('>= 8.0')]
+	public function testBug14368(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14368.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0')]
 	public function testBug11310(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-11310.php'], [

--- a/tests/PHPStan/Rules/Comparison/data/bug-14368.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-14368.php
@@ -1,0 +1,54 @@
+<?php // lint >= 8.0
+
+namespace Bug14368;
+
+final class Snowflake
+{
+	public function __construct(
+		private readonly int $value,
+	) {}
+
+	public static function cast(int $snowflake): self
+	{
+		return new self($snowflake);
+	}
+
+	public function equals(?self $other): bool
+	{
+		return $this->value === $other?->value;
+	}
+}
+
+final class BalanceId
+{
+	public static function work(): Snowflake
+	{
+		/** @var Snowflake */
+		static $work = Snowflake::cast(1);
+		return $work;
+	}
+
+	public static function holiday(): Snowflake
+	{
+		/** @var Snowflake */
+		static $holiday = Snowflake::cast(2);
+		return $holiday;
+	}
+}
+
+function test(Snowflake $balanceId): void
+{
+	// First match — no error expected
+	$a = match (true) {
+		$balanceId->equals(BalanceId::work()) => -1.0,
+		$balanceId->equals(BalanceId::holiday()) => 1.0,
+		default => throw new \InvalidArgumentException(),
+	};
+
+	// Second match — should not report match.alwaysTrue
+	$b = match (true) {
+		$balanceId->equals(BalanceId::work()) => -2.0,
+		$balanceId->equals(BalanceId::holiday()) => 2.0,
+		default => throw new \InvalidArgumentException(),
+	};
+}


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/14368

## Summary

- After an exhaustive `match(true)` with a throwing default arm, the post-match scope carried conditional expressions encoding relationships between arm-narrowed types (e.g. "if `equals(A)` is false, then `equals(B)` is true")
- When a subsequent `match(true)` filtered by falsey for the first arm, these conditional expressions activated and incorrectly narrowed the second arm's condition to `true`, causing a false positive `match.alwaysTrue`
- The fix restores the pre-match conditional expressions after the arm body scope merge, preventing match-internal type relationships from leaking into the post-match scope

## Root cause

PR #5066 (fix #9601) changed `MatchHandler` to exclude always-terminating arms (e.g. `default => throw ...`) from the arm body scope merge. This is correct for type resolution, but the `mergeWith` call also creates `conditionalExpressions` that encode relationships between the narrowed types of different arms. These conditional expressions survived into the post-match scope and were activated by subsequent code that narrowed the same expressions.