### PR TITLE
fix: generic sealed class-string match exhaustiveness for ::class comparisons

### DIFF
--- a/src/Type/Generic/GenericClassStringType.php
+++ b/src/Type/Generic/GenericClassStringType.php
@@ -18,6 +18,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\SubtractableType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
@@ -222,12 +223,14 @@ class GenericClassStringType extends ClassStringType
 
 					if ($classReflection->getAllowedSubTypes() !== null) {
 						$objectTypeToRemove = new ObjectType($typeToRemove->getValue());
-						$remainingType = TypeCombinator::remove($generic, $objectTypeToRemove);
+						$baseType = new ObjectType($genericObjectClassNames[0],
+							$generic instanceof SubtractableType ? $generic->getSubtractedType() : null);
+						$remainingType = TypeCombinator::remove($baseType, $objectTypeToRemove);
 						if ($remainingType instanceof NeverType) {
 							return new NeverType();
 						}
 
-						if (!$remainingType->equals($generic)) {
+						if (!$remainingType->equals($baseType)) {
 							return new self($remainingType);
 						}
 					}

--- a/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php
@@ -454,6 +454,12 @@ class MatchExpressionRuleTest extends RuleTestCase
 	}
 
 	#[RequiresPhp('>= 8.0')]
+	public function testGenericSealedClassStringMatch(): void
+	{
+		$this->analyse([__DIR__ . '/data/match-generic-sealed-class-string.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.0')]
 	public function testBug13029(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-13029.php'], []);

--- a/tests/PHPStan/Rules/Comparison/data/match-generic-sealed-class-string.php
+++ b/tests/PHPStan/Rules/Comparison/data/match-generic-sealed-class-string.php
@@ -1,0 +1,45 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace MatchGenericSealedClassString;
+
+/**
+ * @template-covariant T
+ * @phpstan-sealed BarCov|BazCov
+ */
+abstract class FooCov {}
+
+/** @template-covariant T @extends FooCov<T> */
+final class BarCov extends FooCov {}
+
+/** @template-covariant T @extends FooCov<T> */
+final class BazCov extends FooCov {}
+
+/** @param FooCov<string> $foo */
+function testTemplateCovariant(FooCov $foo): string {
+	return match ($foo::class) {
+		BarCov::class => 'bar',
+		BazCov::class => 'baz',
+	};
+}
+
+/**
+ * @template T
+ * @phpstan-sealed BarInv|BazInv
+ */
+abstract class FooInv {}
+
+/** @template T @extends FooInv<T> */
+final class BarInv extends FooInv {}
+
+/** @template T @extends FooInv<T> */
+final class BazInv extends FooInv {}
+
+/** @param FooInv<covariant string> $foo */
+function testCovariantParam(FooInv $foo): string {
+	return match ($foo::class) {
+		BarInv::class => 'bar',
+		BazInv::class => 'baz',
+	};
+}


### PR DESCRIPTION
## Summary

`GenericClassStringType::tryRemove()` did not correctly handle `@phpstan-sealed` hierarchies when the sealed class has generic type parameters (`@template`). Match expressions on `$foo::class` falsely reported "Match expression does not handle remaining values" even when all allowed subtypes were covered.

Follow-up to https://github.com/phpstan/phpstan-src/pull/5305

## Motivation

The fix in #5305 passed `$generic` (e.g. `FooCov<string>`) directly to `TypeCombinator::remove()`, which couldn't correctly subtract sealed subtypes from a generic type. This meant sealed exhaustiveness still failed when the sealed class had template parameters.

## Changes

- **`src/Type/Generic/GenericClassStringType.php`** — In the sealed-aware removal path of `tryRemove()`, construct a plain `ObjectType` (with the existing subtracted type carried over) instead of passing the generic type directly to `TypeCombinator::remove()`. This allows sealed subtraction to work correctly regardless of template parameters.

## Test Cases

- **`tests/PHPStan/Rules/Comparison/data/match-generic-sealed-class-string.php`** — Two scenarios:
  - Covariant template sealed hierarchy (`FooCov<T>` sealed to `BarCov|BazCov`) — exhaustive match produces no error
  - Invariant template with covariant param (`FooInv<T>` sealed to `BarInv|BazInv`) — exhaustive match produces no error
- **`tests/PHPStan/Rules/Comparison/MatchExpressionRuleTest.php`** — Added `testGenericSealedClassStringMatch()` rule test method.