### PR TITLE
More precise `dirname()` return type

### DIFF
--- a/stubs/core.stub
+++ b/stubs/core.stub
@@ -461,3 +461,8 @@ function proc_open($command, array $descriptor_spec, &$pipes, ?string $cwd = nul
  * @param-out list<int>    $weights
  */
 function getmxrr(string $hostname, &$hosts, &$weights = null): bool {}
+
+/**
+ * @return ($path is non-empty-string ? non-empty-string : string)
+ */
+function dirname(string $path, int $levels = 1): string {}

--- a/tests/PHPStan/Rules/Constants/data/value-assigned-to-define.php
+++ b/tests/PHPStan/Rules/Constants/data/value-assigned-to-define.php
@@ -12,5 +12,6 @@ define('OTHER_CONSTANT', false); // fine - not in dynamicConstantNames
 define('A_NON_EMPTY_STRING', '');
 define('A_NON_EMPTY_STRING', '0');
 define('A_NON_EMPTY_STRING', getString());
+define('A_NON_EMPTY_STRING', dirname(__DIR__, 2));
 
 function getString(): string {}


### PR DESCRIPTION
given a `non-empty-string`-path, `dirname()` will return a `non-empty-string`

see e.g. https://3v4l.org/YK9T1#veol

---

we applied the same logic already for pathinfo:

https://github.com/phpstan/phpstan-src/blob/c86f75a941e8945caaab88851a1988d665532f50/src/Type/Php/PathinfoFunctionDynamicReturnTypeExtension.php#L50

----

use case: prevents a 
> Configuration defined type for constant APP_ROOT (non-empty-string) does not accept value string.

 error in `define('APP_ROOT', dirname(__DIR__, 2));` when using `dynamicConstantNames`