### PR TITLE
Fix phpstan/phpstan#14467: dynamic throw extensions on union types

### DIFF
--- a/src/Analyser/ExprHandler/Helper/MethodThrowPointHelper.php
+++ b/src/Analyser/ExprHandler/Helper/MethodThrowPointHelper.php
@@ -11,11 +11,14 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Reflection\Type\UnionTypeMethodReflection;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\TypeCombinator;
 use ReflectionFunction;
 use ReflectionMethod;
 use Throwable;
+use function count;
 use function in_array;
 
 #[AutowiredService]
@@ -37,6 +40,42 @@ final class MethodThrowPointHelper
 		MutatingScope $scope,
 	): ?InternalThrowPoint
 	{
+		if ($methodReflection instanceof UnionTypeMethodReflection) {
+			$throwPoints = [];
+			foreach ($methodReflection->getMethods() as $innerMethodReflection) {
+				$throwPoint = $this->getThrowPoint($innerMethodReflection, $parametersAcceptor, $normalizedMethodCall, $scope);
+				if ($throwPoint === null) {
+					continue;
+				}
+
+				$throwPoints[] = $throwPoint;
+			}
+
+			if (count($throwPoints) === 0) {
+				return null;
+			}
+
+			$throwTypes = [];
+			$canContainAnyThrowable = false;
+			$isExplicit = false;
+			foreach ($throwPoints as $throwPoint) {
+				$throwTypes[] = $throwPoint->getType();
+				if ($throwPoint->canContainAnyThrowable()) {
+					$canContainAnyThrowable = true;
+				}
+				if (!$throwPoint->isExplicit()) {
+					continue;
+				}
+				$isExplicit = true;
+			}
+
+			if (!$isExplicit) {
+				return InternalThrowPoint::createImplicit($scope, $normalizedMethodCall);
+			}
+
+			return InternalThrowPoint::createExplicit($scope, TypeCombinator::union(...$throwTypes), $normalizedMethodCall, $canContainAnyThrowable);
+		}
+
 		if ($normalizedMethodCall instanceof MethodCall) {
 			foreach ($this->dynamicThrowTypeExtensionProvider->getDynamicMethodThrowTypeExtensions() as $extension) {
 				if (!$extension->isMethodSupported($methodReflection)) {

--- a/src/Reflection/Type/UnionTypeMethodReflection.php
+++ b/src/Reflection/Type/UnionTypeMethodReflection.php
@@ -34,6 +34,14 @@ final class UnionTypeMethodReflection implements ExtendedMethodReflection
 		return $this->methods[0]->getDeclaringClass();
 	}
 
+	/**
+	 * @return ExtendedMethodReflection[]
+	 */
+	public function getMethods(): array
+	{
+		return $this->methods;
+	}
+
 	public function isStatic(): bool
 	{
 		foreach ($this->methods as $method) {

--- a/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
+++ b/tests/PHPStan/Rules/Exceptions/CatchWithUnthrownExceptionRuleTest.php
@@ -748,6 +748,12 @@ class CatchWithUnthrownExceptionRuleTest extends RuleTestCase
 		]);
 	}
 
+	#[RequiresPhp('>= 8.3.0')]
+	public function testBug14467(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14467.php'], []);
+	}
+
 	public function testBug5952(): void
 	{
 		$this->analyse([__DIR__ . '/data/bug-5952.php'], [

--- a/tests/PHPStan/Rules/Exceptions/data/bug-14467.php
+++ b/tests/PHPStan/Rules/Exceptions/data/bug-14467.php
@@ -1,0 +1,38 @@
+<?php // lint >= 8.3
+
+// FQN must sort after \DateTime so methods[0] resolves to DateTime.
+namespace TestBug14467;
+
+class Foo
+{
+
+	/** @throws \DateMalformedStringException */
+	public function modify(string $s): self
+	{
+		return $this;
+	}
+
+}
+
+class Bar
+{
+
+	/** @param \DateTime|Foo $obj */
+	public function caseDateTimeFirst($obj): void
+	{
+		try {
+			$obj->modify('+1 day');
+		} catch (\DateMalformedStringException $e) {
+		}
+	}
+
+	/** @param Foo|\DateTime $obj */
+	public function caseFooFirst($obj): void
+	{
+		try {
+			$obj->modify('+1 day');
+		} catch (\DateMalformedStringException $e) {
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary
Dynamic throw type extensions only fire on the first union member when the receiver is a union, so dead-catch detection on `Foo|DateTime` misses throws declared on either side.

### Root cause
`MethodThrowPointHelper::getThrowPoint` passes the `UnionTypeMethodReflection` straight to each extension's `isMethodSupported`. The reflection forwards `getDeclaringClass()` to `methods[0]`, so any extension that branches on the declaring class only sees the first inner method.

### Fix
Special-case `UnionTypeMethodReflection` in the helper. Iterate inner methods, recurse, and union the resulting throw types via `TypeCombinator::union`. The combined point is explicit if any inner point was; otherwise implicit.

### Test
Regression fixture at `tests/PHPStan/Rules/Exceptions/data/bug-14467.php`. The user-defined class FQN must sort after `\DateTime` so `methods[0]` exposes the bug at the rule level.

Closes https://github.com/phpstan/phpstan/issues/14467
