### PR TITLE
Fix PHP 7.4 build

### DIFF
--- a/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
+++ b/tests/PHPStan/Analyser/AnalyserIntegrationTest.php
@@ -220,6 +220,7 @@ class AnalyserIntegrationTest extends PHPStanTestCase
 		$this->assertNoErrors($errors);
 	}
 
+	#[RequiresPhp('>= 8.0.0')]
 	public function testBug14604(): void
 	{
 		// crash


### PR DESCRIPTION
fixes

```
1) PHPStan\Analyser\AnalyserIntegrationTest::testBug14604
Failed asserting that actual size 4 matches expected size 0.

Emitted errors:
- Throw expression is supported only on PHP 8.0 and later
  in /home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/data/bug-14604.php on line 11

- Throw expression is supported only on PHP 8.0 and later
  in /home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/data/bug-14604.php on line 17

- Throw expression is supported only on PHP 8.0 and later
  in /home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/data/bug-14604.php on line 29

- Throw expression is supported only on PHP 8.0 and later
  in /home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/data/bug-14604.php on line 45

/home/runner/work/phpstan-src/phpstan-src/src/Testing/PHPStanTestCase.php:158
/home/runner/work/phpstan-src/phpstan-src/tests/PHPStan/Analyser/AnalyserIntegrationTest.php:206
/home/runner/work/phpstan-src/phpstan-src/tests/vendor/phpunit/phpunit/src/TextUI/Command.php:146

```