### PR TITLE
Guard `*scanf()` return type extension by counter

### DIFF
--- a/src/Type/Php/SscanfFunctionDynamicReturnTypeExtension.php
+++ b/src/Type/Php/SscanfFunctionDynamicReturnTypeExtension.php
@@ -5,7 +5,9 @@ namespace PHPStan\Type\Php;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Rules\Functions\PrintfHelper;
 use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
 use PHPStan\Type\Accessory\AccessoryNonFalsyStringType;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
@@ -14,6 +16,8 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
+use PHPStan\Type\NeverType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -24,6 +28,13 @@ use function preg_match_all;
 #[AutowiredService]
 final class SscanfFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
+
+	public function __construct(
+		private PrintfHelper $printfHelper,
+		private PhpVersion $phpVersion,
+	)
+	{
+	}
 
 	public function isFunctionSupported(FunctionReflection $functionReflection): bool
 	{
@@ -47,44 +58,70 @@ final class SscanfFunctionDynamicReturnTypeExtension implements DynamicFunctionR
 		}
 		$formatType = $formatType[0];
 
-		if (preg_match_all('/%(\d*)(\[[^\]]+\]|[cdeEfosux]{1})/', $formatType->getValue(), $matches) > 0) {
-			$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
-
-			for ($i = 0; $i < count($matches[0]); $i++) {
-				$length = $matches[1][$i];
-				$specifier = $matches[2][$i];
-
-				$type = new StringType();
-				if ($length !== '') {
-					if (((int) $length) > 1) {
-						$type = new IntersectionType([
-							$type,
-							new AccessoryNonFalsyStringType(),
-						]);
-					} else {
-						$type = new IntersectionType([
-							$type,
-							new AccessoryNonEmptyStringType(),
-						]);
-					}
-				}
-
-				if (in_array($specifier, ['d', 'o', 'u', 'x'], true)) {
-					$type = new IntegerType();
-				}
-
-				if (in_array($specifier, ['e', 'E', 'f'], true)) {
-					$type = new FloatType();
-				}
-
-				$type = TypeCombinator::addNull($type);
-				$arrayBuilder->setOffsetValueType(new ConstantIntegerType($i), $type);
-			}
-
-			return TypeCombinator::addNull($arrayBuilder->getArray());
+		$formatValue = $formatType->getValue();
+		$placeholderCount = $this->printfHelper->getScanfPlaceholdersCount($formatValue);
+		if ($placeholderCount === null) {
+			return $this->phpVersion->throwsValueErrorForInternalFunctions() ? new NeverType() : new NullType();
 		}
 
-		return null;
+		if ($placeholderCount === 0) {
+			return TypeCombinator::addNull(
+				ConstantArrayTypeBuilder::createEmpty()->getArray(),
+			);
+		}
+
+		if (preg_match_all('/%(\d*)(\[[^\]]+\]|[cdeEfosux]{1})/', $formatValue, $matches) !== $placeholderCount) {
+			$safeBuilder = ConstantArrayTypeBuilder::createEmpty();
+			for ($i = 0; $i < $placeholderCount; ++$i) {
+				$safeBuilder->setOffsetValueType(
+					new ConstantIntegerType($i),
+					TypeCombinator::union(
+						new FloatType(),
+						new IntegerType(),
+						new IntersectionType([
+							new StringType(),
+							new AccessoryNonEmptyStringType(),
+						]),
+						new NullType(),
+					),
+				);
+			}
+			return TypeCombinator::addNull($safeBuilder->getArray());
+		}
+
+		$arrayBuilder = ConstantArrayTypeBuilder::createEmpty();
+		for ($i = 0; $i < count($matches[0]); $i++) {
+			$length = $matches[1][$i];
+			$specifier = $matches[2][$i];
+
+			$type = new StringType();
+			if ($length !== '') {
+				if (((int) $length) > 1) {
+					$type = new IntersectionType([
+						$type,
+						new AccessoryNonFalsyStringType(),
+					]);
+				} else {
+					$type = new IntersectionType([
+						$type,
+						new AccessoryNonEmptyStringType(),
+					]);
+				}
+			}
+
+			if (in_array($specifier, ['d', 'o', 'u', 'x'], true)) {
+				$type = new IntegerType();
+			}
+
+			if (in_array($specifier, ['e', 'E', 'f'], true)) {
+				$type = new FloatType();
+			}
+
+			$type = TypeCombinator::addNull($type);
+			$arrayBuilder->setOffsetValueType(new ConstantIntegerType($i), $type);
+		}
+
+		return TypeCombinator::addNull($arrayBuilder->getArray());
 	}
 
 }

--- a/tests/PHPStan/Analyser/NodeScopeResolverTest.php
+++ b/tests/PHPStan/Analyser/NodeScopeResolverTest.php
@@ -285,6 +285,12 @@ class NodeScopeResolverTest extends TypeInferenceTestCase
 		yield __DIR__ . '/../Rules/Variables/data/bug-14124.php';
 		yield __DIR__ . '/../Rules/Variables/data/bug-14124b.php';
 		yield __DIR__ . '/../Rules/Arrays/data/bug-14308.php';
+
+		if (PHP_VERSION_ID < 80000) {
+			yield __DIR__ . '/data/sscanf-php74.php';
+		} else {
+			yield __DIR__ . '/data/sscanf-php80.php';
+		}
 	}
 
 	/**

--- a/tests/PHPStan/Analyser/data/sscanf-php74.php
+++ b/tests/PHPStan/Analyser/data/sscanf-php74.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SscanfPHP74;
+
+use function PHPStan\Testing\assertType;
+
+function sscanfInvalidFormatMixingPositionalWithSequential(string $s) {
+	assertType('null', sscanf($s, '%1$s %s'));
+}

--- a/tests/PHPStan/Analyser/data/sscanf-php80.php
+++ b/tests/PHPStan/Analyser/data/sscanf-php80.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SscanfPHP80;
+
+use function PHPStan\Testing\assertType;
+
+function sscanfInvalidFormatMixingPositionalWithSequential(string $s) {
+	assertType('*NEVER*', sscanf($s, '%1$s %s'));
+}

--- a/tests/PHPStan/Analyser/nsrt/bug-14597.php
+++ b/tests/PHPStan/Analyser/nsrt/bug-14597.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Bug14597;
+
+use function PHPStan\Testing\assertType;
+
+function sscanfNulTerminator(string $s) {
+	// NUL byte terminates sscanf format string – placeholders after \0 are ignored
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%d\0%d"));
+	assertType('array{float|int|non-empty-string|null, float|int|non-empty-string|null}|null', sscanf($s, "%d %s\0%d"));
+	assertType('array{}|null', sscanf($s, "\0%d%s"));
+}
+
+function fscanfNulTerminator($r) {
+	// Same for fscanf
+	assertType('array{float|int|non-empty-string|null}|null', fscanf($r, "%d\0%d"));
+	assertType('array{float|int|non-empty-string|null, float|int|non-empty-string|null}|null', fscanf($r, "%d %s\0%d"));
+	assertType('array{}|null', fscanf($r, "\0%d%s"));
+}
+
+function sscanfEdgeCases(string $s) {
+	// Empty format string – no placeholders
+	assertType('array{}|null', sscanf($s, ""));
+
+	// %n – counts characters consumed, returns integer
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%n"));
+
+	// %% – literal percent, not a placeholder
+	assertType('array{}|null', sscanf($s, "%%"));
+
+	// %i – integer with base detection
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%i"));
+
+	// %X – uppercase hex, same as %x
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%X"));
+
+	// %D – uppercase alias for %d
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%D"));
+
+	// Size modifiers (l, L, h) – consumed by ValidateFormat, no effect on PHP type
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%ld"));
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%lf"));
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%Lf"));
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%hd"));
+	assertType('array{float|int|non-empty-string|null}|null', sscanf($s, "%lu"));
+	assertType('array{float|int|non-empty-string|null, float|int|non-empty-string|null, float|int|non-empty-string|null}|null', sscanf($s, "%ld %lf %s"));
+}


### PR DESCRIPTION
Use the recently fixed `PrintfHelper::getScanfPlaceholdersCount()` to guard the return‑type extension against format‑induced imprecisions.

The counter now guards the extension’s independent regex‑based counting, syncing it with the `PrintfParametersRule` for the first time.

Invalid formats (uncountable) now return a precise error type (`NeverType`/`NullType`) instead of a false `array|null`. Valid formats (countable) that the old regex would miscount or ignore are now handled by a counter‑sized safe skeleton. The regex is now an optional precision layer, not the foundation for structural correctness. The counter overrides the regex wherever they disagree.

This is the same approach as in dd63663420 ("Fix counting `*scanf()` format string placeholders (#5594)", 2026-05-10) that eliminated the count regression, now applied to the return‑type logic.

Removes the old bottom‑of‑method `return null;` as a natural consequence.

For example, an invalid format (mixing positional `%n$` with sequential `%`) now correctly returns `null` on 7.4.

- https://phpstan.org/r/087c4c5f-9a00-47cc-8d36-f21fb1b27a31