### PR TITLE
Preserve TemplateArrayType across offset writes and traversal

### DIFF
--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -70,6 +70,17 @@ class ArrayType implements Type
 		return $this->itemType;
 	}
 
+	/**
+	 * Build a same-kind array with new key/item types. Subclasses
+	 * (e.g. {@see TemplateArrayType}) override this to preserve their
+	 * extra metadata across array-mutating operations such as offset
+	 * writes and unsets.
+	 */
+	protected function withTypes(Type $keyType, Type $itemType): self
+	{
+		return new self($keyType, $itemType);
+	}
+
 	public function getReferencedClasses(): array
 	{
 		return array_merge(
@@ -354,7 +365,7 @@ class ArrayType implements Type
 			}
 
 			return new IntersectionType([
-				new self(
+				$this->withTypes(
 					TypeCombinator::union($this->keyType, $offsetType),
 					TypeCombinator::union($this->itemType, $valueType),
 				),
@@ -364,7 +375,7 @@ class ArrayType implements Type
 		}
 
 		return new IntersectionType([
-			new self(
+			$this->withTypes(
 				TypeCombinator::union($this->keyType, $offsetType),
 				$unionValues ? TypeCombinator::union($this->itemType, $valueType) : $valueType,
 			),
@@ -621,7 +632,7 @@ class ArrayType implements Type
 				return new ConstantArrayType([], []);
 			}
 
-			return new self($keyType, $itemType);
+			return $this->withTypes($keyType, $itemType);
 		}
 
 		return $this;
@@ -664,7 +675,7 @@ class ArrayType implements Type
 				return new ConstantArrayType([], []);
 			}
 
-			return new self($keyType, $itemType);
+			return $this->withTypes($keyType, $itemType);
 		}
 
 		return $this;

--- a/src/Type/Generic/TemplateArrayType.php
+++ b/src/Type/Generic/TemplateArrayType.php
@@ -35,4 +35,16 @@ final class TemplateArrayType extends ArrayType implements TemplateType
 		$this->default = $default;
 	}
 
+	protected function withTypes(Type $keyType, Type $itemType): ArrayType
+	{
+		return new self(
+			$this->scope,
+			$this->strategy,
+			$this->variance,
+			$this->name,
+			new ArrayType($keyType, $itemType),
+			$this->default,
+		);
+	}
+
 }

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -41,6 +41,7 @@ use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Enum\EnumCaseObjectType;
+use PHPStan\Type\Generic\TemplateArrayType;
 use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeMap;
 use PHPStan\Type\Generic\TemplateTypeVariance;
@@ -398,6 +399,21 @@ class IntersectionType implements CompoundType
 		$isList = $this->isList()->yes();
 		$isArray = $this->isArray()->yes();
 		$isNonEmptyArray = $this->isIterableAtLeastOnce()->yes();
+		// When a TemplateArrayType carries the array refinement, we describe
+		// it via its own describe() (e.g. "T of array") rather than collapsing
+		// it into a generic `array<...>` prefix. In that case the
+		// `NonEmptyArrayType` and `AccessoryArrayListType` markers must
+		// describe themselves explicitly — they cannot be absorbed into a
+		// non-existent `non-empty-array` prefix.
+		$hasTemplateArray = false;
+		if ($isArray || $isList) {
+			foreach ($this->types as $type) {
+				if ($type instanceof TemplateArrayType) {
+					$hasTemplateArray = true;
+					break;
+				}
+			}
+		}
 		$describedTypes = [];
 		foreach ($this->getSortedTypes() as $i => $type) {
 			if ($type instanceof AccessoryNonEmptyStringType
@@ -436,6 +452,14 @@ class IntersectionType implements CompoundType
 				continue;
 			}
 			if ($isList || $isArray) {
+				if ($type instanceof TemplateArrayType) {
+					// Preserve the template's own describe (e.g. "T of array")
+					// instead of collapsing it to a generic array shape — the
+					// other intersection members already carry the array
+					// refinement.
+					$describedTypes[$i] = $type->describe($level);
+					continue;
+				}
 				if ($type instanceof ArrayType) {
 					$keyType = $type->getKeyType();
 					$valueType = $type->getItemType();
@@ -473,6 +497,9 @@ class IntersectionType implements CompoundType
 					continue;
 				}
 				if ($type instanceof NonEmptyArrayType || $type instanceof AccessoryArrayListType) {
+					if ($hasTemplateArray) {
+						$describedTypes[$i] = $type->describe($level);
+					}
 					continue;
 				}
 			}

--- a/tests/PHPStan/Rules/Functions/data/bug-3931.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-3931.php
@@ -11,7 +11,7 @@ use function PHPStan\Testing\assertType;
  */
 function addSomeKey(array $arr, int $value): array {
 	$arr['mykey'] = $value;
-	assertType("non-empty-array&hasOffsetValue('mykey', int)", $arr); // should preserve T
+	assertType("T of array (function Bug3931\\addSomeKey(), argument)&hasOffsetValue('mykey', int)&non-empty-array", $arr);
 	return $arr;
 }
 

--- a/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
+++ b/tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php
@@ -1066,4 +1066,9 @@ class TypesAssignedToPropertiesRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/../Methods/data/bug-10924.php'], []);
 	}
 
+	public function testBug10749(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-10749.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Properties/data/bug-10749.php
+++ b/tests/PHPStan/Rules/Properties/data/bug-10749.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace Bug10749;
+
+use ArrayAccess;
+
+/**
+ * @template T of array<string, mixed>
+ * @implements ArrayAccess<key-of<T>, value-of<T>>
+ */
+abstract class Base implements ArrayAccess
+{
+
+	/** @var T */
+	protected array $data = [];
+
+	/**
+	 * @template K of key-of<T>
+	 * @param K|null $offset
+	 * @param T[K] $value
+	 */
+	public function offsetSet($offset, $value): void
+	{
+		$this->data[$offset] = $value;
+	}
+
+}


### PR DESCRIPTION
## Summary

`ArrayType::setOffsetValueType`, `traverse`, and `traverseSimultaneously` built the result via `new self(...)`, which always produces a plain `ArrayType` even when called on a `TemplateArrayType`. The template wrapping was dropped — `$arr['mykey'] = $value` on a `T of array` parameter returned `non-empty-array & hasOffsetValue('mykey', int)`, losing the T part (see bug-3931 and bug-10749).

- Add a protected `ArrayType::withTypes(Type, Type): self` factory that subclasses override. Mirrors the existing `recreate()` pattern in `ConstantArrayType` / `TemplateConstantArrayType` and `GenericObjectType` / `TemplateGenericObjectType`. Different name to avoid confusion with `ConstantArrayType::recreate`.
- Route the relevant `new self(...)` sites in `ArrayType` through `$this->withTypes(...)` and override on `TemplateArrayType` to rebuild the template wrapper around the new bound.
- Limit the change to operations that don't break T's contract: `setOffsetValueType` adds/updates a key (the user can express the augmentation with `@return T & array{...}`); `traverse` and `traverseSimultaneously` are pure type rewrites. `unsetOffset`, `setExistingOffsetValueType`, and `generalizeValues` keep their plain `new self(...)` — they can break a more specific T's contract, and the existing return-type diagnostic (bug-6568) relies on the widening.
- Fix `IntersectionType::describeItself` to preserve a `TemplateArrayType`'s own describe ("T of array") instead of collapsing it into a generic `non-empty-array<...>` prefix; emit `non-empty-array` / `list` separately when the template carries the array refinement.
- Update the bug-3931 fixture to assert the new (correct) inferred type.
- Add regression test for #10749 in `TypesAssignedToPropertiesRuleTest`.

Closes https://github.com/phpstan/phpstan/issues/10749

## Test plan

- [x] `make phpstan`
- [x] `vendor/bin/phpunit tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php --filter testBug3931`
- [x] `vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php --filter bug-3931`
- [x] `vendor/bin/phpunit tests/PHPStan/Rules/Functions/ReturnTypeRuleTest.php --filter testBug6568` (still detects the contract-break warning)
- [x] `vendor/bin/phpunit tests/PHPStan/Rules/Properties/TypesAssignedToPropertiesRuleTest.php --filter testBug10749` (fails when the fix is reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)