### PR TITLE
Fix ObjectType::equals

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1474,12 +1474,6 @@ parameters:
 			path: src/Type/ObjectShapeType.php
 
 		-
-			rawMessage: 'Doing instanceof PHPStan\Type\Enum\EnumCaseObjectType is error-prone and deprecated. Use Type::getEnumCases() instead.'
-			identifier: phpstanApi.instanceofType
-			count: 1
-			path: src/Type/ObjectType.php
-
-		-
 			rawMessage: Doing instanceof PHPStan\Type\Generic\GenericObjectType is error-prone and deprecated.
 			identifier: phpstanApi.instanceofType
 			count: 1
@@ -1488,7 +1482,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\ObjectType is error-prone and deprecated. Use Type::isObject() or Type::getObjectClassNames() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 3
+			count: 2
 			path: src/Type/ObjectType.php
 
 		-

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -42,7 +42,6 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
-use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -626,19 +625,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function equals(Type $type): bool
 	{
-		if (!$type instanceof self) {
-			return false;
-		}
-
-		if ($type instanceof EnumCaseObjectType) {
-			return false;
-		}
-
-		if ($type instanceof TemplateType) {
-			return false;
-		}
-
-		if ($type instanceof GenericObjectType && !$this instanceof GenericObjectType) {
+		if (get_class($type) !== static::class) {
 			return false;
 		}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -56,6 +56,7 @@ use function array_key_exists;
 use function array_map;
 use function array_values;
 use function count;
+use function get_class;
 use function implode;
 use function in_array;
 use function sprintf;
@@ -624,11 +625,7 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function equals(Type $type): bool
 	{
-		if (!$type instanceof self) {
-			return false;
-		}
-
-		if ($type instanceof EnumCaseObjectType) {
+		if (get_class($type) !== static::class) {
 			return false;
 		}
 

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -42,6 +42,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Traits\MaybeIterableTypeTrait;
 use PHPStan\Type\Traits\NonArrayTypeTrait;
@@ -625,7 +626,19 @@ class ObjectType implements TypeWithClassName, SubtractableType
 
 	public function equals(Type $type): bool
 	{
-		if (get_class($type) !== static::class) {
+		if (!$type instanceof self) {
+			return false;
+		}
+
+		if ($type instanceof EnumCaseObjectType) {
+			return false;
+		}
+
+		if ($type instanceof TemplateType) {
+			return false;
+		}
+
+		if ($type instanceof GenericObjectType && !$this instanceof GenericObjectType) {
 			return false;
 		}
 

--- a/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
+++ b/tests/PHPStan/Rules/Comparison/ImpossibleCheckTypeFunctionCallRuleTest.php
@@ -1195,6 +1195,13 @@ class ImpossibleCheckTypeFunctionCallRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.1')]
+	public function testBug14429(): void
+	{
+		$this->treatPhpDocTypesAsCertain = false;
+		$this->analyse([__DIR__ . '/data/bug-14429.php'], []);
+	}
+
 	public function testBug13799(): void
 	{
 		$this->treatPhpDocTypesAsCertain = true;

--- a/tests/PHPStan/Rules/Comparison/data/bug-14429.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-14429.php
@@ -1,0 +1,43 @@
+<?php // lint >= 8.1
+
+declare(strict_types = 1);
+
+namespace Bug14429;
+
+function throw_if(bool $condition, string $message): void
+{
+	if ($condition) { throw new \Exception($message); }
+}
+
+class Foo
+{
+	/**
+	 * @param list<string> $tags
+	 * @param list<float> $scores
+	 * @param \ArrayObject<string, string> $stringMap
+	 * @param \ArrayObject<string, int> $intKeyMap
+	 */
+	public function __construct(
+		public array $tags,
+		public array $scores,
+		public ?\ArrayObject $stringMap = null,
+		public ?\ArrayObject $intKeyMap = null,
+	) {
+		foreach ($tags as $tagsItem) {
+			throw_if(!is_string($tagsItem), 'tags item must be string');
+		}
+		foreach ($scores as $scoresItem) {
+			throw_if(!is_int($scoresItem) && !is_float($scoresItem), 'scores item must be number');
+		}
+		if ($stringMap !== null) {
+			foreach ($stringMap as $stringMapValue) {
+				throw_if(!is_string($stringMapValue), 'stringMap value must be string');
+			}
+		}
+		if ($intKeyMap !== null) {
+			foreach ($intKeyMap as $intKeyMapValue) {
+				throw_if(!is_int($intKeyMapValue), 'intKeyMap value must be int');
+			}
+		}
+	}
+}

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -404,6 +404,19 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-12973.php'], []);
 	}
 
+	public function testBug3028(): void
+	{
+		$this->checkNullables = true;
+		$this->checkExplicitMixed = true;
+		$this->analyse([__DIR__ . '/data/bug-3028.php'], [
+			[
+				'Function Bug3028\run() should return Bug3028\Format<Bug3028\Output> but returns Bug3028\Format<O of Bug3028\Output>.',
+				50,
+				'Template type O on class Bug3028\Format is not covariant. Learn more: <fg=cyan>https://phpstan.org/blog/whats-up-with-template-covariant</>',
+			],
+		]);
+	}
+
 	public function testBug12397(): void
 	{
 		$this->checkNullables = true;

--- a/tests/PHPStan/Rules/Functions/data/bug-3028.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-3028.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace Bug3028;
+
+interface Output { }
+
+final class OutputImpl1 implements Output { }
+final class OutputImpl2 implements Output { }
+
+/** @psalm-template O of Output */
+interface Format
+{
+	/** @psalm-return O */
+	public function output() : Output;
+
+	/** @psalm-param O $o */
+	public function replace(Output $o) : void;
+}
+
+/** @implements Format<OutputImpl1> */
+final class FormatImpl1 implements Format
+{
+	public OutputImpl1 $o;
+
+	public function __construct() {
+		$this->o = new OutputImpl1;
+	}
+
+	public function output() : Output
+	{
+		return new OutputImpl1();
+	}
+
+	/**
+	 * @param OutputImpl1 $o
+	 */
+	public function replace(Output $o) : void
+	{
+		$this->o = $o;
+	}
+}
+
+
+/**
+ * @psalm-template O of Output
+ * @psalm-param    Format<O> $outputFormat
+ * @return Format<Output>
+ */
+function run(Format $outputFormat) : Format {
+	return $outputFormat;
+}
+
+$a = new FormatImpl1;
+run($a)->replace(new OutputImpl2);

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -592,6 +592,10 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 		$this->strictWideningCheck = true;
 		$this->analyse([__DIR__ . '/data/generic-subtype.php'], [
 			[
+				'PHPDoc tag @var with type GenericSubtype\IRepository<E of GenericSubtype\IEntity> is not subtype of type GenericSubtype\IRepository<GenericSubtype\IEntity>.',
+				78,
+			],
+			[
 				'PHPDoc tag @var with type GenericSubtype\IRepository<GenericSubtype\Foo> is not subtype of type GenericSubtype\IRepository<GenericSubtype\IEntity>.',
 				131,
 			],

--- a/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
+++ b/tests/PHPStan/Rules/PhpDoc/WrongVariableNameInVarTagRuleTest.php
@@ -586,6 +586,18 @@ class WrongVariableNameInVarTagRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testGenericSubtype(): void
+	{
+		$this->checkTypeAgainstPhpDocType = true;
+		$this->strictWideningCheck = true;
+		$this->analyse([__DIR__ . '/data/generic-subtype.php'], [
+			[
+				'PHPDoc tag @var with type GenericSubtype\IRepository<GenericSubtype\Foo> is not subtype of type GenericSubtype\IRepository<GenericSubtype\IEntity>.',
+				131,
+			],
+		]);
+	}
+
 	public function testNewIsAlwaysFinalClass(): void
 	{
 		$this->checkTypeAgainstPhpDocType = true;

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-subtype.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-subtype.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace GenericSubtype;
+
+interface IEntity {
+	/**
+	 * @return IRepository<IEntity>
+	 */
+	public function getRepository(): IRepository;
+}
+
+interface IProperty {}
+
+interface IPropertyContainer extends IProperty {}
+
+/**
+ * @template E of IEntity
+ */
+interface IEntityAwareProperty extends IProperty {}
+
+/**
+ * @template E of IEntity
+ * @extends IEntityAwareProperty<E>
+ */
+interface IRelationshipContainer extends IPropertyContainer, IEntityAwareProperty {}
+
+interface IModel {
+	/**
+	 * @template E of IEntity
+	 * @template T of IRepository<E>
+	 * @param class-string<T> $className
+	 * @return T
+	 */
+	public function getRepository(string $className): IRepository;
+}
+
+/**
+ * @template E of IEntity
+ */
+interface IRepository {
+	public function getModel(): IModel;
+}
+
+class PropertyRelationshipMetadata {
+	/** @var class-string<IRepository<IEntity>> */
+	public string $repository;
+}
+
+/**
+ * @template E of IEntity
+ * @implements IRelationshipContainer<E>
+ */
+class HasOne implements IRelationshipContainer
+{
+	/** @var E|null */
+	protected ?IEntity $parent = null;
+
+	/** @var IRepository<E>|null */
+	protected ?IRepository $targetRepository = null;
+
+	protected PropertyRelationshipMetadata $metadataRelationship;
+
+	/**
+	 * @return E
+	 */
+	protected function getParentEntity(): IEntity
+	{
+		return $this->parent ?? throw new \InvalidArgumentException('Relationship is not attached to a parent entity.');
+	}
+
+	/**
+	 * @return IRepository<E>
+	 */
+	protected function getTargetRepository(): IRepository
+	{
+		if ($this->targetRepository === null) {
+			/** @var IRepository<E> $targetRepository */
+			$targetRepository = $this->getParentEntity()
+				->getRepository()
+				->getModel()
+				->getRepository($this->metadataRelationship->repository);
+
+			$this->test($targetRepository);
+
+			$this->targetRepository = $targetRepository;
+		}
+
+		return $this->targetRepository;
+	}
+
+	/**
+	 * @param IRepository<IEntity>
+	 */
+	protected function test(): void {}
+}
+
+class Foo implements IEntity {
+	public function getRepository(): IRepository {
+		throw new \BadMethodCallException();
+	}
+}
+
+/**
+ * @implements IRelationshipContainer<Foo>
+ */
+class HasOne2 implements IRelationshipContainer
+{
+	/** @var Foo|null */
+	protected ?IEntity $parent = null;
+
+	/** @var IRepository<Foo>|null */
+	protected ?IRepository $targetRepository = null;
+
+	protected PropertyRelationshipMetadata $metadataRelationship;
+
+	/**
+	 * @return Foo
+	 */
+	protected function getParentEntity(): IEntity
+	{
+		return $this->parent ?? throw new \InvalidArgumentException('Relationship is not attached to a parent entity.');
+	}
+
+	/**
+	 * @return IRepository<Foo>
+	 */
+	protected function getTargetRepository(): IRepository
+	{
+		if ($this->targetRepository === null) {
+			/** @var IRepository<Foo> $targetRepository */
+			$targetRepository = $this->getParentEntity()
+				->getRepository()
+				->getModel()
+				->getRepository($this->metadataRelationship->repository);
+
+			$this->test($targetRepository);
+
+			$this->targetRepository = $targetRepository;
+		}
+
+		return $this->targetRepository;
+	}
+
+	/**
+	 * @param IRepository<IEntity> $repository
+	 */
+	protected function test($repository): void {}
+}

--- a/tests/PHPStan/Rules/PhpDoc/data/generic-subtype.php
+++ b/tests/PHPStan/Rules/PhpDoc/data/generic-subtype.php
@@ -1,4 +1,4 @@
-<?php
+<?php // lint >= 8.0
 
 namespace GenericSubtype;
 

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -1050,6 +1050,17 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-4525.php'], []);
 	}
 
+	public function testBug5298(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-5298.php'], [
+			[
+				'Property Bug5298\WorldProviderManager::$providers (array<string, Bug5298\WorldProviderManagerEntry<Bug5298\WorldProvider>>) does not accept non-empty-array<string, Bug5298\WorldProviderManagerEntry<Bug5298\WorldProvider>|Bug5298\WorldProviderManagerEntry<T of Bug5298\WorldProvider>>.',
+				37,
+				'Template type TWorldProvider on class Bug5298\WorldProviderManagerEntry is not covariant. Learn more: <fg=cyan>https://phpstan.org/blog/whats-up-with-template-covariant</>',
+			],
+		]);
+	}
+
 	public function testBug10924(): void
 	{
 		$this->analyse([__DIR__ . '/../Methods/data/bug-10924.php'], []);

--- a/tests/PHPStan/Rules/Properties/data/bug-5298.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-5298.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace Bug5298;
+
+interface WorldProvider{}
+
+interface WritableWorldProvider extends WorldProvider{}
+
+/**
+ * @phpstan-template TWorldProvider of WorldProvider
+ * @phpstan-type IsValid \Closure(string $path) : bool
+ * @phpstan-type FromPath \Closure(string $path) : TWorldProvider
+ */
+class WorldProviderManagerEntry{
+	/** @phpstan-param TWorldProvider $provider */
+	public function acceptsTWorldProvider(WorldProvider $provider) : void{}
+}
+
+
+final class WorldProviderManager{
+	/**
+	 * @var WorldProviderManagerEntry[]
+	 * @phpstan-var array<string, WorldProviderManagerEntry<WorldProvider>>
+	 */
+	protected $providers = [];
+
+	/**
+	 * @phpstan-template T of WorldProvider
+	 * @phpstan-param WorldProviderManagerEntry<T> $providerEntry
+	 */
+	public function addProvider(WorldProviderManagerEntry $providerEntry, string $name, bool $overwrite = false) : void{
+		$name = strtolower($name);
+		if(!$overwrite and isset($this->providers[$name])){
+			throw new \InvalidArgumentException("Alias \"$name\" is already assigned");
+		}
+
+		$this->providers[$name] = $providerEntry; //should be an error, T of WorldProvider is not invariant with WorldProvider
+		\PHPStan\dumpType($providerEntry);
+		\PHPStan\dumpType($this->providers);
+	}
+
+	public function doSomething(string $name, WorldProvider $provider) : void{
+		$this->providers[$name]->acceptsTWorldProvider($provider); //error, WorldProvider might not be a subclass of the template bound
+	}
+}
+
+$p = new WorldProviderManager();
+/** @phpstan-var WorldProviderManagerEntry<WritableWorldProvider> */
+$entry = new WorldProviderManagerEntry(); //acceptsTWorldProvider() doesn't accept WorldProvider
+$p->addProvider($entry, "test");
+$p->doSomething("test", new class implements WorldProvider{}); //bang

--- a/tests/PHPStan/Type/ObjectTypeTest.php
+++ b/tests/PHPStan/Type/ObjectTypeTest.php
@@ -31,7 +31,9 @@ use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\Generic\TemplateObjectType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
+use PHPStan\Type\Generic\TemplateTypeParameterStrategy;
 use PHPStan\Type\Generic\TemplateTypeScope;
 use PHPStan\Type\Generic\TemplateTypeVariance;
 use PHPStan\Type\Traits\ConstantNumericComparisonTypeTrait;
@@ -743,6 +745,50 @@ class ObjectTypeTest extends PHPStanTestCase
 		$tModlel = $ancestor->getActiveTemplateTypeMap()->getType('TModlel');
 		$this->assertNotNull($tModlel);
 		$this->assertSame(Model::class, $tModlel->describe(VerbosityLevel::precise()));
+	}
+
+	public static function dataEquals(): array
+	{
+		return [
+			[
+				new ObjectType('Foo'),
+				new ObjectType('Foo'),
+				true,
+			],
+			[
+				new ObjectType('Foo'),
+				new ObjectType('Bar'),
+				false,
+			],
+			[
+				new ObjectType('Foo'),
+				new GenericObjectType('Foo', []),
+				false,
+			],
+			[
+				new ObjectType('Foo'),
+				new TemplateObjectType(
+					TemplateTypeScope::createWithAnonymousFunction(),
+					new TemplateTypeParameterStrategy(),
+					TemplateTypeVariance::createInvariant(),
+					'T',
+					new ObjectType('Foo'),
+					null,
+				),
+				false,
+			],
+		];
+	}
+
+	#[DataProvider('dataEquals')]
+	public function testEquals(ObjectType $type, Type $otherType, bool $expectedResult): void
+	{
+		$actualResult = $type->equals($otherType);
+		$this->assertSame(
+			$expectedResult,
+			$actualResult,
+			sprintf('%s->equals(%s)', $type->describe(VerbosityLevel::precise()), $otherType->describe(VerbosityLevel::precise())),
+		);
 	}
 
 }


### PR DESCRIPTION
https://github.com/phpstan/phpstan-src/pull/5398 shows the behavior before

Closes https://github.com/phpstan/phpstan/issues/3028
Closes https://github.com/phpstan/phpstan/issues/14429
Closes https://github.com/phpstan/phpstan/issues/5298

Failures:
- [x] nextra/orm https://github.com/phpstan/phpstan-src/actions/runs/23979232001/job/69941215879?pr=5399 => This seems justified to me, as proven by the non regression test added ; Prior to this fix we had an inconsistency in the error reported https://github.com/phpstan/phpstan-src/pull/5398

- [x] rector/downgrade https://github.com/phpstan/phpstan-src/actions/runs/23979232001/job/69941215795?pr=5399 => Explain by https://github.com/phpstan/phpstan-src/pull/5399#issuecomment-4187117573

- [x] rector https://github.com/phpstan/phpstan-src/actions/runs/23979232001/job/69941215804?pr=5399 => Explain by https://github.com/phpstan/phpstan-src/pull/5399#issuecomment-4187117573

- [x] rector/src https://github.com/phpstan/phpstan-src/actions/runs/23979232001/job/69941215874?pr=5399 => I think `'#Provide more specific return type "Iterator" over abstract one#'` is reported because before, `new ObjectType(Iterator)` was equals to `new GenericObject(Iterator)`, which not now. I would say it need to be fix on rector codebase

I reported the issue on rector side https://github.com/rectorphp/rector/issues/9729