### PR TITLE
Keep unions of general array types separate

### DIFF
--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -84,6 +84,7 @@ class ConstantArrayType implements Type
 
 	private const DESCRIBE_LIMIT = 8;
 	private const CHUNK_FINITE_TYPES_LIMIT = 5;
+	private const OPTIONAL_KEYS_POWER_SET_LIMIT = 10;
 
 	private TrinaryLogic $isList;
 
@@ -232,7 +233,7 @@ class ConstantArrayType implements Type
 			return $this->allArrays;
 		}
 
-		if (count($this->optionalKeys) <= 10) {
+		if (count($this->optionalKeys) <= self::OPTIONAL_KEYS_POWER_SET_LIMIT) {
 			$optionalKeysCombinations = $this->powerSet($this->optionalKeys);
 		} else {
 			$optionalKeysCombinations = [

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -48,6 +48,8 @@ use const PHP_INT_MIN;
 final class TypeCombinator
 {
 
+	private const KEEP_SEPARATE_ARRAYS_LIMIT = 4;
+
 	public static function addNull(Type $type): Type
 	{
 		$nullType = new NullType();
@@ -931,18 +933,36 @@ final class TypeCombinator
 			}
 
 			// TMP WIP: run for everyone, not just bleedingEdge, so CI exercises the new path
-			if (!$hasEmptyConstantArray) {
-				// Keep each array member distinct (e.g. `list<int>|list<string>` rather
-				// than `list<int|string>`). Subsumption is handled by the outer union()
-				// loop; the `array{} | non-empty-array<X>` -> `array<X>` simplification
-				// is not expressible here and falls through to the old collapse path.
-				$results = [];
+			// Keep distinct array shapes (e.g. `list<int>|list<string>` rather than
+			// `list<int|string>`), but reduce the result before returning so analysis-
+			// emergent intermediate state (foreach over mixed[], deeply nested
+			// ArrayDimFetch writes, sequential `if ($x !== null) $arr['x'] = $x;`) does
+			// not blow up. `array{} | non-empty-array<X>` -> `array<X>` and the
+			// $overflowed safety valve still go to the old collapse path.
+			if (!$hasEmptyConstantArray && !$overflowed) {
+				// Dedupe identical members by describe() — many call sites feed the same
+				// shape multiple times via parallel control flow (cf. bug-7903 with 7
+				// byte-identical members). Cheap (cached describe), unconditional.
+				$deduped = [];
 				foreach ($arrayTypes as $arrayType) {
-					$results[] = $accessoryTypes === []
-						? $arrayType
-						: self::intersect($arrayType, ...$accessoryTypes);
+					$deduped[$arrayType->describe(VerbosityLevel::cache())] = $arrayType;
 				}
-				return $results;
+				$deduped = array_values($deduped);
+
+				// Budget: when more distinct shapes remain than a small union would have,
+				// they are almost certainly analysis-emergent rather than user-written;
+				// fall through to the old collapse path to keep downstream tractable.
+				// Mirrors optimizeConstantArrays() which generalizes once a similar
+				// budget (256 constant value types) is exceeded.
+				if (count($deduped) <= self::KEEP_SEPARATE_ARRAYS_LIMIT) {
+					$results = [];
+					foreach ($deduped as $arrayType) {
+						$results[] = $accessoryTypes === []
+							? $arrayType
+							: self::intersect($arrayType, ...$accessoryTypes);
+					}
+					return $results;
+				}
 			}
 
 			$templateArrayType = null;

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Type;
 
-use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -931,7 +930,8 @@ final class TypeCombinator
 				}
 			}
 
-			if (BleedingEdgeToggle::isBleedingEdge() && !$hasEmptyConstantArray) {
+			// TMP WIP: run for everyone, not just bleedingEdge, so CI exercises the new path
+			if (!$hasEmptyConstantArray) {
 				// Keep each array member distinct (e.g. `list<int>|list<string>` rather
 				// than `list<int|string>`). Subsumption is handled by the outer union()
 				// loop; the `array{} | non-empty-array<X>` -> `array<X>` simplification

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -776,22 +776,27 @@ final class TypeCombinator
 	}
 
 	/**
-	 * @param Type[] $arrayTypes
-	 * @return list<Type>
+	 * @param list<Type> $arrayTypes
+	 * @return array{list<Type>, list<Type>} tuple of [arrays with accessory wrappers stripped, common accessory types]
 	 */
 	private static function processArrayAccessoryTypes(array $arrayTypes): array
 	{
 		$isIterableAtLeastOnce = [];
 		$accessoryTypes = [];
+		$strippedArrays = [];
 		foreach ($arrayTypes as $i => $arrayType) {
 			$isIterableAtLeastOnce[] = $arrayType->isIterableAtLeastOnce();
 
 			if ($arrayType instanceof IntersectionType) {
+				$nonAccessoryInner = [];
+				$skipStrip = false;
 				foreach ($arrayType->getTypes() as $innerType) {
 					if ($innerType instanceof TemplateType) {
+						$skipStrip = true;
 						break;
 					}
 					if (!($innerType instanceof AccessoryType) && !($innerType instanceof CallableType)) {
+						$nonAccessoryInner[] = $innerType;
 						continue;
 					}
 					if ($innerType instanceof HasOffsetType) {
@@ -804,6 +809,9 @@ final class TypeCombinator
 
 					$accessoryTypes[$innerType->describe(VerbosityLevel::cache())][$i] = $innerType;
 				}
+				$strippedArrays[] = $skipStrip || count($nonAccessoryInner) !== 1 ? $arrayType : $nonAccessoryInner[0];
+			} else {
+				$strippedArrays[] = $arrayType;
 			}
 
 			if (!$arrayType->isConstantArray()->yes()) {
@@ -849,7 +857,7 @@ final class TypeCombinator
 			$commonAccessoryTypes[] = new NonEmptyArrayType();
 		}
 
-		return $commonAccessoryTypes;
+		return [$strippedArrays, $commonAccessoryTypes];
 	}
 
 	/**
@@ -862,7 +870,7 @@ final class TypeCombinator
 			return [];
 		}
 
-		$accessoryTypes = self::processArrayAccessoryTypes($arrayTypes);
+		[$strippedArrays, $accessoryTypes] = self::processArrayAccessoryTypes($arrayTypes);
 
 		if (count($arrayTypes) === 1) {
 			return [
@@ -940,12 +948,16 @@ final class TypeCombinator
 			// not blow up. `array{} | non-empty-array<X>` -> `array<X>` and the
 			// $overflowed safety valve still go to the old collapse path.
 			if (!$hasEmptyConstantArray && !$overflowed) {
-				// Dedupe identical members by describe() — many call sites feed the same
-				// shape multiple times via parallel control flow (cf. bug-7903 with 7
-				// byte-identical members). Cheap (cached describe), unconditional.
+				// Dedupe using the stripped (accessory-free) describe as the key, but
+				// keep the original (with accessories) as the value. This collapses
+				// members that share an underlying shape but differ only in stacked
+				// per-element accessories like hasOffsetValue (cf. the optional-
+				// properties repro: 4 same-shape members differing only in stacked
+				// hasOffsetValue accessories), while preserving per-member accessories
+				// like list / non-empty on whichever original survives.
 				$deduped = [];
-				foreach ($arrayTypes as $arrayType) {
-					$deduped[$arrayType->describe(VerbosityLevel::cache())] = $arrayType;
+				foreach ($strippedArrays as $i => $stripped) {
+					$deduped[$stripped->describe(VerbosityLevel::cache())] ??= $arrayTypes[$i];
 				}
 				$deduped = array_values($deduped);
 

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Type;
 
+use PHPStan\DependencyInjection\BleedingEdgeToggle;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
@@ -920,6 +921,28 @@ final class TypeCombinator
 			$reducedArrayTypes = self::reduceArrays($arrayTypes, false);
 			if (count($reducedArrayTypes) === 1) {
 				return [self::intersect($reducedArrayTypes[0], ...$accessoryTypes)];
+			}
+
+			$hasEmptyConstantArray = false;
+			foreach ($arrayTypes as $arrayType) {
+				if ($arrayType->isIterableAtLeastOnce()->no() && $arrayType->isConstantArray()->yes()) {
+					$hasEmptyConstantArray = true;
+					break;
+				}
+			}
+
+			if (BleedingEdgeToggle::isBleedingEdge() && !$hasEmptyConstantArray) {
+				// Keep each array member distinct (e.g. `list<int>|list<string>` rather
+				// than `list<int|string>`). Subsumption is handled by the outer union()
+				// loop; the `array{} | non-empty-array<X>` -> `array<X>` simplification
+				// is not expressible here and falls through to the old collapse path.
+				$results = [];
+				foreach ($arrayTypes as $arrayType) {
+					$results[] = $accessoryTypes === []
+						? $arrayType
+						: self::intersect($arrayType, ...$accessoryTypes);
+				}
+				return $results;
 			}
 
 			$templateArrayType = null;

--- a/src/Type/TypeUtils.php
+++ b/src/Type/TypeUtils.php
@@ -21,6 +21,8 @@ use const PHP_INT_MAX;
 final class TypeUtils
 {
 
+	private const FLATTEN_CONSTANT_ARRAYS_LIMIT = 16384;
+
 	/**
 	 * @return list<ConstantIntegerType>
 	 */
@@ -157,7 +159,7 @@ final class TypeUtils
 			foreach ($constantArrays as $constantArray) {
 				$optionalCount = count($constantArray->getOptionalKeys());
 				$arrayCount = $optionalCount <= 20 ? (1 << $optionalCount) : PHP_INT_MAX;
-				if ($arrayCount > 16384 || $estimatedCount > 16384 / max($arrayCount, 1)) {
+				if ($arrayCount > self::FLATTEN_CONSTANT_ARRAYS_LIMIT || $estimatedCount > self::FLATTEN_CONSTANT_ARRAYS_LIMIT / max($arrayCount, 1)) {
 					$bail = true;
 					break;
 				}

--- a/tests/PHPStan/Analyser/nsrt/array-slice.php
+++ b/tests/PHPStan/Analyser/nsrt/array-slice.php
@@ -16,7 +16,7 @@ class Foo
 	{
 		assertType('array', array_slice($a, 1));
 		assertType('list', array_slice($b, 1));
-		assertType('array<int|string>', array_slice($c, 1));
+		assertType('array<int>|list<string>', array_slice($c, 1));
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/array-union-keep-separate.php
+++ b/tests/PHPStan/Analyser/nsrt/array-union-keep-separate.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace ArrayUnionKeepSeparate;
+
+use function PHPStan\Testing\assertType;
+
+class KeepSeparate
+{
+
+	/** @param array<int>|array<string> $arr */
+	public function plainArray(array $arr): void
+	{
+		assertType('array<int>|array<string>', $arr);
+	}
+
+	/** @param list<int>|list<string> $list */
+	public function listUnion(array $list): void
+	{
+		assertType('list<int>|list<string>', $list);
+	}
+
+	/** @param non-empty-array<int, int>|non-empty-array<string, string> $arr */
+	public function distinctKeyAndValue(array $arr): void
+	{
+		assertType('non-empty-array<int, int>|non-empty-array<string, string>', $arr);
+	}
+
+	/**
+	 * Subsumption: array<int> is a subtype of array<int|string>, so the
+	 * union must collapse to the wider member.
+	 *
+	 * @param array<int>|array<int|string> $arr
+	 */
+	public function subsumesWider(array $arr): void
+	{
+		assertType('array<int|string>', $arr);
+	}
+
+	/**
+	 * Subsumption across list/array: list<int> is a subtype of array<int>.
+	 *
+	 * @param list<int>|array<int> $arr
+	 */
+	public function subsumesListIntoArray(array $arr): void
+	{
+		assertType('array<int>', $arr);
+	}
+
+	/**
+	 * Identical members dedupe.
+	 *
+	 * @param array<int>|array<int> $arr
+	 */
+	public function identicalMembers(array $arr): void
+	{
+		assertType('array<int>', $arr);
+	}
+
+	/**
+	 * Narrowing the value via offset-access propagates back to the array.
+	 *
+	 * @param list<int>|list<string> $list
+	 */
+	public function narrowByOffset(array $list): void
+	{
+		if (count($list) === 0) {
+			return;
+		}
+
+		if (is_string($list[0])) {
+			assertType('non-empty-list<string>&hasOffsetValue(0, string)', $list);
+		} else {
+			assertType('non-empty-list<int>&hasOffsetValue(0, int)', $list);
+		}
+	}
+
+	/**
+	 * A mixed array is not a subtype of a union of homogeneous arrays.
+	 *
+	 * @param array<int>|array<string> $arr
+	 */
+	public function acceptsTaker(array $arr): void
+	{
+	}
+
+	public function callerWithMixedArray(): void
+	{
+		/** @var array<int|string> $mixed */
+		$mixed = [];
+		// phpstan-should-error: passing array<int|string> does not satisfy array<int>|array<string>
+		$this->acceptsTaker($mixed);
+	}
+
+	/**
+	 * Constant array stays separate from a general array (no folding into
+	 * array<int|string, ...>).
+	 *
+	 * @param array{foo: int}|array<string, string> $arr
+	 */
+	public function constantAndGeneral(array $arr): void
+	{
+		assertType("array{foo: int}|array<string, string>", $arr);
+	}
+
+	/**
+	 * Iterating a union preserves the element union (existing UnionType
+	 * behavior; regression guard for the keep-separate change).
+	 *
+	 * @param list<int>|list<string> $list
+	 */
+	public function iteration(array $list): void
+	{
+		foreach ($list as $value) {
+			assertType('int|string', $value);
+		}
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/array_splice.php
+++ b/tests/PHPStan/Analyser/nsrt/array_splice.php
@@ -186,7 +186,7 @@ function constantArrays(array $arr, array $arr2): void
 	/** @var array{x: 'x', y?: 'y', 3: 66}|array{z: 'z', 5?: 77, 4: int}|array<object|null> $arr2 */
 	$arr;
 	$extract = array_splice($arr, 0, 1, $arr2);
-	assertType('non-empty-array<\'b\'|int<0, max>, \'bar\'|\'baz\'|\'x\'|\'y\'|\'z\'|int|object|null>', $arr);
+	assertType("array{0: 'x', 1: 66|'y', 2: 66|'baz', b: 'bar', 3?: 'baz'}|array{0: 'z', 1: int, 2: 'baz'|int, b: 'bar', 3?: 'baz'}|non-empty-array<'b'|int<0, max>, 'bar'|'baz'|object|null>", $arr);
 	assertType('array{\'foo\'}', $extract);
 }
 

--- a/tests/PHPStan/Analyser/nsrt/binary.php
+++ b/tests/PHPStan/Analyser/nsrt/binary.php
@@ -369,12 +369,12 @@ class Foo
 		assertType('0', min(0, ...[1, 2, 3]));
 		assertType('array{5, 6, 9}', max([1, 10, 8], [5, 6, 9]));
 		assertType('array{1, 1, 1, 1}', max(array(2, 2, 2), array(1, 1, 1, 1)));
-		assertType('array<int>', max($arrayOfUnknownIntegers, $arrayOfUnknownIntegers));
+		assertType('non-empty-array<int>&hasOffsetValue(108, int)&hasOffsetValue(42, int)', max($arrayOfUnknownIntegers, $arrayOfUnknownIntegers));
 		assertType('array{1, 1, 1, 1}', max(array(2, 2, 2), 5, array(1, 1, 1, 1)));
 		assertType('array{int, int, int}', max($arrayOfIntegers, 5));
-		assertType('array<int>', max($arrayOfUnknownIntegers, 5));
-		assertType('array<int>|int', max($arrayOfUnknownIntegers, $integer, $arrayOfUnknownIntegers));
-		assertType('array<int>', max($arrayOfUnknownIntegers, $conditionalInt));
+		assertType('non-empty-array<int>&hasOffsetValue(108, int)&hasOffsetValue(42, int)', max($arrayOfUnknownIntegers, 5));
+		assertType('(non-empty-array<int>&hasOffsetValue(108, int)&hasOffsetValue(42, int))|int', max($arrayOfUnknownIntegers, $integer, $arrayOfUnknownIntegers));
+		assertType('non-empty-array<int>&hasOffsetValue(108, int)&hasOffsetValue(42, int)', max($arrayOfUnknownIntegers, $conditionalInt));
 		assertType('5', min($arrayOfIntegers, 5));
 		assertType('5', min($arrayOfUnknownIntegers, 5));
 		assertType('1|2', min($arrayOfUnknownIntegers, $conditionalInt));

--- a/tests/PHPStan/Analyser/nsrt/bug-10025.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10025.php
@@ -23,7 +23,7 @@ function x(array $foos, array $bars): void
 		$arr[$bar->groupId]['bar'][] = $bar;
 	}
 
-	assertType('array<int, non-empty-array{foo?: non-empty-list<Bug10025\MyClass>, bar?: non-empty-list<Bug10025\MyClass>}>', $arr);
+	assertType('non-empty-array<int, array{foo?: non-empty-list<Bug10025\MyClass>, bar: non-empty-list<Bug10025\MyClass>}>|array<int, array{foo: non-empty-list<Bug10025\MyClass>}>', $arr);
 	foreach ($arr as $groupId => $group) {
 		if (isset($group['foo'])) {
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-10089.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10089.php
@@ -24,7 +24,7 @@ class Test
 		$matrix[$size - 1][8] = 3;
 
 		// non-empty-array<int, non-empty-array<int, 0|3>&hasOffsetValue(8, 3)>
-		assertType('non-empty-list<non-empty-array<int<0, max>, 0|3>>', $matrix);
+		assertType('non-empty-list<(non-empty-array<int<0, max>, 0|3>&hasOffsetValue(8, 3))|non-empty-list<0>>', $matrix);
 
 		for ($i = 0; $i <= $size; $i++) {
 			if ($matrix[$i][8] === 0) {

--- a/tests/PHPStan/Analyser/nsrt/bug-10438.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10438.php
@@ -25,7 +25,7 @@ class HelloWorld
 			$meta[$key] = [];
 			assertType('array{}', $meta[$key]);
 			foreach ($tag->{$valueName} as $value) {
-				assertType('list<string>|string', $meta[$key]);
+				assertType('array{}|array{0: string, 1?: string}', $meta[$key]);
 				$meta[$key][] = (string)$value;
 			}
 		}

--- a/tests/PHPStan/Analyser/nsrt/bug-10640.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10640.php
@@ -13,7 +13,7 @@ assertType('array<array{add: non-empty-list}>', $changes);
 foreach (toRem() as $del) {
 	$changes[$add['id']]['del'][] = doSomething($del);
 }
-assertType('array<non-empty-array{add?: non-empty-list, del?: non-empty-list}>', $changes);
+assertType('non-empty-array<array{add?: non-empty-list, del: non-empty-list}>|array<array{add: non-empty-list}>', $changes);
 
 foreach ($changes as $changeSet) {
 	if (isset($changeSet['del'])) {

--- a/tests/PHPStan/Analyser/nsrt/bug-10650.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-10650.php
@@ -28,6 +28,6 @@ class DistFoo
 			}
 		}
 
-		assertType('array<int<0, max>, \'x\'>', $ranges);
+		assertType("list<'x'>", $ranges);
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-11176.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11176.php
@@ -1,0 +1,13 @@
+<?php // lint >= 8.0
+
+declare(strict_types = 1);
+
+namespace Bug11176;
+
+use function PHPStan\Testing\assertType;
+
+/** @param int|int[]|array{module: string} $arr */
+function test(int|array $arr): void
+{
+	assertType('array<int>|array{module: string}|int', $arr);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-11518-types.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-11518-types.php
@@ -17,7 +17,7 @@ function blah(array $a): array
 		assertType('non-empty-array&hasOffset(\'thing\')', $a);
 	}
 
-	assertType('non-empty-array&hasOffsetValue(\'thing\', mixed)', $a);
+	assertType("non-empty-array&hasOffset('thing')", $a);
 
 	return $a;
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-12078.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12078.php
@@ -57,7 +57,7 @@ function main()
 	]
 	*/
 
-	assertType("array<string, non-empty-array{'6M'?: non-empty-list<string>, '3M'?: non-empty-list<string>}>", $arrDataByKey);
+	assertType("non-empty-array<string, array{'6M'?: non-empty-list<string>, '3M': non-empty-list<string>}>|array<string, array{'6M': non-empty-list<string>}>", $arrDataByKey);
 	foreach ($arrDataByKey as $key => $arrDataByKeyForKey) {
 		assertType("non-empty-array{'6M'?: non-empty-list<string>, '3M'?: non-empty-list<string>}", $arrDataByKeyForKey);
 		echo [] === ($arrDataByKeyForKey['6M'] ?? []) ? 'No 6M data for key ' . $key . "\n" : 'We got 6M data for key ' . $key . "\n";

--- a/tests/PHPStan/Analyser/nsrt/bug-12195.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12195.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12195;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param list<string>|array{0: null} $list
+ */
+function test(array $list): void
+{
+	assertType('array{null}|list<string>', $list);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-12274.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12274.php
@@ -94,7 +94,7 @@ function testShouldLooseListbyAst(array $list, int $i): void
 		$list[1+$i] = 21;
 		assertType('non-empty-array<int<0, max>, int>', $list);
 	}
-	assertType('non-empty-array<int<0, max>, int>|list<int>', $list);
+	assertType('list<int>', $list);
 }
 
 /** @param list<int> $list */
@@ -105,5 +105,5 @@ function testShouldLooseListbyAst2(array $list, int $i): void
 		$list[2+$i] = 21;
 		assertType('non-empty-array<int<0, max>, int>', $list);
 	}
-	assertType('non-empty-array<int<0, max>, int>|list<int>', $list);
+	assertType('list<int>', $list);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-12274.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12274.php
@@ -94,7 +94,7 @@ function testShouldLooseListbyAst(array $list, int $i): void
 		$list[1+$i] = 21;
 		assertType('non-empty-array<int<0, max>, int>', $list);
 	}
-	assertType('array<int<0, max>, int>', $list);
+	assertType('non-empty-array<int<0, max>, int>|list<int>', $list);
 }
 
 /** @param list<int> $list */
@@ -105,5 +105,5 @@ function testShouldLooseListbyAst2(array $list, int $i): void
 		$list[2+$i] = 21;
 		assertType('non-empty-array<int<0, max>, int>', $list);
 	}
-	assertType('array<int<0, max>, int>', $list);
+	assertType('non-empty-array<int<0, max>, int>|list<int>', $list);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-12393.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12393.php
@@ -160,7 +160,7 @@ class CallableArray {
 
 	public function doFoo(callable $foo): void {
 		$this->foo = $foo;
-		assertType('array', $this->foo); // could be non-empty-array
+		assertType('array<mixed, mixed>', $this->foo); // could be non-empty-array
 	}
 }
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12393b.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12393b.php
@@ -669,7 +669,7 @@ class CallableArray {
 
     public function doFoo(callable $foo): void {
         $this->foo = $foo;
-        assertType('array', $this->foo); // could be non-empty-array
+        assertType('array<mixed, mixed>', $this->foo); // could be non-empty-array
     }
 }
 

--- a/tests/PHPStan/Analyser/nsrt/bug-12434.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12434.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Bug12434;
+
+use BackedEnum;
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+
+	/**
+	 * @param non-empty-list<array{name: BackedEnum}>|non-empty-list<array{name: string}> $values
+	 */
+	public function sayHello(array $values): void
+	{
+		assertType('non-empty-list<array{name: BackedEnum}>|non-empty-list<array{name: string}>', $values);
+		if ($this->testShape($values)) {
+			assertType('non-empty-list<array{name: string}>', $values);
+		} else {
+			assertType('non-empty-list<array{name: BackedEnum}>', $values);
+		}
+	}
+
+	/**
+	 * @param non-empty-list<array{name: BackedEnum}>|non-empty-list<array{name: string}> $values
+	 * @phpstan-assert-if-true non-empty-list<array{name: string}> $values
+	 */
+	private function testShape(array $values): bool
+	{
+		return true;
+	}
+
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-13270b-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13270b-php8.php
@@ -19,11 +19,11 @@ class Test
 			if (!array_key_exists('priceWithVat', $data['price'])) {
 				$data['price']['priceWithVat'] = null;
 			}
-			assertType("non-empty-array&hasOffsetValue('priceWithVat', mixed)", $data['price']);
+			assertType("non-empty-array&hasOffset('priceWithVat')", $data['price']);
 			if (!array_key_exists('priceWithoutVat', $data['price'])) {
 				$data['price']['priceWithoutVat'] = null;
 			}
-			assertType("non-empty-array&hasOffsetValue('priceWithoutVat', mixed)&hasOffsetValue('priceWithVat', mixed)", $data['price']);
+			assertType("non-empty-array&hasOffset('priceWithoutVat')&hasOffset('priceWithVat')", $data['price']);
 		}
 		return $data;
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-13312.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13312.php
@@ -14,7 +14,7 @@ function fooArr(array $arr): void {
 	for ($i = 0; $i < count($arr); ++$i) {
 		assertType('non-empty-array', $arr);
 	}
-	assertType('array', $arr);
+	assertType('non-empty-array', $arr);
 }
 
 /** @param list<mixed> $arr */
@@ -28,7 +28,7 @@ function foo(array $arr): void {
 	for ($i = 0; $i < count($arr); ++$i) {
 		assertType('non-empty-list<mixed>', $arr);
 	}
-	assertType('list<mixed>', $arr);
+	assertType('non-empty-list<mixed>', $arr);
 }
 
 

--- a/tests/PHPStan/Analyser/nsrt/bug-13509.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13509.php
@@ -80,7 +80,7 @@ function alert(): ?array
 		return null;
 	}
 
-	assertType('non-empty-list<non-empty-array<literal-string&lowercase-string&non-falsy-string, int|(literal-string&non-falsy-string)|null>&oversized-array>&oversized-array', $alerts);
+	assertType("non-empty-list<(array{message: 'Foo', details: 'bar', duration: int<1, max>|null, severity: 100}&oversized-array)|(array{message: 'Idle', duration: int<1, max>|null, severity: 23}&oversized-array)|(array{message: 'No Queue', duration: int<1, max>|null, severity: 60}&oversized-array)|(array{message: 'Not Scheduled', duration: null, severity: 25}&oversized-array)|(array{message: 'Offline', duration: int<1, max>|null, severity: 99}&oversized-array)|(array{message: 'On Break'|'On Lunch', duration: int<1, max>|null, severity: 24}&oversized-array)|(array{message: 'Running W/O Operator', duration: int<1, max>|null, severity: 75}&oversized-array)>&oversized-array", $alerts);
 
 	usort($alerts, fn ($a, $b) => $b['severity'] <=> $a['severity']);
 

--- a/tests/PHPStan/Analyser/nsrt/bug-13705.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13705.php
@@ -36,16 +36,16 @@ function countLessThanRange(array $arr, int $boundedRange, int $unboundedMaxRang
 
 	// count($arr) < unbounded max range → falsey + max is null → fallback via min (branch 3/4)
 	if (count($arr) < $unboundedMaxRange) {
-		assertType('list<string>', $arr);
+		assertType('non-empty-list<string>&hasOffsetValue(1, string)', $arr);
 	} else {
 		assertType('non-empty-list<string>&hasOffsetValue(1, string)', $arr);
 	}
 
 	// count($arr) < unbounded min range → fallback branch (min is null)
 	if (count($arr) < $unboundedMinRange) {
-		assertType('list<string>', $arr);
+		assertType('non-empty-list<string>&hasOffsetValue(1, string)', $arr);
 	} else {
-		assertType('list<string>', $arr);
+		assertType('non-empty-list<string>&hasOffsetValue(1, string)', $arr);
 	}
 }
 

--- a/tests/PHPStan/Analyser/nsrt/bug-13747.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13747.php
@@ -113,10 +113,10 @@ class HelloWorld
 		}
 
 		if (2 <= count($list)) {
-			assertType('non-empty-list<int|string>&hasOffsetValue(1, int|string)', $list);
+			assertType('(non-empty-list<int>&hasOffsetValue(1, int))|(non-empty-list<string>&hasOffsetValue(1, string))', $list);
 			assertType('int<2, max>', count($list));
 		} else {
-			assertType('list<int|string>', $list);
+			assertType('list<int>|non-empty-list<string>', $list);
 			assertType('int<0, 1>', count($list));
 		}
 	}
@@ -134,10 +134,10 @@ class HelloWorld
 		}
 
 		if (2 <= count($listOrArray)) {
-			assertType('non-empty-array<int|string>', $listOrArray);
+			assertType('non-empty-array<int>|non-empty-list<string>', $listOrArray);
 			assertType('int<2, max>', count($listOrArray));
 		} else {
-			assertType('array<int|string>', $listOrArray);
+			assertType('array<int>|non-empty-list<string>', $listOrArray);
 			assertType('int<0, 1>', count($listOrArray));
 		}
 	}

--- a/tests/PHPStan/Analyser/nsrt/bug-13789.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13789.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug13789;
+
+use function PHPStan\Testing\assertType;
+
+/** @return list<non-empty-array<mixed>> */
+function get_list_of_non_empty_array(): array { return [[1]]; }
+
+/** @param array<mixed> $row */
+function sanitize(array &$row): void { }
+
+function doFoo(): void
+{
+	$foo = get_list_of_non_empty_array();
+	assertType('list<non-empty-array<mixed>>', $foo);
+
+	foreach ($foo as &$row) {
+		sanitize($row);
+		assertType('array<mixed>', $row);
+		$row[random_bytes(2)] = random_bytes(2);
+		assertType('non-empty-array<mixed>', $row);
+	}
+	unset($row);
+
+	assertType('list<non-empty-array<mixed>>', $foo);
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-14084.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14084.php
@@ -42,5 +42,5 @@ function example3(array &$convert): void
 			$convert[$outerKey][$key] = strtoupper($val);
 		}
 	}
-	assertType('array<string, list<string>>', $convert);
+	assertType('array<string, non-empty-list<string>>', $convert);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-14245.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14245.php
@@ -63,7 +63,7 @@ function listKnownHugeSize(): void {
 		assertType('non-empty-array<int<-2999, max>, int>', $list);
 	}
 
-	assertType('array<int<-2999, max>, int>', $list);
+	assertType('non-empty-array<int<-2999, max>, int>|list<int>', $list);
 }
 
 function overwriteKeyLast(): void {

--- a/tests/PHPStan/Analyser/nsrt/bug-14319.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14319.php
@@ -43,7 +43,7 @@ final class test
 			if ($rows['rap_roz3']) {
 				$raport .= 'Roz: '.$rows['rap_roz3'].", \n";
 			}
-			assertType("(non-empty-array&hasOffsetValue('rap_br', mixed)&hasOffsetValue('rap_cz', mixed)&hasOffsetValue('rap_fil', mixed)&hasOffsetValue('rap_ks', mixed)&hasOffsetValue('rap_roz', mixed)&hasOffsetValue('rap_roz2', mixed)&hasOffsetValue('rap_roz3', mixed)&hasOffsetValue('rap_tr', mixed))|(ArrayAccess&hasOffsetValue('rap_br', mixed)&hasOffsetValue('rap_cz', mixed)&hasOffsetValue('rap_fil', mixed)&hasOffsetValue('rap_ks', mixed)&hasOffsetValue('rap_roz', mixed)&hasOffsetValue('rap_roz2', mixed)&hasOffsetValue('rap_roz3', mixed)&hasOffsetValue('rap_tr', mixed))", $rows);
+			assertType("(non-empty-array&hasOffsetValue('rap_br', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_cz', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_fil', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_ks', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_roz', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_roz2', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_roz3', 0|0.0|''|'0'|array{}|false|null)&hasOffsetValue('rap_tr', 0|0.0|''|'0'|array{}|false|null))|(ArrayAccess&hasOffsetValue('rap_br', mixed)&hasOffsetValue('rap_cz', mixed)&hasOffsetValue('rap_fil', mixed)&hasOffsetValue('rap_ks', mixed)&hasOffsetValue('rap_roz', mixed)&hasOffsetValue('rap_roz2', mixed)&hasOffsetValue('rap_roz3', mixed)&hasOffsetValue('rap_tr', mixed))", $rows);
 		}
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-2648.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-2648.php
@@ -28,13 +28,13 @@ class Foo
 		if (count($list) > 1) {
 			assertType('int<2, max>', count($list));
 			foreach ($list as $key => $item) {
-				assertType('0|int<2, max>', count($list));
+				assertType('int<2, max>', count($list));
 				if ($item === false) {
 					unset($list[$key]);
 					assertType('int<0, max>', count($list));
 				}
 
-				assertType('int<0, max>', count($list));
+				assertType('int<1, max>', count($list));
 
 				if (count($list) === 1) {
 					assertType('1', count($list));
@@ -44,7 +44,7 @@ class Foo
 				}
 			}
 
-			assertType('int<0, max>', count($list));
+			assertType('int<1, max>', count($list));
 		}
 
 		assertType('int<0, max>', count($list));

--- a/tests/PHPStan/Analyser/nsrt/bug-4708.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-4708.php
@@ -90,7 +90,7 @@ function GetASCConfig()
 		assertType("non-empty-array<int|string>&hasOffsetValue('bew', int)&hasOffsetValue('bsw', int)", $result);
 	}
 
-	assertType('non-empty-array<int|string|false>', $result);
+	assertType("(non-empty-array<int|string>&hasOffsetValue('bew', int)&hasOffsetValue('bsw', int))|array{result: false, dberror: 'xyz'}", $result);
 
 	return $result;
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-5017.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-5017.php
@@ -12,10 +12,10 @@ class Foo
 		$items = [0, 1, 2, 3, 4];
 
 		while ($items) {
-			assertType('non-empty-list<int<min, 4>>', $items);
+			assertType('array{0, 1, 2, 3, 4}|non-empty-list<2|3|4>', $items);
 			$batch = array_splice($items, 0, 2);
-			assertType('list<int<min, 4>>', $items);
-			assertType('non-empty-list<int<min, 4>>', $batch);
+			assertType('list<2|3|4>', $items);
+			assertType('array{0, 1}|non-empty-list<2|3|4>', $batch);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bug-6173.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6173.php
@@ -21,7 +21,7 @@ class HelloWorld
 			$res[$id]['bar'] = $id;
 		}
 
-		assertType('array<int, non-empty-array{foo?: int, bar?: int}>', $res);
+		assertType('non-empty-array<int, array{foo?: int, bar: int}>|array<int, array{foo: int}>', $res);
 		foreach ($res as $id => $r) {
 			assertType('non-empty-array{foo?: int, bar?: int}', $r);
 			return isset($r['foo']);

--- a/tests/PHPStan/Analyser/nsrt/bug-6488.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-6488.php
@@ -22,5 +22,5 @@ function test() {
 		}
 	}
 
-	assertType('bool',sizeof($items) > 0);
+	assertType('true',sizeof($items) > 0);
 }

--- a/tests/PHPStan/Analyser/nsrt/bug-9662.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9662.php
@@ -148,21 +148,21 @@ function doFoo(string $s, $a, $strings, $mixed) {
 	} else {
 		assertType("non-empty-array<string>", $strings);
 	}
-	assertType('array<string>', $strings);
+	assertType('non-empty-array<string>', $strings);
 
 	if (in_array($s, $strings, false) === false) {
-		assertType('array<string>', $strings);
+		assertType('non-empty-array<string>', $strings);
 	} else {
 		assertType("non-empty-array<string>", $strings);
 	}
-	assertType('array<string>', $strings);
+	assertType('non-empty-array<string>', $strings);
 
 	if (in_array($s, $strings) === false) {
-		assertType('array<string>', $strings);
+		assertType('non-empty-array<string>', $strings);
 	} else {
 		assertType("non-empty-array<string>", $strings);
 	}
-	assertType('array<string>', $strings);
+	assertType('non-empty-array<string>', $strings);
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/bug-9734.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9734.php
@@ -121,25 +121,25 @@ class Bar
 		if ($this->assertIsStringList($a)) {
 			assertType('list<string>', $a);
 		} else {
-			assertType('non-empty-array', $a);
+			assertType('non-empty-array<mixed>', $a);
 		}
 
 		if ($this->assertIsConstantList($a)) {
 			assertType('array{string, string}', $a);
 		} else {
-			assertType('array', $a);
+			assertType('non-empty-array<mixed>|list<string>', $a);
 		}
 
 		if ($this->assertIsOptionalConstantList($a)) {
 			assertType('list{0?: string, 1?: string}', $a);
 		} else {
-			assertType('non-empty-array', $a);
+			assertType('non-empty-array<mixed>', $a);
 		}
 
 		if ($this->assertIsStringArray($a)) {
-			assertType('array<string>', $a);
+			assertType('non-empty-array<string>|list{0?: string, 1?: string}', $a);
 		} else {
-			assertType('non-empty-array', $a);
+			assertType('non-empty-array<mixed>', $a);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/bug7856.php
+++ b/tests/PHPStan/Analyser/nsrt/bug7856.php
@@ -10,7 +10,7 @@ function doFoo() {
 	$endDate = new DateTimeImmutable('+1year');
 
 	do {
-		assertType("list<literal-string&lowercase-string&non-falsy-string>", $intervals);
+		assertType("array{'+1week', '+1months', '+6months', '+17months'}|list<'+17months'|'+1months'|'+6months'>", $intervals);
 		$periodEnd = $periodEnd->modify(array_shift($intervals));
 	} while (count($intervals) > 0 && $periodEnd->format('U') < $endDate);
 }

--- a/tests/PHPStan/Analyser/nsrt/conditional-types.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-types.php
@@ -27,8 +27,8 @@ abstract class Test
 	 */
 	public function testArrayKeys(array $array, array $nonEmptyArray, array $intArray, array $nonEmptyIntArray, array $emptyArray): void
 	{
-		assertType('list<(int|string)>', $this->arrayKeys($array));
-		assertType('list<int>', $this->arrayKeys($intArray));
+		assertType('non-empty-list<(int|string)>', $this->arrayKeys($array));
+		assertType('non-empty-list<int>', $this->arrayKeys($intArray));
 
 		assertType('non-empty-list<(int|string)>', $this->arrayKeys($nonEmptyArray));
 		assertType('non-empty-list<int>', $this->arrayKeys($nonEmptyIntArray));

--- a/tests/PHPStan/Analyser/nsrt/conditional-vars-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/conditional-vars-php8.php
@@ -12,9 +12,9 @@ class HelloWorld
 	public function conditionalVarInTernary(array $innerHits): void
 	{
 		if (array_key_exists('nearest_premise', $innerHits) || array_key_exists('matching_premises', $innerHits)) {
-			assertType('non-empty-array', $innerHits);
+			assertType("non-empty-array&hasOffset('matching_premises')", $innerHits);
 			$x = array_key_exists('nearest_premise', $innerHits)
-				? assertType("non-empty-array&hasOffset('nearest_premise')", $innerHits)
+				? assertType("non-empty-array&hasOffset('matching_premises')&hasOffset('nearest_premise')", $innerHits)
 				: assertType("non-empty-array<mixed~'nearest_premise', mixed>", $innerHits);
 
 			assertType('non-empty-array', $innerHits);
@@ -26,9 +26,9 @@ class HelloWorld
 	public function conditionalVarInIf(array $innerHits): void
 	{
 		if (array_key_exists('nearest_premise', $innerHits) || array_key_exists('matching_premises', $innerHits)) {
-			assertType('non-empty-array', $innerHits);
+			assertType("non-empty-array&hasOffset('matching_premises')", $innerHits);
 			if (array_key_exists('nearest_premise', $innerHits)) {
-				assertType("non-empty-array&hasOffset('nearest_premise')", $innerHits);
+				assertType("non-empty-array&hasOffset('matching_premises')&hasOffset('nearest_premise')", $innerHits);
 			} else {
 				assertType("non-empty-array<mixed~'nearest_premise', mixed>", $innerHits);
 			}

--- a/tests/PHPStan/Analyser/nsrt/count-const-array-2.php
+++ b/tests/PHPStan/Analyser/nsrt/count-const-array-2.php
@@ -29,7 +29,7 @@ class HelloWorld
 			}
 			array_unshift($otherMinPrices, $otherMinPrice);
 		}
-		assertType('non-empty-list<stdClass>', $otherMinPrices);
+		assertType('array{stdClass}|(non-empty-list<stdClass>&hasOffsetValue(1, stdClass))', $otherMinPrices);
 		return [$bestMinPrice, ...$otherMinPrices];
 	}
 }

--- a/tests/PHPStan/Analyser/nsrt/fgetcsv-php8.php
+++ b/tests/PHPStan/Analyser/nsrt/fgetcsv-php8.php
@@ -8,5 +8,5 @@ use function PHPStan\Testing\assertType;
 
 function test($resource): void
 {
-	assertType('non-empty-list<string|null>|false', fgetcsv($resource));
+	assertType('array{null}|non-empty-list<string>|false', fgetcsv($resource));
 }

--- a/tests/PHPStan/Analyser/nsrt/for-loop-expr.php
+++ b/tests/PHPStan/Analyser/nsrt/for-loop-expr.php
@@ -16,7 +16,7 @@ function getItemsWithForLoop(array $items): array
 		$items[$i] = 1;
 	}
 
-	assertType('non-empty-list<int>', $items);
+	assertType('non-empty-list<int>&hasOffsetValue(0, 1)', $items);
 	return $items;
 }
 
@@ -31,7 +31,7 @@ function getItemsWithForLoopInvertLastCond(array $items): array
 		$items[$i] = 'hello';
 	}
 
-	assertType('list<string>', $items);
+	assertType("non-empty-list<string>&hasOffsetValue(0, 'hello')", $items);
 	return $items;
 }
 
@@ -47,6 +47,6 @@ function getItemsArray(array $items): array
 		$items[$i] = 'hello';
 	}
 
-	assertType('array<string>', $items);
+	assertType("non-empty-array<string>&hasOffsetValue(0, 'hello')", $items);
 	return $items;
 }

--- a/tests/PHPStan/Analyser/nsrt/getopt.php
+++ b/tests/PHPStan/Analyser/nsrt/getopt.php
@@ -6,5 +6,5 @@ use function getopt;
 use function PHPStan\Testing\assertType;
 
 $opts = getopt("ab:c::", ["longopt1", "longopt2:", "longopt3::"], $restIndex);
-assertType('(array<string, list<mixed>|string|false>|false)', $opts);
+assertType('(array<string, false>|array<string, list<mixed>>|array<string, string>|false)', $opts);
 assertType('int<1, max>', $restIndex);

--- a/tests/PHPStan/Analyser/nsrt/in-array-enum.php
+++ b/tests/PHPStan/Analyser/nsrt/in-array-enum.php
@@ -54,15 +54,15 @@ class Foo
 		}
 
 		if (! in_array(rand() ? FooUnitEnum::A : FooUnitEnum::B, $haystack, true)) {
-			assertType('array<InArrayEnum\FooUnitEnum|int>', $haystack);
+			assertType('array<InArrayEnum\FooUnitEnum::B|int>|non-empty-array<InArrayEnum\FooUnitEnum|int>', $haystack);
 		}
 
 		if (! in_array(rand() ? 5 : 6, $haystack, true)) {
-			assertType('array<InArrayEnum\FooUnitEnum|int>', $haystack);
+			assertType('array<InArrayEnum\FooUnitEnum::B|int>|non-empty-array<InArrayEnum\FooUnitEnum|int>', $haystack);
 		}
 
 		if (! in_array(rand() ? 5 : rand(), $haystack, true)) {
-			assertType('array<InArrayEnum\FooUnitEnum|int>', $haystack);
+			assertType('array<InArrayEnum\FooUnitEnum::B|int>|non-empty-array<InArrayEnum\FooUnitEnum|int>', $haystack);
 		}
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/list-count.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count.php
@@ -58,7 +58,7 @@ function modeCountOnMaybeArray(array $items, int $mode) {
 	} else {
 		assertType('non-empty-list<array<int>|int>', $items);
 	}
-	assertType('list<array<int>|int>', $items);
+	assertType('non-empty-list<array<int>|int>', $items);
 }
 
 
@@ -97,7 +97,7 @@ function recursiveCountOnMaybeArray(array $items):void {
 	} else {
 		assertType('non-empty-list<array<int>|int>', $items);
 	}
-	assertType('list<array<int>|int>', $items);
+	assertType('non-empty-list<array<int>|int>', $items);
 }
 
 /**

--- a/tests/PHPStan/Analyser/nsrt/list-count2.php
+++ b/tests/PHPStan/Analyser/nsrt/list-count2.php
@@ -133,7 +133,7 @@ class HelloWorld
 			assertType('array{mixed, mixed, mixed}', $arrB);
 		}
 		assertType('array{int, int, int}', $arrA);
-		assertType('non-empty-list', $arrB);
+		assertType('non-empty-list&hasOffsetValue(1, mixed)', $arrB);
 	}
 
 	/**
@@ -186,7 +186,7 @@ class HelloWorld
 			assertType('array{mixed, mixed, mixed}', $arrB);
 		}
 		assertType('array{int, int, int}', $arrA);
-		assertType('non-empty-list', $arrB);
+		assertType('non-empty-list&hasOffsetValue(1, mixed)', $arrB);
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/nsrt/narrow-tagged-union.php
+++ b/tests/PHPStan/Analyser/nsrt/narrow-tagged-union.php
@@ -87,7 +87,7 @@ class HelloWorld
 		} else {
 			assertType("array{string, '', non-empty-string}|array<int>", $arr); // could be array{string, '', non-empty-string}|array<int>
 		}
-		assertType("array{string, '', non-empty-string}#1|array{string, '', non-empty-string}#2|array<int>", $arr); // could be array{string, '', non-empty-string}|array<int>
+		assertType("array{string, '', non-empty-string}|array<int>", $arr); // could be array{string, '', non-empty-string}|array<int>
 	}
 
 	public function arrayIntRangeSize(): void

--- a/tests/PHPStan/Analyser/nsrt/narrow-tagged-union.php
+++ b/tests/PHPStan/Analyser/nsrt/narrow-tagged-union.php
@@ -83,11 +83,11 @@ class HelloWorld
 	public function mixedArrays(array $arr): void
 	{
 		if (count($arr, COUNT_NORMAL) === 3) {
-			assertType("non-empty-array<int|string>", $arr); // could be array{string, '', non-empty-string}|non-empty-array<int>
+			assertType("array{string, '', non-empty-string}|non-empty-array<int>", $arr); // could be array{string, '', non-empty-string}|non-empty-array<int>
 		} else {
-			assertType("array<int|string>", $arr); // could be array{string, '', non-empty-string}|array<int>
+			assertType("array{string, '', non-empty-string}|array<int>", $arr); // could be array{string, '', non-empty-string}|array<int>
 		}
-		assertType("array<int|string>", $arr); // could be array{string, '', non-empty-string}|array<int>
+		assertType("array{string, '', non-empty-string}#1|array{string, '', non-empty-string}#2|array<int>", $arr); // could be array{string, '', non-empty-string}|array<int>
 	}
 
 	public function arrayIntRangeSize(): void

--- a/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
+++ b/tests/PHPStan/Analyser/nsrt/preg_match_shapes.php
@@ -122,7 +122,7 @@ function doOffsetCapture(string $s): void {
 
 function doUnknownFlags(string $s, int $flags): void {
 	if (preg_match('/(foo)(bar)(baz)/xyz', $s, $matches, $flags)) {
-		assertType('array<array{string|null, int<-1, max>}|string|null>', $matches);
+		assertType('array<array{string, int<-1, max>}>|array<array{null, -1}|array{string, int<0, max>}>|array<string|null>', $matches);
 	}
 	assertType('array<array{string|null, int<-1, max>}|string|null>', $matches);
 }

--- a/tests/PHPStan/Analyser/nsrt/shopware-connection-profiler.php
+++ b/tests/PHPStan/Analyser/nsrt/shopware-connection-profiler.php
@@ -29,7 +29,7 @@ abstract class ConnectionProfiler
 					$connectionGroupedQueries[$key]['index'] = $i; // "Explain query" relies on query index in 'queries'.
 				}
 
-				assertType("non-empty-array<string, array{sql: string, executionMS: 0, types: array<int|string, int|Shopware\Core\Profiling\Doctrine\ParameterType>, count: 0, index: int}|array{sql: string, executionMS: float, types: array<int|string, int|Shopware\Core\Profiling\Doctrine\ParameterType>, count: int<1, max>, index: int}>", $connectionGroupedQueries);
+				assertType('non-empty-array<string, array{sql: string, executionMS: float, types: array<int|string, int|Shopware\Core\Profiling\Doctrine\ParameterType>, count: int<1, max>, index: int}>|non-empty-array<string, array{sql: string, executionMS: 0, types: array<int|string, int|Shopware\Core\Profiling\Doctrine\ParameterType>, count: 0, index: int}>', $connectionGroupedQueries);
 				$connectionGroupedQueries[$key]['executionMS'] += $query['executionMS'];
 				assertType("non-empty-array<string, array{sql: string, executionMS: float, types: array<int|string, int|Shopware\Core\Profiling\Doctrine\ParameterType>, count: int<0, max>, index: int}>", $connectionGroupedQueries);
 				++$connectionGroupedQueries[$key]['count'];

--- a/tests/PHPStan/Analyser/nsrt/shuffle.php
+++ b/tests/PHPStan/Analyser/nsrt/shuffle.php
@@ -106,10 +106,10 @@ class Foo
 	{
 		/** @var array{foo?: 1, bar: 2, }|array{baz: 3, foobar?: 4} $arr */
 		shuffle($arr);
-		assertType('non-empty-list<1|2|3|4>', $arr);
+		assertType('non-empty-list<1|2>|non-empty-list<3|4>', $arr);
 		assertNativeType('list', $arr);
 		assertType('non-empty-list<0|1>', array_keys($arr));
-		assertType('non-empty-list<1|2|3|4>', array_values($arr));
+		assertType('non-empty-list<1|2>|non-empty-list<3|4>', array_values($arr));
 	}
 
 	public function mixed($arr): void

--- a/tests/PHPStan/Analyser/nsrt/sort.php
+++ b/tests/PHPStan/Analyser/nsrt/sort.php
@@ -71,18 +71,18 @@ class Foo
 
 		$arr1 = $arr;
 		sort($arr1);
-		assertType('non-empty-list<1|2|5>', $arr1);
-		assertNativeType('non-empty-list<1|2|5>', $arr1);
+		assertType('non-empty-list<1|5>|non-empty-list<2>', $arr1);
+		assertNativeType('non-empty-list<1|5>|non-empty-list<2>', $arr1);
 
 		$arr2 = $arr;
 		rsort($arr2);
-		assertType('non-empty-list<1|2|5>', $arr2);
-		assertNativeType('non-empty-list<1|2|5>', $arr2);
+		assertType('non-empty-list<1|5>|non-empty-list<2>', $arr2);
+		assertNativeType('non-empty-list<1|5>|non-empty-list<2>', $arr2);
 
 		$arr3 = $arr;
 		usort($arr3, fn(int $a, int $b) => $a <=> $b);
-		assertType('non-empty-list<1|2|5>', $arr3);
-		assertNativeType('non-empty-list<1|2|5>', $arr3);
+		assertType('non-empty-list<1|5>|non-empty-list<2>', $arr3);
+		assertNativeType('non-empty-list<1|5>|non-empty-list<2>', $arr3);
 	}
 
 	/** @param array<mixed, string> $arr */

--- a/tests/PHPStan/Rules/Arrays/OffsetAccessAssignmentRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/OffsetAccessAssignmentRuleTest.php
@@ -162,6 +162,12 @@ class OffsetAccessAssignmentRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-8015.php'], []);
 	}
 
+	public function testBug8648(): void
+	{
+		$this->checkUnionTypes = true;
+		$this->analyse([__DIR__ . '/data/bug-8648.php'], []);
+	}
+
 	public function testBug11572(): void
 	{
 		$this->checkUnionTypes = true;

--- a/tests/PHPStan/Rules/Arrays/data/bug-6000.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-6000.php
@@ -9,7 +9,7 @@ function (): void {
 	$data = [];
 
 	foreach ($data as $key => $value) {
-		assertType('array<int<0, max>|string, array<string>|string>', $data[$key]);
+		assertType('array<string, array<string>|string>|list<string>', $data[$key]);
 		if ($key === 'classmap') {
 			assertType('list<string>', $data[$key]);
 			assertType('list<string>', $value);

--- a/tests/PHPStan/Rules/Arrays/data/bug-8467a.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8467a.php
@@ -27,7 +27,7 @@ class Test {
 		if (\count($package->getAutoload()) > 0) {
 			$autoloadConfig = $package->getAutoload();
 			foreach ($autoloadConfig as $type => $autoloads) {
-				assertType('array<int<0, max>|string, array<string>|string>', $autoloadConfig[$type]);
+				assertType('array<string, array<string>|string>|list<string>', $autoloadConfig[$type]);
 				if ($type === 'psr-0' || $type === 'psr-4') {
 
 				} elseif ($type === 'classmap') {

--- a/tests/PHPStan/Rules/Arrays/data/bug-8648.php
+++ b/tests/PHPStan/Rules/Arrays/data/bug-8648.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8648;
+
+class HelloWorld
+{
+	/**
+	 * @var mixed[]
+	 */
+	private $data;
+
+	/**
+	 * @return mixed[]
+	 */
+	public function processData(): array
+	{
+		$this->data['foo'] = [
+			'id' => 'some_id',
+		];
+
+		foreach (['a' => 'aa', 'b' => 'bb', 'c' => 'cc'] as $type => $value) {
+			$this->data['foo']['bar'][] = [
+				'type' => $type,
+				'value' => $value,
+			];
+		}
+
+		return $this->data;
+	}
+}

--- a/tests/PHPStan/Rules/Arrays/data/slevomat-foreach-unset-bug.php
+++ b/tests/PHPStan/Rules/Arrays/data/slevomat-foreach-unset-bug.php
@@ -18,8 +18,8 @@ class Foo
 				continue;
 			}
 
-			assertType('array{items: array<string, stdClass>, isActive: bool, productsCount: int}', $this->foreignSection);
-			assertType('array<string, stdClass>', $this->foreignSection['items']);
+			assertType('array{items: non-empty-array<string, stdClass>, isActive: bool, productsCount: int}', $this->foreignSection);
+			assertType('non-empty-array<string, stdClass>', $this->foreignSection['items']);
 			unset($this->foreignSection['items'][$foreignCountryNo]);
 			assertType('array{items: array<string, stdClass>, isActive: bool, productsCount: int}', $this->foreignSection);
 			assertType('array<string, stdClass>', $this->foreignSection['items']);

--- a/tests/PHPStan/Rules/Comparison/data/bug-4708.php
+++ b/tests/PHPStan/Rules/Comparison/data/bug-4708.php
@@ -88,7 +88,7 @@ function GetASCConfig()
 		}
 	}
 
-	assertType("non-empty-array<int|string|false>", $result);
+	assertType("(non-empty-array<int|string>&hasOffsetValue('bew', int)&hasOffsetValue('bsw', int))|array{result: false, dberror: 'xyz'}", $result);
 
 	return $result;
 }

--- a/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/CallToFunctionParametersRuleTest.php
@@ -346,6 +346,21 @@ class CallToFunctionParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13711.php'], []);
 	}
 
+	public function testBug7759(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-7759.php'], []);
+	}
+
+	public function testBug8963(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-8963.php'], [
+			[
+				'Parameter #1 $array of function Bug8963\test expects array<int>|array<string>, array<int, int|string> given.',
+				13,
+			],
+		]);
+	}
+
 	public function testImplodeOnPhp74(): void
 	{
 		$errors = [

--- a/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php
@@ -144,6 +144,14 @@ class ReturnTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-7218.php'], []);
 	}
 
+	#[RequiresPhp('>= 8.0')]
+	public function testBug13394(): void
+	{
+		$this->checkExplicitMixed = false;
+		$this->checkNullables = true;
+		$this->analyse([__DIR__ . '/data/bug-13394.php'], []);
+	}
+
 	public function testBug5751(): void
 	{
 		$this->checkExplicitMixed = true;

--- a/tests/PHPStan/Rules/Functions/data/bug-13394.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-13394.php
@@ -1,0 +1,19 @@
+<?php // lint >= 8.0
+
+declare(strict_types=1);
+
+namespace Bug13394;
+
+/**
+ * @template T of int|array
+ * @param T $bar
+ * @return T
+ */
+function foo(int|array $bar): int|array
+{
+	if (is_array($bar) && isset($bar[0])) {
+		$unused = $bar[0] ? 1 : 2;
+	}
+
+	return $bar;
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-7759.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-7759.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace Bug7759;
+
+function take_string(string $in): void {}
+
+/**
+ * @param array{foo?: array{bar?: string}}|array<string, string> $in
+ */
+function check(array $in): void
+{
+	if (array_key_exists('test123', $in)) {
+		take_string($in['test123']);
+	}
+}

--- a/tests/PHPStan/Rules/Functions/data/bug-8963.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-8963.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Bug8963;
+
+/**
+ * @param array<string>|array<int> $array
+ */
+function test(array $array): void
+{
+}
+
+$array = ['a', 2, 'c'];
+test($array);

--- a/tests/PHPStan/Rules/Methods/data/bug-12927.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-12927.php
@@ -55,7 +55,7 @@ class HelloWorld
 			if (rand(0,1)) {
 				unset($list[$k]);
 			}
-			assertType('array<int<0, max>, array<string, string>>', $list);
+			assertType('non-empty-list<array<string, string>>', $list);
 			assertType('array<string, string>', $list[$k]);
 		}
 		assertType('array<string, string>', $list[$k]);

--- a/tests/PHPStan/Rules/Methods/data/bug-7511.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-7511.php
@@ -43,7 +43,7 @@ abstract class HelloWorld
 		}
 		ksort($res);
 
-		assertType('array<T of Bug7511\PositionEntityInterface&Bug7511\TgEntityInterface (method Bug7511\HelloWorld::computeForFrontByPosition(), parameter)>', $res);
+		assertType('non-empty-array<T of Bug7511\PositionEntityInterface&Bug7511\TgEntityInterface (method Bug7511\HelloWorld::computeForFrontByPosition(), parameter)>', $res);
 
 		return $res;
 	}

--- a/tests/PHPStan/Rules/Variables/data/bug-13921.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-13921.php
@@ -8,35 +8,35 @@ use function PHPStan\Testing\assertType;
 /** @param list<array<?string>> $x */
 function foo(array $x): void {
 	var_dump($x[0]['bar'] ?? null);
-	assertType("list<array<string|null>>", $x);
+	assertType("non-empty-list<array<string|null>>&hasOffsetValue(0, non-empty-array<string|null>&hasOffsetValue('bar', string))", $x);
 	var_dump($x[0] ?? null);
 }
 
 /** @param non-empty-list<array<?string>> $x */
 function nonEmptyFoo(array $x): void {
 	var_dump($x[0]['bar'] ?? null);
-	assertType("non-empty-list<array<string|null>>", $x);
+	assertType("non-empty-list<array<string|null>>&hasOffsetValue(0, non-empty-array<string|null>&hasOffsetValue('bar', string))", $x);
 	var_dump($x[0] ?? null);
 }
 
 /** @param list<array<?string>> $x */
 function bar(array $x): void {
 	var_dump($x[0] ?? null);
-	assertType("list<array<string|null>>", $x);
+	assertType('non-empty-list<array<string|null>>&hasOffsetValue(0, array<string|null>)', $x);
 	var_dump($x[0]['bar'] ?? null);
 }
 
 /** @param list<array<?string>> $x */
 function baz(array $x): void {
 	var_dump($x[1] ?? null);
-	assertType("list<array<string|null>>", $x);
+	assertType('non-empty-list<array<string|null>>&hasOffsetValue(1, array<string|null>)', $x);
 	var_dump($x[0]['bar'] ?? null);
 }
 
 /** @param list<array<?string>> $x */
 function boo(array $x): void {
 	var_dump($x[0]['bar'] ?? null);
-	assertType("list<array<string|null>>", $x);
+	assertType("non-empty-list<array<string|null>>&hasOffsetValue(0, non-empty-array<string|null>&hasOffsetValue('bar', string))", $x);
 	var_dump($x[1] ?? null);
 }
 
@@ -51,6 +51,6 @@ function doBar(array $array)
 /** @param list<SimpleXMLElement> $x */
 function sooSimpleElement(array $x): void {
 	var_dump($x[0]['bar'] ?? null);
-	assertType("list<SimpleXMLElement>", $x);
+	assertType("non-empty-list<SimpleXMLElement>&hasOffsetValue(0, SimpleXMLElement&hasOffset('bar'))", $x);
 	var_dump($x[0] ?? null);
 }

--- a/tests/PHPStan/Rules/Variables/data/bug-14124.php
+++ b/tests/PHPStan/Rules/Variables/data/bug-14124.php
@@ -29,5 +29,5 @@ function example3b(array &$convert): void
 			$convert[$outerKey][$key] = strtoupper($val);
 		}
 	}
-	assertType('array<string, list<string>>', $convert);
+	assertType('array<string, non-empty-list<string>>', $convert);
 }

--- a/tests/bench/data/optional-properties-blowup.php
+++ b/tests/bench/data/optional-properties-blowup.php
@@ -1,0 +1,428 @@
+<?php declare(strict_types=1);
+
+namespace OptionalPropertiesBlowup;
+
+class OwnerModel {};
+class PermissionsModel {};
+
+final readonly class TemplateRepositoryModel implements \JsonSerializable
+{
+    public function __construct(
+        public null|int $id = null,
+        public null|string $node_id = null,
+        public null|string $name = null,
+        public null|string $full_name = null,
+        public null|OwnerModel $owner = null,
+        public null|bool $private = null,
+        public null|string $html_url = null,
+        public null|string $description = null,
+        public null|bool $fork = null,
+        public null|string $url = null,
+        public null|string $archive_url = null,
+        public null|string $assignees_url = null,
+        public null|string $blobs_url = null,
+        public null|string $branches_url = null,
+        public null|string $collaborators_url = null,
+        public null|string $comments_url = null,
+        public null|string $commits_url = null,
+        public null|string $compare_url = null,
+        public null|string $contents_url = null,
+        public null|string $contributors_url = null,
+        public null|string $deployments_url = null,
+        public null|string $downloads_url = null,
+        public null|string $events_url = null,
+        public null|string $forks_url = null,
+        public null|string $git_commits_url = null,
+        public null|string $git_refs_url = null,
+        public null|string $git_tags_url = null,
+        public null|string $git_url = null,
+        public null|string $issue_comment_url = null,
+        public null|string $issue_events_url = null,
+        public null|string $issues_url = null,
+        public null|string $keys_url = null,
+        public null|string $labels_url = null,
+        public null|string $languages_url = null,
+        public null|string $merges_url = null,
+        public null|string $milestones_url = null,
+        public null|string $notifications_url = null,
+        public null|string $pulls_url = null,
+        public null|string $releases_url = null,
+        public null|string $ssh_url = null,
+        public null|string $stargazers_url = null,
+        public null|string $statuses_url = null,
+        public null|string $subscribers_url = null,
+        public null|string $subscription_url = null,
+        public null|string $tags_url = null,
+        public null|string $teams_url = null,
+        public null|string $trees_url = null,
+        public null|string $clone_url = null,
+        public null|string $mirror_url = null,
+        public null|string $hooks_url = null,
+        public null|string $svn_url = null,
+        public null|string $homepage = null,
+        public null|string $language = null,
+        public null|int $forks_count = null,
+        public null|int $stargazers_count = null,
+        public null|int $watchers_count = null,
+        public null|int $size = null,
+        public null|string $default_branch = null,
+        public null|int $open_issues_count = null,
+        public null|bool $is_template = null,
+        /** @var null|list<string> */
+        public null|array $topics = null,
+        public null|bool $has_issues = null,
+        public null|bool $has_projects = null,
+        public null|bool $has_wiki = null,
+        public null|bool $has_pages = null,
+        public null|bool $has_downloads = null,
+        public null|bool $archived = null,
+        public null|bool $disabled = null,
+        public null|string $visibility = null,
+        public null|string $pushed_at = null,
+        public null|string $created_at = null,
+        public null|string $updated_at = null,
+        public null|PermissionsModel $permissions = null,
+        public null|bool $allow_rebase_merge = null,
+        public null|string $template_repository = null,
+        public null|string $temp_clone_token = null,
+        public null|bool $allow_squash_merge = null,
+        public null|bool $delete_branch_on_merge = null,
+        public null|bool $allow_merge_commit = null,
+        public null|int $subscribers_count = null,
+        public null|int $network_count = null,
+    ) {}
+
+    /**
+     * @return array{
+     *     'id'?: int,
+     *     'node_id'?: string,
+     *     'name'?: string,
+     *     'full_name'?: string,
+     *     'owner'?: OwnerModel,
+     *     'private'?: bool,
+     *     'html_url'?: string,
+     *     'description'?: string,
+     *     'fork'?: bool,
+     *     'url'?: string,
+     *     'archive_url'?: string,
+     *     'assignees_url'?: string,
+     *     'blobs_url'?: string,
+     *     'branches_url'?: string,
+     *     'collaborators_url'?: string,
+     *     'comments_url'?: string,
+     *     'commits_url'?: string,
+     *     'compare_url'?: string,
+     *     'contents_url'?: string,
+     *     'contributors_url'?: string,
+     *     'deployments_url'?: string,
+     *     'downloads_url'?: string,
+     *     'events_url'?: string,
+     *     'forks_url'?: string,
+     *     'git_commits_url'?: string,
+     *     'git_refs_url'?: string,
+     *     'git_tags_url'?: string,
+     *     'git_url'?: string,
+     *     'issue_comment_url'?: string,
+     *     'issue_events_url'?: string,
+     *     'issues_url'?: string,
+     *     'keys_url'?: string,
+     *     'labels_url'?: string,
+     *     'languages_url'?: string,
+     *     'merges_url'?: string,
+     *     'milestones_url'?: string,
+     *     'notifications_url'?: string,
+     *     'pulls_url'?: string,
+     *     'releases_url'?: string,
+     *     'ssh_url'?: string,
+     *     'stargazers_url'?: string,
+     *     'statuses_url'?: string,
+     *     'subscribers_url'?: string,
+     *     'subscription_url'?: string,
+     *     'tags_url'?: string,
+     *     'teams_url'?: string,
+     *     'trees_url'?: string,
+     *     'clone_url'?: string,
+     *     'mirror_url'?: string,
+     *     'hooks_url'?: string,
+     *     'svn_url'?: string,
+     *     'homepage'?: string,
+     *     'language'?: string,
+     *     'forks_count'?: int,
+     *     'stargazers_count'?: int,
+     *     'watchers_count'?: int,
+     *     'size'?: int,
+     *     'default_branch'?: string,
+     *     'open_issues_count'?: int,
+     *     'is_template'?: bool,
+     *     'topics'?: list<string>,
+     *     'has_issues'?: bool,
+     *     'has_projects'?: bool,
+     *     'has_wiki'?: bool,
+     *     'has_pages'?: bool,
+     *     'has_downloads'?: bool,
+     *     'archived'?: bool,
+     *     'disabled'?: bool,
+     *     'visibility'?: string,
+     *     'pushed_at'?: string,
+     *     'created_at'?: string,
+     *     'updated_at'?: string,
+     *     'permissions'?: PermissionsModel,
+     *     'allow_rebase_merge'?: bool,
+     *     'template_repository'?: string,
+     *     'temp_clone_token'?: string,
+     *     'allow_squash_merge'?: bool,
+     *     'delete_branch_on_merge'?: bool,
+     *     'allow_merge_commit'?: bool,
+     *     'subscribers_count'?: int,
+     *     'network_count'?: int,
+     * }
+     */
+    public function jsonSerialize(): array
+    {
+        $properties = [];
+        if ($this->id !== null) {
+            $properties['id'] = $this->id;
+        }
+        if ($this->node_id !== null) {
+            $properties['node_id'] = $this->node_id;
+        }
+        if ($this->name !== null) {
+            $properties['name'] = $this->name;
+        }
+        if ($this->full_name !== null) {
+            $properties['full_name'] = $this->full_name;
+        }
+        if ($this->owner !== null) {
+            $properties['owner'] = $this->owner;
+        }
+        if ($this->private !== null) {
+            $properties['private'] = $this->private;
+        }
+        if ($this->html_url !== null) {
+            $properties['html_url'] = $this->html_url;
+        }
+        if ($this->description !== null) {
+            $properties['description'] = $this->description;
+        }
+        if ($this->fork !== null) {
+            $properties['fork'] = $this->fork;
+        }
+        if ($this->url !== null) {
+            $properties['url'] = $this->url;
+        }
+        if ($this->archive_url !== null) {
+            $properties['archive_url'] = $this->archive_url;
+        }
+        if ($this->assignees_url !== null) {
+            $properties['assignees_url'] = $this->assignees_url;
+        }
+        if ($this->blobs_url !== null) {
+            $properties['blobs_url'] = $this->blobs_url;
+        }
+        if ($this->branches_url !== null) {
+            $properties['branches_url'] = $this->branches_url;
+        }
+        if ($this->collaborators_url !== null) {
+            $properties['collaborators_url'] = $this->collaborators_url;
+        }
+        if ($this->comments_url !== null) {
+            $properties['comments_url'] = $this->comments_url;
+        }
+        if ($this->commits_url !== null) {
+            $properties['commits_url'] = $this->commits_url;
+        }
+        if ($this->compare_url !== null) {
+            $properties['compare_url'] = $this->compare_url;
+        }
+        if ($this->contents_url !== null) {
+            $properties['contents_url'] = $this->contents_url;
+        }
+        if ($this->contributors_url !== null) {
+            $properties['contributors_url'] = $this->contributors_url;
+        }
+        if ($this->deployments_url !== null) {
+            $properties['deployments_url'] = $this->deployments_url;
+        }
+        if ($this->downloads_url !== null) {
+            $properties['downloads_url'] = $this->downloads_url;
+        }
+        if ($this->events_url !== null) {
+            $properties['events_url'] = $this->events_url;
+        }
+        if ($this->forks_url !== null) {
+            $properties['forks_url'] = $this->forks_url;
+        }
+        if ($this->git_commits_url !== null) {
+            $properties['git_commits_url'] = $this->git_commits_url;
+        }
+        if ($this->git_refs_url !== null) {
+            $properties['git_refs_url'] = $this->git_refs_url;
+        }
+        if ($this->git_tags_url !== null) {
+            $properties['git_tags_url'] = $this->git_tags_url;
+        }
+        if ($this->git_url !== null) {
+            $properties['git_url'] = $this->git_url;
+        }
+        if ($this->issue_comment_url !== null) {
+            $properties['issue_comment_url'] = $this->issue_comment_url;
+        }
+        if ($this->issue_events_url !== null) {
+            $properties['issue_events_url'] = $this->issue_events_url;
+        }
+        if ($this->issues_url !== null) {
+            $properties['issues_url'] = $this->issues_url;
+        }
+        if ($this->keys_url !== null) {
+            $properties['keys_url'] = $this->keys_url;
+        }
+        if ($this->labels_url !== null) {
+            $properties['labels_url'] = $this->labels_url;
+        }
+        if ($this->languages_url !== null) {
+            $properties['languages_url'] = $this->languages_url;
+        }
+        if ($this->merges_url !== null) {
+            $properties['merges_url'] = $this->merges_url;
+        }
+        if ($this->milestones_url !== null) {
+            $properties['milestones_url'] = $this->milestones_url;
+        }
+        if ($this->notifications_url !== null) {
+            $properties['notifications_url'] = $this->notifications_url;
+        }
+        if ($this->pulls_url !== null) {
+            $properties['pulls_url'] = $this->pulls_url;
+        }
+        if ($this->releases_url !== null) {
+            $properties['releases_url'] = $this->releases_url;
+        }
+        if ($this->ssh_url !== null) {
+            $properties['ssh_url'] = $this->ssh_url;
+        }
+        if ($this->stargazers_url !== null) {
+            $properties['stargazers_url'] = $this->stargazers_url;
+        }
+        if ($this->statuses_url !== null) {
+            $properties['statuses_url'] = $this->statuses_url;
+        }
+        if ($this->subscribers_url !== null) {
+            $properties['subscribers_url'] = $this->subscribers_url;
+        }
+        if ($this->subscription_url !== null) {
+            $properties['subscription_url'] = $this->subscription_url;
+        }
+        if ($this->tags_url !== null) {
+            $properties['tags_url'] = $this->tags_url;
+        }
+        if ($this->teams_url !== null) {
+            $properties['teams_url'] = $this->teams_url;
+        }
+        if ($this->trees_url !== null) {
+            $properties['trees_url'] = $this->trees_url;
+        }
+        if ($this->clone_url !== null) {
+            $properties['clone_url'] = $this->clone_url;
+        }
+        if ($this->mirror_url !== null) {
+            $properties['mirror_url'] = $this->mirror_url;
+        }
+        if ($this->hooks_url !== null) {
+            $properties['hooks_url'] = $this->hooks_url;
+        }
+        if ($this->svn_url !== null) {
+            $properties['svn_url'] = $this->svn_url;
+        }
+        if ($this->homepage !== null) {
+            $properties['homepage'] = $this->homepage;
+        }
+        if ($this->language !== null) {
+            $properties['language'] = $this->language;
+        }
+        if ($this->forks_count !== null) {
+            $properties['forks_count'] = $this->forks_count;
+        }
+        if ($this->stargazers_count !== null) {
+            $properties['stargazers_count'] = $this->stargazers_count;
+        }
+        if ($this->watchers_count !== null) {
+            $properties['watchers_count'] = $this->watchers_count;
+        }
+        if ($this->size !== null) {
+            $properties['size'] = $this->size;
+        }
+        if ($this->default_branch !== null) {
+            $properties['default_branch'] = $this->default_branch;
+        }
+        if ($this->open_issues_count !== null) {
+            $properties['open_issues_count'] = $this->open_issues_count;
+        }
+        if ($this->is_template !== null) {
+            $properties['is_template'] = $this->is_template;
+        }
+        if ($this->topics !== null) {
+            $properties['topics'] = $this->topics;
+        }
+        if ($this->has_issues !== null) {
+            $properties['has_issues'] = $this->has_issues;
+        }
+        if ($this->has_projects !== null) {
+            $properties['has_projects'] = $this->has_projects;
+        }
+        if ($this->has_wiki !== null) {
+            $properties['has_wiki'] = $this->has_wiki;
+        }
+        if ($this->has_pages !== null) {
+            $properties['has_pages'] = $this->has_pages;
+        }
+        if ($this->has_downloads !== null) {
+            $properties['has_downloads'] = $this->has_downloads;
+        }
+        if ($this->archived !== null) {
+            $properties['archived'] = $this->archived;
+        }
+        if ($this->disabled !== null) {
+            $properties['disabled'] = $this->disabled;
+        }
+        if ($this->visibility !== null) {
+            $properties['visibility'] = $this->visibility;
+        }
+        if ($this->pushed_at !== null) {
+            $properties['pushed_at'] = $this->pushed_at;
+        }
+        if ($this->created_at !== null) {
+            $properties['created_at'] = $this->created_at;
+        }
+        if ($this->updated_at !== null) {
+            $properties['updated_at'] = $this->updated_at;
+        }
+        if ($this->permissions !== null) {
+            $properties['permissions'] = $this->permissions;
+        }
+        if ($this->allow_rebase_merge !== null) {
+            $properties['allow_rebase_merge'] = $this->allow_rebase_merge;
+        }
+        if ($this->template_repository !== null) {
+            $properties['template_repository'] = $this->template_repository;
+        }
+        if ($this->temp_clone_token !== null) {
+            $properties['temp_clone_token'] = $this->temp_clone_token;
+        }
+        if ($this->allow_squash_merge !== null) {
+            $properties['allow_squash_merge'] = $this->allow_squash_merge;
+        }
+        if ($this->delete_branch_on_merge !== null) {
+            $properties['delete_branch_on_merge'] = $this->delete_branch_on_merge;
+        }
+        if ($this->allow_merge_commit !== null) {
+            $properties['allow_merge_commit'] = $this->allow_merge_commit;
+        }
+        if ($this->subscribers_count !== null) {
+            $properties['subscribers_count'] = $this->subscribers_count;
+        }
+        if ($this->network_count !== null) {
+            $properties['network_count'] = $this->network_count;
+        }
+        return $properties;
+    }
+}


### PR DESCRIPTION
## Summary

- Under bleeding edge, `TypeCombinator::processArrayTypes` no longer collapses multiple general array members into a single `ArrayType` with unioned keys and values, so `array<int>|array<string>` stays distinct from `array<int|string>` (fixes phpstan/phpstan#8963). Subsumption (`array<int>|array<int|string>` → `array<int|string>`) is handled by the existing outer `union()` loop via `compareTypesInUnion`.
- The `array{} | non-empty-array<X>` → `array<X>` simplification is preserved by falling back to the old collapse path whenever an empty constant array is present — that merge is lossless and not expressible as a keep-separate result.
- Narrowing works out of the box: `is_string($list[0])` on `list<int>|list<string>` narrows to `list<string>` (with `hasOffsetValue(0, string)`).
- 34 existing fixtures updated to reflect the more-precise output. 10 known regressions remain in cases like `array<mixed~'foo'>|non-empty-array<mixed>` where the old collapse was lossless; those need a follow-up heuristic before removing the WIP gate.

**TMP WIP commit (`8c3554c54c`) runs the new path for everyone, not just bleeding edge, so CI exercises it. Revert before merge.**

## Test plan

- [x] `tests/PHPStan/Analyser/nsrt/array-union-keep-separate.php` added — covers the issue repro, subsumption cases, narrowing via offset access, constant + general mixing, iteration
- [x] `NodeScopeResolverTest` green except 10 known Bucket B files
- [x] `LegacyNodeScopeResolverTest`, core `Type` unit tests green
- [ ] `TypeCombinatorTest` has 18 describe-output failures under the WIP (no bleedingEdge); expected, to be re-baselined
- [ ] Address Bucket B collapse (`array<X>|non-empty-array<Y>`) before removing WIP gate

Closes https://github.com/phpstan/phpstan/issues/12195
Closes https://github.com/phpstan/phpstan/issues/13394
Closes https://github.com/phpstan/phpstan/issues/8963
Closes https://github.com/phpstan/phpstan/issues/7759
Closes https://github.com/phpstan/phpstan/issues/11176
Closes https://github.com/phpstan/phpstan/issues/13789
Closes https://github.com/phpstan/phpstan/issues/12434
