### PR TITLE
Reduce false positives about constant conditions in traits

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -268,6 +268,12 @@ jobs:
               composer install
               ../../bin/phpstan
           - script: |
+              cd e2e/in-trait
+              OUTPUT=$(../bashunit -a exit_code "1" "../../bin/phpstan --error-format=raw")
+              ../bashunit -a contains 'FooTrait.php:10:Strict comparison using === between int<0, max> and false will always evaluate to false.' "$OUTPUT"
+              ../bashunit -a contains 'FooTrait.php (in context of class E2EInTrait\Bar):18:Strict comparison using === between E2EInTrait\Bar and null will always evaluate to false.' "$OUTPUT"
+              ../bashunit -a contains 'FooTrait.php (in context of class E2EInTrait\Foo):18:Strict comparison using === between E2EInTrait\Foo and null will always evaluate to false.' "$OUTPUT"
+          - script: |
               cd e2e/result-cache-meta-extension
               composer install
               ../../bin/phpstan -vvv

--- a/build/baseline-8.0.neon
+++ b/build/baseline-8.0.neon
@@ -13,19 +13,7 @@ parameters:
 			path: ../src/Type/ClosureTypeFactory.php
 
 		-
-			message: '#^Strict comparison using \=\=\= between list\<non\-falsy\-string\> and false will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: ../src/Type/Php/MbFunctionsReturnTypeExtension.php
-
-		-
 			message: '#^Strict comparison using \=\=\= between int\<0, max\> and false will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: ../src/Type/Php/MbStrlenFunctionReturnTypeExtension.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between list\<non\-falsy\-string\> and false will always evaluate to false\.$#'
 			identifier: identical.alwaysFalse
 			count: 1
 			path: ../src/Type/Php/MbStrlenFunctionReturnTypeExtension.php

--- a/e2e/in-trait/phpstan.neon
+++ b/e2e/in-trait/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+	level: 8
+	paths:
+		- src

--- a/e2e/in-trait/src/Bar.php
+++ b/e2e/in-trait/src/Bar.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace E2EInTrait;
+
+class Bar
+{
+
+	use FooTrait;
+
+	public function getSth(): ?self
+	{
+		return rand(0, 1) ? $this : null;
+	}
+
+	public function getSth2(): self
+	{
+		return $this;
+	}
+
+}

--- a/e2e/in-trait/src/Foo.php
+++ b/e2e/in-trait/src/Foo.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace E2EInTrait;
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function getSth(): self
+	{
+		return $this;
+	}
+
+	public function getSth2(): self
+	{
+		return $this;
+	}
+
+}

--- a/e2e/in-trait/src/FooTrait.php
+++ b/e2e/in-trait/src/FooTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace E2EInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo(int $i): void
+	{
+		if (abs($i) === false) {
+
+		}
+
+		if ($this->getSth() === null) {
+
+		}
+
+		if ($this->getSth2() === null) {
+
+		}
+	}
+
+}

--- a/src/Analyser/Error.php
+++ b/src/Analyser/Error.php
@@ -106,6 +106,28 @@ final class Error implements JsonSerializable
 		);
 	}
 
+	public function removeTraitContext(): self
+	{
+		if ($this->traitFilePath === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		return new self(
+			$this->message,
+			$this->traitFilePath,
+			$this->line,
+			$this->canBeIgnored,
+			$this->filePath,
+			null,
+			$this->tip,
+			$this->nodeLine,
+			$this->nodeType,
+			$this->identifier,
+			$this->metadata,
+			$this->fixedErrorDiff,
+		);
+	}
+
 	public function getTraitFilePath(): ?string
 	{
 		return $this->traitFilePath;

--- a/src/Analyser/RuleErrorTransformer.php
+++ b/src/Analyser/RuleErrorTransformer.php
@@ -22,6 +22,7 @@ use PHPStan\Rules\LineRuleError;
 use PHPStan\Rules\MetadataRuleError;
 use PHPStan\Rules\NonIgnorableRuleError;
 use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrors\TransformedRuleError;
 use PHPStan\Rules\TipRuleError;
 use PHPStan\ShouldNotHappenException;
 use SebastianBergmann\Diff\Differ;
@@ -55,6 +56,10 @@ final class RuleErrorTransformer
 		Node $node,
 	): Error
 	{
+		if ($ruleError instanceof TransformedRuleError) {
+			return $ruleError->getError();
+		}
+
 		$line = $node->getStartLine();
 		$canBeIgnored = true;
 		$fileName = $scope->getFileDescription();

--- a/src/Rules/Classes/ImpossibleInstanceOfRule.php
+++ b/src/Rules/Classes/ImpossibleInstanceOfRule.php
@@ -3,10 +3,14 @@
 namespace PHPStan\Rules\Classes;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Parser\LastConditionVisitor;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
+use PHPStan\Rules\Comparison\PossiblyImpureTipHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
@@ -29,6 +33,8 @@ final class ImpossibleInstanceOfRule implements Rule
 
 	public function __construct(
 		private RuleLevelHelper $ruleLevelHelper,
+		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -44,7 +50,7 @@ final class ImpossibleInstanceOfRule implements Rule
 		return Node\Expr\Instanceof_::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if ($node->class instanceof Node\Name) {
 			$className = $scope->resolveName($node->class);
@@ -74,40 +80,48 @@ final class ImpossibleInstanceOfRule implements Rule
 
 		$instanceofType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node) : $scope->getNativeType($node);
 		if (!$instanceofType instanceof ConstantBooleanType) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
 		$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
 			if (!$this->treatPhpDocTypesAsCertain) {
-				return $ruleErrorBuilder;
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
 
 			$instanceofTypeWithoutPhpDocs = $scope->getNativeType($node);
 			if ($instanceofTypeWithoutPhpDocs instanceof ConstantBooleanType) {
-				return $ruleErrorBuilder;
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
 
 			if (!$this->treatPhpDocTypesAsCertainTip) {
-				return $ruleErrorBuilder;
+				return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 			}
 
-			return $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
+			$ruleErrorBuilder = $ruleErrorBuilder->treatPhpDocTypesAsCertainTip();
+
+			return $this->possiblyImpureTipHelper->addTip($scope, $node, $ruleErrorBuilder);
 		};
 
 		if (!$instanceofType->getValue()) {
 			$exprType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node->expr) : $scope->getNativeType($node->expr);
 
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Instanceof between %s and %s will always evaluate to false.',
-					$exprType->describe(VerbosityLevel::typeOnly()),
-					$classType->describe(VerbosityLevel::getRecommendedLevelByType($classType)),
-				)))->identifier('instanceof.alwaysFalse')->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Instanceof between %s and %s will always evaluate to false.',
+				$exprType->describe(VerbosityLevel::typeOnly()),
+				$classType->describe(VerbosityLevel::getRecommendedLevelByType($classType)),
+			)))->identifier('instanceof.alwaysFalse')->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
 		$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
 		if ($isLast === true && !$this->reportAlwaysTrueInLastCondition) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -123,7 +137,13 @@ final class ImpossibleInstanceOfRule implements Rule
 
 		$errorBuilder->identifier('instanceof.alwaysTrue');
 
-		return [$errorBuilder->build()];
+		$ruleError = $errorBuilder->build();
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, true, $ruleError);
+			return [];
+		}
+
+		return [$ruleError];
 	}
 
 }

--- a/src/Rules/Comparison/BooleanAndConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanAndConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -24,6 +26,7 @@ final class BooleanAndConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -41,7 +44,7 @@ final class BooleanAndConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$errors = [];
@@ -49,6 +52,8 @@ final class BooleanAndConstantConditionRule implements Rule
 		$nodeText = $originalNode->getOperatorSigil();
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$identifierType = $originalNode instanceof Node\Expr\BinaryOp\BooleanAnd ? 'booleanAnd' : 'logicalAnd';
+		$isInTrait = $scope->isInTrait();
+		$hasLeftOrRightError = false;
 		if ($leftType instanceof ConstantBooleanType) {
 			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
@@ -80,8 +85,18 @@ final class BooleanAndConstantConditionRule implements Rule
 				if ($leftType->getValue() && $isLast === false && !$this->reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
-				$errors[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				$hasLeftOrRightError = true;
+				if ($isInTrait) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->left, $leftType->getValue(), $ruleError);
+				} else {
+					$errors[] = $ruleError;
+				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
 			}
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
 		}
 
 		$rightScope = $node->getRightScope();
@@ -123,11 +138,21 @@ final class BooleanAndConstantConditionRule implements Rule
 				if ($rightType->getValue() && $isLast === false && !$this->reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
-				$errors[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				$hasLeftOrRightError = true;
+				if ($isInTrait) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->right, $rightType->getValue(), $ruleError);
+				} else {
+					$errors[] = $ruleError;
+				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
 			}
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
 		}
 
-		if (count($errors) === 0 && !$scope->isInFirstLevelStatement()) {
+		if (count($errors) === 0 && !$hasLeftOrRightError && !$scope->isInFirstLevelStatement()) {
 			$nodeType = $this->treatPhpDocTypesAsCertain ? $scope->getType($originalNode) : $scope->getNativeType($originalNode);
 			if ($nodeType instanceof ConstantBooleanType) {
 				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
@@ -161,8 +186,17 @@ final class BooleanAndConstantConditionRule implements Rule
 
 					$errorBuilder->identifier(sprintf('%s.always%s', $identifierType, $nodeType->getValue() ? 'True' : 'False'));
 
-					$errors[] = $errorBuilder->build();
+					$ruleError = $errorBuilder->build();
+					if ($isInTrait) {
+						$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode, $nodeType->getValue(), $ruleError);
+					} else {
+						$errors[] = $ruleError;
+					}
+				} else {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode);
 				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode);
 			}
 		}
 

--- a/src/Rules/Comparison/BooleanNotConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanNotConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -22,6 +24,7 @@ final class BooleanNotConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -39,7 +42,7 @@ final class BooleanNotConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->expr);
@@ -74,12 +77,17 @@ final class BooleanNotConstantConditionRule implements Rule
 
 				$errorBuilder->identifier(sprintf('booleanNot.always%s', $exprType->getValue() ? 'False' : 'True'));
 
-				return [
-					$errorBuilder->build(),
-				];
+				$ruleError = $errorBuilder->build();
+				if ($scope->isInTrait()) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->expr, !$exprType->getValue(), $ruleError);
+					return [];
+				}
+
+				return [$ruleError];
 			}
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->expr);
 		return [];
 	}
 

--- a/src/Rules/Comparison/BooleanOrConstantConditionRule.php
+++ b/src/Rules/Comparison/BooleanOrConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -24,6 +26,7 @@ final class BooleanOrConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -41,7 +44,7 @@ final class BooleanOrConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$originalNode = $node->getOriginalNode();
@@ -49,6 +52,8 @@ final class BooleanOrConstantConditionRule implements Rule
 		$messages = [];
 		$leftType = $this->helper->getBooleanType($scope, $originalNode->left);
 		$identifierType = $originalNode instanceof Node\Expr\BinaryOp\BooleanOr ? 'booleanOr' : 'logicalOr';
+		$isInTrait = $scope->isInTrait();
+		$hasLeftOrRightError = false;
 		if ($leftType instanceof ConstantBooleanType) {
 			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
 				if (!$this->treatPhpDocTypesAsCertain) {
@@ -80,8 +85,18 @@ final class BooleanOrConstantConditionRule implements Rule
 				if ($leftType->getValue() && $isLast === false && !$this->reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
-				$messages[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				$hasLeftOrRightError = true;
+				if ($isInTrait) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->left, $leftType->getValue(), $ruleError);
+				} else {
+					$messages[] = $ruleError;
+				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
 			}
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->left);
 		}
 
 		$rightScope = $node->getRightScope();
@@ -123,11 +138,21 @@ final class BooleanOrConstantConditionRule implements Rule
 				if ($rightType->getValue() && $isLast === false && !$this->reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
-				$messages[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				$hasLeftOrRightError = true;
+				if ($isInTrait) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->right, $rightType->getValue(), $ruleError);
+				} else {
+					$messages[] = $ruleError;
+				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
 			}
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->right);
 		}
 
-		if (count($messages) === 0 && !$scope->isInFirstLevelStatement()) {
+		if (count($messages) === 0 && !$hasLeftOrRightError && !$scope->isInFirstLevelStatement()) {
 			$nodeType = $this->treatPhpDocTypesAsCertain ? $scope->getType($originalNode) : $scope->getNativeType($originalNode);
 			if ($nodeType instanceof ConstantBooleanType) {
 				$addTip = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $originalNode): RuleErrorBuilder {
@@ -161,8 +186,17 @@ final class BooleanOrConstantConditionRule implements Rule
 
 					$errorBuilder->identifier(sprintf('%s.always%s', $identifierType, $nodeType->getValue() ? 'True' : 'False'));
 
-					$messages[] = $errorBuilder->build();
+					$ruleError = $errorBuilder->build();
+					if ($isInTrait) {
+						$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode, $nodeType->getValue(), $ruleError);
+					} else {
+						$messages[] = $ruleError;
+					}
+				} else {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode);
 				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode);
 			}
 		}
 

--- a/src/Rules/Comparison/ConstantConditionInTraitCollector.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitCollector.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * @implements Collector<never, array{class-string<Rule<covariant Node>>, trait-string, string, null}|array{class-string<Rule<covariant Node>>, trait-string, string, bool, Error|array<mixed>}>
+ */
+final class ConstantConditionInTraitCollector implements Collector
+{
+
+	public function getNodeType(): string
+	{
+		throw new ShouldNotHappenException();
+	}
+
+	public function processNode(Node $node, Scope $scope)
+	{
+		throw new ShouldNotHappenException();
+	}
+
+}

--- a/src/Rules/Comparison/ConstantConditionInTraitHelper.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitHelper.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
+use PHPStan\Analyser\RuleErrorTransformer;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Node\Printer\ExprPrinter;
+use PHPStan\Rules\FixableNodeRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\ShouldNotHappenException;
+use function sprintf;
+
+#[AutowiredService]
+final class ConstantConditionInTraitHelper
+{
+
+	public function __construct(
+		private ExprPrinter $exprPrinter,
+		private RuleErrorTransformer $ruleErrorTransformer,
+	)
+	{
+	}
+
+	/**
+	 * @param class-string<Rule<covariant Node>> $ruleName
+	 */
+	public function emitNoError(
+		string $ruleName,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $expr,
+	): void
+	{
+		if (!$scope->isInTrait()) {
+			return;
+		}
+
+		$exprString = sprintf('%s:%d', $this->exprPrinter->printExpr($expr), $expr->getStartLine());
+		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
+			$ruleName,
+			$scope->getTraitReflection()->getName(),
+			$exprString,
+			null,
+		]);
+	}
+
+	/**
+	 * @param class-string<Rule<covariant Node>> $ruleName
+	 */
+	public function emitError(
+		string $ruleName,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
+		Expr $expr,
+		bool $value,
+		RuleError $ruleError,
+	): void
+	{
+		if ($ruleError instanceof FixableNodeRuleError) {
+			throw new ShouldNotHappenException('Fixable errors are not supported by ConstantConditionInTraitHelper.');
+		}
+
+		if (!$scope->isInTrait()) {
+			return;
+		}
+
+		$exprString = sprintf('%s:%d', $this->exprPrinter->printExpr($expr), $expr->getStartLine());
+		$scope->emitCollectedData(ConstantConditionInTraitCollector::class, [
+			$ruleName,
+			$scope->getTraitReflection()->getName(),
+			$exprString,
+			$value,
+			$this->ruleErrorTransformer->transform($ruleError, $scope, [], $expr),
+		]);
+	}
+
+}

--- a/src/Rules/Comparison/ConstantConditionInTraitRule.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitRule.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Comparison;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\RegisteredRule;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrors\TransformedRuleError;
+use function array_values;
+use function count;
+use function is_array;
+use function var_export;
+
+/**
+ * @implements Rule<CollectedDataNode>
+ */
+#[RegisteredRule(level: 0)]
+final class ConstantConditionInTraitRule implements Rule
+{
+
+	public function getNodeType(): string
+	{
+		return CollectedDataNode::class;
+	}
+
+	public function processNode(Node $node, Scope $scope): array
+	{
+		$errorsByRuleTraitExprValue = [];
+		foreach ($node->get(ConstantConditionInTraitCollector::class) as $fileData) {
+			foreach ($fileData as $data) {
+				$ruleName = $data[0];
+				$traitName = $data[1];
+				$exprString = $data[2];
+				$value = $data[3];
+				$valueKey = var_export($value, true);
+				if ($data[3] === null) {
+					$errorsByRuleTraitExprValue[$ruleName][$traitName][$exprString][$valueKey][] = null;
+					// no error reported
+					continue;
+				}
+
+				$error = $data[4];
+				$errorsByRuleTraitExprValue[$ruleName][$traitName][$exprString][$valueKey][] = $error;
+			}
+		}
+
+		$transformedErrors = [];
+		foreach ($errorsByRuleTraitExprValue as $ruleData) {
+			foreach ($ruleData as $traitData) {
+				foreach ($traitData as $valueData) {
+					if (count($valueData) > 1) {
+						continue;
+					}
+
+					$uniquedErrors = [];
+					foreach ($valueData as $errors) {
+						foreach ($errors as $errorObject) {
+							if ($errorObject === null) {
+								continue;
+							}
+							if (is_array($errorObject)) {
+								$errorObject = Error::decode($errorObject);
+							}
+
+							$message = $errorObject->getMessage();
+							$uniquedErrors[$message] = $errorObject;
+						}
+					}
+
+					$uniquedErrors = array_values($uniquedErrors);
+					if (count($uniquedErrors) === 0) {
+						continue;
+					}
+
+					if (count($uniquedErrors) === 1) {
+						// report directly in trait, no "in context of"
+						$transformedErrors[] = new TransformedRuleError($uniquedErrors[0]);
+						continue;
+					}
+
+					// report each error in its context
+					foreach ($uniquedErrors as $uniquedError) {
+						$transformedErrors[] = new TransformedRuleError($uniquedError);
+					}
+				}
+			}
+		}
+
+		return $transformedErrors;
+	}
+
+}

--- a/src/Rules/Comparison/ConstantConditionInTraitRule.php
+++ b/src/Rules/Comparison/ConstantConditionInTraitRule.php
@@ -77,7 +77,7 @@ final class ConstantConditionInTraitRule implements Rule
 
 					if (count($uniquedErrors) === 1) {
 						// report directly in trait, no "in context of"
-						$transformedErrors[] = new TransformedRuleError($uniquedErrors[0]);
+						$transformedErrors[] = new TransformedRuleError($uniquedErrors[0]->removeTraitContext());
 						continue;
 					}
 

--- a/src/Rules/Comparison/ConstantLooseComparisonRule.php
+++ b/src/Rules/Comparison/ConstantLooseComparisonRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -21,6 +23,7 @@ final class ConstantLooseComparisonRule implements Rule
 
 	public function __construct(
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -36,7 +39,7 @@ final class ConstantLooseComparisonRule implements Rule
 		return Node\Expr\BinaryOp::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if (!$node instanceof Node\Expr\BinaryOp\Equal && !$node instanceof Node\Expr\BinaryOp\NotEqual) {
 			return [];
@@ -44,6 +47,7 @@ final class ConstantLooseComparisonRule implements Rule
 
 		$nodeType = $this->treatPhpDocTypesAsCertain ? $scope->getType($node) : $scope->getNativeType($node);
 		if (!$nodeType->isTrue()->yes() && !$nodeType->isFalse()->yes()) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -66,18 +70,23 @@ final class ConstantLooseComparisonRule implements Rule
 		};
 
 		if ($nodeType->isFalse()->yes()) {
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Loose comparison using %s between %s and %s will always evaluate to false.',
-					$node->getOperatorSigil(),
-					$scope->getType($node->left)->describe(VerbosityLevel::value()),
-					$scope->getType($node->right)->describe(VerbosityLevel::value()),
-				)))->identifier(sprintf('%s.alwaysFalse', $node instanceof Node\Expr\BinaryOp\Equal ? 'equal' : 'notEqual'))->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Loose comparison using %s between %s and %s will always evaluate to false.',
+				$node->getOperatorSigil(),
+				$scope->getType($node->left)->describe(VerbosityLevel::value()),
+				$scope->getType($node->right)->describe(VerbosityLevel::value()),
+			)))->identifier(sprintf('%s.alwaysFalse', $node instanceof Node\Expr\BinaryOp\Equal ? 'equal' : 'notEqual'))->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
 		$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
 		if ($isLast === true && !$this->reportAlwaysTrueInLastCondition) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -93,7 +102,13 @@ final class ConstantLooseComparisonRule implements Rule
 
 		$errorBuilder->identifier(sprintf('%s.alwaysTrue', $node instanceof Node\Expr\BinaryOp\Equal ? 'equal' : 'notEqual'));
 
-		return [$errorBuilder->build()];
+		$ruleError = $errorBuilder->build();
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, true, $ruleError);
+			return [];
+		}
+
+		return [$ruleError];
 	}
 
 }

--- a/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
+++ b/src/Rules/Comparison/DoWhileLoopConstantConditionRule.php
@@ -6,6 +6,8 @@ use PhpParser\Node;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Continue_;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -25,6 +27,7 @@ final class DoWhileLoopConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -38,23 +41,26 @@ final class DoWhileLoopConstantConditionRule implements Rule
 		return DoWhileLoopConditionNode::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->getCond());
 		if ($exprType instanceof ConstantBooleanType) {
 			if ($exprType->getValue()) {
 				if ($node->hasYield()) {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
 					return [];
 				}
 				foreach ($node->getExitPoints() as $exitPoint) {
 					$statement = $exitPoint->getStatement();
 					if (!$statement instanceof Continue_) {
+						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
 						return [];
 					}
 					if (!$statement->num instanceof Int_) {
 						continue;
 					}
 					if ($statement->num->value > 1) {
+						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
 						return [];
 					}
 				}
@@ -62,6 +68,7 @@ final class DoWhileLoopConstantConditionRule implements Rule
 				foreach ($node->getExitPoints() as $exitPoint) {
 					$statement = $exitPoint->getStatement();
 					if ($statement instanceof Break_) {
+						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
 						return [];
 					}
 				}
@@ -85,17 +92,22 @@ final class DoWhileLoopConstantConditionRule implements Rule
 				return $this->possiblyImpureTipHelper->addTip($scope, $node->getCond(), $ruleErrorBuilder);
 			};
 
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Do-while loop condition is always %s.',
-					$exprType->getValue() ? 'true' : 'false',
-				)))
-					->line($node->getCond()->getStartLine())
-					->identifier(sprintf('doWhile.always%s', $exprType->getValue() ? 'True' : 'False'))
-					->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Do-while loop condition is always %s.',
+				$exprType->getValue() ? 'true' : 'false',
+			)))
+				->line($node->getCond()->getStartLine())
+				->identifier(sprintf('doWhile.always%s', $exprType->getValue() ? 'True' : 'False'))
+				->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->getCond(), $exprType->getValue(), $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->getCond());
 		return [];
 	}
 

--- a/src/Rules/Comparison/ElseIfConstantConditionRule.php
+++ b/src/Rules/Comparison/ElseIfConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -22,6 +24,7 @@ final class ElseIfConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -39,7 +42,7 @@ final class ElseIfConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->cond);
@@ -75,10 +78,17 @@ final class ElseIfConstantConditionRule implements Rule
 
 				$errorBuilder->identifier(sprintf('elseif.always%s', $exprType->getValue() ? 'True' : 'False'));
 
-				return [$errorBuilder->build()];
+				$ruleError = $errorBuilder->build();
+				if ($scope->isInTrait()) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
+					return [];
+				}
+
+				return [$ruleError];
 			}
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
 		return [];
 	}
 

--- a/src/Rules/Comparison/IfConstantConditionRule.php
+++ b/src/Rules/Comparison/IfConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -21,6 +23,7 @@ final class IfConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -36,7 +39,7 @@ final class IfConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->cond);
@@ -59,16 +62,21 @@ final class IfConstantConditionRule implements Rule
 				return $this->possiblyImpureTipHelper->addTip($scope, $node->cond, $ruleErrorBuilder);
 			};
 
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'If condition is always %s.',
-					$exprType->getValue() ? 'true' : 'false',
-				)))
-					->identifier(sprintf('if.always%s', $exprType->getValue() ? 'True' : 'False'))
-					->line($node->cond->getStartLine())->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'If condition is always %s.',
+				$exprType->getValue() ? 'true' : 'false',
+			)))
+				->identifier(sprintf('if.always%s', $exprType->getValue() ? 'True' : 'False'))
+				->line($node->cond->getStartLine())->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
 		return [];
 	}
 

--- a/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeFunctionCallRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -21,6 +23,7 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 	public function __construct(
 		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -36,7 +39,7 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		return Node\Expr\FuncCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if (!$node->name instanceof Node\Name) {
 			return [];
@@ -45,6 +48,7 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		$functionName = (string) $node->name;
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
 		if ($isAlways === null) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -67,17 +71,22 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 		};
 
 		if (!$isAlways) {
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Call to function %s()%s will always evaluate to false.',
-					$functionName,
-					$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-				)))->identifier('function.impossibleType')->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Call to function %s()%s will always evaluate to false.',
+				$functionName,
+				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
+			)))->identifier('function.impossibleType')->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
 		$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
 		if ($isLast === true && !$this->reportAlwaysTrueInLastCondition) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -92,7 +101,13 @@ final class ImpossibleCheckTypeFunctionCallRule implements Rule
 
 		$errorBuilder->identifier('function.alreadyNarrowedType');
 
-		return [$errorBuilder->build()];
+		$ruleError = $errorBuilder->build();
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, true, $ruleError);
+			return [];
+		}
+
+		return [$ruleError];
 	}
 
 }

--- a/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeMethodCallRule.php
@@ -4,6 +4,8 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -24,6 +26,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 	public function __construct(
 		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -39,7 +42,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 		return Node\Expr\MethodCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if (!$node->name instanceof Node\Identifier) {
 			return [];
@@ -47,6 +50,7 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
 		if ($isAlways === null) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -70,18 +74,23 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 
 		if (!$isAlways) {
 			$method = $this->getMethod($node->var, $node->name->name, $scope);
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Call to method %s::%s()%s will always evaluate to false.',
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-				)))->identifier('method.impossibleType')->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Call to method %s::%s()%s will always evaluate to false.',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName(),
+				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
+			)))->identifier('method.impossibleType')->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
 		$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
 		if ($isLast === true && !$this->reportAlwaysTrueInLastCondition) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -98,7 +107,13 @@ final class ImpossibleCheckTypeMethodCallRule implements Rule
 
 		$errorBuilder->identifier('method.alreadyNarrowedType');
 
-		return [$errorBuilder->build()];
+		$ruleError = $errorBuilder->build();
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, true, $ruleError);
+			return [];
+		}
+
+		return [$ruleError];
 	}
 
 	private function getMethod(

--- a/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
+++ b/src/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRule.php
@@ -4,6 +4,8 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -24,6 +26,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 	public function __construct(
 		private ImpossibleCheckTypeHelper $impossibleCheckTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -39,7 +42,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		return Node\Expr\StaticCall::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if (!$node->name instanceof Node\Identifier) {
 			return [];
@@ -47,6 +50,7 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 
 		$isAlways = $this->impossibleCheckTypeHelper->findSpecifiedType($scope, $node);
 		if ($isAlways === null) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -71,18 +75,23 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 		if (!$isAlways) {
 			$method = $this->getMethod($node->class, $node->name->name, $scope);
 
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Call to static method %s::%s()%s will always evaluate to false.',
-					$method->getDeclaringClass()->getDisplayName(),
-					$method->getName(),
-					$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
-				)))->identifier('staticMethod.impossibleType')->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Call to static method %s::%s()%s will always evaluate to false.',
+				$method->getDeclaringClass()->getDisplayName(),
+				$method->getName(),
+				$this->impossibleCheckTypeHelper->getArgumentsDescription($scope, $node->getArgs()),
+			)))->identifier('staticMethod.impossibleType')->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
 		$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
 		if ($isLast === true && !$this->reportAlwaysTrueInLastCondition) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -99,7 +108,13 @@ final class ImpossibleCheckTypeStaticMethodCallRule implements Rule
 
 		$errorBuilder->identifier('staticMethod.alreadyNarrowedType');
 
-		return [$errorBuilder->build()];
+		$ruleError = $errorBuilder->build();
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, true, $ruleError);
+			return [];
+		}
+
+		return [$ruleError];
 	}
 
 	/**

--- a/src/Rules/Comparison/LogicalXorConstantConditionRule.php
+++ b/src/Rules/Comparison/LogicalXorConstantConditionRule.php
@@ -4,6 +4,8 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\LogicalXor;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -23,6 +25,7 @@ final class LogicalXorConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -38,9 +41,10 @@ final class LogicalXorConstantConditionRule implements Rule
 		return LogicalXor::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		$errors = [];
+		$isInTrait = $scope->isInTrait();
 		$leftType = $this->helper->getBooleanType($scope, $node->left);
 		if ($leftType instanceof ConstantBooleanType) {
 			$addTipLeft = function (RuleErrorBuilder $ruleErrorBuilder) use ($scope, $node): RuleErrorBuilder {
@@ -72,8 +76,17 @@ final class LogicalXorConstantConditionRule implements Rule
 				if ($leftType->getValue() && $isLast === false && !$this->reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
-				$errors[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				if ($isInTrait) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->left, $leftType->getValue(), $ruleError);
+				} else {
+					$errors[] = $ruleError;
+				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->left);
 			}
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->left);
 		}
 
 		$rightType = $this->helper->getBooleanType($scope, $node->right);
@@ -110,8 +123,17 @@ final class LogicalXorConstantConditionRule implements Rule
 				if ($rightType->getValue() && $isLast === false && !$this->reportAlwaysTrueInLastCondition) {
 					$errorBuilder->tip('Remove remaining cases below this one and this error will disappear too.');
 				}
-				$errors[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				if ($isInTrait) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->right, $rightType->getValue(), $ruleError);
+				} else {
+					$errors[] = $ruleError;
+				}
+			} else {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->right);
 			}
+		} else {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->right);
 		}
 
 		return $errors;

--- a/src/Rules/Comparison/MatchExpressionRule.php
+++ b/src/Rules/Comparison/MatchExpressionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -31,6 +33,7 @@ final class MatchExpressionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $constantConditionRuleHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 	)
@@ -42,7 +45,7 @@ final class MatchExpressionRule implements Rule
 		return MatchExpressionNode::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		$matchCondition = $node->getCondition();
 		$matchConditionType = $scope->getType($matchCondition);
@@ -71,6 +74,7 @@ final class MatchExpressionRule implements Rule
 
 				$armConditionResult = $armConditionScope->getType($armConditionExpr);
 				if (!$armConditionResult instanceof ConstantBooleanType) {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
 					continue;
 				}
 				if ($armConditionResult->getValue()) {
@@ -80,6 +84,7 @@ final class MatchExpressionRule implements Rule
 				if (!$this->treatPhpDocTypesAsCertain) {
 					$armConditionNativeResult = $armConditionScope->getNativeType($armConditionExpr);
 					if (!$armConditionNativeResult instanceof ConstantBooleanType) {
+						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
 						continue;
 					}
 					if ($armConditionNativeResult->getValue()) {
@@ -90,6 +95,7 @@ final class MatchExpressionRule implements Rule
 				if ($matchConditionType instanceof ConstantBooleanType) {
 					$armConditionStandaloneResult = $this->constantConditionRuleHelper->getBooleanType($armConditionScope, $armCondition->getCondition());
 					if (!$armConditionStandaloneResult instanceof ConstantBooleanType) {
+						$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
 						continue;
 					}
 				}
@@ -102,11 +108,17 @@ final class MatchExpressionRule implements Rule
 						$armConditionScope->getType($armCondition->getCondition())->describe(VerbosityLevel::value()),
 					))->line($armLine)->identifier('match.alwaysFalse');
 					$this->possiblyImpureTipHelper->addTip($armConditionScope, $armConditionExpr, $errorBuilder);
-					$errors[] = $errorBuilder->build();
+					$ruleError = $errorBuilder->build();
+					if ($scope->isInTrait()) {
+						$this->constantConditionInTraitHelper->emitError(self::class, $scope, $armConditionExpr, false, $ruleError);
+					} else {
+						$errors[] = $ruleError;
+					}
 					continue;
 				}
 
 				if ($i === $armsCount - 1) {
+					$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $armConditionExpr);
 					continue;
 				}
 
@@ -120,7 +132,12 @@ final class MatchExpressionRule implements Rule
 					->identifier('match.alwaysTrue')
 					->tip('Remove remaining cases below this one and this error will disappear too.');
 				$this->possiblyImpureTipHelper->addTip($armConditionScope, $armConditionExpr, $errorBuilder);
-				$errors[] = $errorBuilder->build();
+				$ruleError = $errorBuilder->build();
+				if ($scope->isInTrait()) {
+					$this->constantConditionInTraitHelper->emitError(self::class, $scope, $armConditionExpr, true, $ruleError);
+				} else {
+					$errors[] = $ruleError;
+				}
 			}
 		}
 

--- a/src/Rules/Comparison/NumberComparisonOperatorsConstantConditionRule.php
+++ b/src/Rules/Comparison/NumberComparisonOperatorsConstantConditionRule.php
@@ -4,6 +4,8 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -24,6 +26,7 @@ final class NumberComparisonOperatorsConstantConditionRule implements Rule
 
 	public function __construct(
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -39,7 +42,7 @@ final class NumberComparisonOperatorsConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		if (
@@ -88,17 +91,22 @@ final class NumberComparisonOperatorsConstantConditionRule implements Rule
 					throw new ShouldNotHappenException();
 			}
 
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Comparison operation "%s" between %s and %s is always %s.',
-					$node->getOperatorSigil(),
-					$scope->getType($node->left)->describe(VerbosityLevel::value()),
-					$scope->getType($node->right)->describe(VerbosityLevel::value()),
-					$exprType->getValue() ? 'true' : 'false',
-				)))->identifier(sprintf('%s.always%s', $nodeType, $exprType->getValue() ? 'True' : 'False'))->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Comparison operation "%s" between %s and %s is always %s.',
+				$node->getOperatorSigil(),
+				$scope->getType($node->left)->describe(VerbosityLevel::value()),
+				$scope->getType($node->right)->describe(VerbosityLevel::value()),
+				$exprType->getValue() ? 'true' : 'false',
+			)))->identifier(sprintf('%s.always%s', $nodeType, $exprType->getValue() ? 'True' : 'False'))->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, $exprType->getValue(), $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 		return [];
 	}
 

--- a/src/Rules/Comparison/StrictComparisonOfDifferentTypesRule.php
+++ b/src/Rules/Comparison/StrictComparisonOfDifferentTypesRule.php
@@ -3,7 +3,9 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
 use PHPStan\Analyser\MutatingScope;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\RicherScopeGetTypeHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
@@ -28,6 +30,7 @@ final class StrictComparisonOfDifferentTypesRule implements Rule
 	public function __construct(
 		private RicherScopeGetTypeHelper $richerScopeGetTypeHelper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter]
@@ -43,7 +46,7 @@ final class StrictComparisonOfDifferentTypesRule implements Rule
 		return Node\Expr\BinaryOp::class;
 	}
 
-	public function processNode(Node $node, Scope $scope): array
+	public function processNode(Node $node, Scope&NodeCallbackInvoker&CollectedDataEmitter $scope): array
 	{
 		if (!$scope instanceof MutatingScope) {
 			throw new ShouldNotHappenException();
@@ -59,6 +62,7 @@ final class StrictComparisonOfDifferentTypesRule implements Rule
 
 		$nodeType = $nodeTypeResult->type;
 		if (!$nodeType instanceof ConstantBooleanType) {
+			$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
 			return [];
 		}
 
@@ -116,18 +120,26 @@ final class StrictComparisonOfDifferentTypesRule implements Rule
 		}
 
 		if (!$nodeType->getValue()) {
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Strict comparison using %s between %s and %s will always evaluate to false.',
-					$node->getOperatorSigil(),
-					$leftType->describe($verbosity),
-					$rightType->describe($verbosity),
-				)))->identifier(sprintf('%s.alwaysFalse', $node instanceof Node\Expr\BinaryOp\Identical ? 'identical' : 'notIdentical'))->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Strict comparison using %s between %s and %s will always evaluate to false.',
+				$node->getOperatorSigil(),
+				$leftType->describe($verbosity),
+				$rightType->describe($verbosity),
+			)))->identifier(sprintf('%s.alwaysFalse', $node instanceof Node\Expr\BinaryOp\Identical ? 'identical' : 'notIdentical'))->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
 		$isLast = $node->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME);
 		if ($isLast === true && !$this->reportAlwaysTrueInLastCondition) {
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node);
+				return [];
+			}
 			return [];
 		}
 
@@ -150,10 +162,13 @@ final class StrictComparisonOfDifferentTypesRule implements Rule
 		}
 
 		$errorBuilder->identifier(sprintf('%s.alwaysTrue', $node instanceof Node\Expr\BinaryOp\Identical ? 'identical' : 'notIdentical'));
+		$ruleError = $errorBuilder->build();
+		if ($scope->isInTrait()) {
+			$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node, true, $ruleError);
+			return [];
+		}
 
-		return [
-			$errorBuilder->build(),
-		];
+		return [$ruleError];
 	}
 
 }

--- a/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
+++ b/src/Rules/Comparison/TernaryOperatorConstantConditionRule.php
@@ -3,6 +3,8 @@
 namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -21,6 +23,7 @@ final class TernaryOperatorConstantConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -36,7 +39,7 @@ final class TernaryOperatorConstantConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->cond);
@@ -58,14 +61,19 @@ final class TernaryOperatorConstantConditionRule implements Rule
 
 				return $this->possiblyImpureTipHelper->addTip($scope, $node->cond, $ruleErrorBuilder);
 			};
-			return [
-				$addTip(RuleErrorBuilder::message(sprintf(
-					'Ternary operator condition is always %s.',
-					$exprType->getValue() ? 'true' : 'false',
-				)))->identifier(sprintf('ternary.always%s', $exprType->getValue() ? 'True' : 'False'))->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message(sprintf(
+				'Ternary operator condition is always %s.',
+				$exprType->getValue() ? 'true' : 'false',
+			)))->identifier(sprintf('ternary.always%s', $exprType->getValue() ? 'True' : 'False'))->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, $exprType->getValue(), $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
 		return [];
 	}
 

--- a/src/Rules/Comparison/WhileLoopAlwaysFalseConditionRule.php
+++ b/src/Rules/Comparison/WhileLoopAlwaysFalseConditionRule.php
@@ -4,6 +4,8 @@ namespace PHPStan\Rules\Comparison;
 
 use PhpParser\Node;
 use PhpParser\Node\Stmt\While_;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -21,6 +23,7 @@ final class WhileLoopAlwaysFalseConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -36,7 +39,7 @@ final class WhileLoopAlwaysFalseConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		$exprType = $this->helper->getBooleanType($scope, $node->cond);
@@ -59,13 +62,18 @@ final class WhileLoopAlwaysFalseConditionRule implements Rule
 				return $this->possiblyImpureTipHelper->addTip($scope, $node->cond, $ruleErrorBuilder);
 			};
 
-			return [
-				$addTip(RuleErrorBuilder::message('While loop condition is always false.'))->line($node->cond->getStartLine())
-					->identifier('while.alwaysFalse')
-					->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message('While loop condition is always false.'))->line($node->cond->getStartLine())
+				->identifier('while.alwaysFalse')
+				->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $node->cond, false, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $node->cond);
 		return [];
 	}
 

--- a/src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
+++ b/src/Rules/Comparison/WhileLoopAlwaysTrueConditionRule.php
@@ -6,6 +6,8 @@ use PhpParser\Node;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Continue_;
+use PHPStan\Analyser\CollectedDataEmitter;
+use PHPStan\Analyser\NodeCallbackInvoker;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredParameter;
 use PHPStan\DependencyInjection\RegisteredRule;
@@ -25,6 +27,7 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 	public function __construct(
 		private ConstantConditionRuleHelper $helper,
 		private PossiblyImpureTipHelper $possiblyImpureTipHelper,
+		private ConstantConditionInTraitHelper $constantConditionInTraitHelper,
 		#[AutowiredParameter]
 		private bool $treatPhpDocTypesAsCertain,
 		#[AutowiredParameter(ref: '%tips.treatPhpDocTypesAsCertain%')]
@@ -40,7 +43,7 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 
 	public function processNode(
 		Node $node,
-		Scope $scope,
+		Scope&NodeCallbackInvoker&CollectedDataEmitter $scope,
 	): array
 	{
 		foreach ($node->getExitPoints() as $exitPoint) {
@@ -70,12 +73,14 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 		$exprType = $this->helper->getBooleanType($scope, $originalNode->cond);
 		if ($exprType->isTrue()->yes()) {
 			if ($node->hasYield()) {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
 				return [];
 			}
 
 			$ref = $scope->getFunction() ?? $scope->getAnonymousFunctionReflection();
 
 			if ($ref !== null && $ref->getReturnType() instanceof NeverType) {
+				$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
 				return [];
 			}
 
@@ -97,13 +102,18 @@ final class WhileLoopAlwaysTrueConditionRule implements Rule
 				return $this->possiblyImpureTipHelper->addTip($scope, $originalNode->cond, $ruleErrorBuilder);
 			};
 
-			return [
-				$addTip(RuleErrorBuilder::message('While loop condition is always true.'))->line($originalNode->cond->getStartLine())
-					->identifier('while.alwaysTrue')
-					->build(),
-			];
+			$ruleError = $addTip(RuleErrorBuilder::message('While loop condition is always true.'))->line($originalNode->cond->getStartLine())
+				->identifier('while.alwaysTrue')
+				->build();
+			if ($scope->isInTrait()) {
+				$this->constantConditionInTraitHelper->emitError(self::class, $scope, $originalNode->cond, true, $ruleError);
+				return [];
+			}
+
+			return [$ruleError];
 		}
 
+		$this->constantConditionInTraitHelper->emitNoError(self::class, $scope, $originalNode->cond);
 		return [];
 	}
 

--- a/src/Rules/RuleErrors/TransformedRuleError.php
+++ b/src/Rules/RuleErrors/TransformedRuleError.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\RuleErrors;
+
+use PHPStan\Analyser\Error;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * @internal Use PHPStan\Rules\RuleErrorBuilder instead.
+ */
+final class TransformedRuleError implements IdentifierRuleError
+{
+
+	public function __construct(private Error $error)
+	{
+	}
+
+	public function getError(): Error
+	{
+		return $this->error;
+	}
+
+	public function getIdentifier(): string
+	{
+		$identifier = $this->error->getIdentifier();
+		if ($identifier === null) {
+			throw new ShouldNotHappenException();
+		}
+
+		return $identifier;
+	}
+
+	public function getMessage(): string
+	{
+		return $this->error->getMessage();
+	}
+
+}

--- a/src/Type/Generic/TemplateTypeTrait.php
+++ b/src/Type/Generic/TemplateTypeTrait.php
@@ -132,7 +132,7 @@ trait TemplateTypeTrait
 	public function getTypeWithoutSubtractedType(): Type
 	{
 		$bound = $this->getBound();
-		if (!$bound instanceof SubtractableType) { // @phpstan-ignore instanceof.alwaysTrue
+		if (!$bound instanceof SubtractableType) {
 			return $this;
 		}
 
@@ -149,7 +149,7 @@ trait TemplateTypeTrait
 	public function changeSubtractedType(?Type $subtractedType): Type
 	{
 		$bound = $this->getBound();
-		if (!$bound instanceof SubtractableType) { // @phpstan-ignore instanceof.alwaysTrue
+		if (!$bound instanceof SubtractableType) {
 			return $this;
 		}
 
@@ -166,7 +166,7 @@ trait TemplateTypeTrait
 	public function getSubtractedType(): ?Type
 	{
 		$bound = $this->getBound();
-		if (!$bound instanceof SubtractableType) { // @phpstan-ignore instanceof.alwaysTrue
+		if (!$bound instanceof SubtractableType) {
 			return null;
 		}
 

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -2,8 +2,12 @@
 
 namespace PHPStan\Rules\Classes;
 
+use PHPStan\Rules\Comparison\ConstantConditionInTraitHelper;
+use PHPStan\Rules\Comparison\ConstantConditionInTraitRule;
+use PHPStan\Rules\Comparison\PossiblyImpureTipHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -11,7 +15,7 @@ use function sprintf;
 use const PHP_VERSION_ID;
 
 /**
- * @extends RuleTestCase<ImpossibleInstanceOfRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class ImpossibleInstanceOfRuleTest extends RuleTestCase
 {
@@ -33,12 +37,18 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 			discoveringSymbolsTip: true,
 		);
 
-		return new ImpossibleInstanceOfRule(
-			$ruleLevelHelper,
-			treatPhpDocTypesAsCertain: $this->treatPhpDocTypesAsCertain,
-			reportAlwaysTrueInLastCondition: $this->reportAlwaysTrueInLastCondition,
-			treatPhpDocTypesAsCertainTip: true,
-		);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new ImpossibleInstanceOfRule(
+				$ruleLevelHelper,
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				treatPhpDocTypesAsCertain: $this->treatPhpDocTypesAsCertain,
+				reportAlwaysTrueInLastCondition: $this->reportAlwaysTrueInLastCondition,
+				treatPhpDocTypesAsCertainTip: true,
+			),
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -600,6 +610,44 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([$file], []);
+	}
+
+	public function testPossiblyImpureTip(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$learnMore = ' Learn more: <fg=cyan>https://phpstan.org/blog/remembering-and-forgetting-returned-values</>';
+		$this->analyse([__DIR__ . '/data/possibly-impure-instanceof-tip.php'], [
+			// maybe-impure: tip expected
+			[
+				'Instanceof between PossiblyImpureInstanceofTip\Cat and PossiblyImpureInstanceofTip\Cat will always evaluate to true.',
+				41,
+				'If PossiblyImpureInstanceofTip\Holder::maybeImpureMethod() is impure, add <fg=cyan>@phpstan-impure</> PHPDoc tag above its declaration.' . $learnMore,
+			],
+			// pure: no tip, error explained by type
+			[
+				'Instanceof between PossiblyImpureInstanceofTip\Cat and PossiblyImpureInstanceofTip\Cat will always evaluate to true.',
+				53,
+			],
+			// impure: no error - $holder invalidated
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';
+		$this->analyse([__DIR__ . '/data/impossible-instanceof-in-trait.php'], [
+			[
+				'Instanceof between ImpossibleInstanceofInTrait\Cat and stdClass will always evaluate to false.',
+				25,
+				$tipText,
+			],
+			[
+				'Instanceof between ImpossibleInstanceofInTrait\Dog and stdClass will always evaluate to false.',
+				25,
+				$tipText,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -536,6 +536,12 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug12267(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-12267.php'], []);
+	}
+
 	#[RequiresPhp('>= 8.0')]
 	public function testNewIsAlwaysFinalClass(): void
 	{

--- a/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/ImpossibleInstanceOfRuleTest.php
@@ -546,6 +546,12 @@ class ImpossibleInstanceOfRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug10353(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-10353.php'], []);
+	}
+
 	public function testBug12267(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Classes/data/bug-10353.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-10353.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10353;
+
+trait Foo
+{
+	public function test(): string
+	{
+		if ($this instanceof HelloWorld) {
+			return 'hello world';
+		}
+		if ($this instanceof OtherClass) {
+			return 'other class';
+		}
+		throw new \Error();
+	}
+}
+
+class HelloWorld
+{
+	use Foo;
+
+	function bar(): string
+	{
+		return $this->test();
+	}
+}
+
+class OtherClass
+{
+	use Foo;
+
+	function bar(): string
+	{
+		return $this->test();
+	}
+}

--- a/tests/PHPStan/Rules/Classes/data/bug-12267.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-12267.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bug12267b;
+
+abstract class Model
+{
+}
+
+class A11yAudit extends Model
+{
+}
+
+class A11yPhase extends Model
+{
+}
+
+/**
+ * @template TModel of ?Model
+ */
+class Form
+{
+	/** @var TModel */
+	protected $model;
+}
+
+trait ContainsA11yPhaseResultFields
+{
+	/** @return list<string> */
+	protected function getFileExistsHelpBlock(string $field): array
+	{
+		if (!($this->model instanceof A11yPhase)) {
+			return [];
+		}
+
+		return [];
+	}
+}
+
+/**
+ * @extends Form<A11yPhase>
+ */
+class EditA11yPhaseForm extends Form
+{
+	use ContainsA11yPhaseResultFields;
+}
+
+/**
+ * @extends Form<null>
+ */
+class SubmitA11yAuditPhaseForm extends Form
+{
+	use ContainsA11yPhaseResultFields;
+}

--- a/tests/PHPStan/Rules/Classes/data/impossible-instanceof-in-trait.php
+++ b/tests/PHPStan/Rules/Classes/data/impossible-instanceof-in-trait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ImpossibleInstanceofInTrait;
+
+class Dog {}
+class Cat {}
+
+trait FooTrait
+{
+
+	/** @var Dog|Cat */
+	protected $animal;
+
+	public function doFoo(): void
+	{
+		// sometimes true, sometimes false
+		if ($this->animal instanceof Dog) {
+
+		}
+	}
+
+	public function doFoo2(): void
+	{
+		// always false
+		if ($this->animal instanceof \stdClass) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	/** @use FooTrait */
+	use FooTrait;
+
+	/** @var Dog */
+	protected $animal;
+
+}
+
+class FooAnother
+{
+
+	/** @use FooTrait */
+	use FooTrait;
+
+	/** @var Cat */
+	protected $animal;
+
+}

--- a/tests/PHPStan/Rules/Classes/data/possibly-impure-instanceof-tip.php
+++ b/tests/PHPStan/Rules/Classes/data/possibly-impure-instanceof-tip.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace PossiblyImpureInstanceofTip;
+
+class Dog {}
+class Cat extends Dog {}
+
+class Holder
+{
+	/** @phpstan-pure */
+	public function getAnimal(): Dog
+	{
+		return new Dog();
+	}
+
+	public function maybeImpureMethod(): int
+	{
+		return rand(1, 100);
+	}
+
+	/** @phpstan-pure */
+	public function pureMethod(): int
+	{
+		return 42;
+	}
+
+	/** @phpstan-impure */
+	public function impureMethod(): int
+	{
+		echo 'hello';
+		return rand(1, 100);
+	}
+}
+
+function testMaybeImpure(Holder $holder): void
+{
+	if ($holder->getAnimal() instanceof Cat) {
+		$holder->maybeImpureMethod();
+
+		// tip expected: maybeImpureMethod() might have changed the object
+		if ($holder->getAnimal() instanceof Cat) {
+			return;
+		}
+	}
+}
+
+function testPure(Holder $holder): void
+{
+	if ($holder->getAnimal() instanceof Cat) {
+		$holder->pureMethod();
+
+		// no tip - pureMethod() cannot change anything
+		if ($holder->getAnimal() instanceof Cat) {
+			return;
+		}
+	}
+}
+
+function testImpure(Holder $holder): void
+{
+	if ($holder->getAnimal() instanceof Cat) {
+		$holder->impureMethod();
+
+		// no error - $holder invalidated by impure call
+		if ($holder->getAnimal() instanceof Cat) {
+			return;
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanAndConstantConditionRuleTest.php
@@ -3,11 +3,12 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @extends RuleTestCase<BooleanAndConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class BooleanAndConstantConditionRuleTest extends RuleTestCase
 {
@@ -18,21 +19,26 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new BooleanAndConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new BooleanAndConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -444,6 +450,18 @@ class BooleanAndConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-8555.php'], []);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->reportAlwaysTrueInLastCondition = true;
+		$this->analyse([__DIR__ . '/data/boolean-and-in-trait.php'], [
+			[
+				'Left side of && is always true.',
+				19,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
@@ -236,6 +236,12 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-5984.php'], []);
 	}
 
+	public function testBug12267(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-12267.php'], []);
+	}
+
 	public function testBug6702(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanNotConstantConditionRuleTest.php
@@ -3,11 +3,12 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * @extends RuleTestCase<BooleanNotConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class BooleanNotConstantConditionRuleTest extends RuleTestCase
 {
@@ -18,21 +19,26 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new BooleanNotConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new BooleanNotConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -234,6 +240,17 @@ class BooleanNotConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-6702.php'], []);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/boolean-not-in-trait.php'], [
+			[
+				'Negated boolean expression is always false.',
+				19,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/BooleanOrConstantConditionRuleTest.php
@@ -3,12 +3,13 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<BooleanOrConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class BooleanOrConstantConditionRuleTest extends RuleTestCase
 {
@@ -19,21 +20,26 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new BooleanOrConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new BooleanOrConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -380,6 +386,18 @@ class BooleanOrConstantConditionRuleTest extends RuleTestCase
 			[
 				'Result of || is always true.',
 				10,
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->reportAlwaysTrueInLastCondition = true;
+		$this->analyse([__DIR__ . '/data/boolean-or-in-trait.php'], [
+			[
+				'Left side of || is always true.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ConstantLooseComparisonRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ConstantLooseComparisonRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -10,7 +11,7 @@ use function array_merge;
 use const PHP_VERSION_ID;
 
 /**
- * @extends RuleTestCase<ConstantLooseComparisonRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class ConstantLooseComparisonRuleTest extends RuleTestCase
 {
@@ -21,12 +22,17 @@ class ConstantLooseComparisonRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ConstantLooseComparisonRule(
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new ConstantLooseComparisonRule(
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -246,6 +252,17 @@ class ConstantLooseComparisonRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-13098.php'], []);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/loose-comparison-in-trait.php'], [
+			[
+				'Loose comparison using == between 1 and null will always evaluate to false.',
+				19,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -3,30 +3,36 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends RuleTestCase<DoWhileLoopConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule
 	{
-		return new DoWhileLoopConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new DoWhileLoopConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->shouldTreatPhpDocTypesAsCertain(),
+					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->shouldTreatPhpDocTypesAsCertain(),
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testBug6189(): void
@@ -72,6 +78,16 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 			[
 				'Do-while loop condition is always false.',
 				152,
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/do-while-in-trait.php'], [
+			[
+				'Do-while loop condition is always false.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/DoWhileLoopConstantConditionRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<CompositeRule>
@@ -82,6 +83,7 @@ class DoWhileLoopConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.2')]
 	public function testInTrait(): void
 	{
 		$this->analyse([__DIR__ . '/data/do-while-in-trait.php'], [

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -3,12 +3,13 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<ElseIfConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class ElseIfConstantConditionRuleTest extends RuleTestCase
 {
@@ -19,21 +20,26 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ElseIfConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new ElseIfConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -148,6 +154,17 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 				'Elseif condition is always false.',
 				13,
 				"• Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.\n• If Bug6947\HelloWorld::getValue() is impure, add <fg=cyan>@phpstan-impure</> PHPDoc tag above its declaration. Learn more: <fg=cyan>https://phpstan.org/blog/remembering-and-forgetting-returned-values</>",
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/elseif-condition-in-trait.php'], [
+			[
+				'Elseif condition is always false.',
+				23,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ElseIfConstantConditionRuleTest.php
@@ -158,6 +158,7 @@ class ElseIfConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.2')]
 	public function testInTrait(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/IfConstantConditionRuleTest.php
@@ -3,11 +3,12 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<IfConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class IfConstantConditionRuleTest extends RuleTestCase
 {
@@ -16,20 +17,25 @@ class IfConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new IfConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new IfConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -209,6 +215,17 @@ class IfConstantConditionRuleTest extends RuleTestCase
 				'If condition is always true.',
 				25,
 				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/if-condition-in-trait.php'], [
+			[
+				'If condition is always true.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1147,6 +1147,50 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13628.php'], []);
 	}
 
+	public function testBug13023(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-13023.php'], []);
+	}
+
+	public function testBug9095(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-9095.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.1')]
+	public function testBug7599(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-7599.php'], []);
+	}
+
+	public function testBug13474(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-13474.php'], []);
+	}
+
+	public function testBug13687(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-13687.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.1')]
+	public function testBug12798(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-12798.php'], []);
+	}
+
+	public function testBug4570(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-4570.php'], []);
+	}
+
 	public function testBug9666(): void
 	{
 		$tipText = 'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.';

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1166,6 +1166,7 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7599.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	public function testBug13474(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -13,7 +14,7 @@ use function array_values;
 use function count;
 
 /**
- * @extends RuleTestCase<ImpossibleCheckTypeFunctionCallRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 {
@@ -24,18 +25,23 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ImpossibleCheckTypeFunctionCallRule(
-			new ImpossibleCheckTypeHelper(
-				self::createReflectionProvider(),
-				$this->getTypeSpecifier(),
-				[stdClass::class],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new ImpossibleCheckTypeFunctionCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					[stdClass::class],
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -1203,6 +1209,17 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 				'Call to function in_array() with arguments \'c\', list<\'a\'|\'b\'> and true will always evaluate to false.',
 				24,
 				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/impossible-function-call-in-trait.php'], [
+			[
+				'Call to function is_string() with int will always evaluate to false.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeGenericOverwriteRuleTest.php
@@ -21,6 +21,7 @@ class ImpossibleCheckTypeGenericOverwriteRuleTest extends RuleTestCase
 				true,
 			),
 			new PossiblyImpureTipHelper(true),
+			self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 			true,
 			false,
 			true,

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleEqualsTest.php
@@ -21,6 +21,7 @@ class ImpossibleCheckTypeMethodCallRuleEqualsTest extends RuleTestCase
 				true,
 			),
 			new PossiblyImpureTipHelper(true),
+			self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 			true,
 			false,
 			true,

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeMethodCallRuleTest.php
@@ -3,12 +3,13 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<ImpossibleCheckTypeMethodCallRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 {
@@ -19,18 +20,23 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 
 	public function getRule(): Rule
 	{
-		return new ImpossibleCheckTypeMethodCallRule(
-			new ImpossibleCheckTypeHelper(
-				self::createReflectionProvider(),
-				$this->getTypeSpecifier(),
-				[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new ImpossibleCheckTypeMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					[],
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -301,6 +307,17 @@ class ImpossibleCheckTypeMethodCallRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-10337.php'], []);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/impossible-method-call-in-trait.php'], [
+			[
+				'Call to method ImpossibleMethodCallInTrait\TypeChecker::isString() with int will always evaluate to false.',
+				30,
+			],
+		]);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -3,12 +3,13 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<ImpossibleCheckTypeStaticMethodCallRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 {
@@ -19,18 +20,23 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 
 	public function getRule(): Rule
 	{
-		return new ImpossibleCheckTypeStaticMethodCallRule(
-			new ImpossibleCheckTypeHelper(
-				self::createReflectionProvider(),
-				$this->getTypeSpecifier(),
-				[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new ImpossibleCheckTypeStaticMethodCallRule(
+				new ImpossibleCheckTypeHelper(
+					self::createReflectionProvider(),
+					$this->getTypeSpecifier(),
+					[],
+					$this->treatPhpDocTypesAsCertain,
+				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -166,6 +172,17 @@ class ImpossibleCheckTypeStaticMethodCallRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-13566.php'], []);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/impossible-static-method-call-in-trait.php'], [
+			[
+				'Call to static method ImpossibleStaticMethodCallInTrait\TypeChecker::isString() with int will always evaluate to false.',
+				28,
+			],
+		]);
 	}
 
 	public static function getAdditionalConfigFiles(): array

--- a/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PHPStan\Rules\Rule as TRule;
 use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<CompositeRule>
@@ -77,6 +78,7 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.2')]
 	public function testInTrait(): void
 	{
 		$this->analyse([__DIR__ . '/data/logical-xor-in-trait.php'], [

--- a/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/LogicalXorConstantConditionRuleTest.php
@@ -3,31 +3,37 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule as TRule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends RuleTestCase<LogicalXorConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class LogicalXorConstantConditionRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): TRule
 	{
-		return new LogicalXorConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new LogicalXorConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->shouldTreatPhpDocTypesAsCertain(),
+					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
+				false,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->shouldTreatPhpDocTypesAsCertain(),
-			false,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -67,6 +73,16 @@ class LogicalXorConstantConditionRuleTest extends RuleTestCase
 			[
 				'Right side of xor is always false.',
 				24,
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/logical-xor-in-trait.php'], [
+			[
+				'Left side of xor is always false.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -3,11 +3,12 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<MatchExpressionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class MatchExpressionRuleTest extends RuleTestCase
 {
@@ -16,19 +17,24 @@ class MatchExpressionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new MatchExpressionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new MatchExpressionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -474,6 +480,18 @@ class MatchExpressionRuleTest extends RuleTestCase
 			[
 				'Match arm comparison between 1|2|3|4|5|6 and 0 is always false.',
 				74,
+			],
+		]);
+	}
+
+	#[RequiresPhp('>= 8.0')]
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/match-in-trait.php'], [
+			[
+				'Match arm comparison between true and false is always false.',
+				21,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/NumberComparisonOperatorsConstantConditionRuleTest.php
@@ -3,12 +3,13 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<NumberComparisonOperatorsConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 {
@@ -19,11 +20,16 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new NumberComparisonOperatorsConstantConditionRule(
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			true,
-		);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new NumberComparisonOperatorsConstantConditionRule(
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				true,
+			),
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldPolluteScopeWithAlwaysIterableForeach(): bool
@@ -294,6 +300,17 @@ class NumberComparisonOperatorsConstantConditionRuleTest extends RuleTestCase
 			[
 				'Comparison operation "<" between int<min, 0> and int<1, max> is always true.',
 				41,
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/number-comparison-in-trait.php'], [
+			[
+				'Comparison operation ">" between 1 and 0 is always true.',
+				19,
+				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1041,6 +1041,21 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-3761.php'], []);
 	}
 
+	public function testBug8060(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8060.php'], []);
+	}
+
+	public function testBug9515(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-9515.php'], []);
+	}
+
+	public function testBug4121(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-4121.php'], []);
+	}
+
 	public function testBug13208(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-13208.php'], []);

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Analyser\RicherScopeGetTypeHelper;
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
@@ -11,7 +12,7 @@ use const PHP_INT_SIZE;
 use const PHP_VERSION_ID;
 
 /**
- * @extends RuleTestCase<StrictComparisonOfDifferentTypesRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 {
@@ -22,13 +23,18 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new StrictComparisonOfDifferentTypesRule(
-			self::getContainer()->getByType(RicherScopeGetTypeHelper::class),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			$this->reportAlwaysTrueInLastCondition,
-			true,
-		);
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new StrictComparisonOfDifferentTypesRule(
+				self::getContainer()->getByType(RicherScopeGetTypeHelper::class),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
+				$this->treatPhpDocTypesAsCertain,
+				$this->reportAlwaysTrueInLastCondition,
+				true,
+			),
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -1152,6 +1158,16 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 			[
 				'Strict comparison using !== between string and null will always evaluate to true.',
 				328,
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/strict-comparison-in-trait.php'], [
+			[
+				'Strict comparison using !== between string and null will always evaluate to true.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/StrictComparisonOfDifferentTypesRuleTest.php
@@ -1046,6 +1046,7 @@ class StrictComparisonOfDifferentTypesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-8060.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.2')]
 	public function testBug9515(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-9515.php'], []);

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -106,6 +106,12 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7580.php'], []);
 	}
 
+	public function testBug11949(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/bug-11949.php'], []);
+	}
+
 	public function testBug3370(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -3,10 +3,11 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends RuleTestCase<TernaryOperatorConstantConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 {
@@ -15,20 +16,25 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new TernaryOperatorConstantConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new TernaryOperatorConstantConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->treatPhpDocTypesAsCertain,
+					),
 					$this->treatPhpDocTypesAsCertain,
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->treatPhpDocTypesAsCertain,
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->treatPhpDocTypesAsCertain,
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	protected function shouldTreatPhpDocTypesAsCertain(): bool
@@ -104,6 +110,17 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 	{
 		$this->treatPhpDocTypesAsCertain = true;
 		$this->analyse([__DIR__ . '/data/bug-3370.php'], []);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->treatPhpDocTypesAsCertain = true;
+		$this->analyse([__DIR__ . '/data/ternary-in-trait.php'], [
+			[
+				'Ternary operator condition is always true.',
+				17,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/TernaryOperatorConstantConditionRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<CompositeRule>
@@ -106,6 +107,7 @@ class TernaryOperatorConstantConditionRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7580.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.1')]
 	public function testBug11949(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
@@ -5,6 +5,7 @@ namespace PHPStan\Rules\Comparison;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
  * @extends RuleTestCase<CompositeRule>
@@ -50,6 +51,7 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.2')]
 	public function testInTrait(): void
 	{
 		$this->analyse([__DIR__ . '/data/while-false-in-trait.php'], [

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysFalseConditionRuleTest.php
@@ -3,30 +3,36 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends RuleTestCase<WhileLoopAlwaysFalseConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule
 	{
-		return new WhileLoopAlwaysFalseConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new WhileLoopAlwaysFalseConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->shouldTreatPhpDocTypesAsCertain(),
+					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->shouldTreatPhpDocTypesAsCertain(),
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -40,6 +46,16 @@ class WhileLoopAlwaysFalseConditionRuleTest extends RuleTestCase
 				'While loop condition is always false.',
 				20,
 				'Because the type is coming from a PHPDoc, you can turn off this check by setting <fg=cyan>treatPhpDocTypesAsCertain: false</> in your <fg=cyan>%configurationFile%</>.',
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/while-false-in-trait.php'], [
+			[
+				'While loop condition is always false.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysTrueConditionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/WhileLoopAlwaysTrueConditionRuleTest.php
@@ -3,31 +3,37 @@
 namespace PHPStan\Rules\Comparison;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Testing\CompositeRule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 
 /**
- * @extends RuleTestCase<WhileLoopAlwaysTrueConditionRule>
+ * @extends RuleTestCase<CompositeRule>
  */
 class WhileLoopAlwaysTrueConditionRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule
 	{
-		return new WhileLoopAlwaysTrueConditionRule(
-			new ConstantConditionRuleHelper(
-				new ImpossibleCheckTypeHelper(
-					self::createReflectionProvider(),
-					$this->getTypeSpecifier(),
-					[],
+		// @phpstan-ignore argument.type
+		return new CompositeRule([
+			new WhileLoopAlwaysTrueConditionRule(
+				new ConstantConditionRuleHelper(
+					new ImpossibleCheckTypeHelper(
+						self::createReflectionProvider(),
+						$this->getTypeSpecifier(),
+						[],
+						$this->shouldTreatPhpDocTypesAsCertain(),
+					),
 					$this->shouldTreatPhpDocTypesAsCertain(),
 				),
+				new PossiblyImpureTipHelper(true),
+				self::getContainer()->getByType(ConstantConditionInTraitHelper::class),
 				$this->shouldTreatPhpDocTypesAsCertain(),
+				true,
 			),
-			new PossiblyImpureTipHelper(true),
-			$this->shouldTreatPhpDocTypesAsCertain(),
-			true,
-		);
+			new ConstantConditionInTraitRule(),
+		]);
 	}
 
 	public function testRule(): void
@@ -70,6 +76,16 @@ class WhileLoopAlwaysTrueConditionRuleTest extends RuleTestCase
 			[
 				'While loop condition is always true.',
 				44,
+			],
+		]);
+	}
+
+	public function testInTrait(): void
+	{
+		$this->analyse([__DIR__ . '/data/while-true-in-trait.php'], [
+			[
+				'While loop condition is always true.',
+				19,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Comparison/data/boolean-and-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-and-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BooleanAndInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// left side: sometimes constant, sometimes not
+		if ($this->doBar() && rand(0, 1)) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// left side: always constant
+		if ($this->doBar2() && rand(0, 1)) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): \stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/boolean-not-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-not-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BooleanNotInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		if (!$this->doBar()) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always constant (negation of always-truthy is always false)
+		if (!$this->doBar2()) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): \stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/boolean-or-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/boolean-or-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace BooleanOrInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// left side: sometimes constant, sometimes not
+		if ($this->doBar() || rand(0, 1)) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// left side: always constant
+		if ($this->doBar2() || rand(0, 1)) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): \stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-11949.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-11949.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.1
 
 namespace Bug11949;
 

--- a/tests/PHPStan/Rules/Comparison/data/bug-11949.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-11949.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Bug11949;
+
+function trans(string $key): string
+{
+	return $key;
+}
+
+trait EnumString
+{
+
+	/** @var array<string, string> */
+	static protected ?array $_translatedValues;
+
+	static public function getValueIndex(string $value): int
+	{
+		return ($i = array_search($value, self::NAMES)) === false ? -1 : $i;
+	}
+
+	/** @return array<string, string> */
+	static public function getTranslatedValues(): array
+	{
+		return self::$_translatedValues ??= array_map(static::getTranslatedValue(...), array_combine(self::NAMES, self::NAMES));
+	}
+
+	static public function getTranslatedValue(string $value): string
+	{
+		return self::TRANSLATION ? trans(self::TRANSLATION . $value) : $value;
+	}
+
+}
+
+abstract class UserStatus
+{
+
+	use EnumString;
+
+	const ACTIVE = 'active';
+	const PENDING = 'pending';
+	const BLOCKED = 'blocked';
+
+	protected const NAMES = [
+		self::ACTIVE,
+		self::PENDING,
+		self::BLOCKED,
+	];
+
+	protected const TRANSLATION = 'users.statuses.';
+
+}
+
+abstract class SystemCheckStatus
+{
+
+	use EnumString;
+
+	const SUCCESS = 'success';
+	const FAILURE = 'failure';
+
+	protected const NAMES = [
+		self::SUCCESS,
+		self::FAILURE,
+	];
+
+	protected const TRANSLATION = '';
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-12267.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-12267.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Bug12267;
+
+/**
+ * @template TModel = mixed
+ */
+trait PrintSomething
+{
+	/** @var TModel */
+	protected $model;
+
+	public function printIt(): void
+	{
+		if (!$this->model) {
+			return;
+		}
+
+		echo $this->model;
+	}
+}
+
+class Class1
+{
+	/** @use PrintSomething<null> */
+	use PrintSomething;
+
+	public function what(): void
+	{
+		$this->printIt();
+	}
+}
+
+class Class2
+{
+	/** @use PrintSomething<\Exception> */
+	use PrintSomething;
+
+	public function what(): void
+	{
+		$this->printIt();
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-12798.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-12798.php
@@ -1,0 +1,53 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace Bug12798;
+
+interface Colorable
+{
+	public function color(): string;
+}
+
+trait HasColors
+{
+	/** @return array<string|int, string> */
+	public static function colors(): array
+	{
+		/** @phpstan-ignore return.type */
+		return array_reduce(self::cases(), function (array $colors, self $case) {
+			$key = is_subclass_of($case, \BackedEnum::class) ? $case->value : $case->name;
+			$color = is_subclass_of($case, Colorable::class) ? $case->color() : 'gray';
+
+			$colors[$key] = $color;
+			return $colors;
+		}, []);
+	}
+}
+
+enum AlertLevelBacked: int implements Colorable
+{
+	use HasColors;
+
+	case Low      = 1;
+	case Medium   = 2;
+	case Critical = 3;
+
+	public function color(): string
+	{
+		return match ($this) {
+			self::Low      => 'green',
+			self::Medium   => 'yellow',
+			self::Critical => 'red',
+		};
+	}
+}
+
+enum AlertLevel
+{
+	use HasColors;
+
+	case Low;
+	case Medium;
+	case Critical;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-13023.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13023.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bug13023;
+
+class SomeClass
+{
+	use MyTrait;
+}
+
+class SomeClass2
+{
+	use MyTrait;
+}
+
+trait MyTrait
+{
+	public function getRandom(): int
+	{
+		$value = random_int(1, 100);
+		if (is_a($this, SomeClass::class)) {
+			return $value * $value;
+		}
+		return $value;
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-13474.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13474.php
@@ -1,0 +1,91 @@
+<?php // lint >= 8.0
+
+namespace Bug13474;
+
+/**
+ * @template TValue of mixed
+ */
+interface ModelInterface
+{
+	/**
+	 * @return TValue
+	 */
+	public function getValue(): mixed;
+}
+
+/**
+ * @implements ModelInterface<int>
+ */
+class ModelA implements ModelInterface
+{
+	#[\Override]
+	public function getValue(): int
+	{
+		return 0;
+	}
+}
+
+/**
+ * @implements ModelInterface<string>
+ */
+class ModelB implements ModelInterface
+{
+	#[\Override]
+	public function getValue(): string
+	{
+		return 'foo';
+	}
+}
+
+/**
+ * @template T of ModelInterface
+ */
+trait ModelTrait
+{
+	/**
+	 * @return T
+	 */
+	abstract function model(): ModelInterface;
+
+	/**
+	 * @return template-type<T, ModelInterface, 'TValue'>
+	 */
+	public function getValue(): mixed
+	{
+		return $this->model()->getValue();
+	}
+
+	public function test(): void
+	{
+		if (is_string($this->getValue())) {
+			echo 'string';
+			return;
+		}
+
+		echo 'other';
+	}
+}
+
+class TestA
+{
+	/** @use ModelTrait<ModelA> */
+	use ModelTrait;
+
+	#[\Override]
+	function model(): ModelA
+	{
+		return new ModelA();
+	}
+}
+
+class TestB
+{
+	/** @use ModelTrait<ModelB> */
+	use ModelTrait;
+
+	#[\Override]
+	function model(): ModelB
+	{
+		return new ModelB();
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-13687.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-13687.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13687;
+
+trait MyTrait
+{
+	public function foo(): void
+	{
+		if (method_exists($this, 'bar')) {
+			$this->bar();
+		}
+
+		if (property_exists($this, 'baz')) {
+			$a = $this->baz;
+		}
+	}
+}
+
+class A
+{
+	use MyTrait;
+
+	public string $baz = 'baz';
+}
+
+class B
+{
+	use MyTrait;
+
+	public function bar(): void
+	{
+		echo 'bar';
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-4121.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4121.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4121;
+
+trait Foo
+{
+	public function bar(): void
+	{
+		echo self::class === One::class
+			? "-ONE-"
+			: "-TWO-";
+	}
+}
+
+class One
+{
+	use Foo;
+}
+
+class Two
+{
+	use Foo;
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-4570.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4570.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace Bug4570;
+
+trait MyLogic
+{
+	public function fetchValue(): string
+	{
+		if (array_key_exists('valueToFetch', self::MY_CONST_ARRAY)) {
+			return self::MY_CONST_ARRAY['valueToFetch'];
+		}
+
+		return 'defaultValue';
+	}
+}
+
+final class FirstConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'    => 'abc',
+		'valueToFetch' => '123',
+	];
+}
+
+final class SecondConsumer
+{
+	use MyLogic;
+
+	private const MY_CONST_ARRAY = [
+		'someValue'      => 'abc',
+		'someOtherValue' => '123',
+	];
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-7599.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-7599.php
@@ -1,0 +1,41 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace Bug7599;
+
+trait TraitForEnum
+{
+	/**
+	 * @return array<int, string>
+	 */
+	public static function fooMethod(): array
+	{
+		return array_map(
+			fn(self $enum): string => method_exists($enum, 'barMethod')
+				? $enum->barMethod()
+				: $enum->name,
+			static::cases()
+		);
+	}
+}
+
+enum TestEnum: string
+{
+	use TraitForEnum;
+
+	case Foo = 'foo';
+	case Bar = 'bar';
+}
+
+enum SecondEnum: string
+{
+	use TraitForEnum;
+
+	case Baz = 'baz';
+
+	public function barMethod(): string
+	{
+		return 'blah';
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-8060.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-8060.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8060;
+
+trait ExampleTrait
+{
+	public function doSomething(): void
+	{
+		$anything = $this->getAnything();
+
+		if ($anything !== null) {
+			return;
+		}
+
+		echo 'foo';
+	}
+
+	abstract protected function getAnything(): ?string;
+}
+
+class Example
+{
+	use ExampleTrait;
+
+	protected function getAnything(): string
+	{
+		return 'foo';
+	}
+}
+
+class Example2
+{
+	use ExampleTrait;
+
+	protected function getAnything(): ?string
+	{
+		return 'foo';
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-9095.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-9095.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9095;
+
+class HelloWorld
+{
+	use SomeTrait;
+
+	public string $message = 'Hello';
+
+	public function foo(): void
+	{
+		$this->bar();
+	}
+}
+
+class EmptyClass
+{
+	use SomeTrait;
+}
+
+trait SomeTrait
+{
+	public function bar(): void
+	{
+		if (property_exists($this, 'message')) {
+			if (!is_string($this->message)) {
+				return;
+			}
+
+			echo $this->message . "\n";
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-9515.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-9515.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9515;
+
+trait Foo
+{
+	abstract public function getFoo(): ?string;
+
+	public function getName(): string
+	{
+		$str = 'Hello';
+
+		if ($this->getFoo() !== null) {
+			$str .= ' World';
+		}
+
+		return $str;
+	}
+}
+
+class Bar
+{
+	use Foo;
+
+	public function getFoo(): string
+	{
+		return "Bar";
+	}
+}
+
+class Zar
+{
+	use Foo;
+
+	public function getFoo(): null
+	{
+		return null;
+	}
+}

--- a/tests/PHPStan/Rules/Comparison/data/bug-9515.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-9515.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php // lint >= 8.2
+
+declare(strict_types = 1);
 
 namespace Bug9515;
 

--- a/tests/PHPStan/Rules/Comparison/data/do-while-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/do-while-in-trait.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DoWhileInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		do {
+		} while ($this->doBar());
+	}
+
+	public function doFoo2()
+	{
+		// always falsy
+		do {
+		} while ($this->doBar2());
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): null
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/do-while-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/do-while-in-trait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.2
 
 namespace DoWhileInTrait;
 

--- a/tests/PHPStan/Rules/Comparison/data/elseif-condition-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/elseif-condition-in-trait.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ElseIfConditionInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		$x = rand(0, 1);
+		// sometimes falsy, sometimes not
+		if ($x) {
+		} elseif ($this->doBar()) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		$x = rand(0, 1);
+		// always falsy
+		if ($x) {
+		} elseif ($this->doBar2()) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): null
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/elseif-condition-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/elseif-condition-in-trait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.2
 
 namespace ElseIfConditionInTrait;
 

--- a/tests/PHPStan/Rules/Comparison/data/if-condition-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/if-condition-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace IfConditionInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes truthy, sometimes not
+		if ($this->doBar()) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always truthy
+		if ($this->doBar2()) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): \stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/impossible-function-call-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-function-call-in-trait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ImpossibleFunctionCallInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		if (is_string($this->doBar())) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always false
+		if (is_string($this->doBar2())) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): int
+	{
+
+	}
+
+	public function doBar2(): int
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	/** @return int|string */
+	public function doBar()
+	{
+
+	}
+
+	public function doBar2(): int
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/impossible-method-call-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-method-call-in-trait.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ImpossibleMethodCallInTrait;
+
+class TypeChecker
+{
+	/** @phpstan-assert-if-true string $value */
+	public function isString(mixed $value): bool
+	{
+		return is_string($value);
+	}
+}
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		$checker = new TypeChecker();
+		// sometimes constant, sometimes not
+		if ($checker->isString($this->doBar())) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		$checker = new TypeChecker();
+		// always false
+		if ($checker->isString($this->doBar2())) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): int
+	{
+
+	}
+
+	public function doBar2(): int
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	/** @return int|string */
+	public function doBar()
+	{
+
+	}
+
+	public function doBar2(): int
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/impossible-static-method-call-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/impossible-static-method-call-in-trait.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace ImpossibleStaticMethodCallInTrait;
+
+class TypeChecker
+{
+	/** @phpstan-assert-if-true string $value */
+	public static function isString(mixed $value): bool
+	{
+		return is_string($value);
+	}
+}
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		if (TypeChecker::isString($this->doBar())) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always false
+		if (TypeChecker::isString($this->doBar2())) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): int
+	{
+
+	}
+
+	public function doBar2(): int
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	/** @return int|string */
+	public function doBar()
+	{
+
+	}
+
+	public function doBar2(): int
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/logical-xor-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/logical-xor-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace LogicalXorInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// left side: sometimes constant, sometimes not
+		if ($this->doBar() xor rand(0, 1)) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// left side: always constant (always false)
+		if ($this->doBar2() xor rand(0, 1)) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): null
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/logical-xor-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/logical-xor-in-trait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.2
 
 namespace LogicalXorInTrait;
 

--- a/tests/PHPStan/Rules/Comparison/data/loose-comparison-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/loose-comparison-in-trait.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace LooseComparisonInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		if ($this->doBar() == null) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always false
+		if ($this->doBar2() == null) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	/** @return 1 */
+	public function doBar(): int
+	{
+
+	}
+
+	/** @return 1 */
+	public function doBar2(): int
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?int
+	{
+
+	}
+
+	/** @return 1 */
+	public function doBar2(): int
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/match-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-in-trait.php
@@ -1,4 +1,4 @@
-<?php // lint >= 8.0
+<?php // lint >= 8.2
 
 namespace MatchInTrait;
 

--- a/tests/PHPStan/Rules/Comparison/data/match-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-in-trait.php
@@ -1,0 +1,60 @@
+<?php // lint >= 8.0
+
+namespace MatchInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		match (true) {
+			$this->doBar() => 'yes',
+			default => 'no',
+		};
+	}
+
+	public function doFoo2()
+	{
+		// always false
+		match (true) {
+			$this->doBar2() => 'yes',
+			default => 'no',
+		};
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): false
+	{
+
+	}
+
+	public function doBar2(): false
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): bool
+	{
+
+	}
+
+	public function doBar2(): false
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/number-comparison-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/number-comparison-in-trait.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace NumberComparisonInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes constant, sometimes not
+		if ($this->doBar() > 0) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always constant
+		if ($this->doBar2() > 0) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	/** @return 1 */
+	public function doBar(): int
+	{
+
+	}
+
+	/** @return 1 */
+	public function doBar2(): int
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): int
+	{
+
+	}
+
+	/** @return 1 */
+	public function doBar2(): int
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/strict-comparison-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/strict-comparison-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace StrictComparisonInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes nullable, sometimes not
+		if ($this->doBar() !== null) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always not nullable
+		if ($this->doBar2() !== null) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	 use FooTrait;
+
+	public function doBar(): string
+	{
+
+	}
+
+	public function doBar2(): string
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?string
+	{
+
+	}
+
+	public function doBar2(): string
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/ternary-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/ternary-in-trait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace TernaryInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes truthy, sometimes not
+		$x = $this->doBar() ? 'yes' : 'no';
+	}
+
+	public function doFoo2()
+	{
+		// always truthy
+		$x = $this->doBar2() ? 'yes' : 'no';
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): \stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/while-false-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/while-false-in-trait.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.2
 
 namespace WhileFalseInTrait;
 

--- a/tests/PHPStan/Rules/Comparison/data/while-false-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/while-false-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WhileFalseInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo()
+	{
+		// sometimes falsy, sometimes not
+		while ($this->doBar()) {
+
+		}
+	}
+
+	public function doFoo2()
+	{
+		// always falsy
+		while ($this->doBar2()) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): null
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): null
+	{
+
+	}
+
+}

--- a/tests/PHPStan/Rules/Comparison/data/while-true-in-trait.php
+++ b/tests/PHPStan/Rules/Comparison/data/while-true-in-trait.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WhileTrueInTrait;
+
+trait FooTrait
+{
+
+	public function doFoo(): void
+	{
+		// sometimes truthy, sometimes not
+		while ($this->doBar()) {
+
+		}
+	}
+
+	public function doFoo2(): void
+	{
+		// always truthy
+		while ($this->doBar2()) {
+
+		}
+	}
+
+}
+
+class Foo
+{
+
+	use FooTrait;
+
+	public function doBar(): \stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}
+
+class FooAnother
+{
+
+	use FooTrait;
+
+	public function doBar(): ?\stdClass
+	{
+
+	}
+
+	public function doBar2(): \stdClass
+	{
+
+	}
+
+}


### PR DESCRIPTION
  - When a rule detects a constant condition inside a trait, instead of reporting it directly, it emits
  the result via ConstantConditionInTraitCollector. The ConstantConditionInTraitRule then aggregates
  results across all classes using the trait and only reports the error when all usages agree (the
  condition is always-true or always-false in every context).
  - Errors that differ across trait usages (e.g., always-true in one class but not constant in another)
  are suppressed as false positives.
  - Errors where all usages agree are still reported, with deduplication — if the message is identical
  across contexts, it's reported once directly in the trait; if messages differ (different type
  descriptions per class), each is reported in its context.


Fixes phpstan/phpstan#13023

Closes https://github.com/phpstan/phpstan/issues/7599
Closes https://github.com/phpstan/phpstan/issues/13023
Closes https://github.com/phpstan/phpstan/issues/13474 
Closes https://github.com/phpstan/phpstan/issues/13687
Closes https://github.com/phpstan/phpstan/issues/12798

Closes https://github.com/phpstan/phpstan/issues/11949
Closes https://github.com/phpstan/phpstan/issues/12267
Closes https://github.com/phpstan/phpstan/issues/9515
Closes https://github.com/phpstan/phpstan/issues/4570
Closes https://github.com/phpstan/phpstan/issues/4121

Closes https://github.com/phpstan/phpstan/issues/8060
Closes https://github.com/phpstan/phpstan/issues/10353