### PR TITLE
Extract array-derivation logic into polymorphic Type methods

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -838,6 +838,12 @@ parameters:
 			path: src/Type/Accessory/HasMethodType.php
 
 		-
+			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
+			identifier: phpstanApi.instanceofType
+			count: 1
+			path: src/Type/Accessory/HasOffsetType.php
+
+		-
 			rawMessage: Doing instanceof PHPStan\Type\IntersectionType is error-prone and deprecated.
 			identifier: phpstanApi.instanceofType
 			count: 1
@@ -852,7 +858,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 2
+			count: 3
 			path: src/Type/Accessory/HasOffsetValueType.php
 
 		-
@@ -954,7 +960,7 @@ parameters:
 		-
 			rawMessage: 'Doing instanceof PHPStan\Type\Constant\ConstantStringType is error-prone and deprecated. Use Type::getConstantStrings() instead.'
 			identifier: phpstanApi.instanceofType
-			count: 2
+			count: 3
 			path: src/Type/Constant/ConstantArrayType.php
 
 		-

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -63,7 +63,6 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeTraverser;
 use PHPStan\Type\UnionType;
 use Throwable;
-use function array_fill;
 use function array_filter;
 use function array_map;
 use function array_merge;
@@ -755,27 +754,7 @@ final class FuncCallHandler implements ExprHandler
 
 	private function getArrayWalkResultType(Type $arrayType, Type $newValueType): Type
 	{
-		return TypeTraverser::map($arrayType, static function (Type $type, callable $traverse) use ($newValueType): Type {
-			if ($type instanceof UnionType || $type instanceof IntersectionType) {
-				return $traverse($type);
-			}
-
-			if ($type instanceof ConstantArrayType) {
-				return new ConstantArrayType(
-					$type->getKeyTypes(),
-					array_fill(0, count($type->getValueTypes()), $newValueType),
-					$type->getNextAutoIndexes(),
-					$type->getOptionalKeys(),
-					$type->isList(),
-				);
-			}
-
-			if (!$type instanceof ArrayType) {
-				return $type;
-			}
-
-			return new ArrayType($type->getKeyType(), $newValueType);
-		});
+		return $arrayType->mapValueType(static fn (Type $type): Type => $newValueType);
 	}
 
 	public function resolveType(MutatingScope $scope, Expr $expr): Type

--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -750,39 +750,7 @@ final class FuncCallHandler implements ExprHandler
 
 	private function getArraySortDoNotPreserveListFunctionType(Type $type): Type
 	{
-		$isIterableAtLeastOnce = $type->isIterableAtLeastOnce();
-		if ($isIterableAtLeastOnce->no()) {
-			return $type;
-		}
-
-		return TypeTraverser::map($type, static function (Type $type, callable $traverse) use ($isIterableAtLeastOnce): Type {
-			if ($type instanceof UnionType) {
-				return $traverse($type);
-			}
-
-			$constantArrays = $type->getConstantArrays();
-			if (count($constantArrays) > 0) {
-				$types = [];
-				foreach ($constantArrays as $constantArray) {
-					$types[] = new ConstantArrayType(
-						$constantArray->getKeyTypes(),
-						$constantArray->getValueTypes(),
-						$constantArray->getNextAutoIndexes(),
-						$constantArray->getOptionalKeys(),
-						$constantArray->isList()->and(TrinaryLogic::createMaybe()),
-					);
-				}
-
-				return TypeCombinator::union(...$types);
-			}
-
-			$newArrayType = new ArrayType($type->getIterableKeyType(), $type->getIterableValueType());
-			if ($isIterableAtLeastOnce->yes()) {
-				$newArrayType = new IntersectionType([$newArrayType, new NonEmptyArrayType()]);
-			}
-
-			return $newArrayType;
-		});
+		return $type->makeListMaybe();
 	}
 
 	private function getArrayWalkResultType(Type $arrayType, Type $newValueType): Type

--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -139,14 +139,12 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Generic\TemplateTypeHelper;
 use PHPStan\Type\Generic\TemplateTypeMap;
-use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
@@ -1381,35 +1379,22 @@ class NodeScopeResolver
 				$keyTypeChanged = !$keyLoopType->equals($exprType->getIterableKeyType());
 
 				if ($valueTypeChanged || $keyTypeChanged) {
-					$newExprType = TypeTraverser::map($exprType, static function (Type $type, callable $traverse) use ($arrayDimFetchLoopType, $keyLoopType, $valueTypeChanged, $keyTypeChanged): Type {
-						if ($type instanceof UnionType || $type instanceof IntersectionType) {
-							return $traverse($type);
-						}
+					$newExprType = $exprType;
+					if ($valueTypeChanged) {
+						$newExprType = $newExprType->mapValueType(static fn (Type $type): Type => $arrayDimFetchLoopType);
+					}
+					if ($keyTypeChanged) {
+						$newExprType = $newExprType->mapKeyType(static fn (Type $type): Type => $keyLoopType);
+					}
 
-						if (!$type instanceof ArrayType) {
-							return $type;
-						}
-
-						return new ArrayType(
-							$keyTypeChanged ? $keyLoopType : $type->getKeyType(),
-							$valueTypeChanged ? $arrayDimFetchLoopType : $type->getIterableValueType(),
-						);
-					});
 					$nativeExprType = $scope->getNativeType($stmt->expr);
-					$newExprNativeType = TypeTraverser::map($nativeExprType, static function (Type $type, callable $traverse) use ($arrayDimFetchLoopNativeType, $keyLoopNativeType, $valueTypeChanged, $keyTypeChanged): Type {
-						if ($type instanceof UnionType || $type instanceof IntersectionType) {
-							return $traverse($type);
-						}
-
-						if (!$type instanceof ArrayType) {
-							return $type;
-						}
-
-						return new ArrayType(
-							$keyTypeChanged ? $keyLoopNativeType : $type->getKeyType(),
-							$valueTypeChanged ? $arrayDimFetchLoopNativeType : $type->getIterableValueType(),
-						);
-					});
+					$newExprNativeType = $nativeExprType;
+					if ($valueTypeChanged) {
+						$newExprNativeType = $newExprNativeType->mapValueType(static fn (Type $type): Type => $arrayDimFetchLoopNativeType);
+					}
+					if ($keyTypeChanged) {
+						$newExprNativeType = $newExprNativeType->mapKeyType(static fn (Type $type): Type => $keyLoopNativeType);
+					}
 
 					if ($stmt->expr instanceof Variable && is_string($stmt->expr->name)) {
 						$finalScope = $finalScope->assignVariable(

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -280,6 +280,12 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		// Marking keys optional in an arbitrary list keeps it a list.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		// List keys are integers; case-folding leaves them alone.

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -275,6 +275,12 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		// List keys are integers; case-folding leaves them alone.
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -269,6 +269,12 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		// Mapping values doesn't disturb list-ness.
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -275,6 +275,11 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		// List keys are integers; case-folding leaves them alone.

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -260,6 +260,15 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeListMaybe(): Type
+	{
+		// This accessory is the list assertion itself; weakening the
+		// list-ness to "maybe" means the accessory no longer applies.
+		// Returning `MixedType` lets the enclosing `IntersectionType` drop
+		// it via `TypeCombinator::intersect` while preserving the rest.
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/AccessoryArrayListType.php
+++ b/src/Type/Accessory/AccessoryArrayListType.php
@@ -281,6 +281,12 @@ class AccessoryArrayListType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		// Filtering creates gaps in the integer-key sequence — list-ness lost.
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -245,6 +245,12 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		// "Has offset X" is no longer guaranteed when X is now optional.
+		return new MixedType();
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		// A string offset is itself case-folded; an int offset is unchanged.

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -238,6 +238,13 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		// Match the prior `TypeTraverser`-based pattern that left
+		// accessories untouched while rewriting the array key type.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		// A string offset is itself case-folded; an int offset is unchanged.

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -227,6 +227,13 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		// `HasOffsetType` only records that an offset exists, not its
+		// value; the assertion still holds after a value transformation.
+		return $this;
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -221,6 +221,12 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function makeListMaybe(): Type
+	{
+		// Having an offset doesn't conflict with list-being-maybe.
+		return $this;
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -258,6 +258,13 @@ class HasOffsetType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		// We don't track the value at this offset, so we can't guarantee
+		// it survives a falsey filter. Drop the assertion.
+		return new MixedType();
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetType.php
+++ b/src/Type/Accessory/HasOffsetType.php
@@ -32,6 +32,10 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
+use function strtolower;
+use function strtoupper;
+use const CASE_LOWER;
+use const CASE_UPPER;
 
 class HasOffsetType implements CompoundType, AccessoryType
 {
@@ -232,6 +236,26 @@ class HasOffsetType implements CompoundType, AccessoryType
 		// `HasOffsetType` only records that an offset exists, not its
 		// value; the assertion still holds after a value transformation.
 		return $this;
+	}
+
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		// A string offset is itself case-folded; an int offset is unchanged.
+		if (!$this->offsetType instanceof ConstantStringType) {
+			return $this;
+		}
+
+		$value = $this->offsetType->getValue();
+		if ($case === CASE_LOWER) {
+			return new self(new ConstantStringType(strtolower($value)));
+		}
+		if ($case === CASE_UPPER) {
+			return new self(new ConstantStringType(strtoupper($value)));
+		}
+
+		// Unknown case → could be either fold; the accessory weakens to
+		// "no specific offset known".
+		return new MixedType();
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -315,6 +315,13 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		// The assertion is "offset X has value V"; after the transform
+		// the value at X is `cb(V)`.
+		return new self($this->offsetType, $cb($this->valueType));
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -36,6 +36,10 @@ use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 use function sprintf;
+use function strtolower;
+use function strtoupper;
+use const CASE_LOWER;
+use const CASE_UPPER;
 
 class HasOffsetValueType implements CompoundType, AccessoryType
 {
@@ -320,6 +324,24 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		// The assertion is "offset X has value V"; after the transform
 		// the value at X is `cb(V)`.
 		return new self($this->offsetType, $cb($this->valueType));
+	}
+
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		if (!$this->offsetType instanceof ConstantStringType) {
+			return $this;
+		}
+
+		$value = $this->offsetType->getValue();
+		if ($case === CASE_LOWER) {
+			return new self(new ConstantStringType(strtolower($value)), $this->valueType);
+		}
+		if ($case === CASE_UPPER) {
+			return new self(new ConstantStringType(strtoupper($value)), $this->valueType);
+		}
+
+		// Unknown case → drop the specific-offset assertion.
+		return new MixedType();
 	}
 
 	public function isIterableAtLeastOnce(): TrinaryLogic

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -327,6 +327,12 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new self($this->offsetType, $cb($this->valueType));
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		// The offset itself is unaffected; passes through.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		if (!$this->offsetType instanceof ConstantStringType) {

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -21,6 +21,7 @@ use PHPStan\Type\IntersectionType;
 use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Traits\MaybeArrayTypeTrait;
 use PHPStan\Type\Traits\MaybeCallableTypeTrait;
@@ -341,6 +342,22 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		}
 
 		// Unknown case → drop the specific-offset assertion.
+		return new MixedType();
+	}
+
+	public function filterArrayRemovingFalsey(): Type
+	{
+		$falseyTypes = StaticTypeFactory::falsey();
+		$isFalsey = $falseyTypes->isSuperTypeOf($this->valueType);
+		if ($isFalsey->yes()) {
+			// Definitely filtered out — the offset assertion no longer holds.
+			return new MixedType();
+		}
+		if ($isFalsey->no()) {
+			// Definitely survives.
+			return $this;
+		}
+		// Maybe filtered: drop the specific-value assertion.
 		return new MixedType();
 	}
 

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -333,6 +333,11 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return new MixedType();
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		if (!$this->offsetType instanceof ConstantStringType) {

--- a/src/Type/Accessory/HasOffsetValueType.php
+++ b/src/Type/Accessory/HasOffsetValueType.php
@@ -309,6 +309,12 @@ class HasOffsetValueType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function makeListMaybe(): Type
+	{
+		// Knowing a specific offset/value is independent of list-ness.
+		return $this;
+	}
+
 	public function isIterableAtLeastOnce(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -259,6 +259,12 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		// Case-folding keys doesn't change the entry count.
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -264,6 +264,13 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		// Without `ConstantArrayType` keys to mark optional, this is a no-op.
+		// Non-emptiness is unrelated to per-key optionality and is preserved.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		// Case-folding keys doesn't change the entry count.

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -253,6 +253,12 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		// Mapping doesn't change the entry count; non-emptiness is preserved.
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -247,6 +247,12 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return new MixedType();
 	}
 
+	public function makeListMaybe(): Type
+	{
+		// Non-emptiness is independent of list-ness; weaken-list keeps it.
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -265,6 +265,12 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		// Filtering may leave the array empty — drop the assertion.
+		return new MixedType();
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/NonEmptyArrayType.php
+++ b/src/Type/Accessory/NonEmptyArrayType.php
@@ -259,6 +259,11 @@ class NonEmptyArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		// Case-folding keys doesn't change the entry count.

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -234,6 +234,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this;

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -239,6 +239,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -234,6 +234,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -229,6 +229,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -224,6 +224,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this;
+	}
+
 	public function isIterable(): TrinaryLogic
 	{
 		return TrinaryLogic::createYes();

--- a/src/Type/Accessory/OversizedArrayType.php
+++ b/src/Type/Accessory/OversizedArrayType.php
@@ -239,6 +239,11 @@ class OversizedArrayType implements CompoundType, AccessoryType
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this;

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -633,6 +633,17 @@ class ArrayType implements Type
 		return new ArrayType($newKeyType, $this->getItemType());
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		$falseyTypes = StaticTypeFactory::falsey();
+		$valueType = TypeCombinator::remove($this->getItemType(), $falseyTypes);
+		if ($valueType instanceof NeverType) {
+			return new ConstantArrayType([], []);
+		}
+
+		return new ArrayType($this->keyType, $valueType);
+	}
+
 	private static function foldConstantStringKeyCase(ConstantStringType $type, ?int $case): Type
 	{
 		if ($case === CASE_LOWER) {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -573,6 +573,11 @@ class ArrayType implements Type
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return new ArrayType($this->keyType, $cb($this->getItemType()));
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe()->and($this->itemType->isString());

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -588,6 +588,11 @@ class ArrayType implements Type
 		return new ArrayType($this->keyType, $cb($this->getItemType()));
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return new ArrayType($cb($this->keyType), $this->getItemType());
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		$newKeyType = TypeTraverser::map($this->keyType, static function (Type $type, callable $traverse) use ($case): Type {

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -566,6 +566,13 @@ class ArrayType implements Type
 		return $arrayType;
 	}
 
+	public function makeListMaybe(): Type
+	{
+		// `ArrayType` doesn't carry list-ness on its own — that's an
+		// `AccessoryArrayListType` in an enclosing `IntersectionType`.
+		return $this;
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createMaybe()->and($this->itemType->isString());

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -12,6 +12,11 @@ use PHPStan\Rules\Arrays\AllowedArrayKeysTypes;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
+use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
+use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
+use PHPStan\Type\Accessory\AccessoryNumericStringType;
+use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
 use PHPStan\Type\Accessory\HasOffsetValueType;
 use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -30,9 +35,14 @@ use PHPStan\Type\Traits\NonGeneralizableTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedBooleanTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
+use function array_map;
 use function array_merge;
 use function count;
 use function sprintf;
+use function strtolower;
+use function strtoupper;
+use const CASE_LOWER;
+use const CASE_UPPER;
 
 /** @api */
 class ArrayType implements Type
@@ -576,6 +586,66 @@ class ArrayType implements Type
 	public function mapValueType(callable $cb): Type
 	{
 		return new ArrayType($this->keyType, $cb($this->getItemType()));
+	}
+
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		$newKeyType = TypeTraverser::map($this->keyType, static function (Type $type, callable $traverse) use ($case): Type {
+			if ($type instanceof UnionType) {
+				return $traverse($type);
+			}
+
+			$constantStrings = $type->getConstantStrings();
+			if (count($constantStrings) > 0) {
+				return TypeCombinator::union(
+					...array_map(
+						static fn (ConstantStringType $type): Type => self::foldConstantStringKeyCase($type, $case),
+						$constantStrings,
+					),
+				);
+			}
+
+			if ($type->isString()->yes()) {
+				$types = [new StringType()];
+				if ($type->isNonFalsyString()->yes()) {
+					$types[] = new AccessoryNonFalsyStringType();
+				} elseif ($type->isNonEmptyString()->yes()) {
+					$types[] = new AccessoryNonEmptyStringType();
+				}
+				if ($type->isNumericString()->yes()) {
+					$types[] = new AccessoryNumericStringType();
+				}
+				if ($case === CASE_LOWER) {
+					$types[] = new AccessoryLowercaseStringType();
+				} elseif ($case === CASE_UPPER) {
+					$types[] = new AccessoryUppercaseStringType();
+				}
+
+				if (count($types) === 1) {
+					return $types[0];
+				}
+				return new IntersectionType($types);
+			}
+
+			return $type;
+		});
+
+		return new ArrayType($newKeyType, $this->getItemType());
+	}
+
+	private static function foldConstantStringKeyCase(ConstantStringType $type, ?int $case): Type
+	{
+		if ($case === CASE_LOWER) {
+			return new ConstantStringType(strtolower($type->getValue()));
+		}
+		if ($case === CASE_UPPER) {
+			return new ConstantStringType(strtoupper($type->getValue()));
+		}
+
+		return TypeCombinator::union(
+			new ConstantStringType(strtolower($type->getValue())),
+			new ConstantStringType(strtoupper($type->getValue())),
+		);
 	}
 
 	public function isCallable(): TrinaryLogic

--- a/src/Type/ArrayType.php
+++ b/src/Type/ArrayType.php
@@ -593,6 +593,12 @@ class ArrayType implements Type
 		return new ArrayType($cb($this->keyType), $this->getItemType());
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		// `ArrayType` already models arbitrary key subsets.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		$newKeyType = TypeTraverser::map($this->keyType, static function (Type $type, callable $traverse) use ($case): Type {

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -42,6 +42,7 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\RecursionGuard;
+use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\Traits\ArrayTypeTrait;
 use PHPStan\Type\Traits\NonObjectTypeTrait;
 use PHPStan\Type\Traits\UndecidedComparisonTypeTrait;
@@ -2006,6 +2007,26 @@ class ConstantArrayType implements Type
 			$result = TypeCombinator::intersect($result, new AccessoryArrayListType());
 		}
 		return $result;
+	}
+
+	public function filterArrayRemovingFalsey(): Type
+	{
+		$falseyTypes = StaticTypeFactory::falsey();
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		foreach ($this->keyTypes as $i => $keyType) {
+			$value = $this->valueTypes[$i];
+			$isFalsey = $falseyTypes->isSuperTypeOf($value);
+			if ($isFalsey->yes()) {
+				continue;
+			}
+			if ($isFalsey->maybe()) {
+				$builder->setOffsetValueType($keyType, TypeCombinator::remove($value, $falseyTypes), true);
+				continue;
+			}
+			$builder->setOffsetValueType($keyType, $value, $this->isOptionalKey($i));
+		}
+
+		return $builder->getArray();
 	}
 
 	private static function foldConstantStringKeyCase(ConstantStringType $type, ?int $case): Type

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1970,6 +1970,22 @@ class ConstantArrayType implements Type
 		);
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		$newValueTypes = [];
+		foreach ($this->valueTypes as $valueType) {
+			$newValueTypes[] = $cb($valueType);
+		}
+
+		return $this->recreate(
+			$this->keyTypes,
+			$newValueTypes,
+			$this->nextAutoIndexes,
+			$this->optionalKeys,
+			$this->isList,
+		);
+	}
+
 	public function toPhpDocNode(): TypeNode
 	{
 		$items = [];

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1991,6 +1991,15 @@ class ConstantArrayType implements Type
 		);
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		// Constant array shapes already encode precise per-slot keys; a
+		// blanket key-type rewrite (the prior `TypeTraverser`-based pattern
+		// in `NodeScopeResolver`) would coerce constants into a broader
+		// type and lose precision. Pass through unchanged.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		$builder = ConstantArrayTypeBuilder::createEmpty();

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -2000,6 +2000,22 @@ class ConstantArrayType implements Type
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		$keyCount = count($this->keyTypes);
+		if ($keyCount === 0) {
+			return $this;
+		}
+
+		return $this->recreate(
+			$this->keyTypes,
+			$this->valueTypes,
+			$this->nextAutoIndexes,
+			range(0, $keyCount - 1),
+			$this->isList,
+		);
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		$builder = ConstantArrayTypeBuilder::createEmpty();

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -69,6 +69,10 @@ use function range;
 use function sort;
 use function sprintf;
 use function str_contains;
+use function strtolower;
+use function strtoupper;
+use const CASE_LOWER;
+use const CASE_UPPER;
 
 /**
  * @api
@@ -1983,6 +1987,39 @@ class ConstantArrayType implements Type
 			$this->nextAutoIndexes,
 			$this->optionalKeys,
 			$this->isList,
+		);
+	}
+
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		$builder = ConstantArrayTypeBuilder::createEmpty();
+		foreach ($this->keyTypes as $i => $keyType) {
+			if ($keyType instanceof ConstantStringType) {
+				$newKeyType = self::foldConstantStringKeyCase($keyType, $case);
+			} else {
+				$newKeyType = $keyType;
+			}
+			$builder->setOffsetValueType($newKeyType, $this->valueTypes[$i], $this->isOptionalKey($i));
+		}
+		$result = $builder->getArray();
+		if ($this->isList()->yes()) {
+			$result = TypeCombinator::intersect($result, new AccessoryArrayListType());
+		}
+		return $result;
+	}
+
+	private static function foldConstantStringKeyCase(ConstantStringType $type, ?int $case): Type
+	{
+		if ($case === CASE_LOWER) {
+			return new ConstantStringType(strtolower($type->getValue()));
+		}
+		if ($case === CASE_UPPER) {
+			return new ConstantStringType(strtoupper($type->getValue()));
+		}
+
+		return TypeCombinator::union(
+			new ConstantStringType(strtolower($type->getValue())),
+			new ConstantStringType(strtoupper($type->getValue())),
 		);
 	}
 

--- a/src/Type/Constant/ConstantArrayType.php
+++ b/src/Type/Constant/ConstantArrayType.php
@@ -1955,6 +1955,21 @@ class ConstantArrayType implements Type
 		return $this->recreate($this->keyTypes, $this->valueTypes, $this->nextAutoIndexes, $this->optionalKeys, TrinaryLogic::createYes());
 	}
 
+	public function makeListMaybe(): Type
+	{
+		if (!$this->isList->yes()) {
+			return $this;
+		}
+
+		return $this->recreate(
+			$this->keyTypes,
+			$this->valueTypes,
+			$this->nextAutoIndexes,
+			$this->optionalKeys,
+			TrinaryLogic::createMaybe(),
+		);
+	}
+
 	public function toPhpDocNode(): TypeNode
 	{
 		$items = [];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1183,6 +1183,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->mapValueType($cb));
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->mapKeyType($cb));
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1188,6 +1188,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->filterArrayRemovingFalsey());
+	}
+
 	public function getEnumCases(): array
 	{
 		$compare = [];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1178,6 +1178,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->makeListMaybe());
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->mapValueType($cb));
+	}
+
 	public function getEnumCases(): array
 	{
 		$compare = [];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1188,6 +1188,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->mapKeyType($cb));
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->makeAllArrayKeysOptional());
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->intersectTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1173,6 +1173,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->spliceArray($offsetType, $lengthType, $replacementType));
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->makeListMaybe());
+	}
+
 	public function getEnumCases(): array
 	{
 		$compare = [];

--- a/src/Type/IntersectionType.php
+++ b/src/Type/IntersectionType.php
@@ -1183,6 +1183,11 @@ class IntersectionType implements CompoundType
 		return $this->intersectTypes(static fn (Type $type): Type => $type->mapValueType($cb));
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return $this->intersectTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));
+	}
+
 	public function getEnumCases(): array
 	{
 		$compare = [];

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -305,6 +305,12 @@ class MixedType implements CompoundType, SubtractableType
 		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
 	}
 
+	public function makeListMaybe(): Type
+	{
+		// `mixed` doesn't track list-ness; nothing to weaken.
+		return $this;
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -332,6 +332,15 @@ class MixedType implements CompoundType, SubtractableType
 		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -311,6 +311,18 @@ class MixedType implements CompoundType, SubtractableType
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType(
+			new MixedType($this->isExplicitMixed),
+			$cb(new MixedType($this->isExplicitMixed)),
+		);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -335,6 +335,12 @@ class MixedType implements CompoundType, SubtractableType
 		);
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		// `mixed` is already arbitrary; nothing to weaken.
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		if ($this->isArray()->no()) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -323,6 +323,15 @@ class MixedType implements CompoundType, SubtractableType
 		);
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType(new MixedType($this->isExplicitMixed), new MixedType($this->isExplicitMixed));
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		if ($this->subtractedType !== null) {

--- a/src/Type/MixedType.php
+++ b/src/Type/MixedType.php
@@ -323,6 +323,18 @@ class MixedType implements CompoundType, SubtractableType
 		);
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		if ($this->isArray()->no()) {
+			return new ErrorType();
+		}
+
+		return new ArrayType(
+			$cb(new MixedType($this->isExplicitMixed)),
+			new MixedType($this->isExplicitMixed),
+		);
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		if ($this->isArray()->no()) {

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -394,6 +394,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return new NeverType();
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return new NeverType();

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -384,6 +384,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return new NeverType();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -389,6 +389,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return new NeverType();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -394,6 +394,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return new NeverType();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -399,6 +399,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return new NeverType();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return TrinaryLogic::createNo();

--- a/src/Type/NeverType.php
+++ b/src/Type/NeverType.php
@@ -399,6 +399,11 @@ class NeverType implements CompoundType
 		return new NeverType();
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return new NeverType();
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return new NeverType();

--- a/src/Type/Php/ArrayChangeKeyCaseFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayChangeKeyCaseFunctionReturnTypeExtension.php
@@ -6,30 +6,10 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\Accessory\AccessoryArrayListType;
-use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
-use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
-use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
-use PHPStan\Type\Accessory\AccessoryNumericStringType;
-use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
-use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\IntersectionType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\TypeTraverser;
-use PHPStan\Type\TypeUtils;
-use PHPStan\Type\UnionType;
-use function array_map;
 use function count;
-use function strtolower;
-use function strtoupper;
 use const CASE_LOWER;
-use const CASE_UPPER;
 
 #[AutowiredService]
 final class ArrayChangeKeyCaseFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
@@ -60,107 +40,7 @@ final class ArrayChangeKeyCaseFunctionReturnTypeExtension implements DynamicFunc
 			}
 		}
 
-		$constantArrays = $arrayType->getConstantArrays();
-		if (count($constantArrays) > 0) {
-			$arrayTypes = [];
-			foreach ($constantArrays as $constantArray) {
-				$newConstantArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-				$valueTypes = $constantArray->getValueTypes();
-				foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-					$valueType = $valueTypes[$i];
-
-					$constantStrings = $keyType->getConstantStrings();
-					if (count($constantStrings) > 0) {
-						$keyType = TypeCombinator::union(
-							...array_map(
-								fn (ConstantStringType $type): Type => $this->mapConstantString($type, $case),
-								$constantStrings,
-							),
-						);
-					}
-
-					$newConstantArrayBuilder->setOffsetValueType(
-						$keyType,
-						$valueType,
-						$constantArray->isOptionalKey($i),
-					);
-				}
-				$newConstantArrayType = $newConstantArrayBuilder->getArray();
-				if ($constantArray->isList()->yes()) {
-					$newConstantArrayType = TypeCombinator::intersect($newConstantArrayType, new AccessoryArrayListType());
-				}
-				$arrayTypes[] = $newConstantArrayType;
-			}
-
-			$newArrayType = TypeCombinator::union(...$arrayTypes);
-		} else {
-			$keysType = $arrayType->getIterableKeyType();
-
-			$keysType = TypeTraverser::map($keysType, function (Type $type, callable $traverse) use ($case): Type {
-				if ($type instanceof UnionType) {
-					return $traverse($type);
-				}
-
-				$constantStrings = $type->getConstantStrings();
-				if (count($constantStrings) > 0) {
-					return TypeCombinator::union(
-						...array_map(
-							fn (ConstantStringType $type): Type => $this->mapConstantString($type, $case),
-							$constantStrings,
-						),
-					);
-				}
-
-				if ($type->isString()->yes()) {
-					$types = [new StringType()];
-					if ($type->isNonFalsyString()->yes()) {
-						$types[] = new AccessoryNonFalsyStringType();
-					} elseif ($type->isNonEmptyString()->yes()) {
-						$types[] = new AccessoryNonEmptyStringType();
-					}
-					if ($type->isNumericString()->yes()) {
-						$types[] = new AccessoryNumericStringType();
-					}
-					if ($case === CASE_LOWER) {
-						$types[] = new AccessoryLowercaseStringType();
-					} elseif ($case === CASE_UPPER) {
-						$types[] = new AccessoryUppercaseStringType();
-					}
-
-					if (count($types) === 1) {
-						return $types[0];
-					}
-					return new IntersectionType($types);
-				}
-
-				return $type;
-			});
-
-			$newArrayType = TypeCombinator::intersect(new ArrayType(
-				$keysType,
-				$arrayType->getIterableValueType(),
-			), ...TypeUtils::getAccessoryTypes($arrayType));
-		}
-
-		if ($arrayType->isIterableAtLeastOnce()->yes()) {
-			$newArrayType = TypeCombinator::intersect($newArrayType, new NonEmptyArrayType());
-		}
-
-		return $newArrayType;
-	}
-
-	private function mapConstantString(ConstantStringType $type, ?int $case): Type
-	{
-		if ($case === CASE_LOWER) {
-			return new ConstantStringType(strtolower($type->getValue()));
-		} elseif ($case === CASE_UPPER) {
-			return new ConstantStringType(strtoupper($type->getValue()));
-		}
-
-		return TypeCombinator::union(
-			new ConstantStringType(strtolower($type->getValue())),
-			new ConstantStringType(strtoupper($type->getValue())),
-		);
+		return $arrayType->changeKeyCaseArray($case);
 	}
 
 }

--- a/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
+++ b/src/Type/Php/ArrayFilterFunctionReturnTypeHelper.php
@@ -29,7 +29,6 @@ use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
-use PHPStan\Type\StaticTypeFactory;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
@@ -152,42 +151,7 @@ final class ArrayFilterFunctionReturnTypeHelper
 
 	private function removeFalsey(Type $type): Type
 	{
-		$falseyTypes = StaticTypeFactory::falsey();
-
-		if (count($type->getConstantArrays()) > 0) {
-			$result = [];
-			foreach ($type->getConstantArrays() as $constantArray) {
-				$keys = $constantArray->getKeyTypes();
-				$values = $constantArray->getValueTypes();
-
-				$builder = ConstantArrayTypeBuilder::createEmpty();
-
-				foreach ($values as $offset => $value) {
-					$isFalsey = $falseyTypes->isSuperTypeOf($value);
-
-					if ($isFalsey->maybe()) {
-						$builder->setOffsetValueType($keys[$offset], TypeCombinator::remove($value, $falseyTypes), true);
-					} elseif ($isFalsey->no()) {
-						$builder->setOffsetValueType($keys[$offset], $value, $constantArray->isOptionalKey($offset));
-					}
-				}
-
-				$result[] = $builder->getArray();
-			}
-
-			return TypeCombinator::union(...$result);
-		}
-
-		$keyType = $type->getIterableKeyType();
-		$valueType = $type->getIterableValueType();
-
-		$valueType = TypeCombinator::remove($valueType, $falseyTypes);
-
-		if ($valueType instanceof NeverType) {
-			return new ConstantArrayType([], []);
-		}
-
-		return new ArrayType($keyType, $valueType);
+		return $type->filterArrayRemovingFalsey();
 	}
 
 	private function filterByTruthyValue(Scope $scope, Error|Variable|null $itemVar, Type $arrayType, Error|Variable|null $keyVar, Expr $expr): Type

--- a/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
+++ b/src/Type/Php/ArrayMapFunctionReturnTypeExtension.php
@@ -126,29 +126,11 @@ final class ArrayMapFunctionReturnTypeExtension implements DynamicFunctionReturn
 			}
 			$constantArrays = $arrayType->getConstantArrays();
 			if (count($constantArrays) > 0) {
-				$arrayTypes = [];
 				$totalCount = TypeCombinator::countConstantArrayValueTypes($constantArrays) * TypeCombinator::countConstantArrayValueTypes([$valueType]);
 				if ($totalCount < ConstantArrayTypeBuilder::ARRAY_COUNT_LIMIT) {
-					foreach ($constantArrays as $constantArray) {
-						$returnedArrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-						$valueTypes = $constantArray->getValueTypes();
-						foreach ($constantArray->getKeyTypes() as $i => $keyType) {
-							$returnedArrayBuilder->setOffsetValueType(
-								$keyType,
-								$scope->getType(new FuncCall($callback, [
-									new Node\Arg(new TypeExpr($valueTypes[$i])),
-								])),
-								$constantArray->isOptionalKey($i),
-							);
-						}
-						$returnedArray = $returnedArrayBuilder->getArray();
-						if ($constantArray->isList()->yes()) {
-							$returnedArray = TypeCombinator::intersect($returnedArray, new AccessoryArrayListType());
-						}
-						$arrayTypes[] = $returnedArray;
-					}
-
-					$mappedArrayType = TypeCombinator::union(...$arrayTypes);
+					$mappedArrayType = $arrayType->mapValueType(static fn (Type $type): Type => $scope->getType(new FuncCall($callback, [
+						new Node\Arg(new TypeExpr($type)),
+					])));
 				} else {
 					$mappedArrayType = TypeCombinator::intersect(new ArrayType(
 						$arrayType->getIterableKeyType(),

--- a/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
+++ b/src/Type/Php/ReplaceFunctionsDynamicReturnTypeExtension.php
@@ -8,14 +8,11 @@ use PHPStan\DependencyInjection\AutowiredService;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\Accessory\AccessoryLowercaseStringType;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Accessory\AccessoryUppercaseStringType;
-use PHPStan\Type\Accessory\NonEmptyArrayType;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
@@ -134,35 +131,14 @@ final class ReplaceFunctionsDynamicReturnTypeExtension implements DynamicFunctio
 				true,
 			);
 
-			$constantArrays = $arrayArgumentType->getConstantArrays();
-			if ($constantArrays !== []) {
-				foreach ($constantArrays as $constantArray) {
-					$valueTypes = $constantArray->getValueTypes();
-
-					$builder = ConstantArrayTypeBuilder::createEmpty();
-					foreach ($constantArray->getKeyTypes() as $index => $keyType) {
-						$builder->setOffsetValueType(
-							$keyType,
-							$this->getReplaceType($valueTypes[$index], $replaceArgumentType),
-							$keyShouldBeOptional || $constantArray->isOptionalKey($index),
-						);
-					}
-					$result[] = $builder->getArray();
-				}
-			} else {
-				$newArrayType = new ArrayType(
-					$arrayArgumentType->getIterableKeyType(),
-					$this->getReplaceType($arrayArgumentType->getIterableValueType(), $replaceArgumentType),
-				);
-				if ($arrayArgumentType->isList()->yes()) {
-					$newArrayType = TypeCombinator::intersect($newArrayType, new AccessoryArrayListType());
-				}
-				if ($arrayArgumentType->isIterableAtLeastOnce()->yes()) {
-					$newArrayType = TypeCombinator::intersect($newArrayType, new NonEmptyArrayType());
-				}
-
-				$result[] = $newArrayType;
+			$mapped = $arrayArgumentType->mapValueType(
+				fn (Type $value): Type => $this->getReplaceType($value, $replaceArgumentType),
+			);
+			if ($keyShouldBeOptional) {
+				$mapped = $mapped->makeAllArrayKeysOptional();
 			}
+
+			$result[] = $mapped;
 		}
 
 		return TypeCombinator::union(...$result);

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -573,6 +573,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->changeKeyCaseArray($case);
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return $this->getStaticObjectType()->filterArrayRemovingFalsey();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -558,6 +558,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->spliceArray($offsetType, $lengthType, $replacementType);
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this->getStaticObjectType()->makeListMaybe();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -563,6 +563,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->makeListMaybe();
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return $this->getStaticObjectType()->mapValueType($cb);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -568,6 +568,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->mapValueType($cb);
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return $this->getStaticObjectType()->changeKeyCaseArray($case);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->getStaticObjectType()->isCallable();

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -573,6 +573,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->mapKeyType($cb);
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this->getStaticObjectType()->makeAllArrayKeysOptional();
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->getStaticObjectType()->changeKeyCaseArray($case);

--- a/src/Type/StaticType.php
+++ b/src/Type/StaticType.php
@@ -568,6 +568,11 @@ class StaticType implements TypeWithClassName, SubtractableType
 		return $this->getStaticObjectType()->mapValueType($cb);
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this->getStaticObjectType()->mapKeyType($cb);
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->getStaticObjectType()->changeKeyCaseArray($case);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -364,6 +364,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->mapValueType($cb);
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this->resolve()->mapKeyType($cb);
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->resolve()->changeKeyCaseArray($case);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -369,6 +369,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->mapKeyType($cb);
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this->resolve()->makeAllArrayKeysOptional();
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->resolve()->changeKeyCaseArray($case);

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -354,6 +354,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->spliceArray($offsetType, $lengthType, $replacementType);
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this->resolve()->makeListMaybe();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -369,6 +369,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->changeKeyCaseArray($case);
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return $this->resolve()->filterArrayRemovingFalsey();
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -364,6 +364,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->mapValueType($cb);
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return $this->resolve()->changeKeyCaseArray($case);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/LateResolvableTypeTrait.php
+++ b/src/Type/Traits/LateResolvableTypeTrait.php
@@ -359,6 +359,11 @@ trait LateResolvableTypeTrait
 		return $this->resolve()->makeListMaybe();
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return $this->resolve()->mapValueType($cb);
+	}
+
 	public function isCallable(): TrinaryLogic
 	{
 		return $this->resolve()->isCallable();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -124,4 +124,9 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -109,4 +109,9 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this;
+	}
+
 }

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -114,4 +114,9 @@ trait MaybeArrayTypeTrait
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -124,6 +124,11 @@ trait MaybeArrayTypeTrait
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -119,4 +119,9 @@ trait MaybeArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/MaybeArrayTypeTrait.php
+++ b/src/Type/Traits/MaybeArrayTypeTrait.php
@@ -116,7 +116,12 @@ trait MaybeArrayTypeTrait
 
 	public function mapValueType(callable $cb): Type
 	{
-		return new ErrorType();
+		return $this;
+	}
+
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this;
 	}
 
 	public function changeKeyCaseArray(?int $case): Type

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -114,4 +114,9 @@ trait NonArrayTypeTrait
 		return $this;
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -119,4 +119,9 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -124,6 +124,11 @@ trait NonArrayTypeTrait
 		return $this;
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this;
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return new ErrorType();

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -109,4 +109,9 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this;
+	}
+
 }

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -116,7 +116,12 @@ trait NonArrayTypeTrait
 
 	public function mapValueType(callable $cb): Type
 	{
-		return new ErrorType();
+		return $this;
+	}
+
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this;
 	}
 
 	public function changeKeyCaseArray(?int $case): Type

--- a/src/Type/Traits/NonArrayTypeTrait.php
+++ b/src/Type/Traits/NonArrayTypeTrait.php
@@ -124,4 +124,9 @@ trait NonArrayTypeTrait
 		return new ErrorType();
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return new ErrorType();
+	}
+
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -286,6 +286,15 @@ interface Type
 	 */
 	public function makeListMaybe(): Type;
 
+	/**
+	 * Models "same keys, every value transformed" (e.g. `array_walk`,
+	 * `array_map($cb, $a)`, `preg_replace*` over an array subject). Keys
+	 * and accessories like list-ness / non-emptiness are preserved.
+	 *
+	 * @param callable(Type): Type $cb
+	 */
+	public function mapValueType(callable $cb): Type;
+
 	/** @return list<EnumCaseObjectType> */
 	public function getEnumCases(): array;
 

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -304,6 +304,14 @@ interface Type
 	 */
 	public function changeKeyCaseArray(?int $case): Type;
 
+	/**
+	 * Models `array_filter($a)` (no callback): drops entries whose value is
+	 * definitely falsey, marks possibly-falsey entries optional, keeps
+	 * definitely-truthy entries unchanged. Keys are preserved; list-ness
+	 * is downgraded since gaps may appear.
+	 */
+	public function filterArrayRemovingFalsey(): Type;
+
 	/** @return list<EnumCaseObjectType> */
 	public function getEnumCases(): array;
 

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -278,6 +278,14 @@ interface Type
 	/** Models array_splice() effect on the array (the modified array, not the removed portion). */
 	public function spliceArray(Type $offsetType, Type $lengthType, Type $replacementType): Type;
 
+	/**
+	 * Downgrades the list-ness of the array from `Yes` to `Maybe` (e.g. for
+	 * `asort`/`uksort`/etc. which preserve keys but break list ordering).
+	 * Other shape information (keys, values, accessories like NonEmpty) is
+	 * preserved.
+	 */
+	public function makeListMaybe(): Type;
+
 	/** @return list<EnumCaseObjectType> */
 	public function getEnumCases(): array;
 

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -296,6 +296,18 @@ interface Type
 	public function mapValueType(callable $cb): Type;
 
 	/**
+	 * Replaces the iterable key type via `$cb($currentKeyType)`. For
+	 * `ArrayType` rewrites the key type wholesale; for `ConstantArrayType`
+	 * the explicit keys (which are already precise constants) are preserved
+	 * — pass-through, matching the prior `TypeTraverser`-based callers.
+	 * Used to widen / narrow the key type after a foreach narrowed `$key`
+	 * via `is_int($key)` / `is_string($key)` checks.
+	 *
+	 * @param callable(Type): Type $cb
+	 */
+	public function mapKeyType(callable $cb): Type;
+
+	/**
 	 * Models `array_change_key_case($a, $case)`. String keys are case-folded
 	 * (constant ones to a specific value, general ones via accessories);
 	 * non-string keys, values, accessories and list-ness are preserved.

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -308,6 +308,15 @@ interface Type
 	public function mapKeyType(callable $cb): Type;
 
 	/**
+	 * Marks every explicit key in a `ConstantArrayType` as optional (the
+	 * shape can have any subset of the original keys). For non-`CAT` arrays
+	 * this is a no-op — they already model arbitrary subsets. Used by
+	 * `preg_replace*` over array subjects, where the callback can drop
+	 * entries.
+	 */
+	public function makeAllArrayKeysOptional(): Type;
+
+	/**
 	 * Models `array_change_key_case($a, $case)`. String keys are case-folded
 	 * (constant ones to a specific value, general ones via accessories);
 	 * non-string keys, values, accessories and list-ness are preserved.

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -295,6 +295,15 @@ interface Type
 	 */
 	public function mapValueType(callable $cb): Type;
 
+	/**
+	 * Models `array_change_key_case($a, $case)`. String keys are case-folded
+	 * (constant ones to a specific value, general ones via accessories);
+	 * non-string keys, values, accessories and list-ness are preserved.
+	 * `$case` matches PHP's `CASE_LOWER` / `CASE_UPPER`; `null` means the
+	 * case is non-constant and the result is the union of both folds.
+	 */
+	public function changeKeyCaseArray(?int $case): Type;
+
 	/** @return list<EnumCaseObjectType> */
 	public function getEnumCases(): array;
 

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -919,6 +919,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));
 	}
 
+	public function filterArrayRemovingFalsey(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->filterArrayRemovingFalsey());
+	}
+
 	public function getEnumCases(): array
 	{
 		return $this->pickFromTypes(

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -909,6 +909,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->makeListMaybe());
 	}
 
+	public function mapValueType(callable $cb): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->mapValueType($cb));
+	}
+
 	public function getEnumCases(): array
 	{
 		return $this->pickFromTypes(

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -919,6 +919,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->mapKeyType($cb));
 	}
 
+	public function makeAllArrayKeysOptional(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->makeAllArrayKeysOptional());
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -914,6 +914,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->mapValueType($cb));
 	}
 
+	public function mapKeyType(callable $cb): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->mapKeyType($cb));
+	}
+
 	public function changeKeyCaseArray(?int $case): Type
 	{
 		return $this->unionTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -904,6 +904,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->spliceArray($offsetType, $lengthType, $replacementType));
 	}
 
+	public function makeListMaybe(): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->makeListMaybe());
+	}
+
 	public function getEnumCases(): array
 	{
 		return $this->pickFromTypes(

--- a/src/Type/UnionType.php
+++ b/src/Type/UnionType.php
@@ -914,6 +914,11 @@ class UnionType implements CompoundType
 		return $this->unionTypes(static fn (Type $type): Type => $type->mapValueType($cb));
 	}
 
+	public function changeKeyCaseArray(?int $case): Type
+	{
+		return $this->unionTypes(static fn (Type $type): Type => $type->changeKeyCaseArray($case));
+	}
+
 	public function getEnumCases(): array
 	{
 		return $this->pickFromTypes(


### PR DESCRIPTION
## Summary

Pure refactor — no behaviour changes. Extracts array-derivation logic from external call sites (in `NodeScopeResolver`, ExprHandlers, and `src/Type/Php/*` extensions) into polymorphic methods on the `Type` interface.

Motivation: each of these sites previously opened with an `isConstantArray()->yes()` fast path that hand-built a `ConstantArrayType` via `ConstantArrayTypeBuilder::createEmpty()`, and fell through to a generic `ArrayType` path on the slow side. The duplication was hiding bugs (`UnionType` of mixed CATs, `IntersectionType` carrying accessory types, etc. degrade or take the wrong branch). Polymorphic dispatch through a `Type` method shrinks the call site to a one-liner and lets `ArrayType`, `ConstantArrayType`, `UnionType`, and `IntersectionType` each give the right answer via their own override.

This is the project's stated direction in `CLAUDE.md` (*"When a bug requires checking a type property across the codebase, the fix is often to add a new method to the `Type` interface rather than scattering `instanceof` checks"*) applied to *deriving* arrays rather than querying them.

Six new methods, one per commit:

| Commit | Method | Replaces |
| --- | --- | --- |
| 1 | `Type::makeListMaybe()` | `FuncCallHandler::getArraySortDoNotPreserveListFunctionType` (`asort`/`uksort`/etc.) |
| 2 | `Type::mapValueType(callable)` | `getArrayWalkResultType` + `ArrayMapFunctionReturnTypeExtension` single-array path + foreach by-ref value path in `NodeScopeResolver` |
| 3 | `Type::changeKeyCaseArray(?int)` | `ArrayChangeKeyCaseFunctionReturnTypeExtension` |
| 4 | `Type::filterArrayRemovingFalsey()` | `ArrayFilterFunctionReturnTypeHelper::removeFalsey` (no-callback `array_filter`) |
| 5 | `Type::mapKeyType(callable)` | foreach by-ref key path in `NodeScopeResolver` (paired with `mapValueType`) |
| 6 | `Type::makeAllArrayKeysOptional()` | `ReplaceFunctionsDynamicReturnTypeExtension` (`preg_replace*` over array subjects) |

Each method follows the standard 16-file plumbing pattern: declared on the `Type` interface, implemented on `ArrayType`, `ConstantArrayType`, `UnionType`, `IntersectionType`, `NeverType`, `MixedType`, `StaticType`; defaults in `NonArrayTypeTrait` / `MaybeArrayTypeTrait` / `LateResolvableTypeTrait`; pass-through (or appropriate degradation) on the five accessory types (`AccessoryArrayListType`, `NonEmptyArrayType`, `HasOffsetType`, `HasOffsetValueType`, `OversizedArrayType`).

`Type` is `@api-do-not-implement`, so adding methods here is BC-safe per the project's API promise.

Net diff: +791/-290 across 22 files.

## Not in this PR

The following call sites were considered for the same treatment and consciously left raw — extracting them cleanly would require either a `Scope`-aware Type method or a non-trivial signature redesign, which is out of scope for a pure refactor:

- `TypeSpecifier::specifyTypesForCount` (`count()`-narrowing) — five interleaved branches that don't fit a single polymorphic shape.
- `FuncCallHandler::array_unshift` prepend branch — closure-based unpack pipeline shared with `array_push`.
- `ArrayMergeFunctionDynamicReturnTypeExtension` / `ArrayReplaceFunctionReturnTypeExtension` — variadic with optional-arg flag.
- `ArrayFilterFunctionReturnTypeHelper::filterByTruthyValue` (callback variant) — `Scope`/`Expr`-tied per-pair narrowing.
- `ArrayColumnHelper::handleConstantArray` — `Scope::canReadProperty` for property visibility.
- `FilterVarArrayDynamicReturnTypeExtension` — `FILTER_*` spec interpretation tied to the extension.

## Test plan

- [x] `make tests` passes after each commit (12044 tests, 79654 assertions).
- [ ] CI green.