### PR TITLE
Fix built-in function signatures overridden by vendor stubs

### DIFF
--- a/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
+++ b/src/Reflection/SignatureMap/NativeFunctionReflectionProvider.php
@@ -24,6 +24,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypehintHelper;
 use function array_key_exists;
 use function array_map;
+use function function_exists;
 use function str_contains;
 use function strtolower;
 
@@ -76,7 +77,7 @@ final class NativeFunctionReflectionProvider
 			$isDeprecated = $reflectionFunction->isDeprecated();
 			if ($reflectionFunction->getFileName() !== null) {
 				$fileName = $reflectionFunction->getFileName();
-				if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill')) {
+				if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill') && !function_exists($functionName)) {
 					return null;
 				}
 				$docComment = $reflectionFunction->getDocComment();

--- a/tests/PHPStan/Rules/Functions/Bug14450Test.php
+++ b/tests/PHPStan/Rules/Functions/Bug14450Test.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use PHPStan\Rules\FunctionCallParametersCheck;
+use PHPStan\Rules\NullsafeCheck;
+use PHPStan\Rules\PhpDoc\UnresolvableTypeHelper;
+use PHPStan\Rules\Properties\PropertyReflectionFinder;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleLevelHelper;
+use PHPStan\Testing\RuleTestCase;
+use function array_merge;
+
+/**
+ * @extends RuleTestCase<CallToFunctionParametersRule>
+ */
+class Bug14450Test extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		$reflectionProvider = self::createReflectionProvider();
+		return new CallToFunctionParametersRule(
+			$reflectionProvider,
+			new FunctionCallParametersCheck(
+				new RuleLevelHelper(
+					$reflectionProvider,
+					checkNullables: true,
+					checkThisOnly: false,
+					checkUnionTypes: true,
+					checkExplicitMixed: false,
+					checkImplicitMixed: false,
+					checkBenevolentUnionTypes: false,
+					discoveringSymbolsTip: true,
+				),
+				new NullsafeCheck(),
+				new UnresolvableTypeHelper(),
+				new PropertyReflectionFinder(),
+				$reflectionProvider,
+				checkArgumentTypes: true,
+				checkArgumentsPassedByReference: true,
+				checkExtraArguments: true,
+				checkMissingTypehints: true,
+			),
+		);
+	}
+
+	public function testBug14450(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14450.php'], []);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return array_merge(
+			parent::getAdditionalConfigFiles(),
+			[__DIR__ . '/bug-14450.neon'],
+		);
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/bug-14450.neon
+++ b/tests/PHPStan/Rules/Functions/bug-14450.neon
@@ -1,0 +1,3 @@
+parameters:
+	scanFiles:
+		- data/bug-14450-stubs.php

--- a/tests/PHPStan/Rules/Functions/data/bug-14450-stubs.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14450-stubs.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Simulates incorrect vendor stubs (e.g. jetbrains/phpstorm-stubs)
+ * where optional parameters lack default values.
+ *
+ * @param array|string $search
+ * @param array|string $replace
+ * @param array|string $subject
+ * @param int $count
+ * @return array|string
+ */
+function str_replace(array|string $search, array|string $replace, array|string $subject, &$count): array|string {}
+
+/**
+ * @return string
+ */
+function substr(string $string, int $offset, ?int $length): string {}

--- a/tests/PHPStan/Rules/Functions/data/bug-14450.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14450.php
@@ -1,0 +1,14 @@
+<?php
+
+// Built-in PHP functions called with optional parameters omitted.
+// These should not report errors even when incorrect vendor stubs
+// are present (e.g. jetbrains/phpstorm-stubs with missing defaults).
+
+$a = str_replace('foo', 'bar', 'foobar');
+$b = substr('hello', 1);
+$c = array_keys(['a' => 1, 'b' => 2]);
+$d = strtotime('now');
+$e = array_filter([0, 1, 2, '', null]);
+$f = phpversion();
+$g = ['a' => 1, 'b' => 2];
+array_walk_recursive($g, function(&$v) { $v = ''; });


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan/issues/14450

## Problem

Since 2.1.29 (commit 326c6ec), `NativeFunctionReflectionProvider` skips signature map corrections for functions where `isInternal()` returns false. This was correct for userland classes/methods sharing names with PECL extensions (#13556, #12151, #11303, #9486).

However, when **any** vendor package ships incorrect stubs for core PHP functions (e.g. `jetbrains/phpstorm-stubs` with optional parameters lacking default values), BetterReflection resolves built-in functions like `substr()` and `str_replace()` from those vendor `.php` files. Since they come from files, `isInternal()` returns false, and PHPStan's correct signature corrections are skipped — causing false-positive `arguments.count` errors.

`jetbrains/phpstorm-stubs` is the most common case — it arrives as a transitive dependency via `roave/better-reflection` (12.6M downloads, 100+ dependents including `roave/backward-compatibility-check`, `kcs/class-finder`, `php-tui/php-tui`, `lucasbustamante/stubz`). Users never install it directly and have no reason to know it's in their vendor directory.

[JetBrains/phpstorm-stubs#1863](https://github.com/JetBrains/phpstorm-stubs/pull/1863) fixes 199 incorrect signatures but is merged and **not yet released** (latest release: v2025.3, September 2025).

## Fix

Added a `function_exists()` check: if the function exists in PHP's runtime, it is a core built-in that cannot be redeclared (`function substr() {}` is a fatal error), so signature corrections should always apply.

```php
// Before:
if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill')) {

// After:
if (!$reflectionFunctionAdapter->isInternal() && !str_contains(strtolower($fileName), 'polyfill') && !function_exists($functionName)) {
```

The `isInternal()` guard is preserved for functions from unloaded PECL extensions (e.g. `swf_actiongotoframe`, `http_redirect`), which CAN be redeclared — `function_exists()` correctly returns false for those.

## Why `function_exists()` is safe

- `PhpStormStubsMap.php` (loaded via Composer `autoload_files`) is a class with constant arrays — it does not define functions. `function_exists()` is unaffected by stub loading.
- Core built-in functions always return `function_exists() = true` and cannot be redeclared.
- Loaded PECL extension functions return `function_exists() = true` and `isInternal() = true` — already handled by the existing guard.
- Unloaded PECL functions return `function_exists() = false` — guard correctly skips corrections.
- Functions disabled via `disable_functions` are removed from PHP's function table — `function_exists() = false` — guard correctly skips corrections (they can be redeclared).

## Test

`Bug14450Test` uses a `scanFiles` config to load a stub file with intentionally incorrect signatures (simulating any vendor package with wrong stubs). The test **fails without the fix** (reports `str_replace` and `substr` errors) and **passes with the fix**.

Reproduction repository: https://github.com/bartech/phpstan-14450-repro