### PR TITLE
Fix #14499: Mark Lua::__construct $lua_script_file parameter as optional

### DIFF
--- a/resources/functionMap.php
+++ b/resources/functionMap.php
@@ -5468,7 +5468,7 @@ return [
 'lstat' => ['array|false', 'filename'=>'string'],
 'ltrim' => ['string', 'str'=>'string', 'character_mask='=>'string'],
 'Lua::__call' => ['mixed', 'lua_func'=>'callable', 'args='=>'array', 'use_self='=>'int'],
-'Lua::__construct' => ['void', 'lua_script_file'=>'string'],
+'Lua::__construct' => ['void', 'lua_script_file='=>'string'],
 'Lua::assign' => ['mixed', 'name'=>'string', 'value'=>'string'],
 'Lua::call' => ['mixed', 'lua_func'=>'callable', 'args='=>'array', 'use_self='=>'int'],
 'Lua::eval' => ['mixed', 'statements'=>'string'],

--- a/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
+++ b/tests/PHPStan/Rules/Classes/InstantiationRuleTest.php
@@ -646,4 +646,9 @@ class InstantiationRuleTest extends RuleTestCase
 		]);
 	}
 
+	public function testBug14499(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14499.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Classes/data/bug-14499.php
+++ b/tests/PHPStan/Rules/Classes/data/bug-14499.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Bug14499;
+
+$lua = new \Lua();
+$lua2 = new \Lua('/path/to/script.lua');


### PR DESCRIPTION
`Lua::__construct` in `resources/functionMap.php` incorrectly marked `$lua_script_file` as required, causing a false positive "Class Lua constructor invoked with 0 parameters, 1 required." Fix: add `=` suffix to make the parameter optional, matching the PHP documentation and phpstorm-stubs definition.

Closes https://github.com/phpstan/phpstan/issues/14499