### PR TITLE
Eliminate the parallelization overhead when not needed

### DIFF
--- a/e2e/bug-11826/phpstan.neon.dist
+++ b/e2e/bug-11826/phpstan.neon.dist
@@ -4,5 +4,10 @@ parameters:
         - src
         - rules
 
+    # force the use of parallel processing
+    parallel:
+        jobSize: 1
+        minimumNumberOfJobsPerProcess: 1
+
 rules:
     - Rules\DummyRule

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -80,7 +80,7 @@ final class AnalyserRunner
 				$mainScript = $_SERVER['argv'][0];
 			}
 
-			if ($mainScript !== null && $schedule->getNumberOfProcesses() > 0) {
+			if ($mainScript !== null && $schedule->getNumberOfProcesses() > 1) {
 				$loop = new StreamSelectLoop();
 				$result = null;
 				$promise = $this->parallelAnalyser->analyse($loop, $schedule, $mainScript, $postFileCallback, $projectConfigFile, $tmpFile, $insteadOfFile, $input, null);


### PR DESCRIPTION
The main target of this optimization is partial analysis run with a small number of files.

In my test runs with single file analyzed, it cuts down the total time almost in half (8.9 s -> 5.0 s).

Note this actually reverts commit 21590573d4cf113d13b8ea0518ebd06eeee9a98e (Run the parallel worker even for a low number of files) - I am not sure, what the motivation has been then.
