### PR TITLE
Fix 2.2.x build after f2af15b571

### DIFF
--- a/src/Type/Accessory/AccessoryDecimalIntegerStringType.php
+++ b/src/Type/Accessory/AccessoryDecimalIntegerStringType.php
@@ -456,6 +456,11 @@ class AccessoryDecimalIntegerStringType implements CompoundType, AccessoryType
 		return [];
 	}
 
+	public function getDefaultBaseType(): Type
+	{
+		return new StringType();
+	}
+
 	public function toPhpDocNode(): TypeNode
 	{
 		return new IdentifierTypeNode($this->inverse ? 'non-decimal-int-string' : 'decimal-int-string');


### PR DESCRIPTION
fixes

```
PHP Fatal error:  Class PHPStan\Type\Accessory\AccessoryDecimalIntegerStringType contains 1 abstract method and must therefore be declared abstract or implement the remaining methods 
(PHPStan\Type\Accessory\AccessoryType::getDefaultBaseType) in /Users/staabm/workspace/phpstan-src/src/Type/Accessory/AccessoryDecimalIntegerStringType.php on line 50
```