### PR TITLE
Fix build

### DIFF
--- a/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php
+++ b/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php
@@ -36,7 +36,7 @@ class MethodCallWithPossiblyRenamedNamedArgumentRuleTest extends RuleTestCase
 			),
 			new OverridingMethodRule(
 				$phpVersion,
-				new MethodSignatureRule(new ParentMethodHelper($phpClassReflectionExtension), true, true),
+				new MethodSignatureRule(new ParentMethodHelper($phpClassReflectionExtension), true, true, true),
 				false,
 				new MethodParameterComparisonHelper($phpVersion),
 				new MethodVisibilityComparisonHelper(),


### PR DESCRIPTION
fixes

```
There were 2 errors:

1) PHPStan\Rules\Methods\MethodCallWithPossiblyRenamedNamedArgumentRuleTest::testRule
ArgumentCountError: Too few arguments to function PHPStan\Rules\Methods\MethodSignatureRule::__construct(), 3 passed in /Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php on line 39 and exactly 4 expected

/Users/staabm/workspace/phpstan-src/src/Rules/Methods/MethodSignatureRule.php:40
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php:39
/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:301
/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:162
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php:52

2) PHPStan\Rules\Methods\MethodCallWithPossiblyRenamedNamedArgumentRuleTest::testBug7434
ArgumentCountError: Too few arguments to function PHPStan\Rules\Methods\MethodSignatureRule::__construct(), 3 passed in /Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php on line 39 and exactly 4 expected

/Users/staabm/workspace/phpstan-src/src/Rules/Methods/MethodSignatureRule.php:40
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php:39
/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:301
/Users/staabm/workspace/phpstan-src/src/Testing/RuleTestCase.php:162
/Users/staabm/workspace/phpstan-src/tests/PHPStan/Rules/Methods/MethodCallWithPossiblyRenamedNamedArgumentRuleTest.php:62

ERRORS!
Tests: 12038, Assertions: 85393, Errors: 2, Skipped: 179.
make: *** [tests] Error 2
```

which we got after merging https://github.com/phpstan/phpstan-src/pull/5584 into 2.2.x