### PR TITLE
Process unrolled foreach iteration body in original context

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -3986,7 +3986,7 @@ class NodeScopeResolver
 					$iterScope,
 					$iterStorage,
 					new NoopNodeCallback(),
-					$context->enterDeep(),
+					$context,
 				)->filterOutLoopExitPoints();
 
 				$iterEndScope = $bodyResult->getScope();

--- a/tests/PHPStan/Analyser/nsrt/bug-14489.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14489.php
@@ -23,7 +23,7 @@ function () {
 	}
 
 	$values = array_values($cData);
-	assertType('list{0?: array{1}|array{4}, 1?: array{1}|array{4}}', $values);
+	assertType('array{array{1}, array{4}}', $values);
 };
 
 function () {

--- a/tests/PHPStan/Analyser/nsrt/bug-14543.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14543.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Bug14543;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @return non-empty-list<int>
+ */
+function getItems(): array
+{
+	return [1, 2, 3];
+}
+
+$result = [];
+
+foreach (['a', 'b'] as $key) {
+	foreach (getItems() as $i) {
+		$result[] = $i;
+	}
+}
+
+
+assertType('non-empty-list<int>', $result);

--- a/tests/PHPStan/Analyser/nsrt/bug-9332.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-9332.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Bug9332;
+
+use function PHPStan\Testing\assertType;
+
+class HelloWorld
+{
+	public function sayHello(): void
+	{
+		$data = ['a' => 'asdfghi'];
+		foreach (['b', 'c'] as $x) {
+			foreach (['d', 'e'] as $y) {
+				$data[$x . $y] = mt_rand(1, 1000);
+			}
+		}
+
+		assertType("array{a: 'asdfghi', bd: int<1, 1000>, be: int<1, 1000>, cd: int<1, 1000>, ce: int<1, 1000>}", $data);
+		$this->doSomething($data);
+	}
+
+	/**
+	 * @param array{a: string, bd: int, be: int, cd: int, ce: int} $a
+	 */
+	private function doSomething(array $a): void
+	{
+
+	}
+}


### PR DESCRIPTION
## Summary

- The unrolled-constant-array foreach path was processing each iteration's body with `$context->enterDeep()`, which suppresses `LOOP_SCOPE_ITERATIONS` stabilization in nested loops. Because unrolling visits each element exactly once (no outer iteration to converge accumulators), nested loops inside the body produced single-element constant arrays instead of stabilized list/non-empty-list types.
- Fixed by passing the original `$context` to `processStmtNodesInternal`, so nested loops inside an unrolled iteration's body can stabilize on their own (the non-unrolled path still uses `enterDeep` because the outer 3-iteration loop is what makes accumulators converge there).
- Added regression tests `bug-14543.php` and `bug-9332.php` for the reported cases.
- Updated `bug-14489.php` expectation to the more precise `array{array{1}, array{4}}` since the inner foreach over a fully-known constant array now also unrolls and produces precise sequential types (verified to match runtime output via `php -r`).

## Test plan

- [x] `vendor/bin/phpunit tests/PHPStan/Analyser/NodeScopeResolverTest.php` — 1557 tests, 0 failures
- [x] New regression tests pass with the fix and fail without it
- [x] Manual reproduction from the bug reports now reports the precise types

Closes https://github.com/phpstan/phpstan/issues/9332
Closes https://github.com/phpstan/phpstan/issues/14543

🤖 Generated with [Claude Code](https://claude.com/claude-code)