### PR TITLE
Fix output in agent tool use

### DIFF
--- a/src/Command/ErrorsConsoleStyle.php
+++ b/src/Command/ErrorsConsoleStyle.php
@@ -4,6 +4,7 @@ namespace PHPStan\Command;
 
 use OndraM\CiDetector\CiDetector;
 use Override;
+use PHPStan\Internal\AgentDetector;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\TableSeparator;
@@ -95,9 +96,10 @@ final class ErrorsConsoleStyle extends SymfonyStyle
 		}
 
 		$ci = $this->isCiDetected();
-		$this->progressBar->setOverwrite(!$ci);
+		$agent = AgentDetector::isRunningInAgent();
+		$this->progressBar->setOverwrite(!$ci && !$agent);
 
-		if ($ci) {
+		if ($ci || $agent) {
 			$this->progressBar->minSecondsBetweenRedraws(15);
 			$this->progressBar->maxSecondsBetweenRedraws(30);
 		} elseif (DIRECTORY_SEPARATOR === '\\') {

--- a/tests/PHPStan/Command/ErrorsConsoleStyleTest.php
+++ b/tests/PHPStan/Command/ErrorsConsoleStyleTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command;
+
+use Override;
+use PHPStan\Internal\AgentDetector;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\StreamOutput;
+use function fclose;
+use function fopen;
+use function getenv;
+use function putenv;
+use function rewind;
+use function rtrim;
+use function str_replace;
+use function stream_get_contents;
+
+class ErrorsConsoleStyleTest extends TestCase
+{
+
+	/** @var array<string, string|false> */
+	private array $originalEnvVars = [];
+
+	#[Override]
+	protected function setUp(): void
+	{
+		foreach ([...AgentDetector::ENV_VARS, 'GITHUB_ACTIONS'] as $var) {
+			$this->originalEnvVars[$var] = getenv($var);
+			putenv($var);
+		}
+	}
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		foreach ($this->originalEnvVars as $var => $value) {
+			putenv($var . ($value !== false ? '=' . $value : ''));
+		}
+	}
+
+	public function testProgressOutputInAgentDoesNotOverwrite(): void
+	{
+		$agentOutput = $this->renderProgressOutput(true);
+		$regularOutput = $this->renderProgressOutput(false);
+
+		self::assertSame(
+			rtrim(<<<'EOT'
+				 0/2 [>---------------------------]   0%
+				 2/2 [============================] 100%
+				EOT),
+			$agentOutput,
+		);
+		self::assertSame(
+			" 0/2 [>---------------------------]   0%\033[1G\033[2K 2/2 [============================] 100%",
+			$regularOutput,
+		);
+	}
+
+	private function renderProgressOutput(bool $isAgent): string
+	{
+		if ($isAgent) {
+			putenv('AI_AGENT=1');
+		} else {
+			putenv('AI_AGENT');
+		}
+
+		$stream = fopen('php://memory', 'w+');
+		self::assertNotFalse($stream);
+
+		$output = new StreamOutput($stream, StreamOutput::VERBOSITY_NORMAL, true);
+		$errorStyle = new ErrorsConsoleStyle(new StringInput(''), $output);
+
+		$progressBar = $errorStyle->createProgressBar(2);
+		$progressBar->setBarCharacter('=');
+		$progressBar->setEmptyBarCharacter('-');
+		$progressBar->setProgressCharacter('>');
+		$progressBar->setProgress(0);
+		$progressBar->display();
+		$progressBar->setProgress(2);
+		$progressBar->display();
+
+		rewind($stream);
+		$contents = stream_get_contents($stream);
+		fclose($stream);
+
+		self::assertIsString($contents);
+
+		return str_replace(["\r\n", "\r"], "\n", $contents);
+	}
+
+}


### PR DESCRIPTION
In agent tool uses, I just noticed that output tries to overwrite the progress bar but it's not possible in the terminal used by the agent.

```
Note: Using configuration file /Users/paul/Workspace/CodeIgniter4/phpstan.neon.
   0/946 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   0% < 1 sec[1G[2K  20/946 [░░░░░░░░░░░░░░░░░░░░░░░░░░░░]   2% 2 secs[1G[2K  40/946 [▓░░░░░░░░░░░░░░░░░░░░░░░░░░░]   4% 3 secs[1G[2K  80/946 [▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░]   8% 5 secs[1G[2K 140/946 [▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░]  14% 6 secs[1G[2K 200/946 [▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░]  21% 7 secs[1G[2K 260/946 [▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░]  27% 8 secs[1G[2K 300/946 [▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░]  31% 9 secs[1G[2K 340/946 [▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░]  35% 10 secs[1G[2K 380/946 [▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░]  40% 10 secs[1G[2K 420/946 [▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░]  44% 11 secs[1G[2K 480/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  50% 11 secs[1G[2K 500/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░]  52% 12 secs[1G[2K 560/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░░░]  59% 13 secs[1G[2K 620/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░]  65% 14 secs[1G[2K 640/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░]  67% 15 secs[1G[2K 680/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░]  71% 17 secs[1G[2K 720/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░]  76% 17 secs[1G[2K 760/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░]  80% 18 secs[1G[2K 800/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░]  84% 20 secs[1G[2K 840/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░]  88% 21 secs[1G[2K 860/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░]  90% 21 secs[1G[2K 946/946 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 21 secs


[30;42m                                                                                [39;49m
[30;42m [OK] No errors                                                                 [39;49m
[30;42m                                                                                [39;49m

Elapsed time: 23.12 seconds
Used memory: 2.58 GB
```

This change is purely cosmetic for agents just to be consistent with CI environments.