### PR TITLE
Track $arr[$key] existence across array_key_first/last + !== null

### DIFF
--- a/src/Analyser/TypeSpecifier.php
+++ b/src/Analyser/TypeSpecifier.php
@@ -847,6 +847,31 @@ final class TypeSpecifier
 						$specifiedTypes = $specifiedTypes->unionWith(
 							$this->create($dimFetch, $arrayType->getIterableValueType(), TypeSpecifierContext::createTrue(), $scope),
 						);
+					} elseif ($expr->var instanceof Expr\Variable && is_string($expr->var->name)) {
+						// The array might be empty here, so we cannot register
+						// $arr[$key] unconditionally. Attach a conditional holder
+						// that fires once the user narrows $key to non-null
+						// (e.g. `if ($key !== null)`), giving the deep-write
+						// path the same shape information `isset($arr[$key])`
+						// would have provided.
+						$keyType = $scope->getType($expr->expr);
+						$nonNullKeyType = TypeCombinator::removeNull($keyType);
+						if (!$nonNullKeyType instanceof NeverType && !$keyType->isNull()->yes()) {
+							$dimFetch = new ArrayDimFetch($arrayArg, $expr->var);
+							$dimFetchString = $this->exprPrinter->printExpr($dimFetch);
+							$keyExprString = $this->exprPrinter->printExpr($expr->var);
+
+							$holder = new ConditionalExpressionHolder(
+								[$keyExprString => ExpressionTypeHolder::createYes($expr->var, $nonNullKeyType)],
+								ExpressionTypeHolder::createYes($dimFetch, $arrayType->getIterableValueType()),
+							);
+
+							$specifiedTypes = $specifiedTypes->unionWith(
+								(new SpecifiedTypes([], []))->setNewConditionalExpressionHolders([
+									$dimFetchString => [$holder->getKey() => $holder],
+								]),
+							);
+						}
 					}
 				}
 			}

--- a/src/Parser/RichParser.php
+++ b/src/Parser/RichParser.php
@@ -361,7 +361,6 @@ final class RichParser implements Parser
 			throw new IgnoreParseException('Missing identifier', 1);
 		}
 
-		/** @phpstan-ignore return.type (return type is correct, not sure why it's being changed from array shape to key-value shape) */
 		return $identifiers;
 	}
 

--- a/tests/PHPStan/Analyser/nsrt/array-key-last-existing.php
+++ b/tests/PHPStan/Analyser/nsrt/array-key-last-existing.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace ArrayKeyLastExisting;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Mirrors the RichParser pattern: the array starts empty, gets entries
+ * appended in some loop branches, and an existing entry's nested key is
+ * updated in others. `if ($key !== null)` should be enough to let PHPStan
+ * track that `$arr[$key]` exists and the deep write should preserve the
+ * outer shape, just like `isset($arr[$key])` does.
+ */
+function appendThenUpdateLast(string $name, string $comment): void
+{
+	$identifiers = [];
+	$c = rand(100, 200);
+	for ($i = 0; $i < $c; $i++) {
+		if (rand(0, 1) === 1) {
+			$key = array_key_last($identifiers);
+			if ($key !== null) {
+				$identifiers[$key]['comment'] = $comment;
+			}
+			continue;
+		}
+
+		$identifiers[] = ['name' => $name, 'comment' => null];
+	}
+
+	assertType('list<array{name: string, comment: string|null}>', $identifiers);
+}
+
+function appendThenUpdateFirst(string $name, string $comment): void
+{
+	$identifiers = [];
+	$c = rand(100, 200);
+	for ($i = 0; $i < $c; $i++) {
+		if (rand(0, 1) === 1) {
+			$key = array_key_first($identifiers);
+			if ($key !== null) {
+				$identifiers[$key]['comment'] = $comment;
+			}
+			continue;
+		}
+
+		$identifiers[] = ['name' => $name, 'comment' => null];
+	}
+
+	assertType('list<array{name: string, comment: string|null}>', $identifiers);
+}
+
+/**
+ * @param list<array{name: 'x', comment: null}> $list
+ */
+function maybeEmptyArray(array $list): void
+{
+	$key = array_key_last($list);
+	if ($key !== null) {
+		assertType('array{name: \'x\', comment: null}', $list[$key]);
+		$list[$key]['comment'] = 'hello';
+		assertType('non-empty-list<array{name: \'x\', comment: \'hello\'}>', $list);
+	}
+}


### PR DESCRIPTION
## Summary

- Attaches a conditional holder when `$key = array_key_first/last($arr)` runs against a possibly-empty array, so `if ($key !== null)` lands `$arr[$key]` back in scope (matching what `isset($arr[$key])` already does).
- Lets `AssignHandler`'s precise `setExistingOffsetValueType` path fire on deep writes like `$arr[$key]['comment'] = $val`, so untouched inner keys stay required instead of being generalised to optional.
- Drops the `@phpstan-ignore return.type` workaround in `RichParser::parseIdentifiers()` that this exact pattern needed.

## Test plan

- [x] `make phpstan` (was reporting `Sealed array shape can only accept a constant array` on `RichParser::parseIdentifiers()`'s return; now clean)
- [x] `make tests` (no new failures vs `2.1.x`)
- [x] `make cs`
- [x] New regression nsrt: `tests/PHPStan/Analyser/nsrt/array-key-last-existing.php`
- [x] User-supplied reproduction from `test.php` now returns the expected shape on the `if (\$key !== null)` form

🤖 Generated with [Claude Code](https://claude.com/claude-code)