### PR TITLE
Fix counting `*scanf()` format string placeholders

### DIFF
--- a/src/Rules/Functions/PrintfHelper.php
+++ b/src/Rules/Functions/PrintfHelper.php
@@ -5,12 +5,14 @@ namespace PHPStan\Rules\Functions;
 use Nette\Utils\Strings;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Php\PhpVersion;
+use ValueError;
 use function array_filter;
 use function array_keys;
 use function count;
 use function in_array;
 use function max;
 use function sprintf;
+use function sscanf;
 use function strlen;
 use const PREG_SET_ORDER;
 
@@ -26,24 +28,33 @@ final class PrintfHelper
 
 	public function getPrintfPlaceholdersCount(string $format): ?int
 	{
-		return $this->getPlaceholdersCount(self::PRINTF_SPECIFIER_PATTERN, $format, false);
+		return $this->getPlaceholdersCount(self::PRINTF_SPECIFIER_PATTERN, $format);
 	}
 
 	/** @phpstan-return array<int, non-empty-list<PrintfPlaceholder>> parameter index => placeholders */
 	public function getPrintfPlaceholders(string $format): ?array
 	{
-		return $this->parsePlaceholders(self::PRINTF_SPECIFIER_PATTERN, $format, false);
+		return $this->parsePlaceholders(self::PRINTF_SPECIFIER_PATTERN, $format);
 	}
 
 	public function getScanfPlaceholdersCount(string $format): ?int
 	{
-		return $this->getPlaceholdersCount('(?<specifier>[cdDeEfinosuxX%s]|\[[^\]]+\])', $format, true);
+		try {
+			$result = @sscanf('', '%*n' . $format);
+		} catch (ValueError) {
+			return null;
+		}
+
+		if ($result === null) {
+			return null;
+		}
+		return count($result);
 	}
 
 	/**
 	 * @phpstan-return array<int, non-empty-list<PrintfPlaceholder>>|null parameter index => placeholders
 	 */
-	private function parsePlaceholders(string $specifiersPattern, string $format, bool $isScanf): ?array
+	private function parsePlaceholders(string $specifiersPattern, string $format): ?array
 	{
 		$addSpecifier = '';
 		if ($this->phpVersion->supportsHhPrintfSpecifier()) {
@@ -72,10 +83,6 @@ final class PrintfHelper
 			$showValueSuffix = false;
 
 			if (isset($placeholder['width']) && $placeholder['width'] !== '') {
-				if ($isScanf) {
-					// In scanf, * means assignment suppression - skip this placeholder entirely
-					continue;
-				}
 				$parsedPlaceholders[] = new PrintfPlaceholder(
 					sprintf('"%s" (width)', $placeholder[0]),
 					$parameterIdx++,
@@ -136,9 +143,9 @@ final class PrintfHelper
 		return 'mixed';
 	}
 
-	private function getPlaceholdersCount(string $specifiersPattern, string $format, bool $isScanf): ?int
+	private function getPlaceholdersCount(string $specifiersPattern, string $format): ?int
 	{
-		$placeholdersMap = $this->parsePlaceholders($specifiersPattern, $format, $isScanf);
+		$placeholdersMap = $this->parsePlaceholders($specifiersPattern, $format);
 		if ($placeholdersMap === null) {
 			return null;
 		}

--- a/tests/PHPStan/Rules/Functions/PrintfHelperTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfHelperTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Functions;
+
+use Override;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Testing\PHPStanTestCase;
+use const PHP_VERSION_ID;
+
+class PrintfHelperTest extends PHPStanTestCase
+{
+
+	private PrintfHelper $printf;
+
+	#[Override]
+	protected function setUp(): void
+	{
+		$this->printf = new PrintfHelper(new PhpVersion(PHP_VERSION_ID));
+	}
+
+	public function testReturnsNullForInvalidPattern(): void
+	{
+		$this->assertNull($this->printf->getScanfPlaceholdersCount('%a'));
+	}
+
+}

--- a/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
@@ -85,6 +85,14 @@ class PrintfParametersRuleTest extends RuleTestCase
 				29,
 			],
 			[
+				'Call to sscanf contains an invalid placeholder.',
+				38,
+			],
+			[
+				'Call to fscanf contains an invalid placeholder.',
+				39,
+			],
+			[
 				'Call to sprintf contains 2 placeholders, 1 value given.',
 				45,
 			],

--- a/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
+++ b/tests/PHPStan/Rules/Functions/PrintfParametersRuleTest.php
@@ -155,4 +155,9 @@ class PrintfParametersRuleTest extends RuleTestCase
 		$this->analyse([__DIR__ . '/data/bug-10260.php'], []);
 	}
 
+	public function testBug14567(): void
+	{
+		$this->analyse([__DIR__ . '/data/bug-14567.php'], []);
+	}
+
 }

--- a/tests/PHPStan/Rules/Functions/data/bug-14567.php
+++ b/tests/PHPStan/Rules/Functions/data/bug-14567.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bug14567;
+
+// NUL byte terminates sscanf/fscanf format string scanning
+
+// Placeholders after \0 should not be counted
+sscanf("12\0003 456 789", "%d %c %d\0 %d %*d", $num, $c, $num);
+
+// Only 1 placeholder active before NUL
+sscanf('123 456', "%d\0%d", $a);
+
+// Only 1 placeholder active before NUL (fscanf)
+fscanf(STDIN, "%d\0%d", $a2);
+
+// No placeholders after NUL
+sscanf('123', "\0%d");
+
+// Multiple placeholders, NUL in middle
+sscanf('123 456 789', "%d %d\0%d", $b, $c);
+
+// %n specifier - counts characters consumed, 1 placeholder
+sscanf('hello', "%n", $n);
+
+// %% - literal percent, 0 placeholders
+sscanf('100%', "100%%");
+
+// %i specifier - integer with base detection, 1 placeholder
+sscanf('0xff', "%i", $hex);
+
+// Mixed with %n
+sscanf('hello world', "%s%n", $word, $pos);
+
+// %D specifier - uppercase alias for %d, 1 placeholder
+sscanf('42', "%D", $dval);
+
+// %g specifier - general float, 1 placeholder
+sscanf('1.5', "%g", $gval);
+
+// Size modifiers (l, L, h) - consumed before specifier, 1 placeholder each
+sscanf('42', "%ld", $long);
+sscanf('3.14', "%lf", $longf);
+sscanf('3.14', "%Lf", $longdouble);
+sscanf('42', "%hd", $short);
+
+// Size modifier with width
+sscanf('42', "%10ld", $widelong);
+
+// Size modifier with suppression - 0 capturing placeholders
+sscanf('42 hello', "%*ld %s", $afterskip);
+
+// Mixed size modifiers
+sscanf('42 3.14 hello', "%ld %lf %s", $mix1, $mix2, $mix3);

--- a/tests/PHPStan/Rules/Functions/data/printf.php
+++ b/tests/PHPStan/Rules/Functions/data/printf.php
@@ -35,8 +35,8 @@ sscanf($str, "%20[^\n]\r\n%d", $string, $number); // ok
 sscanf($str, "%20[^abcde]a%d", $string, $number); // ok
 printf("%.E", 3.14159); // ok
 sprintf("%.E", 3.14159); // ok
-sscanf($str, '%.E', $number); // ok
-fscanf($str, '%.E', $number); // ok
+sscanf($str, '%.E', $number); // bad scan conversion character '.'
+fscanf($resource, '%.E', $number); // bad scan conversion character '.'
 sscanf($str, '%[A-Z]%d', $char, $number); // ok
 sprintf('%s %s %s', ...[1]); // do not detect unpacked arguments
 sprintf('%s %s %s', ...[1, 2, 3]); // ok


### PR DESCRIPTION
Update PrintfHelper.php:

Make `public function getScanfPlaceholdersCount(string $format): ?int` returning the sscanf() vetted number of placeholders that give/return/assign conversions.

refs:

- https://github.com/phpstan/phpstan-src/pull/5591
- https://github.com/phpstan/phpstan/issues/14567