### PR TITLE
Lock Composer autoload around phar:// reads in forked workers

### DIFF
--- a/src/Command/FixerApplication.php
+++ b/src/Command/FixerApplication.php
@@ -25,6 +25,7 @@ use PHPStan\Internal\DirectoryCreator;
 use PHPStan\Internal\DirectoryCreatorException;
 use PHPStan\Internal\HttpClientFactory;
 use PHPStan\Parallel\ForkParallelChecker;
+use PHPStan\Parallel\PharAutoloaderLock;
 use PHPStan\PhpDoc\StubFilesProvider;
 use PHPStan\Process\ForkedProcessPromise;
 use PHPStan\Process\ProcessCanceledException;
@@ -100,6 +101,7 @@ final class FixerApplication
 		private HttpClientFactory $httpClientFactory,
 		private ForkParallelChecker $forkParallelChecker,
 		private FixerWorkerRunner $fixerWorkerRunner,
+		private PharAutoloaderLock $pharAutoloaderLock,
 	)
 	{
 	}
@@ -457,8 +459,13 @@ final class FixerApplication
 			});
 		});
 
+		$useFork = $this->forkParallelChecker->isSupported();
+		if ($useFork) {
+			$this->pharAutoloaderLock->install();
+		}
+
 		$process = $this->createProcessPromise(
-			$this->forkParallelChecker->isSupported(),
+			$useFork,
 			$loop,
 			$server,
 			$mainScript,

--- a/src/Parallel/ParallelAnalyser.php
+++ b/src/Parallel/ParallelAnalyser.php
@@ -54,6 +54,7 @@ final class ParallelAnalyser
 		private int $decoderBufferSize,
 		private ForkParallelChecker $forkParallelChecker,
 		private WorkerRunner $workerRunner,
+		private PharAutoloaderLock $pharAutoloaderLock,
 	)
 	{
 		$this->processTimeout = max($processTimeout, self::DEFAULT_TIMEOUT);
@@ -175,6 +176,9 @@ final class ParallelAnalyser
 		};
 
 		$useFork = $this->forkParallelChecker->isSupported();
+		if ($useFork) {
+			$this->pharAutoloaderLock->install();
+		}
 
 		for ($i = 0; $i < $numberOfProcesses; $i++) {
 			if (count($jobs) === 0) {

--- a/src/Parallel/PharAutoloaderLock.php
+++ b/src/Parallel/PharAutoloaderLock.php
@@ -57,6 +57,19 @@ final class PharAutoloaderLock
 
 	private bool $installed = false;
 
+	/**
+	 * Re-entrancy depth for the lock-protected autoload section, per process.
+	 *
+	 * PHP class declarations can trigger nested autoloads (declaring `class
+	 * Foo extends Bar` autoloads Bar mid-declaration), so the wrapper can be
+	 * called recursively in a single process. `flock` is per-OFD on BSD/macOS,
+	 * so two `fopen` + `LOCK_EX` calls from the same process on the same file
+	 * self-deadlock. The race we actually care about is cross-process — only
+	 * the outermost call needs to take the lock; nested ones are already
+	 * inside the critical section.
+	 */
+	private static int $depth = 0;
+
 	public function install(): void
 	{
 		if ($this->installed) {
@@ -79,15 +92,25 @@ final class PharAutoloaderLock
 		foreach (spl_autoload_functions() as $callback) {
 			spl_autoload_unregister($callback);
 			spl_autoload_register(static function (string $class) use ($callback, $lockPath): void {
+				if (self::$depth > 0) {
+					// Already inside this process's locked autoload — nested
+					// reads from libphar are sequential within a single
+					// process, so they don't need (and would deadlock on) a
+					// second flock.
+					$callback($class);
+					return;
+				}
 				$fh = fopen($lockPath, 'r');
 				if ($fh === false) {
 					$callback($class);
 					return;
 				}
 				flock($fh, LOCK_EX);
+				self::$depth++;
 				try {
 					$callback($class);
 				} finally {
+					self::$depth--;
 					flock($fh, LOCK_UN);
 					fclose($fh);
 				}

--- a/src/Parallel/PharAutoloaderLock.php
+++ b/src/Parallel/PharAutoloaderLock.php
@@ -2,7 +2,6 @@
 
 namespace PHPStan\Parallel;
 
-use Composer\Autoload\ClassLoader;
 use Phar;
 use PHPStan\DependencyInjection\AutowiredService;
 use function fclose;
@@ -10,7 +9,9 @@ use function flock;
 use function fopen;
 use function getmypid;
 use function register_shutdown_function;
+use function spl_autoload_functions;
 use function spl_autoload_register;
+use function spl_autoload_unregister;
 use function sys_get_temp_dir;
 use function touch;
 use function uniqid;
@@ -70,17 +71,22 @@ final class PharAutoloaderLock
 		$lockPath = sys_get_temp_dir() . '/phpstan-fork-phar-lock-' . getmypid() . '-' . uniqid();
 		touch($lockPath);
 
-		foreach (ClassLoader::getRegisteredLoaders() as $loader) {
-			$loader->unregister();
-			spl_autoload_register(static function (string $class) use ($loader, $lockPath): void {
+		// Wrap every registered autoloader callable. Using spl_autoload_*
+		// rather than Composer\Autoload\ClassLoader::getRegisteredLoaders()
+		// keeps this file free of any reference to Composer's namespace —
+		// php-scoper would otherwise rewrite that reference to the prefixed
+		// form, which does not exist at runtime inside the built phar.
+		foreach (spl_autoload_functions() as $callback) {
+			spl_autoload_unregister($callback);
+			spl_autoload_register(static function (string $class) use ($callback, $lockPath): void {
 				$fh = fopen($lockPath, 'r');
 				if ($fh === false) {
-					$loader->loadClass($class);
+					$callback($class);
 					return;
 				}
 				flock($fh, LOCK_EX);
 				try {
-					$loader->loadClass($class);
+					$callback($class);
 				} finally {
 					flock($fh, LOCK_UN);
 					fclose($fh);

--- a/src/Parallel/PharAutoloaderLock.php
+++ b/src/Parallel/PharAutoloaderLock.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Parallel;
+
+use Composer\Autoload\ClassLoader;
+use Phar;
+use PHPStan\DependencyInjection\AutowiredService;
+use function fclose;
+use function flock;
+use function fopen;
+use function getmypid;
+use function register_shutdown_function;
+use function spl_autoload_register;
+use function sys_get_temp_dir;
+use function touch;
+use function uniqid;
+use function unlink;
+use const LOCK_EX;
+use const LOCK_UN;
+
+/**
+ * Serialises Composer autoload reads from a shared phar fd so concurrent
+ * forked workers can't race on its seek cursor.
+ *
+ * When PHPStan is run from a .phar (composer-distributed install), PHP's
+ * built-in phar:// stream wrapper caches a single fd internally; after
+ * pcntl_fork() that fd's open file description (and its seek cursor) is
+ * shared between parent and every forked child, so concurrent lazy class
+ * loads across workers can interleave and read garbage offsets — surfacing
+ * as spurious parse errors against phar-internal files.
+ *
+ * The minimal-surgery fix here: wrap every registered Composer ClassLoader
+ * so that loadClass() acquires an exclusive flock on a tmp file before its
+ * `include`, and releases it after. Two workers can never be inside
+ * `include 'phar://…'` at the same time, so the cursor can't be moved out
+ * from under either of them.
+ *
+ * Cost model: per-class load takes one flock pair. A worker contends with
+ * siblings only during its initial "loading wave" — the few hundred classes
+ * it touches once. After that its symbol table is populated and the lock
+ * is never taken again, so workers run fully parallel for the rest of the
+ * analysis.
+ *
+ * Covers only autoload. Non-class phar reads — file_get_contents('phar://…')
+ * etc. — still go through the unlocked built-in wrapper; in practice those
+ * happen during boot, which is pre-fork, so they don't race. If a lazy
+ * non-class phar read does fire post-fork, the alternative extract-and-
+ * reroute approach (see #5669) is the comprehensive fix.
+ *
+ * No-op when not running inside a phar; called by ParallelAnalyser and
+ * FixerApplication right before they fork. Idempotent.
+ */
+#[AutowiredService]
+final class PharAutoloaderLock
+{
+
+	private bool $installed = false;
+
+	public function install(): void
+	{
+		if ($this->installed) {
+			return;
+		}
+		$this->installed = true;
+
+		if (Phar::running(false) === '') {
+			return;
+		}
+
+		$lockPath = sys_get_temp_dir() . '/phpstan-fork-phar-lock-' . getmypid() . '-' . uniqid();
+		touch($lockPath);
+
+		foreach (ClassLoader::getRegisteredLoaders() as $loader) {
+			$loader->unregister();
+			spl_autoload_register(static function (string $class) use ($loader, $lockPath): void {
+				$fh = fopen($lockPath, 'r');
+				if ($fh === false) {
+					$loader->loadClass($class);
+					return;
+				}
+				flock($fh, LOCK_EX);
+				try {
+					$loader->loadClass($class);
+				} finally {
+					flock($fh, LOCK_UN);
+					fclose($fh);
+				}
+			});
+		}
+
+		$parentPid = getmypid();
+		register_shutdown_function(static function () use ($parentPid, $lockPath): void {
+			if (getmypid() !== $parentPid) {
+				return;
+			}
+			@unlink($lockPath);
+		});
+	}
+
+}


### PR DESCRIPTION
Alternative to #5669. Same problem (PHP's built-in `phar://` wrapper
caches one fd, after `pcntl_fork()` parent and forked children share
its OFD, concurrent class loads race on the seek cursor and produce
spurious parse errors). Different fix: wrap every registered Composer
`ClassLoader` so `loadClass()` takes an exclusive `flock` on a tmp file
before its `include` and releases it after. Two workers can never be
inside `include 'phar://…'` simultaneously, so the cursor can't be
moved out from under either of them.

## Cost

One `flock` pair per autoload. Each worker only contends with siblings
during its initial loading wave — a few hundred classes touched once.
After its symbol table is populated the lock is never taken again and
workers run fully parallel for the rest of the analysis.

## Scope

Covers only class autoload. Non-class `phar://` reads
(`file_get_contents`, stat, dir iteration) still go through the
unlocked built-in wrapper. In practice those happen during boot, which
is pre-fork, so they don't race. If a lazy non-class phar read does
fire post-fork, #5669 (extract-and-reroute) is the comprehensive fix.

## Wiring

`ParallelAnalyser` and `FixerApplication` call the (idempotent)
`install()` once they have decided to take the fork path. No-op when
not running inside a phar. Cleanup hook unlinks the lock tmpfile on
parent shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)