### PR TITLE
Update phpstorm stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,6 +130,7 @@
 			],
 			"jetbrains/phpstorm-stubs": [
 				"patches/PDO.patch",
+				"patches/ReflectionClass.patch",
 				"patches/ReflectionProperty.patch",
 				"patches/SessionHandler.patch",
 				"patches/xmlreader.patch",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"hoa/compiler": "3.17.08.08",
 		"hoa/exception": "^1.0",
 		"hoa/file": "1.17.07.11",
-		"jetbrains/phpstorm-stubs": "dev-master#5f24d7aef6ada9de9a894ce899345b3054d6c639",
+		"jetbrains/phpstorm-stubs": "dev-master#59e06fde7aaeddf92b0b38da6d1c51ee03b18fb3",
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.1.4",
 		"nette/neon": "3.3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58fc43f852fa229903e298663a220281",
+    "content-hash": "15ae348844ba6ca6313df9aa3465de7e",
     "packages": [
         {
             "name": "clue/ndjson-react",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea8405e631700cf88d7327911ea0f9d2",
+    "content-hash": "58fc43f852fa229903e298663a220281",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -1632,12 +1632,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/JetBrains/phpstorm-stubs",
-                "reference": "5f24d7aef6ada9de9a894ce899345b3054d6c639"
+                "reference": "59e06fde7aaeddf92b0b38da6d1c51ee03b18fb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/5f24d7aef6ada9de9a894ce899345b3054d6c639",
-                "reference": "5f24d7aef6ada9de9a894ce899345b3054d6c639",
+                "url": "https://api.github.com/repos/JetBrains/phpstorm-stubs/zipball/59e06fde7aaeddf92b0b38da6d1c51ee03b18fb3",
+                "reference": "59e06fde7aaeddf92b0b38da6d1c51ee03b18fb3",
                 "shasum": ""
             },
             "require-dev": {
@@ -1669,7 +1669,7 @@
                 "stubs",
                 "type"
             ],
-            "time": "2026-04-02T11:15:54+00:00"
+            "time": "2026-04-17T08:49:15+00:00"
         },
         {
             "name": "nette/bootstrap",

--- a/patches/PDO.patch
+++ b/patches/PDO.patch
@@ -1,9 +1,10 @@
 --- PDO/PDO.php	2021-12-26 15:44:39.000000000 +0100
 +++ PDO/PDO.php	2022-01-03 22:54:21.000000000 +0100
-@@ -1476,7 +1476,7 @@ namespace {
+@@ -1610,7 +1610,7 @@ namespace {
           * @return array|false if one or more notifications is pending, returns a single row,
           * with fields message and pid, otherwise <b>FALSE</b>.
           */
+         #[Deprecated('use Pdo\Pgsql::getNotify instead', '\Pdo\Pgsql::getNotify(%parametersList%)', since: '8.5')]
 -        public function pgsqlGetNotify($fetchMode = PDO::FETCH_DEFAULT, $timeoutMilliseconds = 0) {}
 +        public function pgsqlGetNotify($fetchMode = 1, $timeoutMilliseconds = 0) {}
 

--- a/patches/ReflectionClass.patch
+++ b/patches/ReflectionClass.patch
@@ -1,0 +1,20 @@
+--- Reflection/ReflectionClass.php	2026-04-24 11:57:10
++++ Reflection/ReflectionClass.php	2026-04-25 21:47:47
+@@ -305,7 +305,7 @@
+      *
+      * @link https://php.net/manual/en/reflectionclass.getconstants.php
+      * @param int|null $filter [optional] allows the filtering of constants defined in a class by their visibility. Since 8.0.
+-     * @return array<string, scalar|array<scalar>> An array of constants, where the keys hold the name and
++     * @return array<string, mixed> An array of constants, where the keys hold the name and
+      * the values the value of the constants.
+      */
+     #[Pure]
+@@ -317,7 +317,7 @@
+      *
+      * @link https://php.net/manual/en/reflectionclass.getconstant.php
+      * @param string $name Name of the constant.
+-     * @return scalar|array<scalar> Value of the constant with the name name.
++     * @return mixed Value of the constant with the name name.
+      * Returns {@see false} if the constant was not found in the class.
+      */
+     #[Pure]


### PR DESCRIPTION
Once https://github.com/JetBrains/phpstorm-stubs/pull/1879 is merged we will be able to delete the patch added