### PR TITLE
Fix wrong signature for DateInterval::createFromDateString in 8.3+

### DIFF
--- a/resources/functionMap_php83delta.php
+++ b/resources/functionMap_php83delta.php
@@ -23,6 +23,7 @@ return [
 	'new' => [
 		'DateTime::modify' => ['static', 'modify'=>'string'],
 		'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
+		'DateInterval::createFromDateString' => ['DateInterval', 'time'=>'string'],
 		'str_decrement' => ['non-empty-string', 'string'=>'non-empty-string'],
 		'str_increment' => ['non-falsy-string', 'string'=>'non-empty-string'],
 		'gc_status' => ['array{running:bool,protected:bool,full:bool,runs:int,collected:int,threshold:int,buffer_size:int,roots:int,application_time:float,collector_time:float,destructor_time:float,free_time:float}'],

--- a/src/Type/Php/DateIntervalCreateFromDateStringMethodThrowTypeExtension.php
+++ b/src/Type/Php/DateIntervalCreateFromDateStringMethodThrowTypeExtension.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Php;
+
+use DateInterval;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodThrowTypeExtension;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
+
+#[AutowiredService]
+final class DateIntervalCreateFromDateStringMethodThrowTypeExtension implements DynamicStaticMethodThrowTypeExtension
+{
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'createFromDateString' && $methodReflection->getDeclaringClass()->getName() === DateInterval::class;
+	}
+
+	public function getThrowTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+	{
+		if (count($methodCall->getArgs()) === 0) {
+			return null;
+		}
+
+		if (!$this->phpVersion->hasDateTimeExceptions()) {
+			return null;
+		}
+
+		$valueType = $scope->getType($methodCall->getArgs()[0]->value);
+		$constantStrings = $valueType->getConstantStrings();
+
+		foreach ($constantStrings as $constantString) {
+			try {
+				DateInterval::createFromDateString($constantString->getValue());
+			} catch (\Exception) { // phpcs:ignore
+				return $methodReflection->getThrowType();
+			}
+
+			$valueType = TypeCombinator::remove($valueType, $constantString);
+		}
+
+		if (!$valueType instanceof NeverType) {
+			return $methodReflection->getThrowType();
+		}
+
+		return null;
+	}
+
+}

--- a/src/Type/Php/DateIntervalDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateIntervalDynamicReturnTypeExtension.php
@@ -50,17 +50,10 @@ implements DynamicStaticMethodReturnTypeExtension
 		foreach ($strings as $string) {
 			try {
 				$result = @DateInterval::createFromDateString($string->getValue());
-				if ($this->phpVersion->hasDateTimeExceptions()) {
-					return new ObjectType(DateInterval::class);
-				}
 			} catch (Throwable) {
-				if ($this->phpVersion->hasDateTimeExceptions()) {
-					return new NeverType();
-				}
 				$possibleReturnTypes[] = false;
 				continue;
 			}
-			// @phpstan-ignore instanceof.alwaysTrue (should only run for < 8.3 and then statement isn't true)
 			$possibleReturnTypes[] = $result instanceof DateInterval ? DateInterval::class : false;
 		}
 
@@ -74,6 +67,9 @@ implements DynamicStaticMethodReturnTypeExtension
 		}
 
 		if (in_array(false, $possibleReturnTypes, true)) {
+			if ($this->phpVersion->hasDateTimeExceptions()) {
+				return new NeverType();
+			}
 			return new ConstantBooleanType(false);
 		}
 

--- a/src/Type/Php/DateIntervalDynamicReturnTypeExtension.php
+++ b/src/Type/Php/DateIntervalDynamicReturnTypeExtension.php
@@ -6,9 +6,11 @@ use DateInterval;
 use PhpParser\Node\Expr\StaticCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Throwable;
@@ -19,6 +21,10 @@ use function in_array;
 final class DateIntervalDynamicReturnTypeExtension
 implements DynamicStaticMethodReturnTypeExtension
 {
+
+	public function __construct(private PhpVersion $phpVersion)
+	{
+	}
 
 	public function getClass(): string
 	{
@@ -44,10 +50,17 @@ implements DynamicStaticMethodReturnTypeExtension
 		foreach ($strings as $string) {
 			try {
 				$result = @DateInterval::createFromDateString($string->getValue());
+				if ($this->phpVersion->hasDateTimeExceptions()) {
+					return new ObjectType(DateInterval::class);
+				}
 			} catch (Throwable) {
+				if ($this->phpVersion->hasDateTimeExceptions()) {
+					return new NeverType();
+				}
 				$possibleReturnTypes[] = false;
 				continue;
 			}
+			// @phpstan-ignore instanceof.alwaysTrue (should only run for < 8.3 and then statement isn't true)
 			$possibleReturnTypes[] = $result instanceof DateInterval ? DateInterval::class : false;
 		}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-14479-83.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14479-83.php
@@ -1,0 +1,13 @@
+<?php // lint >= 8.3
+
+namespace Bug14479Php83;
+
+use function PHPStan\Testing\assertType;
+
+function test(string $input) {
+	assertType(\DateInterval::class, \DateInterval::createFromDateString($input));
+}
+
+function test2() {
+	assertType('*NEVER*', \DateInterval::createFromDateString('foo'));
+}

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -141,6 +141,10 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 				'Dead catch - ArithmeticError is never thrown in the try block.',
 				762,
 			],
+			[
+				'Dead catch - DateMalformedIntervalStringException is never thrown in the try block.',
+				800,
+			],
 		]);
 	}
 
@@ -232,6 +236,10 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 			[
 				'Dead catch - Exception is never thrown in the try block.',
 				555,
+			],
+			[
+				'Dead catch - DateMalformedIntervalStringException is never thrown in the try block.',
+				800,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Exceptions/data/unthrown-exception.php
+++ b/tests/PHPStan/Rules/Exceptions/data/unthrown-exception.php
@@ -790,3 +790,24 @@ class TestIntdivWithRange
 	}
 
 }
+
+class TestDateIntervalCreateFromDateString
+{
+	public function doFoo(): void
+	{
+		try {
+			\DateInterval::createFromDateString('P10D');
+		} catch (\DateMalformedIntervalStringException $e) {
+
+		}
+	}
+
+	public function doBar(): void
+	{
+		try {
+			\DateInterval::createFromDateString('invalid');
+		} catch (\DateMalformedIntervalStringException $e) {
+
+		}
+	}
+}


### PR DESCRIPTION
Fixes phpstan/phpstan#14479

# Summary

In php8.3 the signature changed from

```php
DateInterval::createFromDateString(string $datetime): DateInterval|false
```

to

```php
DateInterval::createFromDateString(string $datetime): DateInterval
```

now it instead throws an DateMalformedStringException

Reference: https://www.php.net/manual/en/dateinterval.createfromdatestring.php

----

This pr collides with the fix for phpstan/phpstan#8442 but I don't know how to solve that.

