### PR TITLE
Test result-cache restore does not trigger reflection in all 1st party extensions

### DIFF
--- a/e2e/result-cache-restore-without-reflection/composer.json
+++ b/e2e/result-cache-restore-without-reflection/composer.json
@@ -2,7 +2,14 @@
     "require-dev": {
         "phpstan/phpstan-symfony": "@dev",
         "phpstan/extension-installer": "^1.4",
-        "phpstan/phpstan-doctrine": "@dev"
+        "phpstan/phpstan-doctrine": "@dev",
+        "phpstan/phpstan-beberlei-assert": "@dev",
+        "phpstan/phpstan-phpunit": "@dev",
+        "phpstan/phpstan-webmozart-assert": "@dev",
+        "phpstan/phpstan-mockery": "@dev",
+        "phpstan/phpstan-nette": "@dev",
+        "phpstan/phpstan-dibi": "@dev",
+        "php-standard-library/phpstan-extension": "@dev"
     },
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
cover all [official extensions](https://phpstan.org/user-guide/extension-library) to make sure we don't have similar bugs (and don't get those in the future)