### PR TITLE
Don't report "no value type specified in iterable type array&callable"

### DIFF
--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -73,8 +73,22 @@ final class MissingTypehintCheck
 			if ($type instanceof AccessoryType) {
 				return $type;
 			}
-			if ($type->isCallable()->yes() && $type->isArray()->yes()) {
-				return $type;
+			if (
+				$type instanceof IntersectionType
+				&& $type->isCallable()->yes()
+				&& $type->isArray()->yes()
+			) {
+				$nonArrayInner = [];
+				foreach ($type->getTypes() as $innerType) {
+					if ($innerType->isArray()->yes()) {
+						continue;
+					}
+					$nonArrayInner[] = $innerType;
+				}
+				if (count($nonArrayInner) === 1) {
+					return $traverse($nonArrayInner[0]);
+				}
+				return $traverse(new IntersectionType($nonArrayInner));
 			}
 			if ($type instanceof ConditionalType || $type instanceof ConditionalTypeForParameter) {
 				$iterablesWithMissingValueTypehint = array_merge(

--- a/src/Rules/MissingTypehintCheck.php
+++ b/src/Rules/MissingTypehintCheck.php
@@ -73,6 +73,9 @@ final class MissingTypehintCheck
 			if ($type instanceof AccessoryType) {
 				return $type;
 			}
+			if ($type->isCallable()->yes() && $type->isArray()->yes()) {
+				return $type;
+			}
 			if ($type instanceof ConditionalType || $type instanceof ConditionalTypeForParameter) {
 				$iterablesWithMissingValueTypehint = array_merge(
 					$iterablesWithMissingValueTypehint,

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -973,9 +973,7 @@ class IntersectionType implements CompoundType
 			}
 		}
 
-		$result = $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->hasOffsetValueType($offsetType));
-
-		if (!$result->yes() && $this->isCallable()->yes() && $this->isArray()->yes()) {
+		if ($this->isCallable()->yes() && $this->isArray()->yes()) {
 			$arrayKeyOffsetType = $offsetType->toArrayKey();
 			$callableArrayOffsetType = new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(1)]);
 			if ($callableArrayOffsetType->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
@@ -983,7 +981,7 @@ class IntersectionType implements CompoundType
 			}
 		}
 
-		return $result;
+		return $this->intersectResults(static fn (Type $type): TrinaryLogic => $type->hasOffsetValueType($offsetType));
 	}
 
 	public function getOffsetValueType(Type $offsetType): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -800,10 +800,11 @@ class IntersectionType implements CompoundType
 
 	public function getIterableValueType(): Type
 	{
+		$result = $this->intersectTypes(static fn (Type $type): Type => $type->getIterableValueType());
 		if ($this->isCallable()->yes() && $this->isArray()->yes()) {
-			return new UnionType([new ObjectWithoutClassType(), new StringType()]);
+			return TypeCombinator::intersect($result, new UnionType([new ObjectWithoutClassType(), new StringType()]));
 		}
-		return $this->intersectTypes(static fn (Type $type): Type => $type->getIterableValueType());
+		return $result;
 	}
 
 	public function getFirstIterableValueType(): Type

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1004,17 +1004,14 @@ class IntersectionType implements CompoundType
 
 		if ($this->isCallable()->yes() && $this->isArray()->yes()) {
 			$arrayKeyOffsetType = $offsetType->toArrayKey();
-			$callableArrayOffsetType = new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(1)]);
-			if ($callableArrayOffsetType->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
-				if ((new ConstantIntegerType(0))->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
-					$narrowedType = new UnionType([new ClassStringType(), new ObjectWithoutClassType()]);
-				} elseif ((new ConstantIntegerType(1))->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
-					$narrowedType = new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]);
-				} else {
-					$narrowedType = new UnionType([new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]), new ObjectWithoutClassType()]);
-				}
-				$result = TypeCombinator::intersect($result, $narrowedType);
+			if ((new ConstantIntegerType(0))->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
+				$narrowedType = new UnionType([new ClassStringType(), new ObjectWithoutClassType()]);
+			} elseif ((new ConstantIntegerType(1))->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
+				$narrowedType = new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]);
+			} else {
+				$narrowedType = new UnionType([new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]), new ObjectWithoutClassType()]);
 			}
+			$result = TypeCombinator::intersect($result, $narrowedType);
 		}
 
 		return $result;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -802,7 +802,13 @@ class IntersectionType implements CompoundType
 	{
 		$result = $this->intersectTypes(static fn (Type $type): Type => $type->getIterableValueType());
 		if ($this->isCallable()->yes() && $this->isArray()->yes()) {
-			return TypeCombinator::intersect($result, new UnionType([new ObjectWithoutClassType(), new StringType()]));
+			return TypeCombinator::intersect(
+				$result,
+				new UnionType([
+					new ObjectWithoutClassType(),
+					new IntersectionType([new StringType(), new AccessoryNonEmptyStringType()]),
+				])
+			);
 		}
 		return $result;
 	}

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -807,7 +807,7 @@ class IntersectionType implements CompoundType
 				new UnionType([
 					new ObjectWithoutClassType(),
 					new IntersectionType([new StringType(), new AccessoryNonEmptyStringType()]),
-				])
+				]),
 			);
 		}
 		return $result;

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -806,7 +806,7 @@ class IntersectionType implements CompoundType
 				$result,
 				new UnionType([
 					new ObjectWithoutClassType(),
-					new IntersectionType([new StringType(), new AccessoryNonEmptyStringType()]),
+					new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]),
 				]),
 			);
 		}
@@ -1009,9 +1009,9 @@ class IntersectionType implements CompoundType
 				if ((new ConstantIntegerType(0))->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
 					$narrowedType = new UnionType([new ClassStringType(), new ObjectWithoutClassType()]);
 				} elseif ((new ConstantIntegerType(1))->isSuperTypeOf($arrayKeyOffsetType)->yes()) {
-					$narrowedType = new StringType();
+					$narrowedType = new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]);
 				} else {
-					$narrowedType = new UnionType([new StringType(), new ObjectWithoutClassType()]);
+					$narrowedType = new UnionType([new IntersectionType([new StringType(), new AccessoryNonFalsyStringType()]), new ObjectWithoutClassType()]);
 				}
 				$result = TypeCombinator::intersect($result, $narrowedType);
 			}

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -782,6 +782,9 @@ class IntersectionType implements CompoundType
 
 	public function getIterableKeyType(): Type
 	{
+		if ($this->isCallable()->yes() && $this->isArray()->yes()) {
+			return new UnionType([new ConstantIntegerType(0), new ConstantIntegerType(1)]);
+		}
 		return $this->intersectTypes(static fn (Type $type): Type => $type->getIterableKeyType());
 	}
 
@@ -797,6 +800,9 @@ class IntersectionType implements CompoundType
 
 	public function getIterableValueType(): Type
 	{
+		if ($this->isCallable()->yes() && $this->isArray()->yes()) {
+			return new UnionType([new ObjectWithoutClassType(), new StringType()]);
+		}
 		return $this->intersectTypes(static fn (Type $type): Type => $type->getIterableValueType());
 	}
 

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -190,6 +190,7 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield __DIR__ . '/../Rules/Variables/data/bug-7417.php';
 		yield __DIR__ . '/../Rules/Arrays/data/bug-7469.php';
 		yield __DIR__ . '/../Rules/Variables/data/bug-3391.php';
+		yield __DIR__ . '/../Rules/Methods/data/bug-14549.php';
 
 		yield __DIR__ . '/../Rules/Functions/data/bug-anonymous-function-method-constant.php';
 

--- a/tests/PHPStan/Analyser/nsrt/bug-3842.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-3842.php
@@ -22,7 +22,7 @@ function testIsArrayOnCallable(callable $value): void {
 	if (is_array($value)) {
 		assertType('array<mixed, mixed>&callable(): mixed', $value);
 		assertType('class-string|object', $value[0]);
-		assertType('string', $value[1]);
+		assertType('non-falsy-string', $value[1]);
 	}
 }
 
@@ -30,7 +30,7 @@ function testIsArrayOnCallable(callable $value): void {
 function testCallableArrayPhpDoc(array $value): void {
 	assertType('array&callable(): mixed', $value);
 	assertType('class-string|object', $value[0]);
-	assertType('string', $value[1]);
+	assertType('non-falsy-string', $value[1]);
 }
 
 function testIsStringOnCallable(callable $value): void {
@@ -50,7 +50,7 @@ function checkClassString(array $values): void {
 /** @param 0|1 $offset */
 function testCallableArrayUnionOffset(callable $value, int $offset): void {
 	if (is_array($value)) {
-		assertType('object|string', $value[$offset]);
+		assertType('object|non-falsy-string', $value[$offset]);
 	}
 }
 

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -153,8 +153,8 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14549.php'], [
 			[
 				'Method Bug14549\MondayMorning::call() has parameter $task with no signature specified for callable.',
-				10
-			]
+				10,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -152,7 +152,7 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 	{
 		$this->analyse([__DIR__ . '/data/bug-14549.php'], [
 			[
-				'Method Bug14549\MondayMorning::call() has parameter $task with no signature specified for callable.',
+				'Method Bug14549\Foo::doFoo() has parameter $task with no signature specified for callable.',
 				12,
 			],
 		]);

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -155,6 +155,16 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 				'Method Bug14549\Foo::doFoo() has parameter $task with no signature specified for callable.',
 				12,
 			],
+			[
+				'Method Bug14549\Foo::doIntersection() has parameter $array with no value type specified in iterable type array.',
+				46,
+				MissingTypehintCheck::MISSING_ITERABLE_VALUE_TYPE_TIP,
+			],
+			[
+				'Method Bug14549\Foo::doIntersection() has parameter $array with no value type specified in iterable type array.',
+				46,
+				MissingTypehintCheck::MISSING_ITERABLE_VALUE_TYPE_TIP,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -148,4 +148,14 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug14549(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14549.php'], [
+			[
+				'Method Bug14549\MondayMorning::call() has parameter $task with no signature specified for callable.',
+				10
+			]
+		]);
+	}
+
 }

--- a/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MissingMethodParameterTypehintRuleTest.php
@@ -153,7 +153,7 @@ class MissingMethodParameterTypehintRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-14549.php'], [
 			[
 				'Method Bug14549\MondayMorning::call() has parameter $task with no signature specified for callable.',
-				10,
+				12,
 			],
 		]);
 	}

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -2,6 +2,8 @@
 
 namespace Bug14549;
 
+use function PHPStan\Testing\assertType;
+
 class MondayMorning
 {
 	/**
@@ -9,6 +11,12 @@ class MondayMorning
 	 */
 	public function call(array $task): void
 	{
+		foreach($task as $k => $v) {
+			assertType('0|1', $k);
+			assertType('object|string', $v);
+		}
+		assertType('class-string|object', $task[0]);
+		assertType('string', $task[1]);
 	}
 }
 

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -31,6 +31,11 @@ class Foo
 				assertType('non-empty-list<string>&callable(): mixed&hasOffsetValue(0, non-empty-string)', $list);
 				assertType('non-empty-string', $list[0]);
 				assertType('string', $list[1]);
+
+				foreach($list as $k => $v) {
+					assertType('0|1', $k);
+					assertType('string', $v);
+				}
 			}
 		}
 	}

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bug14549;
+
+class MondayMorning
+{
+	/**
+	 * @param callable-array $task
+	 */
+	public function call(array $task): void
+	{
+	}
+}
+
+

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -4,12 +4,12 @@ namespace Bug14549;
 
 use function PHPStan\Testing\assertType;
 
-class MondayMorning
+class Foo
 {
 	/**
 	 * @param callable-array $task
 	 */
-	public function call(array $task): void
+	public function doFoo(array $task): void
 	{
 		foreach($task as $k => $v) {
 			assertType('0|1', $k);
@@ -17,6 +17,22 @@ class MondayMorning
 		}
 		assertType('class-string|object', $task[0]);
 		assertType('string', $task[1]);
+	}
+
+	/**
+	 * @param non-empty-list<string> $list
+	 */
+	public function doBar(array $list): void
+	{
+		if ($list[0] !== '') {
+			assertType('non-empty-list<string>&hasOffsetValue(0, non-empty-string)', $list);
+
+			if (is_callable($list)) {
+				assertType('non-empty-list<string>&callable(): mixed&hasOffsetValue(0, non-empty-string)', $list);
+				assertType('non-empty-string', $list[0]);
+				assertType('string', $list[1]);
+			}
+		}
 	}
 }
 

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -13,10 +13,10 @@ class Foo
 	{
 		foreach($task as $k => $v) {
 			assertType('0|1', $k);
-			assertType('object|non-empty-string', $v);
+			assertType('object|non-falsy-string', $v);
 		}
 		assertType('class-string|object', $task[0]);
-		assertType('string', $task[1]);
+		assertType('non-falsy-string', $task[1]);
 	}
 
 	/**
@@ -30,11 +30,11 @@ class Foo
 			if (is_callable($list)) {
 				assertType('non-empty-list<string>&callable(): mixed&hasOffsetValue(0, non-empty-string)', $list);
 				assertType('non-empty-string', $list[0]);
-				assertType('string', $list[1]);
+				assertType('non-falsy-string', $list[1]);
 
 				foreach($list as $k => $v) {
 					assertType('0|1', $k);
-					assertType('non-empty-string', $v);
+					assertType('non-falsy-string', $v);
 				}
 			}
 		}

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -39,6 +39,14 @@ class Foo
 			}
 		}
 	}
+
+	/**
+	 * @param (array&callable(array): array) $array
+	 */
+	public function doIntersection($array): void
+	{
+	}
+
 }
 
 

--- a/tests/PHPStan/Rules/Methods/data/bug-14549.php
+++ b/tests/PHPStan/Rules/Methods/data/bug-14549.php
@@ -13,7 +13,7 @@ class Foo
 	{
 		foreach($task as $k => $v) {
 			assertType('0|1', $k);
-			assertType('object|string', $v);
+			assertType('object|non-empty-string', $v);
 		}
 		assertType('class-string|object', $task[0]);
 		assertType('string', $task[1]);
@@ -34,7 +34,7 @@ class Foo
 
 				foreach($list as $k => $v) {
 					assertType('0|1', $k);
-					assertType('string', $v);
+					assertType('non-empty-string', $v);
 				}
 			}
 		}

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -185,4 +185,21 @@ class ConstantStringTypeTest extends PHPStanTestCase
 		$this->assertInstanceOf(ErrorType::class, $result);
 	}
 
+	#[DataProvider('dataIsCallable')]
+	public function testIsCallable(TrinaryLogic $trinaryLogic, string $constantValue): void
+	{
+		$this->assertSame(
+			$trinaryLogic,
+			(new ConstantStringType($constantValue))->isCallable()
+		);
+	}
+
+	public static function dataIsCallable(): iterable
+	{
+		yield [TrinaryLogic::createNo(), ''];
+		yield [TrinaryLogic::createNo(), '0'];
+		yield [TrinaryLogic::createYes(), 'substr'];
+		yield [TrinaryLogic::createYes(), self::class.'::dataIsCallable'];
+		yield [TrinaryLogic::createMaybe(), self::class.'::methodDoesNotExist'];
+	}
 }

--- a/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
+++ b/tests/PHPStan/Type/Constant/ConstantStringTypeTest.php
@@ -190,7 +190,7 @@ class ConstantStringTypeTest extends PHPStanTestCase
 	{
 		$this->assertSame(
 			$trinaryLogic,
-			(new ConstantStringType($constantValue))->isCallable()
+			(new ConstantStringType($constantValue))->isCallable(),
 		);
 	}
 
@@ -199,7 +199,8 @@ class ConstantStringTypeTest extends PHPStanTestCase
 		yield [TrinaryLogic::createNo(), ''];
 		yield [TrinaryLogic::createNo(), '0'];
 		yield [TrinaryLogic::createYes(), 'substr'];
-		yield [TrinaryLogic::createYes(), self::class.'::dataIsCallable'];
-		yield [TrinaryLogic::createMaybe(), self::class.'::methodDoesNotExist'];
+		yield [TrinaryLogic::createYes(), self::class . '::dataIsCallable'];
+		yield [TrinaryLogic::createMaybe(), self::class . '::methodDoesNotExist'];
 	}
+
 }


### PR DESCRIPTION
refs https://github.com/phpstan/phpstan/issues/14549

the `&callable`-intersection already implies the value/key type of the array