### PR TITLE
Fix PHPUnit warnings

### DIFF
--- a/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToMethodStatementWithoutSideEffectsRuleTest.php
@@ -54,7 +54,7 @@ class CallToMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('< 8')]
+	#[RequiresPhp('< 8.0.0')]
 	public function testRulePhp7(): void
 	{
 		$this->analyse([__DIR__ . '/data/method-call-statement-no-side-effects.php'], [

--- a/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/CallToStaticMethodStatementWithoutSideEffectsRuleTest.php
@@ -43,7 +43,7 @@ class CallToStaticMethodStatementWithoutSideEffectsRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('< 8')]
+	#[RequiresPhp('< 8.0.0')]
 	public function testRulePhp7(): void
 	{
 		$this->analyse([__DIR__ . '/data/static-method-call-statement-no-side-effects.php'], [

--- a/tests/PHPStan/Rules/TooWideTypehints/TooWidePropertyTypeRuleTest.php
+++ b/tests/PHPStan/Rules/TooWideTypehints/TooWidePropertyTypeRuleTest.php
@@ -138,7 +138,7 @@ class TooWidePropertyTypeRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-13624.php'], []);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug11844(): void
 	{
 		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-11844.php'], []);

--- a/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
+++ b/tests/PHPStan/Rules/Variables/DefinedVariableRuleTest.php
@@ -1531,7 +1531,7 @@ class DefinedVariableRuleTest extends RuleTestCase
 		]);
 	}
 
-	#[RequiresPhp('>= 8.0')]
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug10729(): void
 	{
 		$this->cliArgumentsVariablesRegistered = true;


### PR DESCRIPTION
```
There were 4 PHPUnit test runner warnings:

1) Incomplete version requirement "8" used by PHPStan\Rules\Methods\CallToMethodStatementWithoutSideEffectsRuleTest::testRulePhp7()

2) Incomplete version requirement "8" used by PHPStan\Rules\Methods\CallToStaticMethodStatementWithoutSideEffectsRuleTest::testRulePhp7()

3) Incomplete version requirement "8.0" used by PHPStan\Rules\TooWideTypehints\TooWidePropertyTypeRuleTest::testBug11844()

4) Incomplete version requirement "8.0" used by PHPStan\Rules\Variables\DefinedVariableRuleTest::testBug10729()
```