### PR TITLE
Merge conditional-expression holders for the same target

### DIFF
--- a/src/Analyser/MutatingScope.php
+++ b/src/Analyser/MutatingScope.php
@@ -3348,7 +3348,18 @@ class MutatingScope implements Scope, NodeCallbackInvoker
 	public function addConditionalExpressions(string $exprString, array $conditionalExpressionHolders): self
 	{
 		$conditionalExpressions = $this->conditionalExpressions;
-		$conditionalExpressions[$exprString] = $conditionalExpressionHolders;
+		// Merge rather than overwrite: multiple independent holders can target the same
+		// expression (e.g. `$xIsA = $x instanceof A && $y instanceof A` stores a holder
+		// for `$x` keyed on `$xIsA`; later `$yIsA = $y instanceof A && $x instanceof A`
+		// stores another holder for the same target `$x` keyed on `$yIsA`). Replacing
+		// the existing entry here would throw away the earlier binding, breaking
+		// narrowing inside later `if ($xIsA) { … }` inside `if ($xIsA || $yIsA)`.
+		// Holder keys (`getKey()`) disambiguate identical entries so we still dedupe.
+		$existing = $conditionalExpressions[$exprString] ?? [];
+		foreach ($conditionalExpressionHolders as $holder) {
+			$existing[$holder->getKey()] = $holder;
+		}
+		$conditionalExpressions[$exprString] = $existing;
 		return $this->scopeFactory->create(
 			$this->context,
 			$this->isDeclareStrictTypes(),

--- a/tests/PHPStan/Analyser/nsrt/bug-12677.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-12677.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bug12677;
+
+use function PHPStan\Testing\assertType;
+
+class Foo
+{
+	public function getBool(): bool
+	{
+		return true;
+	}
+}
+
+function test1(?Foo $foo): void
+{
+	$hasFoo = $foo !== null;
+
+	$bool = $foo?->getBool() ?? false;
+
+	if ($hasFoo) {
+		assertType(Foo::class, $foo);
+	}
+}
+
+function test2(?Foo $foo): void
+{
+	$hasFoo = $foo !== null;
+
+	$bool = $foo !== null ? $foo->getBool() : false;
+
+	if ($hasFoo) {
+		assertType(Foo::class, $foo);
+	}
+}
+
+function test3(?Foo $foo): void
+{
+	$hasFoo = $foo !== null;
+
+	$bool = $hasFoo ? $foo->getBool() : false;
+
+	if ($hasFoo) {
+		assertType(Foo::class, $foo);
+	}
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-7716.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-7716.php
@@ -15,7 +15,7 @@ class HelloWorld
 		$hasBar = isset($array['bar']) && $array['bar'] > 1;
 
 		if ($hasFoo) {
-			assertType('array{foo?: int, bar?: int}', $array);
+			assertType('array{foo: int, bar?: int}', $array);
 			assertType('int<2, max>', $array['foo']);
 			return $array['foo'];
 		}
@@ -44,7 +44,7 @@ class HelloWorld
 		}
 
 		if ($hasBar) {
-			assertType('array{foo?: int, bar?: int}', $array);
+			assertType('array{foo?: int, bar: int}', $array);
 			assertType('int<2, max>', $array['bar']);
 			return $array['bar'];
 		}

--- a/tests/PHPStan/Analyser/nsrt/multi-assign.php
+++ b/tests/PHPStan/Analyser/nsrt/multi-assign.php
@@ -55,12 +55,12 @@ function (bool $b): void {
 function (bool $b): void {
 	$foo = $bar = $baz = $b;
 	if ($bar) {
-		assertType('bool', $b);
+		assertType('true', $b);
 		assertType('bool', $foo);
 		assertType('true', $bar);
 		assertType('bool', $baz);
 	} else {
-		assertType('bool', $b);
+		assertType('false', $b);
 		assertType('bool', $foo);
 		assertType('false', $bar);
 		assertType('bool', $baz);
@@ -70,12 +70,12 @@ function (bool $b): void {
 function (bool $b): void {
 	$foo = $bar = $baz = $b;
 	if ($baz) {
-		assertType('bool', $b);
+		assertType('true', $b);
 		assertType('bool', $foo);
 		assertType('bool', $bar);
 		assertType('true', $baz);
 	} else {
-		assertType('bool', $b);
+		assertType('false', $b);
 		assertType('bool', $foo);
 		assertType('bool', $bar);
 		assertType('false', $baz);

--- a/tests/PHPStan/Analyser/nsrt/or-condition-ternary-narrowing.php
+++ b/tests/PHPStan/Analyser/nsrt/or-condition-ternary-narrowing.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OrConditionTernaryNarrowing;
+
+use function PHPStan\Testing\assertType;
+
+class A {}
+class B {}
+
+/**
+ * Mirrors the shape used in TypeCombinator::intersect() where
+ * `$constArrayIsI` / `$constArrayIsJ` pair up with `$constArray` /
+ * `$otherArray` picked via ternaries inside a nested for-loop over an
+ * `$types` list that gets spliced during iteration.
+ *
+ * @param list<A|B> $types
+ */
+function loopWithTernary(array $types): void
+{
+	$typesCount = count($types);
+	for ($i = 0; $i < $typesCount; $i++) {
+		for ($j = $i + 1; $j < $typesCount; $j++) {
+			$iIsA = $types[$i] instanceof A && ($types[$j] instanceof A || $types[$j] instanceof B);
+			$jIsA = $types[$j] instanceof A && ($types[$i] instanceof A || $types[$i] instanceof B);
+
+			if ($iIsA || $jIsA) {
+				$a = $iIsA ? $types[$i] : $types[$j];
+
+				// `$a` is definitely A: when `$iIsA` holds, the ternary picks
+				// `$types[$i]` which is A; when `$iIsA` is false, the outer
+				// OR forces `$jIsA` so the ternary picks `$types[$j]` which
+				// is A.
+				assertType(A::class, $a);
+			}
+		}
+	}
+}
+
+/**
+ * Same pattern but with plain variables — each `$xIsA`/`$yIsA` records two
+ * narrowings (both `$x` and `$y`). The earlier holder (from the first
+ * assignment) must survive the second assignment so that inside the
+ * outer `if ($xIsA || $yIsA)` the nested `if ($xIsA)` can still fire the
+ * conditional holders attached to `$xIsA`.
+ *
+ * @param A|B $x
+ * @param A|B $y
+ */
+function twoStoredAndNarrowings($x, $y): void
+{
+	$xBothA = $x instanceof A && $y instanceof A;
+	$yBothA = $y instanceof A && $x instanceof A;
+
+	if ($xBothA || $yBothA) {
+		if ($xBothA) {
+			assertType(A::class, $x);
+			assertType(A::class, $y);
+		} else {
+			assertType(A::class, $x);
+			assertType(A::class, $y);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`MutatingScope::addConditionalExpressions` replaced any existing conditional holders for a given target expression with the new ones. When multiple assignments in the same scope produced holders for the same target, the earlier ones were dropped.

Concretely:
```php
\$xIsA = \$x instanceof A && \$y instanceof A;  // stores: \$x when [\$xIsA:true] => A
\$yIsA = \$y instanceof A && \$x instanceof A;  // OVERWROTE \$x's entry with \$yIsA-keyed holder
```

So inside `if (\$xIsA || \$yIsA) { if (\$xIsA) { … } }`, the `\$xIsA`-keyed holder for `\$x` and `\$y` was already gone and the nested `if (\$xIsA)` left `\$x`/`\$y` un-narrowed.

The fix: merge incoming holders with the existing ones in `addConditionalExpressions`, keyed by `\$holder->getKey()` for deduplication.

Same bug had been preventing the `\$constArrayIsI || \$constArrayIsJ` + ternary pattern around `src/Type/TypeCombinator.php:1650` from narrowing — the undefined-method errors PHPStan emitted on `\$constArray` / `\$otherArray` (`isUnsealed`, `getValueTypes`, `getKeyTypes`, `isOptionalKey`, call-into `intersectDefiniteConstantArrays`) are gone after this change.

## Test plan

- [x] New NSRT `or-condition-ternary-narrowing.php` covers both the TypeCombinator shape (nested for-loop + `\$types[\$i]` + `&&`-extended booleans + `if (|| )` + ternary) and a plain-variable reproducer exercising the truthy branch of the nested `if`.
- [x] `bug-7716.php` and `multi-assign.php` expectations updated — both were documenting the previous lost-holder behaviour; now `\$hasFoo = isset(\$array['foo']) && …` correctly marks `foo` required in the truthy branch, and `\$foo = \$bar = \$baz = \$b` aliases all three, so `if (\$bar)` / `if (\$baz)` narrows `\$b`.
- [x] `tests/PHPStan/Analyser/NodeScopeResolverTest.php`: 1543 tests pass; the single remaining failure (`bug-14489.php`) is pre-existing and unrelated.
- [x] `tests/PHPStan/Analyser/` + `tests/PHPStan/Rules/`: goes from 23 → 20 baseline failures. Three tests that were previously failing (from the same lost-holder pattern) now pass; no new regressions.
- [x] `tests/PHPStan/Type/`: no change (15 pre-existing failures unchanged).
- [x] `bin/phpstan analyse src/Type/TypeCombinator.php`: the 1658/1661/1668/1669/1677 cluster of errors on `\$constArray`/`\$otherArray` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes https://github.com/phpstan/phpstan/issues/12677