### PR TITLE
Resolve generic parameter defaults that reference other template parameters

### DIFF
--- a/src/Reflection/ClassReflection.php
+++ b/src/Reflection/ClassReflection.php
@@ -40,6 +40,7 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
@@ -1736,8 +1737,16 @@ final class ClassReflection
 
 		$map = [];
 		$i = 0;
+		$className = $this->getName();
 		foreach ($resolvedPhpDoc->getTemplateTags() as $tag) {
-			$map[$tag->getName()] = $types[$i] ?? $tag->getDefault() ?? $tag->getBound();
+			$type = $types[$i] ?? $tag->getDefault() ?? $tag->getBound();
+			if ($type instanceof TemplateType && $type->getScope()->getClassName() === $className) {
+				$resolved = $map[$type->getName()] ?? null;
+				if ($resolved !== null && !$resolved instanceof TemplateType) {
+					$type = $resolved;
+				}
+			}
+			$map[$tag->getName()] = $type;
 			$i++;
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/template-default-referring-other.php
+++ b/tests/PHPStan/Analyser/nsrt/template-default-referring-other.php
@@ -1,0 +1,117 @@
+<?php // lint >= 8.1
+
+namespace TemplateDefaultReferringOther;
+
+use function PHPStan\Testing\assertType;
+
+class MoneyValue
+{
+
+    public function __construct(
+        public readonly string $currency,
+        public readonly int $cents,
+    )
+    {
+    }
+
+}
+
+/**
+ * @template-contravariant DI
+ * @template-contravariant EI
+ * @template-covariant DO of EI = EI
+ * @template-covariant EO of DI = DI
+ */
+interface Codec
+{
+
+    /**
+     * @param DI $data
+     * @return DO
+     */
+    public function decode(mixed $data): mixed;
+
+    /**
+     * @param EI $data
+     * @return EO
+     */
+    public function encode(mixed $data): mixed;
+
+}
+
+/**
+ * @implements Codec<
+ *   array{currency: string, cents: int},
+ *   MoneyValue,
+ * >
+ */
+class MoneyCodec implements Codec
+{
+
+    public function decode(mixed $data): MoneyValue
+    {
+        return new MoneyValue($data['currency'], $data['cents']);
+    }
+
+    public function encode(mixed $data): array
+    {
+        return [
+            'currency' => $data->currency,
+            'cents' => $data->cents,
+        ];
+    }
+
+}
+
+/**
+ * @implements Codec<
+ *   string,
+ *   \DateTimeInterface,
+ *   \DateTimeImmutable,
+ *   string,
+ * >
+ */
+class DateTimeInterfaceCodec implements Codec
+{
+
+    public function decode(mixed $data): \DateTimeImmutable
+    {
+       return new \DateTimeImmutable($data);
+    }
+
+    public function encode(mixed $data): string
+    {
+        return $data->format('c');
+    }
+
+}
+
+/**
+ * @param Codec<array{currency: string, cents: int}, MoneyValue> $moneyCodec
+ * @param Codec<string, \DateTimeInterface, \DateTimeImmutable, string> $dtCodec
+ */
+function test(
+    Codec $moneyCodec,
+    Codec $dtCodec,
+    string $dtString,
+    \DateTimeInterface $dtInterface,
+): void
+{
+    assertType('TemplateDefaultReferringOther\MoneyValue', $moneyCodec->decode(['currency' => 'CZK', 'cents' => 123]));
+    assertType('array{currency: string, cents: int}', $moneyCodec->encode(new MoneyValue('CZK', 100)));
+
+    assertType('DateTimeImmutable', $dtCodec->decode($dtString));
+    assertType('string', $dtCodec->encode($dtInterface));
+}
+
+function testMoneyCodecDirect(MoneyCodec $codec): void
+{
+    assertType('TemplateDefaultReferringOther\MoneyValue', $codec->decode(['currency' => 'CZK', 'cents' => 123]));
+    assertType('array{currency: string, cents: int}', $codec->encode(new MoneyValue('CZK', 100)));
+}
+
+function testDateTimeCodecDirect(DateTimeInterfaceCodec $codec): void
+{
+    assertType('DateTimeImmutable', $codec->decode('2024-01-01'));
+    assertType('string', $codec->encode(new \DateTimeImmutable()));
+}


### PR DESCRIPTION
## Summary

When a template parameter has a default referencing another template parameter (e.g. `@template DO of EI = EI`), the default was left as an unresolved TemplateType instead of being substituted with the concrete type.

### Root cause

`TemplateTypeHelper::resolveTemplateTypes` returns resolved values (`$newType`) without re-invoking the callback. When the standins map has `DO → TemplateType(EI)` and `EI → MoneyValue`, resolving `DO` yields `TemplateType(EI)` — but that is never resolved further to `MoneyValue`. This is because TypeTraverser's `$traverse` traverses **inner types** (bound, default) but does not re-invoke the callback on the type itself, so `$traverse($newType)` wouldn't help either.

### Fix

Single-point fix in `ClassReflection::typeMapFromList` — the gateway where all type arguments enter the standins map (active template type map). After building the map, any entry that is a TemplateType referencing another entry in the same class scope is resolved to that entry's concrete type.

**Why `typeMapFromList` and not elsewhere:**
- It's the **single point** through which all standins flow (via `GenericObjectType::getClassReflection()` → `withTypes()`)
- No changes needed in `TypeNodeResolver`, `resolveTemplateTypes`, or `FileTypeMapper`
- Minimal, 8-line change — just a map lookup, no TypeTraverser needed
- No risk to existing `resolveTemplateTypes` behavior

### Example

```php
/**
 * @template-contravariant DI
 * @template-contravariant EI
 * @template-covariant DO of EI = EI
 * @template-covariant EO of DI = DI
 */
interface Codec {
    /** @param DI $data @return DO */
    public function decode(mixed $data): mixed;
    /** @param EI $data @return EO */
    public function encode(mixed $data): mixed;
}

/** @param Codec<array{currency: string, cents: int}, MoneyValue> $codec */
function test(Codec $codec): void {
    $codec->decode([...]); // Before: EI (unresolved), After: MoneyValue
    $codec->encode(new MoneyValue(...)); // Before: DI (unresolved), After: array{currency: string, cents: int}
}
```

## Test plan

- [x] New test `tests/PHPStan/Analyser/nsrt/template-default-referring-other.php` passes
- [x] All existing `template-default` tests pass
- [x] Full NodeScopeResolverTest (1480 tests) — no regressions
- [x] Rules tests (2917 tests) — no regressions
- [x] Generics rules tests (41 tests) — all pass

Co-Authored-By: Claude Code