### PR TITLE
Partly revert wrong expectations

### DIFF
--- a/tests/PHPStan/Rules/Arrays/OffsetAccessAssignmentRuleTest.php
+++ b/tests/PHPStan/Rules/Arrays/OffsetAccessAssignmentRuleTest.php
@@ -222,15 +222,4 @@ class OffsetAccessAssignmentRuleTest extends RuleTestCase
 		]);
 	}
 
-	public function testBug9004(): void
-	{
-		$this->checkUnionTypes = true;
-		$this->analyse([__DIR__ . '/../../Analyser/nsrt/bug-9004.php'], [
-			[
-				'Cannot assign new offset to list<int>|string.',
-				14,
-			],
-		]);
-	}
-
 }


### PR DESCRIPTION
the error is not expected, therefore we shouldn't assert it in https://github.com/phpstan/phpstan-src/pull/5585

see discussion in https://github.com/phpstan/phpstan-src/pull/5585#discussion_r3177905151