### PR TITLE
Allow GMP in increment/decrement operations

### DIFF
--- a/src/Rules/Operators/InvalidIncDecOperationRule.php
+++ b/src/Rules/Operators/InvalidIncDecOperationRule.php
@@ -113,7 +113,7 @@ final class InvalidIncDecOperationRule implements Rule
 			$deprecatedString = true;
 		}
 
-		$allowedTypes = [new FloatType(), new IntegerType(), $string, new ObjectType('SimpleXMLElement')];
+		$allowedTypes = [new FloatType(), new IntegerType(), $string, new ObjectType('SimpleXMLElement'), new ObjectType('GMP')];
 		$deprecatedNull = false;
 		if (
 			!$this->phpVersion->deprecatesDecOnNonNumericString()

--- a/tests/PHPStan/Rules/Operators/InvalidIncDecOperationRuleTest.php
+++ b/tests/PHPStan/Rules/Operators/InvalidIncDecOperationRuleTest.php
@@ -249,4 +249,9 @@ class InvalidIncDecOperationRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/inc-dec-bcmath-number.php'], []);
 	}
 
+	public function testGmp(): void
+	{
+		$this->analyse([__DIR__ . '/data/inc-dec-gmp.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Operators/data/inc-dec-gmp.php
+++ b/tests/PHPStan/Rules/Operators/data/inc-dec-gmp.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace IncDecGmp;
+
+use GMP;
+
+function testPreInc(GMP $x): void {
+	++$x;
+}
+
+function testPostInc(GMP $x): void {
+	$x++;
+}
+
+function testPreDec(GMP $x): void {
+	--$x;
+}
+
+function testPostDec(GMP $x): void {
+	$x--;
+}


### PR DESCRIPTION
## Summary

- Add GMP to allowed types in `InvalidIncDecOperationRule`
- GMP supports `++` and `--` via operator overloading (since PHP 5.6)

Relates to phpstan/phpstan#13965 (partially - addresses inc/dec for GMP; unary +/- still need `UnaryOperatorTypeSpecifyingExtension`)

## Test plan

- Added test for GMP increment/decrement operations
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)