### PR TITLE
Experiment: fork parallel workers via pcntl_fork()

### DIFF
--- a/build/baseline-7.4.neon
+++ b/build/baseline-7.4.neon
@@ -11,9 +11,9 @@ parameters:
 			path: ../src/Parallel/ParallelAnalyser.php
 
 		-
-			message: "#^Class PHPStan\\\\Parallel\\\\Process has an uninitialized property \\$process\\. Give it default value or assign it in the constructor\\.$#"
+			message: "#^Class PHPStan\\\\Parallel\\\\SpawnedProcess has an uninitialized property \\$process\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1
-			path: ../src/Parallel/Process.php
+			path: ../src/Parallel/SpawnedProcess.php
 		-
 			message: "#^Class PHPStan\\\\PhpDoc\\\\ResolvedPhpDocBlock has an uninitialized property \\$phpDocNodes\\. Give it default value or assign it in the constructor\\.$#"
 			count: 1

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,10 @@
 		"phpstan/phpstan": "2.1.x",
 		"symfony/polyfill-php73": "*"
 	},
+	"suggest": {
+		"ext-pcntl": "Enables forking parallel analysis workers from the already-booted process (experimental, skips the per-worker re-boot)",
+		"ext-posix": "Used together with ext-pcntl for forked parallel analysis workers"
+	},
 	"require-dev": {
 		"cweagans/composer-patches": "^1.7.3",
 		"php-parallel-lint/php-parallel-lint": "^1.2.0",

--- a/src/Command/AnalyseCommand.php
+++ b/src/Command/AnalyseCommand.php
@@ -840,7 +840,7 @@ final class AnalyseCommand extends Command
 		$fixerApplication = $container->getByType(FixerApplication::class);
 
 		return $fixerApplication->run(
-			$inceptionResult->getProjectConfigFile(),
+			$inceptionResult,
 			$input,
 			$output,
 			count($files),

--- a/src/Command/AnalyserRunner.php
+++ b/src/Command/AnalyserRunner.php
@@ -83,7 +83,7 @@ final class AnalyserRunner
 			if ($mainScript !== null && $schedule->getNumberOfProcesses() > 0) {
 				$loop = new StreamSelectLoop();
 				$result = null;
-				$promise = $this->parallelAnalyser->analyse($loop, $schedule, $mainScript, $postFileCallback, $projectConfigFile, $tmpFile, $insteadOfFile, $input, null);
+				$promise = $this->parallelAnalyser->analyse($loop, $schedule, $allAnalysedFiles, $mainScript, $postFileCallback, $projectConfigFile, $tmpFile, $insteadOfFile, $input, null);
 				$promise->then(static function (AnalyserResult $tmp) use (&$result): void {
 					$result = $tmp;
 				});

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -28,6 +28,7 @@ use PHPStan\Process\ProcessCanceledException;
 use PHPStan\Process\ProcessCrashedException;
 use PHPStan\Process\ProcessHelper;
 use PHPStan\Process\ProcessPromise;
+use PHPStan\Process\SpawnedProcessPromise;
 use PHPStan\ShouldNotHappenException;
 use React\ChildProcess\Process;
 use React\EventLoop\LoopInterface;
@@ -446,16 +447,7 @@ final class FixerApplication
 			});
 		});
 
-		$process = new ProcessPromise($loop, ProcessHelper::getWorkerCommand(
-			$mainScript,
-			'fixer:worker',
-			$projectConfigFile,
-			[
-				'--server-port',
-				(string) $serverPort,
-			],
-			$input,
-		));
+		$process = $this->createProcessPromise($loop, $mainScript, $projectConfigFile, $input, $serverPort);
 		$this->processInProgress = $process->run();
 
 		$this->processInProgress->then(function () use ($server): void {
@@ -564,6 +556,29 @@ final class FixerApplication
 		}
 
 		return $stubFiles;
+	}
+
+	/**
+	 * @param int<0, 65535> $serverPort
+	 */
+	private function createProcessPromise(
+		LoopInterface $loop,
+		string $mainScript,
+		?string $projectConfigFile,
+		InputInterface $input,
+		int $serverPort,
+	): ProcessPromise
+	{
+		return new SpawnedProcessPromise($loop, ProcessHelper::getWorkerCommand(
+			$mainScript,
+			'fixer:worker',
+			$projectConfigFile,
+			[
+				'--server-port',
+				(string) $serverPort,
+			],
+			$input,
+		));
 	}
 
 }

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -19,11 +19,14 @@ use PHPStan\File\FileMonitor;
 use PHPStan\File\FileMonitorResult;
 use PHPStan\File\FileReader;
 use PHPStan\File\FileWriter;
+use PHPStan\File\PathNotFoundException;
 use PHPStan\Internal\ComposerHelper;
 use PHPStan\Internal\DirectoryCreator;
 use PHPStan\Internal\DirectoryCreatorException;
 use PHPStan\Internal\HttpClientFactory;
+use PHPStan\Parallel\ForkParallelChecker;
 use PHPStan\PhpDoc\StubFilesProvider;
+use PHPStan\Process\ForkedProcessPromise;
 use PHPStan\Process\ProcessCanceledException;
 use PHPStan\Process\ProcessCrashedException;
 use PHPStan\Process\ProcessHelper;
@@ -95,18 +98,25 @@ final class FixerApplication
 		#[AutowiredParameter]
 		private string $usedLevel,
 		private HttpClientFactory $httpClientFactory,
+		private ForkParallelChecker $forkParallelChecker,
+		private FixerWorkerRunner $fixerWorkerRunner,
 	)
 	{
 	}
 
 	public function run(
-		?string $projectConfigFile,
+		InceptionResult $inceptionResult,
 		InputInterface $input,
 		OutputInterface $output,
 		int $filesCount,
 		string $mainScript,
 	): int
 	{
+		$projectConfigFile = $inceptionResult->getProjectConfigFile();
+		if ($this->forkParallelChecker->isSupported() && $output->isVerbose()) {
+			$output->writeln('Note: using pcntl_fork() for the PHPStan Pro worker (experimental).');
+		}
+
 		$loop = new StreamSelectLoop();
 		$server = new TcpServer('127.0.0.1:0', $loop);
 		/** @var string $serverAddress */
@@ -115,7 +125,7 @@ final class FixerApplication
 		/** @var int<0, 65535> $serverPort */
 		$serverPort = parse_url($serverAddress, PHP_URL_PORT);
 
-		$server->on('connection', function (ConnectionInterface $connection) use ($loop, $projectConfigFile, $input, $output, $mainScript, $filesCount): void {
+		$server->on('connection', function (ConnectionInterface $connection) use ($loop, $inceptionResult, $projectConfigFile, $input, $output, $mainScript, $filesCount): void {
 			// phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
 			$jsonInvalidUtf8Ignore = defined('JSON_INVALID_UTF8_IGNORE') ? JSON_INVALID_UTF8_IGNORE : 0;
 			// phpcs:enable
@@ -158,6 +168,7 @@ final class FixerApplication
 
 			$this->analyse(
 				$loop,
+				$inceptionResult,
 				$mainScript,
 				$projectConfigFile,
 				$input,
@@ -165,7 +176,7 @@ final class FixerApplication
 				$encoder,
 			);
 
-			$this->monitorFileChanges($loop, function (FileMonitorResult $changes) use ($loop, $mainScript, $projectConfigFile, $input, $encoder, $output): void {
+			$this->monitorFileChanges($loop, function (FileMonitorResult $changes) use ($loop, $inceptionResult, $mainScript, $projectConfigFile, $input, $encoder, $output): void {
 				if ($this->processInProgress !== null) {
 					$this->processInProgress->cancel();
 					$this->processInProgress = null;
@@ -179,6 +190,7 @@ final class FixerApplication
 
 				$this->analyse(
 					$loop,
+					$inceptionResult,
 					$mainScript,
 					$projectConfigFile,
 					$input,
@@ -418,6 +430,7 @@ final class FixerApplication
 
 	private function analyse(
 		LoopInterface $loop,
+		InceptionResult $inceptionResult,
 		string $mainScript,
 		?string $projectConfigFile,
 		InputInterface $input,
@@ -447,7 +460,16 @@ final class FixerApplication
 			});
 		});
 
-		$process = $this->createProcessPromise($loop, $mainScript, $projectConfigFile, $input, $serverPort);
+		$process = $this->createProcessPromise(
+			$this->forkParallelChecker->isSupported(),
+			$loop,
+			$server,
+			$mainScript,
+			$projectConfigFile,
+			$input,
+			$serverPort,
+			$inceptionResult,
+		);
 		$this->processInProgress = $process->run();
 
 		$this->processInProgress->then(function () use ($server): void {
@@ -562,13 +584,37 @@ final class FixerApplication
 	 * @param int<0, 65535> $serverPort
 	 */
 	private function createProcessPromise(
+		bool $useFork,
 		LoopInterface $loop,
+		TcpServer $server,
 		string $mainScript,
 		?string $projectConfigFile,
 		InputInterface $input,
 		int $serverPort,
+		InceptionResult $inceptionResult,
 	): ProcessPromise
 	{
+		if ($useFork) {
+			try {
+				[$inceptionFiles, $isOnlyFiles] = $inceptionResult->getFiles();
+			} catch (PathNotFoundException | InceptionNotSuccessfulException) {
+				throw new ShouldNotHappenException();
+			}
+
+			return new ForkedProcessPromise(
+				$loop,
+				$this->fixerWorkerRunner,
+				$server,
+				$inceptionResult->getErrorOutput(),
+				$inceptionFiles,
+				$isOnlyFiles,
+				$inceptionResult->getProjectConfigArray(),
+				$projectConfigFile,
+				$serverPort,
+				$input,
+			);
+		}
+
 		return new SpawnedProcessPromise($loop, ProcessHelper::getWorkerCommand(
 			$mainScript,
 			'fixer:worker',

--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -113,9 +113,6 @@ final class FixerApplication
 	): int
 	{
 		$projectConfigFile = $inceptionResult->getProjectConfigFile();
-		if ($this->forkParallelChecker->isSupported() && $output->isVerbose()) {
-			$output->writeln('Note: using pcntl_fork() for the PHPStan Pro worker (experimental).');
-		}
 
 		$loop = new StreamSelectLoop();
 		$server = new TcpServer('127.0.0.1:0', $loop);

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -2,46 +2,17 @@
 
 namespace PHPStan\Command;
 
-use Clue\React\NDJson\Encoder;
 use Override;
-use PHPStan\Analyser\AnalyserResult;
-use PHPStan\Analyser\AnalyserResultFinalizer;
-use PHPStan\Analyser\Error;
-use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
-use PHPStan\Analyser\Ignore\IgnoredErrorHelperResult;
-use PHPStan\Analyser\InternalError;
-use PHPStan\Analyser\ResultCache\ResultCacheManager;
-use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
-use PHPStan\DependencyInjection\Container;
 use PHPStan\File\PathNotFoundException;
-use PHPStan\Parallel\ParallelAnalyser;
-use PHPStan\Parallel\Scheduler;
-use PHPStan\Process\CpuCoreCounter;
 use PHPStan\ShouldNotHappenException;
-use React\EventLoop\LoopInterface;
-use React\EventLoop\StreamSelectLoop;
-use React\Promise\PromiseInterface;
-use React\Socket\ConnectionInterface;
-use React\Socket\TcpConnector;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use function array_diff;
-use function array_key_exists;
-use function count;
-use function filemtime;
-use function in_array;
 use function is_array;
 use function is_bool;
-use function is_file;
 use function is_string;
-use function memory_get_peak_usage;
-use function React\Promise\resolve;
-use function sprintf;
-use function usort;
-use const JSON_INVALID_UTF8_IGNORE;
 
 final class FixerWorkerCommand extends Command
 {
@@ -121,318 +92,25 @@ final class FixerWorkerCommand extends Command
 
 		$container = $inceptionResult->getContainer();
 
-		/** @var IgnoredErrorHelper $ignoredErrorHelper */
-		$ignoredErrorHelper = $container->getByType(IgnoredErrorHelper::class);
-		$ignoredErrorHelperResult = $ignoredErrorHelper->initialize();
-		if (count($ignoredErrorHelperResult->getErrors()) > 0) {
+		try {
+			[$inceptionFiles, $isOnlyFiles] = $inceptionResult->getFiles();
+		} catch (PathNotFoundException | InceptionNotSuccessfulException) {
 			throw new ShouldNotHappenException();
 		}
 
-		$loop = new StreamSelectLoop();
-		$tcpConnector = new TcpConnector($loop);
-		$tcpConnector->connect(sprintf('127.0.0.1:%d', (int) $serverPort))->then(function (ConnectionInterface $connection) use ($container, $inceptionResult, $configuration, $input, $ignoredErrorHelperResult, $loop): void {
-			// phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
-			$jsonInvalidUtf8Ignore = defined('JSON_INVALID_UTF8_IGNORE') ? JSON_INVALID_UTF8_IGNORE : 0;
-			// phpcs:enable
-			$out = new Encoder($connection, $jsonInvalidUtf8Ignore);
-			//$in = new Decoder($connection, true, 512, $jsonInvalidUtf8Ignore, 128 * 1024 * 1024);
+		// Everything after the boot lives in FixerWorkerRunner so a
+		// pcntl_fork()-ed child can reuse it without re-booting (see
+		// FixerApplication).
+		$fixerWorkerRunner = $container->getByType(FixerWorkerRunner::class);
 
-			/** @var ResultCacheManager $resultCacheManager */
-			$resultCacheManager = $container->getByType(ResultCacheManagerFactory::class)->create([]);
-			$projectConfigArray = $inceptionResult->getProjectConfigArray();
-
-			/** @var AnalyserResultFinalizer $analyserResultFinalizer */
-			$analyserResultFinalizer = $container->getByType(AnalyserResultFinalizer::class);
-
-			try {
-				[$inceptionFiles, $isOnlyFiles] = $inceptionResult->getFiles();
-			} catch (PathNotFoundException | InceptionNotSuccessfulException) {
-				throw new ShouldNotHappenException();
-			}
-
-			$out->write([
-				'action' => 'analysisStart',
-				'result' => [
-					'analysedFiles' => $inceptionFiles,
-				],
-			]);
-
-			$resultCache = $resultCacheManager->restore($inceptionFiles, false, false, $projectConfigArray, $inceptionResult->getErrorOutput());
-
-			$errorsFromResultCacheTmp = $resultCache->getErrors();
-			$locallyIgnoredErrorsFromResultCacheTmp = $resultCache->getLocallyIgnoredErrors();
-			foreach ($resultCache->getFilesToAnalyse() as $fileToAnalyse) {
-				unset($errorsFromResultCacheTmp[$fileToAnalyse]);
-				unset($locallyIgnoredErrorsFromResultCacheTmp[$fileToAnalyse]);
-			}
-
-			$errorsFromResultCache = [];
-			foreach ($errorsFromResultCacheTmp as $errorsByFile) {
-				foreach ($errorsByFile as $error) {
-					$errorsFromResultCache[] = $error;
-				}
-			}
-
-			[$errorsFromResultCache, $ignoredErrorsFromResultCache] = $this->filterErrors($errorsFromResultCache, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles, false);
-
-			foreach ($locallyIgnoredErrorsFromResultCacheTmp as $locallyIgnoredErrors) {
-				foreach ($locallyIgnoredErrors as $locallyIgnoredError) {
-					$ignoredErrorsFromResultCache[] = [$locallyIgnoredError, null];
-				}
-			}
-
-			$out->write([
-				'action' => 'analysisStream',
-				'result' => [
-					'errors' => $errorsFromResultCache,
-					'ignoredErrors' => $ignoredErrorsFromResultCache,
-					'analysedFiles' => array_diff($inceptionFiles, $resultCache->getFilesToAnalyse()),
-				],
-			]);
-
-			$filesToAnalyse = $resultCache->getFilesToAnalyse();
-			usort($filesToAnalyse, static function (string $a, string $b): int {
-				$aTime = @filemtime($a);
-				if ($aTime === false) {
-					return 1;
-				}
-
-				$bTime = @filemtime($b);
-				if ($bTime === false) {
-					return -1;
-				}
-
-				// files are sorted from the oldest
-				// because ParallelAnalyser reverses the scheduler jobs to do the smallest
-				// jobs first
-				return $aTime <=> $bTime;
-			});
-
-			$this->runAnalyser(
-				$loop,
-				$container,
-				$filesToAnalyse,
-				$inceptionFiles,
-				$configuration,
-				$input,
-				function (array $errors, array $locallyIgnoredErrors, array $analysedFiles) use ($out, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles): void {
-					$internalErrors = [];
-					foreach ($errors as $fileSpecificError) {
-						if (!$fileSpecificError->hasNonIgnorableException()) {
-							continue;
-						}
-
-						$internalErrors[] = $this->transformErrorIntoInternalError($fileSpecificError);
-					}
-
-					if (count($internalErrors) > 0) {
-						$out->write(['action' => 'analysisCrash', 'data' => [
-							'internalErrors' => $internalErrors,
-						]]);
-						return;
-					}
-
-					[$errors, $ignoredErrors] = $this->filterErrors($errors, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles, false);
-					foreach ($locallyIgnoredErrors as $locallyIgnoredError) {
-						$ignoredErrors[] = [$locallyIgnoredError, null];
-					}
-					$out->write([
-						'action' => 'analysisStream',
-						'result' => [
-							'errors' => $errors,
-							'ignoredErrors' => $ignoredErrors,
-							'analysedFiles' => $analysedFiles,
-						],
-					]);
-				},
-			)->then(function (AnalyserResult $intermediateAnalyserResult) use ($analyserResultFinalizer, $resultCacheManager, $resultCache, $inceptionResult, $isOnlyFiles, $ignoredErrorHelperResult, $inceptionFiles, $out): void {
-				$analyserResult = $resultCacheManager->process(
-					$intermediateAnalyserResult,
-					$resultCache,
-					$inceptionResult->getErrorOutput(),
-					false,
-					true,
-				)->getAnalyserResult();
-				$finalizerResult = $analyserResultFinalizer->finalize($analyserResult, $isOnlyFiles, false);
-
-				$internalErrors = [];
-				foreach ($finalizerResult->getAnalyserResult()->getInternalErrors() as $internalError) {
-					$internalErrors[] = new InternalError(
-						$internalError->getTraceAsString() !== null ? sprintf('Internal error: %s', $internalError->getMessage()) : $internalError->getMessage(),
-						$internalError->getContextDescription(),
-						$internalError->getTrace(),
-						$internalError->getTraceAsString(),
-						$internalError->shouldReportBug(),
-					);
-				}
-
-				foreach ($finalizerResult->getAnalyserResult()->getUnorderedErrors() as $fileSpecificError) {
-					if (!$fileSpecificError->hasNonIgnorableException()) {
-						continue;
-					}
-
-					$internalErrors[] = $this->transformErrorIntoInternalError($fileSpecificError);
-				}
-
-				$hasInternalErrors = count($internalErrors) > 0 || $finalizerResult->getAnalyserResult()->hasReachedInternalErrorsCountLimit();
-
-				if ($hasInternalErrors) {
-					$out->write(['action' => 'analysisCrash', 'data' => [
-						'internalErrors' => count($internalErrors) > 0 ? $internalErrors : [
-							new InternalError(
-								'Internal error occurred',
-								'running analyser in PHPStan Pro worker',
-								trace: [],
-								traceAsString: null,
-								shouldReportBug: false,
-							),
-						],
-					]]);
-				}
-
-				[$collectorErrors, $ignoredCollectorErrors] = $this->filterErrors($finalizerResult->getCollectorErrors(), $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles, $hasInternalErrors);
-				foreach ($finalizerResult->getLocallyIgnoredCollectorErrors() as $locallyIgnoredCollectorError) {
-					$ignoredCollectorErrors[] = [$locallyIgnoredCollectorError, null];
-				}
-				$out->write([
-					'action' => 'analysisStream',
-					'result' => [
-						'errors' => $collectorErrors,
-						'ignoredErrors' => $ignoredCollectorErrors,
-						'analysedFiles' => [],
-					],
-				]);
-
-				$ignoredErrorHelperProcessedResult = $ignoredErrorHelperResult->process(
-					$finalizerResult->getErrors(),
-					$isOnlyFiles,
-					$inceptionFiles,
-					$hasInternalErrors,
-				);
-				$ignoreFileErrors = [];
-				foreach ($ignoredErrorHelperProcessedResult->getNotIgnoredErrors() as $error) {
-					if ($error->getIdentifier() === null) {
-						continue;
-					}
-					if (!in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched', 'ignore.unmatchedLine', 'ignore.unmatchedIdentifier', 'ignore.noComment'], true)) {
-						continue;
-					}
-					$ignoreFileErrors[] = $error;
-				}
-
-				$out->end([
-					'action' => 'analysisEnd',
-					'result' => [
-						'ignoreFileErrors' => $ignoreFileErrors,
-						'ignoreNotFileErrors' => $ignoredErrorHelperProcessedResult->getOtherIgnoreMessages(),
-					],
-				]);
-			});
-		});
-		$loop->run();
-
-		return 0;
-	}
-
-	private function transformErrorIntoInternalError(Error $error): InternalError
-	{
-		$message = $error->getMessage();
-		$metadata = $error->getMetadata();
-		if (
-			$error->getIdentifier() === 'phpstan.internal'
-			&& array_key_exists(InternalError::STACK_TRACE_AS_STRING_METADATA_KEY, $metadata)
-		) {
-			$message = sprintf('Internal error: %s', $message);
-		}
-
-		return new InternalError(
-			$message,
-			sprintf('analysing file %s', $error->getTraitFilePath() ?? $error->getFilePath()),
-			$metadata[InternalError::STACK_TRACE_METADATA_KEY] ?? [],
-			$metadata[InternalError::STACK_TRACE_AS_STRING_METADATA_KEY] ?? null,
-			shouldReportBug: true,
-		);
-	}
-
-	/**
-	 * @param string[] $inceptionFiles
-	 * @param list<Error> $errors
-	 * @return array{list<Error>, list<array{Error, mixed[]|string}>}
-	 */
-	private function filterErrors(array $errors, IgnoredErrorHelperResult $ignoredErrorHelperResult, bool $onlyFiles, array $inceptionFiles, bool $hasInternalErrors): array
-	{
-		$ignoredErrorHelperProcessedResult = $ignoredErrorHelperResult->process($errors, $onlyFiles, $inceptionFiles, $hasInternalErrors);
-		$finalErrors = [];
-		foreach ($ignoredErrorHelperProcessedResult->getNotIgnoredErrors() as $error) {
-			if ($error->getIdentifier() === null) {
-				$finalErrors[] = $error;
-				continue;
-			}
-			if (in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched'], true)) {
-				continue;
-			}
-			$finalErrors[] = $error;
-		}
-
-		return [
-			$finalErrors,
-			$ignoredErrorHelperProcessedResult->getIgnoredErrors(),
-		];
-	}
-
-	/**
-	 * @param string[] $files
-	 * @param string[] $allAnalysedFiles
-	 * @param callable(list<Error>, list<Error>, string[]): void $onFileAnalysisHandler
-	 * @return PromiseInterface<AnalyserResult>
-	 */
-	private function runAnalyser(LoopInterface $loop, Container $container, array $files, array $allAnalysedFiles, ?string $configuration, InputInterface $input, callable $onFileAnalysisHandler): PromiseInterface
-	{
-		/** @var ParallelAnalyser $parallelAnalyser */
-		$parallelAnalyser = $container->getByType(ParallelAnalyser::class);
-		$filesCount = count($files);
-		if ($filesCount === 0) {
-			return resolve(new AnalyserResult(
-				unorderedErrors: [],
-				filteredPhpErrors: [],
-				allPhpErrors: [],
-				locallyIgnoredErrors: [],
-				linesToIgnore: [],
-				unmatchedLineIgnores: [],
-				internalErrors: [],
-				collectedData: [],
-				dependencies: [],
-				usedTraitDependencies: [],
-				exportedNodes: [],
-				reachedInternalErrorsCountLimit: false,
-				peakMemoryUsageBytes: memory_get_peak_usage(true),
-				processedFiles: [],
-			));
-		}
-
-		/** @var Scheduler $scheduler */
-		$scheduler = $container->getByType(Scheduler::class);
-
-		/** @var CpuCoreCounter $cpuCoreCounter */
-		$cpuCoreCounter = $container->getByType(CpuCoreCounter::class);
-
-		$schedule = $scheduler->scheduleWork($cpuCoreCounter->getNumberOfCpuCores(), $files);
-		$mainScript = null;
-		if (isset($_SERVER['argv'][0]) && is_file($_SERVER['argv'][0])) {
-			$mainScript = $_SERVER['argv'][0];
-		}
-
-		return $parallelAnalyser->analyse(
-			$loop,
-			$schedule,
-			$allAnalysedFiles,
-			$mainScript,
-			null,
+		return $fixerWorkerRunner->run(
+			$inceptionResult->getErrorOutput(),
+			$inceptionFiles,
+			$isOnlyFiles,
+			$inceptionResult->getProjectConfigArray(),
 			$configuration,
-			null,
-			null,
+			(int) $serverPort,
 			$input,
-			$onFileAnalysisHandler,
 		);
 	}
 

--- a/src/Command/FixerWorkerCommand.php
+++ b/src/Command/FixerWorkerCommand.php
@@ -212,6 +212,7 @@ final class FixerWorkerCommand extends Command
 				$loop,
 				$container,
 				$filesToAnalyse,
+				$inceptionFiles,
 				$configuration,
 				$input,
 				function (array $errors, array $locallyIgnoredErrors, array $analysedFiles) use ($out, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles): void {
@@ -381,10 +382,11 @@ final class FixerWorkerCommand extends Command
 
 	/**
 	 * @param string[] $files
+	 * @param string[] $allAnalysedFiles
 	 * @param callable(list<Error>, list<Error>, string[]): void $onFileAnalysisHandler
 	 * @return PromiseInterface<AnalyserResult>
 	 */
-	private function runAnalyser(LoopInterface $loop, Container $container, array $files, ?string $configuration, InputInterface $input, callable $onFileAnalysisHandler): PromiseInterface
+	private function runAnalyser(LoopInterface $loop, Container $container, array $files, array $allAnalysedFiles, ?string $configuration, InputInterface $input, callable $onFileAnalysisHandler): PromiseInterface
 	{
 		/** @var ParallelAnalyser $parallelAnalyser */
 		$parallelAnalyser = $container->getByType(ParallelAnalyser::class);
@@ -423,6 +425,7 @@ final class FixerWorkerCommand extends Command
 		return $parallelAnalyser->analyse(
 			$loop,
 			$schedule,
+			$allAnalysedFiles,
 			$mainScript,
 			null,
 			$configuration,

--- a/src/Command/FixerWorkerRunner.php
+++ b/src/Command/FixerWorkerRunner.php
@@ -1,0 +1,374 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Command;
+
+use Clue\React\NDJson\Encoder;
+use PHPStan\Analyser\AnalyserResult;
+use PHPStan\Analyser\AnalyserResultFinalizer;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\Ignore\IgnoredErrorHelper;
+use PHPStan\Analyser\Ignore\IgnoredErrorHelperResult;
+use PHPStan\Analyser\InternalError;
+use PHPStan\Analyser\ResultCache\ResultCacheManager;
+use PHPStan\Analyser\ResultCache\ResultCacheManagerFactory;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Parallel\ParallelAnalyser;
+use PHPStan\Parallel\Scheduler;
+use PHPStan\Process\CpuCoreCounter;
+use PHPStan\ShouldNotHappenException;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\StreamSelectLoop;
+use React\Promise\PromiseInterface;
+use React\Socket\ConnectionInterface;
+use React\Socket\TcpConnector;
+use Symfony\Component\Console\Input\InputInterface;
+use function array_diff;
+use function array_key_exists;
+use function count;
+use function filemtime;
+use function in_array;
+use function is_file;
+use function memory_get_peak_usage;
+use function React\Promise\resolve;
+use function sprintf;
+use function usort;
+use const JSON_INVALID_UTF8_IGNORE;
+
+/**
+ * The PHPStan Pro worker logic that runs *after* the application boot.
+ *
+ * Extracted from FixerWorkerCommand so it can be reused without re-booting: a
+ * pcntl_fork()-ed child (see ForkedProcessPromise) inherits the already-booted
+ * DI container and calls run() directly, while FixerWorkerCommand still calls
+ * it after the expensive CommandHelper::begin() boot of a freshly spawned
+ * process.
+ *
+ * It connects back to FixerApplication's TCP server, restores the result
+ * cache, analyses the changed files and streams the results.
+ */
+#[AutowiredService]
+final class FixerWorkerRunner
+{
+
+	public function __construct(
+		private IgnoredErrorHelper $ignoredErrorHelper,
+		private ResultCacheManagerFactory $resultCacheManagerFactory,
+		private AnalyserResultFinalizer $analyserResultFinalizer,
+		private ParallelAnalyser $parallelAnalyser,
+		private Scheduler $scheduler,
+		private CpuCoreCounter $cpuCoreCounter,
+	)
+	{
+	}
+
+	/**
+	 * @param string[] $inceptionFiles
+	 * @param mixed[]|null $projectConfigArray
+	 */
+	public function run(
+		Output $errorOutput,
+		array $inceptionFiles,
+		bool $isOnlyFiles,
+		?array $projectConfigArray,
+		?string $configuration,
+		int $serverPort,
+		InputInterface $input,
+	): int
+	{
+		$ignoredErrorHelperResult = $this->ignoredErrorHelper->initialize();
+		if (count($ignoredErrorHelperResult->getErrors()) > 0) {
+			throw new ShouldNotHappenException();
+		}
+
+		// Always a fresh event loop: in a forked child the parent's inherited
+		// loop must never be touched.
+		$loop = new StreamSelectLoop();
+		$tcpConnector = new TcpConnector($loop);
+		$tcpConnector->connect(sprintf('127.0.0.1:%d', $serverPort))->then(function (ConnectionInterface $connection) use ($errorOutput, $inceptionFiles, $isOnlyFiles, $projectConfigArray, $configuration, $input, $ignoredErrorHelperResult, $loop): void {
+			// phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+			$jsonInvalidUtf8Ignore = defined('JSON_INVALID_UTF8_IGNORE') ? JSON_INVALID_UTF8_IGNORE : 0;
+			// phpcs:enable
+			$out = new Encoder($connection, $jsonInvalidUtf8Ignore);
+			//$in = new Decoder($connection, true, 512, $jsonInvalidUtf8Ignore, 128 * 1024 * 1024);
+
+			/** @var ResultCacheManager $resultCacheManager */
+			$resultCacheManager = $this->resultCacheManagerFactory->create([]);
+
+			$out->write([
+				'action' => 'analysisStart',
+				'result' => [
+					'analysedFiles' => $inceptionFiles,
+				],
+			]);
+
+			$resultCache = $resultCacheManager->restore($inceptionFiles, false, false, $projectConfigArray, $errorOutput);
+
+			$errorsFromResultCacheTmp = $resultCache->getErrors();
+			$locallyIgnoredErrorsFromResultCacheTmp = $resultCache->getLocallyIgnoredErrors();
+			foreach ($resultCache->getFilesToAnalyse() as $fileToAnalyse) {
+				unset($errorsFromResultCacheTmp[$fileToAnalyse]);
+				unset($locallyIgnoredErrorsFromResultCacheTmp[$fileToAnalyse]);
+			}
+
+			$errorsFromResultCache = [];
+			foreach ($errorsFromResultCacheTmp as $errorsByFile) {
+				foreach ($errorsByFile as $error) {
+					$errorsFromResultCache[] = $error;
+				}
+			}
+
+			[$errorsFromResultCache, $ignoredErrorsFromResultCache] = $this->filterErrors($errorsFromResultCache, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles, false);
+
+			foreach ($locallyIgnoredErrorsFromResultCacheTmp as $locallyIgnoredErrors) {
+				foreach ($locallyIgnoredErrors as $locallyIgnoredError) {
+					$ignoredErrorsFromResultCache[] = [$locallyIgnoredError, null];
+				}
+			}
+
+			$out->write([
+				'action' => 'analysisStream',
+				'result' => [
+					'errors' => $errorsFromResultCache,
+					'ignoredErrors' => $ignoredErrorsFromResultCache,
+					'analysedFiles' => array_diff($inceptionFiles, $resultCache->getFilesToAnalyse()),
+				],
+			]);
+
+			$filesToAnalyse = $resultCache->getFilesToAnalyse();
+			usort($filesToAnalyse, static function (string $a, string $b): int {
+				$aTime = @filemtime($a);
+				if ($aTime === false) {
+					return 1;
+				}
+
+				$bTime = @filemtime($b);
+				if ($bTime === false) {
+					return -1;
+				}
+
+				// files are sorted from the oldest
+				// because ParallelAnalyser reverses the scheduler jobs to do the smallest
+				// jobs first
+				return $aTime <=> $bTime;
+			});
+
+			$this->runAnalyser(
+				$loop,
+				$filesToAnalyse,
+				$inceptionFiles,
+				$configuration,
+				$input,
+				function (array $errors, array $locallyIgnoredErrors, array $analysedFiles) use ($out, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles): void {
+					$internalErrors = [];
+					foreach ($errors as $fileSpecificError) {
+						if (!$fileSpecificError->hasNonIgnorableException()) {
+							continue;
+						}
+
+						$internalErrors[] = $this->transformErrorIntoInternalError($fileSpecificError);
+					}
+
+					if (count($internalErrors) > 0) {
+						$out->write(['action' => 'analysisCrash', 'data' => [
+							'internalErrors' => $internalErrors,
+						]]);
+						return;
+					}
+
+					[$errors, $ignoredErrors] = $this->filterErrors($errors, $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles, false);
+					foreach ($locallyIgnoredErrors as $locallyIgnoredError) {
+						$ignoredErrors[] = [$locallyIgnoredError, null];
+					}
+					$out->write([
+						'action' => 'analysisStream',
+						'result' => [
+							'errors' => $errors,
+							'ignoredErrors' => $ignoredErrors,
+							'analysedFiles' => $analysedFiles,
+						],
+					]);
+				},
+			)->then(function (AnalyserResult $intermediateAnalyserResult) use ($resultCacheManager, $resultCache, $errorOutput, $isOnlyFiles, $ignoredErrorHelperResult, $inceptionFiles, $out): void {
+				$analyserResult = $resultCacheManager->process(
+					$intermediateAnalyserResult,
+					$resultCache,
+					$errorOutput,
+					false,
+					true,
+				)->getAnalyserResult();
+				$finalizerResult = $this->analyserResultFinalizer->finalize($analyserResult, $isOnlyFiles, false);
+
+				$internalErrors = [];
+				foreach ($finalizerResult->getAnalyserResult()->getInternalErrors() as $internalError) {
+					$internalErrors[] = new InternalError(
+						$internalError->getTraceAsString() !== null ? sprintf('Internal error: %s', $internalError->getMessage()) : $internalError->getMessage(),
+						$internalError->getContextDescription(),
+						$internalError->getTrace(),
+						$internalError->getTraceAsString(),
+						$internalError->shouldReportBug(),
+					);
+				}
+
+				foreach ($finalizerResult->getAnalyserResult()->getUnorderedErrors() as $fileSpecificError) {
+					if (!$fileSpecificError->hasNonIgnorableException()) {
+						continue;
+					}
+
+					$internalErrors[] = $this->transformErrorIntoInternalError($fileSpecificError);
+				}
+
+				$hasInternalErrors = count($internalErrors) > 0 || $finalizerResult->getAnalyserResult()->hasReachedInternalErrorsCountLimit();
+
+				if ($hasInternalErrors) {
+					$out->write(['action' => 'analysisCrash', 'data' => [
+						'internalErrors' => count($internalErrors) > 0 ? $internalErrors : [
+							new InternalError(
+								'Internal error occurred',
+								'running analyser in PHPStan Pro worker',
+								trace: [],
+								traceAsString: null,
+								shouldReportBug: false,
+							),
+						],
+					]]);
+				}
+
+				[$collectorErrors, $ignoredCollectorErrors] = $this->filterErrors($finalizerResult->getCollectorErrors(), $ignoredErrorHelperResult, $isOnlyFiles, $inceptionFiles, $hasInternalErrors);
+				foreach ($finalizerResult->getLocallyIgnoredCollectorErrors() as $locallyIgnoredCollectorError) {
+					$ignoredCollectorErrors[] = [$locallyIgnoredCollectorError, null];
+				}
+				$out->write([
+					'action' => 'analysisStream',
+					'result' => [
+						'errors' => $collectorErrors,
+						'ignoredErrors' => $ignoredCollectorErrors,
+						'analysedFiles' => [],
+					],
+				]);
+
+				$ignoredErrorHelperProcessedResult = $ignoredErrorHelperResult->process(
+					$finalizerResult->getErrors(),
+					$isOnlyFiles,
+					$inceptionFiles,
+					$hasInternalErrors,
+				);
+				$ignoreFileErrors = [];
+				foreach ($ignoredErrorHelperProcessedResult->getNotIgnoredErrors() as $error) {
+					if ($error->getIdentifier() === null) {
+						continue;
+					}
+					if (!in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched', 'ignore.unmatchedLine', 'ignore.unmatchedIdentifier', 'ignore.noComment'], true)) {
+						continue;
+					}
+					$ignoreFileErrors[] = $error;
+				}
+
+				$out->end([
+					'action' => 'analysisEnd',
+					'result' => [
+						'ignoreFileErrors' => $ignoreFileErrors,
+						'ignoreNotFileErrors' => $ignoredErrorHelperProcessedResult->getOtherIgnoreMessages(),
+					],
+				]);
+			});
+		});
+		$loop->run();
+
+		return 0;
+	}
+
+	private function transformErrorIntoInternalError(Error $error): InternalError
+	{
+		$message = $error->getMessage();
+		$metadata = $error->getMetadata();
+		if (
+			$error->getIdentifier() === 'phpstan.internal'
+			&& array_key_exists(InternalError::STACK_TRACE_AS_STRING_METADATA_KEY, $metadata)
+		) {
+			$message = sprintf('Internal error: %s', $message);
+		}
+
+		return new InternalError(
+			$message,
+			sprintf('analysing file %s', $error->getTraitFilePath() ?? $error->getFilePath()),
+			$metadata[InternalError::STACK_TRACE_METADATA_KEY] ?? [],
+			$metadata[InternalError::STACK_TRACE_AS_STRING_METADATA_KEY] ?? null,
+			shouldReportBug: true,
+		);
+	}
+
+	/**
+	 * @param string[] $inceptionFiles
+	 * @param list<Error> $errors
+	 * @return array{list<Error>, list<array{Error, mixed[]|string}>}
+	 */
+	private function filterErrors(array $errors, IgnoredErrorHelperResult $ignoredErrorHelperResult, bool $onlyFiles, array $inceptionFiles, bool $hasInternalErrors): array
+	{
+		$ignoredErrorHelperProcessedResult = $ignoredErrorHelperResult->process($errors, $onlyFiles, $inceptionFiles, $hasInternalErrors);
+		$finalErrors = [];
+		foreach ($ignoredErrorHelperProcessedResult->getNotIgnoredErrors() as $error) {
+			if ($error->getIdentifier() === null) {
+				$finalErrors[] = $error;
+				continue;
+			}
+			if (in_array($error->getIdentifier(), ['ignore.count', 'ignore.unmatched'], true)) {
+				continue;
+			}
+			$finalErrors[] = $error;
+		}
+
+		return [
+			$finalErrors,
+			$ignoredErrorHelperProcessedResult->getIgnoredErrors(),
+		];
+	}
+
+	/**
+	 * @param string[] $files
+	 * @param string[] $allAnalysedFiles
+	 * @param callable(list<Error>, list<Error>, string[]): void $onFileAnalysisHandler
+	 * @return PromiseInterface<AnalyserResult>
+	 */
+	private function runAnalyser(LoopInterface $loop, array $files, array $allAnalysedFiles, ?string $configuration, InputInterface $input, callable $onFileAnalysisHandler): PromiseInterface
+	{
+		$filesCount = count($files);
+		if ($filesCount === 0) {
+			return resolve(new AnalyserResult(
+				unorderedErrors: [],
+				filteredPhpErrors: [],
+				allPhpErrors: [],
+				locallyIgnoredErrors: [],
+				linesToIgnore: [],
+				unmatchedLineIgnores: [],
+				internalErrors: [],
+				collectedData: [],
+				dependencies: [],
+				usedTraitDependencies: [],
+				exportedNodes: [],
+				reachedInternalErrorsCountLimit: false,
+				peakMemoryUsageBytes: memory_get_peak_usage(true),
+				processedFiles: [],
+			));
+		}
+
+		$schedule = $this->scheduler->scheduleWork($this->cpuCoreCounter->getNumberOfCpuCores(), $files);
+		$mainScript = null;
+		if (isset($_SERVER['argv'][0]) && is_file($_SERVER['argv'][0])) {
+			$mainScript = $_SERVER['argv'][0];
+		}
+
+		return $this->parallelAnalyser->analyse(
+			$loop,
+			$schedule,
+			$allAnalysedFiles,
+			$mainScript,
+			null,
+			$configuration,
+			null,
+			null,
+			$input,
+			$onFileAnalysisHandler,
+		);
+	}
+
+}

--- a/src/Command/WorkerCommand.php
+++ b/src/Command/WorkerCommand.php
@@ -2,46 +2,24 @@
 
 namespace PHPStan\Command;
 
-use Clue\React\NDJson\Decoder;
-use Clue\React\NDJson\Encoder;
 use Override;
-use PHPStan\Analyser\FileAnalyser;
-use PHPStan\Analyser\InternalError;
-use PHPStan\Analyser\NodeScopeResolver;
-use PHPStan\Collectors\Registry as CollectorRegistry;
-use PHPStan\DependencyInjection\Container;
 use PHPStan\File\PathNotFoundException;
-use PHPStan\Rules\Registry as RuleRegistry;
+use PHPStan\Parallel\WorkerRunner;
 use PHPStan\ShouldNotHappenException;
-use React\EventLoop\StreamSelectLoop;
-use React\Socket\ConnectionInterface;
-use React\Socket\TcpConnector;
-use React\Stream\ReadableStreamInterface;
-use React\Stream\WritableStreamInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
-use function array_fill_keys;
-use function array_filter;
-use function array_merge;
-use function array_unshift;
-use function array_values;
-use function defined;
 use function is_array;
 use function is_bool;
 use function is_string;
-use function memory_get_peak_usage;
 use function sprintf;
 
 final class WorkerCommand extends Command
 {
 
 	private const NAME = 'worker';
-
-	private int $errorCount = 0;
 
 	/**
 	 * @param string[] $composerAutoloaderProjectPaths
@@ -122,13 +100,11 @@ final class WorkerCommand extends Command
 		} catch (InceptionNotSuccessfulException $e) {
 			return 1;
 		}
-		$loop = new StreamSelectLoop();
 
 		$container = $inceptionResult->getContainer();
 
 		try {
 			[$analysedFiles] = $inceptionResult->getFiles();
-			$analysedFiles = $this->switchTmpFile($analysedFiles, $insteadOfFile, $tmpFile);
 		} catch (PathNotFoundException $e) {
 			$inceptionResult->getErrorOutput()->writeLineFormatted(sprintf('<error>%s</error>', $e->getMessage()));
 			return 1;
@@ -136,182 +112,18 @@ final class WorkerCommand extends Command
 			return 1;
 		}
 
-		$nodeScopeResolver = $container->getByType(NodeScopeResolver::class);
-		$nodeScopeResolver->setAnalysedFiles($analysedFiles);
+		// Everything after the boot lives in WorkerRunner so a pcntl_fork()-ed
+		// child can reuse it without re-booting (see ParallelAnalyser).
+		$workerRunner = $container->getByType(WorkerRunner::class);
 
-		$analysedFiles = array_fill_keys($analysedFiles, true);
-
-		$tcpConnector = new TcpConnector($loop);
-		$tcpConnector->connect(sprintf('127.0.0.1:%d', (int) $port))->then(function (ConnectionInterface $connection) use ($container, $identifier, $output, $analysedFiles, $tmpFile, $insteadOfFile): void {
-			// phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
-			$jsonInvalidUtf8Ignore = defined('JSON_INVALID_UTF8_IGNORE') ? JSON_INVALID_UTF8_IGNORE : 0;
-			// phpcs:enable
-			$out = new Encoder($connection, $jsonInvalidUtf8Ignore);
-			$in = new Decoder($connection, true, options: $jsonInvalidUtf8Ignore, maxlength: $container->getParameter('parallel')['buffer']);
-			$out->write(['action' => 'hello', 'identifier' => $identifier]);
-			$this->runWorker($container, $out, $in, $output, $analysedFiles, $tmpFile, $insteadOfFile);
-		});
-
-		$loop->run();
-
-		if ($this->errorCount > 0) {
-			return 1;
-		}
-
-		return 0;
-	}
-
-	/**
-	 * @param array<string, true> $analysedFiles
-	 */
-	private function runWorker(
-		Container $container,
-		WritableStreamInterface $out,
-		ReadableStreamInterface $in,
-		OutputInterface $output,
-		array $analysedFiles,
-		?string $tmpFile,
-		?string $insteadOfFile,
-	): void
-	{
-		$handleError = function (Throwable $error) use ($out, $output): void {
-			$this->errorCount++;
-			$output->writeln(sprintf('Error: %s', $error->getMessage()));
-			$out->write([
-				'action' => 'result',
-				'result' => [
-					'errors' => [],
-					'internalErrors' => [
-						new InternalError(
-							$error->getMessage(),
-							'communicating with main process in parallel worker',
-							InternalError::prepareTrace($error),
-							$error->getTraceAsString(),
-							shouldReportBug: true,
-						),
-					],
-					'filteredPhpErrors' => [],
-					'allPhpErrors' => [],
-					'locallyIgnoredErrors' => [],
-					'linesToIgnore' => [],
-					'unmatchedLineIgnores' => [],
-					'collectedData' => [],
-					'memoryUsage' => memory_get_peak_usage(true),
-					'dependencies' => [],
-					'exportedNodes' => [],
-					'files' => [],
-					'internalErrorsCount' => 1,
-				],
-			]);
-			$out->end();
-		};
-		$out->on('error', $handleError);
-		$fileAnalyser = $container->getByType(FileAnalyser::class);
-		$ruleRegistry = $container->getByType(RuleRegistry::class);
-		$collectorRegistry = $container->getByType(CollectorRegistry::class);
-		$in->on('data', static function (array $json) use ($fileAnalyser, $ruleRegistry, $collectorRegistry, $out, $analysedFiles, $tmpFile, $insteadOfFile): void {
-			$action = $json['action'];
-			if ($action !== 'analyse') {
-				return;
-			}
-
-			$internalErrorsCount = 0;
-			$files = $json['files'];
-			$errors = [];
-			$internalErrors = [];
-			$filteredPhpErrors = [];
-			$allPhpErrors = [];
-			$locallyIgnoredErrors = [];
-			$linesToIgnore = [];
-			$unmatchedLineIgnores = [];
-			$collectedData = [];
-			$dependencies = [];
-			$usedTraitDependencies = [];
-			$exportedNodes = [];
-			$processedFiles = [];
-			foreach ($files as $file) {
-				try {
-					if ($file === $insteadOfFile) {
-						$file = $tmpFile;
-					}
-					$fileAnalyserResult = $fileAnalyser->analyseFile($file, $analysedFiles, $ruleRegistry, $collectorRegistry, null);
-					$fileErrors = $fileAnalyserResult->getErrors();
-					$filteredPhpErrors = array_merge($filteredPhpErrors, $fileAnalyserResult->getFilteredPhpErrors());
-					$allPhpErrors = array_merge($allPhpErrors, $fileAnalyserResult->getAllPhpErrors());
-					$linesToIgnore[$file] = $fileAnalyserResult->getLinesToIgnore();
-					$unmatchedLineIgnores[$file] = $fileAnalyserResult->getUnmatchedLineIgnores();
-					$dependencies[$file] = $fileAnalyserResult->getDependencies();
-					$usedTraitDependencies[$file] = $fileAnalyserResult->getUsedTraitDependencies();
-					$exportedNodes[$file] = $fileAnalyserResult->getExportedNodes();
-					$processedFiles = array_merge($processedFiles, $fileAnalyserResult->getProcessedFiles());
-					foreach ($fileErrors as $fileError) {
-						$errors[] = $fileError;
-					}
-					foreach ($fileAnalyserResult->getLocallyIgnoredErrors() as $locallyIgnoredError) {
-						$locallyIgnoredErrors[] = $locallyIgnoredError;
-					}
-					foreach ($fileAnalyserResult->getCollectedData() as $collectedFile => $dataPerCollector) {
-						foreach ($dataPerCollector as $collectorType => $collectorData) {
-							foreach ($collectorData as $data) {
-								$collectedData[$collectedFile][$collectorType][] = $data;
-							}
-						}
-					}
-				} catch (Throwable $t) {
-					$internalErrorsCount++;
-					$internalErrors[] = new InternalError(
-						$t->getMessage(),
-						sprintf('analysing file %s', $file),
-						InternalError::prepareTrace($t),
-						$t->getTraceAsString(),
-						shouldReportBug: true,
-					);
-				}
-			}
-
-			$out->write([
-				'action' => 'result',
-				'result' => [
-					'errors' => $errors,
-					'internalErrors' => $internalErrors,
-					'filteredPhpErrors' => $filteredPhpErrors,
-					'allPhpErrors' => $allPhpErrors,
-					'locallyIgnoredErrors' => $locallyIgnoredErrors,
-					'linesToIgnore' => $linesToIgnore,
-					'unmatchedLineIgnores' => $unmatchedLineIgnores,
-					'collectedData' => $collectedData,
-					'memoryUsage' => memory_get_peak_usage(true),
-					'dependencies' => $dependencies,
-					'usedTraitDependencies' => $usedTraitDependencies,
-					'exportedNodes' => $exportedNodes,
-					'files' => $files,
-					'processedFiles' => $processedFiles,
-					'internalErrorsCount' => $internalErrorsCount,
-				]]);
-		});
-		$in->on('error', $handleError);
-	}
-
-	/**
-	 * @param string[] $analysedFiles
-	 * @return string[]
-	 */
-	private function switchTmpFile(
-		array $analysedFiles,
-		?string $insteadOfFile,
-		?string $tmpFile,
-	): array
-	{
-		if ($insteadOfFile === null) {
-			return $analysedFiles;
-		}
-		$analysedFiles = array_values(array_filter($analysedFiles, static fn (string $file): bool => $file !== $insteadOfFile));
-
-		if ($tmpFile !== null) {
-			array_unshift($analysedFiles, $tmpFile);
-		}
-
-		return $analysedFiles;
+		return $workerRunner->run(
+			$output,
+			$analysedFiles,
+			(int) $port,
+			$identifier,
+			$tmpFile,
+			$insteadOfFile,
+		);
 	}
 
 }

--- a/src/Parallel/ForkParallelChecker.php
+++ b/src/Parallel/ForkParallelChecker.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parallel;
+
+use PHPStan\DependencyInjection\AutowiredService;
+use function function_exists;
+use function getenv;
+use function opcache_get_status;
+
+/**
+ * Decides whether parallel analysis should fork workers via pcntl_fork()
+ * (see ForkedProcess) instead of spawning fresh PHP processes (see SpawnedProcess).
+ *
+ * Experimental and opt-in: enabled only when PHPSTAN_PARALLEL_FORK=1 is set,
+ * the pcntl/posix functions exist, and OPcache + JIT are both off — their
+ * shared memory is not safe to populate concurrently from forked children and
+ * doing so corrupts analysis results.
+ */
+#[AutowiredService]
+final class ForkParallelChecker
+{
+
+	public function isSupported(): bool
+	{
+		if (
+			!function_exists('pcntl_fork')
+			|| !function_exists('pcntl_waitpid')
+			|| !function_exists('pcntl_wifexited')
+			|| !function_exists('pcntl_wexitstatus')
+			|| !function_exists('posix_kill')
+		) {
+			return false;
+		}
+
+		if (getenv('PHPSTAN_PARALLEL_FORK') !== '1') {
+			return false;
+		}
+
+		// OPcache's shared memory and the JIT buffer are not safe to populate
+		// concurrently from multiple forked children — doing so corrupts
+		// analysis results. Forked workers require OPcache and JIT to be off.
+		if ($this->isOpcacheOrJitEnabled()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function isOpcacheOrJitEnabled(): bool
+	{
+		if (!function_exists('opcache_get_status')) {
+			return false;
+		}
+
+		$status = opcache_get_status(false);
+		if ($status === false) {
+			return false;
+		}
+
+		if (($status['opcache_enabled'] ?? false) === true) {
+			return true;
+		}
+
+		return ($status['jit']['enabled'] ?? false) === true;
+	}
+
+}

--- a/src/Parallel/ForkParallelChecker.php
+++ b/src/Parallel/ForkParallelChecker.php
@@ -2,10 +2,13 @@
 
 namespace PHPStan\Parallel;
 
+use PHPStan\Command\Output;
 use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Diagnose\DiagnoseExtension;
 use function function_exists;
 use function getenv;
 use function opcache_get_status;
+use function sprintf;
 
 /**
  * Decides whether parallel analysis should fork workers via pcntl_fork()
@@ -17,10 +20,33 @@ use function opcache_get_status;
  * doing so corrupts analysis results.
  */
 #[AutowiredService]
-final class ForkParallelChecker
+final class ForkParallelChecker implements DiagnoseExtension
 {
 
 	public function isSupported(): bool
+	{
+		return $this->getDisabledReason() === null;
+	}
+
+	public function print(Output $output): void
+	{
+		$output->writeLineFormatted('<info>Parallel worker creation:</info>');
+
+		$reason = $this->getDisabledReason();
+		if ($reason === null) {
+			$output->writeLineFormatted('Mechanism:                 fork (pcntl_fork — experimental)');
+			$output->writeLineFormatted('');
+			return;
+		}
+
+		$output->writeLineFormatted('Mechanism:                 spawn (react/child-process)');
+		if (getenv('PHPSTAN_PARALLEL_FORK') === '1') {
+			$output->writeLineFormatted(sprintf('Reason fork not used:      %s', $reason));
+		}
+		$output->writeLineFormatted('');
+	}
+
+	private function getDisabledReason(): ?string
 	{
 		if (
 			!function_exists('pcntl_fork')
@@ -29,21 +55,18 @@ final class ForkParallelChecker
 			|| !function_exists('pcntl_wexitstatus')
 			|| !function_exists('posix_kill')
 		) {
-			return false;
+			return 'pcntl/posix functions are not available';
 		}
 
 		if (getenv('PHPSTAN_PARALLEL_FORK') !== '1') {
-			return false;
+			return 'PHPSTAN_PARALLEL_FORK environment variable is not set to "1"';
 		}
 
-		// OPcache's shared memory and the JIT buffer are not safe to populate
-		// concurrently from multiple forked children — doing so corrupts
-		// analysis results. Forked workers require OPcache and JIT to be off.
 		if ($this->isOpcacheOrJitEnabled()) {
-			return false;
+			return 'OPcache or JIT is enabled (forked workers require both to be off — their shared memory corrupts under concurrent population)';
 		}
 
-		return true;
+		return null;
 	}
 
 	private function isOpcacheOrJitEnabled(): bool

--- a/src/Parallel/ForkedProcess.php
+++ b/src/Parallel/ForkedProcess.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parallel;
+
+use PHPStan\ShouldNotHappenException;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use React\Socket\TcpServer;
+use Symfony\Component\Console\Output\StreamOutput;
+use Throwable;
+use function fclose;
+use function pcntl_fork;
+use function pcntl_waitpid;
+use function pcntl_wexitstatus;
+use function pcntl_wifexited;
+use function rewind;
+use function stream_get_contents;
+use function tmpfile;
+use const WNOHANG;
+
+/**
+ * Parallel worker backed by pcntl_fork(): the worker is forked from the
+ * already-booted main process, so it inherits the DI container for free and
+ * skips the application re-boot that a {@see SpawnedProcess} pays.
+ *
+ * The forked child still talks to ParallelAnalyser over the same TCP + NDJSON
+ * protocol — only the process-creation mechanism differs.
+ */
+final class ForkedProcess extends ProcessBase
+{
+
+	private const WAITPID_POLL_INTERVAL = 0.01;
+
+	/** @var resource|null */
+	private $stdOut = null;
+
+	private ?TimerInterface $waitTimer = null;
+
+	/**
+	 * @param string[] $analysedFiles
+	 */
+	public function __construct(
+		LoopInterface $loop,
+		float $timeoutSeconds,
+		private WorkerRunner $workerRunner,
+		private TcpServer $server,
+		private int $serverPort,
+		private string $identifier,
+		private array $analysedFiles,
+		private ?string $tmpFile,
+		private ?string $insteadOfFile,
+	)
+	{
+		parent::__construct($loop, $timeoutSeconds);
+	}
+
+	/**
+	 * @param callable(mixed[] $json) : void $onData
+	 * @param callable(Throwable $exception): void $onError
+	 * @param callable(?int $exitCode, string $output) : void $onExit
+	 */
+	public function start(callable $onData, callable $onError, callable $onExit): void
+	{
+		$this->setCallbacks($onData, $onError);
+
+		// Created before the fork so the parent can read what the child wrote.
+		$tmpStdOut = tmpfile();
+		if ($tmpStdOut === false) {
+			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
+		}
+		$this->stdOut = $tmpStdOut;
+
+		$pid = pcntl_fork();
+
+		if ($pid === -1) {
+			fclose($this->stdOut);
+			$this->stdOut = null;
+			// Deferred so it runs after ParallelAnalyser has attached this
+			// process to the pool — otherwise tryQuitProcess() would no-op.
+			$this->loop->futureTick(static function () use ($onExit): void {
+				$onExit(null, 'pcntl_fork() failed.');
+			});
+			return;
+		}
+
+		if ($pid === 0) {
+			// Child: drop the inherited listening socket immediately, then run
+			// the worker on its own fresh event loop and never return.
+			$this->server->close();
+			$output = new StreamOutput($this->stdOut);
+			$exitCode = $this->workerRunner->run(
+				$output,
+				$this->analysedFiles,
+				$this->serverPort,
+				$this->identifier,
+				$this->tmpFile,
+				$this->insteadOfFile,
+			);
+			exit($exitCode);
+		}
+
+		// Parent: poll for the child to exit and report it through $onExit.
+		$this->waitTimer = $this->loop->addPeriodicTimer(self::WAITPID_POLL_INTERVAL, function () use ($pid, $onExit): void {
+			$status = 0;
+			$result = pcntl_waitpid($pid, $status, WNOHANG);
+			if ($result === 0) {
+				return;
+			}
+
+			$this->cancelWaitTimer();
+			$this->cancelTimer();
+
+			$exitCode = null;
+			if ($result > 0 && pcntl_wifexited($status)) {
+				$exitStatus = pcntl_wexitstatus($status);
+				if ($exitStatus !== false) {
+					$exitCode = $exitStatus;
+				}
+			}
+
+			$output = '';
+			if ($this->stdOut !== null) {
+				rewind($this->stdOut);
+				$output = (string) stream_get_contents($this->stdOut);
+				fclose($this->stdOut);
+				$this->stdOut = null;
+			}
+
+			$onExit($exitCode, $output);
+		});
+	}
+
+	public function quit(): void
+	{
+		// Ending the connection makes the child's event loop drain and the
+		// child exit; the waitpid poll timer must keep running until then so
+		// the child is actually reaped (otherwise: zombie + hang).
+		$this->endConnection();
+	}
+
+	private function cancelWaitTimer(): void
+	{
+		if ($this->waitTimer === null) {
+			return;
+		}
+
+		$this->loop->cancelTimer($this->waitTimer);
+		$this->waitTimer = null;
+	}
+
+}

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -27,6 +27,7 @@ use function array_sum;
 use function count;
 use function defined;
 use function escapeshellarg;
+use function fwrite;
 use function ini_get;
 use function max;
 use function memory_get_usage;
@@ -34,6 +35,7 @@ use function parse_url;
 use function sprintf;
 use function str_contains;
 use const PHP_URL_PORT;
+use const STDERR;
 
 #[AutowiredService]
 final class ParallelAnalyser
@@ -52,12 +54,15 @@ final class ParallelAnalyser
 		float $processTimeout,
 		#[AutowiredParameter(ref: '%parallel.buffer%')]
 		private int $decoderBufferSize,
+		private ForkParallelChecker $forkParallelChecker,
+		private WorkerRunner $workerRunner,
 	)
 	{
 		$this->processTimeout = max($processTimeout, self::DEFAULT_TIMEOUT);
 	}
 
 	/**
+	 * @param string[] $allAnalysedFiles
 	 * @param Closure(int, list<string>=): void|null $postFileCallback
 	 * @param (callable(list<Error>, list<Error>, string[]): void)|null $onFileAnalysisHandler
 	 * @return PromiseInterface<AnalyserResult>
@@ -65,6 +70,7 @@ final class ParallelAnalyser
 	public function analyse(
 		LoopInterface $loop,
 		Schedule $schedule,
+		array $allAnalysedFiles,
 		string $mainScript,
 		?Closure $postFileCallback,
 		?string $projectConfigFile,
@@ -170,6 +176,11 @@ final class ParallelAnalyser
 			$this->processPool->quitAll();
 		};
 
+		$useFork = $this->forkParallelChecker->isSupported();
+		if ($useFork && $input->hasParameterOption(['-v', '-vv', '-vvv', '--verbose'], true)) {
+			fwrite(STDERR, "Note: using pcntl_fork() for parallel workers (experimental).\n");
+		}
+
 		for ($i = 0; $i < $numberOfProcesses; $i++) {
 			if (count($jobs) === 0) {
 				break;
@@ -191,10 +202,17 @@ final class ParallelAnalyser
 			}
 
 			$process = $this->createProcess(
+				$useFork,
 				$loop,
+				$server,
+				$serverPort,
+				$processIdentifier,
+				$allAnalysedFiles,
 				$mainScript,
 				$projectConfigFile,
 				$commandOptions,
+				$tmpFile,
+				$insteadOfFile,
 				$input,
 			);
 			$process->start(function (array $json) use ($process, &$internalErrors, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$exportedNodes, &$peakMemoryUsages, &$jobs, $postFileCallback, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, $processIdentifier, $onFileAnalysisHandler, &$allProcessedFiles): void {
@@ -356,16 +374,38 @@ final class ParallelAnalyser
 	}
 
 	/**
+	 * @param string[] $allAnalysedFiles
 	 * @param string[] $commandOptions
 	 */
 	private function createProcess(
+		bool $useFork,
 		LoopInterface $loop,
+		TcpServer $server,
+		int $serverPort,
+		string $processIdentifier,
+		array $allAnalysedFiles,
 		string $mainScript,
 		?string $projectConfigFile,
 		array $commandOptions,
+		?string $tmpFile,
+		?string $insteadOfFile,
 		InputInterface $input,
 	): Process
 	{
+		if ($useFork) {
+			return new ForkedProcess(
+				$loop,
+				$this->processTimeout,
+				$this->workerRunner,
+				$server,
+				$serverPort,
+				$processIdentifier,
+				$allAnalysedFiles,
+				$tmpFile,
+				$insteadOfFile,
+			);
+		}
+
 		return new SpawnedProcess(ProcessHelper::getWorkerCommand(
 			$mainScript,
 			'worker',

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -27,7 +27,6 @@ use function array_sum;
 use function count;
 use function defined;
 use function escapeshellarg;
-use function fwrite;
 use function ini_get;
 use function max;
 use function memory_get_usage;
@@ -35,7 +34,6 @@ use function parse_url;
 use function sprintf;
 use function str_contains;
 use const PHP_URL_PORT;
-use const STDERR;
 
 #[AutowiredService]
 final class ParallelAnalyser
@@ -177,9 +175,6 @@ final class ParallelAnalyser
 		};
 
 		$useFork = $this->forkParallelChecker->isSupported();
-		if ($useFork && $input->hasParameterOption(['-v', '-vv', '-vvv', '--verbose'], true)) {
-			fwrite(STDERR, "Note: using pcntl_fork() for parallel workers (experimental).\n");
-		}
 
 		for ($i = 0; $i < $numberOfProcesses; $i++) {
 			if (count($jobs) === 0) {

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -190,13 +190,13 @@ final class ParallelAnalyser
 				$commandOptions[] = escapeshellarg($insteadOfFile);
 			}
 
-			$process = new Process(ProcessHelper::getWorkerCommand(
+			$process = $this->createProcess(
+				$loop,
 				$mainScript,
-				'worker',
 				$projectConfigFile,
 				$commandOptions,
 				$input,
-			), $loop, $this->processTimeout);
+			);
 			$process->start(function (array $json) use ($process, &$internalErrors, &$errors, &$filteredPhpErrors, &$allPhpErrors, &$locallyIgnoredErrors, &$linesToIgnore, &$unmatchedLineIgnores, &$collectedData, &$dependencies, &$usedTraitDependencies, &$exportedNodes, &$peakMemoryUsages, &$jobs, $postFileCallback, &$internalErrorsCount, &$reachedInternalErrorsCountLimit, $processIdentifier, $onFileAnalysisHandler, &$allProcessedFiles): void {
 				$fileErrors = [];
 				foreach ($json['errors'] as $jsonError) {
@@ -353,6 +353,26 @@ final class ParallelAnalyser
 		}
 
 		return $deferred->promise();
+	}
+
+	/**
+	 * @param string[] $commandOptions
+	 */
+	private function createProcess(
+		LoopInterface $loop,
+		string $mainScript,
+		?string $projectConfigFile,
+		array $commandOptions,
+		InputInterface $input,
+	): Process
+	{
+		return new SpawnedProcess(ProcessHelper::getWorkerCommand(
+			$mainScript,
+			'worker',
+			$projectConfigFile,
+			$commandOptions,
+			$input,
+		), $loop, $this->processTimeout);
 	}
 
 }

--- a/src/Parallel/Process.php
+++ b/src/Parallel/Process.php
@@ -2,151 +2,36 @@
 
 namespace PHPStan\Parallel;
 
-use PHPStan\ShouldNotHappenException;
-use React\EventLoop\LoopInterface;
-use React\EventLoop\TimerInterface;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 use Throwable;
-use function fclose;
-use function rewind;
-use function sprintf;
-use function stream_get_contents;
-use function tmpfile;
 
-final class Process
+/**
+ * A parallel analysis worker as seen by ParallelAnalyser / ProcessPool.
+ *
+ * Implementations differ only in how the worker process comes to life:
+ * SpawnedProcess spawns a fresh PHP process via react/child-process,
+ * ForkedProcess forks the already-booted main process via pcntl_fork(). Both
+ * then speak the same TCP + NDJSON protocol, so request()/quit()/
+ * bindConnection() behave identically and live in ProcessBase.
+ */
+interface Process
 {
-
-	private \React\ChildProcess\Process $process;
-
-	private ?WritableStreamInterface $in = null;
-
-	/** @var resource */
-	private $stdOut;
-
-	/** @var resource */
-	private $stdErr;
-
-	/** @var callable(mixed[] $json) : void */
-	private $onData;
-
-	/** @var callable(Throwable $exception): void */
-	private $onError;
-
-	private ?TimerInterface $timer = null;
-
-	public function __construct(
-		private string $command,
-		private LoopInterface $loop,
-		private float $timeoutSeconds,
-	)
-	{
-	}
 
 	/**
 	 * @param callable(mixed[] $json) : void $onData
 	 * @param callable(Throwable $exception): void $onError
 	 * @param callable(?int $exitCode, string $output) : void $onExit
 	 */
-	public function start(callable $onData, callable $onError, callable $onExit): void
-	{
-		$tmpStdOut = tmpfile();
-		if ($tmpStdOut === false) {
-			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
-		}
-		$tmpStdErr = tmpfile();
-		if ($tmpStdErr === false) {
-			throw new ShouldNotHappenException('Failed creating temp file for stderr.');
-		}
-		$this->stdOut = $tmpStdOut;
-		$this->stdErr = $tmpStdErr;
-		$this->process = new \React\ChildProcess\Process($this->command, fds: [
-			1 => $this->stdOut,
-			2 => $this->stdErr,
-		]);
-		$this->process->start($this->loop);
-		$this->onData = $onData;
-		$this->onError = $onError;
-		$this->process->on('exit', function ($exitCode) use ($onExit): void {
-			$this->cancelTimer();
-
-			$output = '';
-			rewind($this->stdOut);
-			$output .= stream_get_contents($this->stdOut);
-
-			rewind($this->stdErr);
-			$output .= stream_get_contents($this->stdErr);
-
-			$onExit($exitCode, $output);
-			fclose($this->stdOut);
-			fclose($this->stdErr);
-		});
-	}
-
-	private function cancelTimer(): void
-	{
-		if ($this->timer === null) {
-			return;
-		}
-
-		$this->loop->cancelTimer($this->timer);
-		$this->timer = null;
-	}
+	public function start(callable $onData, callable $onError, callable $onExit): void;
 
 	/**
 	 * @param mixed[] $data
 	 */
-	public function request(array $data): void
-	{
-		$this->cancelTimer();
-		if ($this->in === null) {
-			throw new ShouldNotHappenException();
-		}
-		$this->in->write($data);
-		$this->timer = $this->loop->addTimer($this->timeoutSeconds, function (): void {
-			$onError = $this->onError;
-			$onError(new ProcessTimedOutException(sprintf('Child process timed out after %.1f seconds. Try making it longer with parallel.processTimeout setting.', $this->timeoutSeconds)));
-		});
-	}
+	public function request(array $data): void;
 
-	public function quit(): void
-	{
-		$this->cancelTimer();
-		if (!$this->process->isRunning()) {
-			return;
-		}
+	public function quit(): void;
 
-		foreach ($this->process->pipes as $pipe) {
-			$pipe->close();
-		}
-
-		if ($this->in === null) {
-			return;
-		}
-
-		$this->in->end();
-	}
-
-	public function bindConnection(ReadableStreamInterface $out, WritableStreamInterface $in): void
-	{
-		$out->on('data', function (array $json): void {
-			$this->cancelTimer();
-			if ($json['action'] !== 'result') {
-				return;
-			}
-
-			$onData = $this->onData;
-			$onData($json['result']);
-		});
-		$this->in = $in;
-		$out->on('error', function (Throwable $error): void {
-			$onError = $this->onError;
-			$onError($error);
-		});
-		$in->on('error', function (Throwable $error): void {
-			$onError = $this->onError;
-			$onError($error);
-		});
-	}
+	public function bindConnection(ReadableStreamInterface $out, WritableStreamInterface $in): void;
 
 }

--- a/src/Parallel/ProcessBase.php
+++ b/src/Parallel/ProcessBase.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parallel;
+
+use PHPStan\ShouldNotHappenException;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use Throwable;
+use function sprintf;
+
+/**
+ * Process-creation-agnostic half of a parallel worker: the TCP/NDJSON
+ * connection plus the per-request timeout timer. Subclasses only implement
+ * start() (how the worker process is created) and quit() (how it is torn down).
+ */
+abstract class ProcessBase implements Process
+{
+
+	private ?WritableStreamInterface $in = null;
+
+	/** @var callable(mixed[] $json) : void */
+	private $onData;
+
+	/** @var callable(Throwable $exception): void */
+	private $onError;
+
+	private ?TimerInterface $timer = null;
+
+	public function __construct(
+		protected LoopInterface $loop,
+		protected float $timeoutSeconds,
+	)
+	{
+	}
+
+	/**
+	 * @param callable(mixed[] $json) : void $onData
+	 * @param callable(Throwable $exception): void $onError
+	 */
+	protected function setCallbacks(callable $onData, callable $onError): void
+	{
+		$this->onData = $onData;
+		$this->onError = $onError;
+	}
+
+	protected function cancelTimer(): void
+	{
+		if ($this->timer === null) {
+			return;
+		}
+
+		$this->loop->cancelTimer($this->timer);
+		$this->timer = null;
+	}
+
+	/** Cancels the timeout timer and ends the writable side of the connection. */
+	protected function endConnection(): void
+	{
+		$this->cancelTimer();
+		if ($this->in === null) {
+			return;
+		}
+
+		$this->in->end();
+	}
+
+	/**
+	 * @param mixed[] $data
+	 */
+	public function request(array $data): void
+	{
+		$this->cancelTimer();
+		if ($this->in === null) {
+			throw new ShouldNotHappenException();
+		}
+		$this->in->write($data);
+		$this->timer = $this->loop->addTimer($this->timeoutSeconds, function (): void {
+			$onError = $this->onError;
+			$onError(new ProcessTimedOutException(sprintf('Child process timed out after %.1f seconds. Try making it longer with parallel.processTimeout setting.', $this->timeoutSeconds)));
+		});
+	}
+
+	public function bindConnection(ReadableStreamInterface $out, WritableStreamInterface $in): void
+	{
+		$out->on('data', function (array $json): void {
+			$this->cancelTimer();
+			if ($json['action'] !== 'result') {
+				return;
+			}
+
+			$onData = $this->onData;
+			$onData($json['result']);
+		});
+		$this->in = $in;
+		$out->on('error', function (Throwable $error): void {
+			$onError = $this->onError;
+			$onError($error);
+		});
+		$in->on('error', function (Throwable $error): void {
+			$onError = $this->onError;
+			$onError($error);
+		});
+	}
+
+}

--- a/src/Parallel/SpawnedProcess.php
+++ b/src/Parallel/SpawnedProcess.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parallel;
+
+use PHPStan\ShouldNotHappenException;
+use React\ChildProcess\Process;
+use React\EventLoop\LoopInterface;
+use Throwable;
+use function fclose;
+use function rewind;
+use function stream_get_contents;
+use function tmpfile;
+
+/**
+ * Parallel worker backed by a freshly spawned PHP process (react/child-process).
+ * The spawned worker re-boots the whole application via WorkerCommand.
+ *
+ * @see ForkedProcess for the pcntl_fork()-based alternative that skips the re-boot.
+ */
+final class SpawnedProcess extends ProcessBase
+{
+
+	private Process $process;
+
+	/** @var resource */
+	private $stdOut;
+
+	/** @var resource */
+	private $stdErr;
+
+	public function __construct(
+		private string $command,
+		LoopInterface $loop,
+		float $timeoutSeconds,
+	)
+	{
+		parent::__construct($loop, $timeoutSeconds);
+	}
+
+	/**
+	 * @param callable(mixed[] $json) : void $onData
+	 * @param callable(Throwable $exception): void $onError
+	 * @param callable(?int $exitCode, string $output) : void $onExit
+	 */
+	public function start(callable $onData, callable $onError, callable $onExit): void
+	{
+		$tmpStdOut = tmpfile();
+		if ($tmpStdOut === false) {
+			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
+		}
+		$tmpStdErr = tmpfile();
+		if ($tmpStdErr === false) {
+			throw new ShouldNotHappenException('Failed creating temp file for stderr.');
+		}
+		$this->stdOut = $tmpStdOut;
+		$this->stdErr = $tmpStdErr;
+		$this->process = new Process($this->command, fds: [
+			1 => $this->stdOut,
+			2 => $this->stdErr,
+		]);
+		$this->process->start($this->loop);
+		$this->setCallbacks($onData, $onError);
+		$this->process->on('exit', function ($exitCode) use ($onExit): void {
+			$this->cancelTimer();
+
+			$output = '';
+			rewind($this->stdOut);
+			$output .= stream_get_contents($this->stdOut);
+
+			rewind($this->stdErr);
+			$output .= stream_get_contents($this->stdErr);
+
+			$onExit($exitCode, $output);
+			fclose($this->stdOut);
+			fclose($this->stdErr);
+		});
+	}
+
+	public function quit(): void
+	{
+		$this->cancelTimer();
+		if (!$this->process->isRunning()) {
+			return;
+		}
+
+		foreach ($this->process->pipes as $pipe) {
+			$pipe->close();
+		}
+
+		$this->endConnection();
+	}
+
+}

--- a/src/Parallel/WorkerRunner.php
+++ b/src/Parallel/WorkerRunner.php
@@ -1,0 +1,247 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parallel;
+
+use Clue\React\NDJson\Decoder;
+use Clue\React\NDJson\Encoder;
+use PHPStan\Analyser\FileAnalyser;
+use PHPStan\Analyser\InternalError;
+use PHPStan\Analyser\NodeScopeResolver;
+use PHPStan\Collectors\Registry as CollectorRegistry;
+use PHPStan\DependencyInjection\AutowiredParameter;
+use PHPStan\DependencyInjection\AutowiredService;
+use PHPStan\Rules\Registry as RuleRegistry;
+use React\EventLoop\StreamSelectLoop;
+use React\Socket\ConnectionInterface;
+use React\Socket\TcpConnector;
+use React\Stream\ReadableStreamInterface;
+use React\Stream\WritableStreamInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use function array_fill_keys;
+use function array_filter;
+use function array_merge;
+use function array_unshift;
+use function array_values;
+use function defined;
+use function memory_get_peak_usage;
+use function sprintf;
+
+/**
+ * The parallel worker logic that runs *after* the application boot.
+ *
+ * Extracted from WorkerCommand so it can be reused without re-booting: a
+ * pcntl_fork()-ed child (see ForkedProcess) inherits the already-booted DI
+ * container and calls run() directly, while WorkerCommand still calls it after
+ * the expensive CommandHelper::begin() boot of a freshly spawned process.
+ *
+ * It connects back to ParallelAnalyser's TCP server, performs the NDJSON
+ * handshake and analyses the files it is handed.
+ */
+#[AutowiredService]
+final class WorkerRunner
+{
+
+	public function __construct(
+		private FileAnalyser $fileAnalyser,
+		private RuleRegistry $ruleRegistry,
+		private CollectorRegistry $collectorRegistry,
+		private NodeScopeResolver $nodeScopeResolver,
+		#[AutowiredParameter(ref: '%parallel.buffer%')]
+		private int $decoderBufferSize,
+	)
+	{
+	}
+
+	/**
+	 * @param string[] $analysedFiles the full analysed-files list (raw, before tmp-file substitution)
+	 * @return int exit code (0 on success, 1 if a worker-communication error occurred)
+	 */
+	public function run(
+		OutputInterface $output,
+		array $analysedFiles,
+		int $port,
+		string $identifier,
+		?string $tmpFile,
+		?string $insteadOfFile,
+	): int
+	{
+		$analysedFiles = $this->switchTmpFile($analysedFiles, $insteadOfFile, $tmpFile);
+		$this->nodeScopeResolver->setAnalysedFiles($analysedFiles);
+		$analysedFiles = array_fill_keys($analysedFiles, true);
+
+		// Always a fresh event loop: in a forked child the parent's inherited
+		// loop must never be touched.
+		$loop = new StreamSelectLoop();
+		$errorCount = 0;
+
+		$tcpConnector = new TcpConnector($loop);
+		$tcpConnector->connect(sprintf('127.0.0.1:%d', $port))->then(function (ConnectionInterface $connection) use ($identifier, $output, $analysedFiles, $tmpFile, $insteadOfFile, &$errorCount): void {
+			// phpcs:disable SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly
+			$jsonInvalidUtf8Ignore = defined('JSON_INVALID_UTF8_IGNORE') ? JSON_INVALID_UTF8_IGNORE : 0;
+			// phpcs:enable
+			$out = new Encoder($connection, $jsonInvalidUtf8Ignore);
+			$in = new Decoder($connection, true, options: $jsonInvalidUtf8Ignore, maxlength: $this->decoderBufferSize);
+			$out->write(['action' => 'hello', 'identifier' => $identifier]);
+			$this->runWorker($out, $in, $output, $analysedFiles, $tmpFile, $insteadOfFile, $errorCount);
+		});
+
+		$loop->run();
+
+		return $errorCount > 0 ? 1 : 0;
+	}
+
+	/**
+	 * @param array<string, true> $analysedFiles
+	 */
+	private function runWorker(
+		WritableStreamInterface $out,
+		ReadableStreamInterface $in,
+		OutputInterface $output,
+		array $analysedFiles,
+		?string $tmpFile,
+		?string $insteadOfFile,
+		int &$errorCount,
+	): void
+	{
+		$handleError = static function (Throwable $error) use ($out, $output, &$errorCount): void {
+			$errorCount++;
+			$output->writeln(sprintf('Error: %s', $error->getMessage()));
+			$out->write([
+				'action' => 'result',
+				'result' => [
+					'errors' => [],
+					'internalErrors' => [
+						new InternalError(
+							$error->getMessage(),
+							'communicating with main process in parallel worker',
+							InternalError::prepareTrace($error),
+							$error->getTraceAsString(),
+							shouldReportBug: true,
+						),
+					],
+					'filteredPhpErrors' => [],
+					'allPhpErrors' => [],
+					'locallyIgnoredErrors' => [],
+					'linesToIgnore' => [],
+					'unmatchedLineIgnores' => [],
+					'collectedData' => [],
+					'memoryUsage' => memory_get_peak_usage(true),
+					'dependencies' => [],
+					'exportedNodes' => [],
+					'files' => [],
+					'internalErrorsCount' => 1,
+				],
+			]);
+			$out->end();
+		};
+		$out->on('error', $handleError);
+		$fileAnalyser = $this->fileAnalyser;
+		$ruleRegistry = $this->ruleRegistry;
+		$collectorRegistry = $this->collectorRegistry;
+		$in->on('data', static function (array $json) use ($fileAnalyser, $ruleRegistry, $collectorRegistry, $out, $analysedFiles, $tmpFile, $insteadOfFile): void {
+			$action = $json['action'];
+			if ($action !== 'analyse') {
+				return;
+			}
+
+			$internalErrorsCount = 0;
+			$files = $json['files'];
+			$errors = [];
+			$internalErrors = [];
+			$filteredPhpErrors = [];
+			$allPhpErrors = [];
+			$locallyIgnoredErrors = [];
+			$linesToIgnore = [];
+			$unmatchedLineIgnores = [];
+			$collectedData = [];
+			$dependencies = [];
+			$usedTraitDependencies = [];
+			$exportedNodes = [];
+			$processedFiles = [];
+			foreach ($files as $file) {
+				try {
+					if ($file === $insteadOfFile) {
+						$file = $tmpFile;
+					}
+					$fileAnalyserResult = $fileAnalyser->analyseFile($file, $analysedFiles, $ruleRegistry, $collectorRegistry, null);
+					$fileErrors = $fileAnalyserResult->getErrors();
+					$filteredPhpErrors = array_merge($filteredPhpErrors, $fileAnalyserResult->getFilteredPhpErrors());
+					$allPhpErrors = array_merge($allPhpErrors, $fileAnalyserResult->getAllPhpErrors());
+					$linesToIgnore[$file] = $fileAnalyserResult->getLinesToIgnore();
+					$unmatchedLineIgnores[$file] = $fileAnalyserResult->getUnmatchedLineIgnores();
+					$dependencies[$file] = $fileAnalyserResult->getDependencies();
+					$usedTraitDependencies[$file] = $fileAnalyserResult->getUsedTraitDependencies();
+					$exportedNodes[$file] = $fileAnalyserResult->getExportedNodes();
+					$processedFiles = array_merge($processedFiles, $fileAnalyserResult->getProcessedFiles());
+					foreach ($fileErrors as $fileError) {
+						$errors[] = $fileError;
+					}
+					foreach ($fileAnalyserResult->getLocallyIgnoredErrors() as $locallyIgnoredError) {
+						$locallyIgnoredErrors[] = $locallyIgnoredError;
+					}
+					foreach ($fileAnalyserResult->getCollectedData() as $collectedFile => $dataPerCollector) {
+						foreach ($dataPerCollector as $collectorType => $collectorData) {
+							foreach ($collectorData as $data) {
+								$collectedData[$collectedFile][$collectorType][] = $data;
+							}
+						}
+					}
+				} catch (Throwable $t) {
+					$internalErrorsCount++;
+					$internalErrors[] = new InternalError(
+						$t->getMessage(),
+						sprintf('analysing file %s', $file),
+						InternalError::prepareTrace($t),
+						$t->getTraceAsString(),
+						shouldReportBug: true,
+					);
+				}
+			}
+
+			$out->write([
+				'action' => 'result',
+				'result' => [
+					'errors' => $errors,
+					'internalErrors' => $internalErrors,
+					'filteredPhpErrors' => $filteredPhpErrors,
+					'allPhpErrors' => $allPhpErrors,
+					'locallyIgnoredErrors' => $locallyIgnoredErrors,
+					'linesToIgnore' => $linesToIgnore,
+					'unmatchedLineIgnores' => $unmatchedLineIgnores,
+					'collectedData' => $collectedData,
+					'memoryUsage' => memory_get_peak_usage(true),
+					'dependencies' => $dependencies,
+					'usedTraitDependencies' => $usedTraitDependencies,
+					'exportedNodes' => $exportedNodes,
+					'files' => $files,
+					'processedFiles' => $processedFiles,
+					'internalErrorsCount' => $internalErrorsCount,
+				]]);
+		});
+		$in->on('error', $handleError);
+	}
+
+	/**
+	 * @param string[] $analysedFiles
+	 * @return string[]
+	 */
+	private function switchTmpFile(
+		array $analysedFiles,
+		?string $insteadOfFile,
+		?string $tmpFile,
+	): array
+	{
+		if ($insteadOfFile === null) {
+			return $analysedFiles;
+		}
+		$analysedFiles = array_values(array_filter($analysedFiles, static fn (string $file): bool => $file !== $insteadOfFile));
+
+		if ($tmpFile !== null) {
+			array_unshift($analysedFiles, $tmpFile);
+		}
+
+		return $analysedFiles;
+	}
+
+}

--- a/src/Process/ForkedProcessPromise.php
+++ b/src/Process/ForkedProcessPromise.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\Command\FixerWorkerRunner;
+use PHPStan\Command\Output;
+use PHPStan\ShouldNotHappenException;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\TimerInterface;
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use React\Socket\TcpServer;
+use Symfony\Component\Console\Input\InputInterface;
+use function fclose;
+use function pcntl_fork;
+use function pcntl_waitpid;
+use function pcntl_wexitstatus;
+use function pcntl_wifexited;
+use function posix_kill;
+use function rewind;
+use function stream_get_contents;
+use function tmpfile;
+use const SIGTERM;
+use const WNOHANG;
+
+/**
+ * ProcessPromise backed by pcntl_fork(): the PHPStan Pro worker is forked from
+ * the already-booted main process, so it inherits the DI container for free
+ * and skips the application re-boot that a {@see SpawnedProcessPromise} pays.
+ *
+ * The forked child still talks to FixerApplication over the same TCP + NDJSON
+ * protocol — only the process-creation mechanism differs.
+ */
+final class ForkedProcessPromise implements ProcessPromise
+{
+
+	private const WAITPID_POLL_INTERVAL = 0.01;
+
+	/** @var Deferred<string> */
+	private Deferred $deferred;
+
+	private ?int $childPid = null;
+
+	/** @var resource|null */
+	private $stdOut = null;
+
+	private ?TimerInterface $waitTimer = null;
+
+	private bool $canceled = false;
+
+	/**
+	 * @param string[] $inceptionFiles
+	 * @param mixed[]|null $projectConfigArray
+	 */
+	public function __construct(
+		private LoopInterface $loop,
+		private FixerWorkerRunner $fixerWorkerRunner,
+		private TcpServer $server,
+		private Output $errorOutput,
+		private array $inceptionFiles,
+		private bool $isOnlyFiles,
+		private ?array $projectConfigArray,
+		private ?string $configuration,
+		private int $serverPort,
+		private InputInterface $input,
+	)
+	{
+		$this->deferred = new Deferred(function (): void {
+			$this->cancel();
+		});
+	}
+
+	/**
+	 * @return PromiseInterface<string>
+	 */
+	public function run(): PromiseInterface
+	{
+		// Created before the fork so the parent can read what the child wrote.
+		$tmpStdOut = tmpfile();
+		if ($tmpStdOut === false) {
+			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
+		}
+		$this->stdOut = $tmpStdOut;
+
+		$pid = pcntl_fork();
+
+		if ($pid === -1) {
+			fclose($this->stdOut);
+			$this->stdOut = null;
+			// Deferred so it runs after FixerApplication has stored the promise.
+			$this->loop->futureTick(function (): void {
+				$this->deferred->reject(new ProcessCrashedException('pcntl_fork() failed.'));
+			});
+
+			return $this->deferred->promise();
+		}
+
+		if ($pid === 0) {
+			// Child: drop the inherited listening socket immediately, then run
+			// the worker on its own fresh event loop and never return.
+			$this->server->close();
+			$exitCode = $this->fixerWorkerRunner->run(
+				$this->errorOutput,
+				$this->inceptionFiles,
+				$this->isOnlyFiles,
+				$this->projectConfigArray,
+				$this->configuration,
+				$this->serverPort,
+				$this->input,
+			);
+			exit($exitCode);
+		}
+
+		// Parent: poll for the child to exit and resolve/reject accordingly.
+		$this->childPid = $pid;
+		$this->waitTimer = $this->loop->addPeriodicTimer(self::WAITPID_POLL_INTERVAL, function () use ($pid): void {
+			$status = 0;
+			$result = pcntl_waitpid($pid, $status, WNOHANG);
+			if ($result === 0) {
+				return;
+			}
+
+			$this->cancelWaitTimer();
+
+			$output = '';
+			if ($this->stdOut !== null) {
+				rewind($this->stdOut);
+				$output = (string) stream_get_contents($this->stdOut);
+				fclose($this->stdOut);
+				$this->stdOut = null;
+			}
+
+			if ($this->canceled) {
+				// cancel() already rejected the promise; just reap the child.
+				return;
+			}
+
+			$exitCode = null;
+			if ($result > 0 && pcntl_wifexited($status)) {
+				$exitStatus = pcntl_wexitstatus($status);
+				if ($exitStatus !== false) {
+					$exitCode = $exitStatus;
+				}
+			}
+
+			if ($exitCode === 0) {
+				$this->deferred->resolve($output);
+				return;
+			}
+
+			$this->deferred->reject(new ProcessCrashedException($output));
+		});
+
+		return $this->deferred->promise();
+	}
+
+	private function cancel(): void
+	{
+		if ($this->childPid === null) {
+			throw new ShouldNotHappenException('Cancelling process before running');
+		}
+		$this->canceled = true;
+		// SIGTERM the child; the waitpid poll timer keeps running so it still
+		// gets reaped (otherwise: zombie).
+		posix_kill($this->childPid, SIGTERM);
+		$this->deferred->reject(new ProcessCanceledException());
+	}
+
+	private function cancelWaitTimer(): void
+	{
+		if ($this->waitTimer === null) {
+			return;
+		}
+
+		$this->loop->cancelTimer($this->waitTimer);
+		$this->waitTimer = null;
+	}
+
+}

--- a/src/Process/ProcessPromise.php
+++ b/src/Process/ProcessPromise.php
@@ -2,91 +2,23 @@
 
 namespace PHPStan\Process;
 
-use PHPStan\ShouldNotHappenException;
-use React\ChildProcess\Process;
-use React\EventLoop\LoopInterface;
-use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
-use function fclose;
-use function rewind;
-use function stream_get_contents;
-use function tmpfile;
 
-final class ProcessPromise
+/**
+ * A PHPStan Pro analysis worker as seen by FixerApplication.
+ *
+ * Implementations differ only in how the worker process comes to life:
+ * SpawnedProcessPromise spawns a fresh PHP process via react/child-process,
+ * ForkedProcessPromise forks the already-booted main process via pcntl_fork().
+ * Both yield a promise that resolves on success and rejects with
+ * ProcessCrashedException / ProcessCanceledException otherwise.
+ */
+interface ProcessPromise
 {
-
-	/** @var Deferred<string> */
-	private Deferred $deferred;
-
-	private ?Process $process = null;
-
-	private bool $canceled = false;
-
-	public function __construct(private LoopInterface $loop, private string $command)
-	{
-		$this->deferred = new Deferred(function (): void {
-			$this->cancel();
-		});
-	}
 
 	/**
 	 * @return PromiseInterface<string>
 	 */
-	public function run(): PromiseInterface
-	{
-		$tmpStdOutResource = tmpfile();
-		if ($tmpStdOutResource === false) {
-			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
-		}
-		$tmpStdErrResource = tmpfile();
-		if ($tmpStdErrResource === false) {
-			throw new ShouldNotHappenException('Failed creating temp file for stderr.');
-		}
-
-		$this->process = new Process($this->command, fds: [
-			1 => $tmpStdOutResource,
-			2 => $tmpStdErrResource,
-		]);
-		$this->process->start($this->loop);
-
-		$this->process->on('exit', function ($exitCode) use ($tmpStdOutResource, $tmpStdErrResource): void {
-			if ($this->canceled) {
-				fclose($tmpStdOutResource);
-				fclose($tmpStdErrResource);
-				return;
-			}
-			rewind($tmpStdOutResource);
-			$stdOut = stream_get_contents($tmpStdOutResource);
-			fclose($tmpStdOutResource);
-
-			rewind($tmpStdErrResource);
-			$stdErr = stream_get_contents($tmpStdErrResource);
-			fclose($tmpStdErrResource);
-
-			if ($exitCode === null) {
-				$this->deferred->reject(new ProcessCrashedException($stdOut . $stdErr));
-				return;
-			}
-
-			if ($exitCode === 0) {
-				$this->deferred->resolve($stdOut);
-				return;
-			}
-
-			$this->deferred->reject(new ProcessCrashedException($stdOut . $stdErr));
-		});
-
-		return $this->deferred->promise();
-	}
-
-	private function cancel(): void
-	{
-		if ($this->process === null) {
-			throw new ShouldNotHappenException('Cancelling process before running');
-		}
-		$this->canceled = true;
-		$this->process->terminate();
-		$this->deferred->reject(new ProcessCanceledException());
-	}
+	public function run(): PromiseInterface;
 
 }

--- a/src/Process/SpawnedProcessPromise.php
+++ b/src/Process/SpawnedProcessPromise.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Process;
+
+use PHPStan\ShouldNotHappenException;
+use React\ChildProcess\Process;
+use React\EventLoop\LoopInterface;
+use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use function fclose;
+use function rewind;
+use function stream_get_contents;
+use function tmpfile;
+
+/**
+ * ProcessPromise backed by a freshly spawned PHP process (react/child-process).
+ *
+ * @see ForkedProcessPromise for the pcntl_fork()-based alternative that skips
+ * the per-worker application re-boot.
+ */
+final class SpawnedProcessPromise implements ProcessPromise
+{
+
+	/** @var Deferred<string> */
+	private Deferred $deferred;
+
+	private ?Process $process = null;
+
+	private bool $canceled = false;
+
+	public function __construct(private LoopInterface $loop, private string $command)
+	{
+		$this->deferred = new Deferred(function (): void {
+			$this->cancel();
+		});
+	}
+
+	/**
+	 * @return PromiseInterface<string>
+	 */
+	public function run(): PromiseInterface
+	{
+		$tmpStdOutResource = tmpfile();
+		if ($tmpStdOutResource === false) {
+			throw new ShouldNotHappenException('Failed creating temp file for stdout.');
+		}
+		$tmpStdErrResource = tmpfile();
+		if ($tmpStdErrResource === false) {
+			throw new ShouldNotHappenException('Failed creating temp file for stderr.');
+		}
+
+		$this->process = new Process($this->command, fds: [
+			1 => $tmpStdOutResource,
+			2 => $tmpStdErrResource,
+		]);
+		$this->process->start($this->loop);
+
+		$this->process->on('exit', function ($exitCode) use ($tmpStdOutResource, $tmpStdErrResource): void {
+			if ($this->canceled) {
+				fclose($tmpStdOutResource);
+				fclose($tmpStdErrResource);
+				return;
+			}
+			rewind($tmpStdOutResource);
+			$stdOut = stream_get_contents($tmpStdOutResource);
+			fclose($tmpStdOutResource);
+
+			rewind($tmpStdErrResource);
+			$stdErr = stream_get_contents($tmpStdErrResource);
+			fclose($tmpStdErrResource);
+
+			if ($exitCode === null) {
+				$this->deferred->reject(new ProcessCrashedException($stdOut . $stdErr));
+				return;
+			}
+
+			if ($exitCode === 0) {
+				$this->deferred->resolve($stdOut);
+				return;
+			}
+
+			$this->deferred->reject(new ProcessCrashedException($stdOut . $stdErr));
+		});
+
+		return $this->deferred->promise();
+	}
+
+	private function cancel(): void
+	{
+		if ($this->process === null) {
+			throw new ShouldNotHappenException('Cancelling process before running');
+		}
+		$this->canceled = true;
+		$this->process->terminate();
+		$this->deferred->reject(new ProcessCanceledException());
+	}
+
+}


### PR DESCRIPTION
## What

Experimental alternative to the parallel-analysis worker model. Today each
parallel worker is a freshly spawned PHP process (`react/child-process`) that
re-boots the whole application — rebuilds the DI container, re-runs bootstrap
files — via `CommandHelper::begin()`. That boot is pure overhead, repeated per
worker.

This adds a second path: when opted in, workers are `pcntl_fork()`-ed from the
already-booted process, inheriting the DI container for free and skipping the
re-boot. Forked workers still talk to the main process over the **exact same
TCP + NDJSON protocol** — only the process-creation mechanism changes.

Applied to both worker flows:
- `ParallelAnalyser` → `worker` (the analysis workers)
- `FixerApplication` → `fixer:worker` (the PHPStan Pro worker)

## Commits

Refactorings first (interfaces with a single implementation), forking
implementations after, ParallelAnalyser and FixerApplication kept separate —
each commit builds and passes `make cs` + `make phpstan` on its own:

1. **Introduce `Process` interface and `ProcessBase`** — splits the worker into
   a process-creation-agnostic half (the TCP/NDJSON connection + timeout timer)
   and the creation half. Existing impl renamed to `SpawnedProcess`.
2. **Extract `WorkerRunner`** — everything `WorkerCommand` does after the boot,
   made reusable without a re-boot.
3. **Add `pcntl_fork()` parallel worker path** — `ForkParallelChecker` +
   `ForkedProcess`, wired into `ParallelAnalyser`.
4. **Introduce `ProcessPromise` interface** — same split for the Pro worker;
   existing impl renamed to `SpawnedProcessPromise`.
5. **Extract `FixerWorkerRunner`** — the post-boot half of `FixerWorkerCommand`.
6. **Add `pcntl_fork()` PHPStan Pro worker path** — `ForkedProcessPromise`,
   wired into `FixerApplication`.

## Gating

Opt-in and conservative — `ForkParallelChecker::isSupported()` requires **all**
of:
- `PHPSTAN_PARALLEL_FORK=1` in the environment;
- `ext-pcntl` + `ext-posix` functions available;
- **OPcache and JIT both off** — their shared memory is not safe to populate
  concurrently from forked children and doing so corrupts analysis results.

When not supported, the existing spawn path is used unchanged.

## Status / caveats

Experimental. With the gate above, the `worker` fork path produces results
identical to the spawn path and runs noticeably faster on PHPStan's own source.
The Pro (`fixer:worker`) fork path is wired symmetrically but could only be
smoke-tested here — the full Pro flow needs the Pro PHAR. There is also a
separate, still-unexplained result discrepancy between fork and spawn under
`opcache.enable_cli=0` that wants more investigation before this is anything
more than an experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)