### PR TITLE
Lazily initialize AggregateSourceLocator to speedup bootstrapping

### DIFF
--- a/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
@@ -4,9 +4,6 @@ namespace PHPStan\Reflection\BetterReflection;
 
 use Phar;
 use PhpParser\Parser;
-use PHPStan\BetterReflection\Identifier\Identifier;
-use PHPStan\BetterReflection\Identifier\IdentifierType;
-use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\BetterReflection\SourceLocator\Ast\Locator;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber;
@@ -23,6 +20,7 @@ use PHPStan\Reflection\BetterReflection\SourceLocator\AutoloadFunctionsSourceLoc
 use PHPStan\Reflection\BetterReflection\SourceLocator\AutoloadSourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\ComposerJsonAndInstalledJsonSourceLocatorMaker;
 use PHPStan\Reflection\BetterReflection\SourceLocator\FileNodesFetcher;
+use PHPStan\Reflection\BetterReflection\SourceLocator\LazySourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedDirectorySourceLocatorRepository;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedPsrAutoloaderLocatorFactory;
 use PHPStan\Reflection\BetterReflection\SourceLocator\OptimizedSingleFileSourceLocatorRepository;
@@ -31,7 +29,6 @@ use PHPStan\Reflection\BetterReflection\SourceLocator\ReflectionClassSourceLocat
 use PHPStan\Reflection\BetterReflection\SourceLocator\RewriteClassAliasSourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\SkipClassAliasSourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\SkipPolyfillSourceLocator;
-use stdClass;
 use function array_merge;
 use function array_unique;
 use function count;
@@ -84,7 +81,7 @@ final class BetterReflectionSourceLocatorFactory
 
 	public function create(): SourceLocator
 	{
-		$initializer = function() {
+		$initializer = function () {
 			$locators = [
 				$this->optimizedSingleFileSourceLocatorRepository->getOrCreate(
 					PHP_VERSION_ID < 80500
@@ -176,41 +173,7 @@ final class BetterReflectionSourceLocatorFactory
 			return new AggregateSourceLocator($locators);
 		};
 
-		$lazyLocator = new class($initializer) implements SourceLocator {
-			private ?SourceLocator $wrappedSourceLocator = null;
-
-			/**
-			 * @var callable():SourceLocator
-			 */
-			private $initializer;
-
-			/**
-			 * @param callable():SourceLocator $initializer
-			 */
-			public function __construct(callable $initializer)
-			{
-				$this->initializer = $initializer;
-			}
-
-			private function lazyInitialize(): SourceLocator {
-				if ($this->wrappedSourceLocator === null) {
-					$this->wrappedSourceLocator = ($this->initializer)();
-				}
-				return $this->wrappedSourceLocator;
-			}
-
-			public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?\PHPStan\BetterReflection\Reflection\Reflection
-			{
-				return $this->lazyInitialize()->locateIdentifier($reflector, $identifier);
-			}
-
-			public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
-			{
-				return $this->lazyInitialize()->locateIdentifiersByType($reflector, $identifierType);
-			}
-		};
-
-		return new MemoizingSourceLocator($lazyLocator);
+		return new MemoizingSourceLocator(new LazySourceLocator($initializer));
 	}
 
 }

--- a/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
+++ b/src/Reflection/BetterReflection/BetterReflectionSourceLocatorFactory.php
@@ -4,6 +4,9 @@ namespace PHPStan\Reflection\BetterReflection;
 
 use Phar;
 use PhpParser\Parser;
+use PHPStan\BetterReflection\Identifier\Identifier;
+use PHPStan\BetterReflection\Identifier\IdentifierType;
+use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\BetterReflection\SourceLocator\Ast\Locator;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
 use PHPStan\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber;
@@ -28,6 +31,7 @@ use PHPStan\Reflection\BetterReflection\SourceLocator\ReflectionClassSourceLocat
 use PHPStan\Reflection\BetterReflection\SourceLocator\RewriteClassAliasSourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\SkipClassAliasSourceLocator;
 use PHPStan\Reflection\BetterReflection\SourceLocator\SkipPolyfillSourceLocator;
+use stdClass;
 use function array_merge;
 use function array_unique;
 use function count;
@@ -80,95 +84,133 @@ final class BetterReflectionSourceLocatorFactory
 
 	public function create(): SourceLocator
 	{
-		$locators = [
-			$this->optimizedSingleFileSourceLocatorRepository->getOrCreate(
-				PHP_VERSION_ID < 80500
-					? __DIR__ . '/../../../stubs/runtime/Attribute84.php'
-					: __DIR__ . '/../../../stubs/runtime/Attribute85.php',
-			),
-		];
+		$initializer = function() {
+			$locators = [
+				$this->optimizedSingleFileSourceLocatorRepository->getOrCreate(
+					PHP_VERSION_ID < 80500
+						? __DIR__ . '/../../../stubs/runtime/Attribute84.php'
+						: __DIR__ . '/../../../stubs/runtime/Attribute85.php',
+				),
+			];
 
-		if ($this->singleReflectionFile !== null) {
-			$locators[] = $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($this->singleReflectionFile);
-		}
-
-		$astLocator = new Locator($this->parser);
-		$locators[] = new AutoloadFunctionsSourceLocator(
-			new AutoloadSourceLocator($this->fileNodesFetcher, false),
-			new ReflectionClassSourceLocator(
-				$astLocator,
-				$this->reflectionSourceStubber,
-			),
-		);
-
-		$analysedDirectories = [];
-		$analysedFiles = [];
-
-		foreach (array_merge($this->analysedPaths, $this->analysedPathsFromConfig) as $analysedPath) {
-			if (is_file($analysedPath)) {
-				$analysedFiles[] = $analysedPath;
-				continue;
+			if ($this->singleReflectionFile !== null) {
+				$locators[] = $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($this->singleReflectionFile);
 			}
 
-			if (!is_dir($analysedPath)) {
-				continue;
-			}
+			$astLocator = new Locator($this->parser);
+			$locators[] = new AutoloadFunctionsSourceLocator(
+				new AutoloadSourceLocator($this->fileNodesFetcher, false),
+				new ReflectionClassSourceLocator(
+					$astLocator,
+					$this->reflectionSourceStubber,
+				),
+			);
 
-			$analysedDirectories[] = $analysedPath;
-		}
+			$analysedDirectories = [];
+			$analysedFiles = [];
 
-		$fileLocators = [];
-		$analysedFiles = array_unique(array_merge($analysedFiles, $this->scanFiles));
-		foreach ($analysedFiles as $analysedFile) {
-			$fileLocators[] = $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($analysedFile);
-		}
-
-		$directories = array_unique(array_merge($analysedDirectories, $this->scanDirectories));
-		foreach ($directories as $directory) {
-			$fileLocators[] = $this->optimizedDirectorySourceLocatorRepository->getOrCreate($directory);
-		}
-
-		$astPhp8Locator = new Locator($this->php8Parser);
-
-		$composerLocators = [];
-
-		foreach ($this->composerAutoloaderProjectPaths as $composerAutoloaderProjectPath) {
-			$locator = $this->composerJsonAndInstalledJsonSourceLocatorMaker->create($composerAutoloaderProjectPath);
-			if ($locator === null) {
-				continue;
-			}
-			$composerLocators[] = $locator;
-		}
-
-		if (count($composerLocators) > 0) {
-			$fileLocators[] = new SkipPolyfillSourceLocator(new AggregateSourceLocator($composerLocators), $this->phpVersion);
-		}
-
-		if (extension_loaded('phar')) {
-			$pharProtocolPath = Phar::running();
-			if ($pharProtocolPath !== '') {
-				$mappings = [
-					'PHPStan\\BetterReflection\\' => [$pharProtocolPath . '/vendor/ondrejmirtes/better-reflection/src/'],
-				];
-				if ($this->playgroundMode) {
-					$mappings['PHPStan\\'] = [$pharProtocolPath . '/src/'];
-				} else {
-					$mappings['PHPStan\\Testing\\'] = [$pharProtocolPath . '/src/Testing/'];
+			foreach (array_merge($this->analysedPaths, $this->analysedPathsFromConfig) as $analysedPath) {
+				if (is_file($analysedPath)) {
+					$analysedFiles[] = $analysedPath;
+					continue;
 				}
-				$fileLocators[] = $this->optimizedPsrAutoloaderLocatorFactory->create(
-					Psr4Mapping::fromArrayMappings($mappings),
-				);
+
+				if (!is_dir($analysedPath)) {
+					continue;
+				}
+
+				$analysedDirectories[] = $analysedPath;
 			}
-		}
 
-		$locators[] = new RewriteClassAliasSourceLocator(new AggregateSourceLocator($fileLocators));
-		$locators[] = new SkipClassAliasSourceLocator(new PhpInternalSourceLocator($astPhp8Locator, $this->phpstormStubsSourceStubber));
+			$fileLocators = [];
+			$analysedFiles = array_unique(array_merge($analysedFiles, $this->scanFiles));
+			foreach ($analysedFiles as $analysedFile) {
+				$fileLocators[] = $this->optimizedSingleFileSourceLocatorRepository->getOrCreate($analysedFile);
+			}
 
-		$locators[] = new AutoloadSourceLocator($this->fileNodesFetcher, true);
-		$locators[] = new PhpVersionBlacklistSourceLocator(new PhpInternalSourceLocator($astLocator, $this->reflectionSourceStubber), $this->phpstormStubsSourceStubber);
-		$locators[] = new PhpVersionBlacklistSourceLocator(new EvaledCodeSourceLocator($astLocator, $this->reflectionSourceStubber), $this->phpstormStubsSourceStubber);
+			$directories = array_unique(array_merge($analysedDirectories, $this->scanDirectories));
+			foreach ($directories as $directory) {
+				$fileLocators[] = $this->optimizedDirectorySourceLocatorRepository->getOrCreate($directory);
+			}
 
-		return new MemoizingSourceLocator(new AggregateSourceLocator($locators));
+			$astPhp8Locator = new Locator($this->php8Parser);
+
+			$composerLocators = [];
+
+			foreach ($this->composerAutoloaderProjectPaths as $composerAutoloaderProjectPath) {
+				$locator = $this->composerJsonAndInstalledJsonSourceLocatorMaker->create($composerAutoloaderProjectPath);
+				if ($locator === null) {
+					continue;
+				}
+				$composerLocators[] = $locator;
+			}
+
+			if (count($composerLocators) > 0) {
+				$fileLocators[] = new SkipPolyfillSourceLocator(new AggregateSourceLocator($composerLocators), $this->phpVersion);
+			}
+
+			if (extension_loaded('phar')) {
+				$pharProtocolPath = Phar::running();
+				if ($pharProtocolPath !== '') {
+					$mappings = [
+						'PHPStan\\BetterReflection\\' => [$pharProtocolPath . '/vendor/ondrejmirtes/better-reflection/src/'],
+					];
+					if ($this->playgroundMode) {
+						$mappings['PHPStan\\'] = [$pharProtocolPath . '/src/'];
+					} else {
+						$mappings['PHPStan\\Testing\\'] = [$pharProtocolPath . '/src/Testing/'];
+					}
+					$fileLocators[] = $this->optimizedPsrAutoloaderLocatorFactory->create(
+						Psr4Mapping::fromArrayMappings($mappings),
+					);
+				}
+			}
+
+			$locators[] = new RewriteClassAliasSourceLocator(new AggregateSourceLocator($fileLocators));
+			$locators[] = new SkipClassAliasSourceLocator(new PhpInternalSourceLocator($astPhp8Locator, $this->phpstormStubsSourceStubber));
+
+			$locators[] = new AutoloadSourceLocator($this->fileNodesFetcher, true);
+			$locators[] = new PhpVersionBlacklistSourceLocator(new PhpInternalSourceLocator($astLocator, $this->reflectionSourceStubber), $this->phpstormStubsSourceStubber);
+			$locators[] = new PhpVersionBlacklistSourceLocator(new EvaledCodeSourceLocator($astLocator, $this->reflectionSourceStubber), $this->phpstormStubsSourceStubber);
+
+			return new AggregateSourceLocator($locators);
+		};
+
+		$lazyLocator = new class($initializer) implements SourceLocator {
+			private ?SourceLocator $wrappedSourceLocator = null;
+
+			/**
+			 * @var callable():SourceLocator
+			 */
+			private $initializer;
+
+			/**
+			 * @param callable():SourceLocator $initializer
+			 */
+			public function __construct(callable $initializer)
+			{
+				$this->initializer = $initializer;
+			}
+
+			private function lazyInitialize(): SourceLocator {
+				if ($this->wrappedSourceLocator === null) {
+					$this->wrappedSourceLocator = ($this->initializer)();
+				}
+				return $this->wrappedSourceLocator;
+			}
+
+			public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?\PHPStan\BetterReflection\Reflection\Reflection
+			{
+				return $this->lazyInitialize()->locateIdentifier($reflector, $identifier);
+			}
+
+			public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+			{
+				return $this->lazyInitialize()->locateIdentifiersByType($reflector, $identifierType);
+			}
+		};
+
+		return new MemoizingSourceLocator($lazyLocator);
 	}
 
 }

--- a/src/Reflection/BetterReflection/SourceLocator/LazySourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/LazySourceLocator.php
@@ -2,6 +2,7 @@
 
 namespace PHPStan\Reflection\BetterReflection\SourceLocator;
 
+use Override;
 use PHPStan\BetterReflection\Identifier\Identifier;
 use PHPStan\BetterReflection\Identifier\IdentifierType;
 use PHPStan\BetterReflection\Reflection\Reflection;
@@ -26,17 +27,16 @@ final class LazySourceLocator implements SourceLocator
 
 	private function lazyInitialize(): SourceLocator
 	{
-		if ($this->wrappedSourceLocator === null) {
-			$this->wrappedSourceLocator = ($this->initializer)();
-		}
-		return $this->wrappedSourceLocator;
+		return $this->wrappedSourceLocator ??= ($this->initializer)();
 	}
 
+	#[Override]
 	public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?Reflection
 	{
 		return $this->lazyInitialize()->locateIdentifier($reflector, $identifier);
 	}
 
+	#[Override]
 	public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
 	{
 		return $this->lazyInitialize()->locateIdentifiersByType($reflector, $identifierType);

--- a/src/Reflection/BetterReflection/SourceLocator/LazySourceLocator.php
+++ b/src/Reflection/BetterReflection/SourceLocator/LazySourceLocator.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Reflection\BetterReflection\SourceLocator;
+
+use PHPStan\BetterReflection\Identifier\Identifier;
+use PHPStan\BetterReflection\Identifier\IdentifierType;
+use PHPStan\BetterReflection\Reflection\Reflection;
+use PHPStan\BetterReflection\Reflector\Reflector;
+use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
+
+final class LazySourceLocator implements SourceLocator
+{
+
+	private ?SourceLocator $wrappedSourceLocator = null;
+
+	/** @var callable():SourceLocator */
+	private $initializer;
+
+	/**
+	 * @param callable():SourceLocator $initializer
+	 */
+	public function __construct(callable $initializer)
+	{
+		$this->initializer = $initializer;
+	}
+
+	private function lazyInitialize(): SourceLocator
+	{
+		if ($this->wrappedSourceLocator === null) {
+			$this->wrappedSourceLocator = ($this->initializer)();
+		}
+		return $this->wrappedSourceLocator;
+	}
+
+	public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?Reflection
+	{
+		return $this->lazyInitialize()->locateIdentifier($reflector, $identifier);
+	}
+
+	public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+	{
+		return $this->lazyInitialize()->locateIdentifiersByType($reflector, $identifierType);
+	}
+
+}


### PR DESCRIPTION
implement the idea described in https://github.com/phpstan/phpstan-src/pull/5538#issuecomment-4342781825

refs https://github.com/phpstan/phpstan/issues/14072

=> 25% faster end-to-end analysis

---

[review with whitespaces ignored](https://github.com/phpstan/phpstan-src/pull/5577/files?w=1)

---

with `foo.php`
```
<?php

echo "";
```

before this PR
```
➜  phpstan-src git:(2.1.x) ✗ hyperfine 'php bin/phpstan analyze foo.php --debug -vvv'
Benchmark 1: php bin/phpstan analyze foo.php --debug -vvv
  Time (mean ± σ):     772.3 ms ±   9.8 ms    [User: 557.5 ms, System: 210.4 ms]
  Range (min … max):   758.7 ms … 787.8 ms    10 runs
```

after this PR
```
➜  phpstan-src git:(lazy-loca) ✗ hyperfine 'php bin/phpstan analyze foo.php --debug -vvv'
Benchmark 1: php bin/phpstan analyze foo.php --debug -vvv
  Time (mean ± σ):     552.9 ms ±   6.7 ms    [User: 441.0 ms, System: 109.2 ms]
  Range (min … max):   548.6 ms … 571.3 ms    10 runs
```
