### PR TITLE
Fix oversized-array self-rejection in `optimizeConstantArrays`

### DIFF
--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -960,16 +960,22 @@ final class TypeCombinator
 		}
 
 		$reducedArrayTypes = self::optimizeConstantArrays(self::reduceArrays($arrayTypes, true));
+		$emptyArrayType = null;
 		foreach ($reducedArrayTypes as $idx => $reducedArray) {
 			$applied = $accessoryTypes;
 			if ($reducedArray->isIterableAtLeastOnce()->no()) {
-				// Empty arrays cannot satisfy non-empty / oversized constraints —
-				// applying those accessories would produce a contradictory intersection
-				// (e.g. `array{}&oversized-array`) that rejects the very value it
-				// represents, breaking the super-type contract of the union.
+				// Filter accessories that reject empty arrays — applying them
+				// would build a contradictory intersection (e.g.
+				// `array{}&oversized-array`, `array{}&hasOffset('foo')`) that
+				// rejects the very value it represents, breaking the super-type
+				// contract of the union. Today only `OversizedArrayType` can
+				// leak here via the partial-presence special case in
+				// `processArrayAccessoryTypes`; the predicate is general so
+				// that future accessories don't reintroduce the bug.
+				$emptyArrayType ??= new ConstantArrayType([], []);
 				$applied = array_values(array_filter(
 					$applied,
-					static fn (Type $t): bool => !($t instanceof OversizedArrayType) && !($t instanceof NonEmptyArrayType),
+					static fn (Type $t): bool => !$t->accepts($emptyArrayType, true)->no(),
 				));
 			}
 			$reducedArrayTypes[$idx] = self::intersect($reducedArray, ...$applied);

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -27,6 +27,7 @@ use PHPStan\Type\Generic\TemplateType;
 use PHPStan\Type\Generic\TemplateTypeFactory;
 use PHPStan\Type\Generic\TemplateUnionType;
 use function array_fill;
+use function array_filter;
 use function array_key_exists;
 use function array_key_first;
 use function array_merge;

--- a/src/Type/TypeCombinator.php
+++ b/src/Type/TypeCombinator.php
@@ -960,7 +960,18 @@ final class TypeCombinator
 
 		$reducedArrayTypes = self::optimizeConstantArrays(self::reduceArrays($arrayTypes, true));
 		foreach ($reducedArrayTypes as $idx => $reducedArray) {
-			$reducedArrayTypes[$idx] = self::intersect($reducedArray, ...$accessoryTypes);
+			$applied = $accessoryTypes;
+			if ($reducedArray->isIterableAtLeastOnce()->no()) {
+				// Empty arrays cannot satisfy non-empty / oversized constraints —
+				// applying those accessories would produce a contradictory intersection
+				// (e.g. `array{}&oversized-array`) that rejects the very value it
+				// represents, breaking the super-type contract of the union.
+				$applied = array_values(array_filter(
+					$applied,
+					static fn (Type $t): bool => !($t instanceof OversizedArrayType) && !($t instanceof NonEmptyArrayType),
+				));
+			}
+			$reducedArrayTypes[$idx] = self::intersect($reducedArray, ...$applied);
 		}
 		return $reducedArrayTypes;
 	}
@@ -1057,7 +1068,24 @@ final class TypeCombinator
 					$generalizedKeyType = $innerKeyType->generalize(GeneralizePrecision::moreSpecific());
 					$keyTypes[$generalizedKeyType->describe(VerbosityLevel::precise())] = $generalizedKeyType;
 
-					$generalizedValueType = TypeTraverser::map($innerValueTypes[$i], static function (Type $type) use ($traverse): Type {
+					// Inner traversal of the value position. Two subtleties, both
+					// of which produced types that failed to be super-types of
+					// their contributors:
+					// - Empty constant arrays must be left alone; wrapping them
+					//   builds a contradictory `array{}&oversized-array`.
+					// - Fall through via `$innerTraverse`, not the outer
+					//   `$traverse`. The outer callback fully generalizes a
+					//   sealed `ConstantArrayType` into `array<intKey, V>&...`,
+					//   which is correct at the top level but wrong inside a
+					//   value position: it would treat a sealed `array{a: 1}`
+					//   reached via `array{}|array{a: 1}` differently from one
+					//   reached directly, leaving `processArrayTypes` with a
+					//   mix of shapes it cannot unify cleanly.
+					$generalizedValueType = TypeTraverser::map($innerValueTypes[$i], static function (Type $type, callable $innerTraverse): Type {
+						if ($type instanceof ConstantArrayType && $type->isIterableAtLeastOnce()->no()) {
+							return $type;
+						}
+
 						if ($type instanceof ArrayType || $type instanceof ConstantArrayType) {
 							return new IntersectionType([$type, new OversizedArrayType()]);
 						}
@@ -1066,7 +1094,7 @@ final class TypeCombinator
 							return $type->generalize(GeneralizePrecision::moreSpecific());
 						}
 
-						return $traverse($type);
+						return $innerTraverse($type);
 					});
 					$valueTypes[$generalizedValueType->describe(VerbosityLevel::precise())] = $generalizedValueType;
 				}

--- a/tests/PHPStan/Rules/Generators/YieldTypeRuleTest.php
+++ b/tests/PHPStan/Rules/Generators/YieldTypeRuleTest.php
@@ -82,4 +82,14 @@ class YieldTypeRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBugYieldOversizedSelfRejection(): void
+	{
+		// Regression: PHPStan inferred the closure's Generator value type from
+		// its yields, then rejected each yield against that inferred type. The
+		// oversized-array generalization in TypeCombinator::optimizeConstantArrays
+		// produced a constraint that was not a super-type of the variants it was
+		// derived from. Each yield is well-typed; no error must be reported.
+		$this->analyse([__DIR__ . '/data/bug-yield-oversized-self-rejection.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Generators/data/bug-yield-oversized-self-rejection.php
+++ b/tests/PHPStan/Rules/Generators/data/bug-yield-oversized-self-rejection.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types = 1);
+
+namespace BugYieldOversizedSelfRejection;
+
+/**
+ * Reproducer for a regression where `optimizeConstantArrays` produced a
+ * Generator value type that did not accept the very yields it was inferred
+ * from. Each yield is well-typed; the closure's inferred Generator value
+ * type must therefore be a super-type of every value it actually yields.
+ *
+ * @param callable(string): iterable<string, mixed> $fn
+ * @return \Generator<string, mixed>
+ */
+function bridge(callable $fn): \Generator
+{
+	foreach (['a', 'b'] as $kind) {
+		yield from $fn($kind);
+	}
+}
+
+bridge(static function (string $kind): iterable {
+	$key = 'b' === $kind ? 'x' : 'y';
+
+	yield '1' => [
+		'kind' => $kind,
+		'entries' => [[$key => [1, '2022-08-04', [['08:00', '12:00']]]]],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04']],
+	];
+	yield '2' => [
+		'kind' => $kind,
+		'entries' => [[$key => [1, '2022-08-04', [['08:00', '12:00'], ['14:00', '18:00']]]]],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04']],
+	];
+	yield '3' => [
+		'kind' => $kind,
+		'entries' => [[$key => [1, '2022-08-04', [['00:00', '00:00']]]]],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04']],
+	];
+	yield '4' => [
+		'kind' => $kind,
+		'entries' => [[$key => [1, '2022-08-04', [['22:00', '04:00']]]]],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04/2022-08-05']],
+	];
+	yield '5' => [
+		'kind' => $kind,
+		'entries' => [[$key => [1, '2022-08-04', [['16:00', '23:00']], 'lookupIds' => [42]]]],
+		'lookup' => [42 => [1, '2022-08-05T00:05/2022-08-05T02:00']],
+		'targets' => [[1, '2022-08-04/2022-08-05']],
+	];
+	yield '6' => [
+		'kind' => $kind,
+		'entries' => [
+			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
+			[$key => [1, '2022-08-10', [['08:00', '12:00']]]],
+		],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04'], [1, '2022-08-10']],
+	];
+	yield '7' => [
+		'kind' => $kind,
+		'entries' => [
+			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
+			[$key => [1, '2022-08-05', [['08:00', '12:00']]]],
+			[$key => [1, '2022-08-06', [['08:00', '12:00']]]],
+		],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04/2022-08-06']],
+	];
+	yield '8' => [
+		'kind' => $kind,
+		'entries' => [
+			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
+			[$key => [2, '2022-08-05', [['08:00', '12:00']]]],
+			[$key => [2, '2022-08-06', [['08:00', '12:00']]]],
+			[$key => [3, '2022-08-06', [['08:00', '12:00']]]],
+			[$key => [3, '2022-08-10', [['08:00', '12:00']]]],
+		],
+		'lookup' => [],
+		'targets' => [[1, '2022-08-04'], [2, '2022-08-05/2022-08-06'], [3, '2022-08-06'], [3, '2022-08-10']],
+	];
+	yield '9' => [
+		'kind' => $kind,
+		'entries' => [
+			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
+			[$key => [1, '2022-08-05', [['08:00', '12:00']]]],
+		],
+		'lookup' => [],
+		'targets' => [],
+		'flag' => false,
+	];
+});

--- a/tests/PHPStan/Rules/Generators/data/bug-yield-oversized-self-rejection.php
+++ b/tests/PHPStan/Rules/Generators/data/bug-yield-oversized-self-rejection.php
@@ -21,37 +21,37 @@ function bridge(callable $fn): \Generator
 bridge(static function (string $kind): iterable {
 	$key = 'b' === $kind ? 'x' : 'y';
 
-	yield '1' => [
+	yield 'one' => [
 		'kind' => $kind,
 		'entries' => [[$key => [1, '2022-08-04', [['08:00', '12:00']]]]],
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04']],
 	];
-	yield '2' => [
+	yield 'two' => [
 		'kind' => $kind,
 		'entries' => [[$key => [1, '2022-08-04', [['08:00', '12:00'], ['14:00', '18:00']]]]],
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04']],
 	];
-	yield '3' => [
+	yield 'three' => [
 		'kind' => $kind,
 		'entries' => [[$key => [1, '2022-08-04', [['00:00', '00:00']]]]],
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04']],
 	];
-	yield '4' => [
+	yield 'four' => [
 		'kind' => $kind,
 		'entries' => [[$key => [1, '2022-08-04', [['22:00', '04:00']]]]],
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04/2022-08-05']],
 	];
-	yield '5' => [
+	yield 'five' => [
 		'kind' => $kind,
 		'entries' => [[$key => [1, '2022-08-04', [['16:00', '23:00']], 'lookupIds' => [42]]]],
 		'lookup' => [42 => [1, '2022-08-05T00:05/2022-08-05T02:00']],
 		'targets' => [[1, '2022-08-04/2022-08-05']],
 	];
-	yield '6' => [
+	yield 'six' => [
 		'kind' => $kind,
 		'entries' => [
 			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
@@ -60,7 +60,7 @@ bridge(static function (string $kind): iterable {
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04'], [1, '2022-08-10']],
 	];
-	yield '7' => [
+	yield 'seven' => [
 		'kind' => $kind,
 		'entries' => [
 			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
@@ -70,7 +70,7 @@ bridge(static function (string $kind): iterable {
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04/2022-08-06']],
 	];
-	yield '8' => [
+	yield 'eight' => [
 		'kind' => $kind,
 		'entries' => [
 			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],
@@ -82,7 +82,7 @@ bridge(static function (string $kind): iterable {
 		'lookup' => [],
 		'targets' => [[1, '2022-08-04'], [2, '2022-08-05/2022-08-06'], [3, '2022-08-06'], [3, '2022-08-10']],
 	];
-	yield '9' => [
+	yield 'nine' => [
 		'kind' => $kind,
 		'entries' => [
 			[$key => [1, '2022-08-04', [['08:00', '12:00']]]],


### PR DESCRIPTION
## Summary

Fixes a regression introduced in 2.1.52 where the oversized-array generalization in `TypeCombinator` produced a type that was not a super-type of the variants it was derived from, causing `generator.valueType` (and similar) false positives where a closure's inferred Generator value type rejected the very yields it was synthesised from.

This work was authored by Claude (Opus 4.7) — bug analysis, root-cause diagnosis, and the patch. It bisected the regression to commit 2f66c45222 ("Preserve constant array when assigning a union of scalars"), found that commit was itself a correct precision improvement, and located the two latent `TypeCombinator` bugs it exposed.

The fix is two changes in `src/Type/TypeCombinator.php`:

- **`processArrayTypes`** (`~line 962`): when applying common array accessory types to a reduced array result that is already known empty (`isIterableAtLeastOnce()->no()`), skip `OversizedArrayType` and `NonEmptyArrayType`. Otherwise the intersection produces a contradictory `array{}&oversized-array` that rejects the very value it represents.
- **`optimizeConstantArrays`** stage 2 inner traverser (`~line 1071`): fall through via `$innerTraverse`, not the outer `$traverse`. The outer callback fully generalizes a sealed `ConstantArrayType` into `array<intKey, V>&...`, which is correct at the top level but wrong inside a value position. Re-entering it through the outer traverser produced asymmetric treatment — a sealed `array{a: 1}` reached via `array{}|array{a: 1}` got fully generalized while one reached directly was only wrapped, leaving `processArrayTypes` with a mix of shapes it could not unify cleanly. The same callback also now skips wrapping empty constant arrays for the same `array{}&oversized-array` reason as Fix A.

Both parts were verified to be **independently necessary**: reverting either alone re-fails the targeted regression test. Claude decomposed Fix B into its two sub-changes and tested each in isolation.

A symptomatic playground reproducer is at [phpstan.org/r/5b811780-35b4-4ebf-b2a6-cecb90f02b2b](https://phpstan.org/r/5b811780-35b4-4ebf-b2a6-cecb90f02b2b) (~discarded example - with numeric keys - at https://phpstan.org/r/916330d2-806c-426c-9220-cf99aba58a38~).

## Test plan

- [x] New `testBugYieldOversizedSelfRejection` regression test in `tests/PHPStan/Rules/Generators/YieldTypeRuleTest.php` passes — `tests/PHPStan/Rules/Generators/data/bug-yield-oversized-self-rejection.php` is a domain-agnostic version of the playground reproducer that exhibits the bug at level max with `bleedingEdge: true`.
- [x] Verified the new test data file still triggers the bug **without** the fix (9-error variant) and is clean **with** the fix.
- [x] Reproduces and clears the original full reproducer (11 errors → 0) on the file the contributor first hit the bug on.
- [x] `make tests` — 11993 tests, 79545 assertions, 0 new failures (2 pre-existing unrelated failures in `AccessPropertiesInAssignRuleTest::testBug14063` and `CatchWithUnthrownExceptionRuleTest::testBug14479` confirmed pre-existing on the unmodified `2.1.x` HEAD).