### PR TITLE
Use pre-args scope for value types in array_push/array_unshift

### DIFF
--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -267,6 +267,7 @@ final class FuncCallHandler implements ExprHandler
 			}
 		}
 
+		$scopeBeforeArgs = $scope;
 		$argsResult = $nodeScopeResolver->processArgs($stmt, $functionReflection, null, $parametersAcceptor, $normalizedExpr, $scope, $storage, $nodeCallbackForArgs, $context);
 		$scope = $argsResult->getScope();
 		$hasYield = $argsResult->hasYield();
@@ -395,8 +396,8 @@ final class FuncCallHandler implements ExprHandler
 				$stmt,
 				$arrayArg,
 				new NativeTypeExpr(
-					$this->getArrayFunctionAppendingType($functionReflection, $scope, $normalizedExpr),
-					$this->getArrayFunctionAppendingType($functionReflection, $scope->doNotTreatPhpDocTypesAsCertain(), $normalizedExpr),
+					$this->getArrayFunctionAppendingType($functionReflection, $scopeBeforeArgs, $normalizedExpr),
+					$this->getArrayFunctionAppendingType($functionReflection, $scopeBeforeArgs->doNotTreatPhpDocTypesAsCertain(), $normalizedExpr),
 				),
 				$nodeCallback,
 			)->getScope();

--- a/tests/PHPStan/Analyser/nsrt/bug-13510.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-13510.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bug13510;
+
+use function PHPStan\Testing\assertType;
+
+final class Foo
+{
+
+	/** @param non-empty-list<int> $arr */
+	public function test(array $arr): void
+	{
+		array_unshift($arr, array_pop($arr));
+		assertType('non-empty-list<int>', $arr);
+	}
+
+	/** @param non-empty-list<int> $arr */
+	public function testTwoLines(array $arr): void
+	{
+		$popped = array_pop($arr);
+		array_unshift($arr, $popped);
+		assertType('non-empty-list<int>', $arr);
+	}
+
+}


### PR DESCRIPTION
When `array_unshift($arr, array_pop($arr))` is processed, `processArgs` evaluates the nested `array_pop($arr)` argument first, which mutates `$arr`'s type in scope (e.g. `non-empty-list<int>` → `list<int>`). Then `getArrayFunctionAppendingType` re-evaluates the value argument expressions in the already-mutated scope, causing `array_pop($arr)` to return `int|null` instead of `int` — and the resulting array type becomes `non-empty-list<int|null>` instead of `non-empty-list<int>`.

The fix captures the scope before `processArgs` and passes it as a separate `$valuesScope` to `getArrayFunctionAppendingType`. The array type (first arg) still uses the post-args scope (correctly reflecting the post-pop state), while the value types (remaining args) are evaluated using the pre-args scope (correctly reflecting what was actually passed).

Closes https://github.com/phpstan/phpstan/issues/13510