### PR TITLE
Fix ReflectionGetAttributesMethodReturnTypeExtension for union types

### DIFF
--- a/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
+++ b/src/Type/Php/ReflectionGetAttributesMethodReturnTypeExtension.php
@@ -32,8 +32,7 @@ final class ReflectionGetAttributesMethodReturnTypeExtension implements DynamicM
 
 	public function isMethodSupported(MethodReflection $methodReflection): bool
 	{
-		return $methodReflection->getDeclaringClass()->getName() === $this->className
-			&& $methodReflection->getName() === 'getAttributes';
+		return $methodReflection->getName() === 'getAttributes';
 	}
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type

--- a/tests/PHPStan/Analyser/nsrt/reflection-attribute-getattributes-union.php
+++ b/tests/PHPStan/Analyser/nsrt/reflection-attribute-getattributes-union.php
@@ -1,0 +1,54 @@
+<?php // lint >= 8.0
+
+declare(strict_types=1);
+
+namespace ReflectionAttributeGetAttributesUnion;
+
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionProperty;
+use function PHPStan\Testing\assertType;
+
+#[\Attribute]
+class MyAttr {}
+
+// Single type — worked before
+function testSingle(ReflectionClass $ref): void
+{
+	/** @var class-string<MyAttr> $class */
+	$class = MyAttr::class;
+	$attrs = $ref->getAttributes($class, ReflectionAttribute::IS_INSTANCEOF);
+	assertType('list<ReflectionAttribute<ReflectionAttributeGetAttributesUnion\MyAttr>>', $attrs);
+	assertType('ReflectionAttributeGetAttributesUnion\MyAttr', $attrs[0]->newInstance());
+}
+
+// Union type — dynamic extension should fire for all members
+function testUnion(ReflectionClass|ReflectionProperty $ref): void
+{
+	/** @var class-string<MyAttr> $class */
+	$class = MyAttr::class;
+	$attrs = $ref->getAttributes($class, ReflectionAttribute::IS_INSTANCEOF);
+	assertType('list<ReflectionAttribute<ReflectionAttributeGetAttributesUnion\MyAttr>>', $attrs);
+	assertType('ReflectionAttributeGetAttributesUnion\MyAttr', $attrs[0]->newInstance());
+}
+
+// Template T flows through union
+/**
+ * @template T of object
+ * @param ReflectionClass<object>|ReflectionProperty $reflection
+ * @param class-string<T> $attributeClassName
+ * @return T
+ */
+function getSingleAttribute(
+	ReflectionClass|ReflectionProperty $reflection,
+	string $attributeClassName,
+): object
+{
+	$attributes = $reflection->getAttributes($attributeClassName, ReflectionAttribute::IS_INSTANCEOF);
+	assertType('list<ReflectionAttribute<T of object (function ReflectionAttributeGetAttributesUnion\getSingleAttribute(), argument)>>', $attributes);
+
+	$instance = $attributes[0]->newInstance();
+	assertType('T of object (function ReflectionAttributeGetAttributesUnion\getSingleAttribute(), argument)', $instance);
+
+	return $instance;
+}


### PR DESCRIPTION
## Bug

When calling `getAttributes()` on a union type like `ReflectionClass|ReflectionProperty`, the `ReflectionGetAttributesMethodReturnTypeExtension` fails to fire for all members of the union. This causes the return type to fall back to `list<ReflectionAttribute<object>>` instead of the expected `list<ReflectionAttribute<T>>`, producing false `return.type` errors in generic code.

**Reproduction:**

```php
/** @template T of object */
function get(ReflectionClass|ReflectionProperty $ref, class-string<T> $class): T {
    return $ref->getAttributes($class)[0]->newInstance(); // return.type error: returns object, not T
}
```

## Root cause

`isMethodSupported()` checked `$methodReflection->getDeclaringClass()->getName() === $this->className`. When the receiver is a union type, `MethodCallReturnTypeHelper` iterates per class name in the union, but the `$methodReflection` passed to `isMethodSupported` always has the same declaring class (from the first resolved member). So the extension fires for one member but not the others, and the unhandled members fall back to the stub return type.

## Fix

Remove the redundant declaring class check from `isMethodSupported()`. The extension is already registered per-class via `getClass()` and only dispatched for matching classes by `getDynamicMethodReturnTypeExtensionsForClass($className)`, so the check was unnecessary and actively harmful for union types.

Co-Authored-By: Claude Code