### PR TITLE
Fix non regression test

### DIFF
--- a/tests/PHPStan/Analyser/nsrt/bug-14249.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14249.php
@@ -69,6 +69,7 @@ function doTemplated(): void {
 	assertType('false', $v);
 }
 
+/** @phpstan-impure */
 function getMixed(): mixed {}
 
 function maybeCallable() {


### PR DESCRIPTION
While working on https://github.com/phpstan/phpstan-src/pull/5386 I understood why the fix seemed to introduce a regression on bug-14249 file.

It's because the test
```
function doTemplated(): void {
	$f1 = assertIfTemplated(...);
	$f2 = 'Bug14249\assertIfTemplated';

	$v = getMixed();
	assertIfTemplated($v, true);
	assertType('true', $v);

	$v = getMixed();
	$f1($v, true);
	assertType('true', $v);

	$v = getMixed();
	$f2($v, true);
	assertType('true', $v);

	$v = getMixed();
	assertIfTemplated($v, false);
	assertType('false', $v);

	$v = getMixed();
	$f1($v, false);
	assertType('false', $v);

	$v = getMixed();
	$f2($v, false);
	assertType('false', $v);
}
```
is basically wrong.

Since `getMixed` is considered pure by default, it will return the same value.
If you call `assertIfTemplated($v, true);` the first time, it's expected to consider that `getMixed` will allway return a truthy value.

Then `assertIfTemplated($v, false);` would gives NEVER.