### PR TITLE
Wrap issue-bot PR-comment mentions in inline code to avoid notifications

### DIFF
--- a/issue-bot/src/Console/EvaluateCommand.php
+++ b/issue-bot/src/Console/EvaluateCommand.php
@@ -144,7 +144,7 @@ class EvaluateCommand extends Command
 			$text = sprintf(
 				"Result of the [code snippet](https://phpstan.org/r/%s) from %s in [#%d](https://github.com/phpstan/phpstan/issues/%d) changed:\n\n```diff\n%s```",
 				$hash,
-				implode(' ', array_map(static fn (string $user): string => sprintf('@%s', $user), $users)),
+				implode(' ', array_map(static fn (string $user): string => sprintf('`@%s`', $user), $users)),
 				$issue,
 				$issue,
 				$diff,


### PR DESCRIPTION
## Summary

Follow-up to #5715 (PR comments from the issue bot). The PR-comment path renders reporter handles as `@user`; now that this text is posted as a PR comment, every issue commenter gets pinged on each run.

This wraps the handles in inline code (`` `@user` ``) on the PR-comment path only. Inline code is the documented, reliable way to show a handle without GitHub parsing it as a mention, so no notification fires.

The `--post-comments` path (which posts onto the original GitHub issue after a merge to `2.2.x`) is **unchanged** — its ping to the reporter is intentional.

## Test plan

- [ ] On a PR run that detects changes, confirm the comment shows `@user` in monospace and the referenced users are not notified.
- [ ] Confirm push-mode issue comments still mention (and notify) reporters as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)