### PR TITLE
Do fast check first

### DIFF
--- a/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
+++ b/src/Rules/PhpDoc/VarTagTypeRuleHelper.php
@@ -99,12 +99,9 @@ final class VarTagTypeRuleHelper
 				$varTagType->describe($verbosity),
 				$exprNativeType->describe($verbosity),
 			))->identifier('varTag.nativeType')->build();
-		} else {
+		} elseif ($this->checkTypeAgainstPhpDocType || $containsPhpStanType) {
 			$exprType = $scope->getScopeType($expr);
-			if (
-				$this->shouldVarTagTypeBeReported($scope, $expr, $exprType, $varTagType)
-				&& ($this->checkTypeAgainstPhpDocType || $containsPhpStanType)
-			) {
+			if ($this->shouldVarTagTypeBeReported($scope, $expr, $exprType, $varTagType)) {
 				$verbosity = VerbosityLevel::getRecommendedLevelByType($exprType, $varTagType);
 				$errors[] = RuleErrorBuilder::message(sprintf(
 					'PHPDoc tag @var with type %s is not subtype of type %s.',
@@ -114,7 +111,7 @@ final class VarTagTypeRuleHelper
 			}
 		}
 
-		if (count($errors) === 0 && $containsPhpStanType) {
+		if ($containsPhpStanType && count($errors) === 0) {
 			$exprType = $scope->getScopeType($expr);
 			if (!$exprType->equals($varTagType)) {
 				$verbosity = VerbosityLevel::getRecommendedLevelByType($exprType, $varTagType);


### PR DESCRIPTION
While working on https://github.com/phpstan/phpstan-src/pull/5394 I found this

Also, this helper rely a lot on IsSuperTypeOf result but then transform checks into boolean and lose the reason.
I feel like it would be great to keep the reasons to add them as tips of the errors.