### PR TITLE
Improve inference for truethy comparisons

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -1548,6 +1548,20 @@ final class TypeSpecifier
 			)->setRootExpr($rootExpr));
 		}
 
+		if (
+			$context->true()
+			&& $constantType->toBoolean()->isTrue()->yes()
+			&& ($exprNode instanceof FuncCall || $exprNode instanceof Expr\MethodCall || $exprNode instanceof Expr\StaticCall)
+		) {
+			$types = $this->create($exprNode, $constantType, $context, $scope)->setRootExpr($rootExpr);
+
+			return $types->unionWith($this->specifyTypesInCondition(
+				$scope,
+				$exprNode,
+				TypeSpecifierContext::createTrue(),
+			)->setRootExpr($rootExpr));
+		}
+
 		return null;
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string-str-containing-fns.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string-str-containing-fns.php
@@ -100,7 +100,7 @@ class Foo {
 		assertType('string', $s);
 
 		if (strpos($s, ':') === 5) {
-			assertType('string', $s); // could be non-empty-string
+			assertType('non-empty-string', $s);
 		}
 		assertType('string', $s);
 		if (strpos($s, ':') !== 5) {
@@ -152,7 +152,7 @@ class Foo {
 		assertType('string', $s);
 
 		if (mb_strpos($s, ':') === 5) {
-			assertType('string', $s); // could be non-empty-string
+			assertType('non-falsy-string', $s);
 		}
 		assertType('string', $s);
 		if (mb_strpos($s, ':') !== 5) {

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string-str-containing-fns.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string-str-containing-fns.php
@@ -92,19 +92,72 @@ class Foo {
 
 		if (strpos($s, ':') !== false) {
 			assertType('non-falsy-string', $s);
+		} else {
+			assertType('string', $s);
 		}
 		assertType('string', $s);
 		if (strpos($s, ':') === false) {
+			assertType('string', $s);
+		} else {
+			assertType('non-falsy-string', $s);
+		}
+		assertType('string', $s);
+
+		if (strpos($s, '0') == 0) { // 0|false
+			assertType('string', $s);
+		} else {
+			assertType('string', $s);
+		}
+		assertType('string', $s);
+
+		$oneOrZero = rand(0, 1);
+		if (strpos($s, '0') == $oneOrZero) { // 0|1|false
+			assertType('string', $s);
+		} else {
+			assertType('string', $s);
+		}
+		assertType('string', $s);
+
+		$oneOrZero = rand(0, 1);
+		if (strpos($s, '0') === $oneOrZero) {
+			assertType('string', $s); // could be non-empty-string
+		} else {
+			assertType('string', $s);
+		}
+		assertType('string', $s);
+
+		if (strpos($s, '0') == 1) {
+			assertType('string', $s); // could be non-empty-string
+		} else {
+			assertType('string', $s);
+		}
+		assertType('string', $s);
+
+		if (strpos($s, '0') === 0) {
+			assertType('string', $s); // could be non-empty-string
+		} else {
+			assertType('string', $s);
+		}
+		assertType('string', $s);
+
+		if (strpos($s, '0') === 5) {
+			assertType('non-empty-string', $s); // could be non-falsy-string
+		} else {
 			assertType('string', $s);
 		}
 		assertType('string', $s);
 
 		if (strpos($s, ':') === 5) {
 			assertType('non-falsy-string', $s);
+		} else {
+			assertType('string', $s);
 		}
 		assertType('string', $s);
+
 		if (strpos($s, ':') !== 5) {
 			assertType('string', $s);
+		} else {
+			assertType('non-falsy-string', $s);
 		}
 		assertType('string', $s);
 

--- a/tests/PHPStan/Analyser/nsrt/non-empty-string-str-containing-fns.php
+++ b/tests/PHPStan/Analyser/nsrt/non-empty-string-str-containing-fns.php
@@ -100,7 +100,7 @@ class Foo {
 		assertType('string', $s);
 
 		if (strpos($s, ':') === 5) {
-			assertType('non-empty-string', $s);
+			assertType('non-falsy-string', $s);
 		}
 		assertType('string', $s);
 		if (strpos($s, ':') !== 5) {


### PR DESCRIPTION
Apply truthy narrowing for function calls compared to truthy constants (`TypeSpecifier`)

- When a function/method/static-call result is compared via `===` to a truthy constant (non-false, non-0, non-null, non-''), this implies the function returned non-false, enabling type-specifying extensions to narrow argument types
- Limited to `FuncCall`, `MethodCall`, and `StaticCall` expressions to avoid interfering with other narrowing handlers (e.g., `$object::class === 'Foo'`)
- Before: `strpos($s, ':') === 5` → `$s` stays as `string`
- After: `strpos($s, ':') === 5` → `$s` narrowed to `non-falsy-string` (via StrContainingTypeSpecifyingExtension)
- Same improvement applies to `mb_strpos`, `strrpos`, `stripos`, `strripos`, and their `mb_` variants
 
extracted from https://github.com/phpstan/phpstan-src/pull/5508