### PR TITLE
Configuration defined type validation: Improve error message

### DIFF
--- a/src/Rules/Constants/ValueAssignedToClassConstantRule.php
+++ b/src/Rules/Constants/ValueAssignedToClassConstantRule.php
@@ -85,7 +85,7 @@ final class ValueAssignedToClassConstantRule implements Rule
 								'Configuration defined type for constant %s::%s (%s) does not accept value %s.',
 								$constantReflection->getDeclaringClass()->getDisplayName(),
 								$constantName,
-								$configuredType->describe(VerbosityLevel::typeOnly()),
+								$configuredType->describe(VerbosityLevel::precise()),
 								$valueExprType->describe($verbosity),
 							))->acceptsReasonsTip($accepts->reasons)->identifier('classConstant.value')->build(),
 						];

--- a/src/Rules/Constants/ValueAssignedToClassConstantRule.php
+++ b/src/Rules/Constants/ValueAssignedToClassConstantRule.php
@@ -85,7 +85,7 @@ final class ValueAssignedToClassConstantRule implements Rule
 								'Configuration defined type for constant %s::%s (%s) does not accept value %s.',
 								$constantReflection->getDeclaringClass()->getDisplayName(),
 								$constantName,
-								$configuredType->describe(VerbosityLevel::precise()),
+								$configuredType->describe(VerbosityLevel::value()),
 								$valueExprType->describe($verbosity),
 							))->acceptsReasonsTip($accepts->reasons)->identifier('classConstant.value')->build(),
 						];

--- a/src/Rules/Constants/ValueAssignedToDefineRule.php
+++ b/src/Rules/Constants/ValueAssignedToDefineRule.php
@@ -72,7 +72,7 @@ final class ValueAssignedToDefineRule implements Rule
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'Configuration defined type for constant %s (%s) does not accept value %s.',
 				$constantName,
-				$configuredType->describe(VerbosityLevel::typeOnly()),
+				$configuredType->describe(VerbosityLevel::precise()),
 				$valueType->describe($verbosity),
 			))->acceptsReasonsTip($accepts->reasons)->identifier('constant.defineValue')->build();
 		}

--- a/src/Rules/Constants/ValueAssignedToDefineRule.php
+++ b/src/Rules/Constants/ValueAssignedToDefineRule.php
@@ -72,7 +72,7 @@ final class ValueAssignedToDefineRule implements Rule
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'Configuration defined type for constant %s (%s) does not accept value %s.',
 				$constantName,
-				$configuredType->describe(VerbosityLevel::precise()),
+				$configuredType->describe(VerbosityLevel::value()),
 				$valueType->describe($verbosity),
 			))->acceptsReasonsTip($accepts->reasons)->identifier('constant.defineValue')->build();
 		}

--- a/src/Rules/Constants/ValueAssignedToGlobalConstantRule.php
+++ b/src/Rules/Constants/ValueAssignedToGlobalConstantRule.php
@@ -52,7 +52,7 @@ final class ValueAssignedToGlobalConstantRule implements Rule
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'Configuration defined type for constant %s (%s) does not accept value %s.',
 				$constantName,
-				$configuredType->describe(VerbosityLevel::typeOnly()),
+				$configuredType->describe(VerbosityLevel::precise()),
 				$valueType->describe($verbosity),
 			))->acceptsReasonsTip($accepts->reasons)->identifier('constant.value')->build();
 		}

--- a/src/Rules/Constants/ValueAssignedToGlobalConstantRule.php
+++ b/src/Rules/Constants/ValueAssignedToGlobalConstantRule.php
@@ -52,7 +52,7 @@ final class ValueAssignedToGlobalConstantRule implements Rule
 			$errors[] = RuleErrorBuilder::message(sprintf(
 				'Configuration defined type for constant %s (%s) does not accept value %s.',
 				$constantName,
-				$configuredType->describe(VerbosityLevel::precise()),
+				$configuredType->describe(VerbosityLevel::value()),
 				$valueType->describe($verbosity),
 			))->acceptsReasonsTip($accepts->reasons)->identifier('constant.value')->build();
 		}

--- a/tests/PHPStan/Rules/Constants/ValueAssignedToClassConstantWithDynamicNamesRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ValueAssignedToClassConstantWithDynamicNamesRuleTest.php
@@ -38,6 +38,10 @@ class ValueAssignedToClassConstantWithDynamicNamesRuleTest extends RuleTestCase
 				'Configuration defined type for constant ValueAssignedToClassConstantDynamicNames\Foo::MAYBE_BAR (int<1, max>) does not accept value int.',
 				14,
 			],
+			[
+				"Configuration defined type for constant ValueAssignedToClassConstantDynamicNames\Foo::A_NON_EMPTY_STRING (non-empty-string) does not accept value ''.",
+				15,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Constants/ValueAssignedToDefineRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ValueAssignedToDefineRuleTest.php
@@ -42,7 +42,7 @@ class ValueAssignedToDefineRuleTest extends RuleTestCase
 				12,
 			],
 			[
-				"Configuration defined type for constant A_NON_EMPTY_STRING (non-empty-string) does not accept value string.",
+				'Configuration defined type for constant A_NON_EMPTY_STRING (non-empty-string) does not accept value string.',
 				14,
 			],
 		]);

--- a/tests/PHPStan/Rules/Constants/ValueAssignedToDefineRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ValueAssignedToDefineRuleTest.php
@@ -37,6 +37,14 @@ class ValueAssignedToDefineRuleTest extends RuleTestCase
 				'Configuration defined type for constant BAR_CONSTANT (int|string|null) does not accept value int|false.',
 				6,
 			],
+			[
+				"Configuration defined type for constant A_NON_EMPTY_STRING (non-empty-string) does not accept value ''.",
+				12,
+			],
+			[
+				"Configuration defined type for constant A_NON_EMPTY_STRING (non-empty-string) does not accept value string.",
+				14,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Constants/ValueAssignedToGlobalConstantRuleTest.php
+++ b/tests/PHPStan/Rules/Constants/ValueAssignedToGlobalConstantRuleTest.php
@@ -37,6 +37,10 @@ class ValueAssignedToGlobalConstantRuleTest extends RuleTestCase
 				'Configuration defined type for constant MAYBE_CONSTANT (int<1, max>) does not accept value int.',
 				5,
 			],
+			[
+				"Configuration defined type for constant A_NON_EMPTY_STRING (non-empty-string) does not accept value ''.",
+				6,
+			],
 		]);
 	}
 

--- a/tests/PHPStan/Rules/Constants/data/value-assigned-to-class-constant-dynamic-names.php
+++ b/tests/PHPStan/Rules/Constants/data/value-assigned-to-class-constant-dynamic-names.php
@@ -12,4 +12,5 @@ class Foo
 	const BAR = false; // error - configured as int|string|null
 	const BAR2 = 1; // fine - not in dynamicConstantNames
 	const MAYBE_BAR = Bar::DYNAMIC; // error (maybe) - positive-int doesn't fully accept int
+	const A_NON_EMPTY_STRING = '';
 }

--- a/tests/PHPStan/Rules/Constants/data/value-assigned-to-define.php
+++ b/tests/PHPStan/Rules/Constants/data/value-assigned-to-define.php
@@ -9,3 +9,8 @@ define('BAR_CONSTANT', 'hello'); // fine
 define('BAR_CONSTANT', null); // fine
 define('BAR_CONSTANT', rand(0,1) ? 1 : 'hello'); // fine
 define('OTHER_CONSTANT', false); // fine - not in dynamicConstantNames
+define('A_NON_EMPTY_STRING', '');
+define('A_NON_EMPTY_STRING', '0');
+define('A_NON_EMPTY_STRING', getString());
+
+function getString(): string {}

--- a/tests/PHPStan/Rules/Constants/data/value-assigned-to-global-constant.php
+++ b/tests/PHPStan/Rules/Constants/data/value-assigned-to-global-constant.php
@@ -3,3 +3,4 @@
 const BAR_CONSTANT = false; // error
 const OTHER_CONSTANT = false; // fine - not in dynamicConstantNames
 const MAYBE_CONSTANT = DYNAMIC_INT_CONSTANT; // error (maybe) - positive-int doesn't fully accept int
+const A_NON_EMPTY_STRING = '';

--- a/tests/PHPStan/Rules/Constants/value-assigned-dynamic-constant.neon
+++ b/tests/PHPStan/Rules/Constants/value-assigned-dynamic-constant.neon
@@ -6,6 +6,8 @@ parameters:
 		BAR_CONSTANT: 'int|string|null'
 		DYNAMIC_INT_CONSTANT: 'int'
 		MAYBE_CONSTANT: 'positive-int'
+		A_NON_EMPTY_STRING: 'non-empty-string'
 		ValueAssignedToClassConstantDynamicNames\Foo::BAR: 'int|string|null'
 		ValueAssignedToClassConstantDynamicNames\Bar::DYNAMIC: 'int'
 		ValueAssignedToClassConstantDynamicNames\Foo::MAYBE_BAR: 'positive-int'
+		ValueAssignedToClassConstantDynamicNames\Foo::A_NON_EMPTY_STRING: 'non-empty-string'


### PR DESCRIPTION
Improves the error messages..

before PR
> Configuration defined type for constant APP_ROOT (string) does not accept value string.

after PR
> Configuration defined type for constant APP_ROOT (non-empty-string) does not accept value string.

----

followup to https://github.com/phpstan/phpstan-src/pull/5648