### PR TITLE
Fix sealed class-string match exhaustiveness for ::class comparisons

### DIFF
--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -219,6 +219,18 @@ class GenericClassStringType extends ClassStringType
 					if ($classReflection->isFinal() && $genericObjectClassNames[0] === $typeToRemove->getValue()) {
 						return new NeverType();
 					}
+
+					if ($classReflection->getAllowedSubTypes() !== null) {
+						$objectTypeToRemove = new ObjectType($typeToRemove->getValue());
+						$remainingType = TypeCombinator::remove($generic, $objectTypeToRemove);
+						if ($remainingType instanceof NeverType) {
+							return new NeverType();
+						}
+
+						if (!$remainingType->equals($generic)) {
+							return new self($remainingType);
+						}
+					}
 				}
 			} elseif (count($genericObjectClassNames) > 1) {
 				$objectTypeToRemove = new ObjectType($typeToRemove->getValue());

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -448,6 +448,12 @@ class MatchExpressionRuleTest extends RuleTestCase
 	}
 
 	#[RequiresPhp('>= 8.0')]
+	public function testBug12241(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-12241.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0')]
 	public function testBug13029(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-13029.php'], []);

--- a/tests/PHPStan/Rules/Comparison/data/bug-12241.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-12241.php
@@ -1,0 +1,20 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug12241;
+
+/**
+ * @phpstan-sealed Bar|Baz
+ */
+abstract class Foo{}
+
+final class Bar extends Foo{}
+final class Baz extends Foo{}
+
+function (Foo $foo): string {
+	return match ($foo::class) {
+		Bar::class => 'Bar',
+		Baz::class => 'Baz',
+	};
+};


### PR DESCRIPTION
### Summary

`match($foo::class)` on a `@phpstan-sealed` hierarchy falsely reported "Match expression does not handle remaining value" even when all allowed subtypes were covered.

Closes phpstan/phpstan#12241

### Root Cause

`GenericClassStringType::tryRemove()` only handled final classes — it had no awareness of `@phpstan-sealed` hierarchies. Removing a class-string constant for a non-final sealed subtype was a no-op, so the type was never fully exhausted to `never`.

### Fix

Extended `GenericClassStringType::tryRemove()` to check `ClassReflection::getAllowedSubTypes()` and delegate to `TypeCombinator::remove()`, which already handles sealed subtraction via `ObjectType::changeSubtractedType()`.

### Test Plan

- `MatchExpressionRuleTest::testBug12241` — exhaustive match on sealed hierarchy produces no error
- All existing tests pass — no regressions