### PR TITLE
Add external file dependency tracking for incremental cache invalidation

### DIFF
--- a/src/Analyser/Analyser.php
+++ b/src/Analyser/Analyser.php
@@ -75,6 +75,7 @@ final class Analyser
 		$dependencies = [];
 		$usedTraitDependencies = [];
 		$exportedNodes = [];
+		$externalFileDependencies = [];
 		foreach ($files as $file) {
 			if ($preFileCallback !== null) {
 				$preFileCallback($file);
@@ -99,6 +100,10 @@ final class Analyser
 				$collectedData = array_merge($collectedData, $fileAnalyserResult->getCollectedData());
 				$dependencies[$file] = $fileAnalyserResult->getDependencies();
 				$usedTraitDependencies[$file] = $fileAnalyserResult->getUsedTraitDependencies();
+				$fileExternalDeps = $fileAnalyserResult->getExternalFileDependencies();
+				if (count($fileExternalDeps) > 0) {
+					$externalFileDependencies[$file] = $fileExternalDeps;
+				}
 
 				$fileExportedNodes = $fileAnalyserResult->getExportedNodes();
 				if (count($fileExportedNodes) > 0) {
@@ -143,6 +148,7 @@ final class Analyser
 			exportedNodes: $exportedNodes,
 			reachedInternalErrorsCountLimit: $reachedInternalErrorsCountLimit,
 			peakMemoryUsageBytes: memory_get_peak_usage(true),
+			externalFileDependencies: $internalErrorsCount === 0 ? $externalFileDependencies : null,
 		);
 	}
 

--- a/src/Analyser/AnalyserResult.php
+++ b/src/Analyser/AnalyserResult.php
@@ -28,6 +28,7 @@ final class AnalyserResult
 	 * @param array<string, array<string>>|null $dependencies
 	 * @param array<string, array<string>>|null $usedTraitDependencies
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
+	 * @param array<string, list<string>>|null $externalFileDependencies
 	 */
 	public function __construct(
 		private array $unorderedErrors,
@@ -43,6 +44,7 @@ final class AnalyserResult
 		private array $exportedNodes,
 		private bool $reachedInternalErrorsCountLimit,
 		private int $peakMemoryUsageBytes,
+		private ?array $externalFileDependencies = null,
 	)
 	{
 	}
@@ -157,6 +159,14 @@ final class AnalyserResult
 	public function getExportedNodes(): array
 	{
 		return $this->exportedNodes;
+	}
+
+	/**
+	 * @return array<string, list<string>>|null
+	 */
+	public function getExternalFileDependencies(): ?array
+	{
+		return $this->externalFileDependencies;
 	}
 
 	public function hasReachedInternalErrorsCountLimit(): bool

--- a/src/Analyser/AnalyserResultFinalizer.php
+++ b/src/Analyser/AnalyserResultFinalizer.php
@@ -148,6 +148,7 @@ final class AnalyserResultFinalizer
 			exportedNodes: $analyserResult->getExportedNodes(),
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
+			externalFileDependencies: $analyserResult->getExternalFileDependencies(),
 		), $collectorErrors, $locallyIgnoredCollectorErrors);
 	}
 
@@ -167,6 +168,7 @@ final class AnalyserResultFinalizer
 			exportedNodes: $analyserResult->getExportedNodes(),
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
+			externalFileDependencies: $analyserResult->getExternalFileDependencies(),
 		);
 	}
 
@@ -231,6 +233,7 @@ final class AnalyserResultFinalizer
 				exportedNodes: $analyserResult->getExportedNodes(),
 				reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 				peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
+				externalFileDependencies: $analyserResult->getExternalFileDependencies(),
 			),
 			$collectorErrors,
 			$locallyIgnoredCollectorErrors,

--- a/src/Analyser/ExternalFileDependencyRegistrar.php
+++ b/src/Analyser/ExternalFileDependencyRegistrar.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Analyser;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use function array_unique;
+use function array_values;
+
+/**
+ * Allows extensions to declare that the currently analyzed file depends on
+ * an external (non-analyzed) file. When that external file changes, only
+ * the dependent analyzed files are re-analyzed instead of the entire project.
+ *
+ * This is an alternative to ResultCacheMetaExtension for cases where
+ * external data changes should not cause full cache invalidation.
+ *
+ * @api
+ */
+#[AutowiredService]
+final class ExternalFileDependencyRegistrar
+{
+
+	/** @var list<string> */
+	private array $currentFileDependencies = [];
+
+	/**
+	 * Register a dependency on an external file for the currently analyzed file.
+	 */
+	public function add(string $externalFilePath): void
+	{
+		$this->currentFileDependencies[] = $externalFilePath;
+	}
+
+	/**
+	 * @return list<string>
+	 * @internal Used by FileAnalyser after each file analysis
+	 */
+	public function getAndReset(): array
+	{
+		$deps = array_values(array_unique($this->currentFileDependencies));
+		$this->currentFileDependencies = [];
+
+		return $deps;
+	}
+
+}

--- a/src/Analyser/FileAnalyser.php
+++ b/src/Analyser/FileAnalyser.php
@@ -60,6 +60,7 @@ final class FileAnalyser
 		private IgnoreErrorExtensionProvider $ignoreErrorExtensionProvider,
 		private RuleErrorTransformer $ruleErrorTransformer,
 		private LocalIgnoresProcessor $localIgnoresProcessor,
+		private ExternalFileDependencyRegistrar $externalFileDependencyRegistrar,
 		#[AutowiredParameter]
 		private bool $reportIgnoresWithoutComments,
 	)
@@ -247,6 +248,7 @@ final class FileAnalyser
 			$linesToIgnore,
 			$unmatchedLineIgnores,
 			$processedFiles,
+			$this->externalFileDependencyRegistrar->getAndReset(),
 		);
 	}
 

--- a/src/Analyser/FileAnalyserResult.php
+++ b/src/Analyser/FileAnalyserResult.php
@@ -25,6 +25,7 @@ final class FileAnalyserResult
 	 * @param LinesToIgnore $linesToIgnore
 	 * @param LinesToIgnore $unmatchedLineIgnores
 	 * @param list<string> $processedFiles
+	 * @param list<string> $externalFileDependencies
 	 */
 	public function __construct(
 		private array $errors,
@@ -38,6 +39,7 @@ final class FileAnalyserResult
 		private array $linesToIgnore,
 		private array $unmatchedLineIgnores,
 		private array $processedFiles,
+		private array $externalFileDependencies = [],
 	)
 	{
 	}
@@ -128,6 +130,14 @@ final class FileAnalyserResult
 	public function getProcessedFiles(): array
 	{
 		return $this->processedFiles;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	public function getExternalFileDependencies(): array
+	{
+		return $this->externalFileDependencies;
 	}
 
 }

--- a/src/Analyser/ResultCache/ResultCache.php
+++ b/src/Analyser/ResultCache/ResultCache.php
@@ -27,6 +27,7 @@ final class ResultCache
 	 * @param array<string, array<RootExportedNode>> $exportedNodes
 	 * @param array<string, array{string, bool, string}> $projectExtensionFiles
 	 * @param array<string, string> $currentFileHashes
+	 * @param array<string, array<string>> $externalFileDependencies
 	 */
 	public function __construct(
 		private array $filesToAnalyse,
@@ -43,6 +44,7 @@ final class ResultCache
 		private array $exportedNodes,
 		private array $projectExtensionFiles,
 		private array $currentFileHashes,
+		private array $externalFileDependencies = [],
 	)
 	{
 	}
@@ -151,6 +153,16 @@ final class ResultCache
 	public function getCurrentFileHashes(): array
 	{
 		return $this->currentFileHashes;
+	}
+
+	/**
+	 * Inverted external file dependencies: external file => dependent analyzed files.
+	 *
+	 * @return array<string, array<string>>
+	 */
+	public function getExternalFileDependencies(): array
+	{
+		return $this->externalFileDependencies;
 	}
 
 }

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -356,6 +356,22 @@ final class ResultCacheManager
 		$filesToAnalyse = [];
 		$invertedDependenciesToReturn = [];
 		$invertedUsedTraitDependenciesToReturn = [];
+
+		// Check external file dependencies for incremental re-analysis
+		$cachedExternalDependencies = $data['externalDependencies'] ?? [];
+		$externalDependenciesToReturn = $cachedExternalDependencies;
+		foreach ($cachedExternalDependencies as $externalFile => $externalData) {
+			if (!is_file($externalFile) || $this->getFileHash($externalFile) !== $externalData['fileHash']) {
+				if ($output->isVeryVerbose()) {
+					$output->writeLineFormatted(sprintf('External file %s changed, re-analysing dependent files.', $externalFile));
+				}
+				foreach ($externalData['dependentFiles'] as $dependentFile) {
+					if (is_file($dependentFile)) {
+						$filesToAnalyse[] = $dependentFile;
+					}
+				}
+			}
+		}
 		$errors = $data['errorsCallback']();
 		$locallyIgnoredErrors = $data['locallyIgnoredErrorsCallback']();
 		$linesToIgnore = $data['linesToIgnore'];
@@ -515,6 +531,7 @@ final class ResultCacheManager
 			exportedNodes: $filteredExportedNodes,
 			projectExtensionFiles: $data['projectExtensionFiles'],
 			currentFileHashes: $currentFileHashes,
+			externalFileDependencies: $externalDependenciesToReturn,
 		);
 	}
 
@@ -624,7 +641,7 @@ final class ResultCacheManager
 		if ($projectConfigArray !== null) {
 			$meta['projectConfig'] = Neon::encode($projectConfigArray);
 		}
-		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, ?array $dependencies, ?array $usedTraitDependencies, array $exportedNodes, array $projectExtensionFiles) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): bool {
+		$doSave = function (array $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, ?array $dependencies, ?array $usedTraitDependencies, array $exportedNodes, array $projectExtensionFiles, array $externalFileDependencies = []) use ($internalErrors, $resultCache, $output, $onlyFiles, $meta): bool {
 			if ($onlyFiles) {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because only files were passed as analysed paths.');
@@ -672,7 +689,7 @@ final class ResultCacheManager
 				}
 			}
 
-			$this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta);
+			$this->save($resultCache->getLastFullAnalysisTime(), $errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $exportedNodes, $projectExtensionFiles, $resultCache->getCurrentFileHashes(), $meta, $externalFileDependencies);
 
 			if ($output->isVeryVerbose()) {
 				$output->writeLineFormatted('Result cache is saved.');
@@ -688,7 +705,7 @@ final class ResultCacheManager
 				if ($analyserResult->getDependencies() !== null) {
 					$projectExtensionFiles = $this->getProjectExtensionFiles($projectConfigArray, $analyserResult->getDependencies());
 				}
-				$saved = $doSave($freshErrorsByFile, $freshLocallyIgnoredErrorsByFile, $analyserResult->getLinesToIgnore(), $analyserResult->getUnmatchedLineIgnores(), $freshCollectedDataByFile, $analyserResult->getDependencies(), $analyserResult->getUsedTraitDependencies(), $analyserResult->getExportedNodes(), $projectExtensionFiles);
+				$saved = $doSave($freshErrorsByFile, $freshLocallyIgnoredErrorsByFile, $analyserResult->getLinesToIgnore(), $analyserResult->getUnmatchedLineIgnores(), $freshCollectedDataByFile, $analyserResult->getDependencies(), $analyserResult->getUsedTraitDependencies(), $analyserResult->getExportedNodes(), $projectExtensionFiles, $analyserResult->getExternalFileDependencies() ?? []);
 			} else {
 				if ($output->isVeryVerbose()) {
 					$output->writeLineFormatted('Result cache was not saved because it was not requested.');
@@ -706,6 +723,7 @@ final class ResultCacheManager
 		$exportedNodes = $this->mergeExportedNodes($resultCache, $analyserResult->getExportedNodes());
 		$linesToIgnore = $this->mergeLinesToIgnore($resultCache, $analyserResult->getLinesToIgnore());
 		$unmatchedLineIgnores = $this->mergeUnmatchedLineIgnores($resultCache, $analyserResult->getUnmatchedLineIgnores());
+		$externalFileDependencies = $this->mergeExternalFileDependencies($resultCache->getExternalFileDependencies(), $resultCache->getFilesToAnalyse(), $analyserResult->getExternalFileDependencies());
 
 		$saved = false;
 		if ($save !== false) {
@@ -729,7 +747,7 @@ final class ResultCacheManager
 					$projectExtensionFiles[$file] = [$hash, true, $className];
 				}
 			}
-			$saved = $doSave($errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $exportedNodes, $projectExtensionFiles);
+			$saved = $doSave($errorsByFile, $locallyIgnoredErrorsByFile, $linesToIgnore, $unmatchedLineIgnores, $collectedDataByFile, $dependencies, $usedTraitDependencies, $exportedNodes, $projectExtensionFiles, $externalFileDependencies);
 		}
 
 		$flatErrors = [];
@@ -760,6 +778,7 @@ final class ResultCacheManager
 			exportedNodes: $exportedNodes,
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
+			externalFileDependencies: $externalFileDependencies !== [] ? $externalFileDependencies : null,
 		), $saved);
 	}
 
@@ -945,6 +964,45 @@ final class ResultCacheManager
 	}
 
 	/**
+	 * Merges cached inverted external dependencies with fresh analysis results.
+	 *
+	 * @param array<string, array<string>> $cachedExternalDependencies Inverted: external file => dependent analyzed files
+	 * @param string[] $filesToAnalyse Files that were re-analyzed
+	 * @param array<string, list<string>>|null $freshExternalDependencies Non-inverted: analyzed file => external files
+	 * @return array<string, list<string>> Non-inverted: analyzed file => external files
+	 */
+	private function mergeExternalFileDependencies(
+		array $cachedExternalDependencies,
+		array $filesToAnalyse,
+		?array $freshExternalDependencies,
+	): array
+	{
+		if ($freshExternalDependencies === null) {
+			return [];
+		}
+
+		// Un-invert cached external dependencies: external file => [dependents] → dependent => [external files]
+		$cachedPerFile = [];
+		foreach ($cachedExternalDependencies as $externalFile => $externalData) {
+			$dependentFiles = $externalData['dependentFiles'] ?? $externalData;
+			foreach ($dependentFiles as $dependentFile) {
+				$cachedPerFile[$dependentFile][] = $externalFile;
+			}
+		}
+
+		// Replace re-analyzed files with fresh data
+		$merged = $cachedPerFile;
+		foreach ($filesToAnalyse as $file) {
+			unset($merged[$file]);
+			if (array_key_exists($file, $freshExternalDependencies)) {
+				$merged[$file] = $freshExternalDependencies[$file];
+			}
+		}
+
+		return $merged;
+	}
+
+	/**
 	 * @param array<string, list<Error>> $errors
 	 * @param array<string, list<Error>> $locallyIgnoredErrors
 	 * @param array<string, LinesToIgnore> $linesToIgnore
@@ -956,6 +1014,7 @@ final class ResultCacheManager
 	 * @param array<string, array{string, bool, string}> $projectExtensionFiles
 	 * @param array<string, string> $currentFileHashes
 	 * @param mixed[] $meta
+	 * @param array<string, list<string>> $externalFileDependencies
 	 */
 	private function save(
 		int $lastFullAnalysisTime,
@@ -970,6 +1029,7 @@ final class ResultCacheManager
 		array $projectExtensionFiles,
 		array $currentFileHashes,
 		array $meta,
+		array $externalFileDependencies = [],
 	): void
 	{
 		$invertedDependencies = [];
@@ -1043,6 +1103,31 @@ final class ResultCacheManager
 
 		ksort($exportedNodes);
 
+		// Build inverted external dependencies: external file => {hash, dependentFiles}
+		$invertedExternalDependencies = [];
+		foreach ($externalFileDependencies as $analysedFile => $externalFiles) {
+			foreach ($externalFiles as $externalFile) {
+				if (!array_key_exists($externalFile, $invertedExternalDependencies)) {
+					if (!is_file($externalFile)) {
+						continue;
+					}
+					$invertedExternalDependencies[$externalFile] = [
+						'fileHash' => $this->getFileHash($externalFile),
+						'dependentFiles' => [],
+					];
+				}
+				$invertedExternalDependencies[$externalFile]['dependentFiles'][] = $analysedFile;
+			}
+		}
+
+		foreach ($invertedExternalDependencies as $externalFile => $externalData) {
+			$dependentFiles = array_values(array_unique($externalData['dependentFiles']));
+			sort($dependentFiles);
+			$invertedExternalDependencies[$externalFile]['dependentFiles'] = $dependentFiles;
+		}
+
+		ksort($invertedExternalDependencies);
+
 		$file = $this->cacheFilePath;
 
 		FileWriter::write(
@@ -1059,7 +1144,8 @@ return [
 	'unmatchedLineIgnores' => " . var_export($unmatchedLineIgnores, true) . ",
 	'collectedDataCallback' => static function (): array { return " . var_export($collectedData, true) . "; },
 	'dependencies' => " . var_export($invertedDependencies, true) . ",
-	'exportedNodesCallback' => static function (): array { return " . var_export($exportedNodes, true) . '; },
+	'exportedNodesCallback' => static function (): array { return " . var_export($exportedNodes, true) . "; },
+	'externalDependencies' => " . var_export($invertedExternalDependencies, true) . ',
 ];
 ',
 		);

--- a/src/Analyser/ResultCache/ResultCacheManager.php
+++ b/src/Analyser/ResultCache/ResultCacheManager.php
@@ -358,18 +358,24 @@ final class ResultCacheManager
 		$invertedUsedTraitDependenciesToReturn = [];
 
 		// Check external file dependencies for incremental re-analysis
+		/** @var array<string, array{fileHash: string, dependentFiles: list<string>}> $cachedExternalDependencies */
 		$cachedExternalDependencies = $data['externalDependencies'] ?? [];
-		$externalDependenciesToReturn = $cachedExternalDependencies;
+		$externalDependenciesToReturn = [];
 		foreach ($cachedExternalDependencies as $externalFile => $externalData) {
-			if (!is_file($externalFile) || $this->getFileHash($externalFile) !== $externalData['fileHash']) {
-				if ($output->isVeryVerbose()) {
-					$output->writeLineFormatted(sprintf('External file %s changed, re-analysing dependent files.', $externalFile));
+			$externalDependenciesToReturn[$externalFile] = $externalData['dependentFiles'];
+			if (is_file($externalFile) && $this->getFileHash($externalFile) === $externalData['fileHash']) {
+				continue;
+			}
+
+			if ($output->isVeryVerbose()) {
+				$output->writeLineFormatted(sprintf('External file %s changed, re-analysing dependent files.', $externalFile));
+			}
+			foreach ($externalData['dependentFiles'] as $dependentFile) {
+				if (!is_file($dependentFile)) {
+					continue;
 				}
-				foreach ($externalData['dependentFiles'] as $dependentFile) {
-					if (is_file($dependentFile)) {
-						$filesToAnalyse[] = $dependentFile;
-					}
-				}
+
+				$filesToAnalyse[] = $dependentFile;
 			}
 		}
 		$errors = $data['errorsCallback']();
@@ -983,8 +989,7 @@ final class ResultCacheManager
 
 		// Un-invert cached external dependencies: external file => [dependents] → dependent => [external files]
 		$cachedPerFile = [];
-		foreach ($cachedExternalDependencies as $externalFile => $externalData) {
-			$dependentFiles = $externalData['dependentFiles'] ?? $externalData;
+		foreach ($cachedExternalDependencies as $externalFile => $dependentFiles) {
 			foreach ($dependentFiles as $dependentFile) {
 				$cachedPerFile[$dependentFile][] = $externalFile;
 			}
@@ -994,9 +999,11 @@ final class ResultCacheManager
 		$merged = $cachedPerFile;
 		foreach ($filesToAnalyse as $file) {
 			unset($merged[$file]);
-			if (array_key_exists($file, $freshExternalDependencies)) {
-				$merged[$file] = $freshExternalDependencies[$file];
+			if (!array_key_exists($file, $freshExternalDependencies)) {
+				continue;
 			}
+
+			$merged[$file] = $freshExternalDependencies[$file];
 		}
 
 		return $merged;

--- a/src/Command/AnalyseApplication.php
+++ b/src/Command/AnalyseApplication.php
@@ -121,6 +121,7 @@ final class AnalyseApplication
 					exportedNodes: $intermediateAnalyserResult->getExportedNodes(),
 					reachedInternalErrorsCountLimit: $intermediateAnalyserResult->hasReachedInternalErrorsCountLimit(),
 					peakMemoryUsageBytes: $intermediateAnalyserResult->getPeakMemoryUsageBytes(),
+					externalFileDependencies: $intermediateAnalyserResult->getExternalFileDependencies(),
 				);
 			}
 
@@ -346,6 +347,7 @@ final class AnalyseApplication
 			exportedNodes: $exportedNodes,
 			reachedInternalErrorsCountLimit: $analyserResult->hasReachedInternalErrorsCountLimit(),
 			peakMemoryUsageBytes: $analyserResult->getPeakMemoryUsageBytes(),
+			externalFileDependencies: $analyserResult->getExternalFileDependencies(),
 		);
 	}
 

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -228,6 +228,7 @@ final class WorkerCommand extends Command
 			$dependencies = [];
 			$usedTraitDependencies = [];
 			$exportedNodes = [];
+			$externalFileDependencies = [];
 			foreach ($files as $file) {
 				try {
 					if ($file === $insteadOfFile) {
@@ -242,6 +243,10 @@ final class WorkerCommand extends Command
 					$dependencies[$file] = $fileAnalyserResult->getDependencies();
 					$usedTraitDependencies[$file] = $fileAnalyserResult->getUsedTraitDependencies();
 					$exportedNodes[$file] = $fileAnalyserResult->getExportedNodes();
+					$fileExternalDeps = $fileAnalyserResult->getExternalFileDependencies();
+					if (count($fileExternalDeps) > 0) {
+						$externalFileDependencies[$file] = $fileExternalDeps;
+					}
 					foreach ($fileErrors as $fileError) {
 						$errors[] = $fileError;
 					}
@@ -282,6 +287,7 @@ final class WorkerCommand extends Command
 					'dependencies' => $dependencies,
 					'usedTraitDependencies' => $usedTraitDependencies,
 					'exportedNodes' => $exportedNodes,
+					'externalFileDependencies' => $externalFileDependencies,
 					'files' => $files,
 					'internalErrorsCount' => $internalErrorsCount,
 				]]);

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -29,6 +29,7 @@ use function array_filter;
 use function array_merge;
 use function array_unshift;
 use function array_values;
+use function count;
 use function defined;
 use function is_array;
 use function is_bool;

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -92,12 +92,13 @@ final class ParallelAnalyser
 		$usedTraitDependencies = [];
 		$reachedInternalErrorsCountLimit = false;
 		$exportedNodes = [];
+		$externalFileDependencies = [];
 
 		/** @var Deferred<AnalyserResult> $deferred */
 		$deferred = new Deferred();
 
 		$server = new TcpServer('127.0.0.1:0', $loop);
-		$this->processPool = new ProcessPool($server, static function () use ($deferred, &$jobs, &$internalErrors, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$exportedNodes, &$peakMemoryUsages): void {
+		$this->processPool = new ProcessPool($server, static function () use ($deferred, &$jobs, &$internalErrors, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$exportedNodes, &$externalFileDependencies, &$peakMemoryUsages): void {
 			if (count($jobs) > 0 && $internalErrorsCount === 0) {
 				$internalErrors[] = new InternalError(
 					'Some parallel worker jobs have not finished.',
@@ -123,6 +124,7 @@ final class ParallelAnalyser
 				exportedNodes: $exportedNodes,
 				reachedInternalErrorsCountLimit: $reachedInternalErrorsCountLimit,
 				peakMemoryUsageBytes: array_sum($peakMemoryUsages), // not 100% correct as the peak usages of workers might not have met
+				externalFileDependencies: $internalErrorsCount === 0 ? $externalFileDependencies : null,
 			));
 		});
 		$server->on('connection', function (ConnectionInterface $connection) use (&$jobs): void {
@@ -194,7 +196,7 @@ final class ParallelAnalyser
 				$commandOptions,
 				$input,
 			), $loop, $this->processTimeout);
-			$process->start(function (array $json) use ($process, &$internalErrors, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$exportedNodes, &$peakMemoryUsages, &$jobs, $postFileCallback, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, $processIdentifier, $onFileAnalysisHandler): void {
+			$process->start(function (array $json) use ($process, &$internalErrors, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$exportedNodes, &$externalFileDependencies, &$peakMemoryUsages, &$jobs, $postFileCallback, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, $processIdentifier, $onFileAnalysisHandler): void {
 				$fileErrors = [];
 				foreach ($json['errors'] as $jsonError) {
 					$fileErrors[] = Error::decode($jsonError);
@@ -250,6 +252,14 @@ final class ParallelAnalyser
 				 */
 				foreach ($json['usedTraitDependencies'] as $file => $fileUsedTraitDependencies) {
 					$usedTraitDependencies[$file] = $fileUsedTraitDependencies;
+				}
+
+				/**
+				 * @var string $file
+				 * @var list<string> $fileExternalDeps
+				 */
+				foreach ($json['externalFileDependencies'] ?? [] as $file => $fileExternalDeps) {
+					$externalFileDependencies[$file] = $fileExternalDeps;
 				}
 
 				foreach ($json['linesToIgnore'] as $file => $fileLinesToIgnore) {

--- a/src/Testing/RuleTestCase.php
+++ b/src/Testing/RuleTestCase.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\AnalyserResultFinalizer;
 use PHPStan\Analyser\Error;
+use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Fiber\FiberNodeScopeResolver;
 use PHPStan\Analyser\FileAnalyser;
 use PHPStan\Analyser\IgnoreErrorExtensionProvider;
@@ -137,6 +138,7 @@ abstract class RuleTestCase extends PHPStanTestCase
 				new IgnoreErrorExtensionProvider(self::getContainer()),
 				self::getContainer()->getByType(RuleErrorTransformer::class),
 				new LocalIgnoresProcessor(),
+				new ExternalFileDependencyRegistrar(),
 				false,
 			);
 			$this->analyser = new Analyser(

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -6,7 +6,6 @@ use Nette\DI\Container;
 use PhpParser\Lexer;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser\Php7;
-use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
 use PHPStan\Analyser\Ignore\IgnoreLexer;
 use PHPStan\Collectors\Registry as CollectorRegistry;

--- a/tests/PHPStan/Analyser/AnalyserTest.php
+++ b/tests/PHPStan/Analyser/AnalyserTest.php
@@ -6,6 +6,7 @@ use Nette\DI\Container;
 use PhpParser\Lexer;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser\Php7;
+use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
 use PHPStan\Analyser\Ignore\IgnoreLexer;
 use PHPStan\Collectors\Registry as CollectorRegistry;
@@ -847,6 +848,7 @@ class AnalyserTest extends PHPStanTestCase
 			new IgnoreErrorExtensionProvider(new NetteContainer(new Container([]))),
 			$container->getByType(RuleErrorTransformer::class),
 			new LocalIgnoresProcessor(),
+			new ExternalFileDependencyRegistrar(),
 			false,
 		);
 


### PR DESCRIPTION
## Summary

- Introduces `ExternalFileDependencyRegistrar`, a new `@api` service that allows extensions to declare that an analyzed file depends on an external (non-analyzed) file
- When that external file changes, only the dependent analyzed files are re-analyzed instead of triggering full cache invalidation
- This is an alternative to `ResultCacheMetaExtension` for cases where external data changes should cause surgical re-analysis of affected files only, not full invalidation

## Motivation

`ResultCacheMetaExtension` is an all-or-nothing mechanism — when any extension's hash changes, the entire result cache is invalidated. phpstan-symfony uses this to track Symfony DI container changes, but any service definition change (even trivially adding a dependency via autowiring) causes full re-analysis of the entire project. On large codebases this is devastating.

This PR adds a granular alternative: extensions register per-file dependencies on external files during analysis. When those files change, only the affected analyzed files (and their dependents) are re-analyzed.

See companion PR: phpstan/phpstan-symfony#478

## Changes

- New `ExternalFileDependencyRegistrar` service (`@api`) with `add(string $externalFilePath)` method
- `FileAnalyserResult` / `AnalyserResult` carry external dependencies through the pipeline
- `WorkerCommand` / `ParallelAnalyser` serialize and aggregate external deps across parallel workers
- `ResultCacheManager`:
  - `restore()`: checks external file hashes, adds dependent files to incremental re-analysis list
  - `save()`: inverts and stores external dependencies with file hashes
  - `process()`: merges cached + fresh external dependencies

## Test plan

- [x] All 11,719 existing tests pass
- [ ] Add dedicated tests for external dependency cache invalidation

Co-Authored-By: Claude Code