### PR TITLE
Revert "CI: Fix old PHPUnit (#5490)"

### DIFF
--- a/tests/composer.json
+++ b/tests/composer.json
@@ -8,12 +8,6 @@
 	"config": {
 		"platform": {
 			"php": "8.2.99"
-		},
-		"audit": {
-			"ignore": {
-				"PKSA-5jz8-6tcw-pbk4": "PHPUnit argument injection - no fix in 11.x line",
-				"PKSA-z3gr-8qht-p93v": "PHPUnit security advisory - no fix in 11.x line"
-			}
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 436f8f4ad0fb7940e986df56670fe31b45d58405.

workarround no longer needed, because the CVEs affected versions have been fixed upstream 

https://phpc.social/@sebastian/116424686237276260