### PR TITLE
Fix infinite hang when analysing `src/wp-includes/user.php` in wordpress-develop

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,6 +67,12 @@ parameters:
 			path: src/Analyser/MutatingScope.php
 
 		-
+			rawMessage: Doing instanceof PHPStan\Type\IntersectionType is error-prone and deprecated.
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Analyser/MutatingScope.php
+
+		-
 			rawMessage: 'Parameter #2 $node of method PHPStan\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection::__invoke() expects PhpParser\Node\Expr\ArrowFunction|PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\FuncCall|PhpParser\Node\Stmt\Class_|PhpParser\Node\Stmt\Const_|PhpParser\Node\Stmt\Enum_|PhpParser\Node\Stmt\Function_|PhpParser\Node\Stmt\Interface_|PhpParser\Node\Stmt\Trait_, PhpParser\Node\Stmt\ClassLike given.'
 			identifier: argument.type
 			count: 1

--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -139,6 +139,8 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 	public const KEEP_VOID_ATTRIBUTE_NAME = 'keepVoid';
 	private const CONTAINS_SUPER_GLOBAL_ATTRIBUTE_NAME = 'containsSuperGlobal';
 
+	private const COMPLEX_UNION_TYPE_MEMBER_LIMIT = 8;
+
 	/** @var Type[] */
 	private array $resolvedTypes = [];
 
@@ -2743,10 +2745,12 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 					}
 
 					if ($dimType instanceof ConstantIntegerType || $dimType instanceof ConstantStringType) {
-						$varType = TypeCombinator::intersect(
-							$varType,
-							new HasOffsetValueType($dimType, $type),
-						);
+						if (!$this->isComplexUnionType($varType)) {
+							$varType = TypeCombinator::intersect(
+								$varType,
+								new HasOffsetValueType($dimType, $type),
+							);
+						}
 					}
 
 					$scope = $scope->specifyExpressionType(
@@ -3071,9 +3075,36 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 		);
 	}
 
+	/**
+	 * Returns true when the type is a large union with non-trivial
+	 * (IntersectionType) members — a sign of HasOffsetValueType
+	 * combinatorial growth from array|object offset access patterns.
+	 * Operating on such types is expensive and should be skipped.
+	 */
+	private function isComplexUnionType(Type $type): bool
+	{
+		if (!$type instanceof UnionType) {
+			return false;
+		}
+		$types = $type->getTypes();
+		if (count($types) <= self::COMPLEX_UNION_TYPE_MEMBER_LIMIT) {
+			return false;
+		}
+		foreach ($types as $member) {
+			if ($member instanceof IntersectionType) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public function addTypeToExpression(Expr $expr, Type $type): self
 	{
 		$originalExprType = $this->getType($expr);
+		if ($this->isComplexUnionType($originalExprType)) {
+			return $this;
+		}
+
 		$nativeType = $this->getNativeType($expr);
 
 		if ($originalExprType->equals($nativeType)) {
@@ -3097,6 +3128,10 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 
 		$exprType = $this->getType($expr);
 		if ($exprType instanceof NeverType) {
+			return $this;
+		}
+
+		if ($this->isComplexUnionType($exprType)) {
 			return $this;
 		}
 

--- a/tests/bench/data/wordpress-user.php
+++ b/tests/bench/data/wordpress-user.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace BenchComplexUnion;
+
+class WP_User {
+	/** @return array<string, mixed> */
+	public function to_array(): array { return []; }
+}
+
+/** @var array<string, list<callable>> */
+$hooks = [];
+
+/** @return mixed */
+function apply_filters(string $hook, mixed $value, mixed ...$args): mixed {
+	global $hooks;
+	if (isset($hooks[$hook])) { foreach ($hooks[$hook] as $cb) { $value = $cb($value); } }
+	return $value;
+}
+
+function do_action(string $hook, mixed ...$args): void {
+	global $hooks;
+	if (isset($hooks[$hook])) { foreach ($hooks[$hook] as $cb) { $cb(...$args); } }
+}
+
+/** @param array|object $data */
+function insert($data): int {
+	if ($data instanceof \stdClass) { $data = get_object_vars($data); }
+	elseif ($data instanceof WP_User) { $data = $data->to_array(); }
+
+	if (!empty($data["ID"])) {
+		$id = (int)$data["ID"];
+		$update = true;
+		$old_1 = $data["old_1"] ?? "";
+		$old_2 = $data["old_2"] ?? "";
+		$old_3 = $data["old_3"] ?? "";
+		$old_4 = $data["old_4"] ?? "";
+		$old_5 = $data["old_5"] ?? "";
+		$old_6 = $data["old_6"] ?? "";
+		$old_7 = $data["old_7"] ?? "";
+		$old_8 = $data["old_8"] ?? "";
+		$old_9 = $data["old_9"] ?? "";
+		$old_10 = $data["old_10"] ?? "";
+	} else {
+		$id = 0;
+		$update = false;
+		$old_1 = "";
+		$old_2 = "";
+		$old_3 = "";
+		$old_4 = "";
+		$old_5 = "";
+		$old_6 = "";
+		$old_7 = "";
+		$old_8 = "";
+		$old_9 = "";
+		$old_10 = "";
+	}
+
+	$meta_1 = apply_filters("pre_f1", empty($data["f1"]) ? "" : $data["f1"]);
+	$meta_2 = apply_filters("pre_f2", empty($data["f2"]) ? "" : $data["f2"]);
+	$meta_3 = apply_filters("pre_f3", empty($data["f3"]) ? "" : $data["f3"]);
+	$meta_4 = apply_filters("pre_f4", empty($data["f4"]) ? "" : $data["f4"]);
+	$meta_5 = apply_filters("pre_f5", empty($data["f5"]) ? "" : $data["f5"]);
+	$meta_6 = apply_filters("pre_f6", empty($data["f6"]) ? "" : $data["f6"]);
+	$meta_7 = apply_filters("pre_f7", empty($data["f7"]) ? "" : $data["f7"]);
+	$meta_8 = apply_filters("pre_f8", empty($data["f8"]) ? "" : $data["f8"]);
+	$meta_9 = apply_filters("pre_f9", empty($data["f9"]) ? "" : $data["f9"]);
+	$meta_10 = apply_filters("pre_f10", empty($data["f10"]) ? "" : $data["f10"]);
+	$meta_11 = apply_filters("pre_f11", empty($data["f11"]) ? "" : $data["f11"]);
+	$meta_12 = apply_filters("pre_f12", empty($data["f12"]) ? "" : $data["f12"]);
+	$meta_13 = apply_filters("pre_f13", empty($data["f13"]) ? "" : $data["f13"]);
+	$meta_14 = apply_filters("pre_f14", empty($data["f14"]) ? "" : $data["f14"]);
+	$meta_15 = apply_filters("pre_f15", empty($data["f15"]) ? "" : $data["f15"]);
+	$meta_16 = apply_filters("pre_f16", empty($data["f16"]) ? "" : $data["f16"]);
+	$meta_17 = apply_filters("pre_f17", empty($data["f17"]) ? "" : $data["f17"]);
+	$meta_18 = apply_filters("pre_f18", empty($data["f18"]) ? "" : $data["f18"]);
+	$meta_19 = apply_filters("pre_f19", empty($data["f19"]) ? "" : $data["f19"]);
+	$meta_20 = apply_filters("pre_f20", empty($data["f20"]) ? "" : $data["f20"]);
+
+	do_action("after_insert", $id, $data);
+	return $id;
+}

--- a/tests/bench/storage/baseline.xml
+++ b/tests/bench/storage/baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <phpbench xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.5.1">
-  <suite tag="" context="" date="2026-04-16T11:52:44+00:00" config-path="/home/runner/work/phpstan-src/phpstan-src/phpbench.json" uuid="13526402146ceceb090643034efff6d874cdea01">
+  <suite tag="" context="" date="2026-04-16T17:35:00+00:00" config-path="/home/runner/work/phpstan-src/phpstan-src/phpbench.json" uuid="1352640179cda0224dd3841879175ad9bd8c05c3">
     <env>
       <uname>
         <value name="os" type="string">Linux</value>
-        <value name="host" type="string">runnervm35a4x</value>
+        <value name="host" type="string">runnervmeorf1</value>
         <value name="release" type="string">6.17.0-1010-azure</value>
         <value name="version" type="string">#10~24.04.1-Ubuntu SMP Fri Mar  6 22:00:57 UTC 2026</value>
         <value name="machine" type="string">x86_64</value>
@@ -20,9 +20,9 @@
         <value name="enabled" type="boolean"></value>
       </opcache>
       <unix-sysload>
-        <value name="l1" type="double">0.9189453125</value>
-        <value name="l5" type="double">0.30517578125</value>
-        <value name="l15" type="double">0.109375</value>
+        <value name="l1" type="double">0.4375</value>
+        <value name="l5" type="double">0.1552734375</value>
+        <value name="l15" type="double">0.05615234375</value>
       </unix-sysload>
       <vcs>
         <value name="system" type="string">git</value>
@@ -30,9 +30,9 @@
         <value name="version" type="NULL"></value>
       </vcs>
       <sampler>
-        <value name="nothing" type="double">0.0081062316894531</value>
-        <value name="md5" type="double">0.2138614654541</value>
-        <value name="file_rw" type="double">1.5008449554443</value>
+        <value name="nothing" type="double">0.0061988830566406</value>
+        <value name="md5" type="double">0.13899803161621</value>
+        <value name="file_rw" type="double">0.6098747253418</value>
       </sampler>
     </env>
     <benchmark class="\PHPStan\Benchmark\RegressionBench">
@@ -43,625 +43,670 @@
           <parameter name="executor" value="remote" type="string"/>
         </executor>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
+          <parameter-set name="and-chain-truthy-blowup.php">
+            <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/and-chain-truthy-blowup.php" type="string"/>
+          </parameter-set>
+          <iteration time-net="153683" time-revs="1" time-avg="153683" mem-peak="61897424" mem-real="67108864" mem-final="54392096" comp-z-value="1.4061683696836" comp-deviation="0.63451942847414"/>
+          <iteration time-net="153301" time-revs="1" time-avg="153301" mem-peak="54779040" mem-real="56623104" mem-final="47273712" comp-z-value="0.85182748504054" comp-deviation="0.38437864242964"/>
+          <iteration time-net="151922" time-revs="1" time-avg="151922" mem-peak="54779040" mem-real="56623104" mem-final="47273712" comp-z-value="-1.149314085438" comp-deviation="-0.51861649881478"/>
+          <iteration time-net="152039" time-revs="1" time-avg="152039" mem-peak="54779040" mem-real="56623104" mem-final="47273712" comp-z-value="-0.97952905008921" comp-deviation="-0.4420026978535"/>
+          <iteration time-net="152625" time-revs="1" time-avg="152625" mem-peak="54779040" mem-real="56623104" mem-final="47273712" comp-z-value="-0.12915271919695" comp-deviation="-0.058278874235499"/>
+          <stats max="153683" mean="152714" min="151922" mode="152304.52641879" rstdev="0.45124000948543" stdev="689.10666808557" sum="763570" variance="474868"/>
+        </variant>
+        <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-1388.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-1388.php" type="string"/>
           </parameter-set>
-          <iteration time-net="90831" time-revs="1" time-avg="90831" mem-peak="77157864" mem-real="81788928" mem-final="72955184" comp-z-value="-1.4591349146224" comp-deviation="-1.497849525334"/>
-          <iteration time-net="91908" time-revs="1" time-avg="91908" mem-peak="69236872" mem-real="71303168" mem-final="65144144" comp-z-value="-0.32136464018834" comp-deviation="-0.32989127252142"/>
-          <iteration time-net="93647" time-revs="1" time-avg="93647" mem-peak="69236872" mem-real="71303168" mem-final="65144144" comp-z-value="1.5157593219666" comp-deviation="1.555976324174"/>
-          <iteration time-net="92779" time-revs="1" time-avg="92779" mem-peak="69236872" mem-real="71303168" mem-final="65144144" comp-z-value="0.59878197915435" comp-deviation="0.61466920862966"/>
-          <iteration time-net="91896" time-revs="1" time-avg="91896" mem-peak="69236872" mem-real="71303168" mem-final="65144144" comp-z-value="-0.33404174631016" comp-deviation="-0.3429047349483"/>
-          <stats max="93647" mean="92212.2" min="90831" mode="92059.900195696" rstdev="1.026532577847" stdev="946.58827374947" sum="461061" variance="896029.36"/>
+          <iteration time-net="79263" time-revs="1" time-avg="79263" mem-peak="70562264" mem-real="73400320" mem-final="66485600" comp-z-value="0.16977558424243" comp-deviation="0.15086500993131"/>
+          <iteration time-net="80415" time-revs="1" time-avg="80415" mem-peak="69258992" mem-real="71303168" mem-final="65166264" comp-z-value="1.8078113719082" comp-deviation="1.6064470152988"/>
+          <iteration time-net="78743" time-revs="1" time-avg="78743" mem-peak="69258992" mem-real="71303168" mem-final="65166264" comp-z-value="-0.56961556991225" comp-deviation="-0.50616853415817"/>
+          <iteration time-net="78339" time-revs="1" time-avg="78339" mem-peak="69258992" mem-real="71303168" mem-final="65166264" comp-z-value="-1.1440656204478" comp-deviation="-1.0166330568738" reject-count="1"/>
+          <iteration time-net="78958" time-revs="1" time-avg="78958" mem-peak="69258992" mem-real="71303168" mem-final="65166264" comp-z-value="-0.2639057657906" comp-deviation="-0.2345104341981"/>
+          <stats max="80415" mean="79143.6" min="78339" mode="78854.953033268" rstdev="0.88861428811742" stdev="703.2813377305" sum="395718" variance="494604.64"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-1447.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-1447.php" type="string"/>
           </parameter-set>
-          <iteration time-net="21728" time-revs="1" time-avg="21728" mem-peak="66716536" mem-real="69206016" mem-final="63277544" comp-z-value="1.1229765612698" comp-deviation="0.42893063156337"/>
-          <iteration time-net="21733" time-revs="1" time-avg="21733" mem-peak="66716432" mem-real="69206016" mem-final="63277440" comp-z-value="1.1834817639244" comp-deviation="0.45204111817778"/>
-          <iteration time-net="21595" time-revs="1" time-avg="21595" mem-peak="66716432" mem-real="69206016" mem-final="63277440" comp-z-value="-0.48646182934316" comp-deviation="-0.18580831237983"/>
-          <iteration time-net="21521" time-revs="1" time-avg="21521" mem-peak="66716432" mem-real="69206016" mem-final="63277440" comp-z-value="-1.3819388286316" comp-deviation="-0.52784351427304"/>
-          <iteration time-net="21599" time-revs="1" time-avg="21599" mem-peak="66716432" mem-real="69206016" mem-final="63277440" comp-z-value="-0.43805766721946" comp-deviation="-0.1673199230883"/>
-          <stats max="21733" mean="21635.2" min="21521" mode="21594.017612525" rstdev="0.38195866802276" stdev="82.63752174406" sum="108176" variance="6828.96"/>
+          <iteration time-net="18372" time-revs="1" time-avg="18372" mem-peak="66738656" mem-real="69206016" mem-final="63299664" comp-z-value="-1.4983002007777" comp-deviation="-0.49287764718626"/>
+          <iteration time-net="18547" time-revs="1" time-avg="18547" mem-peak="66738552" mem-real="69206016" mem-final="63365096" comp-z-value="1.3830463391794" comp-deviation="0.45496398201809"/>
+          <iteration time-net="18436" time-revs="1" time-avg="18436" mem-peak="66738552" mem-real="69206016" mem-final="63365096" comp-z-value="-0.44455060902195" comp-deviation="-0.14623842279153"/>
+          <iteration time-net="18450" time-revs="1" time-avg="18450" mem-peak="66738552" mem-real="69206016" mem-final="63365096" comp-z-value="-0.21404288582538" comp-deviation="-0.070411092455181"/>
+          <iteration time-net="18510" time-revs="1" time-avg="18510" mem-peak="66738552" mem-real="69206016" mem-final="63365096" comp-z-value="0.77384735644561" comp-deviation="0.25456318041488"/>
+          <stats max="18547" mean="18463" min="18372" mode="18458.98630137" rstdev="0.32895787301533" stdev="60.73549209482" sum="92315" variance="3688.8"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-3686.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-3686.php" type="string"/>
           </parameter-set>
-          <iteration time-net="11551" time-revs="1" time-avg="11551" mem-peak="66333552" mem-real="69206016" mem-final="63834792" comp-z-value="-0.53427369774596" comp-deviation="-0.80039848164752"/>
-          <iteration time-net="11954" time-revs="1" time-avg="11954" mem-peak="66312248" mem-real="69206016" mem-final="63817256" comp-z-value="1.7759441154689" comp-deviation="2.6605520344893"/>
-          <iteration time-net="11487" time-revs="1" time-avg="11487" mem-peak="66312248" mem-real="69206016" mem-final="63817256" comp-z-value="-0.90115692366593" comp-deviation="-1.3500283402896"/>
-          <iteration time-net="11512" time-revs="1" time-avg="11512" mem-peak="66312248" mem-real="69206016" mem-final="63817256" comp-z-value="-0.75784316354095" comp-deviation="-1.1353291767575"/>
-          <iteration time-net="11717" time-revs="1" time-avg="11717" mem-peak="66312248" mem-real="69206016" mem-final="63817256" comp-z-value="0.41732966948396" comp-deviation="0.62520396420535"/>
-          <stats max="11954" mean="11644.2" min="11487" mode="11549.14481409" rstdev="1.4981057181447" stdev="174.4424260322" sum="58221" variance="30430.16"/>
+          <iteration time-net="10437" time-revs="1" time-avg="10437" mem-peak="66355672" mem-real="69206016" mem-final="63856912" comp-z-value="-0.80003538375148" comp-deviation="-0.72480310466842"/>
+          <iteration time-net="10375" time-revs="1" time-avg="10375" mem-peak="66334368" mem-real="69206016" mem-final="63839376" comp-z-value="-1.4509828088511" comp-deviation="-1.3145379142412"/>
+          <iteration time-net="10594" time-revs="1" time-avg="10594" mem-peak="66334368" mem-real="69206016" mem-final="63839376" comp-z-value="0.84833148303305" comp-deviation="0.768557622798"/>
+          <iteration time-net="10530" time-revs="1" time-avg="10530" mem-peak="66334368" mem-real="69206016" mem-final="63839376" comp-z-value="0.17638575389796" comp-deviation="0.15979910969067"/>
+          <iteration time-net="10630" time-revs="1" time-avg="10630" mem-peak="66334368" mem-real="69206016" mem-final="63839376" comp-z-value="1.2263009556715" comp-deviation="1.1109842864209"/>
+          <stats max="10630" mean="10513.2" min="10375" mode="10564.628180039" rstdev="0.90596381033763" stdev="95.245787308416" sum="52566" variance="9071.76"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-4300.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-4300.php" type="string"/>
           </parameter-set>
-          <iteration time-net="5280" time-revs="1" time-avg="5280" mem-peak="66593248" mem-real="69206016" mem-final="66147784" comp-z-value="1.2614185820745" comp-deviation="1.0564997703261"/>
-          <iteration time-net="5242" time-revs="1" time-avg="5242" mem-peak="65734536" mem-real="67108864" mem-final="65289072" comp-z-value="0.39305071760293" comp-deviation="0.32919920379727"/>
-          <iteration time-net="5146" time-revs="1" time-avg="5146" mem-peak="65734536" mem-real="67108864" mem-final="65289072" comp-z-value="-1.8007207294832" comp-deviation="-1.5081917011177"/>
-          <iteration time-net="5229" time-revs="1" time-avg="5229" mem-peak="65734536" mem-real="67108864" mem-final="65289072" comp-z-value="0.095977500810014" comp-deviation="0.080385852090029"/>
-          <iteration time-net="5227" time-revs="1" time-avg="5227" mem-peak="65734536" mem-real="67108864" mem-final="65289072" comp-z-value="0.05027392899572" comp-deviation="0.042106874904299"/>
-          <stats max="5280" mean="5224.8" min="5146" mode="5239.0919765166" rstdev="0.83754891939884" stdev="43.760255940751" sum="26124" variance="1914.96"/>
+          <iteration time-net="5714" time-revs="1" time-avg="5714" mem-peak="65756656" mem-real="69206016" mem-final="65311192" comp-z-value="-0.11715881906807" comp-deviation="-0.15028134064936" reject-count="1"/>
+          <iteration time-net="5639" time-revs="1" time-avg="5639" mem-peak="65756656" mem-real="69206016" mem-final="65311192" comp-z-value="-1.1388927062896" comp-deviation="-1.4608744277077"/>
+          <iteration time-net="5647" time-revs="1" time-avg="5647" mem-peak="65756656" mem-real="69206016" mem-final="65311192" comp-z-value="-1.0299077583193" comp-deviation="-1.3210778317548"/>
+          <iteration time-net="5800" time-revs="1" time-avg="5800" mem-peak="65756656" mem-real="69206016" mem-final="65311192" comp-z-value="1.0544293716126" comp-deviation="1.3525320658442"/>
+          <iteration time-net="5813" time-revs="1" time-avg="5813" mem-peak="65756656" mem-real="69206016" mem-final="65311192" comp-z-value="1.2315299120643" comp-deviation="1.5797015342676"/>
+          <stats max="5813" mean="5722.6" min="5639" mode="5674.4129158512" rstdev="1.2827147102092" stdev="73.404632006434" sum="28613" variance="5388.24"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-4308.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-4308.php" type="string"/>
           </parameter-set>
-          <iteration time-net="2837" time-revs="1" time-avg="2837" mem-peak="53812296" mem-real="56623104" mem-final="53659128" comp-z-value="-0.38331413532546" comp-deviation="-0.56778354128697"/>
-          <iteration time-net="2821" time-revs="1" time-avg="2821" mem-peak="53807808" mem-real="56623104" mem-final="53654640" comp-z-value="-0.76189599737529" comp-deviation="-1.1285574092247"/>
-          <iteration time-net="2934" time-revs="1" time-avg="2934" mem-peak="53807808" mem-real="56623104" mem-final="53654640" comp-z-value="1.9118384033517" comp-deviation="2.8319080330857"/>
-          <iteration time-net="2854" time-revs="1" time-avg="2854" mem-peak="53807808" mem-real="56623104" mem-final="53654640" comp-z-value="0.018929093102496" comp-deviation="0.028038693396894"/>
-          <iteration time-net="2820" time-revs="1" time-avg="2820" mem-peak="53807808" mem-real="56623104" mem-final="53654640" comp-z-value="-0.78555736375341" comp-deviation="-1.1636057759708"/>
-          <stats max="2934" mean="2853.2" min="2820" mode="2832.7162426614" rstdev="1.4812486390696" stdev="42.262986169934" sum="14266" variance="1786.16"/>
+          <iteration time-net="2746" time-revs="1" time-avg="2746" mem-peak="53834416" mem-real="56623104" mem-final="53681248" comp-z-value="1.3721283308612" comp-deviation="0.748459054887"/>
+          <iteration time-net="2701" time-revs="1" time-avg="2701" mem-peak="53829928" mem-real="56623104" mem-final="53676760" comp-z-value="-1.6546253401561" comp-deviation="-0.90255356618726"/>
+          <iteration time-net="2732" time-revs="1" time-avg="2732" mem-peak="53829928" mem-real="56623104" mem-final="53676760" comp-z-value="0.43047163321135" comp-deviation="0.23481068388612"/>
+          <iteration time-net="2729" time-revs="1" time-avg="2729" mem-peak="53829928" mem-real="56623104" mem-final="53676760" comp-z-value="0.22868805514353" comp-deviation="0.1247431758145"/>
+          <iteration time-net="2720" time-revs="1" time-avg="2720" mem-peak="53829928" mem-real="56623104" mem-final="53676760" comp-z-value="-0.37666267905992" comp-deviation="-0.20545934840035"/>
+          <stats max="2746" mean="2725.6" min="2701" mode="2729.3561643836" rstdev="0.54547307132509" stdev="14.867414032037" sum="13628" variance="221.04"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-5081.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-5081.php" type="string"/>
           </parameter-set>
-          <iteration time-net="2793427" time-revs="1" time-avg="2793427" mem-peak="91194840" mem-real="94371840" mem-final="62159912" comp-z-value="0.10548619043355" comp-deviation="0.051009977497164"/>
-          <iteration time-net="2781805" time-revs="1" time-avg="2781805" mem-peak="91740720" mem-real="94371840" mem-final="62772840" comp-z-value="-0.75532023086861" comp-deviation="-0.36525035003546"/>
-          <iteration time-net="2775473" time-revs="1" time-avg="2775473" mem-peak="91740720" mem-real="94371840" mem-final="62772840" comp-z-value="-1.2243123371916" comp-deviation="-0.59204095354058"/>
-          <iteration time-net="2814951" time-revs="1" time-avg="2814951" mem-peak="91740720" mem-real="94371840" mem-final="62772840" comp-z-value="1.6997038304359" comp-deviation="0.82192610981623"/>
-          <iteration time-net="2794358" time-revs="1" time-avg="2794358" mem-peak="91740720" mem-real="94371840" mem-final="62772840" comp-z-value="0.17444254719076" comp-deviation="0.084355216262684"/>
-          <stats max="2814951" mean="2792002.8" min="2775473" mode="2787756.7612524" rstdev="0.48357019328798" stdev="13501.293336566" sum="13960014" variance="182284921.76"/>
+          <iteration time-net="2359542" time-revs="1" time-avg="2359542" mem-peak="91216960" mem-real="94371840" mem-final="62182032" comp-z-value="1.4148909708352" comp-deviation="0.72751334044824"/>
+          <iteration time-net="2350321" time-revs="1" time-avg="2350321" mem-peak="91762840" mem-real="94371840" mem-final="62794960" comp-z-value="0.64932885124411" comp-deviation="0.33387406616862"/>
+          <iteration time-net="2323638" time-revs="1" time-avg="2323638" mem-peak="91762840" mem-real="94371840" mem-final="62794960" comp-z-value="-1.5659942196863" comp-deviation="-0.80520811099253"/>
+          <iteration time-net="2339515" time-revs="1" time-avg="2339515" mem-peak="91762840" mem-real="94371840" mem-final="62794960" comp-z-value="-0.24782593286839" comp-deviation="-0.12742796157951"/>
+          <iteration time-net="2339484" time-revs="1" time-avg="2339484" mem-peak="91762840" mem-real="94371840" mem-final="62794960" comp-z-value="-0.25039966952464" comp-deviation="-0.12875133404482"/>
+          <stats max="2359542" mean="2342500" min="2323638" mode="2343170.9001957" rstdev="0.51418332256286" stdev="12044.744331035" sum="11712500" variance="145075866"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-5231.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-5231.php" type="string"/>
           </parameter-set>
-          <iteration time-net="16247" time-revs="1" time-avg="16247" mem-peak="90827464" mem-real="96468992" mem-final="89871184" comp-z-value="1.8891807917429" comp-deviation="2.8434338958589"/>
-          <iteration time-net="15634" time-revs="1" time-avg="15634" mem-peak="86780624" mem-real="92274688" mem-final="86299640" comp-z-value="-0.68888649529715" comp-deviation="-1.0368532327286"/>
-          <iteration time-net="15700" time-revs="1" time-avg="15700" mem-peak="86780624" mem-real="92274688" mem-final="86299640" comp-z-value="-0.41131318217376" comp-deviation="-0.61907354188557"/>
-          <iteration time-net="15820" time-revs="1" time-avg="15820" mem-peak="86780624" mem-real="92274688" mem-final="86299640" comp-z-value="0.093365568959691" comp-deviation="0.14052589601084"/>
-          <iteration time-net="15588" time-revs="1" time-avg="15588" mem-peak="86780624" mem-real="92274688" mem-final="86299640" comp-z-value="-0.88234668323164" comp-deviation="-1.3280330172556"/>
-          <stats max="16247" mean="15797.8" min="15588" mode="15683.432485323" rstdev="1.5051147610048" stdev="237.77501971401" sum="78989" variance="56536.96"/>
+          <iteration time-net="16077" time-revs="1" time-avg="16077" mem-peak="90849584" mem-real="96468992" mem-final="89893304" comp-z-value="-0.0057342826466594" comp-deviation="-0.0037319002836267"/>
+          <iteration time-net="15948" time-revs="1" time-avg="15948" mem-peak="86802744" mem-real="92274688" mem-final="86321760" comp-z-value="-1.2386050516777" comp-deviation="-0.80609046126288"/>
+          <iteration time-net="15984" time-revs="1" time-avg="15984" mem-peak="86802744" mem-real="92274688" mem-final="86321760" comp-z-value="-0.89454809287833" comp-deviation="-0.58217644424541"/>
+          <iteration time-net="16144" time-revs="1" time-avg="16144" mem-peak="86802744" mem-real="92274688" mem-final="86321760" comp-z-value="0.63459394622992" comp-deviation="0.4129969647211"/>
+          <iteration time-net="16235" time-revs="1" time-avg="16235" mem-peak="86802744" mem-real="92274688" mem-final="86321760" comp-z-value="1.5042934809727" comp-deviation="0.9790018410708"/>
+          <stats max="16235" mean="16077.6" min="15948" mode="16040.671232877" rstdev="0.65080508122507" stdev="104.63383773904" sum="80388" variance="10948.24"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-5231_2.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-5231_2.php" type="string"/>
           </parameter-set>
-          <iteration time-net="15105" time-revs="1" time-avg="15105" mem-peak="72001832" mem-real="75497472" mem-final="71519928" comp-z-value="1.7657737381507" comp-deviation="1.25487672445"/>
-          <iteration time-net="14847" time-revs="1" time-avg="14847" mem-peak="71428960" mem-real="73400320" mem-final="70947056" comp-z-value="-0.66782468301853" comp-deviation="-0.47460081245223"/>
-          <iteration time-net="14791" time-revs="1" time-avg="14791" mem-peak="71428960" mem-real="73400320" mem-final="70947056" comp-z-value="-1.1960475961405" comp-deviation="-0.8499912855783"/>
-          <iteration time-net="14921" time-revs="1" time-avg="14921" mem-peak="71428960" mem-real="73400320" mem-final="70947056" comp-z-value="0.030184166464122" comp-deviation="0.021450884178637"/>
-          <iteration time-net="14925" time-revs="1" time-avg="14925" mem-peak="71428960" mem-real="73400320" mem-final="70947056" comp-z-value="0.067914374544265" comp-deviation="0.048264489401927"/>
-          <stats max="15105" mean="14917.8" min="14791" mode="14880.099804305" rstdev="0.71066677306245" stdev="106.01584787191" sum="74589" variance="11239.36"/>
+          <iteration time-net="15311" time-revs="1" time-avg="15311" mem-peak="72023952" mem-real="75497472" mem-final="71542048" comp-z-value="1.4447705536441" comp-deviation="5.6499358275486"/>
+          <iteration time-net="14101" time-revs="1" time-avg="14101" mem-peak="71451080" mem-real="73400320" mem-final="70969176" comp-z-value="-0.69027142230773" comp-deviation="-2.6993831164351"/>
+          <iteration time-net="13988" time-revs="1" time-avg="13988" mem-peak="71451080" mem-real="73400320" mem-final="70969176" comp-z-value="-0.88965963989661" comp-deviation="-3.4791129021129"/>
+          <iteration time-net="15043" time-revs="1" time-avg="15043" mem-peak="71451080" mem-real="73400320" mem-final="70969176" comp-z-value="0.97188522343327" comp-deviation="3.8006651854101"/>
+          <iteration time-net="14018" time-revs="1" time-avg="14018" mem-peak="71451080" mem-real="73400320" mem-final="70969176" comp-z-value="-0.83672471487302" comp-deviation="-3.2721049944108"/>
+          <stats max="15311" mean="14492.2" min="13988" mode="14083.794520548" rstdev="3.9106111439619" stdev="566.73358820525" sum="72461" variance="321186.96"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-5390.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-5390.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1386" time-revs="1" time-avg="1386" mem-peak="55314776" mem-real="56623104" mem-final="55209728" comp-z-value="0.34987054492282" comp-deviation="0.68284178410577"/>
-          <iteration time-net="1337" time-revs="1" time-avg="1337" mem-peak="55307808" mem-real="56623104" mem-final="55202760" comp-z-value="-1.4739227211642" comp-deviation="-2.876652622403"/>
-          <iteration time-net="1411" time-revs="1" time-avg="1411" mem-peak="55307808" mem-real="56623104" mem-final="55202760" comp-z-value="1.2803773133346" comp-deviation="2.4989103588552"/>
-          <iteration time-net="1394" time-revs="1" time-avg="1394" mem-peak="55307808" mem-real="56623104" mem-final="55202760" comp-z-value="0.64763271081458" comp-deviation="1.2639837280256"/>
-          <iteration time-net="1355" time-revs="1" time-avg="1355" mem-peak="55307808" mem-real="56623104" mem-final="55202760" comp-z-value="-0.80395784790774" comp-deviation="-1.5690832485835"/>
-          <stats max="1411" mean="1376.6" min="1337" mode="1390.7260273972" rstdev="1.9516984039237" stdev="26.867080228413" sum="6883" variance="721.84"/>
+          <iteration time-net="1419" time-revs="1" time-avg="1419" mem-peak="55336896" mem-real="56623104" mem-final="55231848" comp-z-value="-0.58402819581469" comp-deviation="-1.0598242922884"/>
+          <iteration time-net="1433" time-revs="1" time-avg="1433" mem-peak="55329928" mem-real="56623104" mem-final="55224880" comp-z-value="-0.046107489143266" comp-deviation="-0.083670338864876"/>
+          <iteration time-net="1456" time-revs="1" time-avg="1456" mem-peak="55329928" mem-real="56623104" mem-final="55224880" comp-z-value="0.83761938610264" comp-deviation="1.5200111560452"/>
+          <iteration time-net="1468" time-revs="1" time-avg="1468" mem-peak="55329928" mem-real="56623104" mem-final="55224880" comp-z-value="1.2986942775353" comp-deviation="2.3567145446939"/>
+          <iteration time-net="1395" time-revs="1" time-avg="1395" mem-peak="55329928" mem-real="56623104" mem-final="55224880" comp-z-value="-1.50617797868" comp-deviation="-2.7332310695858"/>
+          <stats max="1468" mean="1434.2" min="1395" mode="1439.1428571428" rstdev="1.8146800101149" stdev="26.026140705068" sum="7171" variance="677.36"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-6265.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-6265.php" type="string"/>
           </parameter-set>
-          <iteration time-net="168114" time-revs="1" time-avg="168114" mem-peak="68901952" mem-real="71303168" mem-final="66662464" comp-z-value="-1.1087735158023" comp-deviation="-0.53638432238438"/>
-          <iteration time-net="170181" time-revs="1" time-avg="170181" mem-peak="68907440" mem-real="71303168" mem-final="66667952" comp-z-value="1.4191713961361" comp-deviation="0.68654353374677"/>
-          <iteration time-net="169149" time-revs="1" time-avg="169149" mem-peak="68907440" mem-real="71303168" mem-final="66667952" comp-z-value="0.15703344300575" comp-deviation="0.075967071469391"/>
-          <iteration time-net="168093" time-revs="1" time-avg="168093" mem-peak="68907440" mem-real="71303168" mem-final="66667952" comp-z-value="-1.1344565555462" comp-deviation="-0.54880884341909"/>
-          <iteration time-net="169566" time-revs="1" time-avg="169566" mem-peak="68907440" mem-real="71303168" mem-final="66667952" comp-z-value="0.66702523220668" comp-deviation="0.32268256058729"/>
-          <stats max="170181" mean="169020.6" min="168093" mode="169286.14285714" rstdev="0.48376364941964" stdev="817.66022283098" sum="845103" variance="668568.24"/>
+          <iteration time-net="149558" time-revs="1" time-avg="149558" mem-peak="68924072" mem-real="71303168" mem-final="66684584" comp-z-value="0.65599729218814" comp-deviation="0.28242526324825"/>
+          <iteration time-net="149353" time-revs="1" time-avg="149353" mem-peak="68929560" mem-real="71303168" mem-final="66690072" comp-z-value="0.3367203574812" comp-deviation="0.14496757339571"/>
+          <iteration time-net="149492" time-revs="1" time-avg="149492" mem-peak="68929560" mem-real="71303168" mem-final="66690072" comp-z-value="0.55320569369713" comp-deviation="0.23817059236889"/>
+          <iteration time-net="147860" time-revs="1" time-avg="147860" mem-peak="68929560" mem-real="71303168" mem-final="66690072" comp-z-value="-1.9885501962626" comp-deviation="-0.85612672392058"/>
+          <iteration time-net="149421" time-revs="1" time-avg="149421" mem-peak="68929560" mem-real="71303168" mem-final="66690072" comp-z-value="0.44262685289618" comp-deviation="0.19056329490777"/>
+          <stats max="149558" mean="149136.8" min="147860" mode="149451.66731899" rstdev="0.4305280930447" stdev="642.07582106789" sum="745684" variance="412261.36"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-6442.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-6442.php" type="string"/>
           </parameter-set>
-          <iteration time-net="2934" time-revs="1" time-avg="2934" mem-peak="61234128" mem-real="62914560" mem-final="60119488" comp-z-value="-1.5884806368662" comp-deviation="-1.3980373706143"/>
-          <iteration time-net="3013" time-revs="1" time-avg="3013" mem-peak="61193664" mem-real="62914560" mem-final="60083720" comp-z-value="1.4281051879518" comp-deviation="1.2568893668504"/>
-          <iteration time-net="2970" time-revs="1" time-avg="2970" mem-peak="61193664" mem-real="62914560" mem-final="60083720" comp-z-value="-0.21383393188583" comp-deviation="-0.18819733835193"/>
-          <iteration time-net="2991" time-revs="1" time-avg="2991" mem-peak="61193664" mem-real="62914560" mem-final="60083720" comp-z-value="0.58804331268605" comp-deviation="0.51754268046781"/>
-          <iteration time-net="2970" time-revs="1" time-avg="2970" mem-peak="61193664" mem-real="62914560" mem-final="60083720" comp-z-value="-0.21383393188583" comp-deviation="-0.18819733835193"/>
-          <stats max="3013" mean="2975.6" min="2934" mode="2977.7514677104" rstdev="0.88010979685118" stdev="26.188547115104" sum="14878" variance="685.84"/>
+          <iteration time-net="2573" time-revs="1" time-avg="2573" mem-peak="61254472" mem-real="62914560" mem-final="60141608" comp-z-value="-1.1725798595112" comp-deviation="-2.5083358593513"/>
+          <iteration time-net="2701" time-revs="1" time-avg="2701" mem-peak="61214008" mem-real="62914560" mem-final="60105840" comp-z-value="1.0946440380331" comp-deviation="2.341618672325"/>
+          <iteration time-net="2569" time-revs="1" time-avg="2569" mem-peak="61214008" mem-real="62914560" mem-final="60105840" comp-z-value="-1.2434306063095" comp-deviation="-2.6598969384662"/>
+          <iteration time-net="2673" time-revs="1" time-avg="2673" mem-peak="61214008" mem-real="62914560" mem-final="60105840" comp-z-value="0.59868881044531" comp-deviation="1.2806911185208"/>
+          <iteration time-net="2680" time-revs="1" time-avg="2680" mem-peak="61214008" mem-real="62914560" mem-final="60105840" comp-z-value="0.72267761734227" comp-deviation="1.5459230069718"/>
+          <stats max="2701" mean="2639.2" min="2569" mode="2679.5596868884" rstdev="2.1391599378117" stdev="56.456709078727" sum="13196" variance="3187.36"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-6936.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-6936.php" type="string"/>
           </parameter-set>
-          <iteration time-net="74038" time-revs="1" time-avg="74038" mem-peak="70953280" mem-real="73400320" mem-final="66268080" comp-z-value="1.8296495103117" comp-deviation="1.6544698145072"/>
-          <iteration time-net="72962" time-revs="1" time-avg="72962" mem-peak="70954504" mem-real="73400320" mem-final="66269304" comp-z-value="0.19587119239022" comp-deviation="0.17711751541197"/>
-          <iteration time-net="72327" time-revs="1" time-avg="72327" mem-peak="70954504" mem-real="73400320" mem-final="66269304" comp-z-value="-0.76830095619729" comp-deviation="-0.69474002169346"/>
-          <iteration time-net="72644" time-revs="1" time-avg="72644" mem-peak="70954504" mem-real="73400320" mem-final="66269304" comp-z-value="-0.28697407257172" comp-deviation="-0.25949775513847"/>
-          <iteration time-net="72194" time-revs="1" time-avg="72194" mem-peak="70954504" mem-real="73400320" mem-final="66269304" comp-z-value="-0.97024567393294" comp-deviation="-0.8773495530872"/>
-          <stats max="74038" mean="72833" min="72194" mode="72522.383561644" rstdev="0.90425505277526" stdev="658.5960825878" sum="364165" variance="433748.8"/>
+          <iteration time-net="64096" time-revs="1" time-avg="64096" mem-peak="70995800" mem-real="73400320" mem-final="66290200" comp-z-value="-1.5227345826696" comp-deviation="-2.1793541297845"/>
+          <iteration time-net="65556" time-revs="1" time-avg="65556" mem-peak="70997024" mem-real="73400320" mem-final="66291424" comp-z-value="0.034122903813324" comp-deviation="0.048837067334107"/>
+          <iteration time-net="66953" time-revs="1" time-avg="66953" mem-peak="70997024" mem-real="73400320" mem-final="66291424" comp-z-value="1.5238009234138" comp-deviation="2.1808802881387"/>
+          <iteration time-net="65111" time-revs="1" time-avg="65111" mem-peak="70997024" mem-real="73400320" mem-final="66291424" comp-z-value="-0.44039872734072" comp-deviation="-0.63030340028081"/>
+          <iteration time-net="65904" time-revs="1" time-avg="65904" mem-peak="70997024" mem-real="73400320" mem-final="66291424" comp-z-value="0.40520948278323" comp-deviation="0.57994017459252"/>
+          <stats max="66953" mean="65524" min="64096" mode="65532.886497064" rstdev="1.4312107668585" stdev="937.78654287636" sum="327620" variance="879443.6"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-6948.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-6948.php" type="string"/>
           </parameter-set>
-          <iteration time-net="35676" time-revs="1" time-avg="35676" mem-peak="61429632" mem-real="62914560" mem-final="60916256" comp-z-value="-1.4108367865384" comp-deviation="-0.77928145910857"/>
-          <iteration time-net="36294" time-revs="1" time-avg="36294" mem-peak="61185528" mem-real="62914560" mem-final="60672152" comp-z-value="1.7008589096812" comp-deviation="0.93947636290821"/>
-          <iteration time-net="35984" time-revs="1" time-avg="35984" mem-peak="61185528" mem-real="62914560" mem-final="60672152" comp-z-value="0.13997595526685" comp-deviation="0.077316290375521"/>
-          <iteration time-net="35904" time-revs="1" time-avg="35904" mem-peak="61185528" mem-real="62914560" mem-final="60672152" comp-z-value="-0.26283254909814" comp-deviation="-0.1451766315684"/>
-          <iteration time-net="35923" time-revs="1" time-avg="35923" mem-peak="61185528" mem-real="62914560" mem-final="60672152" comp-z-value="-0.16716552931146" comp-deviation="-0.092334562606719"/>
-          <stats max="36294" mean="35956.2" min="35676" mode="35916.669275929" rstdev="0.55235408272889" stdev="198.60553869417" sum="179781" variance="39444.16"/>
+          <iteration time-net="32534" time-revs="1" time-avg="32534" mem-peak="61474648" mem-real="65011712" mem-final="60938376" comp-z-value="1.9421843342428" comp-deviation="3.7495774629921"/>
+          <iteration time-net="31301" time-revs="1" time-avg="31301" mem-peak="61230544" mem-real="62914560" mem-final="60694272" comp-z-value="-0.094482857559696" comp-deviation="-0.18240842905524"/>
+          <iteration time-net="31112" time-revs="1" time-avg="31112" mem-peak="61230544" mem-real="62914560" mem-final="60694272" comp-z-value="-0.40667271907687" comp-deviation="-0.78512159498951"/>
+          <iteration time-net="30975" time-revs="1" time-avg="30975" mem-peak="61230544" mem-real="62914560" mem-final="60694272" comp-z-value="-0.63296907372159" comp-deviation="-1.2220089163281"/>
+          <iteration time-net="30869" time-revs="1" time-avg="30869" mem-peak="61230544" mem-real="62914560" mem-final="60694272" comp-z-value="-0.80805968388466" comp-deviation="-1.5600385226193"/>
+          <stats max="32534" mean="31358.2" min="30869" mode="31067.757338552" rstdev="1.9305981398794" stdev="605.40082589967" sum="156791" variance="366510.16"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-7140.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-7140.php" type="string"/>
           </parameter-set>
-          <iteration time-net="30454" time-revs="1" time-avg="30454" mem-peak="49865032" mem-real="52428800" mem-final="49533000" comp-z-value="-0.75302021572647" comp-deviation="-0.60510323309204"/>
-          <iteration time-net="30324" time-revs="1" time-avg="30324" mem-peak="49862944" mem-real="52428800" mem-final="49530912" comp-z-value="-1.2810279182315" comp-deviation="-1.0293935259829"/>
-          <iteration time-net="31037" time-revs="1" time-avg="31037" mem-peak="49862944" mem-real="52428800" mem-final="49530912" comp-z-value="1.6148912501232" comp-deviation="1.2976755419493"/>
-          <iteration time-net="30637" time-revs="1" time-avg="30637" mem-peak="49862944" mem-real="52428800" mem-final="49530912" comp-z-value="-0.0097478345077919" comp-deviation="-0.0078330515610667"/>
-          <iteration time-net="30745" time-revs="1" time-avg="30745" mem-peak="49862944" mem-real="52428800" mem-final="49530912" comp-z-value="0.42890471834258" comp-deviation="0.34465426868672"/>
-          <stats max="31037" mean="30639.4" min="30324" mode="30569.573385519" rstdev="0.80356837765407" stdev="246.20852950294" sum="153197" variance="60618.64"/>
+          <iteration time-net="25995" time-revs="1" time-avg="25995" mem-peak="49887152" mem-real="52428800" mem-final="49555120" comp-z-value="1.1894567256656" comp-deviation="0.35904563354181"/>
+          <iteration time-net="25954" time-revs="1" time-avg="25954" mem-peak="49885064" mem-real="52428800" mem-final="49553032" comp-z-value="0.66507257779154" comp-deviation="0.20075669832445"/>
+          <iteration time-net="25764" time-revs="1" time-avg="25764" mem-peak="49885064" mem-real="52428800" mem-final="49553032" comp-z-value="-1.7650003026006" comp-deviation="-0.5327773917072"/>
+          <iteration time-net="25890" time-revs="1" time-avg="25890" mem-peak="49885064" mem-real="52428800" mem-final="49553032" comp-z-value="-0.15347828718266" comp-deviation="-0.046328468844105"/>
+          <iteration time-net="25907" time-revs="1" time-avg="25907" mem-peak="49885064" mem-real="52428800" mem-final="49553032" comp-z-value="0.06394928632611" comp-deviation="0.019303528685044"/>
+          <stats max="25995" mean="25902" min="25764" mode="25930.356164384" rstdev="0.30185682740234" stdev="78.186955433755" sum="129510" variance="6113.2"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-7214.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-7214.php" type="string"/>
           </parameter-set>
-          <iteration time-net="2557" time-revs="1" time-avg="2557" mem-peak="65390032" mem-real="67108864" mem-final="65002440" comp-z-value="-0.3597567809012" comp-deviation="-1.3350825744714"/>
-          <iteration time-net="2774" time-revs="1" time-avg="2774" mem-peak="64747568" mem-real="67108864" mem-final="64359976" comp-z-value="1.8965212958491" comp-deviation="7.0381231671554"/>
-          <iteration time-net="2597" time-revs="1" time-avg="2597" mem-peak="64747568" mem-real="67108864" mem-final="64359976" comp-z-value="0.056147012048165" comp-deviation="0.20836548850132"/>
-          <iteration time-net="2518" time-revs="1" time-avg="2518" mem-peak="64747568" mem-real="67108864" mem-final="64359976" comp-z-value="-0.76526297902682" comp-deviation="-2.8399444358697"/>
-          <iteration time-net="2512" time-revs="1" time-avg="2512" mem-peak="64747568" mem-real="67108864" mem-final="64359976" comp-z-value="-0.82764854796923" comp-deviation="-3.0714616453156"/>
-          <stats max="2774" mean="2591.6" min="2512" mode="2545.3268101761" rstdev="3.7110699376589" stdev="96.176088504368" sum="12958" variance="9249.84"/>
+          <iteration time-net="2413" time-revs="1" time-avg="2413" mem-peak="65412152" mem-real="67108864" mem-final="65024560" comp-z-value="1.8492478649916" comp-deviation="3.1372884253719"/>
+          <iteration time-net="2304" time-revs="1" time-avg="2304" mem-peak="64769688" mem-real="67108864" mem-final="64382096" comp-z-value="-0.8969104086335" comp-deviation="-1.5216276286545" reject-count="1"/>
+          <iteration time-net="2331" time-revs="1" time-avg="2331" mem-peak="64769688" mem-real="67108864" mem-final="64382096" comp-z-value="-0.21666936837775" comp-deviation="-0.36758420242776"/>
+          <iteration time-net="2344" time-revs="1" time-avg="2344" mem-peak="64769688" mem-real="67108864" mem-final="64382096" comp-z-value="0.11085409544909" comp-deviation="0.18806633612584"/>
+          <iteration time-net="2306" time-revs="1" time-avg="2306" mem-peak="64769688" mem-real="67108864" mem-final="64382096" comp-z-value="-0.84652218342937" comp-deviation="-1.4361429304155"/>
+          <stats max="2413" mean="2339.6" min="2304" mode="2321.2778864971" rstdev="1.6965213180799" stdev="39.691812757797" sum="11698" variance="1575.44"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-7581.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-7581.php" type="string"/>
           </parameter-set>
-          <iteration time-net="341296" time-revs="1" time-avg="341296" mem-peak="63669072" mem-real="67108864" mem-final="62352056" comp-z-value="0.48745986362765" comp-deviation="0.17769788776093"/>
-          <iteration time-net="340740" time-revs="1" time-avg="340740" mem-peak="63668664" mem-real="67108864" mem-final="62351648" comp-z-value="0.039776209552719" comp-deviation="0.014499959787568"/>
-          <iteration time-net="340840" time-revs="1" time-avg="340840" mem-peak="63668664" mem-real="67108864" mem-final="62351648" comp-z-value="0.12029485237195" comp-deviation="0.043852105106517"/>
-          <iteration time-net="338418" time-revs="1" time-avg="338418" mem-peak="63668664" mem-real="67108864" mem-final="62351648" comp-z-value="-1.8298666767098" comp-deviation="-0.66705685451843"/>
-          <iteration time-net="342159" time-revs="1" time-avg="342159" mem-peak="63668664" mem-real="67108864" mem-final="62351648" comp-z-value="1.1823357511576" comp-deviation="0.43100690186346"/>
-          <stats max="342159" mean="340690.6" min="338418" mode="341156.03131115" rstdev="0.36453850054137" stdev="1241.9484047254" sum="1703453" variance="1542435.84"/>
+          <iteration time-net="272571" time-revs="1" time-avg="272571" mem-peak="63691192" mem-real="67108864" mem-final="62374176" comp-z-value="-1.326191361064" comp-deviation="-0.52654282375559"/>
+          <iteration time-net="273666" time-revs="1" time-avg="273666" mem-peak="63690784" mem-real="67108864" mem-final="62373768" comp-z-value="-0.31969043206131" comp-deviation="-0.12692791384959"/>
+          <iteration time-net="274359" time-revs="1" time-avg="274359" mem-peak="63690784" mem-real="67108864" mem-final="62373768" comp-z-value="0.31730056684178" comp-deviation="0.12597905652927"/>
+          <iteration time-net="273607" time-revs="1" time-avg="273607" mem-peak="63690784" mem-real="67108864" mem-final="62373768" comp-z-value="-0.37392198896648" comp-deviation="-0.1484596761185"/>
+          <iteration time-net="275866" time-revs="1" time-avg="275866" mem-peak="63690784" mem-real="67108864" mem-final="62373768" comp-z-value="1.7025032152501" comp-deviation="0.67595135719442"/>
+          <stats max="275866" mean="274013.8" min="272571" mode="273686.52837573" rstdev="0.39703382122255" stdev="1087.9274608171" sum="1370069" variance="1183586.16"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-7637.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-7637.php" type="string"/>
           </parameter-set>
-          <iteration time-net="20566" time-revs="1" time-avg="20566" mem-peak="71079056" mem-real="73400320" mem-final="69925688" comp-z-value="-0.59730644176609" comp-deviation="-0.41835331486898"/>
-          <iteration time-net="20442" time-revs="1" time-avg="20442" mem-peak="69390032" mem-real="71303168" mem-final="68248272" comp-z-value="-1.4545517980044" comp-deviation="-1.018767794542"/>
-          <iteration time-net="20740" time-revs="1" time-avg="20740" mem-peak="69390032" mem-real="71303168" mem-final="68248272" comp-z-value="0.60560236456838" comp-deviation="0.42416377757548"/>
-          <iteration time-net="20649" time-revs="1" time-avg="20649" mem-peak="69390032" mem-real="71303168" mem-final="68248272" comp-z-value="-0.023505114606546" comp-deviation="-0.016462977668462"/>
-          <iteration time-net="20865" time-revs="1" time-avg="20865" mem-peak="69390032" mem-real="71303168" mem-final="68248272" comp-z-value="1.4697609898087" comp-deviation="1.029420309504"/>
-          <stats max="20865" mean="20652.4" min="20442" mode="20647.291585127" rstdev="0.70039980421442" stdev="144.64936916558" sum="103262" variance="20923.44"/>
+          <iteration time-net="19217" time-revs="1" time-avg="19217" mem-peak="71101176" mem-real="73400320" mem-final="69947808" comp-z-value="0.70524146253379" comp-deviation="0.65788784478875"/>
+          <iteration time-net="18848" time-revs="1" time-avg="18848" mem-peak="69412152" mem-real="71303168" mem-final="68270392" comp-z-value="-1.3666860826491" comp-deviation="-1.2749195973056"/>
+          <iteration time-net="18937" time-revs="1" time-avg="18937" mem-peak="69412152" mem-real="71303168" mem-final="68270392" comp-z-value="-0.86695288069442" comp-deviation="-0.80874110856198"/>
+          <iteration time-net="19121" time-revs="1" time-avg="19121" mem-peak="69412152" mem-real="71303168" mem-final="68270392" comp-z-value="0.1662034019984" comp-deviation="0.15504363221135"/>
+          <iteration time-net="19334" time-revs="1" time-avg="19334" mem-peak="69412152" mem-real="71303168" mem-final="68270392" comp-z-value="1.3621940988113" comp-deviation="1.2707292288674"/>
+          <stats max="19334" mean="19091.4" min="18848" mode="19161.85518591" rstdev="0.93285474513239" stdev="178.0950308122" sum="95457" variance="31717.84"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-7901.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-7901.php" type="string"/>
           </parameter-set>
-          <iteration time-net="725528" time-revs="1" time-avg="725528" mem-peak="88695672" mem-real="96468992" mem-final="79773072" comp-z-value="1.2021931714899" comp-deviation="0.71249780675941"/>
-          <iteration time-net="720685" time-revs="1" time-avg="720685" mem-peak="106087560" mem-real="115343360" mem-final="97164960" comp-z-value="0.067876321130346" comp-deviation="0.040227919342057"/>
-          <iteration time-net="721126" time-revs="1" time-avg="721126" mem-peak="106087560" mem-real="115343360" mem-final="97164960" comp-z-value="0.17116637502433" comp-deviation="0.10144431834083"/>
-          <iteration time-net="722075" time-revs="1" time-avg="722075" mem-peak="106087560" mem-real="115343360" mem-final="97164960" comp-z-value="0.3934390760343" comp-deviation="0.23317756697991"/>
-          <iteration time-net="712562" time-revs="1" time-avg="712562" mem-peak="106087560" mem-real="115343360" mem-final="97164960" comp-z-value="-1.8346749436789" comp-deviation="-1.0873476114222"/>
-          <stats max="725528" mean="720395.2" min="712562" mode="721950.29745597" rstdev="0.59266499232928" stdev="4269.5301568205" sum="3601976" variance="18228887.76"/>
+          <iteration time-net="619415" time-revs="1" time-avg="619415" mem-peak="88716016" mem-real="96468992" mem-final="79793416" comp-z-value="-1.109068414177" comp-deviation="-0.082944955649767"/>
+          <iteration time-net="620290" time-revs="1" time-avg="620290" mem-peak="106107904" mem-real="115343360" mem-final="97185304" comp-z-value="0.77820280792522" comp-deviation="0.058200194473828"/>
+          <iteration time-net="620465" time-revs="1" time-avg="620465" mem-peak="106107904" mem-real="115343360" mem-final="97185304" comp-z-value="1.1556570523457" comp-deviation="0.086429224498547"/>
+          <iteration time-net="620138" time-revs="1" time-avg="620138" mem-peak="106107904" mem-real="115343360" mem-final="97185304" comp-z-value="0.45035683562861" comp-deviation="0.033681265538072"/>
+          <iteration time-net="619338" time-revs="1" time-avg="619338" mem-peak="106107904" mem-real="115343360" mem-final="97185304" comp-z-value="-1.275148281722" comp-deviation="-0.095365728860643"/>
+          <stats max="620465" mean="619929.2" min="619338" mode="620248.86301369" rstdev="0.074787952293563" stdev="463.63235434987" sum="3099646" variance="214954.96"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-7903.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-7903.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1889065" time-revs="1" time-avg="1889065" mem-peak="74242032" mem-real="77594624" mem-final="69472184" comp-z-value="-1.2248373664626" comp-deviation="-0.32951858439651"/>
-          <iteration time-net="1903702" time-revs="1" time-avg="1903702" mem-peak="73881608" mem-real="77594624" mem-final="69111760" comp-z-value="1.6457465085355" comp-deviation="0.44275597284751"/>
-          <iteration time-net="1898087" time-revs="1" time-avg="1898087" mem-peak="73881608" mem-real="77594624" mem-final="69111760" comp-z-value="0.54454213208444" comp-deviation="0.14649843107494"/>
-          <iteration time-net="1893460" time-revs="1" time-avg="1893460" mem-peak="73881608" mem-real="77594624" mem-final="69111760" comp-z-value="-0.36289734250845" comp-deviation="-0.097630446179154"/>
-          <iteration time-net="1892238" time-revs="1" time-avg="1892238" mem-peak="73881608" mem-real="77594624" mem-final="69111760" comp-z-value="-0.60255393164882" comp-deviation="-0.16210537334676"/>
-          <stats max="1903702" mean="1895310.4" min="1889065" mode="1892989.2054795" rstdev="0.26903047981643" stdev="5098.9626631306" sum="9476552" variance="25999420.24"/>
+          <iteration time-net="1581011" time-revs="1" time-avg="1581011" mem-peak="74428576" mem-real="77594624" mem-final="69494304" comp-z-value="0.080765052800308" comp-deviation="0.0091974928165878"/>
+          <iteration time-net="1583784" time-revs="1" time-avg="1583784" mem-peak="74068152" mem-real="77594624" mem-final="69133880" comp-z-value="1.6210779236077" comp-deviation="0.18460772376854"/>
+          <iteration time-net="1580956" time-revs="1" time-avg="1580956" mem-peak="74068152" mem-real="77594624" mem-final="69133880" comp-z-value="0.050214310681878" comp-deviation="0.0057183861803247"/>
+          <iteration time-net="1580447" time-revs="1" time-avg="1580447" mem-peak="74068152" mem-real="77594624" mem-final="69133880" comp-z-value="-0.23251892092323" comp-deviation="-0.026479164326183"/>
+          <iteration time-net="1578130" time-revs="1" time-avg="1578130" mem-peak="74068152" mem-real="77594624" mem-final="69133880" comp-z-value="-1.5195383661669" comp-deviation="-0.1730444384393"/>
+          <stats max="1583784" mean="1580865.6" min="1578130" mode="1580741.2407045" rstdev="0.11387961126366" stdev="1800.2835998809" sum="7904328" variance="3241021.04"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-8146a.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-8146a.php" type="string"/>
           </parameter-set>
-          <iteration time-net="131137" time-revs="1" time-avg="131137" mem-peak="67343552" mem-real="69206016" mem-final="63677456" comp-z-value="-0.86327569222488" comp-deviation="-0.2279425974196"/>
-          <iteration time-net="131428" time-revs="1" time-avg="131428" mem-peak="67330440" mem-real="69206016" mem-final="63664344" comp-z-value="-0.024780276879636" comp-deviation="-0.0065430785641182"/>
-          <iteration time-net="131958" time-revs="1" time-avg="131958" mem-peak="67330440" mem-real="69206016" mem-final="63664344" comp-z-value="1.5023763215155" comp-deviation="0.39669315852662"/>
-          <iteration time-net="131660" time-revs="1" time-avg="131660" mem-peak="67330440" mem-real="69206016" mem-final="63664344" comp-z-value="0.64371091336125" comp-deviation="0.16996787804918"/>
-          <iteration time-net="131000" time-revs="1" time-avg="131000" mem-peak="67330440" mem-real="69206016" mem-final="63664344" comp-z-value="-1.2580312657723" comp-deviation="-0.33217536059211"/>
-          <stats max="131958" mean="131436.6" min="131000" mode="131314.95890411" rstdev="0.26404380370323" stdev="347.0501980982" sum="657183" variance="120443.84"/>
+          <iteration time-net="109708" time-revs="1" time-avg="109708" mem-peak="67365672" mem-real="69206016" mem-final="63699576" comp-z-value="-1.2991185063979" comp-deviation="-0.26345981465084"/>
+          <iteration time-net="109845" time-revs="1" time-avg="109845" mem-peak="67352560" mem-real="69206016" mem-final="63686464" comp-z-value="-0.6849734567895" comp-deviation="-0.13891186914648"/>
+          <iteration time-net="109920" time-revs="1" time-avg="109920" mem-peak="67352560" mem-real="69206016" mem-final="63686464" comp-z-value="-0.34876266320827" comp-deviation="-0.070728687301021"/>
+          <iteration time-net="110261" time-revs="1" time-avg="110261" mem-peak="67352560" mem-real="69206016" mem-final="63686464" comp-z-value="1.179875744941" comp-deviation="0.23927751282298"/>
+          <iteration time-net="110255" time-revs="1" time-avg="110255" mem-peak="67352560" mem-real="69206016" mem-final="63686464" comp-z-value="1.1529788814545" comp-deviation="0.23382285827534"/>
+          <stats max="110261" mean="109997.8" min="109708" mode="109863.83561644" rstdev="0.20279890814684" stdev="223.07433738555" sum="549989" variance="49762.16"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-8146b.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-8146b.php" type="string"/>
           </parameter-set>
-          <iteration time-net="988953" time-revs="1" time-avg="988953" mem-peak="83306072" mem-real="85983232" mem-final="78779248" comp-z-value="-0.94185104170029" comp-deviation="-0.20504851233873"/>
-          <iteration time-net="992243" time-revs="1" time-avg="992243" mem-peak="83229480" mem-real="85983232" mem-final="78700456" comp-z-value="0.5830947886117" comp-deviation="0.12694440380026"/>
-          <iteration time-net="987897" time-revs="1" time-avg="987897" mem-peak="83229480" mem-real="85983232" mem-final="78700456" comp-z-value="-1.4313169373871" comp-deviation="-0.31160915654626"/>
-          <iteration time-net="993449" time-revs="1" time-avg="993449" mem-peak="83229480" mem-real="85983232" mem-final="78700456" comp-z-value="1.1420870899358" comp-deviation="0.24864150315091"/>
-          <iteration time-net="992383" time-revs="1" time-avg="992383" mem-peak="83229480" mem-real="85983232" mem-final="78700456" comp-z-value="0.64798610053987" comp-deviation="0.14107176193383"/>
-          <stats max="993449" mean="990985" min="987897" mode="992427.69275928" rstdev="0.21770800610738" stdev="2157.4536843233" sum="4954925" variance="4654606.4"/>
+          <iteration time-net="791289" time-revs="1" time-avg="791289" mem-peak="83328192" mem-real="85983232" mem-final="78801368" comp-z-value="-0.85214149793538" comp-deviation="-0.12962000010097"/>
+          <iteration time-net="790938" time-revs="1" time-avg="790938" mem-peak="83251600" mem-real="85983232" mem-final="78722576" comp-z-value="-1.143379731407" comp-deviation="-0.17392050646459"/>
+          <iteration time-net="792960" time-revs="1" time-avg="792960" mem-peak="83251600" mem-real="85983232" mem-final="78722576" comp-z-value="0.53435163064302" comp-deviation="0.081280701134396"/>
+          <iteration time-net="794279" time-revs="1" time-avg="794279" mem-peak="83251600" mem-real="85983232" mem-final="78722576" comp-z-value="1.6287767871929" comp-deviation="0.2477546837373"/>
+          <iteration time-net="792114" time-revs="1" time-avg="792114" mem-peak="83251600" mem-real="85983232" mem-final="78722576" comp-z-value="-0.16760718849362" comp-deviation="-0.02549487830613"/>
+          <stats max="794279" mean="792316" min="790938" mode="791755.2700587" rstdev="0.15211088817411" stdev="1205.1989047456" sum="3961580" variance="1452504.4"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-8147.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-8147.php" type="string"/>
           </parameter-set>
-          <iteration time-net="601205" time-revs="1" time-avg="601205" mem-peak="85668152" mem-real="88080384" mem-final="81768752" comp-z-value="1.9597339384907" comp-deviation="1.8276660690072"/>
-          <iteration time-net="588365" time-revs="1" time-avg="588365" mem-peak="92112864" mem-real="96468992" mem-final="88210120" comp-z-value="-0.37215839296021" comp-deviation="-0.347078373115"/>
-          <iteration time-net="586555" time-revs="1" time-avg="586555" mem-peak="92112864" mem-real="96468992" mem-final="88210120" comp-z-value="-0.70087530261178" comp-deviation="-0.65364281550138"/>
-          <iteration time-net="586534" time-revs="1" time-avg="586534" mem-peak="92112864" mem-real="96468992" mem-final="88210120" comp-z-value="-0.70468914520995" comp-deviation="-0.65719964052354"/>
-          <iteration time-net="589412" time-revs="1" time-avg="589412" mem-peak="92112864" mem-real="96468992" mem-final="88210120" comp-z-value="-0.18201109770872" comp-deviation="-0.16974523986719"/>
-          <stats max="601205" mean="590414.2" min="586534" mode="587739.83561644" rstdev="0.93260928593947" stdev="5506.2576547052" sum="2952071" variance="30318873.36"/>
+          <iteration time-net="494158" time-revs="1" time-avg="494158" mem-peak="85688496" mem-real="88080384" mem-final="81790872" comp-z-value="1.8217382393265" comp-deviation="0.61522623857649"/>
+          <iteration time-net="491321" time-revs="1" time-avg="491321" mem-peak="92133208" mem-real="96468992" mem-final="88232240" comp-z-value="0.11129629301682" comp-deviation="0.037586299854781"/>
+          <iteration time-net="490133" time-revs="1" time-avg="490133" mem-peak="92133208" mem-real="96468992" mem-final="88232240" comp-z-value="-0.60495504015761" comp-deviation="-0.20430169704384"/>
+          <iteration time-net="490796" time-revs="1" time-avg="490796" mem-peak="92133208" mem-real="96468992" mem-final="88232240" comp-z-value="-0.20522891735067" comp-deviation="-0.06930864826961"/>
+          <iteration time-net="489274" time-revs="1" time-avg="489274" mem-peak="92133208" mem-real="96468992" mem-final="88232240" comp-z-value="-1.1228505748351" comp-deviation="-0.37920219311784"/>
+          <stats max="494158" mean="491136.4" min="489274" mode="490459.15851272" rstdev="0.33771385224035" stdev="1658.6356561946" sum="2455682" variance="2751072.24"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-8215.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-8215.php" type="string"/>
           </parameter-set>
-          <iteration time-net="607913" time-revs="1" time-avg="607913" mem-peak="114257720" mem-real="119541760" mem-final="105308000" comp-z-value="-1.1788474119191" comp-deviation="-1.2016765614563"/>
-          <iteration time-net="608605" time-revs="1" time-avg="608605" mem-peak="114257720" mem-real="119541760" mem-final="105308000" comp-z-value="-1.0685197937086" comp-deviation="-1.089212376911"/>
-          <iteration time-net="624530" time-revs="1" time-avg="624530" mem-peak="114257720" mem-real="119541760" mem-final="105308000" comp-z-value="1.4704503219001" comp-deviation="1.4989265521114"/>
-          <iteration time-net="617444" time-revs="1" time-avg="617444" mem-peak="114257720" mem-real="119541760" mem-final="105308000" comp-z-value="0.34070826606316" comp-deviation="0.34730630400759"/>
-          <iteration time-net="618043" time-revs="1" time-avg="618043" mem-peak="114257720" mem-real="119541760" mem-final="105308000" comp-z-value="0.4362086176644" comp-deviation="0.44465608224837"/>
-          <stats max="624530" mean="615307" min="607913" mode="616985.68688845" rstdev="1.019365652676" stdev="6272.2282165113" sum="3076535" variance="39340846.8"/>
+          <iteration time-net="512032" time-revs="1" time-avg="512032" mem-peak="114279840" mem-real="119541760" mem-final="105330120" comp-z-value="0.78317173984285" comp-deviation="0.20266287590284"/>
+          <iteration time-net="510383" time-revs="1" time-avg="510383" mem-peak="114279840" mem-real="119541760" mem-final="105330120" comp-z-value="-0.46388329974858" comp-deviation="-0.12003998462612"/>
+          <iteration time-net="510272" time-revs="1" time-avg="510272" mem-peak="114279840" mem-real="119541760" mem-final="105330120" comp-z-value="-0.54782696827172" comp-deviation="-0.14176225116264"/>
+          <iteration time-net="509314" time-revs="1" time-avg="509314" mem-peak="114279840" mem-real="119541760" mem-final="105330120" comp-z-value="-1.272313765075" comp-deviation="-0.32923911009941"/>
+          <iteration time-net="512981" time-revs="1" time-avg="512981" mem-peak="114279840" mem-real="119541760" mem-final="105330120" comp-z-value="1.5008522932523" comp-deviation="0.3883784699853"/>
+          <stats max="512981" mean="510996.4" min="509314" mode="510297.12915852" rstdev="0.25877194693402" stdev="1322.3153330428" sum="2554982" variance="1748517.84"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-8503.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-8503.php" type="string"/>
           </parameter-set>
-          <iteration time-net="215589" time-revs="1" time-avg="215589" mem-peak="74284144" mem-real="77594624" mem-final="71341144" comp-z-value="-0.44778284432688" comp-deviation="-1.3324460733253"/>
-          <iteration time-net="231395" time-revs="1" time-avg="231395" mem-peak="72687736" mem-real="75497472" mem-final="69744736" comp-z-value="1.9832316632745" comp-deviation="5.9014079608092"/>
-          <iteration time-net="215705" time-revs="1" time-avg="215705" mem-peak="72687736" mem-real="75497472" mem-final="69744736" comp-z-value="-0.42994166484556" comp-deviation="-1.2793569256624"/>
-          <iteration time-net="216126" time-revs="1" time-avg="216126" mem-peak="72687736" mem-real="75497472" mem-final="69744736" comp-z-value="-0.36519048759008" comp-deviation="-1.0866799328514"/>
-          <iteration time-net="213687" time-revs="1" time-avg="213687" mem-peak="72687736" mem-real="75497472" mem-final="69744736" comp-z-value="-0.740316666512" comp-deviation="-2.2029250289702"/>
-          <stats max="231395" mean="218500.4" min="213687" mode="215315.72015656" rstdev="2.9756523507019" stdev="6501.812288893" sum="1092502" variance="42273563.04"/>
+          <iteration time-net="187340" time-revs="1" time-avg="187340" mem-peak="74306264" mem-real="77594624" mem-final="71363264" comp-z-value="1.6829021154335" comp-deviation="1.6024045287751"/>
+          <iteration time-net="182855" time-revs="1" time-avg="182855" mem-peak="72709856" mem-real="75497472" mem-final="69766856" comp-z-value="-0.87169613398072" comp-deviation="-0.8300006399639"/>
+          <iteration time-net="185039" time-revs="1" time-avg="185039" mem-peak="72709856" mem-real="75497472" mem-final="69766856" comp-z-value="0.37228214399491" comp-deviation="0.35447492046551"/>
+          <iteration time-net="184283" time-revs="1" time-avg="184283" mem-peak="72709856" mem-real="75497472" mem-final="69766856" comp-z-value="-0.058325721458195" comp-deviation="-0.055535850452365"/>
+          <iteration time-net="182410" time-revs="1" time-avg="182410" mem-peak="72709856" mem-real="75497472" mem-final="69766856" comp-z-value="-1.1251624039895" comp-deviation="-1.0713429588243"/>
+          <stats max="187340" mean="184385.4" min="182410" mode="183673.85518591" rstdev="0.95216739825791" stdev="1755.6576659474" sum="921927" variance="3082333.84"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-9690.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-9690.php" type="string"/>
           </parameter-set>
-          <iteration time-net="331688" time-revs="1" time-avg="331688" mem-peak="68965480" mem-real="71303168" mem-final="63683184" comp-z-value="-0.33473945751319" comp-deviation="-0.18651382844459"/>
-          <iteration time-net="333489" time-revs="1" time-avg="333489" mem-peak="68995336" mem-real="71303168" mem-final="63713040" comp-z-value="0.63793844339237" comp-deviation="0.35545358851041"/>
-          <iteration time-net="334581" time-revs="1" time-avg="334581" mem-peak="68995336" mem-real="71303168" mem-final="63713040" comp-z-value="1.2277020568232" comp-deviation="0.68406459312722"/>
-          <iteration time-net="332648" time-revs="1" time-avg="332648" mem-peak="68995336" mem-real="71303168" mem-final="63713040" comp-z-value="0.1837340487996" comp-deviation="0.10237496682293"/>
-          <iteration time-net="329133" time-revs="1" time-avg="329133" mem-peak="68995336" mem-real="71303168" mem-final="63713040" comp-z-value="-1.7146350915019" comp-deviation="-0.95537932001596"/>
-          <stats max="334581" mean="332307.8" min="329133" mode="332992.44422701" rstdev="0.55719104592634" stdev="1851.5893065148" sum="1661539" variance="3428382.96"/>
+          <iteration time-net="274206" time-revs="1" time-avg="274206" mem-peak="68407696" mem-real="71303168" mem-final="63867896" comp-z-value="1.8889988684955" comp-deviation="0.47112672495476"/>
+          <iteration time-net="272356" time-revs="1" time-avg="272356" mem-peak="68372016" mem-real="71303168" mem-final="63832216" comp-z-value="-0.82887942262031" comp-deviation="-0.20672709458663"/>
+          <iteration time-net="272400" time-revs="1" time-avg="272400" mem-peak="68372016" mem-real="71303168" mem-final="63832216" comp-z-value="-0.76423799299377" comp-deviation="-0.19060516590564"/>
+          <iteration time-net="272984" time-revs="1" time-avg="272984" mem-peak="68372016" mem-real="71303168" mem-final="63832216" comp-z-value="0.093730072958464" comp-deviation="0.023376796587423"/>
+          <iteration time-net="272655" time-revs="1" time-avg="272655" mem-peak="68372016" mem-real="71303168" mem-final="63832216" comp-z-value="-0.38961152583997" comp-deviation="-0.097171261049938"/>
+          <stats max="274206" mean="272920.2" min="272356" mode="272591.32289628" rstdev="0.24940550934792" stdev="680.67801492336" sum="1364601" variance="463322.56"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-10147.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-10147.php" type="string"/>
           </parameter-set>
-          <iteration time-net="797" time-revs="1" time-avg="797" mem-peak="49864384" mem-real="52428800" mem-final="49620104" comp-z-value="1.9087272817554" comp-deviation="9.3278463648834"/>
-          <iteration time-net="725" time-revs="1" time-avg="725" mem-peak="49924064" mem-real="52428800" mem-final="49621360" comp-z-value="-0.11227807539737" comp-deviation="-0.54869684499314"/>
-          <iteration time-net="720" time-revs="1" time-avg="720" mem-peak="49924064" mem-real="52428800" mem-final="49621360" comp-z-value="-0.25262566964409" comp-deviation="-1.2345679012346"/>
-          <iteration time-net="694" time-revs="1" time-avg="694" mem-peak="49924064" mem-real="52428800" mem-final="49621360" comp-z-value="-0.98243315972703" comp-deviation="-4.80109739369"/>
-          <iteration time-net="709" time-revs="1" time-avg="709" mem-peak="49924064" mem-real="52428800" mem-final="49621360" comp-z-value="-0.56139037698687" comp-deviation="-2.7434842249657"/>
-          <stats max="797" mean="729" min="694" mode="712.94716242662" rstdev="4.8869455862259" stdev="35.625833323587" sum="3645" variance="1269.2"/>
+          <iteration time-net="727" time-revs="1" time-avg="727" mem-peak="49884728" mem-real="52428800" mem-final="49640448" comp-z-value="1.6370673206645" comp-deviation="6.5982404692082"/>
+          <iteration time-net="650" time-revs="1" time-avg="650" mem-peak="49944408" mem-real="52428800" mem-final="49641704" comp-z-value="-1.1641367613614" comp-deviation="-4.692082111437"/>
+          <iteration time-net="657" time-revs="1" time-avg="657" mem-peak="49944408" mem-real="52428800" mem-final="49641704" comp-z-value="-0.90948184481359" comp-deviation="-3.6656891495601"/>
+          <iteration time-net="692" time-revs="1" time-avg="692" mem-peak="49944408" mem-real="52428800" mem-final="49641704" comp-z-value="0.36379273792544" comp-deviation="1.466275659824"/>
+          <iteration time-net="684" time-revs="1" time-avg="684" mem-peak="49944408" mem-real="52428800" mem-final="49641704" comp-z-value="0.072758547585087" comp-deviation="0.29325513196481"/>
+          <stats max="727" mean="682" min="650" mode="672.90410958904" rstdev="4.0305248207692" stdev="27.488179277646" sum="3410" variance="755.6"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-10538.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-10538.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1384277" time-revs="1" time-avg="1384277" mem-peak="80060624" mem-real="83886080" mem-final="70511816" comp-z-value="-0.47952757733357" comp-deviation="-0.26778217597226"/>
-          <iteration time-net="1383713" time-revs="1" time-avg="1383713" mem-peak="82684744" mem-real="85983232" mem-final="73135936" comp-z-value="-0.55229273919757" comp-deviation="-0.30841636324312"/>
-          <iteration time-net="1382489" time-revs="1" time-avg="1382489" mem-peak="82684744" mem-real="85983232" mem-final="73135936" comp-z-value="-0.71020862239179" comp-deviation="-0.39660119519266"/>
-          <iteration time-net="1386178" time-revs="1" time-avg="1386178" mem-peak="82684744" mem-real="85983232" mem-final="73135936" comp-z-value="-0.23426769665365" comp-deviation="-0.13082191001142"/>
-          <iteration time-net="1403312" time-revs="1" time-avg="1403312" mem-peak="82684744" mem-real="85983232" mem-final="73135936" comp-z-value="1.9762966355766" comp-deviation="1.1036216444194"/>
-          <stats max="1403312" mean="1387993.8" min="1382489" mode="1384200.4794521" rstdev="0.5584291469977" stdev="7750.961937721" sum="6939969" variance="60077410.96"/>
+          <iteration time-net="1174326" time-revs="1" time-avg="1174326" mem-peak="80988312" mem-real="83886080" mem-final="70533936" comp-z-value="-1.9688177502844" comp-deviation="-6.6053370333015"/>
+          <iteration time-net="1278523" time-revs="1" time-avg="1278523" mem-peak="83612432" mem-real="88080384" mem-final="73158056" comp-z-value="0.50119464073718" comp-deviation="1.6814961775285"/>
+          <iteration time-net="1289857" time-revs="1" time-avg="1289857" mem-peak="83612432" mem-real="88080384" mem-final="73158056" comp-z-value="0.76986955882348" comp-deviation="2.5828941795012"/>
+          <iteration time-net="1277791" time-revs="1" time-avg="1277791" mem-peak="83612432" mem-real="88080384" mem-final="73158056" comp-z-value="0.4838424226289" comp-deviation="1.6232798957706"/>
+          <iteration time-net="1266404" time-revs="1" time-avg="1266404" mem-peak="83612432" mem-real="88080384" mem-final="73158056" comp-z-value="0.21391112809487" comp-deviation="0.71766678050124"/>
+          <stats max="1289857" mean="1257380.2" min="1174326" mode="1277874.332681" rstdev="3.3549763721641" stdev="42184.808618269" sum="6286901" variance="1779558078.16"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-10772.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-10772.php" type="string"/>
           </parameter-set>
-          <iteration time-net="322510" time-revs="1" time-avg="322510" mem-peak="116791616" mem-real="127930368" mem-final="110002048" comp-z-value="-0.52892723656713" comp-deviation="-0.34903021756299"/>
-          <iteration time-net="326656" time-revs="1" time-avg="326656" mem-peak="129791840" mem-real="140513280" mem-final="115706160" comp-z-value="1.41240803504" comp-deviation="0.9320243876213"/>
-          <iteration time-net="320273" time-revs="1" time-avg="320273" mem-peak="129791840" mem-real="140513280" mem-final="115706160" comp-z-value="-1.5763867162066" comp-deviation="-1.040231170722"/>
-          <iteration time-net="324405" time-revs="1" time-avg="324405" mem-peak="129791840" mem-real="140513280" mem-final="115706160" comp-z-value="0.35839315409747" comp-deviation="0.23649763502366"/>
-          <iteration time-net="324354" time-revs="1" time-avg="324354" mem-peak="129791840" mem-real="140513280" mem-final="115706160" comp-z-value="0.33451276363631" comp-deviation="0.22073936564006"/>
-          <stats max="326656" mean="323639.6" min="320273" mode="324132.77886497" rstdev="0.659883238058" stdev="2135.6434721179" sum="1618198" variance="4560973.04"/>
+          <iteration time-net="255291" time-revs="1" time-avg="255291" mem-peak="116813736" mem-real="127930368" mem-final="110024168" comp-z-value="0.59622398118252" comp-deviation="0.38598651878381"/>
+          <iteration time-net="252069" time-revs="1" time-avg="252069" mem-peak="129813960" mem-real="140513280" mem-final="115728280" comp-z-value="-1.3608192822344" comp-deviation="-0.88097412050046"/>
+          <iteration time-net="256685" time-revs="1" time-avg="256685" mem-peak="129813960" mem-real="140513280" mem-final="115728280" comp-z-value="1.4429397816801" comp-deviation="0.93413770784722"/>
+          <iteration time-net="254558" time-revs="1" time-avg="254558" mem-peak="129813960" mem-real="140513280" mem-final="115728280" comp-z-value="0.15099967575589" comp-deviation="0.097754939455642"/>
+          <iteration time-net="252944" time-revs="1" time-avg="252944" mem-peak="129813960" mem-real="140513280" mem-final="115728280" comp-z-value="-0.82934415638408" comp-deviation="-0.5369050455862"/>
+          <stats max="256685" mean="254309.4" min="252069" mode="254589.2818004" rstdev="0.64738509514204" stdev="1646.3611511452" sum="1271547" variance="2710505.04"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-10979.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-10979.php" type="string"/>
           </parameter-set>
-          <iteration time-net="805289" time-revs="1" time-avg="805289" mem-peak="70403488" mem-real="73400320" mem-final="68433840" comp-z-value="-0.86861245552333" comp-deviation="-0.53860323315093"/>
-          <iteration time-net="806216" time-revs="1" time-avg="806216" mem-peak="70477360" mem-real="73400320" mem-final="68517032" comp-z-value="-0.68396657718217" comp-deviation="-0.42410928774392"/>
-          <iteration time-net="808457" time-revs="1" time-avg="808457" mem-peak="70477360" mem-real="73400320" mem-final="68517032" comp-z-value="-0.2375896479885" comp-deviation="-0.14732295370172"/>
-          <iteration time-net="808976" time-revs="1" time-avg="808976" mem-peak="70477360" mem-real="73400320" mem-final="68517032" comp-z-value="-0.13421185849653" comp-deviation="-0.083221165496496"/>
-          <iteration time-net="819311" time-revs="1" time-avg="819311" mem-peak="70477360" mem-real="73400320" mem-final="68517032" comp-z-value="1.9243805391905" comp-deviation="1.193256640093"/>
-          <stats max="819311" mean="809649.8" min="805289" mode="807292.14285714" rstdev="0.62007311744848" stdev="5020.4207552754" sum="4048249" variance="25204624.56"/>
+          <iteration time-net="431377" time-revs="1" time-avg="431377" mem-peak="70425608" mem-real="73400320" mem-final="68455960" comp-z-value="-1.1854028163036" comp-deviation="-0.50336816593067"/>
+          <iteration time-net="432214" time-revs="1" time-avg="432214" mem-peak="70499480" mem-real="73400320" mem-final="68539152" comp-z-value="-0.73077389527808" comp-deviation="-0.31031503411067"/>
+          <iteration time-net="434037" time-revs="1" time-avg="434037" mem-peak="70499480" mem-real="73400320" mem-final="68539152" comp-z-value="0.25941549902244" comp-deviation="0.11015791607793"/>
+          <iteration time-net="433427" time-revs="1" time-avg="433427" mem-peak="70499480" mem-real="73400320" mem-final="68539152" comp-z-value="-0.071915016898197" comp-deviation="-0.030537914758629"/>
+          <iteration time-net="436742" time-revs="1" time-avg="436742" mem-peak="70499480" mem-real="73400320" mem-final="68539152" comp-z-value="1.7286762294574" comp-deviation="0.73406319872202"/>
+          <stats max="436742" mean="433559.4" min="431377" mode="432878.36007828" rstdev="0.42463891514979" stdev="1841.0619326899" sum="2167797" variance="3389509.04"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-11263.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-11263.php" type="string"/>
           </parameter-set>
-          <iteration time-net="630307" time-revs="1" time-avg="630307" mem-peak="70387208" mem-real="71303168" mem-final="68225824" comp-z-value="-1.3594330796411" comp-deviation="-0.38949282805992"/>
-          <iteration time-net="631340" time-revs="1" time-avg="631340" mem-peak="70661144" mem-real="73400320" mem-final="68496416" comp-z-value="-0.78964716254734" comp-deviation="-0.22624277069324"/>
-          <iteration time-net="634266" time-revs="1" time-avg="634266" mem-peak="70661144" mem-real="73400320" mem-final="68496416" comp-z-value="0.82428661617127" comp-deviation="0.23616736275775"/>
-          <iteration time-net="635236" time-revs="1" time-avg="635236" mem-peak="70661144" mem-real="73400320" mem-final="68496416" comp-z-value="1.3593227629098" comp-deviation="0.38946122107883"/>
-          <iteration time-net="632709" time-revs="1" time-avg="632709" mem-peak="70661144" mem-real="73400320" mem-final="68496416" comp-z-value="-0.0345291368926" comp-deviation="-0.0098929850833977"/>
-          <stats max="635236" mean="632771.6" min="630307" mode="632400.13698629" rstdev="0.28651121845788" stdev="1812.9616212154" sum="3163858" variance="3286829.84"/>
+          <iteration time-net="546953" time-revs="1" time-avg="546953" mem-peak="70407552" mem-real="71303168" mem-final="68247944" comp-z-value="1.131190825438" comp-deviation="0.30523286201106"/>
+          <iteration time-net="545022" time-revs="1" time-avg="545022" mem-peak="70681488" mem-real="73400320" mem-final="68518536" comp-z-value="-0.18119170515606" comp-deviation="-0.048891541103184"/>
+          <iteration time-net="546620" time-revs="1" time-avg="546620" mem-peak="70681488" mem-real="73400320" mem-final="68518536" comp-z-value="0.90487110369394" comp-deviation="0.24416428291368"/>
+          <iteration time-net="545039" time-revs="1" time-avg="545039" mem-peak="70681488" mem-real="73400320" mem-final="68518536" comp-z-value="-0.16963784548744" comp-deviation="-0.045773925954068"/>
+          <iteration time-net="542809" time-revs="1" time-avg="542809" mem-peak="70681488" mem-real="73400320" mem-final="68518536" comp-z-value="-1.6852323784884" comp-deviation="-0.45473167786746"/>
+          <stats max="546953" mean="545288.6" min="542809" mode="545793.32876712" rstdev="0.26983321924739" stdev="1471.369783569" sum="2726443" variance="2164929.04"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-11283.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-11283.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1014134" time-revs="1" time-avg="1014134" mem-peak="69272056" mem-real="71303168" mem-final="66945456" comp-z-value="1.1709564324335" comp-deviation="0.82572716663654"/>
-          <iteration time-net="999042" time-revs="1" time-avg="999042" mem-peak="69277640" mem-real="71303168" mem-final="66951040" comp-z-value="-0.956824827745" comp-deviation="-0.67472728454927"/>
-          <iteration time-net="1014744" time-revs="1" time-avg="1014744" mem-peak="69277640" mem-real="71303168" mem-final="66951040" comp-z-value="1.2569587229655" comp-deviation="0.88637368235503"/>
-          <iteration time-net="1001748" time-revs="1" time-avg="1001748" mem-peak="69277640" mem-real="71303168" mem-final="66951040" comp-z-value="-0.5753130274506" comp-deviation="-0.40569536400138"/>
-          <iteration time-net="999475" time-revs="1" time-avg="999475" mem-peak="69277640" mem-real="71303168" mem-final="66951040" comp-z-value="-0.89577730020344" comp-deviation="-0.63167820044091"/>
-          <stats max="1014744" mean="1005828.6" min="999042" mode="1000609.1272016" rstdev="0.70517326158795" stdev="7092.8343446044" sum="5029143" variance="50308299.04"/>
+          <iteration time-net="919651" time-revs="1" time-avg="919651" mem-peak="69299064" mem-real="71303168" mem-final="66967576" comp-z-value="1.3749621665643" comp-deviation="0.56187306768655"/>
+          <iteration time-net="910966" time-revs="1" time-avg="910966" mem-peak="69304648" mem-real="71303168" mem-final="66973160" comp-z-value="-0.94901930950038" comp-deviation="-0.38781313674628"/>
+          <iteration time-net="911988" time-revs="1" time-avg="911988" mem-peak="69304648" mem-real="71303168" mem-final="66973160" comp-z-value="-0.67554676274873" comp-deviation="-0.27605961908015"/>
+          <iteration time-net="918446" time-revs="1" time-avg="918446" mem-peak="69304648" mem-real="71303168" mem-final="66973160" comp-z-value="1.052521443633" comp-deviation="0.43010889079057"/>
+          <iteration time-net="911512" time-revs="1" time-avg="911512" mem-peak="69304648" mem-real="71303168" mem-final="66973160" comp-z-value="-0.80291753794813" comp-deviation="-0.32810920265068"/>
+          <stats max="919651" mean="914512.6" min="910966" mode="911781.81213307" rstdev="0.4086462023101" stdev="3737.1210095473" sum="4572563" variance="13966073.44"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-11297.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-11297.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1522907" time-revs="1" time-avg="1522907" mem-peak="78593296" mem-real="81788928" mem-final="69055936" comp-z-value="-0.45273939919941" comp-deviation="-0.12231336881842"/>
-          <iteration time-net="1518448" time-revs="1" time-avg="1518448" mem-peak="78716336" mem-real="81788928" mem-final="69178976" comp-z-value="-1.5351871102075" comp-deviation="-0.41475053319447"/>
-          <iteration time-net="1524590" time-revs="1" time-avg="1524590" mem-peak="78716336" mem-real="81788928" mem-final="69178976" comp-z-value="-0.044181539224822" comp-deviation="-0.011936210790859"/>
-          <iteration time-net="1527182" time-revs="1" time-avg="1527182" mem-peak="78716336" mem-real="81788928" mem-final="69178976" comp-z-value="0.58504126116385" comp-deviation="0.15805641761522"/>
-          <iteration time-net="1530733" time-revs="1" time-avg="1530733" mem-peak="78716336" mem-real="81788928" mem-final="69178976" comp-z-value="1.4470667874679" comp-deviation="0.39094369518853"/>
-          <stats max="1530733" mean="1524772" min="1518448" mode="1524987.1780822" rstdev="0.27016285535279" stdev="4119.3675728199" sum="7623860" variance="16969189.2"/>
+          <iteration time-net="1339689" time-revs="1" time-avg="1339689" mem-peak="78615848" mem-real="79691776" mem-final="69078488" comp-z-value="-1.3032141865865" comp-deviation="-0.23798020500344"/>
+          <iteration time-net="1343268" time-revs="1" time-avg="1343268" mem-peak="78738888" mem-real="81788928" mem-final="69201528" comp-z-value="0.15626499665182" comp-deviation="0.028535582501191"/>
+          <iteration time-net="1340908" time-revs="1" time-avg="1340908" mem-peak="78738888" mem-real="81788928" mem-final="69201528" comp-z-value="-0.806118594419" comp-deviation="-0.14720547883184"/>
+          <iteration time-net="1346751" time-revs="1" time-avg="1346751" mem-peak="78738888" mem-real="81788928" mem-final="69201528" comp-z-value="1.5765963727957" comp-deviation="0.28790258107024"/>
+          <iteration time-net="1343808" time-revs="1" time-avg="1343808" mem-peak="78738888" mem-real="81788928" mem-final="69201528" comp-z-value="0.37647141155785" comp-deviation="0.068747520263835"/>
+          <stats max="1346751" mean="1342884.8" min="1339689" mode="1342508.2720156" rstdev="0.18261020134133" stdev="2452.2446370621" sum="6714424" variance="6013503.76"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-11913.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-11913.php" type="string"/>
           </parameter-set>
-          <iteration time-net="154204" time-revs="1" time-avg="154204" mem-peak="76976072" mem-real="79691776" mem-final="69186296" comp-z-value="-0.20076539327997" comp-deviation="-0.18370382645101"/>
-          <iteration time-net="155013" time-revs="1" time-avg="155013" mem-peak="76975600" mem-real="79691776" mem-final="69185824" comp-z-value="0.37153623872673" comp-deviation="0.33996211998618"/>
-          <iteration time-net="151879" time-revs="1" time-avg="151879" mem-peak="76975600" mem-real="79691776" mem-final="69185824" comp-z-value="-1.8455135940409" comp-deviation="-1.6886770346914"/>
-          <iteration time-net="155787" time-revs="1" time-avg="155787" mem-peak="76975600" mem-real="79691776" mem-final="69185824" comp-z-value="0.91907822039939" comp-deviation="0.84097255576169"/>
-          <iteration time-net="155556" time-revs="1" time-avg="155556" mem-peak="76975600" mem-real="79691776" mem-final="69185824" comp-z-value="0.75566452819476" comp-deviation="0.69144618539458"/>
-          <stats max="155787" mean="154487.8" min="151879" mode="155175.18003914" rstdev="0.91501739144275" stdev="1413.5902376573" sum="772439" variance="1998237.36"/>
+          <iteration time-net="130971" time-revs="1" time-avg="130971" mem-peak="77031824" mem-real="79691776" mem-final="69208416" comp-z-value="0.58014083532988" comp-deviation="0.29374962668681"/>
+          <iteration time-net="129930" time-revs="1" time-avg="129930" mem-peak="76997720" mem-real="79691776" mem-final="69207944" comp-z-value="-0.99422467451996" comp-deviation="-0.50341763447315"/>
+          <iteration time-net="130028" time-revs="1" time-avg="130028" mem-peak="76997720" mem-real="79691776" mem-final="69207944" comp-z-value="-0.8460135122094" comp-deviation="-0.42837210940718"/>
+          <iteration time-net="130316" time-revs="1" time-avg="130316" mem-peak="76997720" mem-real="79691776" mem-final="69207944" comp-z-value="-0.41045417807227" comp-deviation="-0.2078301581929"/>
+          <iteration time-net="131692" time-revs="1" time-avg="131692" mem-peak="76997720" mem-real="79691776" mem-final="69207944" comp-z-value="1.6705515294718" comp-deviation="0.84587027538645"/>
+          <stats max="131692" mean="130587.4" min="129930" mode="130209.29941292" rstdev="0.5063419238878" stdev="661.21875351505" sum="652937" variance="437210.24"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-12159.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-12159.php" type="string"/>
           </parameter-set>
-          <iteration time-net="186933" time-revs="1" time-avg="186933" mem-peak="66087488" mem-real="69206016" mem-final="64005856" comp-z-value="-0.96143659282979" comp-deviation="-0.71447464443574"/>
-          <iteration time-net="186851" time-revs="1" time-avg="186851" mem-peak="69976952" mem-real="75497472" mem-final="67895320" comp-z-value="-1.0200433432104" comp-deviation="-0.75802721717119"/>
-          <iteration time-net="188508" time-revs="1" time-avg="188508" mem-peak="69976952" mem-real="75497472" mem-final="67895320" comp-z-value="0.16424184435941" comp-deviation="0.12205342944642"/>
-          <iteration time-net="188397" time-revs="1" time-avg="188397" mem-peak="69976952" mem-real="75497472" mem-final="67895320" comp-z-value="0.084908316405119" comp-deviation="0.06309811757282"/>
-          <iteration time-net="190702" time-revs="1" time-avg="190702" mem-peak="69976952" mem-real="75497472" mem-final="67895320" comp-z-value="1.7323297752757" comp-deviation="1.2873503145877"/>
-          <stats max="190702" mean="188278.2" min="186851" mode="187725.19960861" rstdev="0.74313236022443" stdev="1399.1562314481" sum="941391" variance="1957638.16"/>
+          <iteration time-net="155367" time-revs="1" time-avg="155367" mem-peak="66176408" mem-real="69206016" mem-final="64027976" comp-z-value="-1.557739158482" comp-deviation="-0.23014871048653"/>
+          <iteration time-net="156083" time-revs="1" time-avg="156083" mem-peak="70065872" mem-real="75497472" mem-final="67917440" comp-z-value="1.5542620621461" comp-deviation="0.22963498568635"/>
+          <iteration time-net="155659" time-revs="1" time-avg="155659" mem-peak="70065872" mem-real="75497472" mem-final="67917440" comp-z-value="-0.28859899587945" comp-deviation="-0.042639158416029"/>
+          <iteration time-net="155788" time-revs="1" time-avg="155788" mem-peak="70065872" mem-real="75497472" mem-final="67917440" comp-z-value="0.27208278828399" comp-deviation="0.040198965615119"/>
+          <iteration time-net="155730" time-revs="1" time-avg="155730" mem-peak="70065872" mem-real="75497472" mem-final="67917440" comp-z-value="0.019993303931435" comp-deviation="0.0029539176011144"/>
+          <stats max="156083" mean="155725.4" min="155367" mode="155725.70058709" rstdev="0.14774534570397" stdev="230.07703057889" sum="778627" variance="52935.44"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-12671.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-12671.php" type="string"/>
           </parameter-set>
-          <iteration time-net="560358" time-revs="1" time-avg="560358" mem-peak="82477680" mem-real="85983232" mem-final="75242280" comp-z-value="1.8928216600319" comp-deviation="1.5203099319089"/>
-          <iteration time-net="547917" time-revs="1" time-avg="547917" mem-peak="87177480" mem-real="90177536" mem-final="79942080" comp-z-value="-0.91338863031284" comp-deviation="-0.73363161235902"/>
-          <iteration time-net="551756" time-revs="1" time-avg="551756" mem-peak="87177480" mem-real="90177536" mem-final="79942080" comp-z-value="-0.047458133999566" comp-deviation="-0.038118262271041"/>
-          <iteration time-net="548701" time-revs="1" time-avg="548701" mem-peak="87177480" mem-real="90177536" mem-final="79942080" comp-z-value="-0.7365484351814" comp-deviation="-0.59159398108291"/>
-          <iteration time-net="551100" time-revs="1" time-avg="551100" mem-peak="87177480" mem-real="90177536" mem-final="79942080" comp-z-value="-0.19542646053812" comp-deviation="-0.15696607619595"/>
-          <stats max="560358" mean="551966.4" min="547917" mode="549937.74951076" rstdev="0.80319766199383" stdev="4433.3812197915" sum="2759832" variance="19654869.04"/>
+          <iteration time-net="473847" time-revs="1" time-avg="473847" mem-peak="82678000" mem-real="85983232" mem-final="75264400" comp-z-value="1.9892327295533" comp-deviation="1.3771201398686"/>
+          <iteration time-net="465556" time-revs="1" time-avg="465556" mem-peak="87377800" mem-real="90177536" mem-final="79964200" comp-z-value="-0.57302313682851" comp-deviation="-0.39669652052951"/>
+          <iteration time-net="465318" time-revs="1" time-avg="465318" mem-peak="87377800" mem-real="90177536" mem-final="79964200" comp-z-value="-0.64657480685611" comp-deviation="-0.44761539221866"/>
+          <iteration time-net="466121" time-revs="1" time-avg="466121" mem-peak="87377800" mem-real="90177536" mem-final="79964200" comp-z-value="-0.39841518067054" comp-deviation="-0.27581768647753"/>
+          <iteration time-net="466209" time-revs="1" time-avg="466209" mem-peak="87377800" mem-real="90177536" mem-final="79964200" comp-z-value="-0.37121960519815" comp-deviation="-0.25699054064289"/>
+          <stats max="473847" mean="467410.2" min="465318" mode="465818.72407045" rstdev="0.69228709110262" stdev="3235.820477097" sum="2337051" variance="10470534.16"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-12787.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-12787.php" type="string"/>
           </parameter-set>
-          <iteration time-net="6379" time-revs="1" time-avg="6379" mem-peak="66581928" mem-real="69206016" mem-final="65813152" comp-z-value="-0.31615259003431" comp-deviation="-0.27202801575886"/>
-          <iteration time-net="6304" time-revs="1" time-avg="6304" mem-peak="66586824" mem-real="69206016" mem-final="65818048" comp-z-value="-1.6788792712167" comp-deviation="-1.4445625664436"/>
-          <iteration time-net="6394" time-revs="1" time-avg="6394" mem-peak="66586824" mem-real="69206016" mem-final="65818048" comp-z-value="-0.04360725379783" comp-deviation="-0.037521105621907"/>
-          <iteration time-net="6454" time-revs="1" time-avg="6454" mem-peak="66586824" mem-real="69206016" mem-final="65818048" comp-z-value="1.0465740911481" comp-deviation="0.9005065349259"/>
-          <iteration time-net="6451" time-revs="1" time-avg="6451" mem-peak="66586824" mem-real="69206016" mem-final="65818048" comp-z-value="0.99206502390079" comp-deviation="0.85360515289851"/>
-          <stats max="6454" mean="6396.4" min="6304" mode="6417.600782779" rstdev="0.86043266553451" stdev="55.036715018249" sum="31982" variance="3029.04"/>
+          <iteration time-net="5805" time-revs="1" time-avg="5805" mem-peak="66604048" mem-real="69206016" mem-final="65835272" comp-z-value="-1.1063244528334" comp-deviation="-1.127537811691"/>
+          <iteration time-net="5874" time-revs="1" time-avg="5874" mem-peak="66608944" mem-real="69206016" mem-final="65840168" comp-z-value="0.046793179273923" comp-deviation="0.047690421038292"/>
+          <iteration time-net="5975" time-revs="1" time-avg="5975" mem-peak="66608944" mem-real="69206016" mem-final="65840168" comp-z-value="1.7346900030832" comp-deviation="1.7679520370623"/>
+          <iteration time-net="5820" time-revs="1" time-avg="5820" mem-peak="66608944" mem-real="69206016" mem-final="65840168" comp-z-value="-0.8556467067231" comp-deviation="-0.87205341327156"/>
+          <iteration time-net="5882" time-revs="1" time-avg="5882" mem-peak="66608944" mem-real="69206016" mem-final="65840168" comp-z-value="0.18048797719941" comp-deviation="0.18394876686197"/>
+          <stats max="5975" mean="5871.2" min="5805" mode="5848.2485322896" rstdev="1.0191746271207" stdev="59.83778070751" sum="29356" variance="3580.56"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-12800.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-12800.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1327729" time-revs="1" time-avg="1327729" mem-peak="72520808" mem-real="75497472" mem-final="67885584" comp-z-value="-0.80291786819251" comp-deviation="-0.28922028128685"/>
-          <iteration time-net="1336097" time-revs="1" time-avg="1336097" mem-peak="72257488" mem-real="75497472" mem-final="67622264" comp-z-value="0.94168555957936" comp-deviation="0.3392060050157"/>
-          <iteration time-net="1324770" time-revs="1" time-avg="1324770" mem-peak="72257488" mem-real="75497472" mem-final="67622264" comp-z-value="-1.4198253183332" comp-deviation="-0.51143746354894"/>
-          <iteration time-net="1337349" time-revs="1" time-avg="1337349" mem-peak="72257488" mem-real="75497472" mem-final="67622264" comp-z-value="1.2027089213827" comp-deviation="0.43322963198161"/>
-          <iteration time-net="1331956" time-revs="1" time-avg="1331956" mem-peak="72257488" mem-real="75497472" mem-final="67622264" comp-z-value="0.078348705563665" comp-deviation="0.028222107838495"/>
-          <stats max="1337349" mean="1331580.2" min="1324770" mode="1334124.2465754" rstdev="0.36021153936694" stdev="4796.5055363254" sum="6657901" variance="23006465.36"/>
+          <iteration time-net="1104609" time-revs="1" time-avg="1104609" mem-peak="71543048" mem-real="75497472" mem-final="67907704" comp-z-value="-0.94818120574677" comp-deviation="-0.95172014058537"/>
+          <iteration time-net="1136690" time-revs="1" time-avg="1136690" mem-peak="71279728" mem-real="75497472" mem-final="67644384" comp-z-value="1.9177670184107" comp-deviation="1.9249247773629"/>
+          <iteration time-net="1113316" time-revs="1" time-avg="1113316" mem-peak="71279728" mem-real="75497472" mem-final="67644384" comp-z-value="-0.17034350780286" comp-deviation="-0.17097928772619"/>
+          <iteration time-net="1112913" time-revs="1" time-avg="1112913" mem-peak="71279728" mem-real="75497472" mem-final="67644384" comp-z-value="-0.20634541342723" comp-deviation="-0.20711556471048"/>
+          <iteration time-net="1108586" time-revs="1" time-avg="1108586" mem-peak="71279728" mem-real="75497472" mem-final="67644384" comp-z-value="-0.59289689143381" comp-deviation="-0.59510978434086"/>
+          <stats max="1136690" mean="1115222.8" min="1104609" mode="1110070.9315068" rstdev="1.0037323402079" stdev="11193.851908972" sum="5576114" variance="125302320.56"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-13218.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-13218.php" type="string"/>
           </parameter-set>
-          <iteration time-net="23386" time-revs="1" time-avg="23386" mem-peak="85131792" mem-real="90177536" mem-final="84573920" comp-z-value="-1.1633719994556" comp-deviation="-0.85973004137557"/>
-          <iteration time-net="23499" time-revs="1" time-avg="23499" mem-peak="84747584" mem-real="90177536" mem-final="84189712" comp-z-value="-0.51514203920667" comp-deviation="-0.3806891406091"/>
-          <iteration time-net="23828" time-revs="1" time-avg="23828" mem-peak="84747584" mem-real="90177536" mem-final="84189712" comp-z-value="1.3721823583323" comp-deviation="1.0140405616225"/>
-          <iteration time-net="23467" time-revs="1" time-avg="23467" mem-peak="84747584" mem-real="90177536" mem-final="84189712" comp-z-value="-0.69871158547186" comp-deviation="-0.51634674082615"/>
-          <iteration time-net="23764" time-revs="1" time-avg="23764" mem-peak="84747584" mem-real="90177536" mem-final="84189712" comp-z-value="1.0050432658019" comp-deviation="0.74272536118836"/>
-          <stats max="23828" mean="23588.8" min="23386" mode="23471.632093933" rstdev="0.73899839585091" stdev="174.32085360048" sum="117944" variance="30387.76"/>
+          <iteration time-net="20632" time-revs="1" time-avg="20632" mem-peak="85153912" mem-real="90177536" mem-final="84596040" comp-z-value="-1.6520562089534" comp-deviation="-3.2732932649483"/>
+          <iteration time-net="21569" time-revs="1" time-avg="21569" mem-peak="84769704" mem-real="90177536" mem-final="84211832" comp-z-value="0.56504013563173" comp-deviation="1.1195394323541"/>
+          <iteration time-net="21209" time-revs="1" time-avg="21209" mem-peak="84769704" mem-real="90177536" mem-final="84211832" comp-z-value="-0.28677916431561" comp-deviation="-0.56820845561692"/>
+          <iteration time-net="21333" time-revs="1" time-avg="21333" mem-peak="84769704" mem-real="90177536" mem-final="84211832" comp-z-value="0.0066252612218109" comp-deviation="0.013126928017549"/>
+          <iteration time-net="21908" time-revs="1" time-avg="21908" mem-peak="84769704" mem-real="90177536" mem-final="84211832" comp-z-value="1.3671699764155" comp-deviation="2.7088353601935"/>
+          <stats max="21908" mean="21330.2" min="20632" mode="21418.575342466" rstdev="1.9813449731362" stdev="422.62484545989" sum="106651" variance="178611.76"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-13310.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-13310.php" type="string"/>
           </parameter-set>
-          <iteration time-net="63485" time-revs="1" time-avg="63485" mem-peak="65000480" mem-real="67108864" mem-final="63680792" comp-z-value="-1.4003484504444" comp-deviation="-1.1278757561222"/>
-          <iteration time-net="64610" time-revs="1" time-avg="64610" mem-peak="64992016" mem-real="67108864" mem-final="63672328" comp-z-value="0.77500643322025" comp-deviation="0.62420961482156"/>
-          <iteration time-net="64827" time-revs="1" time-avg="64827" mem-peak="64992016" mem-real="67108864" mem-final="63672328" comp-z-value="1.1946082196693" comp-deviation="0.96216741526137"/>
-          <iteration time-net="64399" time-revs="1" time-avg="64399" mem-peak="64992016" mem-real="67108864" mem-final="63672328" comp-z-value="0.36700653948404" comp-deviation="0.29559626969344"/>
-          <iteration time-net="63725" time-revs="1" time-avg="63725" mem-peak="64992016" mem-real="67108864" mem-final="63672328" comp-z-value="-0.93627274192924" comp-deviation="-0.75409754365418"/>
-          <stats max="64827" mean="64209.2" min="63485" mode="64538.115459882" rstdev="0.80542507528342" stdev="517.15699743888" sum="321046" variance="267451.36"/>
+          <iteration time-net="55448" time-revs="1" time-avg="55448" mem-peak="65022600" mem-real="67108864" mem-final="63702912" comp-z-value="0.3306503116987" comp-deviation="0.098929110432333"/>
+          <iteration time-net="55515" time-revs="1" time-avg="55515" mem-peak="65014136" mem-real="67108864" mem-final="63694448" comp-z-value="0.73491255410401" comp-deviation="0.21988258486602"/>
+          <iteration time-net="55104" time-revs="1" time-avg="55104" mem-peak="65014136" mem-real="67108864" mem-final="63694448" comp-z-value="-1.7449647836361" comp-deviation="-0.52208574337644"/>
+          <iteration time-net="55571" time-revs="1" time-avg="55571" mem-peak="65014136" mem-real="67108864" mem-final="63694448" comp-z-value="1.0728033835771" comp-deviation="0.32097802618372"/>
+          <iteration time-net="55328" time-revs="1" time-avg="55328" mem-peak="65014136" mem-real="67108864" mem-final="63694448" comp-z-value="-0.39340146574367" comp-deviation="-0.11770397810561"/>
+          <stats max="55571" mean="55393.2" min="55104" mode="55473.213307241" rstdev="0.29919557590643" stdev="165.734003753" sum="276966" variance="27467.76"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-13352.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-13352.php" type="string"/>
           </parameter-set>
-          <iteration time-net="2997042" time-revs="1" time-avg="2997042" mem-peak="191157472" mem-real="197132288" mem-final="112837984" comp-z-value="-1.9525741999087" comp-deviation="-1.4170873075144"/>
-          <iteration time-net="3053972" time-revs="1" time-avg="3053972" mem-peak="193090472" mem-real="197132288" mem-final="114770984" comp-z-value="0.62767076078882" comp-deviation="0.4555341704573"/>
-          <iteration time-net="3054852" time-revs="1" time-avg="3054852" mem-peak="193090472" mem-real="197132288" mem-final="114770984" comp-z-value="0.6675551023559" comp-deviation="0.4844803657957"/>
-          <iteration time-net="3041711" time-revs="1" time-avg="3041711" mem-peak="193090472" mem-real="197132288" mem-final="114770984" comp-z-value="0.071964042659319" comp-deviation="0.052228146543529"/>
-          <iteration time-net="3053039" time-revs="1" time-avg="3053039" mem-peak="193090472" mem-real="197132288" mem-final="114770984" comp-z-value="0.58538429410463" comp-deviation="0.42484462471783"/>
-          <stats max="3054852" mean="3040123.2" min="2997042" mode="3051005.5420743" rstdev="0.72575337089911" stdev="22063.796603486" sum="15200616" variance="486811120.56"/>
+          <iteration time-net="2681082" time-revs="1" time-avg="2681082" mem-peak="191223648" mem-real="197132288" mem-final="112860104" comp-z-value="-1.2320317444751" comp-deviation="-0.78886903657948"/>
+          <iteration time-net="2723989" time-revs="1" time-avg="2723989" mem-peak="193156648" mem-real="197132288" mem-final="114793104" comp-z-value="1.2476471273067" comp-deviation="0.79886755493376"/>
+          <iteration time-net="2701133" time-revs="1" time-avg="2701133" mem-peak="193156648" mem-real="197132288" mem-final="114793104" comp-z-value="-0.073245507774865" comp-deviation="-0.046899045752062"/>
+          <iteration time-net="2685952" time-revs="1" time-avg="2685952" mem-peak="193156648" mem-real="197132288" mem-final="114793104" comp-z-value="-0.95058498507509" comp-deviation="-0.60865887971301"/>
+          <iteration time-net="2719846" time-revs="1" time-avg="2719846" mem-peak="193156648" mem-real="197132288" mem-final="114793104" comp-z-value="1.0082151100184" comp-deviation="0.64555940711081"/>
+          <stats max="2723989" mean="2702400.4" min="2681082" mode="2692081.6418786" rstdev="0.64029927809656" stdev="17303.450252479" sum="13512002" variance="299409390.64"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-13685.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-13685.php" type="string"/>
           </parameter-set>
-          <iteration time-net="16510" time-revs="1" time-avg="16510" mem-peak="69620840" mem-real="71303168" mem-final="64995520" comp-z-value="-0.88816530160365" comp-deviation="-2.2104814253222"/>
-          <iteration time-net="17615" time-revs="1" time-avg="17615" mem-peak="69608928" mem-real="71303168" mem-final="65029592" comp-z-value="1.7415845865851" comp-deviation="4.3344863532979"/>
-          <iteration time-net="17010" time-revs="1" time-avg="17010" mem-peak="69608928" mem-real="71303168" mem-final="65029592" comp-z-value="0.30176677449984" comp-deviation="0.75104245640636"/>
-          <iteration time-net="16833" time-revs="1" time-avg="16833" mem-peak="69608928" mem-real="71303168" mem-final="65029592" comp-z-value="-0.11946918044079" comp-deviation="-0.29733699772555"/>
-          <iteration time-net="16448" time-revs="1" time-avg="16448" mem-peak="69608928" mem-real="71303168" mem-final="65029592" comp-z-value="-1.0357168790405" comp-deviation="-2.5777103866566"/>
-          <stats max="17615" mean="16883.2" min="16448" mode="16699.213307241" rstdev="2.4888175898462" stdev="420.19205132891" sum="84416" variance="176561.36"/>
+          <iteration time-net="15119" time-revs="1" time-avg="15119" mem-peak="69642960" mem-real="71303168" mem-final="65017640" comp-z-value="0.78698365163985" comp-deviation="0.60018098584052"/>
+          <iteration time-net="14831" time-revs="1" time-avg="14831" mem-peak="69631048" mem-real="71303168" mem-final="65051712" comp-z-value="-1.7257801141282" comp-deviation="-1.316139678484"/>
+          <iteration time-net="15140" time-revs="1" time-avg="15140" mem-peak="69631048" mem-real="71303168" mem-final="65051712" comp-z-value="0.97020600956043" comp-deviation="0.73991270094752"/>
+          <iteration time-net="15082" time-revs="1" time-avg="15082" mem-peak="69631048" mem-real="71303168" mem-final="65051712" comp-z-value="0.46416330673215" comp-deviation="0.35398701160439"/>
+          <iteration time-net="14972" time-revs="1" time-avg="14972" mem-peak="69631048" mem-real="71303168" mem-final="65051712" comp-z-value="-0.49557285380424" comp-deviation="-0.37794101990844"/>
+          <stats max="15140" mean="15028.8" min="14831" mode="15092.228962818" rstdev="0.76263462981717" stdev="114.61483324596" sum="75144" variance="13136.56"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-13933.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-13933.php" type="string"/>
           </parameter-set>
-          <iteration time-net="392428" time-revs="1" time-avg="392428" mem-peak="71186744" mem-real="73400320" mem-final="66170296" comp-z-value="-0.82814671902334" comp-deviation="-0.30754097794271"/>
-          <iteration time-net="393944" time-revs="1" time-avg="393944" mem-peak="71234320" mem-real="73400320" mem-final="66217872" comp-z-value="0.20891789855423" comp-deviation="0.07758385483538"/>
-          <iteration time-net="394940" time-revs="1" time-avg="394940" mem-peak="71234320" mem-real="73400320" mem-final="66217872" comp-z-value="0.89026114334794" comp-deviation="0.33060782148906"/>
-          <iteration time-net="391523" time-revs="1" time-avg="391523" mem-peak="71234320" mem-real="73400320" mem-final="66217872" comp-z-value="-1.4472387235799" comp-deviation="-0.53744729302461"/>
-          <iteration time-net="395358" time-revs="1" time-avg="395358" mem-peak="71234320" mem-real="73400320" mem-final="66217872" comp-z-value="1.1762064007011" comp-deviation="0.43679659464291"/>
-          <stats max="395358" mean="393638.6" min="391523" mode="394494.9373777" rstdev="0.37136049793858" stdev="1461.8182650384" sum="1968193" variance="2136912.64"/>
+          <iteration time-net="335873" time-revs="1" time-avg="335873" mem-peak="71208864" mem-real="73400320" mem-final="66192416" comp-z-value="-0.074020500360252" comp-deviation="-0.032263690787652"/>
+          <iteration time-net="335345" time-revs="1" time-avg="335345" mem-peak="71256440" mem-real="73400320" mem-final="66239992" comp-z-value="-0.43456315894147" comp-deviation="-0.18941524739168"/>
+          <iteration time-net="335593" time-revs="1" time-avg="335593" mem-peak="71256440" mem-real="73400320" mem-final="66239992" comp-z-value="-0.26521736475939" comp-deviation="-0.11560163747161"/>
+          <iteration time-net="334367" time-revs="1" time-avg="334367" mem-peak="71256440" mem-real="73400320" mem-final="66239992" comp-z-value="-1.1023864924499" comp-deviation="-0.48050278973777"/>
+          <iteration time-net="338729" time-revs="1" time-avg="338729" mem-peak="71256440" mem-real="73400320" mem-final="66239992" comp-z-value="1.8761875165109" comp-deviation="0.81778336538867"/>
+          <stats max="338729" mean="335981.4" min="334367" mode="335374.27201566" rstdev="0.43587507015796" stdev="1464.4591629677" sum="1679907" variance="2144640.64"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-14207-and.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-14207-and.php" type="string"/>
           </parameter-set>
-          <iteration time-net="873764" time-revs="1" time-avg="873764" mem-peak="68692736" mem-real="73400320" mem-final="60686368" comp-z-value="-0.37361494086737" comp-deviation="-0.20715463548757"/>
-          <iteration time-net="881562" time-revs="1" time-avg="881562" mem-peak="68678448" mem-real="73400320" mem-final="60672080" comp-z-value="1.2326532854441" comp-deviation="0.68345725531186"/>
-          <iteration time-net="868875" time-revs="1" time-avg="868875" mem-peak="68678448" mem-real="73400320" mem-final="60672080" comp-z-value="-1.3806738480791" comp-deviation="-0.76552877425627"/>
-          <iteration time-net="880756" time-revs="1" time-avg="880756" mem-peak="68678448" mem-real="73400320" mem-final="60672080" comp-z-value="1.0666296652329" comp-deviation="0.59140375646801"/>
-          <iteration time-net="872932" time-revs="1" time-avg="872932" mem-peak="68678448" mem-real="73400320" mem-final="60672080" comp-z-value="-0.54499416173056" comp-deviation="-0.30217760203606"/>
-          <stats max="881562" mean="875577.8" min="868875" mode="873195.03522505" rstdev="0.55446025527416" stdev="4854.7309050039" sum="4377889" variance="23568412.16"/>
+          <iteration time-net="221318" time-revs="1" time-avg="221318" mem-peak="68728864" mem-real="73400320" mem-final="60708488" comp-z-value="0.65116752146669" comp-deviation="0.22588615482711"/>
+          <iteration time-net="219879" time-revs="1" time-avg="219879" mem-peak="68714576" mem-real="73400320" mem-final="60694200" comp-z-value="-1.2274011701744" comp-deviation="-0.4257781932006"/>
+          <iteration time-net="219970" time-revs="1" time-avg="219970" mem-peak="68714576" mem-real="73400320" mem-final="60694200" comp-z-value="-1.1086035670199" comp-deviation="-0.38456800857897"/>
+          <iteration time-net="221113" time-revs="1" time-avg="221113" mem-peak="68714576" mem-real="73400320" mem-final="60694200" comp-z-value="0.38354654732741" comp-deviation="0.13305002463553"/>
+          <iteration time-net="221816" time-revs="1" time-avg="221816" mem-peak="68714576" mem-real="73400320" mem-final="60694200" comp-z-value="1.3012906684002" comp-deviation="0.45141002231689"/>
+          <stats max="221816" mean="220819.2" min="219879" mode="221277.73385518" rstdev="0.34689407468961" stdev="766.00872057699" sum="1104096" variance="586769.36"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-14207.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-14207.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1532866" time-revs="1" time-avg="1532866" mem-peak="73703632" mem-real="77594624" mem-final="67549464" comp-z-value="1.3499941521989" comp-deviation="0.7941140034398"/>
-          <iteration time-net="1527204" time-revs="1" time-avg="1527204" mem-peak="73703904" mem-real="75497472" mem-final="67549736" comp-z-value="0.71707260926121" comp-deviation="0.42180730899457"/>
-          <iteration time-net="1522385" time-revs="1" time-avg="1522385" mem-peak="73703904" mem-real="75497472" mem-final="67549736" comp-z-value="0.17838505796892" comp-deviation="0.10493236011934"/>
-          <iteration time-net="1508643" time-revs="1" time-avg="1508643" mem-peak="73703904" mem-real="75497472" mem-final="67549736" comp-z-value="-1.3577519683557" comp-deviation="-0.79867742353772"/>
-          <iteration time-net="1512848" time-revs="1" time-avg="1512848" mem-peak="73703904" mem-real="75497472" mem-final="67549736" comp-z-value="-0.8876998510733" comp-deviation="-0.52217624901597"/>
-          <stats max="1532866" mean="1520789.2" min="1508643" mode="1524712.6614481" rstdev="0.5882351432014" stdev="8945.8165284115" sum="7603946" variance="80027633.36"/>
+          <iteration time-net="928171" time-revs="1" time-avg="928171" mem-peak="73725400" mem-real="75497472" mem-final="67571584" comp-z-value="1.6786588211941" comp-deviation="0.4718274991389"/>
+          <iteration time-net="921248" time-revs="1" time-avg="921248" mem-peak="73725672" mem-real="75497472" mem-final="67571856" comp-z-value="-0.9875233893057" comp-deviation="-0.27756723715058"/>
+          <iteration time-net="921252" time-revs="1" time-avg="921252" mem-peak="73725672" mem-real="75497472" mem-final="67571856" comp-z-value="-0.98598291135654" comp-deviation="-0.27713424871418"/>
+          <iteration time-net="923392" time-revs="1" time-avg="923392" mem-peak="73725672" mem-real="75497472" mem-final="67571856" comp-z-value="-0.1618272085587" comp-deviation="-0.045485435243219"/>
+          <iteration time-net="924998" time-revs="1" time-avg="924998" mem-peak="73725672" mem-real="75497472" mem-final="67571856" comp-z-value="0.45667468802697" comp-deviation="0.1283594219691"/>
+          <stats max="928171" mean="923812.2" min="921248" mode="922575.69863014" rstdev="0.28107408913699" stdev="2596.5967264864" sum="4619061" variance="6742314.56"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-14319.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-14319.php" type="string"/>
           </parameter-set>
-          <iteration time-net="73525" time-revs="1" time-avg="73525" mem-peak="82549456" mem-real="85983232" mem-final="81113024" comp-z-value="0.85917150310797" comp-deviation="0.37707102368912"/>
-          <iteration time-net="72926" time-revs="1" time-avg="72926" mem-peak="82553120" mem-real="85983232" mem-final="81116688" comp-z-value="-1.004129475754" comp-deviation="-0.44068981334848"/>
-          <iteration time-net="73014" time-revs="1" time-avg="73014" mem-peak="82553120" mem-real="85983232" mem-final="81116688" comp-z-value="-0.73038909822504" comp-deviation="-0.32055132643812"/>
-          <iteration time-net="73042" time-revs="1" time-avg="73042" mem-peak="82553120" mem-real="85983232" mem-final="81116688" comp-z-value="-0.64328988719309" comp-deviation="-0.28232544423936"/>
-          <iteration time-net="73737" time-revs="1" time-avg="73737" mem-peak="82553120" mem-real="85983232" mem-final="81116688" comp-z-value="1.5186369580641" comp-deviation="0.66649556033682"/>
-          <stats max="73737" mean="73248.8" min="72926" mode="73029.160469668" rstdev="0.43887747943816" stdev="321.4724871587" sum="366244" variance="103344.56"/>
+          <iteration time-net="64383" time-revs="1" time-avg="64383" mem-peak="82571576" mem-real="85983232" mem-final="81135144" comp-z-value="0.028300652677802" comp-deviation="0.066210343734261"/>
+          <iteration time-net="63424" time-revs="1" time-avg="63424" mem-peak="82575240" mem-real="85983232" mem-final="81138808" comp-z-value="-0.60879619985772" comp-deviation="-1.4242995069972"/>
+          <iteration time-net="67243" time-revs="1" time-avg="67243" mem-peak="82575240" mem-real="85983232" mem-final="81138808" comp-z-value="1.928297522596" comp-deviation="4.5113179277717"/>
+          <iteration time-net="63373" time-revs="1" time-avg="63373" mem-peak="82575240" mem-real="85983232" mem-final="81138808" comp-z-value="-0.6426772629227" comp-deviation="-1.5035654114678"/>
+          <iteration time-net="63279" time-revs="1" time-avg="63279" mem-peak="82575240" mem-real="85983232" mem-final="81138808" comp-z-value="-0.70512471249344" comp-deviation="-1.649663353041"/>
+          <stats max="67243" mean="64340.4" min="63279" mode="63589.293542075" rstdev="2.3395341615635" stdev="1505.2656376866" sum="321702" variance="2265824.64"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-14452.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-14452.php" type="string"/>
           </parameter-set>
-          <iteration time-net="24962" time-revs="1" time-avg="24962" mem-peak="67054152" mem-real="69206016" mem-final="65605640" comp-z-value="0.41850792930747" comp-deviation="0.30942334739803"/>
-          <iteration time-net="24964" time-revs="1" time-avg="24964" mem-peak="67053448" mem-real="69206016" mem-final="65604936" comp-z-value="0.42937826513364" comp-deviation="0.31746031746032"/>
-          <iteration time-net="24879" time-revs="1" time-avg="24879" mem-peak="67053448" mem-real="69206016" mem-final="65604936" comp-z-value="-0.032611007478504" comp-deviation="-0.02411091018686"/>
-          <iteration time-net="24540" time-revs="1" time-avg="24540" mem-peak="67053448" mem-real="69206016" mem-final="65604936" comp-z-value="-1.875132930014" comp-deviation="-1.3863773357444"/>
-          <iteration time-net="25080" time-revs="1" time-avg="25080" mem-peak="67053448" mem-real="69206016" mem-final="65604936" comp-z-value="1.0598577430514" comp-deviation="0.78360458107294"/>
-          <stats max="25080" mean="24885" min="24540" mode="24965.870841487" rstdev="0.73934882885027" stdev="183.98695605939" sum="124425" variance="33851.2"/>
+          <iteration time-net="21829" time-revs="1" time-avg="21829" mem-peak="67076272" mem-real="69206016" mem-final="65627760" comp-z-value="-0.63977910597755" comp-deviation="-0.54581571657676"/>
+          <iteration time-net="22022" time-revs="1" time-avg="22022" mem-peak="67075568" mem-real="69206016" mem-final="65627056" comp-z-value="0.39091678261734" comp-deviation="0.33350342615542"/>
+          <iteration time-net="21643" time-revs="1" time-avg="21643" mem-peak="67075568" mem-real="69206016" mem-final="65627056" comp-z-value="-1.6330922421364" comp-deviation="-1.3932424551684"/>
+          <iteration time-net="22125" time-revs="1" time-avg="22125" mem-peak="67075568" mem-real="69206016" mem-final="65627056" comp-z-value="0.94097728274829" comp-deviation="0.80277737279487"/>
+          <iteration time-net="22125" time-revs="1" time-avg="22125" mem-peak="67075568" mem-real="69206016" mem-final="65627056" comp-z-value="0.94097728274829" comp-deviation="0.80277737279487"/>
+          <stats max="22125" mean="21948.8" min="21643" mode="22059.915851272" rstdev="0.85313151285674" stdev="187.2521294939" sum="109744" variance="35063.36"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-14462.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-14462.php" type="string"/>
           </parameter-set>
-          <iteration time-net="126543" time-revs="1" time-avg="126543" mem-peak="63419232" mem-real="65011712" mem-final="62168240" comp-z-value="-1.0010215070484" comp-deviation="-0.48912829788071"/>
-          <iteration time-net="126811" time-revs="1" time-avg="126811" mem-peak="63410864" mem-real="65011712" mem-final="62159872" comp-z-value="-0.56971320497609" comp-deviation="-0.27837848464593"/>
-          <iteration time-net="128288" time-revs="1" time-avg="128288" mem-peak="63410864" mem-real="65011712" mem-final="62159872" comp-z-value="1.8073105344298" comp-deviation="0.88310462784571"/>
-          <iteration time-net="126821" time-revs="1" time-avg="126821" mem-peak="63410864" mem-real="65011712" mem-final="62159872" comp-z-value="-0.55361961161519" comp-deviation="-0.27051468564463"/>
-          <iteration time-net="127362" time-revs="1" time-avg="127362" mem-peak="63410864" mem-real="65011712" mem-final="62159872" comp-z-value="0.31704378920986" comp-deviation="0.15491684032556"/>
-          <stats max="128288" mean="127165" min="126543" mode="126853.75342466" rstdev="0.48862915974997" stdev="621.36527099605" sum="635825" variance="386094.8"/>
+          <iteration time-net="106364" time-revs="1" time-avg="106364" mem-peak="63520120" mem-real="65011712" mem-final="62190360" comp-z-value="-0.018136800346838" comp-deviation="-0.0024443763361862"/>
+          <iteration time-net="106097" time-revs="1" time-avg="106097" mem-peak="63511752" mem-real="65011712" mem-final="62181992" comp-z-value="-1.8806466821141" comp-deviation="-0.25346302316705"/>
+          <iteration time-net="106431" time-revs="1" time-avg="106431" mem-peak="63511752" mem-real="65011712" mem-final="62181992" comp-z-value="0.44923459320526" comp-deviation="0.060545321557702"/>
+          <iteration time-net="106517" time-revs="1" time-avg="106517" mem-peak="63511752" mem-real="65011712" mem-final="62181992" comp-z-value="1.0491441431378" comp-deviation="0.1413977696006"/>
+          <iteration time-net="106424" time-revs="1" time-avg="106424" mem-peak="63511752" mem-real="65011712" mem-final="62181992" comp-z-value="0.40040474611773" comp-deviation="0.053964308344907"/>
+          <stats max="106517" mean="106366.6" min="106097" mode="106429.87671233" rstdev="0.13477439732705" stdev="143.35494410728" sum="531833" variance="20550.64"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="bug-14475.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/bug-14475.php" type="string"/>
           </parameter-set>
-          <iteration time-net="55344" time-revs="1" time-avg="55344" mem-peak="66261272" mem-real="69206016" mem-final="61774056" comp-z-value="-0.97105111179354" comp-deviation="-1.6917600414947"/>
-          <iteration time-net="55963" time-revs="1" time-avg="55963" mem-peak="66208224" mem-real="69206016" mem-final="61721096" comp-z-value="-0.33992906412428" comp-deviation="-0.59222259327417"/>
-          <iteration time-net="56070" time-revs="1" time-avg="56070" mem-peak="66208224" mem-real="69206016" mem-final="61721096" comp-z-value="-0.23083365362249" comp-deviation="-0.40215715392103"/>
-          <iteration time-net="55913" time-revs="1" time-avg="55913" mem-peak="66208224" mem-real="69206016" mem-final="61721096" comp-z-value="-0.39090822791017" comp-deviation="-0.68103821914013"/>
-          <iteration time-net="58192" time-revs="1" time-avg="58192" mem-peak="66208224" mem-real="69206016" mem-final="61721096" comp-z-value="1.9327220574505" comp-deviation="3.36717800783"/>
-          <stats max="58192" mean="56296.4" min="55344" mode="55851.178082192" rstdev="1.7421946393429" stdev="980.79286294304" sum="281482" variance="961954.64"/>
+          <iteration time-net="48543" time-revs="1" time-avg="48543" mem-peak="66283392" mem-real="69206016" mem-final="61796176" comp-z-value="1.3246499747821" comp-deviation="0.39460458882947"/>
+          <iteration time-net="48470" time-revs="1" time-avg="48470" mem-peak="66230344" mem-real="69206016" mem-final="61743216" comp-z-value="0.81783944983925" comp-deviation="0.24362903859597"/>
+          <iteration time-net="48285" time-revs="1" time-avg="48285" mem-peak="66230344" mem-real="69206016" mem-final="61743216" comp-z-value="-0.4665433873446" comp-deviation="-0.1389802325437"/>
+          <iteration time-net="48331" time-revs="1" time-avg="48331" mem-peak="66230344" mem-real="69206016" mem-final="61743216" comp-z-value="-0.14718333053132" comp-deviation="-0.043844954314379"/>
+          <iteration time-net="48132" time-revs="1" time-avg="48132" mem-peak="66230344" mem-real="69206016" mem-final="61743216" comp-z-value="-1.5287627067453" comp-deviation="-0.45540844056733"/>
+          <stats max="48543" mean="48352.2" min="48132" mode="48362.031311155" rstdev="0.29789347853526" stdev="144.03805052832" sum="241761" variance="20746.96"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="conditional-expression-infinite-loop.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/conditional-expression-infinite-loop.php" type="string"/>
           </parameter-set>
-          <iteration time-net="6896" time-revs="1" time-avg="6896" mem-peak="53185432" mem-real="56623104" mem-final="52660224" comp-z-value="1.1856097679628" comp-deviation="1.0047748776987"/>
-          <iteration time-net="6804" time-revs="1" time-avg="6804" mem-peak="53177248" mem-real="56623104" mem-final="52652040" comp-z-value="-0.40442082464036" comp-deviation="-0.34273662008963"/>
-          <iteration time-net="6874" time-revs="1" time-avg="6874" mem-peak="53177248" mem-real="56623104" mem-final="52652040" comp-z-value="0.80538506103594" comp-deviation="0.682543867358"/>
-          <iteration time-net="6832" time-revs="1" time-avg="6832" mem-peak="53177248" mem-real="56623104" mem-final="52652040" comp-z-value="0.079501529630163" comp-deviation="0.067375574889422"/>
-          <iteration time-net="6731" time-revs="1" time-avg="6731" mem-peak="53177248" mem-real="56623104" mem-final="52652040" comp-z-value="-1.6660755339885" comp-deviation="-1.4119576998565"/>
-          <stats max="6896" mean="6827.4" min="6731" mode="6849.8258317025" rstdev="0.84747520208541" stdev="57.860521947179" sum="34137" variance="3347.84"/>
+          <iteration time-net="6387" time-revs="1" time-avg="6387" mem-peak="53207552" mem-real="56623104" mem-final="52682344" comp-z-value="0.030852182728591" comp-deviation="0.046992481203008"/>
+          <iteration time-net="6423" time-revs="1" time-avg="6423" mem-peak="53199368" mem-real="56623104" mem-final="52674160" comp-z-value="0.40107837547168" comp-deviation="0.6109022556391"/>
+          <iteration time-net="6237" time-revs="1" time-avg="6237" mem-peak="53199368" mem-real="56623104" mem-final="52674160" comp-z-value="-1.511756953701" comp-deviation="-2.3026315789474"/>
+          <iteration time-net="6340" time-revs="1" time-avg="6340" mem-peak="53199368" mem-real="56623104" mem-final="52674160" comp-z-value="-0.45249868001933" comp-deviation="-0.68922305764411"/>
+          <iteration time-net="6533" time-revs="1" time-avg="6533" mem-peak="53199368" mem-real="56623104" mem-final="52674160" comp-z-value="1.53232507552" comp-deviation="2.3339598997494"/>
+          <stats max="6533" mean="6384" min="6237" mode="6383.5518590997" rstdev="1.5231493219266" stdev="97.237852711791" sum="31920" variance="9455.2"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="finite-types-optional-keys-blowup.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/finite-types-optional-keys-blowup.php" type="string"/>
           </parameter-set>
-          <iteration time-net="6865" time-revs="1" time-avg="6865" mem-peak="48416880" mem-real="52428800" mem-final="48114512" comp-z-value="-0.6077155435055" comp-deviation="-0.18900843268392"/>
-          <iteration time-net="6867" time-revs="1" time-avg="6867" mem-peak="48414856" mem-real="52428800" mem-final="48112488" comp-z-value="-0.51422084450465" comp-deviation="-0.15993021227101"/>
-          <iteration time-net="6920" time-revs="1" time-avg="6920" mem-peak="48414856" mem-real="52428800" mem-final="48112488" comp-z-value="1.9633886790178" comp-deviation="0.61064262867113"/>
-          <iteration time-net="6875" time-revs="1" time-avg="6875" mem-peak="48414856" mem-real="52428800" mem-final="48112488" comp-z-value="-0.14024204850127" comp-deviation="-0.043617330619366"/>
-          <iteration time-net="6863" time-revs="1" time-avg="6863" mem-peak="48414856" mem-real="52428800" mem-final="48112488" comp-z-value="-0.70121024250634" comp-deviation="-0.21808665309683"/>
-          <stats max="6920" mean="6878" min="6863" mode="6867.4618395303" rstdev="0.31101464279432" stdev="21.391587131393" sum="34390" variance="457.6"/>
+          <iteration time-net="6037" time-revs="1" time-avg="6037" mem-peak="48439000" mem-real="52428800" mem-final="48136632" comp-z-value="0.67568031853231" comp-deviation="0.37242709407109"/>
+          <iteration time-net="5954" time-revs="1" time-avg="5954" mem-peak="48436976" mem-real="52428800" mem-final="48134608" comp-z-value="-1.8279565760294" comp-deviation="-1.0075482991388"/>
+          <iteration time-net="6004" time-revs="1" time-avg="6004" mem-peak="48436976" mem-real="52428800" mem-final="48134608" comp-z-value="-0.31974157930549" comp-deviation="-0.17623782130151"/>
+          <iteration time-net="6036" time-revs="1" time-avg="6036" mem-peak="48436976" mem-real="52428800" mem-final="48134608" comp-z-value="0.64551601859783" comp-deviation="0.35580088451434"/>
+          <iteration time-net="6042" time-revs="1" time-avg="6042" mem-peak="48436976" mem-real="52428800" mem-final="48134608" comp-z-value="0.82650181820471" comp-deviation="0.45555814185481"/>
+          <stats max="6042" mean="6014.6" min="5954" mode="6032.3561643837" rstdev="0.55118831177451" stdev="33.15177219999" sum="30073" variance="1099.04"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="flatten-types-optional-keys-blowup.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/flatten-types-optional-keys-blowup.php" type="string"/>
           </parameter-set>
-          <iteration time-net="1919" time-revs="1" time-avg="1919" mem-peak="48314440" mem-real="52428800" mem-final="48108200" comp-z-value="-1.9656295889229" comp-deviation="-6.454128887589"/>
-          <iteration time-net="2089" time-revs="1" time-avg="2089" mem-peak="48312416" mem-real="52428800" mem-final="48106176" comp-z-value="0.55821504942221" comp-deviation="1.83289460856"/>
-          <iteration time-net="2066" time-revs="1" time-avg="2066" mem-peak="48312416" mem-real="52428800" mem-final="48106176" comp-z-value="0.21675371599905" comp-deviation="0.71170907672808"/>
-          <iteration time-net="2079" time-revs="1" time-avg="2079" mem-peak="48312416" mem-real="52428800" mem-final="48106176" comp-z-value="0.40975360010779" comp-deviation="1.3454226381983"/>
-          <iteration time-net="2104" time-revs="1" time-avg="2104" mem-peak="48312416" mem-real="52428800" mem-final="48106176" comp-z-value="0.78090722339384" comp-deviation="2.5641025641026"/>
-          <stats max="2104" mean="2051.4" min="1919" mode="2084.0880626223" rstdev="3.2834919274519" stdev="67.357553399749" sum="10257" variance="4537.04"/>
+          <iteration time-net="1782" time-revs="1" time-avg="1782" mem-peak="48336560" mem-real="52428800" mem-final="48130320" comp-z-value="1.1883197155638" comp-deviation="0.79185520361991"/>
+          <iteration time-net="1781" time-revs="1" time-avg="1781" mem-peak="48334536" mem-real="52428800" mem-final="48128296" comp-z-value="1.1034397358807" comp-deviation="0.73529411764706"/>
+          <iteration time-net="1752" time-revs="1" time-avg="1752" mem-peak="48334536" mem-real="52428800" mem-final="48128296" comp-z-value="-1.3580796749301" comp-deviation="-0.90497737556561"/>
+          <iteration time-net="1760" time-revs="1" time-avg="1760" mem-peak="48334536" mem-real="52428800" mem-final="48128296" comp-z-value="-0.67903983746504" comp-deviation="-0.45248868778281"/>
+          <iteration time-net="1765" time-revs="1" time-avg="1765" mem-peak="48334536" mem-real="52428800" mem-final="48128296" comp-z-value="-0.25463993904939" comp-deviation="-0.16968325791855"/>
+          <stats max="1782" mean="1768" min="1752" mode="1761.9804305284" rstdev="0.66636545135851" stdev="11.781341180019" sum="8840" variance="138.8"/>
+        </variant>
+        <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
+          <parameter-set name="hash-key-lookup.php">
+            <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/hash-key-lookup.php" type="string"/>
+          </parameter-set>
+          <iteration time-net="468295" time-revs="1" time-avg="468295" mem-peak="73783064" mem-real="77594624" mem-final="67192992" comp-z-value="-0.98697105338753" comp-deviation="-0.32518643199095"/>
+          <iteration time-net="470866" time-revs="1" time-avg="470866" mem-peak="73781008" mem-real="77594624" mem-final="67190936" comp-z-value="0.67391556675867" comp-deviation="0.22204116105051"/>
+          <iteration time-net="468782" time-revs="1" time-avg="468782" mem-peak="73781008" mem-real="77594624" mem-final="67190936" comp-z-value="-0.67236514750998" comp-deviation="-0.22153033015852"/>
+          <iteration time-net="468809" time-revs="1" time-avg="468809" mem-peak="73781008" mem-real="77594624" mem-final="67190936" comp-z-value="-0.65492293096235" comp-deviation="-0.21578348262366"/>
+          <iteration time-net="472362" time-revs="1" time-avg="472362" mem-peak="73781008" mem-real="77594624" mem-final="67190936" comp-z-value="1.6403435651012" comp-deviation="0.54045908372263"/>
+          <stats max="472362" mean="469822.8" min="468295" mode="468852.12328767" rstdev="0.32947919888312" stdev="1547.9683976102" sum="2349114" variance="2396206.16"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="implode-optional-keys-blowup.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/implode-optional-keys-blowup.php" type="string"/>
           </parameter-set>
-          <iteration time-net="2434" time-revs="1" time-avg="2434" mem-peak="61424736" mem-real="65011712" mem-final="61208616" comp-z-value="-0.16764269412933" comp-deviation="-0.26225208982134"/>
-          <iteration time-net="2425" time-revs="1" time-avg="2425" mem-peak="61424384" mem-real="65011712" mem-final="61208264" comp-z-value="-0.4033902327487" comp-deviation="-0.6310440911326"/>
-          <iteration time-net="2409" time-revs="1" time-avg="2409" mem-peak="61424384" mem-real="65011712" mem-final="61208264" comp-z-value="-0.82249696807201" comp-deviation="-1.286674315686"/>
-          <iteration time-net="2515" time-revs="1" time-avg="2515" mem-peak="61424384" mem-real="65011712" mem-final="61208264" comp-z-value="1.954085153445" comp-deviation="3.05687592198"/>
-          <iteration time-net="2419" time-revs="1" time-avg="2419" mem-peak="61424384" mem-real="65011712" mem-final="61208264" comp-z-value="-0.56055525849494" comp-deviation="-0.87690542534011"/>
-          <stats max="2515" mean="2440.4" min="2409" mode="2422.0684931507" rstdev="1.564351439133" stdev="38.176432520601" sum="12202" variance="1457.44"/>
+          <iteration time-net="2353" time-revs="1" time-avg="2353" mem-peak="61446856" mem-real="65011712" mem-final="61230736" comp-z-value="0.97209953262177" comp-deviation="1.457399103139"/>
+          <iteration time-net="2311" time-revs="1" time-avg="2311" mem-peak="61446504" mem-real="65011712" mem-final="61230384" comp-z-value="-0.23583479785498" comp-deviation="-0.35357019661952"/>
+          <iteration time-net="2259" time-revs="1" time-avg="2259" mem-peak="61446504" mem-real="65011712" mem-final="61230384" comp-z-value="-1.73137254035" comp-deviation="-2.5957226629872"/>
+          <iteration time-net="2354" time-revs="1" time-avg="2354" mem-peak="61446504" mem-real="65011712" mem-final="61230384" comp-z-value="1.0008598738236" comp-deviation="1.5005174197999"/>
+          <iteration time-net="2319" time-revs="1" time-avg="2319" mem-peak="61446504" mem-real="65011712" mem-final="61230384" comp-z-value="-0.0057520682403602" comp-deviation="-0.0086236633321757"/>
+          <stats max="2354" mean="2319.2" min="2259" mode="2333.3639921722" rstdev="1.4992282726527" stdev="34.770102099361" sum="11596" variance="1208.96"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="in-array-intersect-blowup.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/in-array-intersect-blowup.php" type="string"/>
           </parameter-set>
-          <iteration time-net="29909" time-revs="1" time-avg="29909" mem-peak="62185112" mem-real="65011712" mem-final="61812656" comp-z-value="-0.46808960206228" comp-deviation="-0.35647654584222"/>
-          <iteration time-net="30277" time-revs="1" time-avg="30277" mem-peak="62184776" mem-real="65011712" mem-final="61812320" comp-z-value="1.1417886554977" comp-deviation="0.86953624733475"/>
-          <iteration time-net="29687" time-revs="1" time-avg="29687" mem-peak="62184776" mem-real="65011712" mem-final="61812320" comp-z-value="-1.4392661596121" comp-deviation="-1.0960820895522"/>
-          <iteration time-net="30274" time-revs="1" time-avg="30274" mem-peak="62184776" mem-real="65011712" mem-final="61812320" comp-z-value="1.1286646479632" comp-deviation="0.85954157782516"/>
-          <iteration time-net="29933" time-revs="1" time-avg="29933" mem-peak="62184776" mem-real="65011712" mem-final="61812320" comp-z-value="-0.36309754178663" comp-deviation="-0.27651918976546"/>
-          <stats max="30277" mean="30016" min="29687" mode="29930.620352251" rstdev="0.76155621545891" stdev="228.58871363215" sum="150080" variance="52252.8"/>
+          <iteration time-net="24884" time-revs="1" time-avg="24884" mem-peak="62213712" mem-real="65011712" mem-final="61834776" comp-z-value="-0.27898150962992" comp-deviation="-0.11159370258271"/>
+          <iteration time-net="25048" time-revs="1" time-avg="25048" mem-peak="62213376" mem-real="65011712" mem-final="61834440" comp-z-value="1.3668086910646" comp-deviation="0.54672885941602"/>
+          <iteration time-net="24998" time-revs="1" time-avg="24998" mem-peak="62213376" mem-real="65011712" mem-final="61834440" comp-z-value="0.86504338597482" comp-deviation="0.34602076124568"/>
+          <iteration time-net="24859" time-revs="1" time-avg="24859" mem-peak="62213376" mem-real="65011712" mem-final="61834440" comp-z-value="-0.52986416217482" comp-deviation="-0.21194775166788"/>
+          <iteration time-net="24770" time-revs="1" time-avg="24770" mem-peak="62213376" mem-real="65011712" mem-final="61834440" comp-z-value="-1.4230064052347" comp-deviation="-0.5692081664111"/>
+          <stats max="25048" mean="24911.8" min="24770" mode="24879.894324853" rstdev="0.40000393836402" stdev="99.648181117369" sum="124559" variance="9929.76"/>
+        </variant>
+        <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
+          <parameter-set name="or-chain-falsey-blowup.php">
+            <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/or-chain-falsey-blowup.php" type="string"/>
+          </parameter-set>
+          <iteration time-net="79291" time-revs="1" time-avg="79291" mem-peak="52652480" mem-real="56623104" mem-final="47850792" comp-z-value="-1.8219563440383" comp-deviation="-2.0532851079389"/>
+          <iteration time-net="80738" time-revs="1" time-avg="80738" mem-peak="52650432" mem-real="56623104" mem-final="47848744" comp-z-value="-0.23588317003793" comp-deviation="-0.26583260451717"/>
+          <iteration time-net="81235" time-revs="1" time-avg="81235" mem-peak="52650432" mem-real="56623104" mem-final="47848744" comp-z-value="0.30888418827458" comp-deviation="0.34810236037612"/>
+          <iteration time-net="81752" time-revs="1" time-avg="81752" mem-peak="52650432" mem-real="56623104" mem-final="47848744" comp-z-value="0.87557377428577" comp-deviation="0.98674295765949"/>
+          <iteration time-net="81750" time-revs="1" time-avg="81750" mem-peak="52650432" mem-real="56623104" mem-final="47848744" comp-z-value="0.8733815515159" comp-deviation="0.98427239442048"/>
+          <stats max="81752" mean="80953.2" min="79291" mode="81395.612524463" rstdev="1.1269672375288" stdev="912.31604173115" sum="404766" variance="832320.56"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="phpdoc-intersection-blowup.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/phpdoc-intersection-blowup.php" type="string"/>
           </parameter-set>
-          <iteration time-net="4590" time-revs="1" time-avg="4590" mem-peak="52147600" mem-real="54525952" mem-final="51835672" comp-z-value="1.5877186965517" comp-deviation="0.90573338023215"/>
-          <iteration time-net="4523" time-revs="1" time-avg="4523" mem-peak="52135136" mem-real="54525952" mem-final="51823208" comp-z-value="-0.99425102842316" comp-deviation="-0.56718255364052"/>
-          <iteration time-net="4544" time-revs="1" time-avg="4544" mem-peak="52135136" mem-real="54525952" mem-final="51823208" comp-z-value="-0.18497693552059" comp-deviation="-0.10552233556103"/>
-          <iteration time-net="4522" time-revs="1" time-avg="4522" mem-peak="52135136" mem-real="54525952" mem-final="51823208" comp-z-value="-1.0327878899899" comp-deviation="-0.58916637354907"/>
-          <iteration time-net="4565" time-revs="1" time-avg="4565" mem-peak="52135136" mem-real="54525952" mem-final="51823208" comp-z-value="0.62429715738197" comp-deviation="0.35613788251846"/>
-          <stats max="4590" mean="4548.8" min="4522" mode="4534.9080234834" rstdev="0.57046212417809" stdev="25.949181104613" sum="22744" variance="673.36"/>
+          <iteration time-net="4463" time-revs="1" time-avg="4463" mem-peak="52167944" mem-real="54525952" mem-final="51856016" comp-z-value="1.0473431438961" comp-deviation="1.3442935646487"/>
+          <iteration time-net="4482" time-revs="1" time-avg="4482" mem-peak="52155480" mem-real="54525952" mem-final="51843552" comp-z-value="1.3834836799438" comp-deviation="1.7757391343839"/>
+          <iteration time-net="4359" time-revs="1" time-avg="4359" mem-peak="52155480" mem-real="54525952" mem-final="51843552" comp-z-value="-0.79258400078625" comp-deviation="-1.0173032381125"/>
+          <iteration time-net="4363" time-revs="1" time-avg="4363" mem-peak="52155480" mem-real="54525952" mem-final="51843552" comp-z-value="-0.72181757214462" comp-deviation="-0.9264725918525"/>
+          <iteration time-net="4352" time-revs="1" time-avg="4352" mem-peak="52155480" mem-real="54525952" mem-final="51843552" comp-z-value="-0.9164252509091" comp-deviation="-1.1762568690676"/>
+          <stats max="4482" mean="4403.8" min="4352" mode="4362.4305283757" rstdev="1.2835273448661" stdev="56.523977213215" sum="22019" variance="3194.96"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="process-called-method-infinite-loop.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/process-called-method-infinite-loop.php" type="string"/>
           </parameter-set>
-          <iteration time-net="14290" time-revs="1" time-avg="14290" mem-peak="82350736" mem-real="88080384" mem-final="81721720" comp-z-value="-1.972889134239" comp-deviation="-3.2223110159964"/>
-          <iteration time-net="14926" time-revs="1" time-avg="14926" mem-peak="82293056" mem-real="88080384" mem-final="81526344" comp-z-value="0.66426405906913" comp-deviation="1.0849395224099"/>
-          <iteration time-net="14811" time-revs="1" time-avg="14811" mem-peak="82293056" mem-real="88080384" mem-final="81526344" comp-z-value="0.18742032128543" comp-deviation="0.30611277411316"/>
-          <iteration time-net="14910" time-revs="1" time-avg="14910" mem-peak="82293056" mem-real="88080384" mem-final="81526344" comp-z-value="0.59792058250792" comp-deviation="0.97658101829905"/>
-          <iteration time-net="14892" time-revs="1" time-avg="14892" mem-peak="82293056" mem-real="88080384" mem-final="81526344" comp-z-value="0.52328417137656" comp-deviation="0.85467770117434"/>
-          <stats max="14926" mean="14765.8" min="14290" mode="14883.68297456" rstdev="1.6332955360106" stdev="241.16915225625" sum="73829" variance="58162.56"/>
+          <iteration time-net="13535" time-revs="1" time-avg="13535" mem-peak="82372856" mem-real="88080384" mem-final="81743840" comp-z-value="-1.9577500879573" comp-deviation="-4.4232914824805"/>
+          <iteration time-net="14228" time-revs="1" time-avg="14228" mem-peak="82315176" mem-real="88080384" mem-final="81548464" comp-z-value="0.20815158981156" comp-deviation="0.47029248520627"/>
+          <iteration time-net="14405" time-revs="1" time-avg="14405" mem-peak="82315176" mem-real="88080384" mem-final="81548464" comp-z-value="0.76134725642785" comp-deviation="1.7201689098535"/>
+          <iteration time-net="14373" time-revs="1" time-avg="14373" mem-peak="82315176" mem-real="88080384" mem-final="81548464" comp-z-value="0.66133448054242" comp-deviation="1.4942025505953"/>
+          <iteration time-net="14266" time-revs="1" time-avg="14266" mem-peak="82315176" mem-real="88080384" mem-final="81548464" comp-z-value="0.32691676117551" comp-deviation="0.73862753682546"/>
+          <stats max="14405" mean="14161.4" min="13535" mode="14316.467710372" rstdev="2.2593749374292" stdev="319.9591223891" sum="70807" variance="102373.84"/>
         </variant>
         <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
           <parameter-set name="union-fast-path.php">
             <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/union-fast-path.php" type="string"/>
           </parameter-set>
-          <iteration time-net="156741" time-revs="1" time-avg="156741" mem-peak="69052672" mem-real="71303168" mem-final="65376376" comp-z-value="-1.2677798284389" comp-deviation="-0.58819649340007"/>
-          <iteration time-net="157516" time-revs="1" time-avg="157516" mem-peak="69047696" mem-real="71303168" mem-final="65371400" comp-z-value="-0.20833474860263" comp-deviation="-0.096658556819245"/>
-          <iteration time-net="157115" time-revs="1" time-avg="157115" mem-peak="69047696" mem-real="71303168" mem-final="65371400" comp-z-value="-0.75651213829857" comp-deviation="-0.35098979884365"/>
-          <iteration time-net="158761" time-revs="1" time-avg="158761" mem-peak="69047696" mem-real="71303168" mem-final="65371400" comp-z-value="1.4936125086827" comp-deviation="0.69297335420414"/>
-          <iteration time-net="158209" time-revs="1" time-avg="158209" mem-peak="69047696" mem-real="71303168" mem-final="65371400" comp-z-value="0.73901420665741" comp-deviation="0.34287149485883"/>
-          <stats max="158761" mean="157668.4" min="156741" mode="157318.14285714" rstdev="0.46395792093044" stdev="731.51503060429" sum="788342" variance="535114.24"/>
+          <iteration time-net="141009" time-revs="1" time-avg="141009" mem-peak="69074792" mem-real="71303168" mem-final="65398496" comp-z-value="1.1497508963929" comp-deviation="0.36042037656242"/>
+          <iteration time-net="140388" time-revs="1" time-avg="140388" mem-peak="69069816" mem-real="71303168" mem-final="65393520" comp-z-value="-0.2601924421932" comp-deviation="-0.081564326923492"/>
+          <iteration time-net="140192" time-revs="1" time-avg="140192" mem-peak="69069816" mem-real="71303168" mem-final="65393520" comp-z-value="-0.70519871330894" comp-deviation="-0.2210635248031"/>
+          <iteration time-net="139914" time-revs="1" time-avg="139914" mem-peak="69069816" mem-real="71303168" mem-final="65393520" comp-z-value="-1.3363810774425" comp-deviation="-0.4189246319997"/>
+          <iteration time-net="141010" time-revs="1" time-avg="141010" mem-peak="69069816" mem-real="71303168" mem-final="65393520" comp-z-value="1.1520213365517" comp-deviation="0.36113210716385"/>
+          <stats max="141010" mean="140502.6" min="139914" mode="140261.45988258" rstdev="0.31347692590905" stdev="440.44323130229" sum="702513" variance="193990.24"/>
+        </variant>
+        <variant sleep="0" output-time-unit="microseconds" output-time-precision="" output-mode="time" revs="1" warmup="1" retry-threshold="10">
+          <parameter-set name="wordpress-user.php">
+            <parameter name="0" value="/home/runner/work/phpstan-src/phpstan-src/tests/bench/data/wordpress-user.php" type="string"/>
+          </parameter-set>
+          <iteration time-net="916655" time-revs="1" time-avg="916655" mem-peak="87422368" mem-real="92274688" mem-final="84069976" comp-z-value="0.3991288572891" comp-deviation="0.064820996675773"/>
+          <iteration time-net="915105" time-revs="1" time-avg="915105" mem-peak="87421872" mem-real="92274688" mem-final="84069480" comp-z-value="-0.64271979343177" comp-deviation="-0.10438167231621"/>
+          <iteration time-net="914119" time-revs="1" time-avg="914119" mem-peak="87421872" mem-real="92274688" mem-final="84069480" comp-z-value="-1.3054699673742" comp-deviation="-0.21201640239756"/>
+          <iteration time-net="918512" time-revs="1" time-avg="918512" mem-peak="87421872" mem-real="92274688" mem-final="84069480" comp-z-value="1.6473307568947" comp-deviation="0.2675367104294"/>
+          <iteration time-net="915915" time-revs="1" time-avg="915915" mem-peak="87421872" mem-real="92274688" mem-final="84069480" comp-z-value="-0.098269853377641" comp-deviation="-0.015959632391368"/>
+          <stats max="918512" mean="916061.2" min="914119" mode="915623.45205479" rstdev="0.16240618910905" stdev="1487.7400848266" sum="4580306" variance="2213370.56"/>
         </variant>
       </subject>
     </benchmark>
     <result key="time" class="PhpBench\Model\Result\TimeResult"/>
     <result key="mem" class="PhpBench\Model\Result\MemoryResult"/>
     <result key="comp" class="PhpBench\Model\Result\ComputedResult"/>
+    <result key="reject" class="PhpBench\Model\Result\RejectionCountResult"/>
   </suite>
 </phpbench>


### PR DESCRIPTION
  Skip expensive type operations on complex union types to prevent exponential HasOffsetValueType growth.

  When a variable has type array|object (common in WordPress) and the code does repeated
  empty($data['key']) ternary checks, each check forks the object branch of the union into with/without
  HasOffsetValueType variants. The array branch is absorbed by isSuperTypeOf, but the object branch is
  not — creating 2^N union members after N checks. Combined with impure function calls (e.g. WordPress's
  apply_filters) that create conditional expressions carrying this huge type, every subsequent
  addTypeToExpression/removeTypeFromExpression call must operate on the massive union, causing analysis
  to hang.

  The fix introduces isComplexUnionType() which detects unions with >8 members containing
  IntersectionType members — the signature of this combinatorial growth. Three call sites skip expensive
  operations on such types:

  - specifyExpressionType — skips HasOffsetValueType propagation to parent expressions
  - addTypeToExpression — skips TypeCombinator::intersect on the existing type
  - removeTypeFromExpression — skips TypeCombinator::remove on the existing type

  Reproduces with WordPress's wp_insert_user() (471-line function with @param array|object $userdata, ~17
   empty() checks, and ~15 impure apply_filters calls). Before: infinite hang. After: ~11 seconds.

  Standalone benchmark included: array|object parameter + instanceof narrowing + empty() ternaries +
  impure apply_filters calls. Before: >60s. After: 1.8s.