### PR TITLE
Fix built-in function signatures overridden by vendor stubs

### DIFF
--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -25,6 +25,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypehintHelper;
 use function array_key_exists;
 use function array_map;
+use function function_exists;
 use function str_contains;
 use function strtolower;
 
@@ -78,7 +79,7 @@ final class NativeFunctionReflectionProvider
 			$isDeprecated = $reflectionFunction->isDeprecated();
 			if ($reflectionFunction->getFileName() !== null) {
 				$fileName = $reflectionFunction->getFileName();
-				if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill')) {
+				if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill') && !function_exists($functionName)) {
 					return null;
 				}
 				$docComment = $reflectionFunction->getDocComment();

--- a/tests/PHPStan/Rules/Functions/Bug14450Test.php
+++ b/tests/PHPStan/Rules/Functions/Bug14450Test.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Rules\FunctionCallParametersCheck;
+use PHPStan\Rules\NullsafeCheck;
+use PHPStan\Rules\PhpDoc\UnresolvableTypeHelper;
+use PHPStan\Rules\Properties\PropertyReflectionFinder;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+use function array_merge;
+
+/**
+ * @extends RuleTestCase<CallToFunctionParametersRule>
+ */
+class Bug14450Test extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$reflectionProvider = self::createReflectionProvider();
+		return new CallToFunctionParametersRule(
+			$reflectionProvider,
+			new FunctionCallParametersCheck(
+				new RuleLevelHelper(
+					$reflectionProvider,
+					checkNullables: true,
+					checkThisOnly: false,
+					checkUnionTypes: true,
+					checkExplicitMixed: false,
+					checkImplicitMixed: false,
+					checkBenevolentUnionTypes: false,
+					discoveringSymbolsTip: true,
+				),
+				new NullsafeCheck(),
+				new UnresolvableTypeHelper(),
+				new PropertyReflectionFinder(),
+				$reflectionProvider,
+				checkArgumentTypes: true,
+				checkArgumentsPassedByReference: true,
+				checkExtraArguments: true,
+				checkMissingTypehints: true,
+			),
+		);
+	}
+
+	public function testBug14450(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14450.php'], []);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return array_merge(
+			parent::getAdditionalConfigFiles(),
+			[__DIR__ . '/bug-14450.neon'],
+		);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/bug-14450.neon
+++ b/tests/PHPStan/Rules/Functions/bug-14450.neon
@@ -1,0 +1,3 @@
+parameters:
+	scanFiles:
+		- data/bug-14450-stubs.php

--- a/tests/PHPStan/Rules/Functions/data/bug-14450-stubs.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14450-stubs.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Simulates vendor/jetbrains/phpstorm-stubs/standard/standard_1.php
+ * where optional parameters lack default values.
+ *
+ * @param array|string $search
+ * @param array|string $replace
+ * @param array|string $subject
+ * @param int $count
+ * @return array|string
+ */
+function str_replace(array|string $search, array|string $replace, array|string $subject, &$count): array|string {}
+
+/**
+ * @return string
+ */
+function substr(string $string, int $offset, ?int $length): string {}

--- a/tests/PHPStan/Rules/Functions/data/bug-14450.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14450.php
@@ -1,0 +1,14 @@
+<?php
+
+// Built-in PHP functions called with optional parameters omitted.
+// These should not report errors even when jetbrains/phpstorm-stubs
+// is present in vendor/ with incorrect signatures (missing defaults).
+
+$a = str_replace('foo', 'bar', 'foobar');
+$b = substr('hello', 1);
+$c = array_keys(['a' => 1, 'b' => 2]);
+$d = strtotime('now');
+$e = array_filter([0, 1, 2, '', null]);
+$f = phpversion();
+$g = ['a' => 1, 'b' => 2];
+array_walk_recursive($g, function(&$v) { $v = ''; });


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/14450

## Summary

When `jetbrains/phpstorm-stubs` is present in `vendor/` as a transitive dependency (e.g. via `roave/better-reflection`), BetterReflection resolves built-in PHP functions like `substr()` and `str_replace()` from those stub files. Since these come from `.php` files, `isInternal()` returns false, and the signature map corrections introduced in 326c6ec are skipped.

The JetBrains stubs have incorrect signatures for 199 functions (optional parameters without default values — [fixed in JetBrains/phpstorm-stubs#1863](https://github.com/JetBrains/phpstorm-stubs/pull/1863) but not yet released). This causes false-positive `arguments.count` errors for standard calls like `str_replace('foo', 'bar', $subject)` and `substr($string, 1)`.

## The fix

Added a `function_exists()` check in `NativeFunctionReflectionProvider`: if the function exists in PHP's runtime, it is a core built-in that cannot be redeclared by userland code, so signature corrections should always apply.

```php
// Before:
if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill')) {

// After:
if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill') && !function_exists($functionName)) {
```

The `isInternal()` guard is preserved for functions from unloaded PECL extensions (e.g. `swf_actiongotoframe`, `http_redirect`), which CAN be redeclared by userland code — `function_exists()` correctly returns false for those.

## Why `function_exists()` is safe here

- `PhpStormStubsMap.php` (loaded via Composer `autoload_files`) is a class with constant arrays — it does not define or include any functions. `function_exists()` is unaffected by stub loading.
- Core PHP built-in functions (`substr`, `str_replace`, etc.) always return `function_exists() = true` — they cannot be redeclared (fatal error).
- PECL extension functions that aren't loaded return `function_exists() = false` — they can be redeclared, and the guard correctly skips corrections for them.
- Functions disabled via `php.ini` `disable_functions` are completely removed from PHP's function table — `function_exists()` returns false, so if someone disables and redeclares a function, their definition is used. This is correct.

## Test

`Bug14450Test` uses a `scanFiles` neon config to load a stub file with intentionally wrong signatures (simulating `jetbrains/phpstorm-stubs`). The test:
- **Fails without the fix** — reports `str_replace` and `substr` argument count errors
- **Passes with the fix** — `function_exists()` recognizes them as core built-ins

## Impact

This regression (introduced in 2.1.29) affects any project with `jetbrains/phpstorm-stubs` in its vendor directory. Key packages in the dependency chain:
- `roave/better-reflection` (12.6M downloads) — requires `jetbrains/phpstorm-stubs` as a hard dependency
- 100+ packages depend on `roave/better-reflection`, including `roave/backward-compatibility-check` (3.4M), `kcs/class-finder` (1.6M), `php-tui/php-tui` (780K)

Reproduction repository: https://github.com/bartech/phpstan-14450-repro