### PR TITLE
Cap cumulative unroll factor when nesting unrolled constant-array foreach

### DIFF
--- a/src/Analyser/NodeScopeResolver.php
+++ b/src/Analyser/NodeScopeResolver.php
@@ -189,6 +189,7 @@ class NodeScopeResolver
 	private const LOOP_SCOPE_ITERATIONS = 3;
 	private const GENERALIZE_AFTER_ITERATION = 1;
 	private const FOREACH_UNROLL_LIMIT = 16;
+	private const FOREACH_UNROLL_NESTED_LIMIT = 16;
 
 	/** @var array<string, true> filePath(string) => bool(true) */
 	private array $analysedFiles = [];
@@ -3896,6 +3897,9 @@ class NodeScopeResolver
 		if ($totalKeys === 0 || $totalKeys > self::FOREACH_UNROLL_LIMIT) {
 			return null;
 		}
+		if ($context->getForeachUnrollFactor() * $totalKeys > self::FOREACH_UNROLL_NESTED_LIMIT) {
+			return null;
+		}
 
 		$nativeIterateeType = $originalScope->getNativeType($stmt->expr);
 		$nativeConstantArrays = $nativeIterateeType->getConstantArrays();
@@ -3907,6 +3911,8 @@ class NodeScopeResolver
 		$allBodyScopes = [];
 		$allChainScopes = [];
 		$allBreakScopes = [];
+
+		$bodyContext = $context->enterUnrolledForeach($totalKeys);
 
 		foreach ($constantArrays as $arrayIndex => $constantArray) {
 			$keyTypes = $constantArray->getKeyTypes();
@@ -3971,7 +3977,7 @@ class NodeScopeResolver
 					$iterScope,
 					$iterStorage,
 					new NoopNodeCallback(),
-					$context,
+					$bodyContext,
 				)->filterOutLoopExitPoints();
 
 				$iterEndScope = $bodyResult->getScope();

--- a/src/Analyser/StatementContext.php
+++ b/src/Analyser/StatementContext.php
@@ -15,6 +15,7 @@ final class StatementContext
 
 	private function __construct(
 		private bool $isTopLevel,
+		private int $foreachUnrollFactor = 1,
 	)
 	{
 	}
@@ -40,13 +41,23 @@ final class StatementContext
 		return $this->isTopLevel;
 	}
 
+	public function getForeachUnrollFactor(): int
+	{
+		return $this->foreachUnrollFactor;
+	}
+
 	public function enterDeep(): self
 	{
 		if ($this->isTopLevel) {
-			return self::createDeep();
+			return new self(false, $this->foreachUnrollFactor);
 		}
 
 		return $this;
+	}
+
+	public function enterUnrolledForeach(int $totalKeys): self
+	{
+		return new self($this->isTopLevel, $this->foreachUnrollFactor * $totalKeys);
 	}
 
 }

--- a/tests/bench/data/bug-14590.php
+++ b/tests/bench/data/bug-14590.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bug14590;
+
+function provider(): array {
+	$cases = [];
+	foreach ([1, 2] as $v0) {
+		foreach ([1, 2] as $v1) {
+			foreach ([1, 2] as $v2) {
+				foreach ([1, 2] as $v3) {
+					foreach ([1, 2] as $v4) {
+						foreach ([1, 2] as $v5) {
+							foreach ([1, 2] as $v6) {
+								foreach ([1, 2] as $v7) {
+									foreach ([1, 2] as $v8) {
+										$cases[] = $v0;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return $cases;
+}


### PR DESCRIPTION
## Summary

- `tryProcessUnrolledConstantArrayForeach` literally evaluates the body once per `(key, value)` pair. With deep nesting the cumulative product explodes — e.g. 9 nested `foreach ([1, 2] as ...)` loops causes 2⁹ = 512 inner body evaluations, and a body that appends to an outer array (like `$cases[] = $v0`) then makes scope merges over a growing constant array compound the cost super-linearly. The per-foreach `FOREACH_UNROLL_LIMIT = 16` doesn't catch this because each individual loop only has 2 keys.
- Threads a new `foreachUnrollFactor` field through `StatementContext` (`getForeachUnrollFactor()`, `enterUnrolledForeach(int)`, preserved across `enterDeep()`). When unrolling would push the cumulative product over `FOREACH_UNROLL_NESTED_LIMIT = 16`, the foreach falls back to the regular non-unrolled analysis path.
- Adds `tests/bench/data/bug-14590.php` so the regression is caught by `RegressionBench`.

Depth-9 reproducer: ~108s → ~3s. PHPStan still cleanly analyses itself; all 12066 existing tests pass.

Closes https://github.com/phpstan/phpstan/issues/14590

## Test plan

- [x] `make tests` — all 12066 tests pass
- [x] `make phpstan` — no errors
- [x] Reproducer from the issue completes in ~3s