### PR TITLE
Prevent duplicate argument re-normalizing

### DIFF
--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -484,28 +484,21 @@ final class FuncCallHandler implements ExprHandler
 	private function getFunctionThrowPoint(
 		FunctionReflection $functionReflection,
 		?ParametersAcceptor $parametersAcceptor,
-		FuncCall $funcCall,
+		FuncCall $normalizedFuncCall,
 		MutatingScope $scope,
 	): ?InternalThrowPoint
 	{
-		$normalizedFuncCall = $funcCall;
-		if ($parametersAcceptor !== null) {
-			$normalizedFuncCall = ArgumentsNormalizer::reorderFuncArguments($parametersAcceptor, $funcCall);
-		}
-
-		if ($normalizedFuncCall !== null) {
-			foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicFunctionThrowTypeExtensions() as $extension) {
-				if (!$extension->isFunctionSupported($functionReflection)) {
-					continue;
-				}
-
-				$throwType = $extension->getThrowTypeFromFunctionCall($functionReflection, $normalizedFuncCall, $scope);
-				if ($throwType === null) {
-					return null;
-				}
-
-				return InternalThrowPoint::createExplicit($scope, $throwType, $funcCall, false);
+		foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicFunctionThrowTypeExtensions() as $extension) {
+			if (!$extension->isFunctionSupported($functionReflection)) {
+				continue;
 			}
+
+			$throwType = $extension->getThrowTypeFromFunctionCall($functionReflection, $normalizedFuncCall, $scope);
+			if ($throwType === null) {
+				return null;
+			}
+
+			return InternalThrowPoint::createExplicit($scope, $throwType, $normalizedFuncCall, false);
 		}
 
 		$throwType = $functionReflection->getThrowType();
@@ -518,7 +511,7 @@ final class FuncCallHandler implements ExprHandler
 
 		if ($throwType !== null) {
 			if (!$throwType->isVoid()->yes()) {
-				return InternalThrowPoint::createExplicit($scope, $throwType, $funcCall, true);
+				return InternalThrowPoint::createExplicit($scope, $throwType, $normalizedFuncCall, true);
 			}
 		} elseif ($this->implicitThrows) {
 			$requiredParameters = null;
@@ -536,11 +529,11 @@ final class FuncCallHandler implements ExprHandler
 				!$functionReflection->isBuiltin()
 				|| $requiredParameters === null
 				|| $requiredParameters > 0
-				|| count($funcCall->getArgs()) > 0
+				|| count($normalizedFuncCall->getArgs()) > 0
 			) {
-				$functionReturnedType = $scope->getType($funcCall);
+				$functionReturnedType = $scope->getType($normalizedFuncCall);
 				if (!(new ObjectType(Throwable::class))->isSuperTypeOf($functionReturnedType)->yes()) {
-					return InternalThrowPoint::createImplicit($scope, $funcCall);
+					return InternalThrowPoint::createImplicit($scope, $normalizedFuncCall);
 				}
 			}
 		}

--- a/src/Analyser/ExprHandler/MethodCallHandler.php
+++ b/src/Analyser/ExprHandler/MethodCallHandler.php
@@ -153,7 +153,7 @@ final class MethodCallHandler implements ExprHandler
 		$scope = $argsResult->getScope();
 
 		if ($methodReflection !== null) {
-			$methodThrowPoint = $this->getMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
+			$methodThrowPoint = $this->getMethodThrowPoint($methodReflection, $parametersAcceptor, $normalizedExpr, $scope);
 			if ($methodThrowPoint !== null) {
 				$throwPoints[] = $methodThrowPoint;
 			}
@@ -235,29 +235,26 @@ final class MethodCallHandler implements ExprHandler
 		return $result;
 	}
 
-	private function getMethodThrowPoint(MethodReflection $methodReflection, ParametersAcceptor $parametersAcceptor, MethodCall $methodCall, MutatingScope $scope): ?InternalThrowPoint
+	private function getMethodThrowPoint(MethodReflection $methodReflection, ParametersAcceptor $parametersAcceptor, MethodCall $normalizedMethodCall, MutatingScope $scope): ?InternalThrowPoint
 	{
-		$normalizedMethodCall = ArgumentsNormalizer::reorderMethodArguments($parametersAcceptor, $methodCall);
-		if ($normalizedMethodCall !== null) {
-			foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicMethodThrowTypeExtensions() as $extension) {
-				if (!$extension->isMethodSupported($methodReflection)) {
-					continue;
-				}
-
-				$throwType = $extension->getThrowTypeFromMethodCall($methodReflection, $normalizedMethodCall, $scope);
-				if ($throwType === null) {
-					return null;
-				}
-
-				return InternalThrowPoint::createExplicit($scope, $throwType, $methodCall, false);
+		foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicMethodThrowTypeExtensions() as $extension) {
+			if (!$extension->isMethodSupported($methodReflection)) {
+				continue;
 			}
+
+			$throwType = $extension->getThrowTypeFromMethodCall($methodReflection, $normalizedMethodCall, $scope);
+			if ($throwType === null) {
+				return null;
+			}
+
+			return InternalThrowPoint::createExplicit($scope, $throwType, $normalizedMethodCall, false);
 		}
 
 		if (
 			in_array($methodReflection->getName(), ['invoke', 'invokeArgs'], true)
 			&& in_array($methodReflection->getDeclaringClass()->getName(), [ReflectionMethod::class, ReflectionFunction::class], true)
 		) {
-			return InternalThrowPoint::createImplicit($scope, $methodCall);
+			return InternalThrowPoint::createImplicit($scope, $normalizedMethodCall);
 		}
 
 		$throwType = $methodReflection->getThrowType();
@@ -270,12 +267,12 @@ final class MethodCallHandler implements ExprHandler
 
 		if ($throwType !== null) {
 			if (!$throwType->isVoid()->yes()) {
-				return InternalThrowPoint::createExplicit($scope, $throwType, $methodCall, true);
+				return InternalThrowPoint::createExplicit($scope, $throwType, $normalizedMethodCall, true);
 			}
 		} elseif ($this->implicitThrows) {
-			$methodReturnedType = $scope->getType($methodCall);
+			$methodReturnedType = $scope->getType($normalizedMethodCall);
 			if (!(new ObjectType(Throwable::class))->isSuperTypeOf($methodReturnedType)->yes()) {
-				return InternalThrowPoint::createImplicit($scope, $methodCall);
+				return InternalThrowPoint::createImplicit($scope, $normalizedMethodCall);
 			}
 		}
 

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -29,7 +29,6 @@ use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\Node\Expr\PossiblyImpureCallExpr;
 use PHPStan\Reflection\Callables\SimpleImpurePoint;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptor;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
@@ -199,7 +198,7 @@ final class StaticCallHandler implements ExprHandler
 		$scopeFunction = $scope->getFunction();
 
 		if ($methodReflection !== null) {
-			$methodThrowPoint = $this->getStaticMethodThrowPoint($methodReflection, $parametersAcceptor, $expr, $scope);
+			$methodThrowPoint = $this->getStaticMethodThrowPoint($methodReflection, $normalizedExpr, $scope);
 			if ($methodThrowPoint !== null) {
 				$throwPoints[] = $methodThrowPoint;
 			}
@@ -269,7 +268,7 @@ final class StaticCallHandler implements ExprHandler
 		);
 	}
 
-	private function getStaticMethodThrowPoint(MethodReflection $methodReflection, ParametersAcceptor $parametersAcceptor, StaticCall $normalizedMethodCall, MutatingScope $scope): ?InternalThrowPoint
+	private function getStaticMethodThrowPoint(MethodReflection $methodReflection, StaticCall $normalizedMethodCall, MutatingScope $scope): ?InternalThrowPoint
 	{
 		foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicStaticMethodThrowTypeExtensions() as $extension) {
 			if (!$extension->isStaticMethodSupported($methodReflection)) {

--- a/src/Analyser/ExprHandler/StaticCallHandler.php
+++ b/src/Analyser/ExprHandler/StaticCallHandler.php
@@ -269,33 +269,30 @@ final class StaticCallHandler implements ExprHandler
 		);
 	}
 
-	private function getStaticMethodThrowPoint(MethodReflection $methodReflection, ParametersAcceptor $parametersAcceptor, StaticCall $methodCall, MutatingScope $scope): ?InternalThrowPoint
+	private function getStaticMethodThrowPoint(MethodReflection $methodReflection, ParametersAcceptor $parametersAcceptor, StaticCall $normalizedMethodCall, MutatingScope $scope): ?InternalThrowPoint
 	{
-		$normalizedMethodCall = ArgumentsNormalizer::reorderStaticCallArguments($parametersAcceptor, $methodCall);
-		if ($normalizedMethodCall !== null) {
-			foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicStaticMethodThrowTypeExtensions() as $extension) {
-				if (!$extension->isStaticMethodSupported($methodReflection)) {
-					continue;
-				}
-
-				$throwType = $extension->getThrowTypeFromStaticMethodCall($methodReflection, $normalizedMethodCall, $scope);
-				if ($throwType === null) {
-					return null;
-				}
-
-				return InternalThrowPoint::createExplicit($scope, $throwType, $methodCall, false);
+		foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicStaticMethodThrowTypeExtensions() as $extension) {
+			if (!$extension->isStaticMethodSupported($methodReflection)) {
+				continue;
 			}
+
+			$throwType = $extension->getThrowTypeFromStaticMethodCall($methodReflection, $normalizedMethodCall, $scope);
+			if ($throwType === null) {
+				return null;
+			}
+
+			return InternalThrowPoint::createExplicit($scope, $throwType, $normalizedMethodCall, false);
 		}
 
 		if ($methodReflection->getThrowType() !== null) {
 			$throwType = $methodReflection->getThrowType();
 			if (!$throwType->isVoid()->yes()) {
-				return InternalThrowPoint::createExplicit($scope, $throwType, $methodCall, true);
+				return InternalThrowPoint::createExplicit($scope, $throwType, $normalizedMethodCall, true);
 			}
 		} elseif ($this->implicitThrows) {
-			$methodReturnedType = $scope->getType($methodCall);
+			$methodReturnedType = $scope->getType($normalizedMethodCall);
 			if (!(new ObjectType(Throwable::class))->isSuperTypeOf($methodReturnedType)->yes()) {
-				return InternalThrowPoint::createImplicit($scope, $methodCall);
+				return InternalThrowPoint::createImplicit($scope, $normalizedMethodCall);
 			}
 		}
 


### PR DESCRIPTION
arguments already have been normalized at the call-site. don't normalize them again in private methods

[review with whitespaces ignored](https://github.com/phpstan/phpstan-src/pull/5393/files?w=1)