### PR TITLE
Fix phpstan/phpstan#12871: Allow readonly property init in child classes on PHP 8.4+

### DIFF
--- a/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
+++ b/src/Rules/Properties/ReadOnlyPropertyAssignRule.php
@@ -9,6 +9,7 @@ use PHPStan\DependencyInjection\RegisteredRule;
 use PHPStan\Node\Expr\SetOffsetValueTypeExpr;
 use PHPStan\Node\Expr\UnsetOffsetExpr;
 use PHPStan\Node\PropertyAssignNode;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
@@ -30,6 +31,7 @@ final class ReadOnlyPropertyAssignRule implements Rule
 	public function __construct(
 		private PropertyReflectionFinder $propertyReflectionFinder,
 		private ConstructorsHelper $constructorsHelper,
+		private PhpVersion $phpVersion,
 	)
 	{
 	}
@@ -77,11 +79,16 @@ final class ReadOnlyPropertyAssignRule implements Rule
 
 			$scopeClassReflection = $scope->getClassReflection();
 			if ($scopeClassReflection->getName() !== $declaringClass->getName()) {
-				$errors[] = RuleErrorBuilder::message(sprintf('Readonly property %s::$%s is assigned outside of its declaring class.', $declaringClass->getDisplayName(), $propertyReflection->getName()))
-					->line($propertyFetch->name->getStartLine())
-					->identifier('property.readOnlyAssignOutOfClass')
-					->build();
-				continue;
+				$allowedInSubclass = $this->phpVersion->supportsAsymmetricVisibility()
+					&& !$propertyReflection->isPrivateSet()
+					&& $scopeClassReflection->isSubclassOfClass($propertyReflection->getDeclaringClass());
+				if (!$allowedInSubclass) {
+					$errors[] = RuleErrorBuilder::message(sprintf('Readonly property %s::$%s is assigned outside of its declaring class.', $declaringClass->getDisplayName(), $propertyReflection->getName()))
+						->line($propertyFetch->name->getStartLine())
+						->identifier('property.readOnlyAssignOutOfClass')
+						->build();
+					continue;
+				}
 			}
 
 			$scopeMethod = $scope->getFunction();

--- a/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Rules\Properties;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\ConstructorsHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
@@ -25,6 +26,7 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 					'ReadonlyPropertyAssign\\TestCase::setUp',
 				],
 			),
+			new PhpVersion(PHP_VERSION_ID),
 		);
 	}
 
@@ -36,25 +38,34 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 				'Readonly property ReadonlyPropertyAssign\Foo::$foo is assigned outside of the constructor.',
 				21,
 			],
-			[
-				'Readonly property ReadonlyPropertyAssign\Foo::$bar is assigned outside of its declaring class.',
-				33,
-			],
-			[
-				'Readonly property ReadonlyPropertyAssign\Foo::$baz is assigned outside of its declaring class.',
-				34,
-			],
-			[
-				'Readonly property ReadonlyPropertyAssign\Foo::$bar is assigned outside of its declaring class.',
-				39,
-			],
 		];
 
 		if (PHP_VERSION_ID < 80400) {
+			// Since PHP 8.4, readonly is implicitly protected(set),
+			// so child classes may initialize the property.
+			$errors[] = [
+				'Readonly property ReadonlyPropertyAssign\Foo::$bar is assigned outside of its declaring class.',
+				33,
+			];
+			$errors[] = [
+				'Readonly property ReadonlyPropertyAssign\Foo::$baz is assigned outside of its declaring class.',
+				34,
+			];
+			$errors[] = [
+				'Readonly property ReadonlyPropertyAssign\Foo::$bar is assigned outside of its declaring class.',
+				39,
+			];
 			// reported by AccessPropertiesInAssignRule on 8.4+
 			$errors[] = [
 				'Readonly property ReadonlyPropertyAssign\Foo::$baz is assigned outside of its declaring class.',
 				46,
+			];
+		} else {
+			// On PHP 8.4+ the assignment is allowed by visibility rules,
+			// but still has to happen in a constructor of the child class.
+			$errors[] = [
+				'Readonly property ReadonlyPropertyAssign\Foo::$bar is assigned outside of the constructor.',
+				39,
 			];
 		}
 
@@ -178,6 +189,19 @@ class ReadOnlyPropertyAssignRuleTest extends RuleTestCase
 	public function testCloneWith(): void
 	{
 		$this->analyse([__DIR__ . '/data/readonly-property-assign-clone-with.php'], []);
+	}
+
+	#[RequiresPhp('>= 8.4.0')]
+	public function testBug12871(): void
+	{
+		// The private(set) assignment in a subclass is reported by AccessPropertiesInAssignRule,
+		// so this rule only reports the write outside of a constructor.
+		$this->analyse([__DIR__ . '/data/bug-12871.php'], [
+			[
+				'Readonly property Bug12871\A::$foo is assigned outside of the constructor.',
+				54,
+			],
+		]);
 	}
 
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-12871.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-12871.php
@@ -1,0 +1,57 @@
+<?php // lint >= 8.4
+
+namespace Bug12871;
+
+abstract readonly class A
+{
+
+	protected string $foo;
+
+	public function __construct()
+	{
+		$this->foo = '';
+	}
+
+}
+
+readonly class B extends A
+{
+
+	public function __construct()
+	{
+		$this->foo = 'foo';
+	}
+
+}
+
+readonly class PrivateSetParent
+{
+
+	public private(set) string $bar;
+
+	public function __construct()
+	{
+		$this->bar = '';
+	}
+
+}
+
+readonly class PrivateSetChild extends PrivateSetParent
+{
+
+	public function __construct()
+	{
+		$this->bar = 'nope'; // report - private(set)
+	}
+
+}
+
+readonly class NonConstructorChild extends A
+{
+
+	public function init(): void
+	{
+		$this->foo = 'nope'; // report - outside constructor
+	}
+
+}


### PR DESCRIPTION
## Summary

Since PHP 8.4, `readonly` properties are implicitly `protected(set)`, so a child class may initialize the parent's readonly property in its own constructor. PHPStan still reported `property.readOnlyAssignOutOfClass` for such assignments.

## Changes

- `src/Rules/Properties/ReadOnlyPropertyAssignRule.php`: allow the "scope != declaring class" case when `PhpVersion::supportsAsymmetricVisibility()` is true, the property is not `private(set)`, and the scope is a subclass of the declaring class. The existing constructor check still applies in the subclass's scope.
- `tests/PHPStan/Rules/Properties/ReadOnlyPropertyAssignRuleTest.php`: inject `PhpVersion`, adjust existing `testRule` expectations for PHP 8.4+ (subclass-constructor writes to `protected`/`public readonly` are no longer reported; subclass non-constructor write now reports "outside of the constructor" instead of "outside of its declaring class").
- Added regression test `testBug12871` with data file `data/bug-12871.php` covering the original snippet plus `private(set)` and non-constructor edge cases.

## Test

`vendor/bin/phpunit tests/PHPStan/Rules/Properties/` — 331 tests pass. Self-analysis `[OK] No errors`.

Fixes phpstan/phpstan#12871