### PR TITLE
POC - sortArray method might be unneeded

### DIFF
--- a/src/Analyser/ExprHandler/FuncCallHandler.php
+++ b/src/Analyser/ExprHandler/FuncCallHandler.php
@@ -463,7 +463,7 @@ final class FuncCallHandler implements ExprHandler
 				$storage,
 				$stmt,
 				$arrayArg,
-				new NativeTypeExpr($scope->getType($arrayArg)->sortArray(), $scope->getNativeType($arrayArg)->sortArray()),
+				new NativeTypeExpr($scope->getType($arrayArg)->shuffleArray(), $scope->getNativeType($arrayArg)->shuffleArray()),
 				$nodeCallback,
 			)->getScope();
 		}

--- a/tests/PHPStan/Analyser/nsrt/sort.php
+++ b/tests/PHPStan/Analyser/nsrt/sort.php
@@ -108,25 +108,25 @@ class Foo
 	{
 		$arr1 = $arr;
 		sort($arr1);
-		assertType('mixed', $arr1);
-		assertNativeType('mixed', $arr1);
+		assertType('list', $arr1);
+		assertNativeType('list', $arr1);
 
 		$arr2 = $arr;
 		rsort($arr2);
-		assertType('mixed', $arr2);
-		assertNativeType('mixed', $arr2);
+		assertType('list', $arr2);
+		assertNativeType('list', $arr2);
 
 		$arr3 = $arr;
 		usort($arr3, fn(int $a, int $b) => $a <=> $b);
-		assertType('mixed', $arr3);
-		assertNativeType('mixed', $arr3);
+		assertType('list', $arr3);
+		assertNativeType('list', $arr3);
 	}
 
 	public function notArray(): void
 	{
 		$arr = 'foo';
 		sort($arr);
-		assertType("'foo'", $arr);
+		assertType("*ERROR*", $arr);
 	}
 }
 
@@ -145,7 +145,7 @@ class Bar
 			return $a['a'] <=> $b['a'];
 		});
 
-		assertType('list<array{a: bool|float|int|string, b: true}>&T (method Sort\Bar::doFoo(), argument)', $array);
+		assertType('list<array{a: bool|float|int|string, b: true}>', $array);
 
 		return $array;
 	}


### PR DESCRIPTION
Show the impact of merging shuffleArray and sortArray into one method, preferring shuffleArray.