### PR TITLE
Merge NeverType pre-scan into existing flattening loop

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -188,58 +188,12 @@ final class TypeCombinator
 			}
 		}
 
-		// Fast path for N>2: strip implicit NeverTypes and short-circuit on mixed
-		if ($typesCount > 2) {
-			$neverCount = 0;
-			$hasUnionOrBenevolent = false;
-			for ($i = 0; $i < $typesCount; $i++) {
-				$t = $types[$i];
-				if (
-					$t instanceof MixedType
-					&& !$t->isExplicitMixed()
-					&& !$t instanceof TemplateMixedType
-					&& $t->getSubtractedType() === null
-				) {
-					return $t;
-				}
-				if ($t instanceof NeverType && !$t->isExplicit()) {
-					$neverCount++;
-				} elseif ($t instanceof UnionType && !$t instanceof TemplateType) {
-					$hasUnionOrBenevolent = true;
-				}
-			}
-
-			if ($neverCount > 0 && !$hasUnionOrBenevolent) {
-				if ($neverCount === $typesCount) {
-					return new NeverType();
-				}
-
-				$filtered = [];
-				for ($i = 0; $i < $typesCount; $i++) {
-					if ($types[$i] instanceof NeverType && !$types[$i]->isExplicit()) {
-						continue;
-					}
-
-					$filtered[] = $types[$i];
-				}
-				$filteredCount = count($filtered);
-
-				if ($filteredCount === 1 && !$filtered[0]->isArray()->yes()) {
-					return $filtered[0];
-				}
-				if ($filteredCount === 2) {
-					return self::union($filtered[0], $filtered[1]);
-				}
-				$types = $filtered;
-				$typesCount = $filteredCount;
-			}
-		}
-
 		$alreadyNormalized = [];
 		$alreadyNormalizedCounter = 0;
 
 		$benevolentTypes = [];
 		$benevolentUnionObject = null;
+		$neverCount = 0;
 		// transform A | (B | C) to A | B | C
 		for ($i = 0; $i < $typesCount; $i++) {
 			if (
@@ -251,8 +205,7 @@ final class TypeCombinator
 				return $types[$i];
 			}
 			if ($types[$i] instanceof NeverType && !$types[$i]->isExplicit()) {
-				array_splice($types, $i--, 1);
-				$typesCount--;
+				$neverCount++;
 				continue;
 			}
 			if ($types[$i] instanceof BenevolentUnionType) {
@@ -281,6 +234,33 @@ final class TypeCombinator
 			$alreadyNormalizedCounter++;
 			array_splice($types, $i, 1, $typesInner);
 			$typesCount += count($typesInner) - 1;
+		}
+
+		// Bulk-remove implicit NeverTypes (skipped during the loop above)
+		if ($neverCount > 0) {
+			if ($neverCount === $typesCount) {
+				return new NeverType();
+			}
+
+			$filtered = [];
+			for ($i = 0; $i < $typesCount; $i++) {
+				if ($types[$i] instanceof NeverType && !$types[$i]->isExplicit()) {
+					continue;
+				}
+				$filtered[] = $types[$i];
+			}
+			$types = $filtered;
+			$typesCount = count($types);
+
+			if ($typesCount === 0) {
+				return new NeverType();
+			}
+			if ($typesCount === 1 && !$types[0]->isArray()->yes()) {
+				return $types[0];
+			}
+			if ($typesCount === 2) {
+				return self::union($types[0], $types[1]);
+			}
 		}
 
 		if ($typesCount === 0) {


### PR DESCRIPTION
Follow-up to #5325 and fe1df1aa0eb90711dfdf97bbb40245e89c8dcf45.

The N>2 pre-scan and the flattening loop both iterate all types checking for MixedType and NeverType. This removes the pre-scan and counts NeverTypes during the existing flattening loop instead. After the loop, a single bulk filter removes them all, replacing the per-element `array_splice` that was there before.

The `$hasUnionOrBenevolent` guard is no longer needed. UnionTypes get flattened first, then the post-loop filter removes any NeverTypes from the result.

The escaped mutant on `!$types[0]->isArray()->yes()` vs `$types[0]->isArray()->no()` is pre-existing — that line is unchanged from before this PR.

