### PR TITLE
bisect: advertise gzip,deflate encoding when supported

### DIFF
--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -9,6 +9,7 @@ use Nette\Utils\Json;
 use Override;
 use PHPStan\Command\Bisect\BinarySearch;
 use PHPStan\File\FileReader;
+use PHPStan\Internal\HttpClientFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -23,7 +24,6 @@ use function array_values;
 use function chmod;
 use function count;
 use function escapeshellarg;
-use function extension_loaded;
 use function getenv;
 use function implode;
 use function is_array;
@@ -107,24 +107,20 @@ final class BisectCommand extends Command
 			return 1;
 		}
 
-		$headers = [
-			'Authorization' => 'token ' . $token,
-			'Accept' => 'application/vnd.github.v3+json',
-		];
-		if (extension_loaded('zlib')) {
-			$headers['Accept-Encoding'] = 'gzip,deflate';
-		}
-
-		$client = new Client([
+		$client = HttpClientFactory::createClient([
 			RequestOptions::TIMEOUT => 30,
 			RequestOptions::CONNECT_TIMEOUT => 10,
-			'headers' => $headers,
+			'headers' => [
+				'Authorization' => 'token ' . $token,
+				'Accept' => 'application/vnd.github.v3+json',
+			],
 		]);
 
 		$io->section(sprintf('Fetching commits between %s and %s...', $good, $bad));
 
 		try {
 			$commits = $this->getCommitsBetween($client, $good, $bad);
+			exit;
 		} catch (GuzzleException $e) {
 			$io->error(sprintf('Failed to fetch commits from GitHub: %s', $e->getMessage()));
 			return 1;

--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -108,8 +108,6 @@ final class BisectCommand extends Command
 		}
 
 		$client = (new HttpClientFactory())->createClient([
-			RequestOptions::TIMEOUT => 30,
-			RequestOptions::CONNECT_TIMEOUT => 10,
 			'headers' => [
 				'Authorization' => 'token ' . $token,
 				'Accept' => 'application/vnd.github.v3+json',

--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -107,7 +107,7 @@ final class BisectCommand extends Command
 			return 1;
 		}
 
-		$client = HttpClientFactory::createClient([
+		$client = (new HttpClientFactory())->createClient([
 			RequestOptions::TIMEOUT => 30,
 			RequestOptions::CONNECT_TIMEOUT => 10,
 			'headers' => [

--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -23,6 +23,7 @@ use function array_values;
 use function chmod;
 use function count;
 use function escapeshellarg;
+use function extension_loaded;
 use function getenv;
 use function implode;
 use function is_array;
@@ -106,7 +107,7 @@ final class BisectCommand extends Command
 			return 1;
 		}
 
-		$headers =  [
+		$headers = [
 			'Authorization' => 'token ' . $token,
 			'Accept' => 'application/vnd.github.v3+json',
 		];
@@ -117,7 +118,7 @@ final class BisectCommand extends Command
 		$client = new Client([
 			RequestOptions::TIMEOUT => 30,
 			RequestOptions::CONNECT_TIMEOUT => 10,
-			'headers' => $headers
+			'headers' => $headers,
 		]);
 
 		$io->section(sprintf('Fetching commits between %s and %s...', $good, $bad));

--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -106,19 +106,25 @@ final class BisectCommand extends Command
 			return 1;
 		}
 
+		$headers =  [
+			'Authorization' => 'token ' . $token,
+			'Accept' => 'application/vnd.github.v3+json',
+		];
+		if (extension_loaded('zlib')) {
+			$headers['Accept-Encoding'] = 'gzip,deflate';
+		}
+
 		$client = new Client([
 			RequestOptions::TIMEOUT => 30,
 			RequestOptions::CONNECT_TIMEOUT => 10,
-			'headers' => [
-				'Authorization' => 'token ' . $token,
-				'Accept' => 'application/vnd.github.v3+json',
-			],
+			'headers' => $headers
 		]);
 
 		$io->section(sprintf('Fetching commits between %s and %s...', $good, $bad));
 
 		try {
 			$commits = $this->getCommitsBetween($client, $good, $bad);
+			exit();
 		} catch (GuzzleException $e) {
 			$io->error(sprintf('Failed to fetch commits from GitHub: %s', $e->getMessage()));
 			return 1;

--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -120,7 +120,6 @@ final class BisectCommand extends Command
 
 		try {
 			$commits = $this->getCommitsBetween($client, $good, $bad);
-			exit;
 		} catch (GuzzleException $e) {
 			$io->error(sprintf('Failed to fetch commits from GitHub: %s', $e->getMessage()));
 			return 1;

--- a/src/Command/BisectCommand.php
+++ b/src/Command/BisectCommand.php
@@ -124,7 +124,6 @@ final class BisectCommand extends Command
 
 		try {
 			$commits = $this->getCommitsBetween($client, $good, $bad);
-			exit();
 		} catch (GuzzleException $e) {
 			$io->error(sprintf('Failed to fetch commits from GitHub: %s', $e->getMessage()));
 			return 1;

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -7,7 +7,6 @@ use Clue\React\NDJson\Encoder;
 use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
 use Nette\Utils\Json;

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -326,10 +326,7 @@ final class FixerApplication
 			$output->writeln('<fg=green>Checking if there\'s a new PHPStan Pro release...</>');
 		}
 
-		$client = $this->httpClientFactory->createClient([
-			RequestOptions::TIMEOUT => 30,
-			RequestOptions::CONNECT_TIMEOUT => 5,
-		]);
+		$client = $this->httpClientFactory->createClient([]);
 
 		$latestUrl = sprintf('https://fixer-download-api.phpstan.com/latest?%s', http_build_query(['phpVersion' => PHP_VERSION_ID, 'branch' => $branch]));
 

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -23,6 +23,7 @@ use PHPStan\File\FileWriter;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Internal\DirectoryCreator;
 use PHPStan\Internal\DirectoryCreatorException;
+use PHPStan\Internal\HttpClientFactory;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\Process\ProcessCanceledException;
 use PHPStan\Process\ProcessCrashedException;
@@ -325,7 +326,7 @@ final class FixerApplication
 			$output->writeln('<fg=green>Checking if there\'s a new PHPStan Pro release...</>');
 		}
 
-		$client = new Client([
+		$client = HttpClientFactory::createClient([
 			RequestOptions::TIMEOUT => 30,
 			RequestOptions::CONNECT_TIMEOUT => 5,
 		]);

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -93,6 +93,7 @@ final class FixerApplication
 		private ?string $editorUrl,
 		#[AutowiredParameter]
 		private string $usedLevel,
+		private HttpClientFactory $httpClientFactory,
 	)
 	{
 	}
@@ -325,7 +326,7 @@ final class FixerApplication
 			$output->writeln('<fg=green>Checking if there\'s a new PHPStan Pro release...</>');
 		}
 
-		$client = HttpClientFactory::createClient([
+		$client = $this->httpClientFactory->createClient([
 			RequestOptions::TIMEOUT => 30,
 			RequestOptions::CONNECT_TIMEOUT => 5,
 		]);

--- a/src/Internal/HttpClientFactory.php
+++ b/src/Internal/HttpClientFactory.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Internal;
+
+use GuzzleHttp\Client;
+use function extension_loaded;
+
+final class HttpClientFactory
+{
+
+	/**
+	 * @see \GuzzleHttp\RequestOptions
+	 */
+	public static function createClient(array $config): Client
+	{
+		if (
+			!isset($config['headers']['Accept-Encoding'])
+			&& extension_loaded('zlib')
+		) {
+			$config['headers']['Accept-Encoding'] = 'gzip,deflate';
+		}
+
+		return new Client($config);
+	}
+
+}

--- a/src/Internal/HttpClientFactory.php
+++ b/src/Internal/HttpClientFactory.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Internal;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
 use PHPStan\DependencyInjection\AutowiredService;
 use function extension_loaded;
 
@@ -10,12 +11,10 @@ use function extension_loaded;
 final class HttpClientFactory
 {
 
-	/**
-	 * @param array<mixed> $defaults
-	 *
-	 * @see \GuzzleHttp\RequestOptions
-	 */
-	public function __construct(private readonly array $defaults = [])
+	public function __construct(
+		private int $timeout = 30,
+		private int $connectTimeout = 10,
+	)
 	{
 	}
 
@@ -33,7 +32,12 @@ final class HttpClientFactory
 			$config['headers']['Accept-Encoding'] = 'gzip,deflate';
 		}
 
-		return new Client($config + $this->defaults);
+		$defaults = [
+			RequestOptions::TIMEOUT => $this->timeout,
+			RequestOptions::CONNECT_TIMEOUT => $this->connectTimeout,
+		];
+
+		return new Client($config + $defaults);
 	}
 
 }

--- a/src/Internal/HttpClientFactory.php
+++ b/src/Internal/HttpClientFactory.php
@@ -9,6 +9,8 @@ final class HttpClientFactory
 {
 
 	/**
+	 * @param array<mixed> $config
+	 *
 	 * @see \GuzzleHttp\RequestOptions
 	 */
 	public static function createClient(array $config): Client

--- a/src/Internal/HttpClientFactory.php
+++ b/src/Internal/HttpClientFactory.php
@@ -3,17 +3,28 @@
 namespace PHPStan\Internal;
 
 use GuzzleHttp\Client;
+use PHPStan\DependencyInjection\AutowiredService;
 use function extension_loaded;
 
+#[AutowiredService]
 final class HttpClientFactory
 {
+
+	/**
+	 * @param array<mixed> $defaults
+	 *
+	 * @see \GuzzleHttp\RequestOptions
+	 */
+	public function __construct(private readonly array $defaults = [])
+	{
+	}
 
 	/**
 	 * @param array<mixed> $config
 	 *
 	 * @see \GuzzleHttp\RequestOptions
 	 */
-	public static function createClient(array $config): Client
+	public function createClient(array $config): Client
 	{
 		if (
 			!isset($config['headers']['Accept-Encoding'])
@@ -22,7 +33,7 @@ final class HttpClientFactory
 			$config['headers']['Accept-Encoding'] = 'gzip,deflate';
 		}
 
-		return new Client($config);
+		return new Client($config + $this->defaults);
 	}
 
 }


### PR DESCRIPTION
time to fetch the commits..

... before this PR
```
➜  phpstan-src git:(bisect-gzip) ✗ time php bin/phpstan bisect foo.php  --good=2.1.0 --bad=2.1.46

Fetching commits between 2.1.0 and 2.1.46...
--------------------------------------------

php bin/phpstan bisect foo.php --good=2.1.0 --bad=2.1.46  0.27s user 0.17s system 0% cpu 54.959 total
```

... after this PR
```
➜  phpstan-src git:(bisect-gzip) ✗ time php bin/phpstan bisect foo.php  --good=2.1.0 --bad=2.1.46

Fetching commits between 2.1.0 and 2.1.46...
--------------------------------------------

php bin/phpstan bisect foo.php --good=2.1.0 --bad=2.1.46  0.22s user 0.08s system 0% cpu 44.516 total
```

-> saves ~10 seconds when downloading big responses