### PR TITLE
avoid SpecifiedTypes allocation in setRootExpr when unchanged

### DIFF
--- a/src/Analyser/SpecifiedTypes.php
+++ b/src/Analyser/SpecifiedTypes.php
@@ -62,6 +62,10 @@ final class SpecifiedTypes
 	 */
 	public function setRootExpr(?Expr $rootExpr): self
 	{
+		if ($this->rootExpr === $rootExpr) {
+			return $this;
+		}
+
 		$self = new self($this->sureTypes, $this->sureNotTypes);
 		$self->overwrite = $this->overwrite;
 		$self->newConditionalExpressionHolders = $this->newConditionalExpressionHolders;


### PR DESCRIPTION
## Problem

`SpecifiedTypes::setRootExpr()` is called on the return value of nearly every `specifyTypesInCondition()` call in `TypeSpecifier`. Each call allocates a new `SpecifiedTypes` object, even when the root expression is already the same object.

Since `specifyTypesInCondition` recurses through the AST and calls `setRootExpr($expr)` at each level, inner calls often set the root to a node that an outer call then overwrites with the same node again. The same `Expr` object reference is passed down and back up the call chain, so identity (`===`) is the right check here.

## Solution

```php
public function setRootExpr(?Expr $rootExpr): self
{
    if ($this->rootExpr === $rootExpr) {
        return $this;
    }
    // ... existing allocation
}
```

## Impact

CI benchmark results to follow.