### PR TITLE
Fix infinite recursion in ConstantArrayType::isCallable() via RecursionGuard

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -520,7 +520,6 @@ class ConstantArrayType implements Type
 			return TrinaryLogic::createNo();
 		}
 
-
 		return $result;
 	}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -42,6 +42,7 @@ use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
+use PHPStan\Type\RecursionGuard;
 use PHPStan\Type\Traits\ArrayTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -494,22 +495,31 @@ class ConstantArrayType implements Type
 
 	public function isCallable(): TrinaryLogic
 	{
-		$hasNonExistentMethod = false;
-		$typeAndMethods = $this->doFindTypeAndMethodNames($hasNonExistentMethod);
-		if ($typeAndMethods === []) {
+		$result = RecursionGuard::run($this, function (): TrinaryLogic {
+			$hasNonExistentMethod = false;
+			$typeAndMethods = $this->doFindTypeAndMethodNames($hasNonExistentMethod);
+			if ($typeAndMethods === []) {
+				return TrinaryLogic::createNo();
+			}
+
+			$results = array_map(
+				static fn (ConstantArrayTypeAndMethod $typeAndMethod): TrinaryLogic => $typeAndMethod->getCertainty(),
+				$typeAndMethods,
+			);
+
+			$result = TrinaryLogic::createYes()->and(...$results);
+
+			if ($hasNonExistentMethod) {
+				$result = $result->and(TrinaryLogic::createMaybe());
+			}
+
+			return $result;
+		});
+
+		if ($result instanceof ErrorType) {
 			return TrinaryLogic::createNo();
 		}
 
-		$results = array_map(
-			static fn (ConstantArrayTypeAndMethod $typeAndMethod): TrinaryLogic => $typeAndMethod->getCertainty(),
-			$typeAndMethods,
-		);
-
-		$result = TrinaryLogic::createYes()->and(...$results);
-
-		if ($hasNonExistentMethod) {
-			$result = $result->and(TrinaryLogic::createMaybe());
-		}
 
 		return $result;
 	}

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -93,6 +93,14 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	public function testConstantArrayCallableDoesNotCauseInfiniteRecursion(): void
+	{
+		// Previously caused infinite recursion / OOM via ConstantArrayType::isCallable()
+		// resolving getMethod() which triggered return type resolution that called isCallable() again
+		$errors = $this->runAnalyse(__DIR__ . '/data/bug-constant-array-callable-recursion.php');
+		$this->assertCount(3, $errors);
+	}
+
 	public function testClassThatExtendsUnknownClassIn3rdPartyPropertyTypeShouldNotCauseAutoloading(): void
 	{
 		// no error about PHPStan\Tests\Baz not being able to be autoloaded

--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -93,6 +93,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	#[RequiresPhp('>= 8.0')]
 	public function testConstantArrayCallableDoesNotCauseInfiniteRecursion(): void
 	{
 		// Previously caused infinite recursion / OOM via ConstantArrayType::isCallable()

--- a/tests/PHPStan/Analyser/data/bug-constant-array-callable-recursion.php
+++ b/tests/PHPStan/Analyser/data/bug-constant-array-callable-recursion.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BugConstantArrayCallableRecursion;
+
+class Period
+{
+
+	/**
+	 * @return array{'BugConstantArrayCallableRecursion\Period', 'endIteration'}
+	 */
+	public function endIteration(): callable
+	{
+		return [self::class, 'endIteration'];
+	}
+
+}
+
+function test(): void
+{
+	$cb = ['BugConstantArrayCallableRecursion\Period', 'endIteration'];
+	is_callable($cb);
+}


### PR DESCRIPTION
## Summary

When PHPStan analyses code that uses CarbonPeriod (from the nesbot/carbon package), it enters a recursive type resolution loop and runs out of memory.                                                                                                                              

**Root cause**: ConstantArrayType::isCallable() had no recursion guard. When checking if [ClassName::class, 'method'] is callable, it calls getMethod('method') to verify the method is static (PHP 8.0+ requirement). That triggers full method resolution — getVariants() → getReturnType() → TypehintHelper::decideType(). If the method's native return type is callable, decideType() checks $phpDocType->isCallable(), which calls ConstantArrayType::isCallable() again, creating an infinite loop.

**Fix**: Wrapped ConstantArrayType::isCallable() in RecursionGuard::run(), identical to the existing pattern in ObjectType::isCallable() (line 1558). When re-entry is detected, ErrorType is returned and converted to TrinaryLogic::createNo().

### Changes:                                                                                                                                
  - src/Type/Constant/ConstantArrayType.php: Added RecursionGuard import and wrapping                                                     
  - tests/PHPStan/Analyser/data/bug-constant-array-callable-recursion.php: Regression test data with the self-referential callable pattern  
  - tests/PHPStan/Analyser/AnalyserIntegrationTest.php: Test verifying analysis completes without OOM