### PR TITLE
Add test for unknown named parameters on native variadic functions

### DIFF
--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -545,6 +545,20 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/number-format-named-arguments.php'], []);
 	}
 
+	public function testBug14408(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			$this->markTestSkipped('Test requires PHP 8.0');
+		}
+
+		$this->analyse([__DIR__ . '/data/bug-14408.php'], [
+			[
+				'Unknown parameter $foo in call to function sprintf.',
+				6,
+			],
+		]);
+	}
+
 	public function testArrayReduceCallback(): void
 	{
 		$this->analyse([__DIR__ . '/data/array_reduce.php'], [

--- a/tests/PHPStan/Rules/Functions/data/bug-14408.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14408.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bug14408;
+
+// This should report an error: sprintf does not accept unknown named parameters
+sprintf(format: '%s', foo: 'bar');
+
+// This should be fine: named parameter matches the signature
+sprintf(format: '%s %s', values: 'hello');
+
+// call_user_func should accept unknown named args (forwards to callback)
+call_user_func('strtolower', str: 'HELLO');


### PR DESCRIPTION
This adds a regression test for https://github.com/phpstan/phpstan/issues/14408.

The test verifies that unknown named arguments passed to native variadic functions like `sprintf()` are properly reported as errors, since PHP rejects them at runtime (`ArgumentCountError: sprintf() does not accept unknown named parameters`).

Based on code analysis, it appears the detection logic at `FunctionCallParametersCheck:707` already handles this case (`!$isNativelyVariadic || $isBuiltin`), combined with the fact that `Php8SignatureMapProvider` strips the variadic parameter from `namedArgumentsVariants`. If the test passes on CI, this confirms the issue is already resolved in 2.0.x. If it fails, it pinpoints where the fix is needed.

Test cases:
- `sprintf(format: '%s', foo: 'bar')` — should report `Unknown parameter $foo`
- `sprintf(format: '%s %s', values: 'hello')` — should pass (known parameter)
- `call_user_func('strtolower', str: 'HELLO')` — should pass (forwards args to callback)